### PR TITLE
fix: detect language from url

### DIFF
--- a/src/image-alt-text/auditEngine.js
+++ b/src/image-alt-text/auditEngine.js
@@ -95,26 +95,21 @@ function detectLanguageFromDom({ document }) {
 }
 
 function detectLanguageFromUrl(pageUrl) {
-  try {
-    const url = new URL(pageUrl);
-    const pathSegments = url.pathname.split('/');
-    const segmentsToCheck = pathSegments.slice(0, -1);
+  const url = new URL(pageUrl);
+  const pathSegments = url.pathname.split('/');
+  const segmentsToCheck = pathSegments.slice(0, -1);
 
-    // Check each path segment for country codes
-    for (const segment of segmentsToCheck) {
-      if (segment.length > 0) {
-        const lowerSegment = segment.toLowerCase();
-        if (validCountryCodes.has(lowerSegment)) {
-          return lowerSegment;
-        }
+  // Check each path segment for country codes
+  for (const segment of segmentsToCheck) {
+    if (segment.length > 0) {
+      const lowerSegment = segment.toLowerCase();
+      if (validCountryCodes.has(lowerSegment)) {
+        return lowerSegment;
       }
     }
-
-    return null;
-  } catch (error) {
-    this.log.error(`[${AUDIT_TYPE}]: Error detecting language from URL ${pageUrl}:`, error);
-    return null;
   }
+
+  return null;
 }
 
 const getPageLanguage = ({ document, pageUrl }) => {

--- a/src/image-alt-text/auditEngine.js
+++ b/src/image-alt-text/auditEngine.js
@@ -152,7 +152,7 @@ export default class AuditEngine {
 
     const pageLanguage = getPageLanguage({ document: pageImages.dom?.window?.document, pageUrl });
 
-    this.log.info(`[${AUDIT_TYPE}]: Language: ${pageLanguage}, Page: ${pageUrl}`);
+    this.log.debug(`[${AUDIT_TYPE}]: Language: ${pageLanguage}, Page: ${pageUrl}`);
 
     pageImages.images.forEach((image) => {
       if (!hasText(image.alt?.trim())) {

--- a/src/image-alt-text/auditEngine.js
+++ b/src/image-alt-text/auditEngine.js
@@ -95,8 +95,7 @@ function detectLanguageFromDom({ document }) {
 }
 
 function detectLanguageFromUrl(pageUrl) {
-  const url = new URL(pageUrl);
-  const pathSegments = url.pathname.split('/');
+  const pathSegments = pageUrl.split('/');
   const segmentsToCheck = pathSegments.slice(0, -1);
 
   // Check each path segment for country codes

--- a/src/image-alt-text/auditEngine.js
+++ b/src/image-alt-text/auditEngine.js
@@ -118,15 +118,21 @@ const getPageLanguage = ({ document, pageUrl }) => {
     return lang;
   }
 
+  if (pageUrl) {
+    const urlLanguage = detectLanguageFromUrl(pageUrl);
+    if (urlLanguage) {
+      return urlLanguage;
+    }
+  }
   lang = detectLanguageFromDom({ document });
   if (lang === UNKNOWN_LANGUAGE) {
     // Check the page URL for the language
-    if (pageUrl) {
-      const urlLanguage = detectLanguageFromUrl(pageUrl);
-      if (urlLanguage) {
-        return urlLanguage;
-      }
-    }
+    // if (pageUrl) {
+    //   const urlLanguage = detectLanguageFromUrl(pageUrl);
+    //   if (urlLanguage) {
+    //     return urlLanguage;
+    //   }
+    // }
 
     const bodyText = document.querySelector('body').textContent;
     const cleanedText = bodyText.replace(/[\n\t]/g, '').replace(/ {2,}/g, ' ');

--- a/src/image-alt-text/country-code.js
+++ b/src/image-alt-text/country-code.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+export const validCountryCodes = new Set([
+  // 2-letter country codes (ISO 3166-1 alpha-2)
+  'jp', 'us', 'gb', 'de', 'fr', 'es', 'it', 'kr', 'cn', 'ru', 'br', 'mx',
+  'ca', 'au', 'in', 'nl', 'se', 'no', 'dk', 'fi', 'pl', 'tr', 'at', 'ch',
+  'be', 'pt', 'ar', 'cl', 'co', 'pe', 've', 'th', 'vn', 'id', 'my', 'sg',
+  'ph', 'sa', 'ae', 'eg', 'ma', 'za', 'ng', 'ke', 'et', 'il', 'ir', 'iq',
+  'pk', 'bd', 'lk', 'np',
+
+  // 3-letter country codes (ISO 3166-1 alpha-3)
+  'usa', 'gbr', 'deu', 'fra', 'esp', 'ita', 'jpn', 'kor', 'chn', 'rus',
+  'bra', 'mex', 'can', 'aus', 'ind', 'nld', 'swe', 'nor', 'dnk', 'fin',
+  'pol', 'tur', 'aut', 'che', 'bel', 'prt', 'arg', 'chl', 'col', 'per',
+  'ven', 'tha', 'vnm', 'idn', 'mys', 'sgp', 'phl', 'sau', 'are', 'egy',
+  'mar', 'zaf', 'nga', 'ken', 'eth', 'isr', 'irn', 'irq', 'pak', 'bgd',
+  'lka', 'npl',
+]);

--- a/src/image-alt-text/suggestionsEngine.js
+++ b/src/image-alt-text/suggestionsEngine.js
@@ -58,7 +58,6 @@ const promptOnlyBatchPromises = (
     model: MODEL,
     imageUrls: batch.filter((image) => !image.blob).map((image) => image.url),
   };
-  log.info(`[${AUDIT_TYPE}]: image batch: ${JSON.stringify(batch)}`);
   const prompt = await getPrompt({ images: batch }, PROMPT_FILE, log);
   return getFirefallResponse(prompt, firefallClient, firefallOptions, log);
 });

--- a/src/image-alt-text/suggestionsEngine.js
+++ b/src/image-alt-text/suggestionsEngine.js
@@ -58,6 +58,7 @@ const promptOnlyBatchPromises = (
     model: MODEL,
     imageUrls: batch.filter((image) => !image.blob).map((image) => image.url),
   };
+  log.info(`[${AUDIT_TYPE}]: image batch: ${batch}`);
   const prompt = await getPrompt({ images: batch }, PROMPT_FILE, log);
   return getFirefallResponse(prompt, firefallClient, firefallOptions, log);
 });

--- a/src/image-alt-text/suggestionsEngine.js
+++ b/src/image-alt-text/suggestionsEngine.js
@@ -58,7 +58,7 @@ const promptOnlyBatchPromises = (
     model: MODEL,
     imageUrls: batch.filter((image) => !image.blob).map((image) => image.url),
   };
-  log.info(`[${AUDIT_TYPE}]: image batch: ${batch}`);
+  log.info(`[${AUDIT_TYPE}]: image batch: ${JSON.stringify(batch)}`);
   const prompt = await getPrompt({ images: batch }, PROMPT_FILE, log);
   return getFirefallResponse(prompt, firefallClient, firefallOptions, log);
 });

--- a/static/prompts/image-alt-text.prompt
+++ b/static/prompts/image-alt-text.prompt
@@ -3,18 +3,18 @@ You are an expert SEO consultant, and your goal is to suggest a description for 
 
 ### Rules:
 
-1. If an image is purely decorative and adds no functional or informational value, use an empty string as the alt text.
-2. Ideal description length is 50-60 characters.
-3. The alt text should be helpful for the user, not the search engine.
-4. Consider key elements of why you chose this image, instead of describing every little detail. No need to say image of or picture of. But, do say if its a logo, illustration, painting, or cartoon.
-5. If you can recognize a person in the image, use their name when known.
-6. Follow the industry guidelines for accessibility, https://www.w3.org/WAI/tutorials/images/
-7. Alt-text should reflect how the image relates to the content. Avoid irrelevant descriptions.
-8. Use natural language, ensuring you're not "stuffing" SEO keys.
-9. Dont duplicate text thats adjacent in the document or website.
-10. End the alt text sentence with a period.
-11. For infographics, describe the key data points and trends.
-12. Mark an image as "not appropriate" (in the "is_appropriate" field) if you find it inappropriate. Examples of that would include images of violence, pornography, drugs, or other sensitive content.
+1. Consider key elements of why you chose this image, instead of describing every little detail. No need to say image of or picture of. But, do say if its a logo, illustration, painting, or cartoon.
+2. If you can recognize a person in the image, use their name when known.
+3. Follow the industry guidelines for accessibility, https://www.w3.org/WAI/tutorials/images/
+4. Alt-text should reflect how the image relates to the content. Avoid irrelevant descriptions.
+5. Use natural language, ensuring you're not "stuffing" SEO keys.
+6. Mark an image as "not appropriate" (in the "is_appropriate" field) if you find it inappropriate. Examples of that would include images of violence, pornography, drugs, or other sensitive content.
+7. If an image is purely decorative and adds no functional or informational value, use an empty string as the alt text.
+8. Ideal description length is 50-60 characters.
+9. The alt text should be helpful for the user, not the search engine.
+10. Dont duplicate text thats adjacent in the document or website.
+11. End the alt text sentence with a period.
+12. For infographics, describe the key data points and trends.
 13. The alt text suggestion must be written in the language specified with the image (the "language" field).
 
 ### Response Format:

--- a/static/prompts/image-alt-text.prompt
+++ b/static/prompts/image-alt-text.prompt
@@ -34,5 +34,5 @@ Given the following list of images: {{images}}, suggest a description for the al
 Use the base64 blob provided if the image format is not supported.
 If an image has text in it, summarize it so that it is helpful for the user.
 In order to avoid security issues, try to not use the exact text that the image provides.
-Each image includes a language property indicating the language for the alt text (e.g., 'jp' for Japanese).
+The images will also have the language of the page they are hosted in. The suggestion should be presented in the language specified with the image.
 If you are unsure what the specified language is, you can use the table of languages and acronyms found here: https://github.com/wooorm/franc/blob/main/packages/franc/readme.md#data

--- a/static/prompts/image-alt-text.prompt
+++ b/static/prompts/image-alt-text.prompt
@@ -8,13 +8,13 @@ You are an expert SEO consultant, and your goal is to suggest a description for 
 3. Follow the industry guidelines for accessibility, https://www.w3.org/WAI/tutorials/images/
 4. Alt-text should reflect how the image relates to the content. Avoid irrelevant descriptions.
 5. Use natural language, ensuring you're not "stuffing" SEO keys.
-6. Mark an image as "not appropriate" (in the "is_appropriate" field) if you find it inappropriate. Examples of that would include images of violence, pornography, drugs, or other sensitive content.
-7. If an image is purely decorative and adds no functional or informational value, use an empty string as the alt text.
-8. Ideal description length is 50-60 characters.
-9. The alt text should be helpful for the user, not the search engine.
-10. Dont duplicate text thats adjacent in the document or website.
-11. End the alt text sentence with a period.
-12. For infographics, describe the key data points and trends.
+6. Dont duplicate text thats adjacent in the document or website.
+7. End the alt text sentence with a period.
+8. For infographics, describe the key data points and trends.
+9. Mark an image as "not appropriate" (in the "is_appropriate" field) if you find it inappropriate. Examples of that would include images of violence, pornography, drugs, or other sensitive content.
+10. If an image is purely decorative and adds no functional or informational value, use an empty string as the alt text.
+11. Ideal description length is 50-60 characters.
+12. The alt text should be helpful for the user, not the search engine.
 
 ### Response Format:
 Your response must be a valid JSON object using the following structure:

--- a/static/prompts/image-alt-text.prompt
+++ b/static/prompts/image-alt-text.prompt
@@ -3,18 +3,18 @@ You are an expert SEO consultant, and your goal is to suggest a description for 
 
 ### Rules:
 
-1. Consider key elements of why you chose this image, instead of describing every little detail. No need to say image of or picture of. But, do say if its a logo, illustration, painting, or cartoon.
-2. If you can recognize a person in the image, use their name when known.
-3. Follow the industry guidelines for accessibility, https://www.w3.org/WAI/tutorials/images/
-4. Alt-text should reflect how the image relates to the content. Avoid irrelevant descriptions.
-5. Use natural language, ensuring you're not "stuffing" SEO keys.
-6. Dont duplicate text thats adjacent in the document or website.
-7. End the alt text sentence with a period.
-8. For infographics, describe the key data points and trends.
-9. Mark an image as "not appropriate" (in the "is_appropriate" field) if you find it inappropriate. Examples of that would include images of violence, pornography, drugs, or other sensitive content.
-10. If an image is purely decorative and adds no functional or informational value, use an empty string as the alt text.
-11. Ideal description length is 50-60 characters.
-12. The alt text should be helpful for the user, not the search engine.
+1. If an image is purely decorative and adds no functional or informational value, use an empty string as the alt text.
+2. Ideal description length is 50-60 characters.
+3. The alt text should be helpful for the user, not the search engine.
+4. Consider key elements of why you chose this image, instead of describing every little detail. No need to say image of or picture of. But, do say if its a logo, illustration, painting, or cartoon.
+5. If you can recognize a person in the image, use their name when known.
+6. Follow the industry guidelines for accessibility, https://www.w3.org/WAI/tutorials/images/
+7. Alt-text should reflect how the image relates to the content. Avoid irrelevant descriptions.
+8. Use natural language, ensuring you're not "stuffing" SEO keys.
+9. Dont duplicate text thats adjacent in the document or website.
+10. End the alt text sentence with a period.
+11. For infographics, describe the key data points and trends.
+12. Mark an image as "not appropriate" (in the "is_appropriate" field) if you find it inappropriate. Examples of that would include images of violence, pornography, drugs, or other sensitive content.
 
 ### Response Format:
 Your response must be a valid JSON object using the following structure:
@@ -34,5 +34,5 @@ Given the following list of images: {{images}}, suggest a description for the al
 Use the base64 blob provided if the image format is not supported.
 If an image has text in it, summarize it so that it is helpful for the user.
 In order to avoid security issues, try to not use the exact text that the image provides.
-The images will also have the language of the page they are hosted in. The suggestion should be presented in the language specified with the image.
+Each image includes a language property indicating the language for the alt text (e.g., 'jp' for Japanese).
 If you are unsure what the specified language is, you can use the table of languages and acronyms found here: https://github.com/wooorm/franc/blob/main/packages/franc/readme.md#data

--- a/static/prompts/image-alt-text.prompt
+++ b/static/prompts/image-alt-text.prompt
@@ -15,6 +15,7 @@ You are an expert SEO consultant, and your goal is to suggest a description for 
 10. End the alt text sentence with a period.
 11. For infographics, describe the key data points and trends.
 12. Mark an image as "not appropriate" (in the "is_appropriate" field) if you find it inappropriate. Examples of that would include images of violence, pornography, drugs, or other sensitive content.
+13. The alt text suggestion must be written in the language specified with the image (the "language" field).
 
 ### Response Format:
 Your response must be a valid JSON object using the following structure:
@@ -28,6 +29,8 @@ Your response must be a valid JSON object using the following structure:
 }]
 **IMPORTANT:**
 - Provide only the JSON object. Do not include any additional text, explanation, or formatting. Do not use markdown.
+- The "suggestion" field must be written in the language specified by the "language" field for each image.
+- If the language is not English, do not provide the suggestion in English.
 
 ### Task:
 Given the following list of images: {{images}}, suggest a description for the alt attribute of each image that is helpful for the user.

--- a/test/audits/image-alt-text/audit-engine.test.js
+++ b/test/audits/image-alt-text/audit-engine.test.js
@@ -437,12 +437,6 @@ describe('AuditEngine', () => {
 
   describe('Language Detection', () => {
     describe('getPageLanguage', () => {
-      it('should return the language from the lang attribute', () => {
-        const dom = new JSDOM('<html lang="en"><body></body></html>').window.document;
-        const lang = getPageLanguage({ document: dom });
-        expect(lang).to.equal('en');
-      });
-
       it('should return the language from meta tags', () => {
         const dom = new JSDOM('<html><head><meta http-equiv="Content-Language" content="fr"></head><body></body></html>').window.document;
         const lang = getPageLanguage({ document: dom });

--- a/test/audits/image-alt-text/audit-engine.test.js
+++ b/test/audits/image-alt-text/audit-engine.test.js
@@ -469,5 +469,23 @@ describe('AuditEngine', () => {
         expect(lang).to.equal('unknown');
       });
     });
+
+    describe('detectCountryFromUrl', () => {
+      it('should detect language from URL country code - jp', () => {
+        const dom = new JSDOM('<html><body></body></html>').window.document;
+        const lang = getPageLanguage({ document: dom, pageUrl: 'https://www.example.com/jp/about/global-network' });
+        expect(lang).to.equal('jp');
+      });
+      it('should return unknown when URL contains unrecognized country codes', () => {
+        const dom = new JSDOM('<html><body></body></html>').window.document;
+        const lang = getPageLanguage({ document: dom, pageUrl: 'https://www.example.com/hk/jp' });
+        expect(lang).to.equal('unknown');
+      });
+      it('should fall back to DOM detection when no country code in URL', () => {
+        const dom = new JSDOM('<html><body>Ceci est une phrase française simple.</body></html>').window.document;
+        const lang = getPageLanguage({ document: dom, pageUrl: 'https://example.com/products' });
+        expect(lang).to.equal('fra');
+      });
+    });
   });
 });


### PR DESCRIPTION
Add a function `detectLanguageFromUrl` to check the URL path for valid country codes and determine the language to use.

This function looks for any valid country code in the URL path segments (the parts between slashes, excluding empty segments and the last segment). If a valid country code is found, it returns the corresponding language code; otherwise, it returns null. The valid country code is defined in `country-code.js` file.

The prompt has been updated with new rules to ensure that the AI model generates alt-text in the specified language provided with each image.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues
- [ASSETS-52137 | Detect language from url](https://jira.corp.adobe.com/browse/ASSETS-52137)

Thanks for contributing!
