### PR TITLE
feat: add preview page authentication to canonical audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@adobe/spacecat-shared-http-utils": "1.11.0",
         "@adobe/spacecat-shared-rum-api-client": "2.24.2",
         "@adobe/spacecat-shared-rum-api-client-v1": "npm:@adobe/spacecat-shared-rum-api-client@1.8.4",
-        "@adobe/spacecat-shared-utils": "1.37.4",
+        "@adobe/spacecat-shared-utils": "1.38.0",
         "@aws-sdk/client-lambda": "3.806.0",
         "@aws-sdk/client-s3": "3.806.0",
         "@aws-sdk/client-sqs": "3.806.0",
@@ -16123,13 +16123,14 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-utils": {
-      "version": "1.37.4",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.37.4.tgz",
-      "integrity": "sha512-tmuRjytorggJo4Y/nI4qF/OPvWvwJkayN1nHT9HLFRvtNYXu8VqrDaw7Vm2FXRGlsIynZiazGZKbYeiBM4wToA==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.38.0.tgz",
+      "integrity": "sha512-UdEtL0Y0ah1gXDbtasmUu6huqmgY0B2uYAKnTKrp7XZQcS56hXeatgKcGGuc7cyCU9O4eWLwjEVG7+9/HOp//g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.1",
         "@aws-sdk/client-s3": "3.806.0",
+        "@aws-sdk/client-secrets-manager": "3.806.0",
         "@aws-sdk/client-sqs": "3.806.0",
         "@json2csv/plainjs": "7.0.6",
         "aws-xray-sdk": "3.10.3",
@@ -16138,6 +16139,236 @@
       "engines": {
         "node": ">=22.0.0 <23.0.0",
         "npm": ">=10.9.0 <12.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/client-secrets-manager": {
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.806.0.tgz",
+      "integrity": "sha512-AYjs1hCI49JtaIX+8wvqT3odWy9shsbAxxbxQXmQtc3lbaZlsJzeKpbvjNapdjQAqUORW/iAz56MtuS03uCzFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.806.0",
+        "@aws-sdk/credential-provider-node": "3.806.0",
+        "@aws-sdk/middleware-host-header": "3.804.0",
+        "@aws-sdk/middleware-logger": "3.804.0",
+        "@aws-sdk/middleware-recursion-detection": "3.804.0",
+        "@aws-sdk/middleware-user-agent": "3.806.0",
+        "@aws-sdk/region-config-resolver": "3.806.0",
+        "@aws-sdk/types": "3.804.0",
+        "@aws-sdk/util-endpoints": "3.806.0",
+        "@aws-sdk/util-user-agent-browser": "3.804.0",
+        "@aws-sdk/util-user-agent-node": "3.806.0",
+        "@smithy/config-resolver": "^4.1.1",
+        "@smithy/core": "^3.3.1",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/hash-node": "^4.0.2",
+        "@smithy/invalid-dependency": "^4.0.2",
+        "@smithy/middleware-content-length": "^4.0.2",
+        "@smithy/middleware-endpoint": "^4.1.3",
+        "@smithy/middleware-retry": "^4.1.4",
+        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-stack": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.0",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.3",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
+        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-body-length-browser": "^4.0.0",
+        "@smithy/util-body-length-node": "^4.0.0",
+        "@smithy/util-defaults-mode-browser": "^4.0.11",
+        "@smithy/util-defaults-mode-node": "^4.0.11",
+        "@smithy/util-endpoints": "^3.0.3",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-retry": "^4.0.3",
+        "@smithy/util-utf8": "^4.0.0",
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/client-secrets-manager/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/core": {
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.806.0.tgz",
+      "integrity": "sha512-HJRINPncdjPK0iL3f6cBpqCMaxVwq2oDbRCzOx04tsLZ0tNgRACBfT3d/zNVRvMt6fnOVKXoN1LAtQaw50pjEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/core": "^3.3.1",
+        "@smithy/node-config-provider": "^4.1.0",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/signature-v4": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.3",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-middleware": "^4.0.2",
+        "fast-xml-parser": "4.4.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.804.0.tgz",
+      "integrity": "sha512-bum1hLVBrn2lJCi423Z2fMUYtsbkGI2s4N+2RI2WSjvbaVyMSv/WcejIrjkqiiMR+2Y7m5exgoKeg4/TODLDPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.804.0.tgz",
+      "integrity": "sha512-w/qLwL3iq0KOPQNat0Kb7sKndl9BtceigINwBU7SpkYWX9L/Lem6f8NPEKrC9Tl4wDBht3Yztub4oRTy/horJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.804.0.tgz",
+      "integrity": "sha512-zqHOrvLRdsUdN/ehYfZ9Tf8svhbiLLz5VaWUz22YndFv6m9qaAcijkpAOlKexsv3nLBMJdSdJ6GUTAeIy3BZzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.806.0.tgz",
+      "integrity": "sha512-XoIromVffgXnc+/mjlR2EVzQVIei3bPVtafIZNsHuEmUvIWJXiWsa2eJpt3BUqa0HF9YPknK7ommNEhqRb8ucg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.806.0",
+        "@aws-sdk/types": "3.804.0",
+        "@aws-sdk/util-endpoints": "3.806.0",
+        "@smithy/core": "^3.3.1",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.806.0.tgz",
+      "integrity": "sha512-cuv5pX55JOlzKC/iLsB5nZ9eUyVgncim3VhhWHZA/KYPh7rLMjOEfZ+xyaE9uLJXGmzOJboFH7+YdTRdIcOgrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/node-config-provider": "^4.1.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/types": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.804.0.tgz",
+      "integrity": "sha512-A9qnsy9zQ8G89vrPPlNG9d1d8QcKRGqJKqwyGgS0dclJpwy6d1EWgQLIolKPl6vcFpLoe6avLOLxr+h8ur5wpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.806.0.tgz",
+      "integrity": "sha512-3YRRgZ+qFuWDdm5uAbxKsr65UAil4KkrFKua9f4m7Be3v24ETiFOOqhanFUIk9/WOtvzF7oFEiDjYKDGlwV2xg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-endpoints": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.804.0.tgz",
+      "integrity": "sha512-KfW6T6nQHHM/vZBBdGn6fMyG/MgX5lq82TDdX4HRQRRuHKLgBWGpKXqqvBwqIaCdXwWHgDrg2VQups6GqOWW2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/types": "^4.2.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.806.0.tgz",
+      "integrity": "sha512-Az2e4/gmPZ4BpB7QRj7U76I+fctXhNcxlcgsaHnMhvt+R30nvzM2EhsyBUvsWl8+r9bnLeYt9BpvEZeq2ANDzA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.806.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/node-config-provider": "^4.1.0",
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
       }
     },
     "node_modules/@adobe/spacecat-shared-utils/node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@adobe/spacecat-shared-http-utils": "1.11.0",
     "@adobe/spacecat-shared-rum-api-client": "2.24.2",
     "@adobe/spacecat-shared-rum-api-client-v1": "npm:@adobe/spacecat-shared-rum-api-client@1.8.4",
