### PR TITLE
feat: audit post processors

### DIFF
--- a/src/common/audit-builder.js
+++ b/src/common/audit-builder.js
@@ -17,6 +17,7 @@ import {
   defaultMessageSender,
   defaultPersister,
   defaultUrlResolver,
+  defaultPostProcessors,
 } from './audit.js';
 
 export class AuditBuilder {
@@ -26,6 +27,7 @@ export class AuditBuilder {
     this.urlResolver = defaultUrlResolver;
     this.persister = defaultPersister;
     this.messageSender = defaultMessageSender;
+    this.postProcessors = defaultPostProcessors;
   }
 
   // message > site
@@ -57,6 +59,11 @@ export class AuditBuilder {
     return this;
   }
 
+  withPostProcessors(postprocessors) {
+    this.postProcessors = postprocessors;
+    return this;
+  }
+
   build() {
     if (typeof this.runner !== 'function') {
       throw Error('"runner" must be a function');
@@ -69,6 +76,7 @@ export class AuditBuilder {
       this.runner,
       this.persister,
       this.messageSender,
+      this.postProcessors,
     );
   }
 }

--- a/src/common/audit.js
+++ b/src/common/audit.js
@@ -56,14 +56,25 @@ export async function noopUrlResolver(site) {
   return site.getBaseURL();
 }
 
+export const defaultPostProcessors = [];
+
 export class Audit {
-  constructor(siteProvider, orgProvider, urlResolver, runner, persister, messageSender) {
+  constructor(
+    siteProvider,
+    orgProvider,
+    urlResolver,
+    runner,
+    persister,
+    messageSender,
+    postProcessors,
+  ) {
     this.siteProvider = siteProvider;
     this.orgProvider = orgProvider;
     this.urlResolver = urlResolver;
     this.runner = runner;
     this.persister = persister;
     this.messageSender = messageSender;
+    this.postProcessors = postProcessors;
   }
 
   async run(message, context) {
@@ -113,6 +124,12 @@ export class Audit {
       };
 
       await this.messageSender(resultMessage, context);
+
+      for (const postProcessor of this.postProcessors) {
+        // eslint-disable-next-line no-await-in-loop
+        await postProcessor(finalUrl, auditData);
+      }
+
       return ok();
     } catch (e) {
       throw new Error(`${type} audit failed for site ${siteId}. Reason: ${e.message}`);


### PR DESCRIPTION
As per previous engineering council action item: https://git.corp.adobe.com/ExpSuccess/spacecat-infrastructure-docs/wiki/Engineering-Council#1-proposal-to-deprecate-the-post-processor---ekrem

This PR introduces the post processing step to the audit sequence in the audit-worker. Post-processor functions added are run sequentially at the end of each audit run.

Documentation: https://github.com/adobe/spacecat-audit-worker/tree/audit-post-processors?tab=readme-ov-file#how-to-add-a-custom-post-processor
