### PR TITLE
fix(experimentation-ess): audit url calculating for rum bundler API

### DIFF
--- a/src/experimentation-ess/all.js
+++ b/src/experimentation-ess/all.js
@@ -13,6 +13,7 @@
 /* c8 ignore start */
 import { AuditBuilder } from '../common/audit-builder.js';
 import { processAudit, postProcessor } from './common.js';
+import { wwwUrlResolver } from '../common/audit.js';
 
 const DAYS = 180;
 
@@ -79,6 +80,7 @@ export async function essExperimentationAllAuditRunner(auditUrl, context, site) 
 
 export default new AuditBuilder()
   .withRunner(essExperimentationAllAuditRunner)
+  .withUrlResolver(wwwUrlResolver)
   .withPostProcessors([postProcessor])
   .withPersister(persistOnlyMetadata)
   .withMessageSender(() => true)

--- a/src/experimentation-ess/daily.js
+++ b/src/experimentation-ess/daily.js
@@ -13,6 +13,7 @@
 /* c8 ignore start */
 import { AuditBuilder } from '../common/audit-builder.js';
 import { processAudit } from './common.js';
+import { wwwUrlResolver } from '../common/audit.js';
 
 const DAYS = 1;
 
@@ -44,5 +45,6 @@ export async function essExperimentationDailyAuditRunner(auditUrl, context, site
 
 export default new AuditBuilder()
   .withRunner(essExperimentationDailyAuditRunner)
+  .withUrlResolver(wwwUrlResolver)
   .build();
 /* c8 ignore stop */


### PR DESCRIPTION
Applying the fix of https://github.com/adobe/spacecat-audit-worker/pull/386 to `experimentation-ess` audits