### PR TITLE
feat: save rum-traffic as metrics to s3

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,7 @@ import metaTags from './metatags/handler.js';
 import costs from './costs/handler.js';
 import structuredData from './structured-data/handler.js';
 import siteDetection from './site-detection/handler.js';
+import rumTraffic from './rum-traffic/rum-traffic.js';
 
 const HANDLERS = {
   apex,
@@ -58,6 +59,7 @@ const HANDLERS = {
   'structured-data': structuredData,
   'forms-opportunities': formsOpportunities,
   'site-detection': siteDetection,
+  'rum-traffic': rumTraffic,
   dummy: (message) => ok(message),
 };
 

--- a/src/rum-traffic/rum-traffic.js
+++ b/src/rum-traffic/rum-traffic.js
@@ -50,6 +50,7 @@ export async function handler(auditUrl, context, site) {
     return acc;
   }, {});
   log.info(`Traffic data: ${JSON.stringify(trafficData, null, 2)}`);
+  console.log('site id', site.id);
   const metricsPath = await storeMetrics(
     trafficData,
     { siteId: site.id, source: 'rum', metric: 'rum-traffic' },

--- a/src/rum-traffic/rum-traffic.js
+++ b/src/rum-traffic/rum-traffic.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import RUMAPIClient from '@adobe/spacecat-shared-rum-api-client';
+import { storeMetrics } from '@adobe/spacecat-shared-utils';
+import { AuditBuilder } from '../common/audit-builder.js';
+import { getRUMDomainkey } from '../support/utils.js';
+import { wwwUrlResolver } from '../common/audit.js';
+
+/* c8 ignore start */
+const DAYS = 30;
+
+/**
+ * Audit handler to collect RUM traffic data for each URL
+ * @param {*} auditUrl
+ * @param {*} context
+ * @param {*} site
+ * @returns
+ */
+
+export async function handler(auditUrl, context, site) {
+  const { log } = context;
+
+  const rumAPIClient = RUMAPIClient.createFrom(context);
+  const domainkey = await getRUMDomainkey(auditUrl, context);
+  const options = {
+    domain: auditUrl,
+    domainkey,
+    interval: DAYS,
+    granularity: 'daily',
+  };
+  const result = await rumAPIClient.query('traffic-acquisition', options);
+  const trafficData = result.reduce((acc, curr) => {
+    acc[curr.url] = {
+      total: curr.total,
+      paid: curr.paid,
+      earned: curr.earned,
+      owned: curr.owned,
+    };
+    return acc;
+  }, {});
+  log.info(`Traffic data: ${JSON.stringify(trafficData, null, 2)}`);
+  const metricsPath = await storeMetrics(
+    trafficData,
+    { siteId: site.id, source: 'rum', metric: 'rum-traffic' },
+    context,
+  );
+
+  log.info(`Saved ${trafficData.length} urls traffic data for ${auditUrl} into internal S3 storage: ${metricsPath}`);
+
+  return {
+    auditResult: {
+      trafficData,
+    },
+    fullAuditRef: auditUrl,
+  };
+}
+
+export default new AuditBuilder()
+  .withUrlResolver(wwwUrlResolver)
+  .withRunner(handler)
+  .withMessageSender(() => true)
+  .build();
+/* c8 ignore end */

--- a/src/rum-traffic/rum-traffic.js
+++ b/src/rum-traffic/rum-traffic.js
@@ -29,6 +29,7 @@ const DAYS = 30;
 
 export async function handler(auditUrl, context, site) {
   const { log } = context;
+  log.info(`running rum traffic audit for: ${auditUrl}`);
 
   const rumAPIClient = RUMAPIClient.createFrom(context);
   const domainkey = await getRUMDomainkey(auditUrl, context);

--- a/src/rum-traffic/rum-traffic.js
+++ b/src/rum-traffic/rum-traffic.js
@@ -16,7 +16,6 @@ import { AuditBuilder } from '../common/audit-builder.js';
 import { getRUMDomainkey } from '../support/utils.js';
 import { wwwUrlResolver } from '../common/audit.js';
 
-/* c8 ignore start */
 const DAYS = 30;
 
 /**
@@ -50,7 +49,6 @@ export async function handler(auditUrl, context, site) {
     return acc;
   }, {});
   log.info(`Traffic data: ${JSON.stringify(trafficData, null, 2)}`);
-  console.log('site id', site.getId());
   const metricsPath = await storeMetrics(
     trafficData,
     { siteId: site.getId(), source: 'rum', metric: 'rum-traffic' },
@@ -63,7 +61,7 @@ export async function handler(auditUrl, context, site) {
     },
   );
 
-  log.info(`Saved ${trafficData.length} urls traffic data for ${auditUrl} into internal S3 storage: ${metricsPath}`);
+  log.info(`Saved ${Object.keys(trafficData).length} urls traffic data for ${auditUrl} into internal S3 storage: ${metricsPath}`);
 
   return {
     auditResult: {
@@ -78,4 +76,3 @@ export default new AuditBuilder()
   .withRunner(handler)
   .withMessageSender(() => true)
   .build();
-/* c8 ignore end */

--- a/src/rum-traffic/rum-traffic.js
+++ b/src/rum-traffic/rum-traffic.js
@@ -32,7 +32,7 @@ export async function handler(auditUrl, context, site) {
   log.info(`running rum traffic audit for: ${auditUrl}`);
 
   const rumAPIClient = RUMAPIClient.createFrom(context);
-  const domainkey = await getRUMDomainkey(auditUrl, context);
+  const domainkey = await getRUMDomainkey(site.getBaseURL(), context);
   const options = {
     domain: auditUrl,
     domainkey,

--- a/src/rum-traffic/rum-traffic.js
+++ b/src/rum-traffic/rum-traffic.js
@@ -50,10 +50,10 @@ export async function handler(auditUrl, context, site) {
     return acc;
   }, {});
   log.info(`Traffic data: ${JSON.stringify(trafficData, null, 2)}`);
-  console.log('site id', site.id);
+  console.log('site id', site.getId());
   const metricsPath = await storeMetrics(
     trafficData,
-    { siteId: site.id, source: 'rum', metric: 'rum-traffic' },
+    { siteId: site.getId(), source: 'rum', metric: 'rum-traffic' },
     {
       ...context,
       s3: {

--- a/src/rum-traffic/rum-traffic.js
+++ b/src/rum-traffic/rum-traffic.js
@@ -57,7 +57,7 @@ export async function handler(auditUrl, context, site) {
       ...context,
       s3: {
         s3Client: context.s3Client,
-        s3BucketName: process.env.S3_IMPORTER_BUCKET_NAME,
+        s3Bucket: process.env.S3_IMPORTER_BUCKET_NAME,
       },
     },
   );

--- a/src/rum-traffic/rum-traffic.js
+++ b/src/rum-traffic/rum-traffic.js
@@ -53,7 +53,13 @@ export async function handler(auditUrl, context, site) {
   const metricsPath = await storeMetrics(
     trafficData,
     { siteId: site.id, source: 'rum', metric: 'rum-traffic' },
-    context,
+    {
+      ...context,
+      s3: {
+        s3Client: context.s3Client,
+        s3BucketName: process.env.S3_IMPORTER_BUCKET_NAME,
+      },
+    },
   );
 
   log.info(`Saved ${trafficData.length} urls traffic data for ${auditUrl} into internal S3 storage: ${metricsPath}`);

--- a/test/audits/rum-traffic.test.js
+++ b/test/audits/rum-traffic.test.js
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import nock from 'nock';
+import esmock from 'esmock';
+
+use(sinonChai);
+
+describe('Rum Traffic Tests', () => {
+  let sandbox;
+  let rumTrafficHandler;
+  let storeMetricsStub;
+  let queryStub;
+  let context;
+
+  const baseURL = 'https://spacecat.com';
+  const auditUrl = 'www.spacecat.com';
+  const siteId = '12345';
+  const domainkey = 'test-domain-key';
+
+  const mockRumData = [
+    {
+      url: 'https://www.spacecat.com/page1',
+      total: 1000,
+      paid: 200,
+      earned: 300,
+      owned: 500,
+    },
+    {
+      url: 'https://www.spacecat.com/page2',
+      total: 2000,
+      paid: 400,
+      earned: 600,
+      owned: 1000,
+    },
+  ];
+
+  const expectedTrafficData = {
+    'https://www.spacecat.com/page1': {
+      total: 1000,
+      paid: 200,
+      earned: 300,
+      owned: 500,
+    },
+    'https://www.spacecat.com/page2': {
+      total: 2000,
+      paid: 400,
+      earned: 600,
+      owned: 1000,
+    },
+  };
+
+  const site = {
+    getBaseURL: () => baseURL,
+    getId: () => siteId,
+  };
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    // Mock the storeMetrics function
+    storeMetricsStub = sandbox.stub().resolves(`metrics/${siteId}/rum/rum-traffic.json`);
+    // Mock RUM API client query
+    queryStub = sandbox.stub().resolves(mockRumData);
+    // Setup common context
+    context = {
+      runtime: { name: 'aws-lambda', region: 'us-east-1' },
+      func: { package: 'spacecat-services', version: 'ci', name: 'test' },
+      log: {
+        info: sandbox.stub(),
+        error: sandbox.stub(),
+      },
+      rumApiClient: {
+        query: queryStub,
+      },
+      s3Client: {
+        send: sandbox.stub().resolves({}),
+      },
+      env: {
+        S3_IMPORTER_BUCKET_NAME: 'test-bucket',
+      },
+    };
+    nock('https://secretsmanager.us-east-1.amazonaws.com/')
+      .post('/', (body) => body.SecretId === '/helix-deploy/spacecat-services/customer-secrets/spacecat_com/ci')
+      .reply(200, {
+        SecretString: JSON.stringify({
+          RUM_DOMAIN_KEY: domainkey,
+        }),
+      });
+
+    // Import and mock the handler function
+    const module = await esmock('../../src/rum-traffic/rum-traffic.js', {
+      '@adobe/spacecat-shared-utils': {
+        storeMetrics: storeMetricsStub,
+      },
+    });
+    rumTrafficHandler = module.handler;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('rum-traffic audit runs RUM API client traffic-acquisition query', async () => {
+    // Run the handler
+    const result = await rumTrafficHandler(auditUrl, context, site);
+
+    // Verify RUM API client query was called with correct parameters
+    expect(queryStub).to.have.been.calledWith('traffic-acquisition', {
+      domain: auditUrl,
+      domainkey,
+      interval: 30,
+      granularity: 'daily',
+    });
+
+    // Verify the result structure
+    expect(result).to.deep.equal({
+      auditResult: {
+        trafficData: expectedTrafficData,
+      },
+      fullAuditRef: auditUrl,
+    });
+  });
+
+  it('rum-traffic audit calls the storeMetrics', async () => {
+    await rumTrafficHandler(auditUrl, context, site);
+    expect(storeMetricsStub).to.have.been.calledOnce;
+  });
+});


### PR DESCRIPTION
For calculating the projected traffic lost/value, we need organic traffic from RUM for the given page. Rather than each opportunity crunching the RUM data separately, adding this `rum-traffic` audit, which will save the rum-traffic data to importer metrics. 
So, the opportunities can obtain the rum-traffic data as 
```
import { getStoredMetrics } from '@adobe/spacecat-shared-utils';

const rumTrafficData = await getStoredMetrics(
    { source: 'rum', metric: 'rum-traffic', siteId },
    context,
  );
const pageOrganicTraffic = rumTrafficData['<url>']?.earned || 0;
```
