### PR TITLE
fix: expose traffic_domain in the broken backlinks audit data (SITES-22464)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@adobe/helix-status": "10.1.0",
         "@adobe/helix-universal": "4.5.2",
         "@adobe/helix-universal-logger": "3.0.16",
-        "@adobe/spacecat-shared-ahrefs-client": "https://gitpkg.now.sh/adobe/spacecat-shared/packages/spacecat-shared-ahrefs-client?ahrefs-domain-traffic",
+        "@adobe/spacecat-shared-ahrefs-client": "1.2.3",
         "@adobe/spacecat-shared-data-access": "1.23.6",
         "@adobe/spacecat-shared-http-utils": "1.3.2",
         "@adobe/spacecat-shared-rum-api-client": "1.8.4",
@@ -303,10 +303,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-ahrefs-client": {
-      "version": "1.2.2",
-      "resolved": "https://gitpkg.now.sh/adobe/spacecat-shared/packages/spacecat-shared-ahrefs-client?ahrefs-domain-traffic",
-      "integrity": "sha512-W7NNOEEfmAiLh7SMaJUIhfg8Au6LsUOSMarLuoVXYb4Ak1AKxAmQEQr1nazA/f0Q+EYbcjxaoieWA3J7GBOvUw==",
-      "license": "Apache-2.0",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-ahrefs-client/-/spacecat-shared-ahrefs-client-1.2.3.tgz",
+      "integrity": "sha512-bHkBUWyr9qr++qkqgDPCu3mmarYYnYtFZ7QGF3/I9mSN42MziGPNrOLDG2Blg4YllCBTuzZw6+wzImpmFrt0VQ==",
       "dependencies": {
         "@adobe/fetch": "4.1.3",
         "@adobe/helix-universal": "4.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@adobe/helix-status": "10.1.0",
         "@adobe/helix-universal": "4.5.2",
         "@adobe/helix-universal-logger": "3.0.16",
-        "@adobe/spacecat-shared-ahrefs-client": "1.2.2",
+        "@adobe/spacecat-shared-ahrefs-client": "https://gitpkg.now.sh/adobe/spacecat-shared/packages/spacecat-shared-ahrefs-client?ahrefs-domain-traffic",
         "@adobe/spacecat-shared-data-access": "1.23.6",
         "@adobe/spacecat-shared-http-utils": "1.3.2",
         "@adobe/spacecat-shared-rum-api-client": "1.8.4",
@@ -304,8 +304,8 @@
     },
     "node_modules/@adobe/spacecat-shared-ahrefs-client": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-ahrefs-client/-/spacecat-shared-ahrefs-client-1.2.2.tgz",
-      "integrity": "sha512-9zbN3oq0dQHLgEcHgouCtM3PUydKPQUEXRpXmq0dBCCCeC1RTtsdUg1zEloppBqF4g2/Q2rLLW+Gano5ZqOQdw==",
+      "resolved": "https://gitpkg.now.sh/adobe/spacecat-shared/packages/spacecat-shared-ahrefs-client?ahrefs-domain-traffic",
+      "integrity": "sha512-W7NNOEEfmAiLh7SMaJUIhfg8Au6LsUOSMarLuoVXYb4Ak1AKxAmQEQr1nazA/f0Q+EYbcjxaoieWA3J7GBOvUw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@adobe/spacecat-shared-data-access": "1.23.6",
     "@adobe/spacecat-shared-http-utils": "1.3.2",
     "@adobe/spacecat-shared-rum-api-client": "1.8.4",
-    "@adobe/spacecat-shared-ahrefs-client": "1.2.2",
+    "@adobe/spacecat-shared-ahrefs-client": "https://gitpkg.now.sh/adobe/spacecat-shared/packages/spacecat-shared-ahrefs-client?ahrefs-domain-traffic",
     "@adobe/spacecat-shared-utils": "1.15.5",
     "@aws-sdk/client-sqs": "3.588.0",
     "diff": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@adobe/spacecat-shared-data-access": "1.23.6",
     "@adobe/spacecat-shared-http-utils": "1.3.2",
     "@adobe/spacecat-shared-rum-api-client": "1.8.4",
-    "@adobe/spacecat-shared-ahrefs-client": "https://gitpkg.now.sh/adobe/spacecat-shared/packages/spacecat-shared-ahrefs-client?ahrefs-domain-traffic",
+    "@adobe/spacecat-shared-ahrefs-client": "1.2.3",
     "@adobe/spacecat-shared-utils": "1.15.5",
     "@aws-sdk/client-sqs": "3.588.0",
     "diff": "5.2.0",

--- a/test/audits/backlinks.test.js
+++ b/test/audits/backlinks.test.js
@@ -55,16 +55,19 @@ describe('Backlinks Tests', () => {
         title: 'backlink that returns 404',
         url_from: 'https://from.com/from-1',
         url_to: 'https://foo.com/returns-404',
+        domain_traffic: 4000,
       },
       {
         title: 'backlink that redirects to www and throw connection error',
         url_from: 'https://from.com/from-2',
         url_to: 'https://foo.com/redirects-throws-error',
+        domain_traffic: 2000,
       },
       {
         title: 'backlink that returns 429',
         url_from: 'https://from.com/from-3',
         url_to: 'https://foo.com/returns-429',
+        domain_traffic: 1000,
       },
     ],
   };
