### PR TITLE
fix: use urls_suggested as the suggested fix for sitemap redirects

### DIFF
--- a/src/sitemap/handler.js
+++ b/src/sitemap/handler.js
@@ -247,7 +247,7 @@ export async function filterValidUrls(urls) {
       acc.notOk.push({
         url: result.url,
         statusCode: result.statusCode,
-        ...(result.finalUrl && { suggestedFix: result.finalUrl }),
+        ...(result.finalUrl && { urls_suggested: result.finalUrl }),
       });
     }
     return acc;
@@ -485,7 +485,7 @@ export function getPagesWithIssues(auditData) {
       sitemapUrl,
       pageUrl: page.url,
       statusCode: page.statusCode ?? 500,
-      ...(page.suggestedFix && { suggestedFix: page.suggestedFix }),
+      ...(page.urls_suggested && { urls_suggested: page.urls_suggested }),
     }));
   });
 }
@@ -511,8 +511,8 @@ export function generateSuggestions(auditUrl, auditData, context) {
     .filter(Boolean)
     .map((issue) => ({
       ...issue,
-      recommendedAction: issue.suggestedFix
-        ? `use this url instead: ${issue.suggestedFix}`
+      recommendedAction: issue.urls_suggested
+        ? `use this url instead: ${issue.urls_suggested}`
         : 'Make sure your sitemaps only include URLs that return the 200 (OK) response code.',
     }));
 

--- a/test/audits/sitemap.test.js
+++ b/test/audits/sitemap.test.js
@@ -783,7 +783,7 @@ describe('Sitemap Audit', () => {
       });
     });
 
-    it('should create redirect recommendation when suggestedFix is present', () => {
+    it('should create redirect recommendation when urls_suggested is present', () => {
       const auditDataWithRedirect = {
         siteId: 'site-id',
         id: 'audit-id',
@@ -796,7 +796,7 @@ describe('Sitemap Audit', () => {
                 {
                   url: 'https://example.com/old-page',
                   statusCode: 301,
-                  suggestedFix: 'https://example.com/new-page',
+                  urls_suggested: 'https://example.com/new-page',
                 },
               ],
             },
@@ -815,7 +815,7 @@ describe('Sitemap Audit', () => {
         sitemapUrl: 'https://example.com/sitemap.xml',
         pageUrl: 'https://example.com/old-page',
         statusCode: 301,
-        suggestedFix: 'https://example.com/new-page',
+        urls_suggested: 'https://example.com/new-page',
         recommendedAction: 'use this url instead: https://example.com/new-page',
       });
     });
@@ -1072,12 +1072,12 @@ describe('filterValidUrls with redirect handling', () => {
       {
         url: 'https://example.com/permanent-redirect',
         statusCode: 301,
-        suggestedFix: 'https://example.com/new-location',
+        urls_suggested: 'https://example.com/new-location',
       },
       {
         url: 'https://example.com/temporary-redirect',
         statusCode: 302,
-        suggestedFix: 'https://example.com/temp-location',
+        urls_suggested: 'https://example.com/temp-location',
       },
       {
         url: 'https://example.com/not-found',
@@ -1102,7 +1102,7 @@ describe('filterValidUrls with redirect handling', () => {
     expect(result.notOk).to.deep.equal([
       {
         url: 'https://example.com/broken-redirect',
-        suggestedFix: 'https://example.com/error',
+        urls_suggested: 'https://example.com/error',
         statusCode: 301,
       },
     ]);
@@ -1110,7 +1110,7 @@ describe('filterValidUrls with redirect handling', () => {
 });
 
 describe('getPagesWithIssues', () => {
-  it('should include suggestedFix in the output when present in the input', () => {
+  it('should include urls_suggested in the output when present in the input', () => {
     const auditData = {
       auditResult: {
         details: {
@@ -1119,7 +1119,7 @@ describe('getPagesWithIssues', () => {
               {
                 url: 'https://example.com/old-page',
                 statusCode: 301,
-                suggestedFix: 'https://example.com/new-page',
+                urls_suggested: 'https://example.com/new-page',
               },
               {
                 url: 'https://example.com/not-found',
@@ -1138,7 +1138,7 @@ describe('getPagesWithIssues', () => {
       sitemapUrl: 'https://example.com/sitemap.xml',
       pageUrl: 'https://example.com/old-page',
       statusCode: 301,
-      suggestedFix: 'https://example.com/new-page',
+      urls_suggested: 'https://example.com/new-page',
     });
     expect(result[1]).to.deep.equal({
       type: 'url',


### PR DESCRIPTION
Rename suggestedFix to urls_suggested to keep consistency across audits. 
