### PR TITLE
feat: introduce genAI generated broken backlink fixes

### DIFF
--- a/src/backlinks/handler.js
+++ b/src/backlinks/handler.js
@@ -66,7 +66,7 @@ export default async function auditBrokenBacklinks(message, context) {
   const { dataAccess, log, sqs } = context;
   const {
     AWS_REGION: region,
-    STATISTICS_SERVICE_LAMBDA: statisticsService,
+    SPACECAT_STATISTICS_LAMBDA_ARN: statisticsServiceArn,
     AUDIT_RESULTS_QUEUE_URL: queueUrl,
   } = context.env;
 
@@ -144,7 +144,7 @@ export default async function auditBrokenBacklinks(message, context) {
         brokenBacklinks: auditResult.brokenBacklinks,
         sitemapUrls,
         region,
-        statisticsService,
+        statisticsServiceArn,
         log,
       });
     } catch (e) {

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -229,13 +229,13 @@ export const extractKeywordsFromUrl = (url, log) => {
  */
 export async function enhanceBacklinksWithFixes(config) {
   const {
-    siteId, brokenBacklinks, sitemapUrls, region, statisticsService, log,
+    siteId, brokenBacklinks, sitemapUrls, region, statisticsServiceArn, log,
   } = config;
 
-  const invoke = async (funcName, payload) => {
+  const invoke = async (funcArn, payload) => {
     const client = new LambdaClient({ region });
     const command = new InvokeCommand({
-      FunctionName: funcName,
+      FunctionName: funcArn,
       Payload: JSON.stringify(payload),
       LogType: LogType.Tail,
       InvocationType: 'Event',
@@ -243,9 +243,9 @@ export async function enhanceBacklinksWithFixes(config) {
 
     try {
       await client.send(command);
-      log.info(`Lambda function ${funcName} invoked successfully.`);
+      log.info(`Lambda function ${funcArn} invoked successfully.`);
     } catch (error) {
-      log.error(`Error invoking Lambda function ${funcName}:`, error);
+      log.error(`Error invoking Lambda function ${funcArn}:`, error);
     }
   };
 
@@ -258,7 +258,7 @@ export async function enhanceBacklinksWithFixes(config) {
     },
   };
 
-  invoke(statisticsService, payload); // No need to await this call
+  invoke(statisticsServiceArn, payload); // No need to await this call
 
   return { status: 'Lambda function invoked' };
 }

--- a/test/audits/backlinks.test.js
+++ b/test/audits/backlinks.test.js
@@ -13,7 +13,6 @@
 /* eslint-env mocha */
 
 import { createSite } from '@adobe/spacecat-shared-data-access/src/models/site.js';
-import { createSiteTopPage } from '@adobe/spacecat-shared-data-access/src/models/site-top-page.js';
 import { createConfiguration } from '@adobe/spacecat-shared-data-access/src/models/configuration.js';
 import { createOrganization } from '@adobe/spacecat-shared-data-access/src/models/organization.js';
 
@@ -22,6 +21,7 @@ import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import nock from 'nock';
+import { LambdaClient } from '@aws-sdk/client-lambda';
 import auditBrokenBacklinks from '../../src/backlinks/handler.js';
 
 chai.use(sinonChai);
@@ -62,26 +62,6 @@ describe('Backlinks Tests', function () {
   };
 
   const configuration = createConfiguration(configurationData);
-
-  const siteTopPage = createSiteTopPage({
-    siteId: site.getId(),
-    url: `${site.getBaseURL()}/foo.html`,
-    traffic: 1000,
-    source: 'ahrefs',
-    geo: 'global',
-    importedAt: new Date('2024-06-18').toISOString(),
-    topKeyword: '404',
-  });
-
-  const siteTopPage2 = createSiteTopPage({
-    siteId: site.getId(),
-    url: `${site.getBaseURL()}/bar.html`,
-    traffic: 500,
-    source: 'ahrefs',
-    geo: 'global',
-    importedAt: new Date('2024-06-18').toISOString(),
-    topKeyword: '429',
-  });
 
   const site2 = createSite({
     id: 'site2',
@@ -169,7 +149,6 @@ describe('Backlinks Tests', function () {
         url_from: 'https://from.com/from-3',
         url_to: 'https://foo.com/returns-429',
         domain_traffic: 1000,
-        url_suggested: 'https://bar.foo.com/bar.html',
       },
       {
         title: 'backlink that times out',
@@ -255,7 +234,6 @@ describe('Backlinks Tests', function () {
   });
 
   it('should filter out excluded URLs and include valid backlinks', async () => {
-    mockDataAccess.getTopPagesForSite.resolves([siteTopPage, siteTopPage2]);
     mockDataAccess.getSiteByID = sinon.stub().withArgs('site1').resolves(siteWithExcludedUrls);
     mockDataAccess.getConfiguration = sinon.stub().resolves(configuration);
 
@@ -287,18 +265,39 @@ describe('Backlinks Tests', function () {
     );
   });
 
-  it('should successfully perform an audit to detect broken backlinks, save and send the proper audit result', async () => {
+  it('should successfully perform an audit to detect broken backlinks, save and send the proper audit result, then trigger suggested fix lambda', async () => {
     mockDataAccess.getSiteByID = sinon.stub().withArgs('site1').resolves(site);
-    mockDataAccess.getTopPagesForSite.resolves([]);
     mockDataAccess.getConfiguration = sinon.stub().resolves(configuration);
+    const invokeStub = sinon.stub(LambdaClient.prototype, 'send').resolves();
+    const url = site.getBaseURL();
 
-    nock(site.getBaseURL())
+    const sampleSitemap = '<?xml version="1.0" encoding="UTF-8"?>\n'
+      + '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n'
+      + `<url> <loc>${url}/foo</loc></url>\n`
+      + `<url> <loc>${url}/bar</loc></url>\n`
+      + '</urlset>';
+
+    nock(url)
       .get(/.*/)
       .reply(200);
 
     nock('https://ahrefs.com')
       .get(/.*/)
       .reply(200, auditResult);
+    nock(url)
+      .get('/robots.txt')
+      .reply(200, 'Allow: /');
+
+    nock(url)
+      .head('/sitemap.xml')
+      .reply(200);
+    nock(url)
+      .head('/sitemap_index.xml')
+      .reply(200);
+
+    nock(url)
+      .get('/sitemap.xml')
+      .reply(200, sampleSitemap);
 
     const expectedMessage = {
       type: message.type,
@@ -314,102 +313,27 @@ describe('Backlinks Tests', function () {
     };
 
     const response = await auditBrokenBacklinks(message, context);
+    const [command] = invokeStub.getCall(0).args;
+    const payload = JSON.parse(command.input.Payload);
 
     expect(response.status).to.equal(204);
     expect(mockDataAccess.addAudit).to.have.been.calledOnce;
     expect(context.sqs.sendMessage).to.have.been.calledOnce;
     expect(context.sqs.sendMessage).to.have.been
       .calledWith(context.env.AUDIT_RESULTS_QUEUE_URL, expectedMessage);
+    expect(invokeStub.calledOnce).to.be.true;
+    expect(payload).to.deep.equal({
+      type: 'broken-backlinks',
+      payload: {
+        siteId: 'site1',
+        brokenBacklinks: auditResult.backlinks,
+        sitemapUrls: [
+          'https://bar.foo.com/foo',
+          'https://bar.foo.com/bar',
+        ],
+      },
+    });
     expect(context.log.info).to.have.been.calledWith('Successfully audited site1 for broken-backlinks type audit');
-  });
-
-  it('should successfully perform an audit to detect broken backlinks based on keywords from top pages', async () => {
-    mockDataAccess.getSiteByID = sinon.stub().withArgs('site1').resolves(site);
-    mockDataAccess.getTopPagesForSite.resolves([siteTopPage, siteTopPage2]);
-    mockDataAccess.getConfiguration = sinon.stub().resolves(configuration);
-
-    nock(site.getBaseURL())
-      .get(/.*/)
-      .reply(200);
-
-    nock('https://ahrefs.com')
-      .get(/.*/)
-      .reply(200, auditResult);
-
-    const expectedEnhancedBacklinks = auditResult.backlinks;
-    expectedEnhancedBacklinks[0].url_suggested = 'https://bar.foo.com/foo.html';
-    expectedEnhancedBacklinks[2].url_suggested = 'https://bar.foo.com/bar.html';
-
-    const expectedMessage = {
-      type: message.type,
-      url: site.getBaseURL(),
-      auditContext: {
-        finalUrl: 'bar.foo.com',
-      },
-      auditResult: {
-        finalUrl: 'bar.foo.com',
-        brokenBacklinks: auditResult.backlinks,
-        fullAuditRef: 'https://ahrefs.com/site-explorer/broken-backlinks?select=title%2Curl_from%2Curl_to%2Ctraffic_domain&limit=50&mode=prefix&order_by=domain_rating_source%3Adesc%2Ctraffic_domain%3Adesc&target=bar.foo.com&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22is_dofollow%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22is_content%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22domain_rating_source%22%2C%22is%22%3A%5B%22gte%22%2C29.5%5D%7D%2C%7B%22field%22%3A%22traffic_domain%22%2C%22is%22%3A%5B%22gte%22%2C500%5D%7D%2C%7B%22field%22%3A%22links_external%22%2C%22is%22%3A%5B%22lte%22%2C300%5D%7D%5D%7D',
-      },
-    };
-
-    const response = await auditBrokenBacklinks(message, context);
-
-    expect(response.status).to.equal(204);
-    expect(mockDataAccess.addAudit).to.have.been.calledOnce;
-    expect(context.sqs.sendMessage).to.have.been.calledOnce;
-    expect(context.sqs.sendMessage).to.have.been
-      .calledWith(context.env.AUDIT_RESULTS_QUEUE_URL, expectedMessage);
-  });
-
-  it('should detect broken backlinks and save the proper audit result, even if the suggested fix fails', async () => {
-    mockDataAccess.getSiteByID = sinon.stub().withArgs('site1').resolves(site);
-    mockDataAccess.getTopPagesForSite.resolves([createSiteTopPage({
-      siteId: site.getId(),
-      url: `${site.getBaseURL()}/foo.html`,
-      traffic: 1000,
-      source: 'ahrefs',
-      geo: 'global',
-      importedAt: new Date('2024-06-18').toISOString(),
-      topKeyword: 'c++',
-    })]);
-    const brokenBacklink = {
-      backlinks: [
-        {
-          title: 'backlink that has a faulty path',
-          url_from: 'https://from.com/from-1',
-          url_to: 'https://foo.com/c++',
-          domain_traffic: 4000,
-        }],
-    };
-    mockDataAccess.getConfiguration = sinon.stub().resolves(configuration);
-    nock(site.getBaseURL())
-      .get(/.*/)
-      .reply(200);
-
-    nock('https://ahrefs.com')
-      .get(/.*/)
-      .reply(200, brokenBacklink);
-
-    const expectedMessage = {
-      type: message.type,
-      url: site.getBaseURL(),
-      auditContext: {
-        finalUrl: 'bar.foo.com',
-      },
-      auditResult: {
-        finalUrl: 'bar.foo.com',
-        brokenBacklinks: brokenBacklink.backlinks,
-        fullAuditRef: 'https://ahrefs.com/site-explorer/broken-backlinks?select=title%2Curl_from%2Curl_to%2Ctraffic_domain&limit=50&mode=prefix&order_by=domain_rating_source%3Adesc%2Ctraffic_domain%3Adesc&target=bar.foo.com&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22is_dofollow%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22is_content%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22domain_rating_source%22%2C%22is%22%3A%5B%22gte%22%2C29.5%5D%7D%2C%7B%22field%22%3A%22traffic_domain%22%2C%22is%22%3A%5B%22gte%22%2C500%5D%7D%2C%7B%22field%22%3A%22links_external%22%2C%22is%22%3A%5B%22lte%22%2C300%5D%7D%5D%7D',
-      },
-    };
-    const response = await auditBrokenBacklinks(message, context);
-
-    expect(response.status).to.equal(204);
-    expect(mockDataAccess.addAudit).to.have.been.calledOnce;
-    expect(context.sqs.sendMessage).to.have.been.calledOnce;
-    expect(context.sqs.sendMessage).to.have.been
-      .calledWith(context.env.AUDIT_RESULTS_QUEUE_URL, expectedMessage);
   });
 
   it('should successfully perform an audit to detect broken backlinks and set finalUrl, for baseUrl redirecting to www domain', async () => {

--- a/test/support/utils.test.js
+++ b/test/support/utils.test.js
@@ -109,7 +109,7 @@ describe('enhanceBacklinksWithFixes', () => {
       ],
       sitemapUrls: ['https://www.example.com/sitemap.xml'],
       region: 'test-region',
-      statisticsService: 'testStatisticsService',
+      statisticsServiceArn: 'testStatisticsService',
       log,
     };
 
@@ -139,7 +139,7 @@ describe('enhanceBacklinksWithFixes', () => {
       ],
       sitemapUrls: ['https://www.example.com/sitemap.xml'],
       region: 'test-region',
-      statisticsService: 'testStatisticsService',
+      statisticsServiceArn: 'testStatisticsService',
       log,
     };
 
@@ -159,7 +159,7 @@ describe('enhanceBacklinksWithFixes', () => {
       ],
       sitemapUrls: ['https://www.example.com/sitemap.xml'],
       region: 'test-region',
-      statisticsService: 'testStatisticsService',
+      statisticsServiceArn: 'testStatisticsService',
       log,
     };
 


### PR DESCRIPTION
This PR replaces the old logic of obtaining the suggested backlink fixes from the SEO keywords with GenAI based ones.

First, the audit is saved without the suggested fixes, then the Statistics Lambda function is triggered that will execute the generation of the suggested fixes