### PR TITLE
feat: enhance form a11y handlers to handle mystique messages

### DIFF
--- a/src/forms-opportunities/guidance-handlers/guidance-accessibility.js
+++ b/src/forms-opportunities/guidance-handlers/guidance-accessibility.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { ok } from '@adobe/spacecat-shared-http-utils';
+
+export default async function handler(message, context) {
+  const { log, dataAccess } = context;
+  const { auditId, siteId, data } = message;
+  const { opportunityId, accessibility: a11yGuidanceOfIssues } = data;
+  const { Opportunity } = dataAccess;
+  log.info(`Message received in accessibility guidance handler: ${JSON.stringify(message, null, 2)}`);
+  const opportunity = await Opportunity.findById(opportunityId);
+  if (!opportunity) {
+    log.error(`[Form Opportunity] [Site Id: ${siteId}] Opportunity not found`);
+    return ok();
+  }
+  const a11yData = opportunity.data.accessibility;
+  a11yGuidanceOfIssues.forEach((a11y) => {
+    const { form, formSource, a11yIssues } = a11y;
+    const formA11yData = a11yData.find(
+      (a11yIssue) => a11yIssue.form === form && a11yIssue.formSource === formSource,
+    );
+    const mergedA11yIssues = [...formA11yData.a11yIssues];
+    a11yIssues.forEach((a11yIssue, index) => {
+      if (mergedA11yIssues.length > index) {
+        mergedA11yIssues[index] = {
+          ...mergedA11yIssues[index],
+          ...a11yIssue,
+        };
+      }
+    });
+    // update the a11yIssues with the guidance
+    formA11yData.a11yIssues = mergedA11yIssues;
+  });
+  opportunity.setUpdatedBy('system');
+  opportunity.setAuditId(auditId);
+  await opportunity.save();
+  log.info(`[Form Opportunity] [Site Id: ${siteId}] Opportunity updated with guidance`);
+  return ok();
+}

--- a/src/forms-opportunities/guidance-handlers/guidance-accessibility.js
+++ b/src/forms-opportunities/guidance-handlers/guidance-accessibility.js
@@ -15,7 +15,7 @@ import { ok } from '@adobe/spacecat-shared-http-utils';
 export default async function handler(message, context) {
   const { log, dataAccess } = context;
   const { auditId, siteId, data } = message;
-  const { opportunityId, accessibility: a11yGuidanceOfIssues } = data;
+  const { opportunityId, a11y: a11yGuidanceOfIssues } = data;
   const { Opportunity } = dataAccess;
   log.info(`Message received in accessibility guidance handler: ${JSON.stringify(message, null, 2)}`);
   const opportunity = await Opportunity.findById(opportunityId);
@@ -44,6 +44,6 @@ export default async function handler(message, context) {
   opportunity.setUpdatedBy('system');
   opportunity.setAuditId(auditId);
   await opportunity.save();
-  log.info(`[Form Opportunity] [Site Id: ${siteId}] Opportunity updated with guidance`);
+  log.info(`[Form Opportunity] [Site Id: ${siteId}] A11y opportunity updated with guidance`);
   return ok();
 }

--- a/src/forms-opportunities/guidance-handlers/guidance-accessibility.js
+++ b/src/forms-opportunities/guidance-handlers/guidance-accessibility.js
@@ -20,7 +20,7 @@ export default async function handler(message, context) {
   log.info(`Message received in accessibility guidance handler: ${JSON.stringify(message, null, 2)}`);
   const opportunity = await Opportunity.findById(opportunityId);
   if (!opportunity) {
-    log.error(`[Form Opportunity] [Site Id: ${siteId}] Opportunity not found`);
+    log.error(`[Form Opportunity] [Site Id: ${siteId}] A11y opportunity not found`);
     return ok();
   }
   const a11yData = opportunity.data.accessibility;

--- a/src/forms-opportunities/handler.js
+++ b/src/forms-opportunities/handler.js
@@ -20,7 +20,7 @@ import { getScrapedDataForSiteId } from '../support/utils.js';
 import createLowConversionOpportunities from './oppty-handlers/low-conversion-handler.js';
 import createLowNavigationOpportunities from './oppty-handlers/low-navigation-handler.js';
 import createLowViewsOpportunities from './oppty-handlers/low-views-handler.js';
-import createAccessibilityOpportunity from './oppty-handlers/accessibility-handler.js';
+import { createAccessibilityOpportunity } from './oppty-handlers/accessibility-handler.js';
 
 const { AUDIT_STEP_DESTINATIONS } = Audit;
 const FORMS_OPPTY_QUERIES = [

--- a/src/forms-opportunities/oppty-handlers/accessibility-handler.js
+++ b/src/forms-opportunities/oppty-handlers/accessibility-handler.js
@@ -250,6 +250,6 @@ export default async function handler(message, context) {
     },
   };
   await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, mystiqueMessage);
-  log.info(`[Form Opportunity] [Site Id: ${site.getId()}] Sent message to mystique for guidance`);
+  log.info(`[Form Opportunity] [Site Id: ${site.getId()}] Sent a11y message to mystique for guidance`);
   return ok();
 }

