### PR TITLE
feat: rum-api-client v2 with customer specific domain key support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "@adobe/spacecat-shared-ahrefs-client": "1.2.6",
         "@adobe/spacecat-shared-data-access": "1.26.1",
         "@adobe/spacecat-shared-http-utils": "1.3.4",
-        "@adobe/spacecat-shared-rum-api-client": "1.8.4",
+        "@adobe/spacecat-shared-rum-api-client": "2.0.3",
+        "@adobe/spacecat-shared-rum-api-client-v1": "npm:@adobe/spacecat-shared-rum-api-client@1.8.4",
         "@adobe/spacecat-shared-utils": "1.15.8",
         "@aws-sdk/client-sqs": "3.592.0",
         "diff": "5.2.0",
@@ -2394,10 +2395,23 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-rum-api-client": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-rum-api-client/-/spacecat-shared-rum-api-client-2.0.3.tgz",
+      "integrity": "sha512-iyIQG/HPBi00HaRPokiP0/USvLLpLtcZK0NDZEJJ9eUCCwHf88SiqohCL4LpPSforO5HtccZdgwi32OzxfhtgQ==",
+      "dependencies": {
+        "@adobe/fetch": "4.1.8",
+        "@adobe/helix-shared-wrap": "2.0.2",
+        "@adobe/helix-universal": "5.0.5",
+        "@adobe/spacecat-shared-utils": "1.4.0",
+        "aws4": "1.13.0",
+        "d3-array": "3.2.4"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-rum-api-client-v1": {
+      "name": "@adobe/spacecat-shared-rum-api-client",
       "version": "1.8.4",
       "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-rum-api-client/-/spacecat-shared-rum-api-client-1.8.4.tgz",
       "integrity": "sha512-Q/HXcJG1P214gIQ0WCzkAeeEzJGuz84mYRj8zsUf0IhUcCIkx9QOqClCYzadEtBAsWjgMi2Ee3H6UZktJFxKBA==",
-      "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.1.3",
         "@adobe/helix-shared-wrap": "2.0.2",
@@ -2406,11 +2420,10 @@
         "aws4": "1.13.0"
       }
     },
-    "node_modules/@adobe/spacecat-shared-rum-api-client/node_modules/@adobe/fetch": {
+    "node_modules/@adobe/spacecat-shared-rum-api-client-v1/node_modules/@adobe/fetch": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.1.3.tgz",
       "integrity": "sha512-d/NfW/QFZwehkElCkzjZQhv7qkAmq1tDQpOKw3trAV9DzACcpnEc+aC2bzfc4pLWu45WcLusUZxl1Yw5F8pKDw==",
-      "license": "Apache-2.0",
       "dependencies": {
         "debug": "4.3.5",
         "http-cache-semantics": "4.1.1",
@@ -2420,11 +2433,37 @@
         "node": ">=14.16"
       }
     },
-    "node_modules/@adobe/spacecat-shared-rum-api-client/node_modules/@adobe/fetch/node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
-      "license": "MIT",
+    "node_modules/@adobe/spacecat-shared-rum-api-client-v1/node_modules/@adobe/helix-universal": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-universal/-/helix-universal-4.5.2.tgz",
+      "integrity": "sha512-QTMhFh8DUyQ7Ih5sZcNM57tfaRlWn805aS//sbD/tCZVoQi5hc1dc4Cw6N+AHvEPVP34KqvIAaMkl1fa8pKoww==",
+      "dependencies": {
+        "@adobe/fetch": "4.1.2",
+        "aws4": "1.12.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-rum-api-client-v1/node_modules/@adobe/helix-universal/node_modules/@adobe/fetch": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.1.2.tgz",
+      "integrity": "sha512-O7yA/NgQGkp/2SFOTrcSFOb91VMZH29QRE9dXev/K8xVJkIL1g1B8IqT2G8sRurgQw2CPBQ2H7GF/FHW/HBxKw==",
+      "dependencies": {
+        "debug": "4.3.4",
+        "http-cache-semantics": "4.1.1",
+        "lru-cache": "7.18.3"
+      },
+      "engines": {
+        "node": ">=14.16"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-rum-api-client-v1/node_modules/@adobe/helix-universal/node_modules/aws4": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
+      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
+    },
+    "node_modules/@adobe/spacecat-shared-rum-api-client-v1/node_modules/@adobe/helix-universal/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -2437,35 +2476,26 @@
         }
       }
     },
