### PR TITLE
fix: ignore login/auth redirects as suggestions

### DIFF
--- a/src/sitemap/handler.js
+++ b/src/sitemap/handler.js
@@ -182,6 +182,13 @@ export async function filterValidUrls(urls) {
   const OTHER_STATUS = 3;
   const BATCH_SIZE = 50;
 
+  /**
+   * Helper function to detect if a URL is a login/authentication page
+   * @param {string} url - URL to check
+   * @returns {boolean} - True if it looks like a login page
+   */
+  const isLoginPage = (url) => /login|signin|sign-in|auth|authentication/i.test(url);
+
   const fetchUrl = async (url) => {
     try {
       const response = await fetch(url, {
@@ -197,6 +204,13 @@ export async function filterValidUrls(urls) {
       if (response.status === 301 || response.status === 302) {
         const redirectUrl = response.headers.get('location');
         const finalUrl = new URL(redirectUrl, url).href;
+
+        // Check if the redirect leads to a login page
+        if (isLoginPage(finalUrl)) {
+          // For login-related redirects, treat them as valid URLs
+          return { status: OK, url };
+        }
+
         try {
           const redirectResponse = await fetch(finalUrl, {
             method: 'HEAD',

--- a/src/sitemap/handler.js
+++ b/src/sitemap/handler.js
@@ -23,6 +23,7 @@ import {
   getSitemapUrlsFromSitemapIndex,
   getUrlWithoutPath,
   toggleWWW,
+  isLoginPage,
 } from '../support/utils.js';
 import { AuditBuilder } from '../common/audit-builder.js';
 import { syncSuggestions } from '../utils/data-access.js';
@@ -182,13 +183,6 @@ export async function filterValidUrls(urls) {
   const OTHER_STATUS = 3;
   const BATCH_SIZE = 50;
 
-  /**
-   * Helper function to detect if a URL is a login/authentication page
-   * @param {string} url - URL to check
-   * @returns {boolean} - True if it looks like a login page
-   */
-  const isLoginPage = (url) => /login|signin|sign-in|auth|authentication/i.test(url);
-
   const fetchUrl = async (url) => {
     try {
       const response = await fetch(url, {
@@ -205,9 +199,8 @@ export async function filterValidUrls(urls) {
         const redirectUrl = response.headers.get('location');
         const finalUrl = new URL(redirectUrl, url).href;
 
-        // Check if the redirect leads to a login page
+        // check if the redirect leads to a login page and treat it as valid URL
         if (isLoginPage(finalUrl)) {
-          // For login-related redirects, treat them as valid URLs
           return { status: OK, url };
         }
 

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -27,6 +27,16 @@ const DEFAULT_CPC_VALUE = 2.69; // $2.69
 
 // weekly pageview threshold to eliminate urls with lack of samples
 
+/**
+ * Checks if a URL appears to be a login or authentication page.
+ *
+ * @param {string} url - URL to check
+ * @returns {boolean} - True if it looks like a login or authentication page
+ */
+export function isLoginPage(url) {
+  return /login|signin|sign-in|auth|authentication/i.test(url);
+}
+
 export async function getRUMUrl(url) {
   const urlWithScheme = prependSchema(url);
   const resp = await fetch(urlWithScheme, {

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -34,7 +34,7 @@ const DEFAULT_CPC_VALUE = 2.69; // $2.69
  * @returns {boolean} - True if it looks like a login or authentication page
  */
 export function isLoginPage(url) {
-  return /login|signin|sign-in|auth|authentication/i.test(url);
+  return /login|log-in|signin|sign-in|auth|authentication/i.test(url);
 }
 
 export async function getRUMUrl(url) {

--- a/test/audits/sitemap.test.js
+++ b/test/audits/sitemap.test.js
@@ -1079,9 +1079,8 @@ describe('Sitemap Audit', () => {
         context.dataAccess.Opportunity.setAuditId,
       ).to.have.been.calledOnceWith('audit-id');
       expect(context.dataAccess.Opportunity.save).to.have.been.calledOnce;
-      expect(
-        context.dataAccess.Opportunity.addSuggestions,
-      ).to.have.been.calledOnceWith(
+      expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledOnceWith(existingSuggestions, 'OUTDATED');
+      expect(context.dataAccess.Opportunity.addSuggestions).to.have.been.calledOnceWith(
         auditDataFailure.suggestions.map((suggestion) => ({
           opportunityId: opptyId,
           type: 'REDIRECT_UPDATE',
@@ -1344,7 +1343,6 @@ describe('filterValidUrls with redirect handling', () => {
           .head(`/url${i + 1}`)
           .reply(200);
       } else {
-        // Remaining URLs are not found
         nock('https://example.com')
           .head(`/url${i + 1}`)
           .reply(404);
@@ -1486,7 +1484,6 @@ describe('filterValidUrls with status code tracking', () => {
 
     const result = await filterValidUrls(urls);
 
-    // Should include 200 responses in ok array
     expect(result.ok).to.deep.equal([
       'https://example.com/ok',
     ]);
@@ -1542,7 +1539,6 @@ describe('filterValidUrls with status code tracking', () => {
 
     const result = await filterValidUrls(urls);
 
-    // All redirects should be in notOk array
     expect(result.notOk).to.have.length(4);
 
     // Redirects to 404 patterns should suggest homepage URL

--- a/test/audits/sitemap.test.js
+++ b/test/audits/sitemap.test.js
@@ -1079,10 +1079,6 @@ describe('Sitemap Audit', () => {
         context.dataAccess.Opportunity.setAuditId,
       ).to.have.been.calledOnceWith('audit-id');
       expect(context.dataAccess.Opportunity.save).to.have.been.calledOnce;
-      expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledOnceWith(
-        existingSuggestions,
-        'OUTDATED',
-      );
       expect(
         context.dataAccess.Opportunity.addSuggestions,
       ).to.have.been.calledOnceWith(
@@ -1397,12 +1393,12 @@ describe('filterValidUrls with redirect handling', () => {
 
     const result = await filterValidUrls(urls);
 
-    // Login redirects should be treated as OK
+    // login redirects should be treated as OK
     expect(result.ok).to.include('https://example.com/myaccount');
     expect(result.ok).to.include('https://example.com/profile');
     expect(result.ok).to.include('https://example.com/cart/checkout');
 
-    // Normal redirects should still be in notOk
+    // normal redirects should still be in notOk
     expect(result.notOk).to.deep.include({
       url: 'https://example.com/normal-redirect',
       statusCode: 302,


### PR DESCRIPTION
Ticket : https://jira.corp.adobe.com/browse/SITES-30357

Details:
the sitemap audit was flagging URL that redirect to login/authentication pages as issues, suggesting alternative URLs.
Since these redirects are intentional - pages like /myaccount/ . should redirect to login pages when the user isn't authenticated.
Solution:  ignore login/authentication redirects in sitemap audit

Tested with https://www.brownthomas.com (siteId: fc2053c8-2b6e-427c-8fd1-11df77d2df26) 

Before:
```
{
	"urlsSuggested": "https://www.brownthomas.com/content/brownthomas/ie/en/login.html",
	"url": "https://www.brownthomas.com/myaccount/",
	"statusCode": 302
}				
```
After:
- the auth and login urls are not longer showed.