### PR TITLE
fix: message received from SQS is not getting logged properly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -84,7 +84,7 @@ async function run(message, context) {
   const { type, siteId } = message;
 
   log.info(`Received ${type} audit request for: ${siteId}`);
-  log.info(`Message ${message}`);
+  log.info(`Message ${JSON.stringify(message)}`);
 
   const handler = HANDLERS[type];
   if (!handler) {


### PR DESCRIPTION
### Fix:
Audit worker message is not logged properly, showing [Object] [Object] in coralogix
#### Before:
![Screenshot 2025-05-07 at 5 31 45 PM](https://github.com/user-attachments/assets/40e4d6e4-e512-49fd-9734-82c7c926313b)

#### After:
![Screenshot 2025-05-07 at 6 07 19 PM](https://github.com/user-attachments/assets/e9592996-4558-4dc7-97b5-de0dec21fe39)


Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues


Thanks for contributing!
