### PR TITLE
fix: handle empty insights from RUM data

### DIFF
--- a/src/experimentation-ess/common.js
+++ b/src/experimentation-ess/common.js
@@ -628,6 +628,10 @@ function filterMultiPageExperimentsByThreshold(
 }
 
 async function processExperimentRUMData(experimentInsights, context, days) {
+  if (Object.keys(experimentInsights).length === 0) {
+    log.info('No Experiment Insights found');
+    return [];
+  }
   log.info('Experiment Insights: ', JSON.stringify(experimentInsights, null, 2));
   const multiPageExperimentNames = getMultiPageExperimentNames(experimentInsights);
   log.info('Multi-Page Experiment Names: ', multiPageExperimentNames.join(', '));


### PR DESCRIPTION
If the insights are empty, we're still trying to fetch the p values which is throwing errors in the logs, so returning empty array, in case there's no experiments during the run.