### PR TITLE
fix: opportunity schema violation

### DIFF
--- a/src/backlinks/opportunity-data-mapper.js
+++ b/src/backlinks/opportunity-data-mapper.js
@@ -26,6 +26,6 @@ export function createOpportunityData() {
       ],
     },
     tags: ['Traffic acquisition'],
-    data: {},
+    data: null,
   };
 }

--- a/src/internal-links/opportunity-data-mapper.js
+++ b/src/internal-links/opportunity-data-mapper.js
@@ -27,6 +27,6 @@ export function createOpportunityData() {
       'Traffic acquisition',
       'Engagement',
     ],
-    data: {},
+    data: null,
   };
 }

--- a/src/metatags/opportunity-data-mapper.js
+++ b/src/metatags/opportunity-data-mapper.js
@@ -26,6 +26,6 @@ export function createOpportunityData() {
       ],
     },
     tags: ['Traffic acquisition'],
-    data: {},
+    data: null,
   };
 }

--- a/src/sitemap/opportunity-data-mapper.js
+++ b/src/sitemap/opportunity-data-mapper.js
@@ -23,6 +23,6 @@ export function createOpportunityData() {
       ],
     },
     tags: ['Traffic Acquisition'],
-    data: {},
+    data: null,
   };
 }

--- a/src/structured-data/opportunity-data-mapper.js
+++ b/src/structured-data/opportunity-data-mapper.js
@@ -20,6 +20,6 @@ export function createOpportunityData() {
       steps: [],
     },
     tags: ['Traffic acquisition'],
-    data: { },
+    data: null,
   };
 }

--- a/test/audits/sitemap.test.js
+++ b/test/audits/sitemap.test.js
@@ -999,7 +999,7 @@ describe('Sitemap Audit', () => {
             ],
           },
           tags: ['Traffic Acquisition'],
-          data: {},
+          data: null,
         },
       );
     });

--- a/test/fixtures/broken-backlinks/opportunity.js
+++ b/test/fixtures/broken-backlinks/opportunity.js
@@ -44,5 +44,5 @@ export const opportunityData = (siteId, auditId) => ({
     ],
   },
   tags: ['Traffic acquisition'],
-  data: { },
+  data: null,
 });

--- a/test/fixtures/internal-links-data.js
+++ b/test/fixtures/internal-links-data.js
@@ -50,7 +50,7 @@ export const expectedOpportunity = {
     'Traffic acquisition',
     'Engagement',
   ],
-  data: { },
+  data: null,
 };
 
 export const expectedSuggestions = [

--- a/test/fixtures/meta-tags-data.js
+++ b/test/fixtures/meta-tags-data.js
@@ -371,7 +371,7 @@ const testData = {
     tags: [
       'Traffic acquisition',
     ],
-    data: { },
+    data: null,
   },
 };
 

--- a/test/fixtures/structured-data/oppty.json
+++ b/test/fixtures/structured-data/oppty.json
@@ -10,5 +10,5 @@
     "steps": []
   },
   "tags": ["Traffic acquisition"],
-  "data": { }
+  "data": null
 }


### PR DESCRIPTION
Opportunity schema requires the data attribute to be either falsy or a non-empty object. cc @martinst06 