### PR TITLE
fix: modified `getObjectFromKey` to parse non JSON objects as well

### DIFF
--- a/test/audits/metatags.test.js
+++ b/test/audits/metatags.test.js
@@ -313,6 +313,7 @@ describe('Meta Tags', () => {
               },
             }),
           },
+          ContentType: 'application/json',
         });
       s3ClientStub.send
         .withArgs(sinon.match.instanceOf(GetObjectCommand).and(sinon.match.has('input', {
@@ -331,6 +332,7 @@ describe('Meta Tags', () => {
               },
             }),
           },
+          ContentType: 'application/json',
         });
       const addAuditStub = sinon.stub().resolves({ getId: () => 'audit-id' });
       dataAccessStub.addAudit = addAuditStub;
@@ -443,6 +445,7 @@ describe('Meta Tags', () => {
               },
             }),
           },
+          ContentType: 'application/json',
         });
       s3ClientStub.send
         .withArgs(sinon.match.instanceOf(GetObjectCommand).and(sinon.match.has('input', {
@@ -462,6 +465,7 @@ describe('Meta Tags', () => {
               },
             }),
           },
+          ContentType: 'application/json',
         });
       s3ClientStub.send
         .withArgs(sinon.match.instanceOf(GetObjectCommand).and(sinon.match.has('input', {
@@ -479,6 +483,7 @@ describe('Meta Tags', () => {
               },
             }),
           },
+          ContentType: 'application/json',
         });
       const addAuditStub = sinon.stub().resolves();
       dataAccessStub.addAudit = addAuditStub;
@@ -601,6 +606,7 @@ describe('Meta Tags', () => {
           Body: {
             transformToString: () => '',
           },
+          ContentType: 'application/json',
         });
       const addAuditStub = sinon.stub().resolves();
       dataAccessStub.addAudit = addAuditStub;
@@ -649,6 +655,7 @@ describe('Meta Tags', () => {
               },
             }),
           },
+          ContentType: 'application/json',
         });
       const result = await auditMetaTags(message, context);
 

--- a/test/utils/s3-utils.test.js
+++ b/test/utils/s3-utils.test.js
@@ -121,7 +121,7 @@ describe('S3 Utility Functions', () => {
     it('should return the S3 object when getObject succeeds', async () => {
       const bucketName = 'test-bucket';
       const key = 'test-key';
-      const expectedObject = { Body: { transformToString: () => '{"tags": {"title": "sample-title"}}' } };
+      const expectedObject = { Body: { transformToString: () => '{"tags": {"title": "sample-title"}}' }, ContentType: 'application/json' };
 
       const s3ClientMock = {
         send: () => expectedObject,
@@ -135,7 +135,20 @@ describe('S3 Utility Functions', () => {
       });
     });
 
-    it('should return null and log an error when getObject fails', async () => {
+    it('should return the raw body if the object is not JSON', async () => {
+      const bucketName = 'test-bucket';
+      const key = 'test-key.test';
+      const expectedObject = { Body: { transformToString: () => 'raw body' }, ContentType: 'abc/def' };
+
+      const s3ClientMock = {
+        send: () => expectedObject,
+      };
+
+      const result = await getObjectFromKey(s3ClientMock, bucketName, key, logMock);
+      expect(result).to.equal('raw body');
+    });
+
+    it('should log an error and return null when getObject fails', async () => {
       const bucketName = 'test-bucket';
       const key = 'test-key';
 


### PR DESCRIPTION
[[SITES-27500] Fix regarding audit-worker reading screenshot data as JSON](https://jira.corp.adobe.com/browse/SITES-27500)


Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
