### PR TITLE
fix: retaining slash at Urls end in Meta-tags

### DIFF
--- a/src/metatags/handler.js
+++ b/src/metatags/handler.js
@@ -74,7 +74,8 @@ export async function fetchAndProcessPageObject(s3Client, bucketName, key, prefi
     log.error(`No Scraped tags found in S3 ${key} object`);
     return null;
   }
-  let pageUrl = key.slice(prefix.length - 1).replace('/scrape.json', ''); // Remove the prefix and scrape.json suffix
+  let pageUrl = object.finalUrl ? new URL(object.finalUrl).pathname
+    : key.slice(prefix.length - 1).replace('/scrape.json', ''); // Remove the prefix and scrape.json suffix
   // handling for homepage
   if (pageUrl === '') {
     pageUrl = '/';

--- a/test/audits/metatags.test.js
+++ b/test/audits/metatags.test.js
@@ -326,6 +326,7 @@ describe('Meta Tags', () => {
         }))).returns({
           Body: {
             transformToString: () => JSON.stringify({
+              finalUrl: 'http://example.com/site-id/',
               scrapeResult: {
                 tags: {
                   title: 'Home Page',
@@ -407,7 +408,7 @@ describe('Meta Tags', () => {
         },
       }));
       expect(addAuditStub.calledOnce).to.be.true;
-    }).timeout(3000);
+    }).timeout(5000);
 
     it('should process site tags and perform SEO checks for pages with invalid H1s', async () => {
       const topPages = [{ getURL: 'http://example.com/blog/page1', getTopKeyword: sinon.stub().returns('page') },

--- a/test/audits/metatags.test.js
+++ b/test/audits/metatags.test.js
@@ -408,7 +408,7 @@ describe('Meta Tags', () => {
         },
       }));
       expect(addAuditStub.calledOnce).to.be.true;
-    }).timeout(5000);
+    });
 
     it('should process site tags and perform SEO checks for pages with invalid H1s', async () => {
       const topPages = [{ getURL: 'http://example.com/blog/page1', getTopKeyword: sinon.stub().returns('page') },


### PR DESCRIPTION
Slash at Urls end is not retained in meta-tags audit results

https://jira.corp.adobe.com/browse/SITES-29515

https://cq-dev.slack.com/archives/C085NJRJG2W/p1740428584585269

> One observation I had: volvo site expect a / at the end of many of their urls otherwise they respond with 'Page not found'. For ex. https://www.volvotrucks.us/about-volvo/facilities/parts-distribution-centers
On metadata opportunity UI, many urls on the page are redirecting to 'page not found' due to above issue. Looks like we need to retain the / at the end of these urls. I have created [SITES-29515](https://jira.corp.adobe.com/browse/SITES-29515) for this and am working on it. The detected metadata suggestions are all fine though.