### PR TITLE
fix: standardized timing for coralogix graph

### DIFF
--- a/src/lhs/handler.js
+++ b/src/lhs/handler.js
@@ -413,7 +413,7 @@ export default async function audit(message, context) {
     const elapsedSeconds = endTime[0] + endTime[1] / 1e9;
     const formattedElapsed = elapsedSeconds.toFixed(2);
 
-    log.info(`Audit for ${type} completed in ${formattedElapsed} seconds`);
+    log.info(`LHS Audit of type ${type} completed in ${formattedElapsed} seconds`);
 
     return noContent();
   } catch (e) {


### PR DESCRIPTION
This is mostly to include other types of audits as well in the graph:

![Screenshot 2023-12-18 at 15 22 22](https://github.com/adobe-rnd/spacecat-audit-worker/assets/1872195/49f89509-374b-46df-b1a8-4fdbdc2ddbb9)
