### PR TITLE
fix: remove docs (there's no openapi)

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -13,7 +13,7 @@ module.exports = {
       message: "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     }],
     ['@semantic-release/exec', {
-      prepareCmd: 'npm run deploy && npm run test-postdeploy && npm run docs',
+      prepareCmd: 'npm run deploy && npm run test-postdeploy',
       publishCmd: 'npm run deploy-routes'
     }],
     ["@semantic-release/github", {}]

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@adobe/spacecat-shared-data-access": "1.1.2",
         "@adobe/spacecat-shared-utils": "1.2.0",
         "@aws-sdk/client-sqs": "3.450.0",
-        "diff": "^5.1.0"
+        "diff": "5.1.0"
       },
       "devDependencies": {
         "@adobe/eslint-config-helix": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -17,10 +17,6 @@
     "deploy-routes": "hedy --no-build -no-hints -l major",
     "deploy-ci": "hedy -v --deploy --test --pkgVersion=ci$CIRCLE_BUILD_NUM -l ci --cleanup-ci=24h",
     "deploy-secrets": "hedy --aws-update-secrets --params-file=secrets/secrets.env",
-    "docs": "npm run docs:lint && npm run docs:build",
-    "docs:build": "npx @redocly/cli build-docs -o ./docs/index.html --config docs/openapi/redocly-config.yaml",
-    "docs:lint": "npx @redocly/cli lint --config docs/openapi/redocly-config.yaml",
-    "docs:serve": "npx @redocly/cli preview-docs --config docs/openapi/redocly-config.yaml",
     "prepare": "husky install"
   },
   "wsk": {


### PR DESCRIPTION
causes on circle ci:
```
> @adobe/spacecat-audit-worker@1.0.0 docs:lint
> npx @redocly/cli lint --config docs/openapi/redocly-config.yaml

    at makeError (/home/circleci/repo/node_modules/execa/lib/error.js:60:11)
    at handlePromise (/home/circleci/repo/node_modules/execa/index.js:118:26)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async module.exports (/home/circleci/repo/node_modules/@semantic-release/exec/lib/exec.js:16:11)
    at async prepare (/home/circleci/repo/node_modules/@semantic-release/exec/index.js:54:5)
    at async validator (file:///home/circleci/repo/node_modules/semantic-release/lib/plugins/normalize.js:36:24)
    at async file:///home/circleci/repo/node_modules/semantic-release/lib/plugins/pipeline.js:38:36
    at async file:///home/circleci/repo/node_modules/semantic-release/lib/plugins/pipeline.js:32:5
    at async pluginsConfigAccumulator.<computed> [as prepare] (file:///home/circleci/repo/node_modules/semantic-release/lib/plugins/index.js:87:11)
    at async run (file:///home/circleci/repo/node_modules/semantic-release/index.js:199:3) {
  shortMessage: 'Command failed with exit code 2: npm run deploy && npm run test-postdeploy && npm run docs',
  command: 'npm run deploy && npm run test-postdeploy && npm run docs',
  escapedCommand: '"npm run deploy && npm run test-postdeploy && npm run docs"',
```