### PR TITLE
fix: use base url overrides in audit url resolution

### DIFF
--- a/src/common/base-audit.js
+++ b/src/common/base-audit.js
@@ -11,7 +11,7 @@
  */
 
 import { ok } from '@adobe/spacecat-shared-http-utils';
-import { composeAuditURL, hasText } from '@adobe/spacecat-shared-utils';
+import { composeAuditURL, hasText, isValidUrl } from '@adobe/spacecat-shared-utils';
 import URI from 'urijs';
 
 import RUMAPIClient from '@adobe/spacecat-shared-rum-api-client';
@@ -61,6 +61,11 @@ export async function defaultUrlResolver(site) {
 
 export async function wwwUrlResolver(site, context) {
   const { log } = context;
+
+  const overrideBaseURL = site.getConfig()?.getFetchConfig()?.overrideBaseURL;
+  if (isValidUrl(overrideBaseURL)) {
+    return overrideBaseURL.replace(/^https?:\/\//, '');
+  }
 
   const baseURL = site.getBaseURL();
   const uri = new URI(baseURL);

--- a/test/audits/metatags.test.js
+++ b/test/audits/metatags.test.js
@@ -704,6 +704,7 @@ describe('Meta Tags', () => {
           getIsLive: sinon.stub().returns(true),
           getId: sinon.stub().returns('site-id'),
           getBaseURL: sinon.stub().returns('http://example.com'),
+          getConfig: sinon.stub(),
         };
 
         audit = {

--- a/test/common/audit.test.js
+++ b/test/common/audit.test.js
@@ -390,9 +390,27 @@ describe('Audit tests', () => {
   });
 
   describe('wwwUrlResolver', () => {
+    it('wwwUrlResolver fet', async () => {
+      const base = 'http://blog.spacecat.com';
+      const resolvedURL = await wwwUrlResolver({
+        getBaseURL: () => base,
+        getConfig: () => ({
+          getFetchConfig() {
+            return {
+              overrideBaseURL: 'https://override.spacecat.com',
+            };
+          },
+
+        }),
+      }, context);
+      expect(resolvedURL).to.equal('override.spacecat.com');
+      expect(context.rumApiClient.retrieveDomainkey).to.not.have.been.called;
+    });
     it('wwwUrlResolver returns subdomain version', async () => {
       const base = 'http://blog.spacecat.com';
-      const resolvedURL = await wwwUrlResolver({ getBaseURL: () => base }, context);
+      const resolvedURL = await wwwUrlResolver({
+        getBaseURL: () => base, getConfig: () => {},
+      }, context);
       expect(resolvedURL).to.equal('blog.spacecat.com');
       expect(context.rumApiClient.retrieveDomainkey).to.not.have.been.called;
     });
@@ -400,7 +418,9 @@ describe('Audit tests', () => {
     it('wwwUrlResolver resolves to www using rum api client', async () => {
       const base = 'http://spacecat.com';
       context.rumApiClient.retrieveDomainkey.withArgs('www.spacecat.com').resolves();
-      const resolvedURL = await wwwUrlResolver({ getBaseURL: () => base }, context);
+      const resolvedURL = await wwwUrlResolver({
+        getBaseURL: () => base, getConfig: () => {},
+      }, context);
       expect(resolvedURL).to.equal('www.spacecat.com');
       expect(context.rumApiClient.retrieveDomainkey).to.have.been.calledOnce;
     });
@@ -408,7 +428,9 @@ describe('Audit tests', () => {
     it('wwwUrlResolver resolves to www for baseURLs with path using rum api client', async () => {
       const base = 'http://spacecat.com/us/en';
       context.rumApiClient.retrieveDomainkey.withArgs('www.spacecat.com').resolves();
-      const resolvedURL = await wwwUrlResolver({ getBaseURL: () => base }, context);
+      const resolvedURL = await wwwUrlResolver({
+        getBaseURL: () => base, getConfig: () => {},
+      }, context);
       expect(resolvedURL).to.equal('www.spacecat.com');
       expect(context.rumApiClient.retrieveDomainkey).to.have.been.calledOnce;
     });
@@ -417,7 +439,9 @@ describe('Audit tests', () => {
       const base = 'http://spacecat.com';
       context.rumApiClient.retrieveDomainkey.withArgs('www.spacecat.com').rejects();
       context.rumApiClient.retrieveDomainkey.withArgs('spacecat.com').resolves();
-      const resolvedURL = await wwwUrlResolver({ getBaseURL: () => base }, context);
+      const resolvedURL = await wwwUrlResolver({
+        getBaseURL: () => base, getConfig: () => {},
+      }, context);
       expect(resolvedURL).to.equal('spacecat.com');
       expect(context.rumApiClient.retrieveDomainkey).to.have.been.calledTwice;
     });
@@ -426,7 +450,9 @@ describe('Audit tests', () => {
       const base = 'http://spacecat.com/us/en';
       context.rumApiClient.retrieveDomainkey.withArgs('www.spacecat.com').rejects();
       context.rumApiClient.retrieveDomainkey.withArgs('spacecat.com').resolves();
-      const resolvedURL = await wwwUrlResolver({ getBaseURL: () => base }, context);
+      const resolvedURL = await wwwUrlResolver({
+        getBaseURL: () => base, getConfig: () => {},
+      }, context);
       expect(resolvedURL).to.equal('spacecat.com');
       expect(context.rumApiClient.retrieveDomainkey).to.have.been.calledTwice;
     });
@@ -435,7 +461,9 @@ describe('Audit tests', () => {
       const base = 'http://spacecat.com';
       context.rumApiClient.retrieveDomainkey.withArgs('www.spacecat.com').rejects();
       context.rumApiClient.retrieveDomainkey.withArgs('spacecat.com').rejects();
-      const resolvedURL = await wwwUrlResolver({ getBaseURL: () => base }, context);
+      const resolvedURL = await wwwUrlResolver({
+        getBaseURL: () => base, getConfig: () => {},
+      }, context);
       expect(resolvedURL).to.equal('www.spacecat.com');
       expect(context.rumApiClient.retrieveDomainkey).to.have.been.calledTwice;
     });
@@ -444,7 +472,9 @@ describe('Audit tests', () => {
       const base = 'http://www.spacecat.com';
       context.rumApiClient.retrieveDomainkey.withArgs('www.spacecat.com').rejects();
       context.rumApiClient.retrieveDomainkey.withArgs('spacecat.com').rejects();
-      const resolvedURL = await wwwUrlResolver({ getBaseURL: () => base }, context);
+      const resolvedURL = await wwwUrlResolver({
+        getBaseURL: () => base, getConfig: () => {},
+      }, context);
       expect(resolvedURL).to.equal('www.spacecat.com');
       expect(context.rumApiClient.retrieveDomainkey).to.have.been.calledTwice;
     });


### PR DESCRIPTION
`wwwUrlResolver` makes use of the `overrideBaseURL` property under site config object for the cases where audit url resolution is extremely problematic.