### PR TITLE
feat: adds gpt recommendations to alt-text audit

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "nodeVersion": 22,
     "static": [
       "static/prompts/broken-backlinks.prompt",
-      "static/prompts/broken-backlinks-followup.prompt"
+      "static/prompts/broken-backlinks-followup.prompt",
+      "static/prompts/image-alt-text.prompt"
     ]
   },
   "repository": {

--- a/src/image-alt-text/opportunityHandler.js
+++ b/src/image-alt-text/opportunityHandler.js
@@ -15,6 +15,7 @@ import { Audit as AuditModel, Suggestion as SuggestionModel } from '@adobe/space
 import suggestionsEngine from './suggestionsEngine.js';
 
 const getImageSuggestionIdentifier = (suggestion) => `${suggestion.pageUrl}/${suggestion.src}`;
+const AUDIT_TYPE = AuditModel.AUDIT_TYPES.ALT_TEXT;
 
 /**
  * Synchronizes existing suggestions with new data
@@ -50,13 +51,13 @@ export async function syncAltTextSuggestions({ opportunity, newSuggestionDTOs, l
     const updateResult = await opportunity.addSuggestions(suggestionsToAdd);
 
     if (isNonEmptyArray(updateResult.errorItems)) {
-      log.error(`[alt-text]: Suggestions for siteId ${opportunity.getSiteId()} contains ${updateResult.errorItems.length} items with errors`);
+      log.error(`[${AUDIT_TYPE}]: Suggestions for siteId ${opportunity.getSiteId()} contains ${updateResult.errorItems.length} items with errors`);
       updateResult.errorItems.forEach((errorItem) => {
-        log.error(`[alt-text]: Item ${JSON.stringify(errorItem.item)} failed with error: ${errorItem.error}`);
+        log.error(`[${AUDIT_TYPE}]: Item ${JSON.stringify(errorItem.item)} failed with error: ${errorItem.error}`);
       });
 
       if (!isNonEmptyArray(updateResult.createdItems)) {
-        throw new Error(`[alt-text]: Failed to create suggestions for siteId ${opportunity.getSiteId()}`);
+        throw new Error(`[${AUDIT_TYPE}]: Failed to create suggestions for siteId ${opportunity.getSiteId()}`);
       }
     }
   }
@@ -78,17 +79,17 @@ export default async function convertToOpportunity(auditUrl, auditData, context)
   const { Opportunity } = dataAccess;
   const { detectedTags } = auditData.auditResult;
 
-  log.info(`[alt-text]: Syncing opportunity and suggestions for ${auditData.siteId}`);
+  log.info(`[${AUDIT_TYPE}]: Syncing opportunity and suggestions for ${auditData.siteId}`);
   let altTextOppty;
 
   try {
     const opportunities = await Opportunity.allBySiteIdAndStatus(auditData.siteId, 'NEW');
     altTextOppty = opportunities.find(
-      (oppty) => oppty.getType() === AuditModel.AUDIT_TYPES.ALT_TEXT,
+      (oppty) => oppty.getType() === AUDIT_TYPE,
     );
   } catch (e) {
-    log.error(`[alt-text]: Fetching opportunities for siteId ${auditData.siteId} failed with error: ${e.message}`);
-    throw new Error(`[alt-text]: Failed to fetch opportunities for siteId ${auditData.siteId}: ${e.message}`);
+    log.error(`[${AUDIT_TYPE}]: Fetching opportunities for siteId ${auditData.siteId} failed with error: ${e.message}`);
+    throw new Error(`[${AUDIT_TYPE}]: Failed to fetch opportunities for siteId ${auditData.siteId}: ${e.message}`);
   }
 
   try {
@@ -97,7 +98,7 @@ export default async function convertToOpportunity(auditUrl, auditData, context)
         siteId: auditData.siteId,
         auditId: auditData.id,
         runbook: 'https://adobe.sharepoint.com/:w:/s/aemsites-engineering/EeEUbjd8QcFOqCiwY0w9JL8BLMnpWypZ2iIYLd0lDGtMUw?e=XSmEjh',
-        type: AuditModel.AUDIT_TYPES.ALT_TEXT,
+        type: AUDIT_TYPE,
         origin: 'AUTOMATION',
         title: 'Missing alt text for images decreases accessibility and discoverability of content',
         description: 'Missing alt text on images leads to poor seo scores, low accessibility scores and search engine failing to surface such images with keyword search',
@@ -115,14 +116,14 @@ export default async function convertToOpportunity(auditUrl, auditData, context)
         tags: ['seo', 'accessibility'],
       };
       altTextOppty = await Opportunity.create(opportunityData);
-      log.debug('[alt-text]: Opportunity created');
+      log.debug(`[${AUDIT_TYPE}]: Opportunity created`);
     } else {
       altTextOppty.setAuditId(auditData.id);
       await altTextOppty.save();
     }
   } catch (e) {
-    log.error(`[alt-text]: Creating alt-text opportunity for siteId ${auditData.siteId} failed with error: ${e.message}`, e);
-    throw new Error(`[alt-text]: Failed to create alt-text opportunity for siteId ${auditData.siteId}: ${e.message}`);
+    log.error(`[${AUDIT_TYPE}]: Creating alt-text opportunity for siteId ${auditData.siteId} failed with error: ${e.message}`, e);
+    throw new Error(`[${AUDIT_TYPE}]: Failed to create alt-text opportunity for siteId ${auditData.siteId}: ${e.message}`);
   }
 
   const imageUrls = detectedTags.imagesWithoutAltText.map(
@@ -145,7 +146,7 @@ export default async function convertToOpportunity(auditUrl, auditData, context)
     };
   });
 
-  log.debug(`[alt-text]: Suggestions: ${JSON.stringify(suggestions)}`);
+  log.debug(`[${AUDIT_TYPE}]: Suggestions: ${JSON.stringify(suggestions)}`);
 
   await syncAltTextSuggestions({
     opportunity: altTextOppty,
@@ -158,5 +159,5 @@ export default async function convertToOpportunity(auditUrl, auditData, context)
     log,
   });
 
-  log.info(`[alt-text]: Successfully synced Opportunity And Suggestions for site: ${auditData.siteId} and alt-text audit type.`);
+  log.info(`[${AUDIT_TYPE}]: Successfully synced Opportunity And Suggestions for site: ${auditData.siteId} and alt-text audit type.`);
 }

--- a/src/image-alt-text/suggestionsEngine.js
+++ b/src/image-alt-text/suggestionsEngine.js
@@ -56,10 +56,6 @@ const generateBatchPromises = (
   const firefallOptions = {
     imageUrls: batch,
     model: MODEL,
-    additionalHeaders: {
-      'Cache-Control': 'no-cache',
-      Pragma: 'no-cache',
-    },
   };
   const prompt = await getPrompt({ images: batch }, PROMPT_FILE, log);
   try {

--- a/src/image-alt-text/suggestionsEngine.js
+++ b/src/image-alt-text/suggestionsEngine.js
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { getPrompt } from '@adobe/spacecat-shared-utils';
+import { FirefallClient } from '@adobe/spacecat-shared-gpt-client';
+import { sleep } from '../support/utils.js';
+
+const PROMPT_FILE = 'image-alt-text';
+const BATCH_SIZE = 10;
+const BATCH_DELAY = 5000;
+const MODEL = 'gpt-4o';
+// https://platform.openai.com/docs/guides/vision
+const SUPPORTED_FORMATS = /\.(webp|png|gif|jpeg|jpg)(?=\?|$)/i;
+
+const filterImages = (imageUrls, auditUrl) => {
+  const imagesFromHost = [];
+  const otherImages = [];
+  const unsupportedFormatImages = [];
+
+  imageUrls.forEach((imageUrl) => {
+    if (!SUPPORTED_FORMATS.test(imageUrl)) {
+      unsupportedFormatImages.push(imageUrl);
+    } else if (imageUrl.includes(auditUrl)) {
+      imagesFromHost.push(imageUrl);
+    } else {
+      otherImages.push(imageUrl);
+    }
+  });
+
+  return { imagesFromHost, otherImages, unsupportedFormatImages };
+};
+
+const chunkArray = (array, chunkSize) => {
+  const chunks = [];
+  for (let i = 0; i < array.length; i += chunkSize) {
+    chunks.push(array.slice(i, i + chunkSize));
+  }
+  return chunks;
+};
+
+const generateBatchPromises = (
+  imageBatches,
+  firefallClient,
+  log,
+) => imageBatches.map(async (batch, index) => {
+  await sleep(index * BATCH_DELAY);
+
+  const firefallOptions = {
+    imageUrls: batch,
+    model: MODEL,
+    additionalHeaders: {
+      'Cache-Control': 'no-cache',
+      Pragma: 'no-cache',
+    },
+  };
+  const prompt = await getPrompt({ images: batch }, PROMPT_FILE, log);
+  try {
+    const response = await firefallClient.fetchChatCompletion(prompt, firefallOptions);
+    if (response.choices?.length >= 1 && response.choices[0].finish_reason !== 'stop') {
+      log.error('[alt-text]: No final suggestions found for batch');
+    }
+
+    const answer = JSON.parse(response.choices[0].message.content);
+    log.info(`[alt-text]: Loaded ${answer.length} alt-text suggestions for batch`);
+    return answer;
+  } catch (err) {
+    log.error('[alt-text]: Error calling Firefall for alt-text suggestion generation for batch', err);
+    return [];
+  }
+});
+
+const getImageSuggestions = async (imageUrls, auditUrl, context) => {
+  const { log } = context;
+  const firefallClient = FirefallClient.createFrom(context);
+
+  const filteredImages = filterImages(imageUrls, auditUrl);
+
+  log.info('[alt-text]: Total images from host:', filteredImages.imagesFromHost.length);
+  log.info('[alt-text]: Other images:', filteredImages.otherImages);
+  log.info('[alt-text]: Unsupported format images:', filteredImages.unsupportedFormatImages);
+
+  const supportedImageBatches = chunkArray(filteredImages.imagesFromHost, BATCH_SIZE);
+
+  const batchPromises = generateBatchPromises(supportedImageBatches, firefallClient, log);
+
+  const batchedResults = await Promise.all(batchPromises);
+
+  const suggestionsByImageUrl = batchedResults.reduce((acc, result) => {
+    result.forEach((item) => {
+      acc[item.image_url] = item;
+    });
+    return acc;
+  }, {});
+
+  log.info(`[alt-text]: Final Merged Suggestions: ${Object.keys(suggestionsByImageUrl).length}`);
+
+  return suggestionsByImageUrl;
+};
+
+export default {
+  getImageSuggestions,
+};

--- a/static/prompts/image-alt-text.prompt
+++ b/static/prompts/image-alt-text.prompt
@@ -1,0 +1,31 @@
+You are tasked with identifying suitable text for the alt attribute of images.
+You are an expert SEO consultant, and your goal is to suggest a description for each image that is helpful for the user.
+
+### Rules:
+1. The alt text should be helpful for the user, not the search engine.
+2. Consider key elements of why you chose this image, instead of describing every little detail. No need to say image of or picture of. But, do say if its a logo, illustration, painting, or cartoon.
+3. If you can recognize a person in the image, use their name when known.
+4. Follow the industry guidelines for accessibility, https://www.w3.org/WAI/tutorials/images/
+5. Alt-text should reflect how the image relates to the content. Avoid irrelevant descriptions.
+6. Use natural language, ensuring you're not "stuffing" SEO keys.
+7. If an image is purely decorative and adds no functional or informational value, use an empty string as the alt text.
+8. Ideal description length is 50-60 characters.
+9. Dont duplicate text thats adjacent in the document or website.
+10. End the alt text sentence with a period.
+11. For infographics, describe the key data points and trends.
+
+
+
+### Response Format:
+Your response must be a valid JSON object using the following structure:
+[{
+  "image_url": "string",
+  "suggestion": "string",
+  "ai_rationale": "string",
+  "confidence_score": number
+}]
+**IMPORTANT:**
+- Provide only the JSON object. Do not include any additional text, explanation, or formatting. Do not use markdown.
+
+### Task:
+Given the following list of images: {{images}}, suggest a description for the alt attribute of each image that is helpful for the user.

--- a/test/audits/image-alt-text/opportunity-handler.test.js
+++ b/test/audits/image-alt-text/opportunity-handler.test.js
@@ -134,7 +134,7 @@ describe('Image Alt Text Opportunity Handler', () => {
     expect(dataAccessStub.Opportunity.create).to.not.have.been.called;
   });
 
-  it('should update existing opportunitywith empty suggestion if none are found', async () => {
+  it('should update existing opportunity with empty suggestion if none are found', async () => {
     dataAccessStub.Opportunity.allBySiteIdAndStatus.resolves([altTextOppty]);
     suggestionsEngine.getImageSuggestions.resolves({});
 

--- a/test/audits/image-alt-text/suggestions-engine.test.js
+++ b/test/audits/image-alt-text/suggestions-engine.test.js
@@ -119,7 +119,7 @@ describe('getImageSuggestions', () => {
     expect(context.log.info.calledWith('[alt-text]: Total images from host:', 0)).to.be.true;
   });
 
-  it('cristoiddio', async () => {
+  it('should handle finish_reason not being a stop', async () => {
     firefallClientStub.fetchChatCompletion.resolves({
       choices: [
         {

--- a/test/audits/image-alt-text/suggestions-engine.test.js
+++ b/test/audits/image-alt-text/suggestions-engine.test.js
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { FirefallClient } from '@adobe/spacecat-shared-gpt-client';
+import suggestionsEngine from '../../../src/image-alt-text/suggestionsEngine.js';
+
+describe('getImageSuggestions', () => {
+  let context;
+  let firefallClientStub;
+
+  beforeEach(() => {
+    context = {
+      log: {
+        info: sinon.stub(),
+        error: sinon.stub(),
+      },
+    };
+
+    firefallClientStub = sinon.createStubInstance(FirefallClient);
+    firefallClientStub.fetchChatCompletion.resolves({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify([
+              { image_url: 'http://example.com/image1.png', suggestion: 'Image 1 description' },
+              { image_url: 'http://example.com/image2.png', suggestion: 'Image 2 description' },
+            ]),
+          },
+          finish_reason: 'stop',
+        },
+      ],
+    });
+
+    sinon.stub(FirefallClient, 'createFrom').returns(firefallClientStub);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should return expected finalResults for a happy path', async () => {
+    const imageUrls = [
+      'https://example.com/image1.png',
+      'https://example.com/image2.png',
+    ];
+    const auditUrl = 'https://example.com';
+
+    const expectedResults = {
+      'http://example.com/image1.png': { image_url: 'http://example.com/image1.png', suggestion: 'Image 1 description' },
+      'http://example.com/image2.png': { image_url: 'http://example.com/image2.png', suggestion: 'Image 2 description' },
+    };
+
+    const result = await suggestionsEngine.getImageSuggestions(imageUrls, auditUrl, context);
+
+    expect(result).to.deep.equal(expectedResults);
+    expect(context.log.info.called).to.be.true;
+    expect(context.log.error.called).to.be.false;
+  });
+
+  it('should handle unsupported image formats', async () => {
+    const imageUrls = [
+      'http://example.com/image1.bmp',
+      'http://example.com/image2.tiff',
+    ];
+    const auditUrl = 'http://example.com';
+
+    const result = await suggestionsEngine.getImageSuggestions(imageUrls, auditUrl, context);
+
+    expect(result).to.deep.equal({});
+    expect(context.log.info.calledWith('[alt-text]: Unsupported format images:', ['http://example.com/image1.bmp', 'http://example.com/image2.tiff'])).to.be.true;
+  });
+
+  it('should handle images not from host', async () => {
+    const imageUrls = [
+      'http://other.com/image1.png',
+      'http://other.com/image2.png',
+    ];
+    const auditUrl = 'http://example.com';
+
+    const result = await suggestionsEngine.getImageSuggestions(imageUrls, auditUrl, context);
+
+    expect(result).to.deep.equal({});
+    expect(context.log.info.calledWith('[alt-text]: Other images:', ['http://other.com/image1.png', 'http://other.com/image2.png'])).to.be.true;
+  });
+
+  it('should handle errors from FirefallClient', async () => {
+    firefallClientStub.fetchChatCompletion.rejects(new Error('Firefall error'));
+
+    const imageUrls = [
+      'http://example.com/image1.png',
+    ];
+    const auditUrl = 'http://example.com';
+
+    const result = await suggestionsEngine.getImageSuggestions(imageUrls, auditUrl, context);
+
+    expect(result).to.deep.equal({});
+    expect(context.log.error.calledWith('[alt-text]: Error calling Firefall for alt-text suggestion generation for batch')).to.be.true;
+  });
+
+  it('should handle empty image list', async () => {
+    const imageUrls = [];
+    const auditUrl = 'http://example.com';
+
+    const result = await suggestionsEngine.getImageSuggestions(imageUrls, auditUrl, context);
+
+    expect(result).to.deep.equal({});
+    expect(context.log.info.calledWith('[alt-text]: Total images from host:', 0)).to.be.true;
+  });
+
+  it('cristoiddio', async () => {
+    firefallClientStub.fetchChatCompletion.resolves({
+      choices: [
+        {
+          message: {
+            content: JSON.stringify([
+              { image_url: 'http://example.com/image1.png', alt_text: 'Image 1 description' },
+              { image_url: 'http://example.com/image2.png', alt_text: 'Image 2 description' },
+            ]),
+          },
+          finish_reason: 'somethingelse',
+        },
+      ],
+    });
+    const imageUrls = [
+      'http://example.com/special-case-image.png',
+    ];
+    const auditUrl = 'http://example.com';
+
+    await suggestionsEngine.getImageSuggestions(imageUrls, auditUrl, context);
+
+    expect(context.log.error.calledWith('[alt-text]: No final suggestions found for batch')).to.be.true;
+  });
+});


### PR DESCRIPTION
Calls Firefall API for recommendations of missing alt-tags:
- using `gpt-4o`
- batches of 10 images
- 5000ms throttle
- For now supports only `webp|png|gif|jpeg|jpg`

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues

https://jira.corp.adobe.com/browse/ASSETS-47238
https://jira.corp.adobe.com/browse/ASSETS-47371

Thanks for contributing!
