### PR TITLE
fix: urlResolver for meta-tags

### DIFF
--- a/src/metatags/handler.js
+++ b/src/metatags/handler.js
@@ -300,7 +300,7 @@ export async function submitForScraping(context) {
 }
 
 export default new AuditBuilder()
-  .withUrlResolver((site) => site.resolveFinalURL())
+  .withUrlResolver((site) => site.getBaseURL())
   .addStep('submit-for-import-top-pages', importTopPages, AUDIT_STEP_DESTINATIONS.IMPORT_WORKER)
   .addStep('submit-for-scraping', submitForScraping, AUDIT_STEP_DESTINATIONS.CONTENT_SCRAPER)
   .addStep('run-audit-and-generate-suggestions', runAuditAndGenerateSuggestions)

--- a/src/metatags/handler.js
+++ b/src/metatags/handler.js
@@ -143,9 +143,9 @@ function getOrganicTrafficForEndpoint(endpoint, rumDataMapMonthly, rumDataMapBiM
 }
 
 // Calculate the projected traffic lost for a site
-async function calculateProjectedTraffic(context, auditUrl, siteId, detectedTags, log) {
+async function calculateProjectedTraffic(context, site, detectedTags, log) {
   const options = {
-    domain: auditUrl,
+    domain: await wwwUrlResolver(site, context),
     interval: 30,
     granularity: 'DAILY',
   };
@@ -179,15 +179,15 @@ async function calculateProjectedTraffic(context, auditUrl, siteId, detectedTags
       });
     });
 
-    const cpcValue = await calculateCPCValue(context, siteId);
-    log.info(`Calculated cpc value: ${cpcValue} for site: ${siteId}`);
+    const cpcValue = await calculateCPCValue(context, site.getId());
+    log.info(`Calculated cpc value: ${cpcValue} for site: ${site.getId()}`);
     const projectedTrafficValue = projectedTrafficLost * cpcValue;
 
     // Skip updating projected traffic data if lost traffic value is insignificant
     return projectedTrafficValue > PROJECTED_VALUE_THRESHOLD
       ? { projectedTrafficLost, projectedTrafficValue } : {};
   } catch (err) {
-    log.warn(`Error while calculating projected traffic for ${auditUrl} : ${siteId}`, err);
+    log.warn(`Error while calculating projected traffic for ${site.getId()}`, err);
     return {};
   }
 }
@@ -237,8 +237,7 @@ export async function runAuditAndGenerateSuggestions(context) {
     projectedTrafficValue,
   } = await calculateProjectedTraffic(
     context,
-    finalUrl,
-    siteId,
+    site,
     detectedTags,
     log,
   );
@@ -301,7 +300,7 @@ export async function submitForScraping(context) {
 }
 
 export default new AuditBuilder()
-  .withUrlResolver(wwwUrlResolver)
+  .withUrlResolver((site) => site.resolveFinalURL())
   .addStep('submit-for-import-top-pages', importTopPages, AUDIT_STEP_DESTINATIONS.IMPORT_WORKER)
   .addStep('submit-for-scraping', submitForScraping, AUDIT_STEP_DESTINATIONS.CONTENT_SCRAPER)
   .addStep('run-audit-and-generate-suggestions', runAuditAndGenerateSuggestions)

--- a/test/audits/metatags.test.js
+++ b/test/audits/metatags.test.js
@@ -845,6 +845,7 @@ describe('Meta Tags', () => {
         const auditStub = await esmock('../../src/metatags/handler.js', {
           '../../src/support/utils.js': { getRUMDomainkey: mockGetRUMDomainkey, calculateCPCValue: mockCalculateCPCValue },
           '@adobe/spacecat-shared-rum-api-client': RUMAPIClientStub,
+          '../../src/common/index.js': { wwwUrlResolver: (siteObj) => siteObj.getBaseURL() },
           '../../src/metatags/metatags-auto-suggest.js': sinon.stub().resolves({
             '/blog/page1': {
               title: {
@@ -895,7 +896,7 @@ describe('Meta Tags', () => {
         expect(result).to.deep.equal({ status: 'complete' });
         expect(logStub.error).to.have.been.calledWith('No Scraped tags found in S3 scrapes/site-id/blog/page3/scrape.json object');
         expect(logStub.error).to.have.been.calledWith('Failed to extract tags from scraped content for bucket test-bucket and prefix scrapes/site-id/');
-      });
+      }).timeout(3000);
 
       it('should handle RUM API errors gracefully', async () => {
         const mockGetRUMDomainkey = sinon.stub().resolves('mockedDomainKey');
@@ -903,6 +904,7 @@ describe('Meta Tags', () => {
         const auditStub = await esmock('../../src/metatags/handler.js', {
           '../../src/support/utils.js': { getRUMDomainkey: mockGetRUMDomainkey, calculateCPCValue: mockCalculateCPCValue },
           '@adobe/spacecat-shared-rum-api-client': RUMAPIClientStub,
+          '../../src/common/index.js': { wwwUrlResolver: (siteObj) => siteObj.getBaseURL() },
           '../../src/metatags/metatags-auto-suggest.js': sinon.stub().resolves({}),
         });
         // Override RUM API response to simulate error
@@ -911,7 +913,7 @@ describe('Meta Tags', () => {
         const result = await auditStub.runAuditAndGenerateSuggestions(context);
 
         expect(result).to.deep.equal({ status: 'complete' });
-        expect(logStub.warn).to.have.been.calledWith('Error while calculating projected traffic for http://example.com : site-id', sinon.match.instanceOf(Error));
+        expect(logStub.warn).to.have.been.calledWith('Error while calculating projected traffic for site-id', sinon.match.instanceOf(Error));
       });
     });
 


### PR DESCRIPTION
### **Issue reported** 
The meta-tag audit identified new opportunities for hersheyland and created new suggestions. But some of them were already ignored, e.g. “Duplicate H1” for  https://www.hersheyland.com/milk-duds and https://www.hersheyland.com/products/milk-duds-candy-5-oz-box.html. So now the same suggestion is in “Current” and “Ignored”.

### **RCA**
The meta-tags audit identifies suggestions through key: url | issue | tagContent
The URLs in both the suggestions are different.
From old audit:
"url": "https://hersheyland.com/milk-duds",
From new audit:
"url": "www.hersheyland.com/milk-duds"
This is because there has been a [change](https://github.com/adobe/spacecat-audit-worker/pull/750) to use the new urlResolver, instead of the old noopUrlResolver, which resulted in this issue.

### **Fix**
Use wwwUrlResolver for resolving domain for RUM, for other things use site base url.
