### PR TITLE
fix: broken internal links result schema update

### DIFF
--- a/src/internal-links/handler.js
+++ b/src/internal-links/handler.js
@@ -50,6 +50,14 @@ function transform404LinksData(responseData, hostUrl, auditUrl, log) {
         (source) => source && hasSameHost(source, hostUrl),
       );
       if (sameDomainSources.length) {
+        // for (const source of sameDomainSources) {
+        //   result.push({
+        //     url_to: source.url_to,
+        //     title: '',
+        //     url_from: source,
+        //     traffic_domain: source.traffic_domain,
+        //   });
+        // }
         result.push({
           url,
           views,
@@ -87,7 +95,10 @@ export async function internalLinksAuditRunner(auditUrl, context, site) {
     granularity: 'hourly',
   };
 
+  log.info('broken-internal-links: Options for RUM call: ', JSON.stringify(options));
+
   const all404Links = await rumAPIClient.query('404', options);
+  log.info('broken-internal-links: All 404 links: ', JSON.stringify(all404Links));
   const auditResult = {
     internalLinks: transform404LinksData(all404Links, finalUrl, auditUrl, log),
     auditContext: {

--- a/src/internal-links/handler.js
+++ b/src/internal-links/handler.js
@@ -49,19 +49,12 @@ function transform404LinksData(responseData, hostUrl, auditUrl, log) {
       const sameDomainSources = allSources.filter(
         (source) => source && hasSameHost(source, hostUrl),
       );
-      if (sameDomainSources.length) {
-        // for (const source of sameDomainSources) {
-        //   result.push({
-        //     url_to: source.url_to,
-        //     title: '',
-        //     url_from: source,
-        //     traffic_domain: source.traffic_domain,
-        //   });
-        // }
+
+      for (const source of sameDomainSources) {
         result.push({
-          url,
-          views,
-          sources: sameDomainSources,
+          url_to: url,
+          url_from: source,
+          traffic_domain: views,
         });
       }
     } catch {

--- a/src/internal-links/handler.js
+++ b/src/internal-links/handler.js
@@ -92,7 +92,9 @@ export async function internalLinksAuditRunner(auditUrl, context, site) {
 
   const all404Links = await rumAPIClient.query('404', options);
   const auditResult = {
-    internalLinks: transform404LinksData(all404Links, finalUrl, auditUrl, log),
+    brokenInternalLinks: transform404LinksData(all404Links, finalUrl, auditUrl, log),
+    fullAuditRef: auditUrl,
+    finalUrl,
     auditContext: {
       interval: INTERVAL,
     },

--- a/src/internal-links/handler.js
+++ b/src/internal-links/handler.js
@@ -91,7 +91,6 @@ export async function internalLinksAuditRunner(auditUrl, context, site) {
   log.info('broken-internal-links: Options for RUM call: ', JSON.stringify(options));
 
   const all404Links = await rumAPIClient.query('404', options);
-  log.info('broken-internal-links: All 404 links: ', JSON.stringify(all404Links));
   const auditResult = {
     internalLinks: transform404LinksData(all404Links, finalUrl, auditUrl, log),
     auditContext: {

--- a/test/audits/internal-links.test.js
+++ b/test/audits/internal-links.test.js
@@ -23,18 +23,14 @@ import { MockContextBuilder } from '../shared.js';
 
 const AUDIT_RESULT_DATA = [
   {
-    url: 'https://www.example.com/article/dogs/breeds/choosing-an-irish-setter',
+    url_to: 'https://www.example.com/article/dogs/breeds/choosing-an-irish-setter',
     views: 100,
-    sources: [
-      'https://www.example.com/article/dogs/just-for-fun/dogs-good-for-men-13-manly-masculine-dog-breeds',
-    ],
+    url_from: 'https://www.example.com/article/dogs/just-for-fun/dogs-good-for-men-13-manly-masculine-dog-breeds',
   },
   {
-    url: 'https://www.example.com/article/dogs/breeds/choosing-a-miniature-poodle',
+    url_to: 'https://www.example.com/article/dogs/breeds/choosing-a-miniature-poodle',
     views: 100,
-    sources: [
-      'https://www.example.com/article/dogs/pet-care/when-is-a-dog-considered-senior',
-    ],
+    url_from: 'https://www.example.com/article/dogs/pet-care/when-is-a-dog-considered-senior',
   },
 ];
 

--- a/test/audits/internal-links.test.js
+++ b/test/audits/internal-links.test.js
@@ -84,7 +84,9 @@ describe('Broken internal links audit', () => {
     });
     expect(result).to.deep.equal({
       auditResult: {
-        internalLinks: AUDIT_RESULT_DATA,
+        brokenInternalLinks: AUDIT_RESULT_DATA,
+        fullAuditRef: auditUrl,
+        finalUrl: auditUrl,
         auditContext: {
           interval: 30,
         },

--- a/test/audits/internal-links.test.js
+++ b/test/audits/internal-links.test.js
@@ -24,13 +24,13 @@ import { MockContextBuilder } from '../shared.js';
 const AUDIT_RESULT_DATA = [
   {
     url_to: 'https://www.example.com/article/dogs/breeds/choosing-an-irish-setter',
-    views: 100,
     url_from: 'https://www.example.com/article/dogs/just-for-fun/dogs-good-for-men-13-manly-masculine-dog-breeds',
+    traffic_domain: 100,
   },
   {
     url_to: 'https://www.example.com/article/dogs/breeds/choosing-a-miniature-poodle',
-    views: 100,
     url_from: 'https://www.example.com/article/dogs/pet-care/when-is-a-dog-considered-senior',
+    traffic_domain: 100,
   },
 ];
 


### PR DESCRIPTION
Issue: https://jira.corp.adobe.com/browse/SITES-25870
Linked PR for reporting: https://github.com/adobe/spacecat-reporting-worker/pull/47

Audit result schema updated to match with broken internal links with some differences.

Updated schema for broken internal links audit result: 
```
 {
    url_to: 'https://www.example.com/article/dogs/breeds/choosing-an-irish-setter',
    url_from: 'https://www.example.com/article/dogs/just-for-fun/dogs-good-for-men-13-manly-masculine-dog-breeds',
    traffic_domain: 100,
  },
```
broken internal links result schema:
```
{
       "url_suggested": "https://www.petplace.com/article/cats/pet-health/cats-and-mating",
       "url_to": "https://example.com/broken-page",
       "title": "Example Page Title",
       "url_from": "https://referrer.com/referring-page",
       "traffic_domain": 50000
}
```
Note:
- `url_suggested` field is not implemented yet.
- `title` is not available from RUM data (checked RUM bundles), so excluded
- At this moment, fully adhering to schema suggested in "Opportunity Data Model" proposed document isn't possible, because we will have to update the Audit common code, which is used application wide and will need to be done and tested separately for all audit types.

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
