### PR TITLE
feat: top pages and backlinks from ahrefs

### DIFF
--- a/src/support/ahrefs-client.js
+++ b/src/support/ahrefs-client.js
@@ -104,8 +104,6 @@ export default class AhrefsAPIClient {
   }
 
   async getTopPages(url, limit = 200) {
-    const MONTH_IN_MS = 30 * 24 * 60 * 60 * 1000;
-
     const filter = {
       and: [
         { field: 'sum_traffic', is: ['gt', 0] },
@@ -117,14 +115,13 @@ export default class AhrefsAPIClient {
         'url',
         'sum_traffic',
       ].join(','),
-      where: JSON.stringify(filter),
       order_by: 'sum_traffic_merged',
       date: new Date().toISOString().split('T')[0],
-      date_compared: new Date(Date.now() - MONTH_IN_MS).toISOString().split('T')[0],
       target: url,
       limit: getLimit(limit, 2000),
       mode: 'prefix',
       output: 'json',
+      where: JSON.stringify(filter),
     };
 
     return this.sendRequest('/site-explorer/top-pages', queryParams);
@@ -147,12 +144,12 @@ export default class AhrefsAPIClient {
         'url_from',
         'url_to',
       ].join(','),
-      where: JSON.stringify(filter),
       order_by: 'domain_rating_source:desc,traffic_domain:desc',
       target: url,
       limit: getLimit(limit, 1000),
       mode: 'prefix',
       output: 'json',
+      where: JSON.stringify(filter),
     };
 
     return this.sendRequest('/site-explorer/all-backlinks', queryParams);

--- a/src/support/ahrefs-client.js
+++ b/src/support/ahrefs-client.js
@@ -21,20 +21,20 @@ export default class AhrefsAPIClient {
     return new AhrefsAPIClient({ apiBaseUrl, apiKey }, fetch);
   }
 
-  constructor(config, httpClient, log = console) {
+  constructor(config, fetchAPI, log = console) {
     const { apiKey, apiBaseUrl } = config;
 
     if (!isValidUrl(apiBaseUrl)) {
       throw new Error(`Invalid Ahrefs API Base URL: ${apiBaseUrl}`);
     }
 
-    if (typeof httpClient !== 'function') {
-      throw Error('"fetch" must be a function');
+    if (typeof fetchAPI !== 'function') {
+      throw Error('"fetchAPI" must be a function');
     }
 
     this.apiBaseUrl = apiBaseUrl;
     this.apiKey = apiKey;
-    this.httpClient = httpClient;
+    this.fetchAPI = fetchAPI;
     this.log = log;
   }
 
@@ -46,7 +46,7 @@ export default class AhrefsAPIClient {
         .join('&')}` : '';
 
     const fullAuditRef = `${this.apiBaseUrl}${endpoint}${queryString}`;
-    const response = await this.httpClient(fullAuditRef, {
+    const response = await this.fetchAPI(fullAuditRef, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/test/support/ahrefs-client.test.js
+++ b/test/support/ahrefs-client.test.js
@@ -18,6 +18,7 @@ import nock from 'nock';
 import sinon from 'sinon';
 
 import AhrefsAPIClient from '../../src/support/ahrefs-client.js';
+import { fetch } from '../../src/support/utils.js';
 
 chai.use(chaiAsPromised);
 const { expect } = chai;
@@ -45,7 +46,7 @@ describe('AhrefsAPIClient', () => {
   };
 
   beforeEach(() => {
-    client = new AhrefsAPIClient(config);
+    client = new AhrefsAPIClient(config, fetch);
   });
 
   afterEach(() => {
@@ -56,6 +57,10 @@ describe('AhrefsAPIClient', () => {
   describe('constructor', () => {
     it('throws error when api base url is missing', () => {
       expect(() => new AhrefsAPIClient({})).to.throw('Invalid Ahrefs API Base URL: undefined');
+    });
+
+    it('throws error when fetch is not a function', () => {
+      expect(() => new AhrefsAPIClient(config, 'fetch')).to.throw('"fetch" must be a function');
     });
   });
 

--- a/test/support/ahrefs-client.test.js
+++ b/test/support/ahrefs-client.test.js
@@ -84,7 +84,7 @@ describe('AhrefsAPIClient', () => {
     });
 
     it('throws error when fetch is not a function', () => {
-      expect(() => new AhrefsAPIClient(config, 'fetch')).to.throw('"fetch" must be a function');
+      expect(() => new AhrefsAPIClient(config, 'fetch')).to.throw('"fetchAPI" must be a function');
     });
   });
 

--- a/test/support/ahrefs-client.test.js
+++ b/test/support/ahrefs-client.test.js
@@ -22,6 +22,9 @@ import { fetch } from '../../src/support/utils.js';
 
 chai.use(chaiAsPromised);
 const { expect } = chai;
+const sandbox = sinon.createSandbox();
+
+const mockDate = '2023-03-12T15:24:51.231Z';
 
 describe('AhrefsAPIClient', () => {
   let client;
@@ -30,7 +33,7 @@ describe('AhrefsAPIClient', () => {
     apiBaseUrl: 'https://example.com',
   };
 
-  const brokenBacklinksResponse = {
+  const backlinksResponse = {
     backlinks: [
       {
         title: 'backlink title',
@@ -44,6 +47,27 @@ describe('AhrefsAPIClient', () => {
       },
     ],
   };
+
+  const topPagesResponse = [
+    {
+      url: 'page-url-1',
+      sum_traffic: 100,
+    },
+    {
+      url: 'page-url-2',
+      sum_traffic: 300,
+    },
+  ];
+
+  before('setup', function () {
+    this.clock = sandbox.useFakeTimers({
+      now: new Date(mockDate).getTime(),
+    });
+  });
+
+  after('clean', function () {
+    this.clock.uninstall();
+  });
 
   beforeEach(() => {
     client = new AhrefsAPIClient(config, fetch);
@@ -68,11 +92,11 @@ describe('AhrefsAPIClient', () => {
     it('returns data when API request was successful', async () => {
       nock(config.apiBaseUrl)
         .get(/.*/)
-        .reply(200, brokenBacklinksResponse);
+        .reply(200, backlinksResponse);
 
       const result = await client.sendRequest('/some-endpoint');
       expect(result).to.deep.equal({
-        result: brokenBacklinksResponse,
+        result: backlinksResponse,
         fullAuditRef: 'https://example.com/some-endpoint',
       });
     });
@@ -119,12 +143,87 @@ describe('AhrefsAPIClient', () => {
             ],
           }),
         })
-        .reply(200, brokenBacklinksResponse);
+        .reply(200, backlinksResponse);
 
       const result = await client.getBrokenBacklinks('test-site.com');
       expect(result).to.deep.equal({
-        result: brokenBacklinksResponse,
+        result: backlinksResponse,
         fullAuditRef: 'https://example.com/site-explorer/broken-backlinks?select=title%2Curl_from%2Curl_to&limit=50&mode=prefix&order_by=domain_rating_source%3Adesc%2Ctraffic_domain%3Adesc&target=test-site.com&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22is_dofollow%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22is_content%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22domain_rating_source%22%2C%22is%22%3A%5B%22gte%22%2C29.5%5D%7D%2C%7B%22field%22%3A%22traffic_domain%22%2C%22is%22%3A%5B%22gte%22%2C500%5D%7D%2C%7B%22field%22%3A%22links_external%22%2C%22is%22%3A%5B%22lte%22%2C300%5D%7D%5D%7D',
+      });
+    });
+  });
+
+  describe('getTopPages', () => {
+    it('sends API request with appropriate endpoint query params', async () => {
+      const specifiedLimit = 50;
+      const target = 'test-site.com';
+
+      const date = mockDate.split('T')[0];
+      const filter = {
+        and: [
+          { field: 'sum_traffic', is: ['gt', 0] },
+        ],
+      };
+      const queryParams = {
+        select: [
+          'url',
+          'sum_traffic',
+        ].join(','),
+        where: JSON.stringify(filter),
+        order_by: 'sum_traffic_merged',
+        date,
+        target,
+        limit: specifiedLimit,
+        mode: 'prefix',
+        output: 'json',
+      };
+
+      nock(config.apiBaseUrl)
+        .get('/site-explorer/top-pages')
+        .query(queryParams)
+        .reply(200, topPagesResponse);
+
+      const result = await client.getTopPages(target, specifiedLimit);
+      expect(result).to.deep.equal({
+        result: topPagesResponse,
+        fullAuditRef: `https://example.com/site-explorer/top-pages?select=url%2Csum_traffic&order_by=sum_traffic_merged&date=${date}&target=${target}&limit=${specifiedLimit}&mode=prefix&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22sum_traffic%22%2C%22is%22%3A%5B%22gt%22%2C0%5D%7D%5D%7D`,
+      });
+    });
+  });
+
+  describe('getBacklinks', () => {
+    it('sends API request with appropriate endpoint query params', async () => {
+      const upperLimit = 1000;
+
+      nock(config.apiBaseUrl)
+        .get('/site-explorer/all-backlinks')
+        .query({
+          select: [
+            'title',
+            'url_from',
+            'url_to',
+          ].join(','),
+          limit: upperLimit,
+          mode: 'prefix',
+          order_by: 'domain_rating_source:desc,traffic_domain:desc',
+          target: 'test-site.com',
+          output: 'json',
+          where: JSON.stringify({
+            and: [
+              { field: 'is_dofollow', is: ['eq', 1] },
+              { field: 'is_content', is: ['eq', 1] },
+              { field: 'domain_rating_source', is: ['gte', 29.5] },
+              { field: 'traffic_domain', is: ['gte', 500] },
+              { field: 'links_external', is: ['lte', 300] },
+            ],
+          }),
+        })
+        .reply(200, backlinksResponse);
+
+      const result = await client.getBacklinks('test-site.com', upperLimit * 3);
+      expect(result).to.deep.equal({
+        result: backlinksResponse,
+        fullAuditRef: `https://example.com/site-explorer/all-backlinks?select=title%2Curl_from%2Curl_to&order_by=domain_rating_source%3Adesc%2Ctraffic_domain%3Adesc&target=test-site.com&limit=${upperLimit}&mode=prefix&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22is_dofollow%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22is_content%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22domain_rating_source%22%2C%22is%22%3A%5B%22gte%22%2C29.5%5D%7D%2C%7B%22field%22%3A%22traffic_domain%22%2C%22is%22%3A%5B%22gte%22%2C500%5D%7D%2C%7B%22field%22%3A%22links_external%22%2C%22is%22%3A%5B%22lte%22%2C300%5D%7D%5D%7D`,
       });
     });
   });


### PR DESCRIPTION
Add top pages and backlinks queries from Ahrefs to be used by the SEO pre go-live assessments and others.

http client to use can be passed via constructor and the usual `fetch` is passed in the `createFrom`. This is required as we'd want to reuse the client in the pre go-live scripts, where we use node-fetch-cache to cache the responses.


Includes also changes from https://github.com/adobe/spacecat-audit-worker/pull/215 as well