### PR TITLE
fix: running audits locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ Expected message body format in `AUDIT_JOBS_QUEUE` is:
 ```json
 {
   "type": "string",
-  "url": "string",
-  "auditContext": "object"
+  "siteId": "string"
 }
 ```
 
@@ -65,20 +64,108 @@ Output message body format sent to `AUDIT_RESULTS_QUEUE` is:
 }
 ```
 
-## Required ENV Variables
+## How to Run Locally
 
-Currently, audit worker requires a couple of env variables:
+### 1. Using `nodemon` and AWS Credentials
 
-```plaintext
-AUDIT_RESULTS_QUEUE_URL=url of the queue to send audit results to
-RUM_DOMAIN_KEY=global domain key for the rum api
-PAGESPEED_API_BASE_URL = URL of the pagespeed api
-DYNAMO_TABLE_NAME_SITES = name of the dynamo table to store site data
-DYNAMO_TABLE_NAME_AUDITS = name of the dynamo table to store audit data
-DYNAMO_TABLE_NAME_LATEST_AUDITS = name of the dynamo table to store latest audit data
-DYNAMO_INDEX_NAME_ALL_SITES = name of the dynamo index to query all sites
-DYNAMO_INDEX_NAME_ALL_LATEST_AUDIT_SCORES = name of the dynamo index to query all latest audits by scores
+Everyone working on Spacecat should have access to the development environments via [KLAM](https://klam.corp.adobe.com/).  
+If you don’t have access, please refer to the engineering onboarding guide or contact your Spacecat team representative.
+
+After logging into KLAM, you’ll receive the following credentials required to access AWS resources such as DynamoDB and S3 for local development:
+
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_SESSION_TOKEN`
+
+**IMPORTANT: DO NOT USE THE AWS TOKENS FROM KLAM PRODUCTION PROFILES. USE ONLY DEV TOKENS.**
+
+
+### Steps to use `nodemon`
+
+#### 1. Create an `.env` File
+
+Create a `.env` file in the root directory with the following environment variables, which are required for all audits.  
+Add any additional environment variables specific to the audit you're working on.
+
 ```
+AWS_REGION=us-east-1
+DYNAMO_TABLE_NAME_DATA=spacecat-services-data
+AWS_ACCESS_KEY_ID=<acquired from KLAM>
+AWS_SECRET_ACCESS_KEY=<acquired from KLAM>
+AWS_SESSION_TOKEN=<acquired from KLAM>
+# ... other required variables depending on the audit
+```
+
+#### 2. Run/Debug with `npm start`
+
+Once your `.env` file is set up, start the local development server using:
+
+```bash
+npm start
+```
+
+To use breakpoints, make sure to use the debugging tools provided by your IDE (e.g., VSCode, WebStorm, etc.).
+
+#### 3. Trigger an Audit
+
+With the server running, you can trigger an audit using a `curl` POST request. The request body should include the audit type and `siteId`:
+
+```json
+{
+  "type": "<audit handler name>",
+  "siteId": "<siteId>"
+}
+```
+
+- A list of audit handler names can be found in the [index.js file](https://github.com/adobe/spacecat-audit-worker/blob/main/src/index.js#L45).
+- You can retrieve a `siteId` using:
+    - The [Spacecat API](https://opensource.adobe.com/spacecat-api-service/#tag/site/operation/getSiteByBaseUrl)
+    - The Slack command: `@spacecat-dev get site domain.com`
+
+Example `curl` request to trigger the "apex" audit:
+
+```bash
+curl -X POST http://localhost:3000 \
+     -H "Content-Type: application/json" \
+     -d '{ "type": "apex", "siteId": "9ab0575a-c238-4470-ae82-9d37fb2d0e78" }'
+```
+
+#### 4. Inspect the Audit Result in DynamoDB
+
+Once the audit completes, the results are saved to DynamoDB by default (unless configured otherwise).
+
+To retrieve the audit result, use the [Spacecat API](https://opensource.adobe.com/spacecat-api-service/#tag/audit/operation/getLatestAuditForSite).
+
+For example, to fetch the result for the "apex" audit triggered above:
+
+```bash
+curl -H "x-api-key: <YOUR_API_KEY>" \
+     "https://spacecat.experiencecloud.live/api/ci/sites/9ab0575a-c238-4470-ae82-9d37fb2d0e78/latest-audit/apex"
+```
+
+**Note:**  
+Always verify the timestamp of the returned audit result. If the audit failed to save (e.g., due to a bug), you might receive results from a previous run.
+
+
+
+
+### 2. Using AWS SAM and Docker.
+
+1. Ensure you have [Docker](https://docs.docker.com/desktop/setup/install/mac-install/), [AWS SAM](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html) and [jq](https://jqlang.org/) installed.
+2. Login to AWS using [KLAM](https://klam.corp.adobe.com/) and login with your [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
+    * KLAM dev project: `SpaceCat Development (AWS3338)`
+3. To provide secrets to the audit, please run `./scripts/populate-env.sh` once. It will fetch all secrets from the AWS Secret Manager.
+4. To run the audit locally, execute the following commands:
+    ```bash
+    source env.sh
+    npm run local-build
+    npm run local-run
+    ```
+5. Starting point of the execution is `src/index-local.js`. Output of the audit can be found in `output.txt`.
+6. To hot reload any changes in the `/src` folder, you can use `npm run local-watch`. Note: This will require to run `npm run local-build` at least once beforehand.
+
+If you need to add additional secrets, make sure to adjust the Lambda `template.yml` accordingly.
+
 
 ## Audit Worker Flow
 
@@ -546,22 +633,3 @@ Here's how messages flow between workers in a step-based audit:
 ```
 
 Each message preserves the `auditContext` to maintain the step chain. The `next` field determines which step runs next, while `auditId` and `fullAuditRef` track the audit state across workers.
-
-## Run Audits locally
-
-You can run the audit locally using AWS SAM and Docker.
-
-1. Ensure you have [Docker](https://docs.docker.com/desktop/setup/install/mac-install/), [AWS SAM](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html) and [jq](https://jqlang.org/) installed.
-2. Login to AWS using [KLAM](https://klam.corp.adobe.com/) and login with your [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
-   * KLAM dev project: `SpaceCat Development (AWS3338)`
-3. To provide secrets to the audit, please run `./scripts/populate-env.sh` once. It will fetch all secrets from the AWS Secret Manager.
-4. To run the audit locally, execute the following commands:
-    ```bash
-    source env.sh
-    npm run local-build
-    npm run local-run
-    ```
-5. Starting point of the execution is `src/index-local.js`. Output of the audit can be found in `output.txt`.
-6. To hot reload any changes in the `/src` folder, you can use `npm run local-watch`. Note: This will require to run `npm run local-build` at least once beforehand.
-
-If you need to add additional secrets, make sure to adjust the Lambda `template.yml` accordingly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,13 +16,13 @@
         "@adobe/helix-universal": "5.2.1",
         "@adobe/helix-universal-logger": "3.0.25",
         "@adobe/spacecat-shared-ahrefs-client": "1.6.19",
-        "@adobe/spacecat-shared-data-access": "2.19.0",
-        "@adobe/spacecat-shared-google-client": "1.4.24",
+        "@adobe/spacecat-shared-data-access": "2.19.1",
+        "@adobe/spacecat-shared-google-client": "1.4.25",
         "@adobe/spacecat-shared-gpt-client": "1.5.11",
         "@adobe/spacecat-shared-http-utils": "1.11.0",
         "@adobe/spacecat-shared-rum-api-client": "2.24.2",
         "@adobe/spacecat-shared-rum-api-client-v1": "npm:@adobe/spacecat-shared-rum-api-client@1.8.4",
-        "@adobe/spacecat-shared-utils": "1.38.0",
+        "@adobe/spacecat-shared-utils": "1.38.1",
         "@aws-sdk/client-lambda": "3.806.0",
         "@aws-sdk/client-s3": "3.806.0",
         "@aws-sdk/client-sqs": "3.806.0",
@@ -40,6 +40,7 @@
         "@adobe/eslint-config-helix": "2.0.9",
         "@adobe/helix-deploy": "https://gitpkg.now.sh/alinarublea/helix-deploy?main",
         "@adobe/helix-universal": "5.2.1",
+        "@adobe/helix-universal-devserver": "1.1.115",
         "@adobe/semantic-release-coralogix": "1.1.36",
         "@adobe/semantic-release-skms-cmr": "1.1.5",
         "@redocly/cli": "1.34.3",
@@ -704,6 +705,19 @@
       "dependencies": {
         "@adobe/fetch": "4.2.1",
         "aws4": "1.13.2"
+      }
+    },
+    "node_modules/@adobe/helix-universal-devserver": {
+      "version": "1.1.115",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-universal-devserver/-/helix-universal-devserver-1.1.115.tgz",
+      "integrity": "sha512-quUnMHFr8R9YwR8l8UJhITvb8xG3oAtxZ1MeFnxhZPKh1zoA9azXhsAlPUsxwvKl9qpcPNYnBtT11dCc1wHgNQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@adobe/helix-deploy": "^12.0.0",
+        "@adobe/helix-universal": "^5.1.0",
+        "express": "5.1.0",
+        "fs-extra": "11.3.0"
       }
     },
     "node_modules/@adobe/helix-universal-logger": {
@@ -1492,12 +1506,12 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-2.19.0.tgz",
-      "integrity": "sha512-LdTGL50KgGoIjBFH1DX+udlZlmgCTmeWkCtsZuUjW7FwvWfqqAo98jvy0qJ23AXI4OTO7UWyyRjK3oEHlAWwDw==",
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-2.19.1.tgz",
+      "integrity": "sha512-O2pLGU+DWXCkfQhnWqijLxs9TiuYvTPIdtYmdcp2U1+uGJ83rNjwrGpkY4fNXSarkjchhmdzDj5dfDqE2TRkEA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/spacecat-shared-utils": "1.33.1",
+        "@adobe/spacecat-shared-utils": "1.38.0",
         "@aws-sdk/client-dynamodb": "3.806.0",
         "@aws-sdk/lib-dynamodb": "3.806.0",
         "@types/joi": "17.2.3",
@@ -1512,29 +1526,16 @@
         "npm": ">=10.9.0 <12.0.0"
       }
     },
