### PR TITLE
fix: step audit queue url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@adobe/helix-universal": "5.0.8",
         "@adobe/helix-universal-logger": "3.0.23",
         "@adobe/spacecat-shared-ahrefs-client": "1.6.7",
-        "@adobe/spacecat-shared-data-access": "2.7.0",
+        "@adobe/spacecat-shared-data-access": "2.7.1",
         "@adobe/spacecat-shared-google-client": "1.4.10",
         "@adobe/spacecat-shared-gpt-client": "1.5.0",
         "@adobe/spacecat-shared-http-utils": "1.9.8",
@@ -1652,9 +1652,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-2.7.0.tgz",
-      "integrity": "sha512-tGM/RkNsXtvCNpNKd05C0v1t9dzSN0hb1WNyUMWAaEXMr7H+XpPnUVV/qwKS9JnTJ+lqt1rDbkdGGHi+PCGQcQ==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-2.7.1.tgz",
+      "integrity": "sha512-Q82g5TpsiH4drBZBoPFCgEdaXs+kCYhIJSwvOHJU1jNgflaS269t6GwZ6TvMqjutLHB942QAmk1oRfsT4oGYHg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.26.4",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@adobe/helix-universal": "5.0.8",
     "@adobe/helix-universal-logger": "3.0.23",
     "@adobe/spacecat-shared-ahrefs-client": "1.6.7",
-    "@adobe/spacecat-shared-data-access": "2.7.0",
+    "@adobe/spacecat-shared-data-access": "2.7.1",
     "@adobe/spacecat-shared-google-client": "1.4.10",
     "@adobe/spacecat-shared-gpt-client": "1.5.0",
     "@adobe/spacecat-shared-http-utils": "1.9.8",

--- a/src/common/step-audit.js
+++ b/src/common/step-audit.js
@@ -72,8 +72,9 @@ export class StepAudit extends BaseAudit {
       fullAuditRef: audit.getFullAuditRef(),
     };
 
+    const queueUrl = destination.getQueueUrl(context);
     const payload = destination.formatPayload(stepResult, auditContext);
-    await sendContinuationMessage({ queueUrl: destination.queueUrl, payload }, context);
+    await sendContinuationMessage({ queueUrl, payload }, context);
 
     log.info(`Step ${step.name} completed for audit ${audit.getId()} of type ${this.type}, message sent to ${step.destination}`);
 

--- a/test/common/step-audit.test.js
+++ b/test/common/step-audit.test.js
@@ -60,6 +60,11 @@ describe('Step-based Audit Tests', () => {
 
     context.dataAccess.Site.findById.resolves(site);
     context.dataAccess.Configuration.findLatest.resolves(configuration);
+
+    context.env = {
+      CONTENT_SCRAPER_QUEUE_URL: 'https://space.cat/content-scraper',
+      IMPORT_WORKER_QUEUE_URL: 'https://space.cat/import-worker',
+    };
   });
 
   afterEach(() => {
@@ -173,7 +178,7 @@ describe('Step-based Audit Tests', () => {
 
       // Verify message sent to content scraper
       expect(context.sqs.sendMessage).to.have.been.calledWith({
-        QueueUrl: process.env.CONTENT_SCRAPER_QUEUE_URL,
+        QueueUrl: 'https://space.cat/content-scraper',
         MessageBody: sinon.match.string,
       });
 
@@ -214,7 +219,7 @@ describe('Step-based Audit Tests', () => {
 
       // Verify message sent to import worker
       expect(context.sqs.sendMessage).to.have.been.calledWith({
-        QueueUrl: process.env.IMPORT_WORKER_QUEUE_URL,
+        QueueUrl: 'https://space.cat/import-worker',
         MessageBody: sinon.match.string,
       });
 


### PR DESCRIPTION
Fixes an issue where the destination configuration of stepped audits would not retrieve the correct queue URL to send the SQS message to.