### PR TITLE
fix: add serviceId to LHSaaS call

### DIFF
--- a/src/lhs/lib.js
+++ b/src/lhs/lib.js
@@ -14,6 +14,7 @@ import { isObject, isValidUrl } from '@adobe/spacecat-shared-utils';
 
 import PSIClient from '../support/psi-client.js';
 import { fetch } from '../support/utils.js';
+import { retrieveSiteBySiteId } from '../utils/data-access.js';
 
 /**
  * Extracts audit scores from an audit.
@@ -148,9 +149,15 @@ async function processAudit(
   strategy,
   log = console,
 ) {
-  const { psiClient } = services;
+  const { dataAccess, psiClient } = services;
 
-  const { lighthouseResult, fullAuditRef, finalUrl } = await psiClient.runAudit(baseURL, strategy);
+  const site = await retrieveSiteBySiteId(dataAccess, baseURL, log);
+
+  const { lighthouseResult, fullAuditRef, finalUrl } = await psiClient.runAudit(
+    baseURL,
+    strategy,
+    site.getId(),
+  );
 
   if (isObject(lighthouseResult.runtimeError)) {
     log.error(

--- a/src/support/psi-client.js
+++ b/src/support/psi-client.js
@@ -127,7 +127,11 @@ function PSIClient(config, log = console) {
    *
    * @param {string} baseURL - The base URL to check.
    * @param {string} strategy - The strategy to use.
-   * @param {string} serviceId - The service ID.
+   * @param {string} [serviceId] - Optional service ID.
+   * If provided, it will be included in the audit URL and be recorded by the PSI
+   * service as its service ID. This can be leveraged to retrieve reports by service ID on
+   * the external PSI service. In the context of SpaceCat, this is used to correlate the
+   * site id with the PSI audit.
    * @return {Promise<{lighthouseResult: object, fullAuditRef: string}>}
    */
   const runAudit = async (baseURL, strategy, serviceId) => {

--- a/test/support/psi-client.test.js
+++ b/test/support/psi-client.test.js
@@ -84,7 +84,7 @@ describe('PSIClient', () => {
         .query(true)
         .reply(200, { lighthouseResult: { score: 0.9 } });
 
-      const result = await client.performPSICheck('testsite.com', 'mobile');
+      const result = await client.performPSICheck('testsite.com', 'mobile', undefined);
       expect(result).to.deep.equal(
         {
           fullAuditRef: 'https://example.com/?url=https%3A%2F%2Ftestsite.com&strategy=mobile&key=testApiKey',
@@ -124,11 +124,11 @@ describe('PSIClient', () => {
         .query(true)
         .reply(200, { lighthouseResult: { score: 0.8 } });
 
-      const result = await client.runAudit('testsite.com', 'mobile');
+      const result = await client.runAudit('testsite.com', 'mobile', '1234');
       expect(result).to.deep.equal(
         {
           finalUrl: 'https://testsite.com/',
-          fullAuditRef: 'https://example.com/?url=https%3A%2F%2Ftestsite.com%2F&strategy=mobile&key=testApiKey',
+          fullAuditRef: 'https://example.com/?url=https%3A%2F%2Ftestsite.com%2F&strategy=mobile&serviceId=1234&key=testApiKey',
           lighthouseResult: {
             score: 0.8,
           },


### PR DESCRIPTION
Adding `serviceId` (our site id) to the call to EaaS LHSaaS). This allows retrieval of reports by site id via the [EaaS LHSaaS API](https://git.corp.adobe.com/pages/Evergreen/eaas-frontend/prod/psi/#/)