@@ -141,7 +144,7 @@ describe('Backlinks Tests', () => {
       auditResult: {
         finalUrl: 'bar.foo.com',
         brokenBacklinks: auditResult.backlinks,
-        fullAuditRef: 'https://ahrefs.com/site-explorer/broken-backlinks?select=title%2Curl_from%2Curl_to&limit=50&mode=prefix&order_by=domain_rating_source%3Adesc%2Ctraffic_domain%3Adesc&target=bar.foo.com&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22is_dofollow%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22is_content%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22domain_rating_source%22%2C%22is%22%3A%5B%22gte%22%2C29.5%5D%7D%2C%7B%22field%22%3A%22traffic_domain%22%2C%22is%22%3A%5B%22gte%22%2C500%5D%7D%2C%7B%22field%22%3A%22links_external%22%2C%22is%22%3A%5B%22lte%22%2C300%5D%7D%5D%7D',
+        fullAuditRef: 'https://ahrefs.com/site-explorer/broken-backlinks?select=title%2Curl_from%2Curl_to%2Ctraffic_domain&limit=50&mode=prefix&order_by=domain_rating_source%3Adesc%2Ctraffic_domain%3Adesc&target=bar.foo.com&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22is_dofollow%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22is_content%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22domain_rating_source%22%2C%22is%22%3A%5B%22gte%22%2C29.5%5D%7D%2C%7B%22field%22%3A%22traffic_domain%22%2C%22is%22%3A%5B%22gte%22%2C500%5D%7D%2C%7B%22field%22%3A%22links_external%22%2C%22is%22%3A%5B%22lte%22%2C300%5D%7D%5D%7D',
       },
     };
 
@@ -179,7 +182,7 @@ describe('Backlinks Tests', () => {
       auditResult: {
         finalUrl: 'www.foo.com',
         brokenBacklinks: auditResult.backlinks,
-        fullAuditRef: 'https://ahrefs.com/site-explorer/broken-backlinks?select=title%2Curl_from%2Curl_to&limit=50&mode=prefix&order_by=domain_rating_source%3Adesc%2Ctraffic_domain%3Adesc&target=www.foo.com&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22is_dofollow%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22is_content%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22domain_rating_source%22%2C%22is%22%3A%5B%22gte%22%2C29.5%5D%7D%2C%7B%22field%22%3A%22traffic_domain%22%2C%22is%22%3A%5B%22gte%22%2C500%5D%7D%2C%7B%22field%22%3A%22links_external%22%2C%22is%22%3A%5B%22lte%22%2C300%5D%7D%5D%7D',
+        fullAuditRef: 'https://ahrefs.com/site-explorer/broken-backlinks?select=title%2Curl_from%2Curl_to%2Ctraffic_domain&limit=50&mode=prefix&order_by=domain_rating_source%3Adesc%2Ctraffic_domain%3Adesc&target=www.foo.com&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22is_dofollow%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22is_content%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22domain_rating_source%22%2C%22is%22%3A%5B%22gte%22%2C29.5%5D%7D%2C%7B%22field%22%3A%22traffic_domain%22%2C%22is%22%3A%5B%22gte%22%2C500%5D%7D%2C%7B%22field%22%3A%22links_external%22%2C%22is%22%3A%5B%22lte%22%2C300%5D%7D%5D%7D',
       },
     };
 
@@ -203,11 +206,13 @@ describe('Backlinks Tests', () => {
         title: 'fixed backlink',
         url_from: 'https://from.com/from-1',
         url_to: 'https://foo.com/fixed',
+        traffic_domain: 4500,
       },
       {
         title: 'fixed backlink via redirect',
         url_from: 'https://from.com/from-2',
         url_to: 'https://foo.com/fixed-via-redirect',
+        traffic_domain: 1500,
       },
     ];
     const allBacklinks = auditResult.backlinks.concat(fixedBacklinks);
@@ -241,7 +246,7 @@ describe('Backlinks Tests', () => {
       auditResult: {
         finalUrl: 'foo.com',
         brokenBacklinks: auditResult.backlinks,
-        fullAuditRef: 'https://ahrefs.com/site-explorer/broken-backlinks?select=title%2Curl_from%2Curl_to&limit=50&mode=prefix&order_by=domain_rating_source%3Adesc%2Ctraffic_domain%3Adesc&target=foo.com&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22is_dofollow%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22is_content%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22domain_rating_source%22%2C%22is%22%3A%5B%22gte%22%2C29.5%5D%7D%2C%7B%22field%22%3A%22traffic_domain%22%2C%22is%22%3A%5B%22gte%22%2C500%5D%7D%2C%7B%22field%22%3A%22links_external%22%2C%22is%22%3A%5B%22lte%22%2C300%5D%7D%5D%7D',
+        fullAuditRef: 'https://ahrefs.com/site-explorer/broken-backlinks?select=title%2Curl_from%2Curl_to%2Ctraffic_domain&limit=50&mode=prefix&order_by=domain_rating_source%3Adesc%2Ctraffic_domain%3Adesc&target=foo.com&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22is_dofollow%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22is_content%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22domain_rating_source%22%2C%22is%22%3A%5B%22gte%22%2C29.5%5D%7D%2C%7B%22field%22%3A%22traffic_domain%22%2C%22is%22%3A%5B%22gte%22%2C500%5D%7D%2C%7B%22field%22%3A%22links_external%22%2C%22is%22%3A%5B%22lte%22%2C300%5D%7D%5D%7D',
       },
     };
 


### PR DESCRIPTION
Uses: https://github.com/adobe/spacecat-shared/pull/251

Fix: https://jira.corp.adobe.com/browse/SITES-22464?focusedCommentId=42023088&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-42023088

Expose traffic_domain - integer (10 units) - The referring domain's estimated monthly organic traffic from search,
in order to have the "Est. traffic" value (see https://cq-dev.slack.com/archives/C05A45JBP9N/p1717513501293899?thread_ts=1717155663.015079&cid=C05A45JBP9N).

No additional cost, since we already include the property in the filter and order clause.