### PR TITLE
fix: run broken backlinks audit only for sites that are live

### DIFF
--- a/src/backlinks/handler.js
+++ b/src/backlinks/handler.js
@@ -32,6 +32,11 @@ export default async function auditBrokenBacklinks(message, context) {
       return notFound('Site not found');
     }
 
+    if (!site.isLive()) {
+      log.info(`Site ${siteId} is not live`);
+      return ok();
+    }
+
     const auditConfig = site.getAuditConfig();
     if (auditConfig.auditsDisabled()) {
       log.info(`Audits disabled for site ${siteId}`);

--- a/test/audits/backlinks.test.js
+++ b/test/audits/backlinks.test.js
@@ -36,12 +36,14 @@ describe('Backlinks Tests', () => {
   const siteData = {
     id: 'site1',
     baseURL: 'https://bar.foo.com',
+    isLive: true,
   };
 
   const site = createSite(siteData);
   const site2 = createSite({
     id: 'site2',
     baseURL: 'https://foo.com',
+    isLive: true,
   });
 
   const auditResult = {
@@ -179,6 +181,20 @@ describe('Backlinks Tests', () => {
 
     expect(response.status).to.equal(200);
     expect(mockLog.info).to.have.been.calledWith('Audit type broken-backlinks disabled for site site1');
+  });
+
+  it('returns a 200 when site is not live', async () => {
+    const siteWithDisabledAudits = createSite({
+      ...siteData,
+      isLive: false,
+    });
+
+    mockDataAccess.getSiteByID.resolves(siteWithDisabledAudits);
+
+    const response = await auditBrokenBacklinks(message, context);
+
+    expect(response.status).to.equal(200);
+    expect(mockLog.info).to.have.been.calledWith('Site site1 is not live');
   });
 
   it('should handle audit api errors gracefully', async () => {


### PR DESCRIPTION
Broken backlinks should run only for sites that are live