### PR TITLE
fix(cwv): audit url calculating for rum bundler API

### DIFF
--- a/src/cwv/handler.js
+++ b/src/cwv/handler.js
@@ -11,38 +11,30 @@
  */
 
 import RUMAPIClient from '@adobe/spacecat-shared-rum-api-client';
+import URI from 'urijs';
+import { hasText } from '@adobe/spacecat-shared-utils';
 import { getRUMDomainkey } from '../support/utils.js';
 import { AuditBuilder } from '../common/audit-builder.js';
-import { hasNonWWWSubdomain } from '../experimentation/handler.js';
 
 const DAILY_THRESHOLD = 1000;
 const INTERVAL = 7; // days
 
+export function getAuditUrl(baseURL) {
+  const uri = new URI(baseURL);
+  return hasText(uri.subdomain()) ? baseURL.replace(/https?:\/\//, '') : baseURL.replace(/https?:\/\//, 'www.');
+}
+
 export async function CWVRunner(auditUrl, context, site) {
   const rumAPIClient = RUMAPIClient.createFrom(context);
   const domainkey = await getRUMDomainkey(site.getBaseURL(), context);
-  let options = {
-    domain: auditUrl,
+  const finalUrl = getAuditUrl(auditUrl);
+  const options = {
+    domain: finalUrl,
     domainkey,
     interval: INTERVAL,
     granularity: 'hourly',
   };
-  let cwvData;
-
-  try {
-    cwvData = await rumAPIClient.query('cwv', options);
-    /* c8 ignore start */
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  } catch (e) {
-    if (!hasNonWWWSubdomain(auditUrl) && !auditUrl.toLowerCase().startsWith('www')) {
-      options = {
-        ...options,
-        domain: `www.${auditUrl}`,
-      };
-      cwvData = await rumAPIClient.query('cwv', options);
-    }
-  }
-  /* c8 ignore stop */
+  const cwvData = await rumAPIClient.query('cwv', options);
   const auditResult = {
     cwv: cwvData.filter((data) => data.pageviews >= DAILY_THRESHOLD * INTERVAL),
     auditContext: {
@@ -52,10 +44,11 @@ export async function CWVRunner(auditUrl, context, site) {
 
   return {
     auditResult,
-    fullAuditRef: auditUrl,
+    fullAuditRef: finalUrl,
   };
 }
 
 export default new AuditBuilder()
+  .withUrlResolver((site) => site.getBaseURL())
   .withRunner(CWVRunner)
   .build();

--- a/test/audits/cwv.test.js
+++ b/test/audits/cwv.test.js
@@ -17,7 +17,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import nock from 'nock';
 import { createSite } from '@adobe/spacecat-shared-data-access/src/models/site.js';
-import { CWVRunner } from '../../src/cwv/handler.js';
+import { CWVRunner, getAuditUrl } from '../../src/cwv/handler.js';
 import { rumData } from '../fixtures/rum-data.js';
 
 use(sinonChai);
@@ -59,7 +59,7 @@ describe('Index Tests', () => {
   });
 
   it('cwv audit runs rum api client cwv query', async () => {
-    const result = await CWVRunner('www.spacecat.com', context, site);
+    const result = await CWVRunner('https://spacecat.com', context, site);
     expect(result).to.deep.equal({
       auditResult: {
         cwv: rumData.filter((data) => data.pageviews >= 7000),
@@ -69,5 +69,14 @@ describe('Index Tests', () => {
       },
       fullAuditRef: auditUrl,
     });
+  });
+
+  it('audit url calculated correctly', async () => {
+    expect(getAuditUrl('http://spacecat.com')).to.equal('www.spacecat.com');
+    expect(getAuditUrl('https://spacecat.com')).to.equal('www.spacecat.com');
+    expect(getAuditUrl('http://www.spacecat.com')).to.equal('www.spacecat.com');
+    expect(getAuditUrl('https://www.spacecat.com')).to.equal('www.spacecat.com');
+    expect(getAuditUrl('http://blog.spacecat.com')).to.equal('blog.spacecat.com');
+    expect(getAuditUrl('https://blog.spacecat.com')).to.equal('blog.spacecat.com');
   });
 });


### PR DESCRIPTION
The new RUM Bundler API needs specific type of a URL param which is different from the previous one calculated via following redirects for pagespeed API.