### PR TITLE
Adds fix to trims any tailing path from url

### DIFF
--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -35,7 +35,10 @@ export async function getRUMUrl(url) {
     },
   });
   const finalUrl = resp.url.split('://')[1];
-  return finalUrl.endsWith('/') ? finalUrl.slice(0, -1) : /* c8 ignore next */ finalUrl;
+  /* Return just the domain part by splitting on '/' and taking first segment.
+   * This is to avoid returning the full URL with path. It will also remove any trailing /.
+   */
+  return finalUrl.split('/')[0];
 }
 
 /**


### PR DESCRIPTION
Some urls that we get as a response from fetch call contains path.
e.g. "www.westjet.com/en-us"
We need to trim path and trailing slash if any, from it. Thats because RUM needs urls without paths.
This is useful fix for westjet, ibm, bitdefender etc.

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues
https://jira.corp.adobe.com/browse/SITES-27731

Thanks for contributing!