-    "node_modules/@adobe/spacecat-shared-data-access/node_modules/@adobe/fetch": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.1.11.tgz",
-      "integrity": "sha512-Zak2kPJuIdg9UQQfUgNm848vRAg2pdOqYYU+7DkCYWO+SgZiMV+qy99BpO1geDiP2rQ2M7JH5oNXRTEvEWglRQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "4.4.0",
-        "http-cache-semantics": "4.1.1",
-        "lru-cache": "7.18.3"
-      },
-      "engines": {
-        "node": ">=14.16"
-      }
-    },
     "node_modules/@adobe/spacecat-shared-data-access/node_modules/@adobe/spacecat-shared-utils": {
-      "version": "1.33.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.33.1.tgz",
-      "integrity": "sha512-0TkOSIZSSyzzgLTz3kdX8ioVj/mMyw6FuwNtJhFmsrc/+MT3fN/tkmTHt08JYj1+guXHW7bz9teKps2E5B6+Og==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.38.0.tgz",
+      "integrity": "sha512-UdEtL0Y0ah1gXDbtasmUu6huqmgY0B2uYAKnTKrp7XZQcS56hXeatgKcGGuc7cyCU9O4eWLwjEVG7+9/HOp//g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/fetch": "4.1.11",
-        "@aws-sdk/client-s3": "3.750.0",
-        "@aws-sdk/client-sqs": "3.750.0",
+        "@adobe/fetch": "4.2.1",
+        "@aws-sdk/client-s3": "3.806.0",
+        "@aws-sdk/client-secrets-manager": "3.806.0",
+        "@aws-sdk/client-sqs": "3.806.0",
         "@json2csv/plainjs": "7.0.6",
         "aws-xray-sdk": "3.10.3",
         "uuid": "11.1.0"
@@ -1544,189 +1545,86 @@
         "npm": ">=10.9.0 <12.0.0"
       }
     },
-    "node_modules/@adobe/spacecat-shared-data-access/node_modules/@aws-sdk/client-s3": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.750.0.tgz",
-      "integrity": "sha512-S9G9noCeBxchoMVkHYrRi1A1xW/VOTP2W7X34lP+Y7Wpl32yMA7IJo0fAGAuTc0q1Nu6/pXDm+oDG7rhTCA1tg==",
+    "node_modules/@adobe/spacecat-shared-data-access/node_modules/@aws-sdk/client-secrets-manager": {
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.806.0.tgz",
+      "integrity": "sha512-AYjs1hCI49JtaIX+8wvqT3odWy9shsbAxxbxQXmQtc3lbaZlsJzeKpbvjNapdjQAqUORW/iAz56MtuS03uCzFg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/credential-provider-node": "3.750.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.734.0",
-        "@aws-sdk/middleware-expect-continue": "3.734.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.750.0",
-        "@aws-sdk/middleware-host-header": "3.734.0",
-        "@aws-sdk/middleware-location-constraint": "3.734.0",
-        "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
-        "@aws-sdk/middleware-sdk-s3": "3.750.0",
-        "@aws-sdk/middleware-ssec": "3.734.0",
-        "@aws-sdk/middleware-user-agent": "3.750.0",
-        "@aws-sdk/region-config-resolver": "3.734.0",
-        "@aws-sdk/signature-v4-multi-region": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-endpoints": "3.743.0",
-        "@aws-sdk/util-user-agent-browser": "3.734.0",
-        "@aws-sdk/util-user-agent-node": "3.750.0",
-        "@aws-sdk/xml-builder": "3.734.0",
-        "@smithy/config-resolver": "^4.0.1",
-        "@smithy/core": "^3.1.4",
-        "@smithy/eventstream-serde-browser": "^4.0.1",
-        "@smithy/eventstream-serde-config-resolver": "^4.0.1",
-        "@smithy/eventstream-serde-node": "^4.0.1",
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/hash-blob-browser": "^4.0.1",
-        "@smithy/hash-node": "^4.0.1",
-        "@smithy/hash-stream-node": "^4.0.1",
-        "@smithy/invalid-dependency": "^4.0.1",
-        "@smithy/md5-js": "^4.0.1",
-        "@smithy/middleware-content-length": "^4.0.1",
-        "@smithy/middleware-endpoint": "^4.0.5",
-        "@smithy/middleware-retry": "^4.0.6",
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/middleware-stack": "^4.0.1",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/node-http-handler": "^4.0.2",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.5",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
+        "@aws-sdk/core": "3.806.0",
+        "@aws-sdk/credential-provider-node": "3.806.0",
+        "@aws-sdk/middleware-host-header": "3.804.0",
+        "@aws-sdk/middleware-logger": "3.804.0",
+        "@aws-sdk/middleware-recursion-detection": "3.804.0",
+        "@aws-sdk/middleware-user-agent": "3.806.0",
+        "@aws-sdk/region-config-resolver": "3.806.0",
+        "@aws-sdk/types": "3.804.0",
+        "@aws-sdk/util-endpoints": "3.806.0",
+        "@aws-sdk/util-user-agent-browser": "3.804.0",
+        "@aws-sdk/util-user-agent-node": "3.806.0",
+        "@smithy/config-resolver": "^4.1.1",
+        "@smithy/core": "^3.3.1",
+        "@smithy/fetch-http-handler": "^5.0.2",
+        "@smithy/hash-node": "^4.0.2",
+        "@smithy/invalid-dependency": "^4.0.2",
+        "@smithy/middleware-content-length": "^4.0.2",
+        "@smithy/middleware-endpoint": "^4.1.3",
+        "@smithy/middleware-retry": "^4.1.4",
+        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-stack": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.0",
+        "@smithy/node-http-handler": "^4.0.4",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.3",
+        "@smithy/types": "^4.2.0",
+        "@smithy/url-parser": "^4.0.2",
         "@smithy/util-base64": "^4.0.0",
         "@smithy/util-body-length-browser": "^4.0.0",
         "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.6",
-        "@smithy/util-defaults-mode-node": "^4.0.6",
-        "@smithy/util-endpoints": "^3.0.1",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-retry": "^4.0.1",
-        "@smithy/util-stream": "^4.1.1",
+        "@smithy/util-defaults-mode-browser": "^4.0.11",
+        "@smithy/util-defaults-mode-node": "^4.0.11",
+        "@smithy/util-endpoints": "^3.0.3",
+        "@smithy/util-middleware": "^4.0.2",
+        "@smithy/util-retry": "^4.0.3",
         "@smithy/util-utf8": "^4.0.0",
-        "@smithy/util-waiter": "^4.0.2",
-        "tslib": "^2.6.2"
+        "@types/uuid": "^9.0.1",
+        "tslib": "^2.6.2",
+        "uuid": "^9.0.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@adobe/spacecat-shared-data-access/node_modules/@aws-sdk/client-sqs": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.750.0.tgz",
-      "integrity": "sha512-UelUCqyE0hTXBm1nMXX36mHSZnnVhRcTQjxux8mgHnlRppMRz1qYNkgV7uOEPuRFeFxxgMxOROnSEDUqfoOuHA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/credential-provider-node": "3.750.0",
-        "@aws-sdk/middleware-host-header": "3.734.0",
-        "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
-        "@aws-sdk/middleware-sdk-sqs": "3.750.0",
-        "@aws-sdk/middleware-user-agent": "3.750.0",
-        "@aws-sdk/region-config-resolver": "3.734.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-endpoints": "3.743.0",
-        "@aws-sdk/util-user-agent-browser": "3.734.0",
-        "@aws-sdk/util-user-agent-node": "3.750.0",
-        "@smithy/config-resolver": "^4.0.1",
-        "@smithy/core": "^3.1.4",
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/hash-node": "^4.0.1",
-        "@smithy/invalid-dependency": "^4.0.1",
-        "@smithy/md5-js": "^4.0.1",
-        "@smithy/middleware-content-length": "^4.0.1",
-        "@smithy/middleware-endpoint": "^4.0.5",
-        "@smithy/middleware-retry": "^4.0.6",
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/middleware-stack": "^4.0.1",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/node-http-handler": "^4.0.2",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.5",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.6",
-        "@smithy/util-defaults-mode-node": "^4.0.6",
-        "@smithy/util-endpoints": "^3.0.1",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-retry": "^4.0.1",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-data-access/node_modules/@aws-sdk/client-sso": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.750.0.tgz",
-      "integrity": "sha512-y0Rx6pTQXw0E61CaptpZF65qNggjqOgymq/RYZU5vWba5DGQ+iqGt8Yq8s+jfBoBBNXshxq8l8Dl5Uq/JTY1wg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/middleware-host-header": "3.734.0",
-        "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
-        "@aws-sdk/middleware-user-agent": "3.750.0",
-        "@aws-sdk/region-config-resolver": "3.734.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-endpoints": "3.743.0",
-        "@aws-sdk/util-user-agent-browser": "3.734.0",
-        "@aws-sdk/util-user-agent-node": "3.750.0",
-        "@smithy/config-resolver": "^4.0.1",
-        "@smithy/core": "^3.1.4",
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/hash-node": "^4.0.1",
-        "@smithy/invalid-dependency": "^4.0.1",
-        "@smithy/middleware-content-length": "^4.0.1",
-        "@smithy/middleware-endpoint": "^4.0.5",
-        "@smithy/middleware-retry": "^4.0.6",
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/middleware-stack": "^4.0.1",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/node-http-handler": "^4.0.2",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.5",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.6",
-        "@smithy/util-defaults-mode-node": "^4.0.6",
-        "@smithy/util-endpoints": "^3.0.1",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-retry": "^4.0.1",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
+    "node_modules/@adobe/spacecat-shared-data-access/node_modules/@aws-sdk/client-secrets-manager/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access/node_modules/@aws-sdk/core": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.750.0.tgz",
-      "integrity": "sha512-bZ5K7N5L4+Pa2epbVpUQqd1XLG2uU8BGs/Sd+2nbgTf+lNQJyIxAg/Qsrjz9MzmY8zzQIeRQEkNmR6yVAfCmmQ==",
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.806.0.tgz",
+      "integrity": "sha512-HJRINPncdjPK0iL3f6cBpqCMaxVwq2oDbRCzOx04tsLZ0tNgRACBfT3d/zNVRvMt6fnOVKXoN1LAtQaw50pjEA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/core": "^3.1.4",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/signature-v4": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.5",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-middleware": "^4.0.1",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/core": "^3.3.1",
+        "@smithy/node-config-provider": "^4.1.0",
+        "@smithy/property-provider": "^4.0.2",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/signature-v4": "^5.1.0",
+        "@smithy/smithy-client": "^4.2.3",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-middleware": "^4.0.2",
         "fast-xml-parser": "4.4.1",
         "tslib": "^2.6.2"
       },
