### PR TITLE
tests(broken-backlinks): reduce time to run tests

### DIFF
--- a/test/audits/backlinks.test.js
+++ b/test/audits/backlinks.test.js
@@ -96,6 +96,13 @@ describe('Backlinks Tests', function () {
 
   const org = createOrganization({ name: 'org4' });
 
+  const brokenBacklinkWithTimeout = {
+    title: 'backlink that times out',
+    url_from: 'https://from.com/from-4',
+    url_to: 'https://foo.com/times-out',
+    domain_traffic: 500,
+  };
+
   const auditResult = {
     backlinks: [
       {
@@ -115,12 +122,6 @@ describe('Backlinks Tests', function () {
         url_from: 'https://from.com/from-3',
         url_to: 'https://foo.com/returns-429',
         domain_traffic: 1000,
-      },
-      {
-        title: 'backlink that times out',
-        url_from: 'https://from.com/from-4',
-        url_to: 'https://foo.com/times-out',
-        domain_traffic: 500,
       },
     ],
   };
@@ -169,12 +170,6 @@ describe('Backlinks Tests', function () {
         url_to: 'https://foo.com/returns-429',
         domain_traffic: 1000,
         url_suggested: 'https://bar.foo.com/bar.html',
-      },
-      {
-        title: 'backlink that times out',
-        url_from: 'https://from.com/from-4',
-        url_to: 'https://foo.com/times-out',
-        domain_traffic: 500,
       },
       {
         title: 'backlink that is not excluded',
@@ -245,7 +240,7 @@ describe('Backlinks Tests', function () {
 
     nock('https://foo.com')
       .get('/times-out')
-      .delay(10000)
+      .delay(3010)
       .reply(200);
   });
   afterEach(() => {
@@ -453,7 +448,7 @@ describe('Backlinks Tests', function () {
     expect(context.log.info).to.have.been.calledWith('Successfully audited site2 for broken-backlinks type audit');
   });
 
-  it('should filter out from audit result broken backlinks the ones that return ok(even with redirection)', async () => {
+  it('should filter out from audit result broken backlinks the ones that return ok (even with redirection)', async () => {
     mockDataAccess.getSiteByID = sinon.stub().withArgs('site2').resolves(site2);
     mockDataAccess.getTopPagesForSite.resolves([]);
     mockDataAccess.getConfiguration = sinon.stub().resolves(configuration);
@@ -472,7 +467,7 @@ describe('Backlinks Tests', function () {
         traffic_domain: 1500,
       },
     ];
-    const allBacklinks = auditResult.backlinks.concat(fixedBacklinks);
+    const allBacklinks = auditResult.backlinks.concat(fixedBacklinks, brokenBacklinkWithTimeout);
 
     nock('https://foo.com')
       .get('/fixed')
@@ -502,7 +497,7 @@ describe('Backlinks Tests', function () {
       },
       auditResult: {
         finalUrl: 'foo.com',
-        brokenBacklinks: auditResult.backlinks,
+        brokenBacklinks: auditResult.backlinks.concat(brokenBacklinkWithTimeout),
         fullAuditRef: 'https://ahrefs.com/site-explorer/broken-backlinks?select=title%2Curl_from%2Curl_to%2Ctraffic_domain&limit=50&mode=prefix&order_by=domain_rating_source%3Adesc%2Ctraffic_domain%3Adesc&target=foo.com&output=json&where=%7B%22and%22%3A%5B%7B%22field%22%3A%22is_dofollow%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22is_content%22%2C%22is%22%3A%5B%22eq%22%2C1%5D%7D%2C%7B%22field%22%3A%22domain_rating_source%22%2C%22is%22%3A%5B%22gte%22%2C29.5%5D%7D%2C%7B%22field%22%3A%22traffic_domain%22%2C%22is%22%3A%5B%22gte%22%2C500%5D%7D%2C%7B%22field%22%3A%22links_external%22%2C%22is%22%3A%5B%22lte%22%2C300%5D%7D%5D%7D',
       },
     };


### PR DESCRIPTION
Reduce time to run tests.
Before: each test in the broken-backlinks suite that was hitting `filterOutValidBacklinks` was taking >3s to run because the setup included a broken backlink that when called was responding with a delay of 10000ms and fetch was waiting 3s for the response and then timing out.
After this fix: there's a single test that is including this case: `should filter out from audit result broken backlinks the ones that return ok (even with redirection)`.