### PR TITLE
fix: disable multiple h1 count check for metadata

### DIFF
--- a/src/metatags/seo-checks.js
+++ b/src/metatags/seo-checks.js
@@ -123,6 +123,8 @@ class SeoChecks {
   }
 
   /**
+   * Disabled, this check might be included in later iterations
+   * https://cq-dev.slack.com/archives/C05A45JBP9N/p1739989459286999
    * Checks if there are more than one H1 tags and adds to detected tags array if found lacking.
    * @param {string} urlPath - The URL of the page.
    * @param {object} pageTags - An object containing the tags of the page.
@@ -193,7 +195,6 @@ class SeoChecks {
     }
     this.checkForMissingTags(urlPath, pageTags);
     this.checkForTagsLength(urlPath, pageTags);
-    this.checkForH1Count(urlPath, pageTags);
     // store tag data in all tags object to be used in later checks like uniqueness
     this.addToAllTags(urlPath, TITLE, pageTags[TITLE]);
     this.addToAllTags(urlPath, DESCRIPTION, pageTags[DESCRIPTION]);

--- a/test/audits/metatags.test.js
+++ b/test/audits/metatags.test.js
@@ -118,6 +118,7 @@ describe('Meta Tags', () => {
       });
     });
 
+    // check disabled, to be included in later iterations
     describe('checkForH1Count', () => {
       it('should detect multiple H1 tags on the page', () => {
         const url = 'https://example.com';
@@ -166,14 +167,13 @@ describe('Meta Tags', () => {
         const pageTags = {
           [TITLE]: '', // Empty title
           [DESCRIPTION]: 'A short description.',
-          [H1]: ['Heading 1', 'Heading 2'], // Multiple H1 tags
+          [H1]: ['Heading 1'], // Multiple H1 tags
         };
 
         seoChecks.performChecks(url, pageTags);
 
         const detectedTags = seoChecks.getDetectedTags();
         expect(detectedTags[url][TITLE][ISSUE]).to.equal('Empty Title');
-        expect(detectedTags[url][H1][ISSUE]).to.equal(MULTIPLE_H1_ON_PAGE);
       });
 
       it('should return if url is invalid', () => {


### PR DESCRIPTION
JIRA: https://jira.corp.adobe.com/browse/SITES-29433
Related slack: https://cq-dev.slack.com/archives/C05A45JBP9N/p1739989459286999

Disabling 'Multiple H1 on a page' check due to below issue:
"For the metadata opportunity, in case of multiple H1 on a page, we show the attached dialog to customer to convert one of them to H1, and others to H2. Now in this issue, there can be same H1s on the page as well in which case the customer might not be able to assess which H1 to keep and which to convert to H2. This also poses an issue with auto-fix where content sdk needs some identifier to identify which of the 2 same H1s to convert to H2."