### PR TITLE
fix: error propagation in handlers

### DIFF
--- a/src/backlinks/handler.js
+++ b/src/backlinks/handler.js
@@ -34,6 +34,8 @@ async function filterOutValidBacklinks(backlinks, log) {
       if (error instanceof AbortError) {
         log.warn(`Request to ${url} timed out after ${timeout}ms`);
         return { ok: false, status: 408 };
+      } else {
+        log.warn(`Request to ${url} failed with error: ${error.message}`);
       }
     } finally {
       clearTimeout(id);

--- a/src/backlinks/handler.js
+++ b/src/backlinks/handler.js
@@ -38,21 +38,16 @@ async function filterOutValidBacklinks(backlinks, log) {
     } finally {
       clearTimeout(id);
     }
-    return null;
+    return { ok: false, status: 500 };
   };
 
   const isStillBrokenBacklink = async (backlink) => {
-    try {
-      const response = await fetchWithTimeout(backlink.url_to, TIMEOUT);
-      if (!response.ok && response.status !== 404
+    const response = await fetchWithTimeout(backlink.url_to, TIMEOUT);
+    if (!response.ok && response.status !== 404
         && response.status >= 400 && response.status < 500) {
-        log.warn(`Backlink ${backlink.url_to} returned status ${response.status}`);
-      }
-      return !response.ok;
-    } catch (error) {
-      log.error(`Failed to check backlink ${backlink.url_to}: ${error.message}`);
-      return true;
+      log.warn(`Backlink ${backlink.url_to} returned status ${response.status}`);
     }
+    return !response.ok;
   };
 
   const backlinkStatuses = await Promise.all(backlinks.map(isStillBrokenBacklink));

--- a/src/common/audit.js
+++ b/src/common/audit.js
@@ -147,7 +147,7 @@ export class Audit {
 
       return ok();
     } catch (e) {
-      throw new Error(`${type} audit failed for site ${siteId}. Reason: ${e.message}`);
+      throw new Error(`${type} audit failed for site ${siteId}. Reason: ${e.message}`, { cause: e });
     }
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -95,7 +95,7 @@ async function run(message, context) {
 
     return result;
   } catch (e) {
-    log.error(`${type} audit for ${siteId} failed after ${getElapsedSeconds(startTime)} seconds`, e);
+    log.error(`${type} audit for ${siteId} failed after ${getElapsedSeconds(startTime)} seconds. `, e);
     return internalServerError();
   }
 }


### PR DESCRIPTION
adding cause to the error within a handler, to be able to retrieve the corresponding stack trace in the log