--- a/src/forms-opportunities/oppty-handlers/accessibility-handler.js
+++ b/src/forms-opportunities/oppty-handlers/accessibility-handler.js
@@ -204,6 +204,7 @@ export async function createAccessibilityOpportunity(auditData, context) {
       deliveryType: site.getDeliveryType(),
       time: new Date().toISOString(),
       data: {
+        url: site.getBaseURL(),
         opportunityId: opportunity?.getId(),
         a11y: a11yData,
       },
@@ -239,6 +240,7 @@ export default async function handler(message, context) {
     deliveryType: site.getDeliveryType(),
     time: new Date().toISOString(),
     data: {
+      url: site.getBaseURL(),
       opportunityId: opportunity?.getId(),
     },
   };

--- a/src/index.js
+++ b/src/index.js
@@ -45,6 +45,8 @@ import highPageViewsLowFormViewsGuidance from './forms-opportunities/guidance-ha
 import highOrganicLowCtrGuidance from './experimentation-opportunities/guidance-high-organic-low-ctr-handler.js';
 import imageAltText from './image-alt-text/handler.js';
 import preflight from './preflight/handler.js';
+import formAccessibilityGuidance from './forms-opportunities/guidance-handlers/guidance-accessibility.js';
+import mystiqueDetectedFormAccessibilityOpportunity from './forms-opportunities/oppty-handlers/accessibility-handler.js';
 
 const HANDLERS = {
   accessibility,
@@ -73,6 +75,8 @@ const HANDLERS = {
   'guidance:high-form-views-low-conversions': highFormViewsLowConversionsGuidance,
   'guidance:high-page-views-low-form-nav': highPageViewsLowFormNavGuidance,
   'guidance:high-page-views-low-form-views': highPageViewsLowFormViewsGuidance,
+  'guidance:forms-a11y': formAccessibilityGuidance,
+  'forms-opportunities:a11y': mystiqueDetectedFormAccessibilityOpportunity,
   preflight,
   dummy: (message) => ok(message),
 };

--- a/src/index.js
+++ b/src/index.js
@@ -76,7 +76,7 @@ const HANDLERS = {
   'guidance:high-page-views-low-form-nav': highPageViewsLowFormNavGuidance,
   'guidance:high-page-views-low-form-views': highPageViewsLowFormViewsGuidance,
   'guidance:forms-a11y': formAccessibilityGuidance,
-  'forms-opportunities:a11y': mystiqueDetectedFormAccessibilityOpportunity,
+  'detect:forms-a11y': mystiqueDetectedFormAccessibilityOpportunity,
   preflight,
   dummy: (message) => ok(message),
 };

--- a/test/audits/forms/accessibility-handler.test.js
+++ b/test/audits/forms/accessibility-handler.test.js
@@ -278,6 +278,7 @@ describe('Forms Opportunities - Accessibility Handler', () => {
       expect(sqsMessage.siteId).to.equal(siteId);
       expect(sqsMessage.auditId).to.equal('test-audit-id');
       expect(sqsMessage.deliveryType).to.equal('aem');
+      expect(sqsMessage.data.url).to.equal('https://example.com');
       expect(sqsMessage.data.opportunityId).to.equal('test-opportunity-id');
     });
 
@@ -365,6 +366,7 @@ describe('Forms Opportunities - Accessibility Handler', () => {
           func: { package: 'spacecat-services', version: 'ci', name: 'test' },
           site: {
             getId: sinon.stub().returns(siteId),
+            getBaseURL: sinon.stub().returns('https://example.com'),
             getDeliveryType: sinon.stub().returns('aem'),
           },
           env: {

--- a/test/audits/forms/accessibility-handler.test.js
+++ b/test/audits/forms/accessibility-handler.test.js
@@ -406,6 +406,12 @@ describe('Forms Opportunities - Accessibility Handler', () => {
                 setAuditId: sandbox.stub(),
               }),
             },
+            Site: {
+              findById: sandbox.stub().resolves({
+                getDeliveryType: sinon.stub().returns('aem'),
+                getBaseURL: sinon.stub().returns('https://example.com'),
+              }),
+            },
           },
         })
         .build();
@@ -457,6 +463,22 @@ describe('Forms Opportunities - Accessibility Handler', () => {
       expect(context.sqs.sendMessage).to.not.have.been.called;
       expect(context.log.info).to.have.been.calledWith(
         '[Form Opportunity] [Site Id: test-site-id] A11y opportunity not detected, skipping guidance',
+      );
+    });
+
+    it('handle error when no site is found', async () => {
+      const message = {
+        auditId,
+        siteId,
+        data: {
+          opportunityId,
+          a11y: [],
+        },
+      };
+      context.dataAccess.Site.findById.rejects(new Error('Site not found'));
+      await mystiqueDetectedFormAccessibilityHandler(message, context);
+      expect(context.log.error).to.have.been.calledWith(
+        '[Form Opportunity] [Site Id: test-site-id] Failed to process a11y opportunity from mystique: Site not found',
       );
     });
 

--- a/test/audits/forms/accessibility-handler.test.js
+++ b/test/audits/forms/accessibility-handler.test.js
@@ -157,7 +157,7 @@ describe('Forms Opportunities - Accessibility Handler', () => {
       await createAccessibilityOpportunity(latestAudit, context);
       expect(context.dataAccess.Opportunity.create).to.not.have.been.called;
       expect(context.log.info).to.have.been.calledWith(
-        `[Form Opportunity] [Site Id: ${siteId}] No a11y data found`,
+        `[Form Opportunity] [Site Id: ${siteId}] No a11y data found to create or update opportunity `,
       );
     });
 
@@ -201,7 +201,7 @@ describe('Forms Opportunities - Accessibility Handler', () => {
       await createAccessibilityOpportunity(latestAudit, context);
       expect(context.dataAccess.Opportunity.create).to.not.have.been.called;
       expect(context.log.info).to.have.been.calledWith(
-        `[Form Opportunity] [Site Id: ${siteId}] No a11y issues found`,
+        `[Form Opportunity] [Site Id: ${siteId}] No a11y issues found to create or update opportunity`,
       );
     });
 
@@ -441,6 +441,23 @@ describe('Forms Opportunities - Accessibility Handler', () => {
       expect(sqsMessage.deliveryType).to.equal('aem');
       expect(sqsMessage.data.opportunityId).to.equal(opportunityId);
       expect(sqsMessage.data.a11y).to.not.exist;
+    });
+
+    it('should not send message to mystique when no opportunity is found', async () => {
+      const message = {
+        auditId,
+        siteId,
+        data: {
+          opportunityId: null,
+          a11y: [],
+        },
+      };
+
+      await mystiqueDetectedFormAccessibilityHandler(message, context);
+      expect(context.sqs.sendMessage).to.not.have.been.called;
+      expect(context.log.info).to.have.been.calledWith(
+        '[Form Opportunity] [Site Id: test-site-id] A11y opportunity not detected, skipping guidance',
+      );
     });
 
     it('should append accessibility issue detected by mystique', async () => {

--- a/test/audits/forms/accessibility-handler.test.js
+++ b/test/audits/forms/accessibility-handler.test.js
@@ -17,7 +17,7 @@ import sinon from 'sinon';
 import nock from 'nock';
 import sinonChai from 'sinon-chai';
 import { FORM_OPPORTUNITY_TYPES } from '../../../src/forms-opportunities/constants.js';
-import createAccessibilityOpportunity from '../../../src/forms-opportunities/oppty-handlers/accessibility-handler.js';
+import mystiqueDetectedFormAccessibilityHandler, { createAccessibilityOpportunity } from '../../../src/forms-opportunities/oppty-handlers/accessibility-handler.js';
 import { MockContextBuilder } from '../../shared.js';
 
 use(sinonChai);
@@ -46,12 +46,17 @@ describe('Forms Opportunities - Accessibility Handler', () => {
           site: {
             getId: sinon.stub().returns(siteId),
             getBaseURL: sinon.stub().returns('https://example.com'),
+            getDeliveryType: sinon.stub().returns('aem'),
           },
           env: {
             S3_SCRAPER_BUCKET_NAME: bucketName,
+            QUEUE_SPACECAT_TO_MYSTIQUE: 'test-queue',
           },
           s3Client: {
             send: sandbox.stub(),
+          },
+          sqs: {
+            sendMessage: sandbox.stub().resolves(),
           },
           log: {
             info: sinon.stub(),
@@ -60,7 +65,8 @@ describe('Forms Opportunities - Accessibility Handler', () => {
           dataAccess: {
             Opportunity: {
               allBySiteIdAndStatus: sandbox.stub().resolves([]),
-              create: sandbox.stub().resolves(),
+              create: sandbox.stub().resolves({ getId: () => 'test-opportunity-id' }),
+              findById: sandbox.stub().resolves(null),
             },
           },
         })
@@ -155,6 +161,50 @@ describe('Forms Opportunities - Accessibility Handler', () => {
       );
     });
 
+    it('should fail when no a11yIssues are present', async () => {
+      const latestAudit = {
+        siteId,
+        auditId: 'test-audit-id',
+        getSiteId: () => siteId,
+        getAuditId: () => 'test-audit-id',
+      };
+
+      context.s3Client.send
+        .onFirstCall()
+        .resolves({
+          CommonPrefixes: [
+            { Prefix: `forms-accessibility/${siteId}/${version}/` },
+          ],
+        })
+        .onSecondCall()
+        .resolves({
+          Contents: [
+            { Key: `forms-accessibility/${siteId}/${version}/form1.json` },
+          ],
+          IsTruncated: false,
+        })
+        .onThirdCall()
+        .resolves({
+          ContentType: 'application/json',
+          Body: {
+            transformToString: sandbox.stub().resolves(JSON.stringify({
+              finalUrl: 'https://example.com/form1',
+              a11yResult: [{
+                form: 'https://example.com/form1',
+                formSource: '#form1',
+                a11yIssues: [],
+              }],
+            })),
+          },
+        });
+
+      await createAccessibilityOpportunity(latestAudit, context);
+      expect(context.dataAccess.Opportunity.create).to.not.have.been.called;
+      expect(context.log.info).to.have.been.calledWith(
+        `[Form Opportunity] [Site Id: ${siteId}] No a11y issues found`,
+      );
+    });
+
     it('should create opportunities when a11y issues are present', async () => {
       const latestAudit = {
         siteId,
@@ -220,6 +270,15 @@ describe('Forms Opportunities - Accessibility Handler', () => {
       expect(successCriteria.criteriaNumber).to.equal('1.1.1');
       expect(successCriteria.name).to.equal('Non-text Content');
       expect(successCriteria).to.have.property('understandingUrl');
+
+      // Verify SQS message was sent
+      expect(context.sqs.sendMessage).to.have.been.calledOnce;
+      const sqsMessage = context.sqs.sendMessage.getCall(0).args[1];
+      expect(sqsMessage.type).to.equal('detect:forms-a11y');
+      expect(sqsMessage.siteId).to.equal(siteId);
+      expect(sqsMessage.auditId).to.equal('test-audit-id');
+      expect(sqsMessage.deliveryType).to.equal('aem');
+      expect(sqsMessage.data.opportunityId).to.equal('test-opportunity-id');
     });
 
     it('should handle errors when processing a11y data', async () => {
@@ -287,8 +346,252 @@ describe('Forms Opportunities - Accessibility Handler', () => {
 
       await createAccessibilityOpportunity(latestAudit, context);
       expect(context.log.error).to.have.been.calledWith(
-        '[Form Opportunity] [Site Id: test-site-id] Failed to create a11y opportunity with error: Network error',
+        '[Form Opportunity] [Site Id: test-site-id] Failed to create/update a11y opportunity with error: Network error',
       );
+    });
+  });
+
+  describe('accessibility handle - mystique detected', async () => {
+    let context;
+    const siteId = 'test-site-id';
+    const auditId = 'test-audit-id';
+    const opportunityId = 'test-opportunity-id';
+
+    beforeEach(() => {
+      context = new MockContextBuilder()
+        .withSandbox(sandbox)
+        .withOverrides({
+          runtime: { name: 'aws-lambda', region: 'us-east-1' },
+          func: { package: 'spacecat-services', version: 'ci', name: 'test' },
+          site: {
+            getId: sinon.stub().returns(siteId),
+            getDeliveryType: sinon.stub().returns('aem'),
+          },
+          env: {
+            QUEUE_SPACECAT_TO_MYSTIQUE: 'test-queue',
+          },
+          sqs: {
+            sendMessage: sandbox.stub().resolves(),
+          },
+          log: {
+            info: sinon.stub(),
+            error: sinon.stub(),
+          },
+          dataAccess: {
+            Opportunity: {
+              findById: sandbox.stub().resolves({
+                getId: () => opportunityId,
+                save: sandbox.stub().resolves({
+                  getId: () => opportunityId,
+                }),
+                data: {
+                  accessibility: [{
+                    form: 'https://example.com/form1',
+                    formSource: '#form1',
+                    a11yIssues: [{
+                      issue: 'Missing alt text',
+                      level: 'error',
+                      successCriterias: ['1.1.1 Non-text Content'],
+                      htmlWithIssues: ['<img src="test.jpg">'],
+                      recommendation: 'Add alt text to image',
+                    }],
+                  }],
+                },
+              }),
+              create: sandbox.stub().resolves({
+                getId: () => opportunityId,
+                setUpdatedBy: sandbox.stub(),
+                setAuditId: sandbox.stub(),
+              }),
+            },
+          },
+        })
+        .build();
+    });
+
+    it('should process message and send to mystique', async () => {
+      const message = {
+        auditId,
+        siteId,
+        data: {
+          opportunityId,
+          a11y: [{
+            form: 'https://example.com/form1',
+            formSource: '#form1',
+            a11yIssues: [{
+              issue: 'Missing alt text',
+              level: 'error',
+              successCriterias: ['1.1.1'],
+              htmlWithIssues: ['<img src="test.jpg">'],
+              recommendation: 'Add alt text to image',
+            }],
+          }],
+        },
+      };
+
+      await mystiqueDetectedFormAccessibilityHandler(message, context);
+
+      expect(context.sqs.sendMessage).to.have.been.calledOnce;
+      const sqsMessage = context.sqs.sendMessage.getCall(0).args[1];
+      expect(sqsMessage.type).to.equal('guidance:forms-a11y');
+      expect(sqsMessage.siteId).to.equal(siteId);
+      expect(sqsMessage.auditId).to.equal(auditId);
+      expect(sqsMessage.deliveryType).to.equal('aem');
+      expect(sqsMessage.data.opportunityId).to.equal(opportunityId);
+      expect(sqsMessage.data.a11y).to.not.exist;
+    });
+
+    it('should append accessibility issue detected by mystique', async () => {
+      const message = {
+        auditId,
+        siteId,
+        data: {
+          opportunityId,
+          a11y: [{
+            form: 'https://example.com/form1',
+            formSource: '#form1',
+            a11yIssues: [{
+              issue: 'Missing alt text',
+              level: 'error',
+              successCriterias: ['1.1.1'],
+              htmlWithIssues: ['<img src="test.jpg">'],
+              recommendation: 'Add alt text to image',
+            }],
+          }],
+        },
+      };
+
+      // mock existing opportunity
+      context.dataAccess.Opportunity.findById.resolves({
+        save: sandbox.stub().resolves({
+          getId: () => opportunityId,
+        }),
+        setUpdatedBy: sandbox.stub(),
+        data: {
+          accessibility: [{
+            form: 'https://example.com/form1',
+            formSource: '#form1',
+            a11yIssues: [],
+          }],
+        },
+      });
+
+      await mystiqueDetectedFormAccessibilityHandler(message, context);
+
+      expect(context.dataAccess.Opportunity.findById).to.have.been.calledOnce;
+      const existingOpportunity = await context.dataAccess.Opportunity.findById
+        .getCall(0).returnValue;
+      expect(existingOpportunity.data.accessibility).to.have.lengthOf(1);
+      expect(existingOpportunity.data.accessibility[0].a11yIssues).to.have.lengthOf(1);
+      expect(existingOpportunity.save).to.have.been.calledOnce;
+    });
+
+    it('should append a11y issues from mystique with empty axe issues', async () => {
+      const message = {
+        auditId,
+        siteId,
+        data: {
+          opportunityId,
+          a11y: [{
+            form: 'https://example.com/form1',
+            formSource: '#form1',
+            a11yIssues: [{
+              issue: 'Missing alt text',
+              level: 'error',
+              successCriterias: ['1.1.1'],
+              htmlWithIssues: ['<img src="test.jpg">'],
+              recommendation: 'Add alt text to image',
+            }],
+          }],
+        },
+      };
+
+      // mock existing opportunity
+      context.dataAccess.Opportunity.findById.resolves({
+        save: sandbox.stub().resolves({
+          getId: () => opportunityId,
+        }),
+        setUpdatedBy: sandbox.stub(),
+        data: {
+          accessibility: [{
+            form: 'https://example.com/form2',
+            formSource: '#form2',
+            a11yIssues: [{
+              issue: 'label missing',
+              level: 'A',
+              successCriterias: ['1.1.1'],
+              htmlWithIssues: ['<label>test</label>'],
+              recommendation: 'Add label to input',
+            }],
+          }],
+        },
+      });
+
+      await mystiqueDetectedFormAccessibilityHandler(message, context);
+
+      expect(context.dataAccess.Opportunity.findById).to.have.been.calledOnce;
+      const existingOpportunity = await context.dataAccess.Opportunity.findById
+        .getCall(0).returnValue;
+      expect(existingOpportunity.data.accessibility).to.have.lengthOf(2);
+      expect(existingOpportunity.data.accessibility[0].a11yIssues).to.have.lengthOf(1);
+      expect(existingOpportunity.save).to.have.been.calledOnce;
+    });
+
+    it('should create a new opportunity when no existing opportunity is found', async () => {
+      const message = {
+        auditId,
+        siteId,
+        data: {
+          a11y: [{
+            form: 'https://example.com/form1',
+            formSource: '#form1',
+            a11yIssues: [{
+              issue: 'Missing alt text',
+              level: 'error',
+              successCriterias: ['1.1.1'],
+              htmlWithIssues: '<img src="test.jpg">',
+              recommendation: 'Add alt text to image',
+            }],
+          }],
+        },
+      };
+      await mystiqueDetectedFormAccessibilityHandler(message, context);
+      expect(context.dataAccess.Opportunity.create).to.have.been.calledOnce;
+      const createArgs = context.dataAccess.Opportunity.create.getCall(0).args[0];
+      expect(createArgs.siteId).to.equal(siteId);
+      expect(createArgs.auditId).to.equal('test-audit-id');
+      expect(createArgs.type).to.equal(FORM_OPPORTUNITY_TYPES.FORM_A11Y);
+    });
+
+    it('should handle errors when processing message', async () => {
+      const message = {
+        auditId,
+        siteId,
+        data: {
+          opportunityId,
+          a11y: [{
+            form: 'https://example.com/form1',
+            formSource: '#form1',
+            a11yIssues: [{
+              issue: 'Missing alt text',
+              level: 'error',
+              successCriterias: ['1.1.1'],
+              htmlWithIssues: '<img src="test.jpg">',
+              recommendation: 'Add alt text to image',
+            }],
+          }],
+        },
+      };
+
+      context.dataAccess.Opportunity.findById.rejects(new Error('Database error'));
+
+      try {
+        await mystiqueDetectedFormAccessibilityHandler(message, context);
+      } catch (error) {
+        expect(error.message).to.equal(
+          '[Form Opportunity] [Site Id: test-site-id] Failed to create/update a11y opportunity with error: Database error',
+        );
+      }
     });
   });
 });

--- a/test/audits/forms/guidance-handlers/guidance-accessibility.test.js
+++ b/test/audits/forms/guidance-handlers/guidance-accessibility.test.js
@@ -115,7 +115,7 @@ describe('Guidance Accessibility Handler', () => {
     const result = await handler(message, mockContext);
 
     expect(result.status).to.deep.equal(200);
-    expect(mockLog.error.calledWith('[Form Opportunity] [Site Id: site123] Opportunity not found')).to.be.true;
+    expect(mockLog.error.calledWith('[Form Opportunity] [Site Id: site123] A11y opportunity not found')).to.be.true;
     expect(mockOpportunity.save.called).to.be.false;
   });
 

--- a/test/audits/forms/guidance-handlers/guidance-accessibility.test.js
+++ b/test/audits/forms/guidance-handlers/guidance-accessibility.test.js
@@ -1,0 +1,167 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import handler from '../../../../src/forms-opportunities/guidance-handlers/guidance-accessibility.js';
+
+describe('Guidance Accessibility Handler', () => {
+  let mockLog;
+  let mockOpportunity;
+  let mockDataAccess;
+  let mockContext;
+
+  beforeEach(() => {
+    mockLog = {
+      info: sinon.spy(),
+      error: sinon.spy(),
+    };
+
+    mockOpportunity = {
+      getId: () => 'opp123',
+      data: {
+        accessibility: [
+          {
+            form: 'form1',
+            formSource: 'source1',
+            a11yIssues: [
+              { issue: 'issue1' },
+              { issue: 'issue2' },
+            ],
+          },
+        ],
+      },
+      setUpdatedBy: sinon.spy(),
+      setAuditId: sinon.spy(),
+      save: sinon.stub().resolves(),
+    };
+
+    mockDataAccess = {
+      Opportunity: {
+        findById: sinon.stub(),
+      },
+    };
+
+    mockContext = {
+      log: mockLog,
+      dataAccess: mockDataAccess,
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should handle message and update opportunity with guidance', async () => {
+    const message = {
+      auditId: 'audit123',
+      siteId: 'site123',
+      data: {
+        opportunityId: 'opp123',
+        accessibility: [
+          {
+            form: 'form1',
+            formSource: 'source1',
+            a11yIssues: [
+              { guidance: 'guidance1' },
+              { guidance: 'guidance2' },
+            ],
+          },
+        ],
+      },
+    };
+
+    mockDataAccess.Opportunity.findById.resolves(mockOpportunity);
+
+    const result = await handler(message, mockContext);
+
+    expect(result.status).to.deep.equal(200);
+    expect(mockDataAccess.Opportunity.findById.calledWith('opp123')).to.be.true;
+    expect(mockOpportunity.setUpdatedBy.calledWith('system')).to.be.true;
+    expect(mockOpportunity.setAuditId.calledWith('audit123')).to.be.true;
+    expect(mockOpportunity.save.called).to.be.true;
+    expect(mockLog.info.called).to.be.true;
+
+    // Verify the guidance was merged correctly
+    expect(mockOpportunity.data.accessibility[0].a11yIssues).to.deep.equal([
+      { issue: 'issue1', guidance: 'guidance1' },
+      { issue: 'issue2', guidance: 'guidance2' },
+    ]);
+  });
+
+  it('should handle case when opportunity is not found', async () => {
+    const message = {
+      auditId: 'audit123',
+      siteId: 'site123',
+      data: {
+        opportunityId: 'opp123',
+        accessibility: [],
+      },
+    };
+
+    mockDataAccess.Opportunity.findById.resolves(null);
+
+    const result = await handler(message, mockContext);
+
+    expect(result.status).to.deep.equal(200);
+    expect(mockLog.error.calledWith('[Form Opportunity] [Site Id: site123] Opportunity not found')).to.be.true;
+    expect(mockOpportunity.save.called).to.be.false;
+  });
+
+  it('should handle multiple forms in accessibility data', async () => {
+    const message = {
+      auditId: 'audit123',
+      siteId: 'site123',
+      data: {
+        opportunityId: 'opp123',
+        accessibility: [
+          {
+            form: 'form1',
+            formSource: 'source1',
+            a11yIssues: [
+              { guidance: 'guidance1' },
+            ],
+          },
+          {
+            form: 'form2',
+            formSource: 'source2',
+            a11yIssues: [
+              { guidance: 'guidance3' },
+            ],
+          },
+        ],
+      },
+    };
+
+    mockOpportunity.data.accessibility.push({
+      form: 'form2',
+      formSource: 'source2',
+      a11yIssues: [
+        { issue: 'issue3' },
+      ],
+    });
+
+    mockDataAccess.Opportunity.findById.resolves(mockOpportunity);
+
+    const result = await handler(message, mockContext);
+
+    expect(result.status).to.deep.equal(200);
+    expect(mockOpportunity.save.called).to.be.true;
+    expect(mockOpportunity.data.accessibility).to.have.lengthOf(2);
+    expect(mockOpportunity.data.accessibility[1].a11yIssues[0]).to.deep.equal({
+      issue: 'issue3',
+      guidance: 'guidance3',
+    });
+  });
+});

--- a/test/audits/forms/guidance-handlers/guidance-accessibility.test.js
+++ b/test/audits/forms/guidance-handlers/guidance-accessibility.test.js
@@ -69,7 +69,7 @@ describe('Guidance Accessibility Handler', () => {
       siteId: 'site123',
       data: {
         opportunityId: 'opp123',
-        accessibility: [
+        a11y: [
           {
             form: 'form1',
             formSource: 'source1',
@@ -106,7 +106,7 @@ describe('Guidance Accessibility Handler', () => {
       siteId: 'site123',
       data: {
         opportunityId: 'opp123',
-        accessibility: [],
+        a11y: [],
       },
     };
 
@@ -125,7 +125,7 @@ describe('Guidance Accessibility Handler', () => {
       siteId: 'site123',
       data: {
         opportunityId: 'opp123',
-        accessibility: [
+        a11y: [
           {
             form: 'form1',
             formSource: 'source1',


### PR DESCRIPTION
- Added new guidance handlers for form accessibility.
- Introduced a new handler for processing messages from mystique regarding detected accessibility issues.
- Updated tests to cover new functionality and ensure proper handling of accessibility data.