-    "node_modules/@adobe/spacecat-shared-rum-api-client/node_modules/@adobe/helix-universal": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/@adobe/helix-universal/-/helix-universal-4.5.2.tgz",
-      "integrity": "sha512-QTMhFh8DUyQ7Ih5sZcNM57tfaRlWn805aS//sbD/tCZVoQi5hc1dc4Cw6N+AHvEPVP34KqvIAaMkl1fa8pKoww==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@adobe/fetch": "4.1.2",
-        "aws4": "1.12.0"
-      }
+    "node_modules/@adobe/spacecat-shared-rum-api-client-v1/node_modules/@adobe/spacecat-shared-utils": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.4.0.tgz",
+      "integrity": "sha512-UMRJa3RZImvqkFSmtCJ1u8zFbLZNi8wtaf+whJAA6xksaW/sGb0iTFqIc78Aui7aS3FnKLjpCjiT2KB7ejNyDQ=="
     },
-    "node_modules/@adobe/spacecat-shared-rum-api-client/node_modules/@adobe/helix-universal/node_modules/@adobe/fetch": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.1.2.tgz",
-      "integrity": "sha512-O7yA/NgQGkp/2SFOTrcSFOb91VMZH29QRE9dXev/K8xVJkIL1g1B8IqT2G8sRurgQw2CPBQ2H7GF/FHW/HBxKw==",
-      "license": "Apache-2.0",
+    "node_modules/@adobe/spacecat-shared-rum-api-client-v1/node_modules/debug": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
       "dependencies": {
-        "debug": "4.3.4",
-        "http-cache-semantics": "4.1.1",
-        "lru-cache": "7.18.3"
+        "ms": "2.1.2"
       },
       "engines": {
-        "node": ">=14.16"
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
-    },
-    "node_modules/@adobe/spacecat-shared-rum-api-client/node_modules/@adobe/helix-universal/node_modules/aws4": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
-      "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==",
-      "license": "MIT"
     },
     "node_modules/@adobe/spacecat-shared-rum-api-client/node_modules/@adobe/spacecat-shared-utils": {
       "version": "1.4.0",
@@ -19744,6 +19774,17 @@
       "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
       "integrity": "sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw=="
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -22143,6 +22184,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/into-stream": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "src/index.js",
   "type": "module",
   "scripts": {
-    "ekrem": "node src/support/utils.js",
     "start": "nodemon",
     "test": "c8 mocha -i -g 'Post-Deploy' --spec=test/**/*.test.js",
     "test-postdeploy": "mocha -g 'Post-Deploy' --spec=test/**/*.test.js",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "src/index.js",
   "type": "module",
   "scripts": {
+    "ekrem": "node src/support/utils.js",
     "start": "nodemon",
     "test": "c8 mocha -i -g 'Post-Deploy' --spec=test/**/*.test.js",
     "test-postdeploy": "mocha -g 'Post-Deploy' --spec=test/**/*.test.js",
@@ -58,10 +59,12 @@
     "@adobe/helix-universal-logger": "3.0.18",
     "@adobe/spacecat-shared-data-access": "1.26.1",
     "@adobe/spacecat-shared-http-utils": "1.3.4",
-    "@adobe/spacecat-shared-rum-api-client": "1.8.4",
+    "@adobe/spacecat-shared-rum-api-client": "2.0.3",
+    "@adobe/spacecat-shared-rum-api-client-v1": "npm:@adobe/spacecat-shared-rum-api-client@1.8.4",
     "@adobe/spacecat-shared-ahrefs-client": "1.2.6",
     "@adobe/spacecat-shared-utils": "1.15.8",
     "@aws-sdk/client-sqs": "3.592.0",
+    "@aws-sdk/client-secrets-manager": "3.592.0",
     "diff": "5.2.0",
     "jsdom": "24.1.0",
     "urijs": "1.19.11"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "@adobe/spacecat-shared-ahrefs-client": "1.2.6",
     "@adobe/spacecat-shared-utils": "1.15.8",
     "@aws-sdk/client-sqs": "3.592.0",
-    "@aws-sdk/client-secrets-manager": "3.592.0",
     "diff": "5.2.0",
     "jsdom": "24.1.0",
     "urijs": "1.19.11"

--- a/src/conversion/handler.js
+++ b/src/conversion/handler.js
@@ -9,7 +9,7 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-import RUMAPIClient, { createConversionURL } from '@adobe/spacecat-shared-rum-api-client';
+import RUMAPIClient, { createConversionURL } from '@adobe/spacecat-shared-rum-api-client-v1';
 
 import { AuditBuilder } from '../common/audit-builder.js';
 import { getRUMUrl } from '../support/utils.js';

--- a/src/cwv/handler.js
+++ b/src/cwv/handler.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import RUMAPIClient, { createRUMURL } from '@adobe/spacecat-shared-rum-api-client';
+import RUMAPIClient, { createRUMURL } from '@adobe/spacecat-shared-rum-api-client-v1';
 import { internalServerError, noContent } from '@adobe/spacecat-shared-http-utils';
 import { composeAuditURL } from '@adobe/spacecat-shared-utils';
 import { retrieveSiteBySiteId } from '../utils/data-access.js';

--- a/src/experimentation/handler.js
+++ b/src/experimentation/handler.js
@@ -11,7 +11,7 @@
  */
 import URI from 'urijs';
 import { hasText } from '@adobe/spacecat-shared-utils';
-import RUMAPIClient, { createExperimentationURL } from '@adobe/spacecat-shared-rum-api-client';
+import RUMAPIClient, { createExperimentationURL } from '@adobe/spacecat-shared-rum-api-client-v1';
 import { AuditBuilder } from '../common/audit-builder.js';
 import { getRUMUrl } from '../support/utils.js';
 

--- a/src/notfound/handler.js
+++ b/src/notfound/handler.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import RUMAPIClient, { create404URL } from '@adobe/spacecat-shared-rum-api-client';
+import RUMAPIClient, { create404URL } from '@adobe/spacecat-shared-rum-api-client-v1';
 import { dateAfterDays } from '@adobe/spacecat-shared-utils';
 import {
   getRUMUrl,

--- a/test/utils/rum-utils.test.js
+++ b/test/utils/rum-utils.test.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import nock from 'nock';
+import chai from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { getRUMDomainkey } from '../../src/support/utils.js';
+
+chai.use(chaiAsPromised);
+const { expect } = chai;
+
+describe('rum utils', () => {
+  let context;
+  let processEnvCopy;
+  beforeEach('setup', () => {
+    context = {
+      env: {
+        AWS_REGION: 'us-east-1',
+        AWS_ACCESS_KEY_ID: 'some-key-id',
+        AWS_SECRET_ACCESS_KEY: 'some-secret-key',
+        AWS_SESSION_TOKEN: 'some-secret-token',
+      },
+      runtime: { name: 'aws-lambda' },
+      func: { package: 'spacecat-services', version: 'ci', name: 'test' },
+    };
+    processEnvCopy = { ...process.env };
+    process.env = {
+      ...process.env,
+      ...context.env,
+    };
+  });
+
+  afterEach('clean up', () => {
+    process.env = processEnvCopy;
+    nock.cleanAll();
+  });
+
+  it('throws error when domain key does not exist', async () => {
+    const scope = nock('https://secretsmanager.us-east-1.amazonaws.com/')
+      .post('/', (body) => body.SecretId === '/helix-deploy/spacecat-services/customer-secrets/some_domain_com/ci')
+      .reply(200, { SecretString: JSON.stringify({ }) });
+
+    await expect(getRUMDomainkey('https://some-domain.com', context, { expiration: 0 })).to.be.rejectedWith('No domainkey found for https://some-domain.com');
+    scope.done();
+  });
+
+  it('returns the rum domain key', async () => {
+    const scope = nock('https://secretsmanager.us-east-1.amazonaws.com/')
+      .post('/', (body) => body.SecretId === '/helix-deploy/spacecat-services/customer-secrets/domain_com/ci')
+      .reply(200, { SecretString: JSON.stringify({ RUM_DOMAIN_KEY: 'pssst' }) });
+
+    const domainkey = await getRUMDomainkey('https://domain.com', context, { expiration: 0 });
+    expect(domainkey).to.equal('pssst');
+    scope.done();
+  });
+});


### PR DESCRIPTION
This PR introduces:

1. `rum-api-client` v1 to v2 upgrade
2. `rum-api-client@v1` is imported as `@adobe/spacecat-shared-rum-api-client-v1` via [npm aliases](https://docs.npmjs.com/cli/v8/using-npm/package-spec#aliases) for the legacy audits using older `rum-api-client` version 
3. Since we currently are not using a "global" domain key for `v2`, a utility `getRUMDomainkey` function introduced to fetch domainkeys from AWS for specific pilot customers

## Related Issues


Thanks for contributing!
