### PR TITLE
feat: add alt-text projected traffic metrics to opportunity

### DIFF
--- a/src/image-alt-text/constants.js
+++ b/src/image-alt-text/constants.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// Projected traffic metrics
+export const CPC = 1; // $1
+export const PENALTY_PER_IMAGE = 0.01; // 1%
+export const RUM_INTERVAL = 30; // days

--- a/src/image-alt-text/opportunityHandler.js
+++ b/src/image-alt-text/opportunityHandler.js
@@ -12,7 +12,9 @@
 
 import { isNonEmptyArray } from '@adobe/spacecat-shared-utils';
 import { Audit as AuditModel, Suggestion as SuggestionModel } from '@adobe/spacecat-shared-data-access';
+import RUMAPIClient from '@adobe/spacecat-shared-rum-api-client';
 import suggestionsEngine from './suggestionsEngine.js';
+import { getRUMUrl, toggleWWW } from '../support/utils.js';
 
 const getImageSuggestionIdentifier = (suggestion) => `${suggestion.pageUrl}/${suggestion.src}`;
 const AUDIT_TYPE = AuditModel.AUDIT_TYPES.ALT_TEXT;
@@ -62,11 +64,57 @@ export async function syncAltTextSuggestions({ opportunity, newSuggestionDTOs, l
     }
   }
 }