-    "@adobe/spacecat-shared-utils": "1.37.4",
+    "@adobe/spacecat-shared-utils": "1.38.0",
     "@aws-sdk/client-lambda": "3.806.0",
     "@aws-sdk/client-s3": "3.806.0",
     "@aws-sdk/client-sqs": "3.806.0",

--- a/src/canonical/handler.js
+++ b/src/canonical/handler.js
@@ -11,9 +11,13 @@
  */
 
 import { JSDOM } from 'jsdom';
-import { composeBaseURL, tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
+import { composeBaseURL, tracingFetch as fetch, retrievePageAuthentication } from '@adobe/spacecat-shared-utils';
 import { AuditBuilder } from '../common/audit-builder.js';
 import { noopUrlResolver } from '../common/index.js';
+
+/**
+ * @import {type RequestOptions} from "@adobe/fetch"
+*/
 
 export const CANONICAL_CHECKS = Object.freeze({
   CANONICAL_TAG_EXISTS: {
@@ -126,9 +130,10 @@ export async function getTopPagesForSiteId(dataAccess, siteId, context, log) {
  *
  * @param {string} url - The URL to validate the canonical tag for.
  * @param {Object} log - The logging object to log information.
+ * @param {RequestOptions} options - The options object to pass to the fetch function.
  * @returns {Promise<Object>} An object containing the canonical URL and an array of checks.
  */
-export async function validateCanonicalTag(url, log) {
+export async function validateCanonicalTag(url, log, options = {}) {
   // in case of undefined or null URL in the 200 top pages list
   if (!url) {
     const errorMessage = 'URL is undefined or null';
@@ -145,7 +150,7 @@ export async function validateCanonicalTag(url, log) {
 
   try {
     log.info(`Fetching URL: ${url}`);
-    const response = await fetch(url);
+    const response = await fetch(url, options);
     const html = await response.text();
     const dom = new JSDOM(html);
     const { document } = dom.window;
@@ -376,10 +381,16 @@ export function validateCanonicalFormat(canonicalUrl, baseUrl, log) {
  *
  * @param {string} canonicalUrl - The canonical URL to validate.
  * @param {Object} log - The logging object to log information.
+ * @param {RequestOptions} options - The options object to pass to the fetch function.
  * @param {Set<string>} [visitedUrls=new Set()] - A set of visited URLs to detect redirect loops.
  * @returns {Promise<Object>} An object with the check result and any error if the check failed.
  */
-export async function validateCanonicalRecursively(canonicalUrl, log, visitedUrls = new Set()) {
+export async function validateCanonicalRecursively(
+  canonicalUrl,
+  log,
+  options = {},
+  visitedUrls = new Set(),
+) {
   const checks = [];
 
   // Check for redirect loops
@@ -397,7 +408,7 @@ export async function validateCanonicalRecursively(canonicalUrl, log, visitedUrl
   visitedUrls.add(canonicalUrl);
 
   try {
-    const response = await fetch(canonicalUrl, { redirect: 'manual' });
+    const response = await fetch(canonicalUrl, { ...options, redirect: 'manual' });
     if (response.ok) {
       log.info(`Canonical URL is accessible: ${canonicalUrl}, statusCode: ${response.status}`);
       checks.push({
@@ -459,9 +470,30 @@ export async function validateCanonicalRecursively(canonicalUrl, log, visitedUrl
  * @returns {Promise<Object>} An object containing the audit results.
  */
 export async function canonicalAuditRunner(baseURL, context, site) {
+  function isPreviewPage(url) {
+    const urlObj = new URL(url);
+    return urlObj.hostname.endsWith('.page');
+  }
+
   const siteId = site.getId();
   const { log, dataAccess } = context;
   log.info(`Starting Canonical Audit with siteId: ${JSON.stringify(siteId)}`);
+
+  /**
+   * @type {RequestOptions}
+   */
+  const options = {};
+  if (isPreviewPage(baseURL)) {
+    try {
+      log.info(`Retrieving page authentication for pageUrl ${baseURL}`);
+      const token = await retrievePageAuthentication(site, context);
+      options.headers = {
+        Authorization: `token ${token}`,
+      };
+    } catch (error) {
+      log.error(`Error retrieving page authentication for pageUrl ${baseURL}: ${error.message}`);
+    }
+  }
 
   try {
     const topPages = await getTopPagesForSiteId(dataAccess, siteId, context, log);
@@ -483,7 +515,9 @@ export async function canonicalAuditRunner(baseURL, context, site) {
       const { url } = page;
       const checks = [];
 
-      const { canonicalUrl, checks: canonicalTagChecks } = await validateCanonicalTag(url, log);
+      const {
+        canonicalUrl, checks: canonicalTagChecks,
+      } = await validateCanonicalTag(url, log, options);
       checks.push(...canonicalTagChecks);
 
       if (canonicalUrl) {
@@ -492,7 +526,7 @@ export async function canonicalAuditRunner(baseURL, context, site) {
         const urlFormatChecks = validateCanonicalFormat(canonicalUrl, baseURL, log);
         checks.push(...urlFormatChecks);
 
-        const urlContentCheck = await validateCanonicalRecursively(canonicalUrl, log);
+        const urlContentCheck = await validateCanonicalRecursively(canonicalUrl, log, options);
         checks.push(...urlContentCheck);
       }
       return { url, checks };

--- a/test/audits/canonical.test.js
+++ b/test/audits/canonical.test.js
@@ -288,7 +288,7 @@ describe('Canonical URL Tests', () => {
         .get('/page2')
         .reply(200);
 
-      const result = await validateCanonicalRecursively(canonicalUrl, log, new Set());
+      const result = await validateCanonicalRecursively(canonicalUrl, log);
 
       expect(result).to.deep.include.members([
         {
@@ -440,10 +440,13 @@ describe('Canonical URL Tests', () => {
     });
 
     it('should detect and handle redirect loop correctly', async () => {
+      const options = {
+        redirect: 'manual',
+      };
       const canonicalUrl = 'http://example.com/redirect-loop';
       const visitedUrls = new Set([canonicalUrl]);
 
-      const result = await validateCanonicalRecursively(canonicalUrl, log, visitedUrls);
+      const result = await validateCanonicalRecursively(canonicalUrl, log, options, visitedUrls);
 
       expect(result).to.deep.include({
         check: 'canonical-url-no-redirect',


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes

## Related Issues
https://jira.corp.adobe.com/browse/SITES-31664

This PR adds support for authenticating preview pages in the canonical audit functionality. When auditing pages on `.page` domains, the system will now retrieve and use the appropriate authentication token.
