### PR TITLE
feat: Filter out decorative (almost all) images from audit suggestions

### DIFF
--- a/src/image-alt-text/auditEngine.js
+++ b/src/image-alt-text/auditEngine.js
@@ -137,9 +137,7 @@ export default class AuditEngine {
           });
         }
 
-        // Since EDS authoring adds images with an empty alt
-        // we need to still show them as suggestions
-        if (!image.isDecorative || (image.isDecorative && image.hasEmptyAlt)) {
+        if (image.shouldShowAsSuggestion) {
           this.auditedImages.imagesWithoutAltText.set(image.src, {
             pageUrl,
             src: image.src,

--- a/src/image-alt-text/auditEngine.js
+++ b/src/image-alt-text/auditEngine.js
@@ -113,7 +113,7 @@ export default class AuditEngine {
     this.log = log;
     this.auditedImages = {
       imagesWithoutAltText: new Map(),
-      presentationalImagesWithoutAltText: new Map(),
+      decorativeImagesWithoutAltText: new Map(),
     };
   }
 
@@ -129,8 +129,8 @@ export default class AuditEngine {
 
     pageImages.images.forEach((image) => {
       if (!hasText(image.alt?.trim())) {
-        if (image.isPresentational) {
-          this.auditedImages.presentationalImagesWithoutAltText.set(image.src, {
+        if (image.isDecorative) {
+          this.auditedImages.decorativeImagesWithoutAltText.set(image.src, {
             pageUrl,
             src: image.src,
             xpath: image.xpath,
@@ -204,15 +204,15 @@ export default class AuditEngine {
       `[${AUDIT_TYPE}]: Found ${Array.from(this.auditedImages.imagesWithoutAltText.values()).length} images without alt text`,
     );
     this.log.info(
-      `[${AUDIT_TYPE}]: Found ${Array.from(this.auditedImages.presentationalImagesWithoutAltText.values()).length} presentational images`,
+      `[${AUDIT_TYPE}]: Found ${Array.from(this.auditedImages.decorativeImagesWithoutAltText.values()).length} decorative images`,
     );
   }
 
   getAuditedTags() {
     return {
       imagesWithoutAltText: Array.from(this.auditedImages.imagesWithoutAltText.values()),
-      presentationalImagesCount: Array.from(
-        this.auditedImages.presentationalImagesWithoutAltText.values(),
+      decorativeImagesCount: Array.from(
+        this.auditedImages.decorativeImagesWithoutAltText.values(),
       ).length,
     };
   }

--- a/src/image-alt-text/auditEngine.js
+++ b/src/image-alt-text/auditEngine.js
@@ -137,12 +137,16 @@ export default class AuditEngine {
           });
         }
 
-        this.auditedImages.imagesWithoutAltText.set(image.src, {
-          pageUrl,
-          src: image.src,
-          xpath: image.xpath,
-          language: pageLanguage,
-        });
+        // Since EDS authoring adds images with an empty alt
+        // we need to still show them as suggestions
+        if (!image.isDecorative || (image.isDecorative && image.hasEmptyAlt)) {
+          this.auditedImages.imagesWithoutAltText.set(image.src, {
+            pageUrl,
+            src: image.src,
+            xpath: image.xpath,
+            language: pageLanguage,
+          });
+        }
       }
     });
   }

--- a/src/image-alt-text/handler.js
+++ b/src/image-alt-text/handler.js
@@ -25,14 +25,20 @@ import convertToOpportunity from './opportunityHandler.js';
 const AUDIT_TYPE = AuditModel.AUDIT_TYPES.ALT_TEXT;
 const { AUDIT_STEP_DESTINATIONS } = AuditModel;
 
-const isImagePresentational = (img) => {
+// Since EDS authoring adds images with an empty alt, we need to still show them as suggestions
+// Otherwise, we would consider them decorative and not create suggestions for them
+const hasEmptyAltAttribute = (img) => {
+  const hasAltAttribute = img.hasAttribute('alt');
+  const isAltEmpty = hasAltAttribute && !img.getAttribute('alt');
+  return isAltEmpty;
+};
+
+const isImageDecorative = (img) => {
   const isHiddenForScreenReader = img.getAttribute('aria-hidden') === 'true';
   const hasRolePresentation = img.getAttribute('role') === 'presentation';
-  const hasAltAttribute = img.hasAttribute('alt');
-  // For presentational images, an image MUST have the alt attribute WITH a falsy value
-  // Not having it at all is not the same, the image is not considered presentational
-  const isAltEmpty = hasAltAttribute && !img.getAttribute('alt');
-  return isHiddenForScreenReader || hasRolePresentation || isAltEmpty;
+  // For decorative images, an image MUST have the alt attribute WITH a falsy value
+  // Not having it at all is not the same, the image is not considered decorative
+  return isHiddenForScreenReader || hasRolePresentation || hasEmptyAltAttribute(img);
 };
 
 export async function processImportStep(context) {
@@ -81,7 +87,7 @@ export async function fetchPageScrapeAndRunAudit(
   const dom = new JSDOM(pageScrape.scrapeResult.rawBody);
   const imageElements = dom.window.document.getElementsByTagName('img');
   const images = Array.from(imageElements).map((img) => ({
-    isPresentational: isImagePresentational(img),
+    isDecorative: isImageDecorative(img),
     src: img.getAttribute('src'),
     alt: img.getAttribute('alt'),
     xpath: getXpath(img),

--- a/src/image-alt-text/handler.js
+++ b/src/image-alt-text/handler.js
@@ -88,6 +88,7 @@ export async function fetchPageScrapeAndRunAudit(
   const imageElements = dom.window.document.getElementsByTagName('img');
   const images = Array.from(imageElements).map((img) => ({
     isDecorative: isImageDecorative(img),
+    hasEmptyAlt: hasEmptyAltAttribute(img),
     src: img.getAttribute('src'),
     alt: img.getAttribute('alt'),
     xpath: getXpath(img),

--- a/src/image-alt-text/opportunityHandler.js
+++ b/src/image-alt-text/opportunityHandler.js
@@ -160,7 +160,7 @@ export default async function convertToOpportunity(auditUrl, auditData, context)
 
   const opportunityData = {
     ...projectedMetrics,
-    presentationalImagesCount: detectedImages.presentationalImagesCount,
+    decorativeImagesCount: detectedImages.decorativeImagesCount,
   };
   opportunityData.dataSources = [
     DATA_SOURCES.RUM,

--- a/src/image-alt-text/utils.js
+++ b/src/image-alt-text/utils.js
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Determines if an image should be shown as a suggestion for alt text improvement.
+ *
+ * In an ideal world, we would only show non-decorative images as suggestions.
+ * However, since EDS authoring adds images with an empty alt,
+ * we need to still show them as suggestions.
+ * Since some other customers will have images marked as decorative in other ways
+ * like using aria-hidden="true", role=presentation, etc.
+ * We need to show them as suggestions if they have an empty alt,
+ * and not show them as suggestions if they are decorative in any other way.
+ *
+ * @param {HTMLImageElement} image - The image element to check
+ * @returns {boolean} True if the image should be shown as a suggestion
+ */
+export const shouldShowImageAsSuggestion = (image) => {
+  const isHiddenForScreenReader = image.getAttribute('aria-hidden') === 'true';
+  const hasRolePresentation = image.getAttribute('role') === 'presentation';
+  return !isHiddenForScreenReader && !hasRolePresentation && !image.getAttribute('alt');
+};
+
+/**
+ * Checks if an image has an empty alt attribute.
+ *
+ * @param {HTMLImageElement} img - The image element to check
+ * @returns {boolean} True if the image has an alt attribute with an empty value
+ */
+export const hasEmptyAltAttribute = (img) => {
+  const hasAltAttribute = img.hasAttribute('alt');
+  const isAltEmpty = hasAltAttribute && !img.getAttribute('alt');
+  return isAltEmpty;
+};
+
+/**
+ * Determines if an image is decorative.
+ *
+ * For decorative images, an image MUST have the alt attribute WITH a falsy value.
+ * Not having it at all is not the same, the image is not considered decorative.
+ *
+ * @param {HTMLImageElement} img - The image element to check
+ * @returns {boolean} True if the image is decorative
+ */
+export const isImageDecorative = (img) => {
+  const isHiddenForScreenReader = img.getAttribute('aria-hidden') === 'true';
+  const hasRolePresentation = img.getAttribute('role') === 'presentation';
+  return isHiddenForScreenReader || hasRolePresentation || hasEmptyAltAttribute(img);
+};

--- a/test/audits/image-alt-text/audit-engine.test.js
+++ b/test/audits/image-alt-text/audit-engine.test.js
@@ -42,7 +42,7 @@ describe('AuditEngine', () => {
       const auditedImages = auditEngine.getAuditedTags();
       expect(auditedImages).to.deep.equal({
         imagesWithoutAltText: [],
-        presentationalImagesCount: 0,
+        decorativeImagesCount: 0,
       });
     });
   });
@@ -53,14 +53,14 @@ describe('AuditEngine', () => {
       const pageTags = {
         images: [
           {
-            src: 'image1.jpg', alt: '', isPresentational: false, xpath: '/html/body/img[1]',
+            src: 'image1.jpg', alt: '', isDecorative: false, xpath: '/html/body/img[1]',
           },
-          { src: 'image2.jpg', isPresentational: false, xpath: '/html/body/img[2]' },
+          { src: 'image2.jpg', isDecorative: false, xpath: '/html/body/img[2]' },
           {
-            src: 'image3.jpg', alt: null, isPresentational: false, xpath: '/html/body/img[3]',
+            src: 'image3.jpg', alt: null, isDecorative: false, xpath: '/html/body/img[3]',
           },
           {
-            src: 'image4.jpg', alt: null, isPresentational: true, xpath: '/html/body/img[4]',
+            src: 'image4.jpg', alt: null, isDecorative: true, xpath: '/html/body/img[4]',
           },
         ],
       };
@@ -69,7 +69,7 @@ describe('AuditEngine', () => {
       const auditedImages = auditEngine.getAuditedTags();
 
       expect(auditedImages.imagesWithoutAltText).to.have.lengthOf(4);
-      expect(auditedImages.presentationalImagesCount).to.equal(1);
+      expect(auditedImages.decorativeImagesCount).to.equal(1);
       expect(auditedImages.imagesWithoutAltText[0]).to.deep.equal({
         pageUrl,
         src: 'image1.jpg',

--- a/test/audits/image-alt-text/audit-engine.test.js
+++ b/test/audits/image-alt-text/audit-engine.test.js
@@ -53,14 +53,16 @@ describe('AuditEngine', () => {
       const pageTags = {
         images: [
           {
-            src: 'image1.jpg', alt: '', isDecorative: false, xpath: '/html/body/img[1]',
-          },
-          { src: 'image2.jpg', isDecorative: false, xpath: '/html/body/img[2]' },
-          {
-            src: 'image3.jpg', alt: null, isDecorative: false, xpath: '/html/body/img[3]',
+            src: 'image1.jpg', alt: '', isDecorative: true, hasEmptyAlt: true, xpath: '/html/body/img[1]',
           },
           {
-            src: 'image4.jpg', alt: null, isDecorative: true, xpath: '/html/body/img[4]',
+            src: 'image2.jpg', isDecorative: false, hasEmptyAlt: false, xpath: '/html/body/img[2]',
+          },
+          {
+            src: 'image3.jpg', alt: null, isDecorative: false, hasEmptyAlt: false, xpath: '/html/body/img[3]',
+          },
+          {
+            src: 'image4.jpg', alt: null, isDecorative: true, hasEmptyAlt: false, xpath: '/html/body/img[4]',
           },
         ],
       };
@@ -68,8 +70,8 @@ describe('AuditEngine', () => {
       auditEngine.performPageAudit(pageUrl, pageTags);
       const auditedImages = auditEngine.getAuditedTags();
 
-      expect(auditedImages.imagesWithoutAltText).to.have.lengthOf(4);
-      expect(auditedImages.decorativeImagesCount).to.equal(1);
+      expect(auditedImages.imagesWithoutAltText).to.have.lengthOf(3);
+      expect(auditedImages.decorativeImagesCount).to.equal(2);
       expect(auditedImages.imagesWithoutAltText[0]).to.deep.equal({
         pageUrl,
         src: 'image1.jpg',

--- a/test/audits/image-alt-text/audit-engine.test.js
+++ b/test/audits/image-alt-text/audit-engine.test.js
@@ -15,7 +15,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { JSDOM } from 'jsdom';
 import { Audit as AuditModel } from '@adobe/spacecat-shared-data-access';
-import AuditEngine, { getPageLanguage, detectLanguageFromText } from '../../../src/image-alt-text/auditEngine.js';
+import AuditEngine, { getPageLanguage, detectLanguageFromText, convertImagesToBase64 } from '../../../src/image-alt-text/auditEngine.js';
 
 describe('AuditEngine', () => {
   let auditEngine;
@@ -474,6 +474,109 @@ describe('AuditEngine', () => {
         const lang = detectLanguageFromText(text);
         expect(lang).to.equal('unknown');
       });
+    });
+  });
+
+  describe('convertImagesToBase64', () => {
+    let fetchStub;
+
+    beforeEach(() => {
+      logStub = {
+        info: sinon.stub(),
+        error: sinon.stub(),
+      };
+      fetchStub = sinon.stub();
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should skip images that exceed size limit based on Content-Length header', async () => {
+      const imageUrls = ['test.svg'];
+      const auditUrl = 'https://example.com';
+
+      // Mock response with Content-Length exceeding 120KB
+      fetchStub.resolves({
+        ok: true,
+        headers: {
+          get: sinon.stub().withArgs('Content-Length').returns('130000'), // 130KB > 120KB limit
+        },
+        arrayBuffer: async () => new ArrayBuffer(8),
+      });
+
+      const result = await convertImagesToBase64(imageUrls, auditUrl, logStub, fetchStub);
+
+      expect(result).to.be.an('array').that.is.empty;
+      expect(logStub.info).to.have.been.calledWith(
+        '[alt-text]: Skipping image test.svg as it exceeds 120KB',
+      );
+    });
+
+    it('should skip images where base64 blob exceeds size limit', async () => {
+      const imageUrls = ['test.svg'];
+      const auditUrl = 'https://example.com';
+
+      // Create a large array buffer that will result in a base64 string > 120KB
+      const largeArrayBuffer = new ArrayBuffer(130000); // 130KB
+
+      fetchStub.resolves({
+        ok: true,
+        headers: {
+          get: sinon.stub().withArgs('Content-Length').returns('1000'), // Small Content-Length
+        },
+        arrayBuffer: async () => largeArrayBuffer,
+      });
+
+      const result = await convertImagesToBase64(imageUrls, auditUrl, logStub, fetchStub);
+
+      expect(result).to.be.an('array').that.is.empty;
+      expect(logStub.info).to.have.been.calledWith(
+        '[alt-text]: Skipping base64 image test.svg as it exceeds 120KB',
+      );
+    });
+
+    it('should successfully convert images within size limits', async () => {
+      const imageUrls = ['test.svg'];
+      const auditUrl = 'https://example.com';
+
+      const smallArrayBuffer = new ArrayBuffer(100); // Small buffer
+
+      fetchStub.resolves({
+        ok: true,
+        headers: {
+          get: sinon.stub().withArgs('Content-Length').returns('100'),
+        },
+        arrayBuffer: async () => smallArrayBuffer,
+      });
+
+      const result = await convertImagesToBase64(imageUrls, auditUrl, logStub, fetchStub);
+
+      expect(result).to.have.lengthOf(1);
+      expect(result[0]).to.have.property('url', 'test.svg');
+      expect(result[0]).to.have.property('blob');
+      expect(result[0].blob).to.match(/^data:image\/svg\+xml;base64,/);
+    });
+
+    it('should handle missing Content-Length header', async () => {
+      const imageUrls = ['test.svg'];
+      const auditUrl = 'https://example.com';
+
+      const smallArrayBuffer = new ArrayBuffer(100);
+
+      fetchStub.resolves({
+        ok: true,
+        headers: {
+          get: sinon.stub().withArgs('Content-Length').returns(null), // No Content-Length
+        },
+        arrayBuffer: async () => smallArrayBuffer,
+      });
+
+      const result = await convertImagesToBase64(imageUrls, auditUrl, logStub, fetchStub);
+
+      expect(result).to.have.lengthOf(1);
+      expect(result[0]).to.have.property('url', 'test.svg');
+      expect(result[0]).to.have.property('blob');
     });
   });
 });

--- a/test/audits/image-alt-text/audit-engine.test.js
+++ b/test/audits/image-alt-text/audit-engine.test.js
@@ -53,16 +53,16 @@ describe('AuditEngine', () => {
       const pageTags = {
         images: [
           {
-            src: 'image1.jpg', alt: '', isDecorative: true, hasEmptyAlt: true, xpath: '/html/body/img[1]',
+            src: 'image1.jpg', alt: '', isDecorative: true, hasEmptyAlt: true, shouldShowAsSuggestion: true, xpath: '/html/body/img[1]',
           },
           {
-            src: 'image2.jpg', isDecorative: false, hasEmptyAlt: false, xpath: '/html/body/img[2]',
+            src: 'image2.jpg', isDecorative: false, hasEmptyAlt: false, shouldShowAsSuggestion: true, xpath: '/html/body/img[2]',
           },
           {
-            src: 'image3.jpg', alt: null, isDecorative: false, hasEmptyAlt: false, xpath: '/html/body/img[3]',
+            src: 'image3.jpg', alt: null, isDecorative: false, hasEmptyAlt: false, shouldShowAsSuggestion: true, xpath: '/html/body/img[3]',
           },
           {
-            src: 'image4.jpg', alt: null, isDecorative: true, hasEmptyAlt: false, xpath: '/html/body/img[4]',
+            src: 'image4.jpg', alt: null, isDecorative: true, hasEmptyAlt: false, shouldShowAsSuggestion: true, xpath: '/html/body/img[4]',
           },
         ],
       };
@@ -70,7 +70,7 @@ describe('AuditEngine', () => {
       auditEngine.performPageAudit(pageUrl, pageTags);
       const auditedImages = auditEngine.getAuditedTags();
 
-      expect(auditedImages.imagesWithoutAltText).to.have.lengthOf(3);
+      expect(auditedImages.imagesWithoutAltText).to.have.lengthOf(4);
       expect(auditedImages.decorativeImagesCount).to.equal(2);
       expect(auditedImages.imagesWithoutAltText[0]).to.deep.equal({
         pageUrl,
@@ -99,8 +99,12 @@ describe('AuditEngine', () => {
       const pageUrl = '/test-page';
       const pageTags = {
         images: [
-          { src: 'image1.jpg', alt: '   ', xpath: '/html/body/img[1]' },
-          { src: 'image2.jpg', alt: '\n\t', xpath: '/html/body/img[2]' },
+          {
+            src: 'image1.jpg', alt: '   ', shouldShowAsSuggestion: true, xpath: '/html/body/img[1]',
+          },
+          {
+            src: 'image2.jpg', alt: '\n\t', shouldShowAsSuggestion: true, xpath: '/html/body/img[2]',
+          },
         ],
       };
 
@@ -171,9 +175,9 @@ describe('AuditEngine', () => {
     it('should log summary of images without alt text', () => {
       const pageTags = {
         images: [
-          { src: 'image1.jpg', alt: '' },
+          { src: 'image1.jpg', alt: '', shouldShowAsSuggestion: true },
           { src: 'image2.jpg', alt: 'Valid alt' },
-          { src: 'image3.jpg' },
+          { src: 'image3.jpg', shouldShowAsSuggestion: true },
         ],
       };
 
@@ -204,11 +208,11 @@ describe('AuditEngine', () => {
   describe('getAuditedTags', () => {
     it('should return accumulated results from all audited pages', () => {
       auditEngine.performPageAudit('/page1', {
-        images: [{ src: 'image1.jpg' }],
+        images: [{ src: 'image1.jpg', shouldShowAsSuggestion: true }],
       });
 
       auditEngine.performPageAudit('/page2', {
-        images: [{ src: 'image2.jpg', alt: '' }],
+        images: [{ src: 'image2.jpg', alt: '', shouldShowAsSuggestion: true }],
       });
 
       const auditedImages = auditEngine.getAuditedTags();
@@ -238,9 +242,9 @@ describe('AuditEngine', () => {
       const pageUrl = '/test-page';
       const pageTags = {
         images: [
-          { src: 'image1.jpg', alt: '' },
-          { src: 'image2.png', alt: '' },
-          { src: 'image3.gif', alt: '' },
+          { src: 'image1.jpg', alt: '', shouldShowAsSuggestion: true },
+          { src: 'image2.png', alt: '', shouldShowAsSuggestion: true },
+          { src: 'image3.gif', alt: '', shouldShowAsSuggestion: true },
         ],
       };
 
@@ -255,9 +259,9 @@ describe('AuditEngine', () => {
       const pageUrl = '/test-page';
       const pageTags = {
         images: [
-          { src: 'image1.tiff', alt: '' },
-          { src: 'image2.bmp', alt: '' },
-          { src: 'image3.svg', alt: '' }],
+          { src: 'image1.tiff', alt: '', shouldShowAsSuggestion: true },
+          { src: 'image2.bmp', alt: '', shouldShowAsSuggestion: true },
+          { src: 'image3.svg', alt: '', shouldShowAsSuggestion: true }],
       };
 
       function createRandomArrayBuffer(size) {
@@ -288,8 +292,8 @@ describe('AuditEngine', () => {
       const pageUrl = '/test-page';
       const pageTags = {
         images: [
-          { src: 'image1.svg', alt: '' },
-          { src: 'image2.svg', alt: '' },
+          { src: 'image1.svg', alt: '', shouldShowAsSuggestion: true },
+          { src: 'image2.svg', alt: '', shouldShowAsSuggestion: true },
         ],
       };
 
@@ -360,7 +364,7 @@ describe('AuditEngine', () => {
       const pageUrl = '/test-page';
       const pageTags = {
         images: [
-          { src: 'image1.svg', alt: '' },
+          { src: 'image1.svg', alt: '', shouldShowAsSuggestion: true },
         ],
       };
 
@@ -381,7 +385,7 @@ describe('AuditEngine', () => {
       const pageUrl = '/test-page';
       const pageTags = {
         images: [
-          { src: 'image1.svg', alt: '' },
+          { src: 'image1.svg', alt: '', shouldShowAsSuggestion: true },
         ],
       };
 

--- a/test/audits/image-alt-text/handler.test.js
+++ b/test/audits/image-alt-text/handler.test.js
@@ -144,7 +144,7 @@ describe('Image Alt Text Handler', () => {
       );
     });
 
-    it('should process images and identify presentational ones', async () => {
+    it('should process images and identify decorative ones', async () => {
       const mockScrapeResult = {
         scrapeResult: {
           rawBody: `
@@ -179,7 +179,7 @@ describe('Image Alt Text Handler', () => {
       expect(result).to.have.property('/page1');
       expect(result['/page1']).to.have.property('images');
       expect(result['/page1'].images).to.have.lengthOf(4);
-      expect(result['/page1'].images.filter((img) => img.isPresentational)).to.have.lengthOf(3);
+      expect(result['/page1'].images.filter((img) => img.isDecorative)).to.have.lengthOf(3);
     });
   });
 
@@ -287,7 +287,7 @@ describe('Image Alt Text Handler', () => {
         },
       });
       auditEngineStub.getAuditedTags.returns(
-        { imagesWithoutAltText: [], presentationalImagesCount: 0 },
+        { imagesWithoutAltText: [], decorativeImagesCount: 0 },
       );
 
       const result = await handlerModule.processAltTextAuditStep(context);

--- a/test/audits/image-alt-text/opportunity-handler.test.js
+++ b/test/audits/image-alt-text/opportunity-handler.test.js
@@ -91,7 +91,7 @@ describe('Image Alt Text Opportunity Handler', () => {
           { pageUrl: '/page2', src: 'image2.jpg' },
           { pageUrl: '/page3', src: 'image1.svg', blob: 'blob' },
         ],
-        presentationalImagesCount: 0,
+        decorativeImagesCount: 0,
       },
     };
 
@@ -138,7 +138,7 @@ describe('Image Alt Text Opportunity Handler', () => {
       data: sinon.match({
         projectedTrafficLost: sinon.match.number,
         projectedTrafficValue: sinon.match.number,
-        presentationalImagesCount: 0,
+        decorativeImagesCount: 0,
         dataSources: [DATA_SOURCES.RUM, DATA_SOURCES.SITE, DATA_SOURCES.AHREFS, DATA_SOURCES.GSC],
       }),
     }));
@@ -419,7 +419,7 @@ describe('Image Alt Text Opportunity Handler', () => {
     expect(altTextOppty.setData).to.have.been.calledWith({
       projectedTrafficLost: 0,
       projectedTrafficValue: 0,
-      presentationalImagesCount: 0,
+      decorativeImagesCount: 0,
       dataSources: [DATA_SOURCES.RUM, DATA_SOURCES.SITE, DATA_SOURCES.AHREFS, DATA_SOURCES.GSC],
     });
 


### PR DESCRIPTION
## Context

We have historically filtered out ALL decorative images because EDS authoring process includes empty alts `alt=""` to all images that don't have a textual alt. This effectively marks them as decorative, but they need fixing, so we allowed all decorative images to be shown as suggestions to alleviate this.

A more correct approach while the issue is not resolved in EDS, is to only show the decorative images that are so because they have an alt that is empty. This will not show other decorative images that:

- Use `aria-hidden="true"`
- Use `role="presentation"`

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [x] ~If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.~

## Related Issues

- [ASSETS-52117 | Filter out decorative (almost all) images from audit suggestions](https://jira.corp.adobe.com/browse/ASSETS-52117)
- [ASSETS-47238 | [EPIC] Alt text audit for Project Success Studio](https://jira.corp.adobe.com/browse/ASSETS-47238)