@@ -1734,154 +1632,44 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@adobe/spacecat-shared-data-access/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.750.0.tgz",
-      "integrity": "sha512-In6bsG0p/P31HcH4DBRKBbcDS/3SHvEPjfXV8ODPWZO/l3/p7IRoYBdQ07C9R+VMZU2D0+/Sc/DWK/TUNDk1+Q==",
+    "node_modules/@adobe/spacecat-shared-data-access/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.804.0.tgz",
+      "integrity": "sha512-bum1hLVBrn2lJCi423Z2fMUYtsbkGI2s4N+2RI2WSjvbaVyMSv/WcejIrjkqiiMR+2Y7m5exgoKeg4/TODLDPQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@adobe/spacecat-shared-data-access/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.750.0.tgz",
-      "integrity": "sha512-wFB9qqfa20AB0dElsQz5ZlZT5o+a+XzpEpmg0erylmGYqEOvh8NQWfDUVpRmQuGq9VbvW/8cIbxPoNqEbPtuWQ==",
+    "node_modules/@adobe/spacecat-shared-data-access/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.804.0.tgz",
+      "integrity": "sha512-w/qLwL3iq0KOPQNat0Kb7sKndl9BtceigINwBU7SpkYWX9L/Lem6f8NPEKrC9Tl4wDBht3Yztub4oRTy/horJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/node-http-handler": "^4.0.2",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.5",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-stream": "^4.1.1",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@adobe/spacecat-shared-data-access/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.750.0.tgz",
-      "integrity": "sha512-2YIZmyEr5RUd3uxXpxOLD9G67Bibm4I/65M6vKFP17jVMUT+R1nL7mKqmhEVO2p+BoeV+bwMyJ/jpTYG368PCg==",
+    "node_modules/@adobe/spacecat-shared-data-access/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.804.0.tgz",
+      "integrity": "sha512-zqHOrvLRdsUdN/ehYfZ9Tf8svhbiLLz5VaWUz22YndFv6m9qaAcijkpAOlKexsv3nLBMJdSdJ6GUTAeIy3BZzw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/credential-provider-env": "3.750.0",
-        "@aws-sdk/credential-provider-http": "3.750.0",
-        "@aws-sdk/credential-provider-process": "3.750.0",
-        "@aws-sdk/credential-provider-sso": "3.750.0",
-        "@aws-sdk/credential-provider-web-identity": "3.750.0",
-        "@aws-sdk/nested-clients": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/credential-provider-imds": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-data-access/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.750.0.tgz",
-      "integrity": "sha512-THWHHAceLwsOiowPEmKyhWVDlEUxH07GHSw5AQFDvNQtGKOQl0HSIFO1mKObT2Q2Vqzji9Bq8H58SO5BFtNPRw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.750.0",
-        "@aws-sdk/credential-provider-http": "3.750.0",
-        "@aws-sdk/credential-provider-ini": "3.750.0",
-        "@aws-sdk/credential-provider-process": "3.750.0",
-        "@aws-sdk/credential-provider-sso": "3.750.0",
-        "@aws-sdk/credential-provider-web-identity": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/credential-provider-imds": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-data-access/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.750.0.tgz",
-      "integrity": "sha512-Q78SCH1n0m7tpu36sJwfrUSxI8l611OyysjQeMiIOliVfZICEoHcLHLcLkiR+tnIpZ3rk7d2EQ6R1jwlXnalMQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-data-access/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.750.0.tgz",
-      "integrity": "sha512-FGYrDjXN/FOQVi/t8fHSv8zCk+NEvtFnuc4cZUj5OIbM4vrfFc5VaPyn41Uza3iv6Qq9rZg0QOwWnqK8lNrqUw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.750.0",
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/token-providers": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-data-access/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.750.0.tgz",
-      "integrity": "sha512-Nz8zs3YJ+GOTSrq+LyzbbC1Ffpt7pK38gcOyNZv76pP5MswKTUKNYBJehqwa+i7FcFQHsCk3TdhR8MT1ZR23uA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/nested-clients": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-data-access/node_modules/@aws-sdk/middleware-sdk-sqs": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.750.0.tgz",
-      "integrity": "sha512-+JEpz0P9wU92N0KsLFgOHAkipx8F3HO6YztycMwdLM+oKkurpE04q6d+N1WdBMIZwJ+YXlBU22L0dnR83hghtg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/smithy-client": "^4.1.5",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1889,50 +1677,90 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.750.0.tgz",
-      "integrity": "sha512-YYcslDsP5+2NZoN3UwuhZGkhAHPSli7HlJHBafBrvjGV/I9f8FuOO1d1ebxGdEP4HyRXUGyh+7Ur4q+Psk0ryw==",
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.806.0.tgz",
+      "integrity": "sha512-XoIromVffgXnc+/mjlR2EVzQVIei3bPVtafIZNsHuEmUvIWJXiWsa2eJpt3BUqa0HF9YPknK7ommNEhqRb8ucg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-endpoints": "3.743.0",
-        "@smithy/core": "^3.1.4",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/core": "3.806.0",
+        "@aws-sdk/types": "3.804.0",
+        "@aws-sdk/util-endpoints": "3.806.0",
+        "@smithy/core": "^3.3.1",
+        "@smithy/protocol-http": "^5.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@adobe/spacecat-shared-data-access/node_modules/@aws-sdk/token-providers": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.750.0.tgz",
-      "integrity": "sha512-X/KzqZw41iWolwNdc8e3RMcNSMR364viHv78u6AefXOO5eRM40c4/LuST1jDzq35/LpnqRhL7/MuixOetw+sFw==",
+    "node_modules/@adobe/spacecat-shared-data-access/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.806.0.tgz",
+      "integrity": "sha512-cuv5pX55JOlzKC/iLsB5nZ9eUyVgncim3VhhWHZA/KYPh7rLMjOEfZ+xyaE9uLJXGmzOJboFH7+YdTRdIcOgrg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/nested-clients": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/shared-ini-file-loader": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/node-config-provider": "^4.1.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-config-provider": "^4.0.0",
+        "@smithy/util-middleware": "^4.0.2",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-data-access/node_modules/@aws-sdk/types": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.804.0.tgz",
+      "integrity": "sha512-A9qnsy9zQ8G89vrPPlNG9d1d8QcKRGqJKqwyGgS0dclJpwy6d1EWgQLIolKPl6vcFpLoe6avLOLxr+h8ur5wpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-data-access/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.806.0.tgz",
+      "integrity": "sha512-3YRRgZ+qFuWDdm5uAbxKsr65UAil4KkrFKua9f4m7Be3v24ETiFOOqhanFUIk9/WOtvzF7oFEiDjYKDGlwV2xg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/types": "^4.2.0",
+        "@smithy/util-endpoints": "^3.0.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-data-access/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.804.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.804.0.tgz",
+      "integrity": "sha512-KfW6T6nQHHM/vZBBdGn6fMyG/MgX5lq82TDdX4HRQRRuHKLgBWGpKXqqvBwqIaCdXwWHgDrg2VQups6GqOWW2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/types": "^4.2.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.750.0.tgz",
-      "integrity": "sha512-84HJj9G9zbrHX2opLk9eHfDceB+UIHVrmflMzWHpsmo9fDuro/flIBqaVDlE021Osj6qIM0SJJcnL6s23j7JEw==",
+      "version": "3.806.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.806.0.tgz",
+      "integrity": "sha512-Az2e4/gmPZ4BpB7QRj7U76I+fctXhNcxlcgsaHnMhvt+R30nvzM2EhsyBUvsWl8+r9bnLeYt9BpvEZeq2ANDzA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
+        "@aws-sdk/middleware-user-agent": "3.806.0",
+        "@aws-sdk/types": "3.804.0",
+        "@smithy/node-config-provider": "^4.1.0",
+        "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1961,15 +1789,15 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-google-client": {
-      "version": "1.4.24",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-google-client/-/spacecat-shared-google-client-1.4.24.tgz",
-      "integrity": "sha512-3aw/bQ0A8u25zGJELW9M8WYEUtN1erhy4u77iNw3r6IaCS4lD9CBSJ8JStQPHkpviN5C+K7Xe1g/NsY19mhCfQ==",
+      "version": "1.4.25",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-google-client/-/spacecat-shared-google-client-1.4.25.tgz",
+      "integrity": "sha512-+q9GfbrKO/5B5bQwPUaVbLdL577vGQm2QovwOx1kLfQkd6sPUzFlsFI1snbeMjzBzWxaZbyOk9ytV0piyNaEqw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.1",
         "@adobe/helix-universal": "5.2.1",
         "@adobe/spacecat-shared-http-utils": "1.9.4",
-        "@adobe/spacecat-shared-utils": "1.26.4",
+        "@adobe/spacecat-shared-utils": "1.38.0",
         "@aws-sdk/client-secrets-manager": "3.806.0",
         "aws-xray-sdk": "3.10.3",
         "google-auth-library": "9.15.1",
@@ -4580,357 +4408,22 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-google-client/node_modules/@adobe/spacecat-shared-utils": {
-      "version": "1.26.4",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.26.4.tgz",
-      "integrity": "sha512-d/GZ6j//dXW9+YjgRO0PhZcvhXMlhfUHrPxcG/2OMD5gkd8fOd39+Y1JMu/6fgpNVOR7iQogb/5d5UXaHEWygg==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.38.0.tgz",
+      "integrity": "sha512-UdEtL0Y0ah1gXDbtasmUu6huqmgY0B2uYAKnTKrp7XZQcS56hXeatgKcGGuc7cyCU9O4eWLwjEVG7+9/HOp//g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@adobe/fetch": "4.1.11",
-        "@aws-sdk/client-s3": "3.726.1",
-        "@aws-sdk/client-secrets-manager": "3.726.1",
-        "@aws-sdk/client-sqs": "3.726.1",
+        "@adobe/fetch": "4.2.1",
+        "@aws-sdk/client-s3": "3.806.0",
+        "@aws-sdk/client-secrets-manager": "3.806.0",
+        "@aws-sdk/client-sqs": "3.806.0",
         "@json2csv/plainjs": "7.0.6",
-        "aws-xray-sdk": "3.10.2",
-        "uuid": "11.0.5"
+        "aws-xray-sdk": "3.10.3",
+        "uuid": "11.1.0"
       },
       "engines": {
         "node": ">=22.0.0 <23.0.0",
         "npm": ">=10.9.0 <12.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@adobe/spacecat-shared-utils/node_modules/@adobe/fetch": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/@adobe/fetch/-/fetch-4.1.11.tgz",
-      "integrity": "sha512-Zak2kPJuIdg9UQQfUgNm848vRAg2pdOqYYU+7DkCYWO+SgZiMV+qy99BpO1geDiP2rQ2M7JH5oNXRTEvEWglRQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "4.4.0",
-        "http-cache-semantics": "4.1.1",
-        "lru-cache": "7.18.3"
-      },
-      "engines": {
-        "node": ">=14.16"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/client-secrets-manager": {
-      "version": "3.726.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.726.1.tgz",
-      "integrity": "sha512-eO9WpE8IyQrs2xWhfQCdHcVTHQTwJ56JGx3FhwhtFWWYHIS0c1bTIAvP5E3jSWAZNaK1iWdVexz3yGi3aAnGzA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.726.0",
-        "@aws-sdk/client-sts": "3.726.1",
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/credential-provider-node": "3.726.0",
-        "@aws-sdk/middleware-host-header": "3.723.0",
-        "@aws-sdk/middleware-logger": "3.723.0",
-        "@aws-sdk/middleware-recursion-detection": "3.723.0",
-        "@aws-sdk/middleware-user-agent": "3.726.0",
-        "@aws-sdk/region-config-resolver": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@aws-sdk/util-endpoints": "3.726.0",
-        "@aws-sdk/util-user-agent-browser": "3.723.0",
-        "@aws-sdk/util-user-agent-node": "3.726.0",
-        "@smithy/config-resolver": "^4.0.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/fetch-http-handler": "^5.0.0",
-        "@smithy/hash-node": "^4.0.0",
-        "@smithy/invalid-dependency": "^4.0.0",
-        "@smithy/middleware-content-length": "^4.0.0",
-        "@smithy/middleware-endpoint": "^4.0.0",
-        "@smithy/middleware-retry": "^4.0.0",
-        "@smithy/middleware-serde": "^4.0.0",
-        "@smithy/middleware-stack": "^4.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/node-http-handler": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/url-parser": "^4.0.0",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.0",
-        "@smithy/util-defaults-mode-node": "^4.0.0",
-        "@smithy/util-endpoints": "^3.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "@smithy/util-retry": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "@types/uuid": "^9.0.1",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/client-secrets-manager/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/client-sts": {
-      "version": "3.726.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.726.1.tgz",
-      "integrity": "sha512-qh9Q9Vu1hrM/wMBOBIaskwnE4GTFaZu26Q6WHwyWNfj7J8a40vBxpW16c2vYXHLBtwRKM1be8uRLkmDwghpiNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.726.0",
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/credential-provider-node": "3.726.0",
-        "@aws-sdk/middleware-host-header": "3.723.0",
-        "@aws-sdk/middleware-logger": "3.723.0",
-        "@aws-sdk/middleware-recursion-detection": "3.723.0",
-        "@aws-sdk/middleware-user-agent": "3.726.0",
-        "@aws-sdk/region-config-resolver": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@aws-sdk/util-endpoints": "3.726.0",
-        "@aws-sdk/util-user-agent-browser": "3.723.0",
-        "@aws-sdk/util-user-agent-node": "3.726.0",
-        "@smithy/config-resolver": "^4.0.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/fetch-http-handler": "^5.0.0",
-        "@smithy/hash-node": "^4.0.0",
-        "@smithy/invalid-dependency": "^4.0.0",
-        "@smithy/middleware-content-length": "^4.0.0",
-        "@smithy/middleware-endpoint": "^4.0.0",
-        "@smithy/middleware-retry": "^4.0.0",
-        "@smithy/middleware-serde": "^4.0.0",
-        "@smithy/middleware-stack": "^4.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/node-http-handler": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/url-parser": "^4.0.0",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.0",
-        "@smithy/util-defaults-mode-node": "^4.0.0",
-        "@smithy/util-endpoints": "^3.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "@smithy/util-retry": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/core": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.723.0.tgz",
-      "integrity": "sha512-UraXNmvqj3vScSsTkjMwQkhei30BhXlW5WxX6JacMKVtl95c7z0qOXquTWeTalYkFfulfdirUhvSZrl+hcyqTw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/property-provider": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/signature-v4": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "fast-xml-parser": "4.4.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.726.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.726.0.tgz",
-      "integrity": "sha512-jjsewBcw/uLi24x8JbnuDjJad4VA9ROCE94uVRbEnGmUEsds75FWOKp3fWZLQlmjLtzsIbJOZLALkZP86liPaw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.723.0",
-        "@aws-sdk/credential-provider-http": "3.723.0",
-        "@aws-sdk/credential-provider-ini": "3.726.0",
-        "@aws-sdk/credential-provider-process": "3.723.0",
-        "@aws-sdk/credential-provider-sso": "3.726.0",
-        "@aws-sdk/credential-provider-web-identity": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/credential-provider-imds": "^4.0.0",
-        "@smithy/property-provider": "^4.0.0",
-        "@smithy/shared-ini-file-loader": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.723.0.tgz",
-      "integrity": "sha512-LLVzLvk299pd7v4jN9yOSaWDZDfH0SnBPb6q+FDPaOCMGBY8kuwQso7e/ozIKSmZHRMGO3IZrflasHM+rI+2YQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.723.0.tgz",
-      "integrity": "sha512-chASQfDG5NJ8s5smydOEnNK7N0gDMyuPbx7dYYcm1t/PKtnVfvWF+DHCTrRC2Ej76gLJVCVizlAJKM8v8Kg3cg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.723.0.tgz",
-      "integrity": "sha512-7usZMtoynT9/jxL/rkuDOFQ0C2mhXl4yCm67Rg7GNTstl67u7w5WN1aIRImMeztaKlw8ExjoTyo6WTs1Kceh7A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.726.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.726.0.tgz",
-      "integrity": "sha512-hZvzuE5S0JmFie1r68K2wQvJbzyxJFdzltj9skgnnwdvLe8F/tz7MqLkm28uV0m4jeHk0LpiBo6eZaPkQiwsZQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@aws-sdk/util-endpoints": "3.726.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.723.0.tgz",
-      "integrity": "sha512-tGF/Cvch3uQjZIj34LY2mg8M2Dr4kYG8VU8Yd0dFnB1ybOEOveIK/9ypUo9ycZpB9oO6q01KRe5ijBaxNueUQg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/types": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.723.0.tgz",
-      "integrity": "sha512-LmK3kwiMZG1y5g3LGihT9mNkeNOmwEyPk6HGcJqh0wOSV4QpWoKu2epyKE4MLQNUUlz2kOVbVbOrwmI6ZcteuA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.726.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.726.0.tgz",
-      "integrity": "sha512-sLd30ASsPMoPn3XBK50oe/bkpJ4N8Bpb7SbhoxcY3Lk+fSASaWxbbXE81nbvCnkxrZCvkPOiDHzJCp1E2im71A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-endpoints": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.723.0.tgz",
-      "integrity": "sha512-Wh9I6j2jLhNFq6fmXydIpqD1WyQLyTfSxjW9B+PXSnPyk3jtQW8AKQur7p97rO8LAUzVI0bv8kb3ZzDEVbquIg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/types": "^4.0.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@adobe/spacecat-shared-utils/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.726.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.726.0.tgz",
-      "integrity": "sha512-iEj6KX9o6IQf23oziorveRqyzyclWai95oZHDJtYav3fvLJKStwSjygO4xSF7ycHcTYeCHSLO1FFOHgGVs4Viw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.726.0",
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@adobe/spacecat-shared-utils/node_modules/aws-xray-sdk": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/aws-xray-sdk/-/aws-xray-sdk-3.10.2.tgz",
-      "integrity": "sha512-T9Qwq65hUQo4GtZ7WPAzpLGd7y8bDKODlJkKAYsQKMcUIIpMPYWsSxd38ZLy3uwTY0ErkrG6Pqmc5Zs1p0BmZg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "aws-xray-sdk-core": "3.10.2",
-        "aws-xray-sdk-express": "3.10.2",
-        "aws-xray-sdk-mysql": "3.10.2",
-        "aws-xray-sdk-postgres": "3.10.2"
-      },
-      "engines": {
-        "node": ">= 14.x"
       }
     },
     "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-dynamodb": {
@@ -5711,314 +5204,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-s3": {
-      "version": "3.726.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.726.1.tgz",
-      "integrity": "sha512-UpOGcob87DiuS2d3fW6vDZg94g57mNiOSkzvR/6GOdvBSlUgk8LLwVzGASB71FdKMl1EGEr4MeD5uKH9JsG+dw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha1-browser": "5.2.0",
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.726.0",
-        "@aws-sdk/client-sts": "3.726.1",
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/credential-provider-node": "3.726.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.726.0",
-        "@aws-sdk/middleware-expect-continue": "3.723.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.723.0",
-        "@aws-sdk/middleware-host-header": "3.723.0",
-        "@aws-sdk/middleware-location-constraint": "3.723.0",
-        "@aws-sdk/middleware-logger": "3.723.0",
-        "@aws-sdk/middleware-recursion-detection": "3.723.0",
-        "@aws-sdk/middleware-sdk-s3": "3.723.0",
-        "@aws-sdk/middleware-ssec": "3.723.0",
-        "@aws-sdk/middleware-user-agent": "3.726.0",
-        "@aws-sdk/region-config-resolver": "3.723.0",
-        "@aws-sdk/signature-v4-multi-region": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@aws-sdk/util-endpoints": "3.726.0",
-        "@aws-sdk/util-user-agent-browser": "3.723.0",
-        "@aws-sdk/util-user-agent-node": "3.726.0",
-        "@aws-sdk/xml-builder": "3.723.0",
-        "@smithy/config-resolver": "^4.0.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/eventstream-serde-browser": "^4.0.0",
-        "@smithy/eventstream-serde-config-resolver": "^4.0.0",
-        "@smithy/eventstream-serde-node": "^4.0.0",
-        "@smithy/fetch-http-handler": "^5.0.0",
-        "@smithy/hash-blob-browser": "^4.0.0",
-        "@smithy/hash-node": "^4.0.0",
-        "@smithy/hash-stream-node": "^4.0.0",
-        "@smithy/invalid-dependency": "^4.0.0",
-        "@smithy/md5-js": "^4.0.0",
-        "@smithy/middleware-content-length": "^4.0.0",
-        "@smithy/middleware-endpoint": "^4.0.0",
-        "@smithy/middleware-retry": "^4.0.0",
-        "@smithy/middleware-serde": "^4.0.0",
-        "@smithy/middleware-stack": "^4.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/node-http-handler": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/url-parser": "^4.0.0",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.0",
-        "@smithy/util-defaults-mode-node": "^4.0.0",
-        "@smithy/util-endpoints": "^3.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "@smithy/util-retry": "^4.0.0",
-        "@smithy/util-stream": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "@smithy/util-waiter": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sts": {
-      "version": "3.726.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.726.1.tgz",
-      "integrity": "sha512-qh9Q9Vu1hrM/wMBOBIaskwnE4GTFaZu26Q6WHwyWNfj7J8a40vBxpW16c2vYXHLBtwRKM1be8uRLkmDwghpiNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.726.0",
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/credential-provider-node": "3.726.0",
-        "@aws-sdk/middleware-host-header": "3.723.0",
-        "@aws-sdk/middleware-logger": "3.723.0",
-        "@aws-sdk/middleware-recursion-detection": "3.723.0",
-        "@aws-sdk/middleware-user-agent": "3.726.0",
-        "@aws-sdk/region-config-resolver": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@aws-sdk/util-endpoints": "3.726.0",
-        "@aws-sdk/util-user-agent-browser": "3.723.0",
-        "@aws-sdk/util-user-agent-node": "3.726.0",
-        "@smithy/config-resolver": "^4.0.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/fetch-http-handler": "^5.0.0",
-        "@smithy/hash-node": "^4.0.0",
-        "@smithy/invalid-dependency": "^4.0.0",
-        "@smithy/middleware-content-length": "^4.0.0",
-        "@smithy/middleware-endpoint": "^4.0.0",
-        "@smithy/middleware-retry": "^4.0.0",
-        "@smithy/middleware-serde": "^4.0.0",
-        "@smithy/middleware-stack": "^4.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/node-http-handler": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/url-parser": "^4.0.0",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.0",
-        "@smithy/util-defaults-mode-node": "^4.0.0",
-        "@smithy/util-endpoints": "^3.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "@smithy/util-retry": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/core": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.723.0.tgz",
-      "integrity": "sha512-UraXNmvqj3vScSsTkjMwQkhei30BhXlW5WxX6JacMKVtl95c7z0qOXquTWeTalYkFfulfdirUhvSZrl+hcyqTw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/property-provider": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/signature-v4": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "fast-xml-parser": "4.4.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.726.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.726.0.tgz",
-      "integrity": "sha512-jjsewBcw/uLi24x8JbnuDjJad4VA9ROCE94uVRbEnGmUEsds75FWOKp3fWZLQlmjLtzsIbJOZLALkZP86liPaw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.723.0",
-        "@aws-sdk/credential-provider-http": "3.723.0",
-        "@aws-sdk/credential-provider-ini": "3.726.0",
-        "@aws-sdk/credential-provider-process": "3.723.0",
-        "@aws-sdk/credential-provider-sso": "3.726.0",
-        "@aws-sdk/credential-provider-web-identity": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/credential-provider-imds": "^4.0.0",
-        "@smithy/property-provider": "^4.0.0",
-        "@smithy/shared-ini-file-loader": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.723.0.tgz",
-      "integrity": "sha512-LLVzLvk299pd7v4jN9yOSaWDZDfH0SnBPb6q+FDPaOCMGBY8kuwQso7e/ozIKSmZHRMGO3IZrflasHM+rI+2YQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.723.0.tgz",
-      "integrity": "sha512-chASQfDG5NJ8s5smydOEnNK7N0gDMyuPbx7dYYcm1t/PKtnVfvWF+DHCTrRC2Ej76gLJVCVizlAJKM8v8Kg3cg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.723.0.tgz",
-      "integrity": "sha512-7usZMtoynT9/jxL/rkuDOFQ0C2mhXl4yCm67Rg7GNTstl67u7w5WN1aIRImMeztaKlw8ExjoTyo6WTs1Kceh7A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.726.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.726.0.tgz",
-      "integrity": "sha512-hZvzuE5S0JmFie1r68K2wQvJbzyxJFdzltj9skgnnwdvLe8F/tz7MqLkm28uV0m4jeHk0LpiBo6eZaPkQiwsZQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@aws-sdk/util-endpoints": "3.726.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.723.0.tgz",
-      "integrity": "sha512-tGF/Cvch3uQjZIj34LY2mg8M2Dr4kYG8VU8Yd0dFnB1ybOEOveIK/9ypUo9ycZpB9oO6q01KRe5ijBaxNueUQg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/types": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.723.0.tgz",
-      "integrity": "sha512-LmK3kwiMZG1y5g3LGihT9mNkeNOmwEyPk6HGcJqh0wOSV4QpWoKu2epyKE4MLQNUUlz2kOVbVbOrwmI6ZcteuA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.726.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.726.0.tgz",
-      "integrity": "sha512-sLd30ASsPMoPn3XBK50oe/bkpJ4N8Bpb7SbhoxcY3Lk+fSASaWxbbXE81nbvCnkxrZCvkPOiDHzJCp1E2im71A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-endpoints": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.723.0.tgz",
-      "integrity": "sha512-Wh9I6j2jLhNFq6fmXydIpqD1WyQLyTfSxjW9B+PXSnPyk3jtQW8AKQur7p97rO8LAUzVI0bv8kb3ZzDEVbquIg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/types": "^4.0.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.726.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.726.0.tgz",
-      "integrity": "sha512-iEj6KX9o6IQf23oziorveRqyzyclWai95oZHDJtYav3fvLJKStwSjygO4xSF7ycHcTYeCHSLO1FFOHgGVs4Viw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.726.0",
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-secrets-manager": {
       "version": "3.806.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-secrets-manager/-/client-secrets-manager-3.806.0.tgz",
@@ -6247,299 +5432,6 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-sqs": {
-      "version": "3.726.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.726.1.tgz",
-      "integrity": "sha512-QSsmlMNVgKUzDpDC3Ya1i0tvFjVcvTBoJfSh7LBkuMJiboY2j2aeD74OX7xGkxu+QLc8wWUjT//KYDm6KwHk7w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.726.0",
-        "@aws-sdk/client-sts": "3.726.1",
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/credential-provider-node": "3.726.0",
-        "@aws-sdk/middleware-host-header": "3.723.0",
-        "@aws-sdk/middleware-logger": "3.723.0",
-        "@aws-sdk/middleware-recursion-detection": "3.723.0",
-        "@aws-sdk/middleware-sdk-sqs": "3.723.0",
-        "@aws-sdk/middleware-user-agent": "3.726.0",
-        "@aws-sdk/region-config-resolver": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@aws-sdk/util-endpoints": "3.726.0",
-        "@aws-sdk/util-user-agent-browser": "3.723.0",
-        "@aws-sdk/util-user-agent-node": "3.726.0",
-        "@smithy/config-resolver": "^4.0.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/fetch-http-handler": "^5.0.0",
-        "@smithy/hash-node": "^4.0.0",
-        "@smithy/invalid-dependency": "^4.0.0",
-        "@smithy/md5-js": "^4.0.0",
-        "@smithy/middleware-content-length": "^4.0.0",
-        "@smithy/middleware-endpoint": "^4.0.0",
-        "@smithy/middleware-retry": "^4.0.0",
-        "@smithy/middleware-serde": "^4.0.0",
-        "@smithy/middleware-stack": "^4.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/node-http-handler": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/url-parser": "^4.0.0",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.0",
-        "@smithy/util-defaults-mode-node": "^4.0.0",
-        "@smithy/util-endpoints": "^3.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "@smithy/util-retry": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sts": {
-      "version": "3.726.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.726.1.tgz",
-      "integrity": "sha512-qh9Q9Vu1hrM/wMBOBIaskwnE4GTFaZu26Q6WHwyWNfj7J8a40vBxpW16c2vYXHLBtwRKM1be8uRLkmDwghpiNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.726.0",
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/credential-provider-node": "3.726.0",
-        "@aws-sdk/middleware-host-header": "3.723.0",
-        "@aws-sdk/middleware-logger": "3.723.0",
-        "@aws-sdk/middleware-recursion-detection": "3.723.0",
-        "@aws-sdk/middleware-user-agent": "3.726.0",
-        "@aws-sdk/region-config-resolver": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@aws-sdk/util-endpoints": "3.726.0",
-        "@aws-sdk/util-user-agent-browser": "3.723.0",
-        "@aws-sdk/util-user-agent-node": "3.726.0",
-        "@smithy/config-resolver": "^4.0.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/fetch-http-handler": "^5.0.0",
-        "@smithy/hash-node": "^4.0.0",
-        "@smithy/invalid-dependency": "^4.0.0",
-        "@smithy/middleware-content-length": "^4.0.0",
-        "@smithy/middleware-endpoint": "^4.0.0",
-        "@smithy/middleware-retry": "^4.0.0",
-        "@smithy/middleware-serde": "^4.0.0",
-        "@smithy/middleware-stack": "^4.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/node-http-handler": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/url-parser": "^4.0.0",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.0",
-        "@smithy/util-defaults-mode-node": "^4.0.0",
-        "@smithy/util-endpoints": "^3.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "@smithy/util-retry": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/core": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.723.0.tgz",
-      "integrity": "sha512-UraXNmvqj3vScSsTkjMwQkhei30BhXlW5WxX6JacMKVtl95c7z0qOXquTWeTalYkFfulfdirUhvSZrl+hcyqTw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/property-provider": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/signature-v4": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "fast-xml-parser": "4.4.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.726.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.726.0.tgz",
-      "integrity": "sha512-jjsewBcw/uLi24x8JbnuDjJad4VA9ROCE94uVRbEnGmUEsds75FWOKp3fWZLQlmjLtzsIbJOZLALkZP86liPaw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.723.0",
-        "@aws-sdk/credential-provider-http": "3.723.0",
-        "@aws-sdk/credential-provider-ini": "3.726.0",
-        "@aws-sdk/credential-provider-process": "3.723.0",
-        "@aws-sdk/credential-provider-sso": "3.726.0",
-        "@aws-sdk/credential-provider-web-identity": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/credential-provider-imds": "^4.0.0",
-        "@smithy/property-provider": "^4.0.0",
-        "@smithy/shared-ini-file-loader": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.723.0.tgz",
-      "integrity": "sha512-LLVzLvk299pd7v4jN9yOSaWDZDfH0SnBPb6q+FDPaOCMGBY8kuwQso7e/ozIKSmZHRMGO3IZrflasHM+rI+2YQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.723.0.tgz",
-      "integrity": "sha512-chASQfDG5NJ8s5smydOEnNK7N0gDMyuPbx7dYYcm1t/PKtnVfvWF+DHCTrRC2Ej76gLJVCVizlAJKM8v8Kg3cg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.723.0.tgz",
-      "integrity": "sha512-7usZMtoynT9/jxL/rkuDOFQ0C2mhXl4yCm67Rg7GNTstl67u7w5WN1aIRImMeztaKlw8ExjoTyo6WTs1Kceh7A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.726.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.726.0.tgz",
-      "integrity": "sha512-hZvzuE5S0JmFie1r68K2wQvJbzyxJFdzltj9skgnnwdvLe8F/tz7MqLkm28uV0m4jeHk0LpiBo6eZaPkQiwsZQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@aws-sdk/util-endpoints": "3.726.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.723.0.tgz",
-      "integrity": "sha512-tGF/Cvch3uQjZIj34LY2mg8M2Dr4kYG8VU8Yd0dFnB1ybOEOveIK/9ypUo9ycZpB9oO6q01KRe5ijBaxNueUQg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/types": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.723.0.tgz",
-      "integrity": "sha512-LmK3kwiMZG1y5g3LGihT9mNkeNOmwEyPk6HGcJqh0wOSV4QpWoKu2epyKE4MLQNUUlz2kOVbVbOrwmI6ZcteuA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.726.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.726.0.tgz",
-      "integrity": "sha512-sLd30ASsPMoPn3XBK50oe/bkpJ4N8Bpb7SbhoxcY3Lk+fSASaWxbbXE81nbvCnkxrZCvkPOiDHzJCp1E2im71A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-endpoints": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.723.0.tgz",
-      "integrity": "sha512-Wh9I6j2jLhNFq6fmXydIpqD1WyQLyTfSxjW9B+PXSnPyk3jtQW8AKQur7p97rO8LAUzVI0bv8kb3ZzDEVbquIg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/types": "^4.0.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.726.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.726.0.tgz",
-      "integrity": "sha512-iEj6KX9o6IQf23oziorveRqyzyclWai95oZHDJtYav3fvLJKStwSjygO4xSF7ycHcTYeCHSLO1FFOHgGVs4Viw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.726.0",
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
       }
     },
     "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/client-sso": {
@@ -8436,37 +7328,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.726.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.726.0.tgz",
-      "integrity": "sha512-vpaP80rZqwu0C3ELayIcRIW84/nd1tadeoqllT+N9TDshuEvq4UJ+w47OBHB7RkHFJoc79lXXNYle0fdQdaE/A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@aws-sdk/util-arn-parser": "3.723.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/@aws-sdk/types": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.723.0.tgz",
-      "integrity": "sha512-LmK3kwiMZG1y5g3LGihT9mNkeNOmwEyPk6HGcJqh0wOSV4QpWoKu2epyKE4MLQNUUlz2kOVbVbOrwmI6ZcteuA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/middleware-endpoint-discovery": {
       "version": "3.714.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.714.0.tgz",
@@ -8550,93 +7411,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.723.0.tgz",
-      "integrity": "sha512-w/O0EkIzkiqvGu7U8Ke7tue0V0HYM5dZQrz6nVU+R8T2LddWJ+njEIHU4Wh8aHPLQXdZA5NQumv0xLPdEutykw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/middleware-expect-continue/node_modules/@aws-sdk/types": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.723.0.tgz",
-      "integrity": "sha512-LmK3kwiMZG1y5g3LGihT9mNkeNOmwEyPk6HGcJqh0wOSV4QpWoKu2epyKE4MLQNUUlz2kOVbVbOrwmI6ZcteuA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.723.0.tgz",
-      "integrity": "sha512-JY76mrUCLa0FHeMZp8X9+KK6uEuZaRZaQrlgq6zkXX/3udukH0T3YdFC+Y9uw5ddbiwZ5+KwgmlhnPpiXKfP4g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@aws-crypto/crc32c": "5.2.0",
-        "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "@smithy/util-stream": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/core": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.723.0.tgz",
-      "integrity": "sha512-UraXNmvqj3vScSsTkjMwQkhei30BhXlW5WxX6JacMKVtl95c7z0qOXquTWeTalYkFfulfdirUhvSZrl+hcyqTw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/property-provider": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/signature-v4": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "fast-xml-parser": "4.4.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/types": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.723.0.tgz",
-      "integrity": "sha512-LmK3kwiMZG1y5g3LGihT9mNkeNOmwEyPk6HGcJqh0wOSV4QpWoKu2epyKE4MLQNUUlz2kOVbVbOrwmI6ZcteuA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.714.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.714.0.tgz",
@@ -8675,33 +7449,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.723.0.tgz",
-      "integrity": "sha512-inp9tyrdRWjGOMu1rzli8i2gTo0P4X6L7nNRXNTKfyPNZcBimZ4H0H1B671JofSI5isaklVy5r4pvv2VjjLSHw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/middleware-location-constraint/node_modules/@aws-sdk/types": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.723.0.tgz",
-      "integrity": "sha512-LmK3kwiMZG1y5g3LGihT9mNkeNOmwEyPk6HGcJqh0wOSV4QpWoKu2epyKE4MLQNUUlz2kOVbVbOrwmI6ZcteuA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/middleware-logger": {
@@ -8768,93 +7515,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.723.0.tgz",
-      "integrity": "sha512-wfjOvNJVp8LDWhq4wO5jtSMb8Vgf4tNlR7QTEQfoYc6AGU3WlK5xyUQcpfcpwytEhQTN9u0cJLQpSyXDO+qSCw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@aws-sdk/util-arn-parser": "3.723.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/signature-v4": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "@smithy/util-stream": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/core": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.723.0.tgz",
-      "integrity": "sha512-UraXNmvqj3vScSsTkjMwQkhei30BhXlW5WxX6JacMKVtl95c7z0qOXquTWeTalYkFfulfdirUhvSZrl+hcyqTw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/core": "^3.0.0",
-        "@smithy/node-config-provider": "^4.0.0",
-        "@smithy/property-provider": "^4.0.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/signature-v4": "^5.0.0",
-        "@smithy/smithy-client": "^4.0.0",
-        "@smithy/types": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.0",
-        "fast-xml-parser": "4.4.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/types": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.723.0.tgz",
-      "integrity": "sha512-LmK3kwiMZG1y5g3LGihT9mNkeNOmwEyPk6HGcJqh0wOSV4QpWoKu2epyKE4MLQNUUlz2kOVbVbOrwmI6ZcteuA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.723.0.tgz",
-      "integrity": "sha512-Bs+8RAeSMik6ZYCGSDJzJieGsDDh2fRbh1HQG94T8kpwBXVxMYihm6e9Xp2cyl+w9fyyCnh0IdCKChP/DvrdhA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/middleware-ssec/node_modules/@aws-sdk/types": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.723.0.tgz",
-      "integrity": "sha512-LmK3kwiMZG1y5g3LGihT9mNkeNOmwEyPk6HGcJqh0wOSV4QpWoKu2epyKE4MLQNUUlz2kOVbVbOrwmI6ZcteuA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/middleware-user-agent": {
@@ -9124,36 +7784,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.723.0.tgz",
-      "integrity": "sha512-lJlVAa5Sl589qO8lwMLVUtnlF1Q7I+6k1Iomv2goY9d1bRl4q2N5Pit2qJVr2AMW0sceQXeh23i2a/CKOqVAdg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.723.0",
-        "@aws-sdk/types": "3.723.0",
-        "@smithy/protocol-http": "^5.0.0",
-        "@smithy/signature-v4": "^5.0.0",
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/signature-v4-multi-region/node_modules/@aws-sdk/types": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.723.0.tgz",
-      "integrity": "sha512-LmK3kwiMZG1y5g3LGihT9mNkeNOmwEyPk6HGcJqh0wOSV4QpWoKu2epyKE4MLQNUUlz2kOVbVbOrwmI6ZcteuA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/types": {
       "version": "3.714.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.714.0.tgz",
@@ -9375,19 +8005,6 @@
       },
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-google-client/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.723.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.723.0.tgz",
-      "integrity": "sha512-5xK2SqGU1mzzsOeemy7cy3fGKxR1sEpUs4pEiIjaT0OIvU+fZaDVUEYWOqsgns6wI90XZEQJlXtI8uAHX/do5Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@adobe/spacecat-shared-google-client/node_modules/@smithy/abort-controller": {
@@ -9730,6 +8347,19 @@
         "@aws-sdk/lib-dynamodb": "^3.654.0",
         "@aws-sdk/util-dynamodb": "^3.654.0",
         "jsonschema": "1.2.7"
+      }
+    },
+    "node_modules/@adobe/spacecat-shared-google-client/node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/@adobe/spacecat-shared-gpt-client": {
@@ -16123,9 +14753,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-utils": {
-      "version": "1.38.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.38.0.tgz",
-      "integrity": "sha512-UdEtL0Y0ah1gXDbtasmUu6huqmgY0B2uYAKnTKrp7XZQcS56hXeatgKcGGuc7cyCU9O4eWLwjEVG7+9/HOp//g==",
+      "version": "1.38.1",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.38.1.tgz",
+      "integrity": "sha512-VsZR+JxYl7Wb5MqvumEkQujAYpK7QtutdMm/zYVLFSDkecxAp4Be58wy/9iA0Jwor/ecmAxVNa7i4XUBGYXHtg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.2.1",
@@ -20222,6 +18852,7 @@
       "version": "3.734.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.734.0.tgz",
       "integrity": "sha512-etC7G18aF7KdZguW27GE/wpbrNmYLVT755EsFc8kXpZj8D6AFKxc7OuveinJmiy0bYXAMspJUWsF6CrGpOw6CQ==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.734.0",
         "@aws-sdk/util-arn-parser": "3.723.0",
@@ -20269,56 +18900,11 @@
       "version": "3.734.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.734.0.tgz",
       "integrity": "sha512-P38/v1l6HjuB2aFUewt7ueAW5IvKkFcv5dalPtbMGRhLeyivBOHwbCyuRKgVs7z7ClTpu9EaViEGki2jEQqEsQ==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.734.0",
         "@smithy/protocol-http": "^5.0.1",
         "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.750.0.tgz",
-      "integrity": "sha512-ach0d2buDnX2TUausUbiXXFWFo3IegLnCrA+Rw8I9AYVpLN9lTaRwAYJwYC6zEuW9Golff8MwkYsp/OaC5tKMw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@aws-crypto/crc32c": "5.2.0",
-        "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-stream": "^4.1.1",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/@aws-sdk/core": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.750.0.tgz",
-      "integrity": "sha512-bZ5K7N5L4+Pa2epbVpUQqd1XLG2uU8BGs/Sd+2nbgTf+lNQJyIxAg/Qsrjz9MzmY8zzQIeRQEkNmR6yVAfCmmQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/core": "^3.1.4",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/signature-v4": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.5",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-middleware": "^4.0.1",
-        "fast-xml-parser": "4.4.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -20343,6 +18929,7 @@
       "version": "3.734.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.734.0.tgz",
       "integrity": "sha512-EJEIXwCQhto/cBfHdm3ZOeLxd2NlJD+X2F+ZTOxzokuhBtY0IONfC/91hOo5tWQweerojwshSMHRCKzRv1tlwg==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.734.0",
         "@smithy/types": "^4.1.0",
@@ -20373,53 +18960,6 @@
         "@aws-sdk/types": "3.734.0",
         "@smithy/protocol-http": "^5.0.1",
         "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.750.0.tgz",
-      "integrity": "sha512-3H6Z46cmAQCHQ0z8mm7/cftY5ifiLfCjbObrbyyp2fhQs9zk6gCKzIX8Zjhw0RMd93FZi3ebRuKJWmMglf4Itw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-arn-parser": "3.723.0",
-        "@smithy/core": "^3.1.4",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/signature-v4": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.5",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-stream": "^4.1.1",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/core": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.750.0.tgz",
-      "integrity": "sha512-bZ5K7N5L4+Pa2epbVpUQqd1XLG2uU8BGs/Sd+2nbgTf+lNQJyIxAg/Qsrjz9MzmY8zzQIeRQEkNmR6yVAfCmmQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/core": "^3.1.4",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/signature-v4": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.5",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-middleware": "^4.0.1",
-        "fast-xml-parser": "4.4.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -20460,6 +19000,7 @@
       "version": "3.734.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.734.0.tgz",
       "integrity": "sha512-d4yd1RrPW/sspEXizq2NSOUivnheac6LPeLSLnaeTbBG9g1KqIqvCzP1TfXEqv2CrWfHEsWtJpX7oyjySSPvDQ==",
+      "dev": true,
       "dependencies": {
         "@aws-sdk/types": "3.734.0",
         "@smithy/types": "^4.1.0",
@@ -20485,119 +19026,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.750.0.tgz",
-      "integrity": "sha512-OH68BRF0rt9nDloq4zsfeHI0G21lj11a66qosaljtEP66PWm7tQ06feKbFkXHT5E1K3QhJW3nVyK8v2fEBY5fg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/middleware-host-header": "3.734.0",
-        "@aws-sdk/middleware-logger": "3.734.0",
-        "@aws-sdk/middleware-recursion-detection": "3.734.0",
-        "@aws-sdk/middleware-user-agent": "3.750.0",
-        "@aws-sdk/region-config-resolver": "3.734.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-endpoints": "3.743.0",
-        "@aws-sdk/util-user-agent-browser": "3.734.0",
-        "@aws-sdk/util-user-agent-node": "3.750.0",
-        "@smithy/config-resolver": "^4.0.1",
-        "@smithy/core": "^3.1.4",
-        "@smithy/fetch-http-handler": "^5.0.1",
-        "@smithy/hash-node": "^4.0.1",
-        "@smithy/invalid-dependency": "^4.0.1",
-        "@smithy/middleware-content-length": "^4.0.1",
-        "@smithy/middleware-endpoint": "^4.0.5",
-        "@smithy/middleware-retry": "^4.0.6",
-        "@smithy/middleware-serde": "^4.0.2",
-        "@smithy/middleware-stack": "^4.0.1",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/node-http-handler": "^4.0.2",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.5",
-        "@smithy/types": "^4.1.0",
-        "@smithy/url-parser": "^4.0.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.6",
-        "@smithy/util-defaults-mode-node": "^4.0.6",
-        "@smithy/util-endpoints": "^3.0.1",
-        "@smithy/util-middleware": "^4.0.1",
-        "@smithy/util-retry": "^4.0.1",
-        "@smithy/util-utf8": "^4.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/core": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.750.0.tgz",
-      "integrity": "sha512-bZ5K7N5L4+Pa2epbVpUQqd1XLG2uU8BGs/Sd+2nbgTf+lNQJyIxAg/Qsrjz9MzmY8zzQIeRQEkNmR6yVAfCmmQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/core": "^3.1.4",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/property-provider": "^4.0.1",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/signature-v4": "^5.0.1",
-        "@smithy/smithy-client": "^4.1.5",
-        "@smithy/types": "^4.1.0",
-        "@smithy/util-middleware": "^4.0.1",
-        "fast-xml-parser": "4.4.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.750.0.tgz",
-      "integrity": "sha512-YYcslDsP5+2NZoN3UwuhZGkhAHPSli7HlJHBafBrvjGV/I9f8FuOO1d1ebxGdEP4HyRXUGyh+7Ur4q+Psk0ryw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@aws-sdk/util-endpoints": "3.743.0",
-        "@smithy/core": "^3.1.4",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.750.0.tgz",
-      "integrity": "sha512-84HJj9G9zbrHX2opLk9eHfDceB+UIHVrmflMzWHpsmo9fDuro/flIBqaVDlE021Osj6qIM0SJJcnL6s23j7JEw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/node-config-provider": "^4.0.1",
-        "@smithy/types": "^4.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
@@ -20718,23 +19146,6 @@
       "integrity": "sha512-wmBJqn1DRXnZu3b4EkE6CWnoWMo1ZMvlfkqU5zPz67xx1GMaXlDCchFvKAXMjk4jn/L1O3tKnoFDNsoLV1kgNQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.750.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.750.0.tgz",
-      "integrity": "sha512-RA9hv1Irro/CrdPcOEXKwJ0DJYJwYCsauGEdRXihrRfy8MNSR9E+mD5/Fr5Rxjaq5AHM05DYnN3mg/DU6VwzSw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.750.0",
-        "@aws-sdk/types": "3.734.0",
-        "@smithy/protocol-http": "^5.0.1",
-        "@smithy/signature-v4": "^5.0.1",
-        "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -20903,6 +19314,7 @@
       "version": "3.734.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.734.0.tgz",
       "integrity": "sha512-Zrjxi5qwGEcUsJ0ru7fRtW74WcTS0rbLcehoFB+rN1GRi2hbLcFaYs4PwVA5diLeAJH0gszv3x4Hr/S87MfbKQ==",
+      "dev": true,
       "dependencies": {
         "@smithy/types": "^4.1.0",
         "tslib": "^2.6.2"
@@ -24422,6 +22834,43 @@
         "node": ">=6.5"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/accepts/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -25095,6 +23544,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
+      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.0",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.6.3",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.0",
+        "raw-body": "^3.0.0",
+        "type-is": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -25230,6 +23700,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/c8": {
@@ -26012,6 +24492,29 @@
       "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
       "dev": true
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
+      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/conventional-changelog-angular": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.0.0.tgz",
@@ -26091,6 +24594,16 @@
       "dev": true,
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
       }
     },
     "node_modules/core-js": {
@@ -26528,6 +25041,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/diff": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
@@ -26765,6 +25288,13 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electrodb": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/electrodb/-/electrodb-3.4.1.tgz",
@@ -26802,6 +25332,16 @@
       "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
       "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
       "dev": true
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/encoding-sniffer": {
       "version": "0.2.0",
@@ -27215,6 +25755,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -27625,6 +26172,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
@@ -27685,6 +26242,72 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
+      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.0",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/extend": {
@@ -27879,6 +26502,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
+      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -28036,6 +26677,16 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/franc-min": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/franc-min/-/franc-min-6.2.0.tgz",
@@ -28047,6 +26698,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/from2": {
@@ -28993,6 +27654,23 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
       "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
     },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -29213,6 +27891,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-array-buffer": {
@@ -29539,6 +28227,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-regex": {
       "version": "1.2.1",
@@ -30881,11 +29576,34 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
       "integrity": "sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==",
       "dev": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -31283,6 +30001,16 @@
       },
       "engines": {
         "node": ">= 4.4.x"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/neo-async": {
@@ -34591,6 +33319,19 @@
       "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
       "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg=="
     },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -34923,6 +33664,16 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-browserify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -34983,6 +33734,16 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
+      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -35425,6 +34186,20 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -35481,6 +34256,32 @@
       "dev": true,
       "dependencies": {
         "safe-buffer": "^5.1.0"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
+      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.6.3",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/rc": {
@@ -35895,6 +34696,23 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/rrweb-cssom": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
@@ -36293,6 +35111,52 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
+      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.5",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "mime-types": "^3.0.1",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/send/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/send/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
@@ -36300,6 +35164,22 @@
       "dev": true,
       "dependencies": {
         "randombytes": "^2.1.0"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/set-cookie-parser": {
@@ -36354,6 +35234,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/sha.js": {
       "version": "2.4.11",
@@ -36907,6 +35794,16 @@
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
       "integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug=="
+    },
+    "node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/stickyfill": {
       "version": "1.1.1",
@@ -37738,6 +36635,16 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/touch": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
@@ -37866,6 +36773,44 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/type-is/node_modules/mime-types": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typed-array-buffer": {
@@ -38065,6 +37010,16 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
@@ -38179,6 +37134,16 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -71,13 +71,13 @@
     "@adobe/helix-universal": "5.2.1",
     "@adobe/helix-universal-logger": "3.0.25",
     "@adobe/spacecat-shared-ahrefs-client": "1.6.19",
-    "@adobe/spacecat-shared-data-access": "2.19.0",
-    "@adobe/spacecat-shared-google-client": "1.4.24",
+    "@adobe/spacecat-shared-data-access": "2.19.1",
+    "@adobe/spacecat-shared-google-client": "1.4.25",
     "@adobe/spacecat-shared-gpt-client": "1.5.11",
     "@adobe/spacecat-shared-http-utils": "1.11.0",
     "@adobe/spacecat-shared-rum-api-client": "2.24.2",
     "@adobe/spacecat-shared-rum-api-client-v1": "npm:@adobe/spacecat-shared-rum-api-client@1.8.4",
-    "@adobe/spacecat-shared-utils": "1.38.0",
+    "@adobe/spacecat-shared-utils": "1.38.1",
     "@aws-sdk/client-lambda": "3.806.0",
     "@aws-sdk/client-s3": "3.806.0",
     "@aws-sdk/client-sqs": "3.806.0",
@@ -95,6 +95,7 @@
     "@adobe/eslint-config-helix": "2.0.9",
     "@adobe/helix-deploy": "https://gitpkg.now.sh/alinarublea/helix-deploy?main",
     "@adobe/helix-universal": "5.2.1",
+    "@adobe/helix-universal-devserver": "1.1.115",
     "@adobe/semantic-release-coralogix": "1.1.36",
     "@adobe/semantic-release-skms-cmr": "1.1.5",
     "@redocly/cli": "1.34.3",
@@ -129,5 +130,13 @@
     "*.js": "eslint",
     "*.ts": "eslint",
     "*.cjs": "eslint"
+  },
+  "nodemonConfig": {
+    "exec": "node --inspect ./test/dev/server.mjs",
+    "watch": [
+      ".env",
+      "."
+    ],
+    "ext": ".js, .cjs, .ejs, .css"
   }
 }

--- a/test/dev/server.mjs
+++ b/test/dev/server.mjs
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { DevelopmentServer } from '@adobe/helix-universal-devserver';
+import { resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+import { main } from '../../src/index.js';
+
+// eslint-disable-next-line no-underscore-dangle
+global.__rootdir = resolve(fileURLToPath(import.meta.url), '..', '..', '..');
+
+async function run() {
+    process.env.HLX_DEV_SERVER_HOST = 'localhost:3000';
+    process.env.HLX_DEV_SERVER_SCHEME = 'http';
+    const devServer = await new DevelopmentServer(main)
+        .init();
+    await devServer.start();
+}
+
+run().then(process.stdout).catch(process.stderr);

--- a/test/dev/server.mjs
+++ b/test/dev/server.mjs
@@ -12,9 +12,9 @@
 import { DevelopmentServer } from '@adobe/helix-universal-devserver';
 import { resolve } from 'path';
 import { fileURLToPath } from 'url';
-import crypto from 'crypto';
 
 import { main } from '../../src/index.js';
+import { hasText } from '@adobe/spacecat-shared-utils';
 
 // eslint-disable-next-line no-underscore-dangle
 global.__rootdir = resolve(fileURLToPath(import.meta.url), '..', '..', '..');
@@ -24,14 +24,7 @@ function checkEnvSafe() {
     const x = Buffer.from(process.env.AWS_SESSION_TOKEN, 'base64')
       .toString('utf8')
       .match(/\d{12}/)?.[0];
-    if (!x) throw new Error('Invalid session token');
-
-    const h = crypto
-      .createHash('md5')
-      .update(['27ff293048214ddc', x, '801d2fcf9dce89b5'].join(''))
-      .digest('hex');
-
-    if (h !== Buffer.from('MTRmNjkxYmY0ZmMzYzc5NjNlYzFjZDlhZWNhZmY1NGY=', 'base64').toString()) {
+    if (!hasText(x) || !x.includes('8203346262')) {
         throw new Error('RUNS ONLY ON DEV!');
     }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -28,6 +28,7 @@ describe('Index Tests', () => {
   let messageBodyJson;
 
   beforeEach('setup', () => {
+    process.env.AWS_EXECUTION_ENV = 'AWS_Lambda_nodejs22.x';
     messageBodyJson = {
       type: 'dummy',
       url: 'site-id',


### PR DESCRIPTION
This update adds detailed instructions for running Spacecat audits locally using two methods:

Nodemon with AWS credentials via KLAM – includes steps for setting up .env, starting the dev server, triggering audits via curl, and viewing results in DynamoDB.

These addition aim to streamline local development and debugging for contributors.

