### PR TITLE
fix: remove domain key

### DIFF
--- a/src/experimentation/handler.js
+++ b/src/experimentation/handler.js
@@ -72,13 +72,17 @@ export default async function auditExperiments(message, context) {
       finalUrl: auditContext.finalUrl,
     };
 
+    const fullAuditRef = rumAPIClient.createExperimentationURL({ url: auditContext.finalUrl });
+    const fullAuditRefURL = new URL(fullAuditRef);
+    fullAuditRefURL.searchParams.delete('domainkey');
+
     const auditData = {
       siteId: site.getId(),
       isLive: site.isLive(),
       auditedAt: new Date().toISOString(),
       auditType: type,
       auditResult,
-      fullAuditRef: rumAPIClient.createExperimentationURL({ url: auditContext.finalUrl }),
+      fullAuditRef: fullAuditRefURL.toString(),
     };
     await dataAccess.addAudit(auditData);
     await sqs.sendMessage(queueUrl, {

--- a/src/notfound/handler.js
+++ b/src/notfound/handler.js
@@ -61,11 +61,14 @@ async function processAuditResult(
   const {
     dataAccess, sqs, rumAPIClient,
   } = services;
+  const fullAuditRef = rumAPIClient.create404URL(auditContext);
+  const fullAuditRefURL = new URL(fullAuditRef);
+  fullAuditRefURL.searchParams.delete('domainkey');
   const auditData = {
     siteId: site.getId(),
     auditType: AUDIT_TYPE,
     auditedAt: new Date().toISOString(),
-    fullAuditRef: rumAPIClient.create404URL(auditContext),
+    fullAuditRef: fullAuditRefURL.toString(),
     isLive: site.isLive(),
     auditResult: { result, finalUrl: auditContext.url },
   };

--- a/test/audits/notfound.test.js
+++ b/test/audits/notfound.test.js
@@ -94,7 +94,7 @@ describe('Index Tests', () => {
       .reply(200);
     context.rumApiClient = {
       get404Sources: sinon.stub().resolves(notFoundData.results.data),
-      create404URL: () => 'abc.com',
+      create404URL: () => 'https://abc.com',
     };
     const resp = await main(request, context);
 


### PR DESCRIPTION
Generic domain key is stored and expose through the API, we should remove it from the Helix API URLs we store