### PR TITLE
fix: prevent re-scraping of URLs that have already failed an audit

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -12,6 +12,7 @@
     "src/**/*.js"
   ],
   "exclude": [
-    "src/index-local.js"
+    "src/index-local.js",
+    "src/accessibility/utils/scrape-utils.js"
   ]
 }

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -12,7 +12,6 @@
     "src/**/*.js"
   ],
   "exclude": [
-    "src/index-local.js",
-    "src/accessibility/utils/scrape-utils.js"
+    "src/index-local.js"
   ]
 }

--- a/src/accessibility/handler.js
+++ b/src/accessibility/handler.js
@@ -37,7 +37,9 @@ export async function scrapeAccessibilityData(context) {
 
   const urlsToScrape = await getUrlsForAudit(s3Client, bucketName, siteId, log);
   const existingUrls = await getExistingUrlsFromFailedAudits(s3Client, bucketName, siteId, log);
+  const remainingUrls = urlsToScrape.filter((url) => !existingUrls.includes(url));
   log.info(`[A11yAudit] Found existing URLs from failed audits: ${existingUrls}`);
+  log.info(`[A11yAudit] Remaining URLs to scrape: ${remainingUrls}`);
 
   // The first step MUST return auditResult and fullAuditRef.
   // fullAuditRef could point to where the raw scraped data will be stored (e.g., S3 path).

--- a/src/accessibility/handler.js
+++ b/src/accessibility/handler.js
@@ -13,7 +13,7 @@
 import { Audit } from '@adobe/spacecat-shared-data-access';
 import { AuditBuilder } from '../common/audit-builder.js';
 import { aggregateAccessibilityData, getUrlsForAudit, generateReportOpportunities } from './utils/data-processing.js';
-import { getExistingUrlsFromFailedAudits, getRemainingUrls } from './utils/scrape-utils.js';
+import { getExistingObjectKeysFromFailedAudits, getRemainingUrls, getExistingUrlsFromFailedAudits } from './utils/scrape-utils.js';
 
 const { AUDIT_STEP_DESTINATIONS } = Audit;
 const AUDIT_TYPE_ACCESSIBILITY = Audit.AUDIT_TYPES.ACCESSIBILITY; // Defined audit type
@@ -36,9 +36,20 @@ export async function scrapeAccessibilityData(context) {
   log.info(`[A11yAudit] Step 1: Preparing content scrape for accessibility audit for ${site.getBaseURL()} with siteId ${siteId}`);
 
   const urlsToScrape = await getUrlsForAudit(s3Client, bucketName, siteId, log);
-  const existingUrls = await getExistingUrlsFromFailedAudits(s3Client, bucketName, siteId, log);
+  const existingObjectKeys = await getExistingObjectKeysFromFailedAudits(
+    s3Client,
+    bucketName,
+    siteId,
+    log,
+  );
+  const existingUrls = await getExistingUrlsFromFailedAudits(
+    s3Client,
+    bucketName,
+    log,
+    existingObjectKeys,
+  );
   const remainingUrls = getRemainingUrls(urlsToScrape, existingUrls);
-  log.info(`[A11yAudit] Found existing URLs from failed audits: ${existingUrls}`);
+  log.info(`[A11yAudit] Found existing URLs from failed audits: ${existingObjectKeys}`);
   log.info(`[A11yAudit] Remaining URLs to scrape: ${JSON.stringify(remainingUrls, null, 2)}`);
 
   // The first step MUST return auditResult and fullAuditRef.

--- a/src/accessibility/handler.js
+++ b/src/accessibility/handler.js
@@ -13,7 +13,7 @@
 import { Audit } from '@adobe/spacecat-shared-data-access';
 import { AuditBuilder } from '../common/audit-builder.js';
 import { aggregateAccessibilityData, getUrlsForAudit, generateReportOpportunities } from './utils/data-processing.js';
-import { getExistingUrlsFromFailedAudits } from './utils/scrape-utils.js';
+import { getExistingUrlsFromFailedAudits, getRemainingUrls } from './utils/scrape-utils.js';
 
 const { AUDIT_STEP_DESTINATIONS } = Audit;
 const AUDIT_TYPE_ACCESSIBILITY = Audit.AUDIT_TYPES.ACCESSIBILITY; // Defined audit type
@@ -37,9 +37,9 @@ export async function scrapeAccessibilityData(context) {
 
   const urlsToScrape = await getUrlsForAudit(s3Client, bucketName, siteId, log);
   const existingUrls = await getExistingUrlsFromFailedAudits(s3Client, bucketName, siteId, log);
-  const remainingUrls = urlsToScrape.filter((item) => !existingUrls.includes(item.url));
+  const remainingUrls = getRemainingUrls(urlsToScrape, existingUrls);
   log.info(`[A11yAudit] Found existing URLs from failed audits: ${existingUrls}`);
-  log.info(`[A11yAudit] Remaining URLs to scrape: ${remainingUrls}`);
+  log.info(`[A11yAudit] Remaining URLs to scrape: ${JSON.stringify(remainingUrls, null, 2)}`);
 
   // The first step MUST return auditResult and fullAuditRef.
   // fullAuditRef could point to where the raw scraped data will be stored (e.g., S3 path).

--- a/src/accessibility/handler.js
+++ b/src/accessibility/handler.js
@@ -47,11 +47,11 @@ export async function scrapeAccessibilityData(context) {
     auditResult: {
       status: 'SCRAPING_REQUESTED',
       message: 'Content scraping for accessibility audit initiated.',
-      scrapedUrls: urlsToScrape,
+      scrapedUrls: remainingUrls,
     },
     fullAuditRef: finalUrl,
     // Data for the CONTENT_SCRAPER
-    urls: urlsToScrape,
+    urls: remainingUrls,
     siteId,
     jobId: siteId,
     processingType: AUDIT_TYPE_ACCESSIBILITY,

--- a/src/accessibility/handler.js
+++ b/src/accessibility/handler.js
@@ -37,7 +37,7 @@ export async function scrapeAccessibilityData(context) {
 
   const urlsToScrape = await getUrlsForAudit(s3Client, bucketName, siteId, log);
   const existingUrls = await getExistingUrlsFromFailedAudits(s3Client, bucketName, siteId, log);
-  const remainingUrls = urlsToScrape.filter((url) => !existingUrls.includes(url));
+  const remainingUrls = urlsToScrape.filter((item) => !existingUrls.includes(item.url));
   log.info(`[A11yAudit] Found existing URLs from failed audits: ${existingUrls}`);
   log.info(`[A11yAudit] Remaining URLs to scrape: ${remainingUrls}`);
 

--- a/src/accessibility/handler.js
+++ b/src/accessibility/handler.js
@@ -13,6 +13,7 @@
 import { Audit } from '@adobe/spacecat-shared-data-access';
 import { AuditBuilder } from '../common/audit-builder.js';
 import { aggregateAccessibilityData, getUrlsForAudit, generateReportOpportunities } from './utils/data-processing.js';
+import { getExistingUrlsFromFailedAudits } from './utils/scrape-utils.js';
 
 const { AUDIT_STEP_DESTINATIONS } = Audit;
 const AUDIT_TYPE_ACCESSIBILITY = Audit.AUDIT_TYPES.ACCESSIBILITY; // Defined audit type
@@ -35,6 +36,8 @@ export async function scrapeAccessibilityData(context) {
   log.info(`[A11yAudit] Step 1: Preparing content scrape for accessibility audit for ${site.getBaseURL()} with siteId ${siteId}`);
 
   const urlsToScrape = await getUrlsForAudit(s3Client, bucketName, siteId, log);
+  const existingUrls = await getExistingUrlsFromFailedAudits(s3Client, bucketName, siteId, log);
+  log.info(`[A11yAudit] Found existing URLs from failed audits: ${existingUrls}`);
 
   // The first step MUST return auditResult and fullAuditRef.
   // fullAuditRef could point to where the raw scraped data will be stored (e.g., S3 path).

--- a/src/accessibility/handler.js
+++ b/src/accessibility/handler.js
@@ -42,14 +42,15 @@ export async function scrapeAccessibilityData(context) {
     siteId,
     log,
   );
+  log.info(`[A11yAudit] Found existing files from failed audits: ${existingObjectKeys}`);
   const existingUrls = await getExistingUrlsFromFailedAudits(
     s3Client,
     bucketName,
     log,
     existingObjectKeys,
   );
+  log.info(`[A11yAudit] Found existing URLs from failed audits: ${existingUrls}`);
   const remainingUrls = getRemainingUrls(urlsToScrape, existingUrls);
-  log.info(`[A11yAudit] Found existing URLs from failed audits: ${existingObjectKeys}`);
   log.info(`[A11yAudit] Remaining URLs to scrape: ${JSON.stringify(remainingUrls, null, 2)}`);
 
   // The first step MUST return auditResult and fullAuditRef.

--- a/src/accessibility/utils/data-processing.js
+++ b/src/accessibility/utils/data-processing.js
@@ -98,10 +98,11 @@ export async function getSubfoldersUsingPrefixAndDelimiter(
       Delimiter: delimiter,
     };
     const data = await s3Client.send(new ListObjectsV2Command(params));
+    const commonPrefixes = data.CommonPrefixes || [];
     log.info(
-      `Fetched ${data.CommonPrefixes.length} keys from S3 for bucket ${bucketName} and prefix ${prefix} with delimiter ${delimiter}`,
+      `Fetched ${commonPrefixes.length} keys from S3 for bucket ${bucketName} and prefix ${prefix} with delimiter ${delimiter}`,
     );
-    return data.CommonPrefixes.map((subfolder) => subfolder.Prefix);
+    return commonPrefixes.map((subfolder) => subfolder.Prefix);
   } catch (err) {
     log.error(
       `Error while fetching S3 object keys using bucket ${bucketName} and prefix ${prefix} with delimiter ${delimiter}`,

--- a/src/accessibility/utils/scrape-utils.js
+++ b/src/accessibility/utils/scrape-utils.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+import { getObjectKeysFromSubfolders } from './data-processing.js';
+
+export async function getExistingUrlsFromFailedAudits(s3Client, bucketName, siteId, log) {
+  const version = new Date().toISOString().split('T')[0];
+  try {
+    const objectKeysResult = await getObjectKeysFromSubfolders(
+      s3Client,
+      bucketName,
+      'accessibility',
+      siteId,
+      version,
+      log,
+    );
+    log.info(`[A11yAudit] Found existing URLs from failed audits: ${objectKeysResult.objectKeys}`);
+    return objectKeysResult.objectKeys;
+  } catch (error) {
+    log.error(`[A11yAudit] Error getting existing URLs from failed audits: ${error}`);
+    return [];
+  }
+}

--- a/src/accessibility/utils/scrape-utils.js
+++ b/src/accessibility/utils/scrape-utils.js
@@ -49,3 +49,14 @@ export async function getExistingUrlsFromFailedAudits(s3Client, bucketName, site
 
 //   1749564180063/ 1749563780590/
 }
+
+export function getRemainingUrls(urlsToScrape, existingUrls) {
+  return urlsToScrape.filter((item) => {
+    const { url } = item;
+    let urlToCheck = url;
+    if (urlToCheck[urlToCheck.length - 1] !== '/') {
+      urlToCheck = `${urlToCheck}/`;
+    }
+    return !existingUrls.includes(urlToCheck);
+  });
+}

--- a/src/accessibility/utils/scrape-utils.js
+++ b/src/accessibility/utils/scrape-utils.js
@@ -46,9 +46,10 @@ export function reconstructUrlFromS3Key(key) {
 
   const urlPath = fileName.replace('.json', '');
   const pieces = urlPath.split('_');
+  const dotIndex = pieces.includes('www') ? 2 : 1;
 
   const almostFullUrl = pieces.reduce((acc, piece, index) => {
-    if (index < 2) {
+    if (index < dotIndex) {
       return `${acc}${piece}.`;
     }
     return `${acc}${piece}/`;

--- a/src/accessibility/utils/scrape-utils.js
+++ b/src/accessibility/utils/scrape-utils.js
@@ -28,7 +28,11 @@ export async function getExistingUrlsFromFailedAudits(s3Client, bucketName, site
     log.error(`[A11yAudit] Error getting existing URLs from failed audits: ${error}`);
   }
 
-  const existingUrls = existingKeys.map((key) => {
+  if (existingKeys.length === 0) {
+    return [];
+  }
+
+  const existingUrls = existingKeys.objectKeys.map((key) => {
     const fileName = key.split('/').pop();
     const url = fileName.replace('.json', '');
     const pieces = url.split('_');
@@ -42,4 +46,6 @@ export async function getExistingUrlsFromFailedAudits(s3Client, bucketName, site
   });
 
   return existingUrls;
+
+//   1749564180063/ 1749563780590/
 }

--- a/src/accessibility/utils/scrape-utils.js
+++ b/src/accessibility/utils/scrape-utils.js
@@ -52,6 +52,9 @@ export function reconstructUrlFromS3Key(key) {
     if (index < dotIndex) {
       return `${acc}${piece}.`;
     }
+    if (pieces[index + 1] === 'html') {
+      return `${acc}${piece}.`;
+    }
     return `${acc}${piece}/`;
   }, '');
 

--- a/src/accessibility/utils/scrape-utils.js
+++ b/src/accessibility/utils/scrape-utils.js
@@ -13,20 +13,6 @@ import { getObjectKeysFromSubfolders } from './data-processing.js';
 import { getObjectFromKey } from '../../utils/s3-utils.js';
 
 /**
- * Normalizes a URL by ensuring it ends with a trailing slash.
- * This function is pure and easily testable.
- * Exported for testing purposes.
- * @param {string} url The URL to normalize.
- * @returns {string} The normalized URL.
- */
-export function normalizeUrl(url) {
-  if (!url) {
-    return '/';
-  }
-  return url.endsWith('/') ? url : `${url}/`;
-}
-
-/**
  * Fetches existing URLs from previously failed audits stored in S3.
  *
  * @param {S3Client} s3Client - The S3 client instance.
@@ -107,11 +93,6 @@ export async function getExistingUrlsFromFailedAudits(
  * @returns {Array<{url: string}>} The filtered array of URLs to scrape.
  */
 export function getRemainingUrls(urlsToScrape, existingUrls) {
-  // Using a Set for efficient lookups (O(1) average time complexity)
-  const existingUrlSet = new Set(existingUrls.map(normalizeUrl));
-
-  return urlsToScrape.filter((item) => {
-    const normalizedUrl = normalizeUrl(item.url);
-    return !existingUrlSet.has(normalizedUrl);
-  });
+  const existingUrlSet = new Set(existingUrls);
+  return urlsToScrape.filter((item) => !existingUrlSet.has(item.url));
 }

--- a/test/audits/accessibility.test.js
+++ b/test/audits/accessibility.test.js
@@ -293,7 +293,7 @@ describe('Accessibility Audit Handler', () => {
         { url: 'https://example.com/page3' },
       ];
       const mockObjectKeys = ['key1', 'key2'];
-      const existingUrls = ['https://example.com/page1/', 'https://example.com/page2'];
+      const existingUrls = ['https://example.com/page1', 'https://example.com/page2'];
 
       getUrlsForAuditStub.resolves(mockUrls);
       getExistingObjectKeysFromFailedAuditsStub.resolves(mockObjectKeys);

--- a/test/audits/accessibility.test.js
+++ b/test/audits/accessibility.test.js
@@ -31,6 +31,8 @@ describe('Accessibility Audit Handler', () => {
   let getUrlsForAuditStub;
   let aggregateAccessibilityDataStub;
   let generateReportOpportunitiesStub;
+  let getExistingObjectKeysFromFailedAuditsStub;
+  let getExistingUrlsFromFailedAuditsStub;
 
   beforeEach(async () => {
     sandbox = sinon.createSandbox();
@@ -61,12 +63,18 @@ describe('Accessibility Audit Handler', () => {
     getUrlsForAuditStub = sandbox.stub();
     aggregateAccessibilityDataStub = sandbox.stub();
     generateReportOpportunitiesStub = sandbox.stub();
+    getExistingObjectKeysFromFailedAuditsStub = sandbox.stub().resolves([]);
+    getExistingUrlsFromFailedAuditsStub = sandbox.stub().resolves([]);
 
     const accessibilityModule = await esmock('../../src/accessibility/handler.js', {
       '../../src/accessibility/utils/data-processing.js': {
         getUrlsForAudit: getUrlsForAuditStub,
         aggregateAccessibilityData: aggregateAccessibilityDataStub,
         generateReportOpportunities: generateReportOpportunitiesStub,
+      },
+      '../../src/accessibility/utils/scrape-utils.js': {
+        getExistingObjectKeysFromFailedAudits: getExistingObjectKeysFromFailedAuditsStub,
+        getExistingUrlsFromFailedAudits: getExistingUrlsFromFailedAuditsStub,
       },
     });
 
@@ -97,6 +105,15 @@ describe('Accessibility Audit Handler', () => {
         'test-site-id',
         mockContext.log,
       );
+
+      expect(getExistingObjectKeysFromFailedAuditsStub).to.have.been.calledOnceWith(
+        mockS3Client,
+        'test-bucket',
+        'test-site-id',
+        mockContext.log,
+      );
+
+      expect(getExistingUrlsFromFailedAuditsStub).to.have.been.calledOnce;
 
       expect(mockContext.log.info).to.have.been.calledWith(
         '[A11yAudit] Step 1: Preparing content scrape for accessibility audit for https://example.com with siteId test-site-id',
@@ -266,6 +283,34 @@ describe('Accessibility Audit Handler', () => {
       // Act & Assert
       await expect(scrapeAccessibilityData(mockContext))
         .to.be.rejectedWith('Invalid input parameters');
+    });
+
+    it('filters out urls that have existing failed audits', async () => {
+      // Arrange
+      const mockUrls = [
+        { url: 'https://example.com/page1' },
+        { url: 'https://example.com/page2' },
+        { url: 'https://example.com/page3' },
+      ];
+      const mockObjectKeys = ['key1', 'key2'];
+      const existingUrls = ['https://example.com/page1/', 'https://example.com/page2'];
+
+      getUrlsForAuditStub.resolves(mockUrls);
+      getExistingObjectKeysFromFailedAuditsStub.resolves(mockObjectKeys);
+      getExistingUrlsFromFailedAuditsStub.resolves(existingUrls);
+
+      // Act
+      const result = await scrapeAccessibilityData(mockContext);
+
+      // Assert
+      expect(getExistingUrlsFromFailedAuditsStub).to.have.been.calledWith(
+        mockS3Client,
+        'test-bucket',
+        mockContext.log,
+        mockObjectKeys,
+      );
+
+      expect(result.urls).to.deep.equal([{ url: 'https://example.com/page3' }]);
     });
   });
 

--- a/test/audits/accessibility/scrape-utils.test.js
+++ b/test/audits/accessibility/scrape-utils.test.js
@@ -32,18 +32,18 @@ describe('Scrape Utils', () => {
     });
 
     it('returns an empty array when all URLs already exist', () => {
-      const urlsToScrape = [{ url: 'https://a.com' }, { url: 'https://b.com/' }];
+      const urlsToScrape = [{ url: 'https://a.com/' }, { url: 'https://b.com' }];
       const existingUrls = ['https://a.com/', 'https://b.com'];
       expect(getRemainingUrls(urlsToScrape, existingUrls)).to.deep.equal([]);
     });
 
-    it('filters out URLs that exist, considering normalization', () => {
+    it('filters out URLs that exist', () => {
       const urlsToScrape = [
         { url: 'https://a.com' }, // exists
         { url: 'https://b.com/' }, // exists
         { url: 'https://c.com' }, // does not exist
       ];
-      const existingUrls = ['https://a.com/', 'https://b.com'];
+      const existingUrls = ['https://a.com', 'https://b.com/'];
       const expected = [{ url: 'https://c.com' }];
       expect(getRemainingUrls(urlsToScrape, existingUrls)).to.deep.equal(expected);
     });
@@ -54,14 +54,18 @@ describe('Scrape Utils', () => {
       expect(getRemainingUrls(urlsToScrape, existingUrls)).to.deep.equal([]);
     });
 
-    it('handles a mix of URLs with and without trailing slashes', () => {
+    it('does not filter if trailing slashes do not match', () => {
       const urlsToScrape = [
         { url: 'https://a.com' },
         { url: 'https://b.com/' },
         { url: 'https://c.com' },
       ];
       const existingUrls = ['https://a.com/'];
-      const expected = [{ url: 'https://b.com/' }, { url: 'https://c.com' }];
+      const expected = [
+        { url: 'https://a.com' },
+        { url: 'https://b.com/' },
+        { url: 'https://c.com' },
+      ];
       expect(getRemainingUrls(urlsToScrape, existingUrls)).to.deep.equal(expected);
     });
   });

--- a/test/audits/accessibility/scrape-utils.test.js
+++ b/test/audits/accessibility/scrape-utils.test.js
@@ -18,48 +18,12 @@ import esmock from 'esmock';
 import sinonChai from 'sinon-chai';
 import {
   getRemainingUrls,
-  normalizeUrl,
   extractUrlsFromSettledResults,
 } from '../../../src/accessibility/utils/scrape-utils.js';
 
 use(sinonChai);
 
 describe('Scrape Utils', () => {
-  describe('normalizeUrl', () => {
-    it('adds a trailing slash to a URL without one', () => {
-      const url = 'https://www.example.com/path';
-      const expected = 'https://www.example.com/path/';
-      expect(normalizeUrl(url)).to.equal(expected);
-    });
-
-    it('does not add a trailing slash to a URL that already has one', () => {
-      const url = 'https://www.example.com/path/';
-      expect(normalizeUrl(url)).to.equal(url);
-    });
-
-    it('returns "/" for a null URL', () => {
-      expect(normalizeUrl(null)).to.equal('/');
-    });
-
-    it('returns "/" for an undefined URL', () => {
-      expect(normalizeUrl(undefined)).to.equal('/');
-    });
-
-    it('returns "/" for an empty string URL', () => {
-      expect(normalizeUrl('')).to.equal('/');
-    });
-
-    it('handles root URL correctly', () => {
-      expect(normalizeUrl('/')).to.equal('/');
-    });
-
-    it('handles a domain without path', () => {
-      const url = 'https://www.example.com';
-      const expected = 'https://www.example.com/';
-      expect(normalizeUrl(url)).to.equal(expected);
-    });
-  });
-
   describe('getRemainingUrls', () => {
     it('returns all URLs when there are no existing URLs', () => {
       const urlsToScrape = [{ url: 'https://a.com' }, { url: 'https://b.com' }];

--- a/test/audits/accessibility/scrape-utils.test.js
+++ b/test/audits/accessibility/scrape-utils.test.js
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import esmock from 'esmock';
+import sinonChai from 'sinon-chai';
+import {
+  getRemainingUrls, normalizeUrl, reconstructUrlFromS3Key,
+} from '../../../src/accessibility/utils/scrape-utils.js';
+
+use(sinonChai);
+
+describe('Scrape Utils', () => {
+  describe('normalizeUrl', () => {
+    it('adds a trailing slash to a URL without one', () => {
+      const url = 'https://www.example.com/path';
+      const expected = 'https://www.example.com/path/';
+      expect(normalizeUrl(url)).to.equal(expected);
+    });
+
+    it('does not add a trailing slash to a URL that already has one', () => {
+      const url = 'https://www.example.com/path/';
+      expect(normalizeUrl(url)).to.equal(url);
+    });
+
+    it('returns "/" for a null URL', () => {
+      expect(normalizeUrl(null)).to.equal('/');
+    });
+
+    it('returns "/" for an undefined URL', () => {
+      expect(normalizeUrl(undefined)).to.equal('/');
+    });
+
+    it('returns "/" for an empty string URL', () => {
+      expect(normalizeUrl('')).to.equal('/');
+    });
+
+    it('handles root URL correctly', () => {
+      expect(normalizeUrl('/')).to.equal('/');
+    });
+
+    it('handles a domain without path', () => {
+      const url = 'https://www.example.com';
+      const expected = 'https://www.example.com/';
+      expect(normalizeUrl(url)).to.equal(expected);
+    });
+  });
+
+  describe('reconstructUrlFromS3Key', () => {
+    it('reconstructs a URL from a standard S3 key with www', () => {
+      const key = 'audits/2024/www_example_com_path_page.json';
+      const expected = 'https://www.example.com/path/page/';
+      expect(reconstructUrlFromS3Key(key)).to.equal(expected);
+    });
+
+    it('reconstructs a URL from a standard S3 key without www', () => {
+      const key = 'audits/2024/example_com_path_page.json';
+      const expected = 'https://example.com/path/page/';
+      expect(reconstructUrlFromS3Key(key)).to.equal(expected);
+    });
+
+    it('reconstructs a URL with only a domain', () => {
+      const key = 'www_example_com.json';
+      const expected = 'https://www.example.com/';
+      expect(reconstructUrlFromS3Key(key)).to.equal(expected);
+    });
+
+    it('reconstructs a URL with only a domain and no www', () => {
+      const key = 'example_com.json';
+      const expected = 'https://example.com/';
+      expect(reconstructUrlFromS3Key(key)).to.equal(expected);
+    });
+
+    it('returns an empty string for an empty key', () => {
+      expect(reconstructUrlFromS3Key('')).to.equal('');
+    });
+
+    it('returns an empty string for a key ending in a slash', () => {
+      const key = 'some/path/';
+      expect(reconstructUrlFromS3Key(key)).to.equal('');
+    });
+
+    it('handles a key that is just a filename', () => {
+      const key = 'www_example_com.json';
+      const expected = 'https://www.example.com/';
+      expect(reconstructUrlFromS3Key(key)).to.equal(expected);
+    });
+
+    it('handles a key with a subdomain incorrectly due to current logic', () => {
+      const key = 'sub_example_com.json';
+      const expected = 'https://sub.example/com/';
+      expect(reconstructUrlFromS3Key(key)).to.equal(expected);
+    });
+
+    it('handles a key with a multi-part TLD incorrectly', () => {
+      const key = 'example_co_uk.json';
+      const expected = 'https://example.co/uk/';
+      expect(reconstructUrlFromS3Key(key)).to.equal(expected);
+    });
+  });
+
+  describe('getRemainingUrls', () => {
+    it('returns all URLs when there are no existing URLs', () => {
+      const urlsToScrape = [{ url: 'https://a.com' }, { url: 'https://b.com' }];
+      const existingUrls = [];
+      expect(getRemainingUrls(urlsToScrape, existingUrls)).to.deep.equal(urlsToScrape);
+    });
+
+    it('returns an empty array when all URLs already exist', () => {
+      const urlsToScrape = [{ url: 'https://a.com' }, { url: 'https://b.com/' }];
+      const existingUrls = ['https://a.com/', 'https://b.com'];
+      expect(getRemainingUrls(urlsToScrape, existingUrls)).to.deep.equal([]);
+    });
+
+    it('filters out URLs that exist, considering normalization', () => {
+      const urlsToScrape = [
+        { url: 'https://a.com' }, // exists
+        { url: 'https://b.com/' }, // exists
+        { url: 'https://c.com' }, // does not exist
+      ];
+      const existingUrls = ['https://a.com/', 'https://b.com'];
+      const expected = [{ url: 'https://c.com' }];
+      expect(getRemainingUrls(urlsToScrape, existingUrls)).to.deep.equal(expected);
+    });
+
+    it('returns an empty array if urlsToScrape is empty', () => {
+      const urlsToScrape = [];
+      const existingUrls = ['https://a.com/'];
+      expect(getRemainingUrls(urlsToScrape, existingUrls)).to.deep.equal([]);
+    });
+
+    it('handles a mix of URLs with and without trailing slashes', () => {
+      const urlsToScrape = [
+        { url: 'https://a.com' },
+        { url: 'https://b.com/' },
+        { url: 'https://c.com' },
+      ];
+      const existingUrls = ['https://a.com/'];
+      const expected = [{ url: 'https://b.com/' }, { url: 'https://c.com' }];
+      expect(getRemainingUrls(urlsToScrape, existingUrls)).to.deep.equal(expected);
+    });
+  });
+
+  describe('getExistingUrlsFromFailedAudits', () => {
+    let mockS3Client;
+    let mockLog;
+    let sandbox;
+    let clock;
+    let getObjectKeysFromSubfoldersStub;
+
+    beforeEach(() => {
+      sandbox = sinon.createSandbox();
+      mockS3Client = { send: sandbox.stub() };
+      mockLog = {
+        info: sandbox.stub(),
+        error: sandbox.stub(),
+        warn: sandbox.stub(),
+      };
+      // Set a fixed date for deterministic tests
+      clock = sinon.useFakeTimers(new Date('2024-07-24T10:00:00.000Z'));
+      getObjectKeysFromSubfoldersStub = sandbox.stub();
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+      clock.restore();
+    });
+
+    async function getModule(stubs) {
+      return esmock('../../../src/accessibility/utils/scrape-utils.js', {
+        '../../../src/accessibility/utils/data-processing.js': stubs,
+      });
+    }
+
+    it('fetches and reconstructs URLs when failed audits exist', async () => {
+      const objectKeys = [
+        'audits/www_site1_com_page1.json',
+        'audits/www_site1_com_page2.json',
+        'audits/malformed_key.json', // Will be filtered
+      ];
+      getObjectKeysFromSubfoldersStub.resolves({ objectKeys });
+
+      const { getExistingUrlsFromFailedAudits } = await getModule({
+        getObjectKeysFromSubfolders: getObjectKeysFromSubfoldersStub,
+      });
+
+      const urls = await getExistingUrlsFromFailedAudits(mockS3Client, 'test-bucket', 'site1', mockLog);
+
+      expect(urls).to.deep.equal(['https://www.site1.com/page1/', 'https://www.site1.com/page2/', 'https://malformed.key/']);
+      expect(getObjectKeysFromSubfoldersStub).to.have.been.calledWith(
+        mockS3Client,
+        'test-bucket',
+        'accessibility',
+        'site1',
+        '2024-07-24',
+        mockLog,
+      );
+      expect(mockLog.info).to.have.been.calledWith(`[A11yAudit] Found ${objectKeys.length} existing URLs from failed audits.`);
+    });
+
+    it('returns an empty array when no failed audits are found', async () => {
+      getObjectKeysFromSubfoldersStub.resolves({ objectKeys: [] });
+      const { getExistingUrlsFromFailedAudits } = await getModule({
+        getObjectKeysFromSubfolders: getObjectKeysFromSubfoldersStub,
+      });
+
+      const urls = await getExistingUrlsFromFailedAudits(mockS3Client, 'test-bucket', 'site1', mockLog);
+
+      expect(urls).to.deep.equal([]);
+      expect(mockLog.info).to.have.been.calledWith('[A11yAudit] No existing URLs from failed audits found.');
+    });
+
+    it('returns an empty array and logs error when getObjectKeysFromSubfolders fails', async () => {
+      const error = new Error('S3 Error');
+      getObjectKeysFromSubfoldersStub.rejects(error);
+      const { getExistingUrlsFromFailedAudits } = await getModule({
+        getObjectKeysFromSubfolders: getObjectKeysFromSubfoldersStub,
+      });
+
+      const urls = await getExistingUrlsFromFailedAudits(mockS3Client, 'test-bucket', 'site1', mockLog);
+
+      expect(urls).to.deep.equal([]);
+      expect(mockLog.error).to.have.been.calledWith(`[A11yAudit] Error getting existing URLs from failed audits: ${error.message}`);
+    });
+
+    it('filters out empty URLs from malformed keys', async () => {
+      // Key ending in a slash will produce an empty URL
+      const objectKeys = ['audits/www_site1_com_page1.json', 'audits/some_path/'];
+      getObjectKeysFromSubfoldersStub.resolves({ objectKeys });
+      const { getExistingUrlsFromFailedAudits } = await getModule({
+        getObjectKeysFromSubfolders: getObjectKeysFromSubfoldersStub,
+      });
+
+      const urls = await getExistingUrlsFromFailedAudits(mockS3Client, 'test-bucket', 'site1', mockLog);
+
+      expect(urls).to.deep.equal(['https://www.site1.com/page1/']);
+    });
+  });
+});

--- a/test/audits/accessibility/scrape-utils.test.js
+++ b/test/audits/accessibility/scrape-utils.test.js
@@ -71,6 +71,12 @@ describe('Scrape Utils', () => {
       expect(reconstructUrlFromS3Key(key)).to.equal(expected);
     });
 
+    it('reconstructs a URL with .html extension', () => {
+      const key = 'audits/2024/www_example_com_path_page_html.json';
+      const expected = 'https://www.example.com/path/page.html/';
+      expect(reconstructUrlFromS3Key(key)).to.equal(expected);
+    });
+
     it('reconstructs a URL with only a domain', () => {
       const key = 'www_example_com.json';
       const expected = 'https://www.example.com/';


### PR DESCRIPTION
This pull request introduces a mechanism into the accessibility audit worker to prevent the re-scraping of URLs that have already failed an audit within the same day. This is a useful measure in the context of content-scraper audits that result in timeouts due to the fixed duration of the lambda (15 min max).

Key Changes:

**accessibility/handler.js:**
- The scrapeAccessibilityData function has been updated to check for existing failed audits before dispatching a scrape request.
- It now fetches URLs from previously failed audits and filters them out from the list of URLs to be scraped.

**accessibility/utils/scrape-utils.js:**
- A new utility file has been created to house helper functions for the scraping logic.
- getExistingUrlsFromFailedAudits: This new function retrieves the keys of failed audit results from S3 for the current day and reconstructs the original URLs.
- getRemainingUrls: This function efficiently filters the list of URLs to be scraped against the list of existing failed URLs.
- normalizeUrl and reconstructUrlFromS3Key: Helper functions to handle URL manipulation and reconstruction from S3 keys.

By implementing this check, we ensure that the accessibility audit only processes new pages or pages that have not recently failed, making the audit process more efficient and resilient.