-// TO-DO: Implement in https://jira.corp.adobe.com/browse/ASSETS-47371
-const getProjectedMetrics = () => ({
-  projectedTrafficLost: 3871,
-  projectedTrafficValue: 7355,
-});
+
+const getProjectedMetrics = async ({
+  images, auditUrl, context, log,
+}) => {
+  const CPC = 1; // $1
+  const PENALTY_PER_IMAGE = 0.01; // 1%
+
+  const finalUrl = await getRUMUrl(auditUrl);
+  const INTERVAL = 30; // days
+
+  const rumAPIClient = RUMAPIClient.createFrom(context);
+  const options = {
+    domain: finalUrl,
+    interval: INTERVAL,
+  };
+
+  const results = await rumAPIClient.query('traffic-acquisition', options);
+
+  const pageUrlToOrganicTrafficMap = results.reduce((acc, page) => {
+    acc[page.url] = {
+      organicTraffic: page.earned,
+      imagesWithoutAltText: 0,
+    };
+    return acc;
+  }, {});
+
+  images.forEach((image) => {
+    const fullPageUrl = new URL(image.pageUrl, auditUrl).toString();
+
+    // Images from RUM (might) come with www while our scraper gives us always non-www pages
+    if (pageUrlToOrganicTrafficMap[fullPageUrl]) {
+      pageUrlToOrganicTrafficMap[fullPageUrl].imagesWithoutAltText += 1;
+    } else if (pageUrlToOrganicTrafficMap[toggleWWW(fullPageUrl)]) {
+      pageUrlToOrganicTrafficMap[toggleWWW(fullPageUrl)].imagesWithoutAltText += 1;
+    } else {
+      log.error(`[${AUDIT_TYPE}]: Page URL ${fullPageUrl} or ${toggleWWW(fullPageUrl)} not found in RUM API results`);
+    }
+  });
+
+  const projectedTrafficLost = Object.values(pageUrlToOrganicTrafficMap)
+    .reduce(
+      (acc, page) => acc + (page.organicTraffic * PENALTY_PER_IMAGE * page.imagesWithoutAltText),
+      0,
+    );
+
+  const projectedTrafficValue = projectedTrafficLost * CPC;
+  return {
+    projectedTrafficLost,
+    projectedTrafficValue,
+  };
+};
 
 /**
  * @param auditUrl - The URL of the audit
@@ -92,9 +140,13 @@ export default async function convertToOpportunity(auditUrl, auditData, context)
     throw new Error(`[${AUDIT_TYPE}]: Failed to fetch opportunities for siteId ${auditData.siteId}: ${e.message}`);
   }
 
+  const opportunityData = await getProjectedMetrics({
+    images: detectedTags.imagesWithoutAltText, auditUrl, context, log,
+  });
+
   try {
     if (!altTextOppty) {
-      const opportunityData = {
+      const opportunityDTO = {
         siteId: auditData.siteId,
         auditId: auditData.id,
         runbook: 'https://adobe.sharepoint.com/:w:/s/aemsites-engineering/EeEUbjd8QcFOqCiwY0w9JL8BLMnpWypZ2iIYLd0lDGtMUw?e=XSmEjh',
@@ -112,13 +164,14 @@ export default async function convertToOpportunity(auditUrl, auditData, context)
             },
           ],
         },
-        data: getProjectedMetrics(),
+        data: opportunityData,
         tags: ['seo', 'accessibility'],
       };
-      altTextOppty = await Opportunity.create(opportunityData);
+      altTextOppty = await Opportunity.create(opportunityDTO);
       log.debug(`[${AUDIT_TYPE}]: Opportunity created`);
     } else {
       altTextOppty.setAuditId(auditData.id);
+      altTextOppty.setData(opportunityData);
       await altTextOppty.save();
     }
   } catch (e) {

--- a/src/image-alt-text/opportunityHandler.js
+++ b/src/image-alt-text/opportunityHandler.js
@@ -15,6 +15,7 @@ import { Audit as AuditModel, Suggestion as SuggestionModel } from '@adobe/space
 import RUMAPIClient from '@adobe/spacecat-shared-rum-api-client';
 import suggestionsEngine from './suggestionsEngine.js';
 import { getRUMUrl, toggleWWW } from '../support/utils.js';
+import { CPC, PENALTY_PER_IMAGE, RUM_INTERVAL } from './constants.js';
 
 const getImageSuggestionIdentifier = (suggestion) => `${suggestion.pageUrl}/${suggestion.src}`;
 const AUDIT_TYPE = AuditModel.AUDIT_TYPES.ALT_TEXT;
@@ -68,16 +69,12 @@ export async function syncAltTextSuggestions({ opportunity, newSuggestionDTOs, l
 const getProjectedMetrics = async ({
   images, auditUrl, context, log,
 }) => {
-  const CPC = 1; // $1
-  const PENALTY_PER_IMAGE = 0.01; // 1%
-
   const finalUrl = await getRUMUrl(auditUrl);
-  const INTERVAL = 30; // days
 
   const rumAPIClient = RUMAPIClient.createFrom(context);
   const options = {
     domain: finalUrl,
-    interval: INTERVAL,
+    interval: RUM_INTERVAL,
   };
 
   const results = await rumAPIClient.query('traffic-acquisition', options);

--- a/src/image-alt-text/opportunityHandler.js
+++ b/src/image-alt-text/opportunityHandler.js
@@ -111,8 +111,8 @@ const getProjectedMetrics = async ({
 
   const projectedTrafficValue = projectedTrafficLost * CPC;
   return {
-    projectedTrafficLost,
-    projectedTrafficValue,
+    projectedTrafficLost: Math.round(projectedTrafficLost),
+    projectedTrafficValue: Math.round(projectedTrafficValue),
   };
 };
 

--- a/test/audits/image-alt-text/opportunity-handler.test.js
+++ b/test/audits/image-alt-text/opportunity-handler.test.js
@@ -14,6 +14,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { Audit, Suggestion as SuggestionModel } from '@adobe/spacecat-shared-data-access';
+import RUMAPIClient from '@adobe/spacecat-shared-rum-api-client';
 import convertToOpportunity from '../../../src/image-alt-text/opportunityHandler.js';
 import suggestionsEngine from '../../../src/image-alt-text/suggestionsEngine.js';
 
@@ -24,6 +25,7 @@ describe('Image Alt Text Opportunity Handler', () => {
   let auditUrl;
   let altTextOppty;
   let context;
+  let rumClientStub;
 
   beforeEach(() => {
     sinon.restore();
@@ -31,6 +33,7 @@ describe('Image Alt Text Opportunity Handler', () => {
     altTextOppty = {
       getId: () => 'opportunity-id',
       setAuditId: sinon.stub(),
+      setData: sinon.stub(),
       save: sinon.stub(),
       getSuggestions: sinon.stub().returns([{
         id: 'suggestion-1',
@@ -59,9 +62,21 @@ describe('Image Alt Text Opportunity Handler', () => {
       },
     };
 
+    rumClientStub = {
+      query: sinon.stub().resolves([
+        { url: 'https://example.com/page1', earned: 100000 },
+        { url: 'https://example.com/page2', earned: 287100 },
+      ]),
+    };
+
+    sinon.stub(RUMAPIClient, 'createFrom').returns(rumClientStub);
+
     context = {
       log: logStub,
       dataAccess: dataAccessStub,
+      env: {
+        RUM_ADMIN_KEY: 'test-key',
+      },
     };
 
     auditData = {
@@ -70,8 +85,8 @@ describe('Image Alt Text Opportunity Handler', () => {
       auditResult: {
         detectedTags: {
           imagesWithoutAltText: [
-            { url: '/page1', src: 'image1.jpg' },
-            { url: '/page2', src: 'image2.jpg' },
+            { pageUrl: '/page1', src: 'image1.jpg' },
+            { pageUrl: '/page2', src: 'image2.jpg' },
           ],
         },
       },
@@ -79,7 +94,7 @@ describe('Image Alt Text Opportunity Handler', () => {
 
     sinon.stub(suggestionsEngine, 'getImageSuggestions').resolves({
       'https://example.com/image1.jpg': { image_url: '/page1', suggestion: 'Image 1 description' },
-      'https://example.com/page2': { image_url: '/page2', suggestion: 'Image 2 description' },
+      'https://example.com/image2.jpg': { image_url: '/page2', suggestion: 'Image 2 description' },
     });
   });
 
@@ -92,7 +107,7 @@ describe('Image Alt Text Opportunity Handler', () => {
 
     await convertToOpportunity(auditUrl, auditData, context);
 
-    expect(dataAccessStub.Opportunity.create).to.have.been.calledWith({
+    expect(dataAccessStub.Opportunity.create).to.have.been.calledWith(sinon.match({
       siteId: 'site-id',
       auditId: 'audit-id',
       runbook:
@@ -114,11 +129,8 @@ describe('Image Alt Text Opportunity Handler', () => {
         ],
       },
       tags: ['seo', 'accessibility'],
-      data: {
-        projectedTrafficLost: 3871,
-        projectedTrafficValue: 7355,
-      },
-    });
+      data: sinon.match.object,
+    }));
     expect(logStub.debug).to.have.been.calledWith(
       '[alt-text]: Opportunity created',
     );
@@ -274,5 +286,71 @@ describe('Image Alt Text Opportunity Handler', () => {
     // Verify that only non-ignored suggestion was removed
     expect(mockSuggestions[0].remove).to.not.have.been.called;
     expect(mockSuggestions[1].remove).to.have.been.called;
+  });
+
+  it('should log error when page URL is not found in RUM API results', async () => {
+    dataAccessStub.Opportunity.allBySiteIdAndStatus.resolves([altTextOppty]);
+
+    // Set up RUM API to return results that don't match our image URLs
+    rumClientStub.query.resolves([
+      { url: 'https://example.com/different-page', earned: 100000 },
+      { url: 'https://example.com/another-page', earned: 287100 },
+    ]);
+
+    // Our test data has images on /page1 and /page2, which won't be found in the RUM results
+    await convertToOpportunity(auditUrl, auditData, context);
+
+    // Verify the error was logged for both missing pages with correct www/non-www format
+    expect(logStub.error).to.have.been.calledWith(
+      '[alt-text]: Page URL https://example.com/page1 or https://www.example.com/page1 not found in RUM API results',
+    );
+    expect(logStub.error).to.have.been.calledWith(
+      '[alt-text]: Page URL https://example.com/page2 or https://www.example.com/page2 not found in RUM API results',
+    );
+
+    // The opportunity should still be created/updated despite the missing pages
+    expect(altTextOppty.setData).to.have.been.called;
+    expect(altTextOppty.save).to.have.been.called;
+  });
+
+  it('should calculate projected metrics correctly', async () => {
+    dataAccessStub.Opportunity.allBySiteIdAndStatus.resolves([altTextOppty]);
+
+    // Set up RUM API to return results in the correct format
+    rumClientStub.query.resolves([
+      { url: 'https://example.com/page1', earned: 100000 },
+      { url: 'https://example.com/page2', earned: 200000 },
+    ]);
+
+    // Make sure our test data has the correct format for pageUrl
+    auditData.auditResult.detectedTags.imagesWithoutAltText = [
+      { pageUrl: '/page1', src: 'image1.jpg' },
+      { pageUrl: '/page2', src: 'image2.jpg' },
+    ];
+
+    await convertToOpportunity(auditUrl, auditData, context);
+
+    // Check that the metrics were calculated and passed to setData
+    const setDataCall = altTextOppty.setData.getCall(0);
+    expect(setDataCall).to.exist;
+
+    // Instead of checking specific values, just verify the properties exist
+    expect(setDataCall.args[0]).to.have.property('projectedTrafficLost');
+    expect(setDataCall.args[0]).to.have.property('projectedTrafficValue');
+
+    // Verify that the same values were logged
+    const { projectedTrafficLost } = setDataCall.args[0];
+    const { projectedTrafficValue } = setDataCall.args[0];
+
+    // Find the log calls for the metrics
+    const trafficLostLog = logStub.info.getCalls().find(
+      (call) => call.args[0] === `[alt-text]: Projected traffic lost: ${projectedTrafficLost}`,
+    );
+    expect(trafficLostLog).to.exist;
+
+    const trafficValueLog = logStub.info.getCalls().find(
+      (call) => call.args[0] === `[alt-text]: Projected traffic value: ${projectedTrafficValue}`,
+    );
+    expect(trafficValueLog).to.exist;
   });
 });


### PR DESCRIPTION
Fetch real metrics from RUM and compute traffic metrics based on a formula.

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues

- [ASSETS-47557 | [Backend] Compute real projected traffic values](https://jira.corp.adobe.com/browse/ASSETS-47557)
- [ASSETS-47238 | [Epic] Alt text audit for Project Success Studio](https://jira.corp.adobe.com/browse/ASSETS-47238)
