### PR TITLE
fix: handling site RUM missing for meta-tags

### DIFF
--- a/src/metatags/constants.js
+++ b/src/metatags/constants.js
@@ -26,6 +26,7 @@ export const SEO_RECOMMENDATION = 'seoRecommendation';
 export const SEO_IMPACT = 'seoImpact';
 export const DUPLICATES = 'duplicates';
 export const MULTIPLE_H1_ON_PAGE = 'Multiple H1 on page';
+export const PROJECTED_VALUE_THRESHOLD = 500;
 
 // SEO Guidelines Suggestions
 export const SHOULD_BE_PRESENT = 'Should be present';

--- a/src/metatags/handler.js
+++ b/src/metatags/handler.js
@@ -175,10 +175,9 @@ async function calculateProjectedTraffic(context, auditUrl, siteId, detectedTags
 
     const cpcValue = await calculateCPCValue(context, siteId);
     log.info(`Calculated cpc value: ${cpcValue} for site: ${siteId}`);
-
     const projectedTrafficValue = projectedTrafficLost * cpcValue;
-    // Skip updating projected traffic data if lost traffic value is insignificant
 
+    // Skip updating projected traffic data if lost traffic value is insignificant
     return projectedTrafficValue > 500 ? { projectedTrafficLost, projectedTrafficValue } : {};
   } catch (err) {
     log.warn(`Error while calculating projected traffic for ${auditUrl} : ${siteId}`, err);

--- a/src/metatags/handler.js
+++ b/src/metatags/handler.js
@@ -179,7 +179,7 @@ async function calculateProjectedTraffic(context, auditUrl, siteId, detectedTags
     const projectedTrafficValue = projectedTrafficLost * cpcValue;
     // Skip updating projected traffic data if lost traffic value is insignificant
 
-    return projectedTrafficValue < 500 ? {} : { projectedTrafficLost, projectedTrafficValue };
+    return projectedTrafficValue > 500 ? { projectedTrafficLost, projectedTrafficValue } : {};
   } catch (err) {
     log.warn(`Error while calculating projected traffic for ${auditUrl} : ${siteId}`, err);
     return {};

--- a/src/metatags/handler.js
+++ b/src/metatags/handler.js
@@ -21,7 +21,12 @@ import metatagsAutoSuggest from './metatags-auto-suggest.js';
 import { convertToOpportunity } from '../common/opportunity.js';
 import { getTopPagesForSiteId } from '../canonical/handler.js';
 import { getIssueRanking, removeTrailingSlash } from './opportunity-utils.js';
-import { DESCRIPTION, H1, TITLE } from './constants.js';
+import {
+  DESCRIPTION,
+  H1,
+  PROJECTED_VALUE_THRESHOLD,
+  TITLE,
+} from './constants.js';
 import { syncSuggestions } from '../utils/data-access.js';
 import { createOpportunityData } from './opportunity-data-mapper.js';
 
@@ -178,7 +183,8 @@ async function calculateProjectedTraffic(context, auditUrl, siteId, detectedTags
     const projectedTrafficValue = projectedTrafficLost * cpcValue;
 
     // Skip updating projected traffic data if lost traffic value is insignificant
-    return projectedTrafficValue > 500 ? { projectedTrafficLost, projectedTrafficValue } : {};
+    return projectedTrafficValue > PROJECTED_VALUE_THRESHOLD
+      ? { projectedTrafficLost, projectedTrafficValue } : {};
   } catch (err) {
     log.warn(`Error while calculating projected traffic for ${auditUrl} : ${siteId}`, err);
     return {};

--- a/src/metatags/handler.js
+++ b/src/metatags/handler.js
@@ -247,8 +247,8 @@ export async function auditMetaTagsRunner(auditUrl, context, site) {
     sourceS3Folder: `${bucketName}/${prefix}`,
     fullAuditRef: '',
     finalUrl: auditUrl,
-    projectedTrafficLost,
-    projectedTrafficValue,
+    ...(projectedTrafficLost && { projectedTrafficLost }),
+    ...(projectedTrafficValue && { projectedTrafficValue }),
   };
   return {
     auditResult,

--- a/test/audits/metatags.test.js
+++ b/test/audits/metatags.test.js
@@ -739,6 +739,308 @@ describe('Meta Tags', () => {
       expect(logStub.error).to.have.been.calledWith('Failed to extract tags from scraped content for bucket test-bucket and prefix scrapes/site-id/');
     });
 
+    it('should handle gracefully if Rum throws error', async () => {
+      const RUMAPIClientStub = {
+        createFrom: sinon.stub().returns({
+          query: sinon.stub().throws(new Error('RUM not available')),
+        }),
+      };
+      const mockGetRUMDomainkey = sinon.stub().resolves('mockedDomainKey');
+      const metatagsOppty = {
+        getId: () => 'opportunity-id',
+        setAuditId: sinon.stub(),
+        save: sinon.stub(),
+        getSuggestions: sinon.stub().returns([]),
+        addSuggestions: sinon.stub().returns({ errorItems: [], createdItems: [1, 2, 3] }),
+        getType: () => 'meta-tags',
+      };
+      const site = {
+        getIsLive: sinon.stub().returns(true),
+        getId: sinon.stub().returns('site-id'),
+        getBaseURL: sinon.stub().returns('http://example.com'),
+      };
+      const topPages = [{ getURL: 'http://example.com/blog/page1', getTopKeyword: sinon.stub().returns('page') },
+        { getURL: 'http://example.com/blog/page2', getTopKeyword: sinon.stub().returns('Test') }];
+
+      dataAccessStub.Site.findById.resolves(site);
+      dataAccessStub.Configuration.findLatest.resolves({
+        isHandlerEnabledForSite: sinon.stub().returns(true),
+      });
+      dataAccessStub.SiteTopPage.allBySiteId.resolves(topPages);
+      dataAccessStub.Opportunity = {
+        allBySiteIdAndStatus: sinon.stub().returns([metatagsOppty]),
+      };
+      s3ClientStub.send
+        .withArgs(sinon.match.instanceOf(ListObjectsV2Command).and(sinon.match.has('input', {
+          Bucket: 'test-bucket',
+          Prefix: 'scrapes/site-id/',
+          MaxKeys: 1000,
+        })))
+        .resolves({
+          Contents: [
+            { Key: 'scrapes/site-id/blog/page1/scrape.json' },
+            { Key: 'scrapes/site-id/blog/page2/scrape.json' },
+          ],
+        });
+
+      s3ClientStub.send
+        .withArgs(sinon.match.instanceOf(GetObjectCommand).and(sinon.match.has('input', {
+          Bucket: 'test-bucket',
+          Key: 'scrapes/site-id/blog/page1/scrape.json',
+        }))).returns({
+          Body: {
+            transformToString: () => JSON.stringify({
+              scrapeResult: {
+                tags: {
+                  title: 'Test Page',
+                  description: '',
+                },
+              },
+            }),
+          },
+          ContentType: 'application/json',
+        });
+      s3ClientStub.send
+        .withArgs(sinon.match.instanceOf(GetObjectCommand).and(sinon.match.has('input', {
+          Bucket: 'test-bucket',
+          Key: 'scrapes/site-id/blog/page2/scrape.json',
+        }))).returns({
+          Body: {
+            transformToString: () => JSON.stringify({
+              scrapeResult: {
+                tags: {
+                  title: 'Test Page',
+                  h1: [
+                    'This is a dummy H1 that is intentionally made to be overly lengthy from SEO perspective',
+                  ],
+                },
+              },
+            }),
+          },
+          ContentType: 'application/json',
+        });
+      const addAuditStub = sinon.stub().resolves({ getId: () => 'audit-id' });
+      dataAccessStub.Audit.create = addAuditStub;
+      const mockCalculateCPCValue = sinon.stub().resolves(2);
+      const auditStub = await esmock('../../src/metatags/handler.js', {
+        '../../src/support/utils.js': { getRUMDomainkey: mockGetRUMDomainkey, calculateCPCValue: mockCalculateCPCValue },
+        '@adobe/spacecat-shared-rum-api-client': RUMAPIClientStub,
+      });
+      const auditInstance = auditStub.default;
+      await auditInstance.runner('http://example.com', context, site);
+      expect(addAuditStub.calledWithMatch({
+        auditResult: {
+          detectedTags: {
+            '/blog/page1': {
+              h1: {
+                seoImpact: 'High',
+                issue: 'Missing H1',
+                issueDetails: 'H1 tag is missing',
+                seoRecommendation: 'Should be present',
+              },
+              title: {
+                tagContent: 'Test Page',
+                seoImpact: 'High',
+                issue: 'Duplicate Title',
+                issueDetails: '2 pages share same title',
+                seoRecommendation: 'Unique across pages',
+                duplicates: [
+                  '/blog/page2',
+                ],
+              },
+              description: {
+                tagContent: '',
+                seoImpact: 'High',
+                issue: 'Empty Description',
+                issueDetails: 'Description tag is empty',
+                seoRecommendation: '140-160 characters long',
+              },
+            },
+            '/blog/page2': {
+              description: {
+                seoImpact: 'High',
+                issue: 'Missing Description',
+                issueDetails: 'Description tag is missing',
+                seoRecommendation: 'Should be present',
+              },
+              title: {
+                tagContent: 'Test Page',
+                seoImpact: 'High',
+                issue: 'Duplicate Title',
+                issueDetails: '2 pages share same title',
+                seoRecommendation: 'Unique across pages',
+                duplicates: [
+                  '/blog/page1',
+                ],
+              },
+              h1: {
+                tagContent: 'This is a dummy H1 that is intentionally made to be overly lengthy from SEO perspective',
+                seoImpact: 'Moderate',
+                issue: 'H1 too long',
+                issueDetails: '17 chars over limit',
+                seoRecommendation: 'Below 70 characters',
+              },
+            },
+          },
+        },
+      }));
+    });
+
+    it('should skip updating projected traffic if value less than 500', async () => {
+      const RUMAPIClientStub = {
+        createFrom: sinon.stub().returns({
+          query: sinon.stub().resolves([
+            {
+              url: 'http://example.com/blog/page1',
+              total: 100,
+              earned: 20,
+              owned: 70,
+              paid: 10,
+            },
+          ]),
+        }),
+      };
+      const mockGetRUMDomainkey = sinon.stub().resolves('mockedDomainKey');
+      const metatagsOppty = {
+        getId: () => 'opportunity-id',
+        setAuditId: sinon.stub(),
+        save: sinon.stub(),
+        getSuggestions: sinon.stub().returns([]),
+        addSuggestions: sinon.stub().returns({ errorItems: [], createdItems: [1, 2, 3] }),
+        getType: () => 'meta-tags',
+      };
+      const site = {
+        getIsLive: sinon.stub().returns(true),
+        getId: sinon.stub().returns('site-id'),
+        getBaseURL: sinon.stub().returns('http://example.com'),
+      };
+      const topPages = [{ getURL: 'http://example.com/blog/page1', getTopKeyword: sinon.stub().returns('page') },
+        { getURL: 'http://example.com/blog/page2', getTopKeyword: sinon.stub().returns('Test') }];
+
+      dataAccessStub.Site.findById.resolves(site);
+      dataAccessStub.Configuration.findLatest.resolves({
+        isHandlerEnabledForSite: sinon.stub().returns(true),
+      });
+      dataAccessStub.SiteTopPage.allBySiteId.resolves(topPages);
+      dataAccessStub.Opportunity = {
+        allBySiteIdAndStatus: sinon.stub().returns([metatagsOppty]),
+      };
+      s3ClientStub.send
+        .withArgs(sinon.match.instanceOf(ListObjectsV2Command).and(sinon.match.has('input', {
+          Bucket: 'test-bucket',
+          Prefix: 'scrapes/site-id/',
+          MaxKeys: 1000,
+        })))
+        .resolves({
+          Contents: [
+            { Key: 'scrapes/site-id/blog/page1/scrape.json' },
+            { Key: 'scrapes/site-id/blog/page2/scrape.json' },
+          ],
+        });
+
+      s3ClientStub.send
+        .withArgs(sinon.match.instanceOf(GetObjectCommand).and(sinon.match.has('input', {
+          Bucket: 'test-bucket',
+          Key: 'scrapes/site-id/blog/page1/scrape.json',
+        }))).returns({
+          Body: {
+            transformToString: () => JSON.stringify({
+              scrapeResult: {
+                tags: {
+                  title: 'Test Page',
+                  description: '',
+                },
+              },
+            }),
+          },
+          ContentType: 'application/json',
+        });
+      s3ClientStub.send
+        .withArgs(sinon.match.instanceOf(GetObjectCommand).and(sinon.match.has('input', {
+          Bucket: 'test-bucket',
+          Key: 'scrapes/site-id/blog/page2/scrape.json',
+        }))).returns({
+          Body: {
+            transformToString: () => JSON.stringify({
+              scrapeResult: {
+                tags: {
+                  title: 'Test Page',
+                  h1: [
+                    'This is a dummy H1 that is intentionally made to be overly lengthy from SEO perspective',
+                  ],
+                },
+              },
+            }),
+          },
+          ContentType: 'application/json',
+        });
+      const addAuditStub = sinon.stub().resolves({ getId: () => 'audit-id' });
+      dataAccessStub.Audit.create = addAuditStub;
+      const mockCalculateCPCValue = sinon.stub().resolves(2);
+      const auditStub = await esmock('../../src/metatags/handler.js', {
+        '../../src/support/utils.js': { getRUMDomainkey: mockGetRUMDomainkey, calculateCPCValue: mockCalculateCPCValue },
+        '@adobe/spacecat-shared-rum-api-client': RUMAPIClientStub,
+      });
+      const auditInstance = auditStub.default;
+      await auditInstance.runner('http://example.com', context, site);
+      expect(addAuditStub.calledWithMatch({
+        auditResult: {
+          detectedTags: {
+            '/blog/page1': {
+              h1: {
+                seoImpact: 'High',
+                issue: 'Missing H1',
+                issueDetails: 'H1 tag is missing',
+                seoRecommendation: 'Should be present',
+              },
+              title: {
+                tagContent: 'Test Page',
+                seoImpact: 'High',
+                issue: 'Duplicate Title',
+                issueDetails: '2 pages share same title',
+                seoRecommendation: 'Unique across pages',
+                duplicates: [
+                  '/blog/page2',
+                ],
+              },
+              description: {
+                tagContent: '',
+                seoImpact: 'High',
+                issue: 'Empty Description',
+                issueDetails: 'Description tag is empty',
+                seoRecommendation: '140-160 characters long',
+              },
+            },
+            '/blog/page2': {
+              description: {
+                seoImpact: 'High',
+                issue: 'Missing Description',
+                issueDetails: 'Description tag is missing',
+                seoRecommendation: 'Should be present',
+              },
+              title: {
+                tagContent: 'Test Page',
+                seoImpact: 'High',
+                issue: 'Duplicate Title',
+                issueDetails: '2 pages share same title',
+                seoRecommendation: 'Unique across pages',
+                duplicates: [
+                  '/blog/page1',
+                ],
+              },
+              h1: {
+                tagContent: 'This is a dummy H1 that is intentionally made to be overly lengthy from SEO perspective',
+                seoImpact: 'Moderate',
+                issue: 'H1 too long',
+                issueDetails: '17 chars over limit',
+                seoRecommendation: 'Below 70 characters',
+              },
+            },
+          },
+        },
+      }));
+    }).timeout(5000);
+
     it('should calculate projected traffic for detected tags', async () => {
       const RUMAPIClientStub = {
         createFrom: sinon.stub().returns({
@@ -838,8 +1140,8 @@ describe('Meta Tags', () => {
       await auditInstance.runner('http://example.com', context, site);
       expect(addAuditStub.calledWithMatch({
         auditResult: {
-          projectedTraffic: 200,
-          projectedTrafficValue: 200,
+          projectedTraffic: 600,
+          projectedTrafficValue: 600,
           detectedTags: {
             '/blog/page1': {
               h1: {

--- a/test/audits/metatags.test.js
+++ b/test/audits/metatags.test.js
@@ -974,6 +974,17 @@ describe('Meta Tags', () => {
           },
           ContentType: 'application/json',
         });
+      const getTopPagesForSiteStub = [
+        { getUrl: () => 'http://example.com/blog/page1' },
+        {
+          getUrl: () => 'http://example.com/blog/page2',
+        },
+        {
+          getUrl: () => 'http://example.com/',
+        },
+      ];
+      dataAccessStub.SiteTopPage.allBySiteId.resolves(topPages);
+      dataAccessStub.SiteTopPage.allBySiteIdAndSourceAndGeo.resolves(getTopPagesForSiteStub);
       const addAuditStub = sinon.stub().resolves({ getId: () => 'audit-id' });
       dataAccessStub.Audit.create = addAuditStub;
       const mockCalculateCPCValue = sinon.stub().resolves(2);
@@ -982,8 +993,8 @@ describe('Meta Tags', () => {
         '@adobe/spacecat-shared-rum-api-client': RUMAPIClientStub,
       });
       const auditInstance = auditStub.default;
-      await auditInstance.runner('http://example.com', context, site);
-      expect(addAuditStub.calledWithMatch({
+      const response = await auditInstance.runner('http://example.com', context, site);
+      expect(response).to.deep.equal({
         auditResult: {
           detectedTags: {
             '/blog/page1': {
@@ -999,12 +1010,8 @@ describe('Meta Tags', () => {
                 issue: 'Duplicate Title',
                 issueDetails: '2 pages share same title',
                 seoRecommendation: 'Unique across pages',
-                duplicates: [
-                  '/blog/page2',
-                ],
               },
               description: {
-                tagContent: '',
                 seoImpact: 'High',
                 issue: 'Empty Description',
                 issueDetails: 'Description tag is empty',
@@ -1024,9 +1031,6 @@ describe('Meta Tags', () => {
                 issue: 'Duplicate Title',
                 issueDetails: '2 pages share same title',
                 seoRecommendation: 'Unique across pages',
-                duplicates: [
-                  '/blog/page1',
-                ],
               },
               h1: {
                 tagContent: 'This is a dummy H1 that is intentionally made to be overly lengthy from SEO perspective',
@@ -1037,8 +1041,12 @@ describe('Meta Tags', () => {
               },
             },
           },
+          finalUrl: 'http://example.com',
+          fullAuditRef: '',
+          sourceS3Folder: 'test-bucket/scrapes/site-id/',
         },
-      }));
+        fullAuditRef: 'http://example.com',
+      });
     }).timeout(5000);
 
     it('should calculate projected traffic for detected tags', async () => {
@@ -1048,9 +1056,9 @@ describe('Meta Tags', () => {
             {
               url: 'http://example.com/blog/page1',
               total: 100,
-              earned: 20,
+              earned: 50000,
               owned: 70,
-              paid: 10,
+              paid: 10000,
             },
           ]),
         }),
@@ -1129,6 +1137,17 @@ describe('Meta Tags', () => {
           },
           ContentType: 'application/json',
         });
+      const getTopPagesForSiteStub = [
+        { getUrl: () => 'http://example.com/blog/page1' },
+        {
+          getUrl: () => 'http://example.com/blog/page2',
+        },
+        {
+          getUrl: () => 'http://example.com/',
+        },
+      ];
+      dataAccessStub.SiteTopPage.allBySiteId.resolves(topPages);
+      dataAccessStub.SiteTopPage.allBySiteIdAndSourceAndGeo.resolves(getTopPagesForSiteStub);
       const addAuditStub = sinon.stub().resolves({ getId: () => 'audit-id' });
       dataAccessStub.Audit.create = addAuditStub;
       const mockCalculateCPCValue = sinon.stub().resolves(2);
@@ -1137,11 +1156,11 @@ describe('Meta Tags', () => {
         '@adobe/spacecat-shared-rum-api-client': RUMAPIClientStub,
       });
       const auditInstance = auditStub.default;
-      await auditInstance.runner('http://example.com', context, site);
-      expect(addAuditStub.calledWithMatch({
+      const response = await auditInstance.runner('http://example.com', context, site);
+      expect(response).to.deep.equal({
         auditResult: {
-          projectedTraffic: 600,
-          projectedTrafficValue: 600,
+          projectedTrafficValue: 2400,
+          projectedTrafficLost: 1200,
           detectedTags: {
             '/blog/page1': {
               h1: {
@@ -1156,12 +1175,8 @@ describe('Meta Tags', () => {
                 issue: 'Duplicate Title',
                 issueDetails: '2 pages share same title',
                 seoRecommendation: 'Unique across pages',
-                duplicates: [
-                  '/blog/page2',
-                ],
               },
               description: {
-                tagContent: '',
                 seoImpact: 'High',
                 issue: 'Empty Description',
                 issueDetails: 'Description tag is empty',
@@ -1181,9 +1196,6 @@ describe('Meta Tags', () => {
                 issue: 'Duplicate Title',
                 issueDetails: '2 pages share same title',
                 seoRecommendation: 'Unique across pages',
-                duplicates: [
-                  '/blog/page1',
-                ],
               },
               h1: {
                 tagContent: 'This is a dummy H1 that is intentionally made to be overly lengthy from SEO perspective',
@@ -1194,8 +1206,12 @@ describe('Meta Tags', () => {
               },
             },
           },
+          finalUrl: 'http://example.com',
+          fullAuditRef: '',
+          sourceS3Folder: 'test-bucket/scrapes/site-id/',
         },
-      }));
+        fullAuditRef: 'http://example.com',
+      });
     }).timeout(5000);
   });
 


### PR DESCRIPTION
If the site doesn't have RUM enabled then the meta-tags audit fails as it tries to calculate projected traffic value but gets an error in rum query. In this PR, this error has been handled so that failure to calculate projected traffic doesn't fails the meta-tags audit.