### PR TITLE
fix: correct typo in site average CTR variable name

### DIFF
--- a/src/experimentation-opportunities/handler.js
+++ b/src/experimentation-opportunities/handler.js
@@ -64,7 +64,7 @@ export async function generateOpportunityAndSuggestions(context) {
     data: {
       url: oppty.page,
       ctr: oppty.trackedPageKPIValue,
-      siteAgerageCtr: oppty.trackedKPISiteAverage,
+      siteAverageCtr: oppty.trackedKPISiteAverage,
     },
   }));
 

--- a/test/audits/experimentation-opportunities.test.js
+++ b/test/audits/experimentation-opportunities.test.js
@@ -182,7 +182,7 @@ describe('Experimentation Opportunities Tests', () => {
     expect(messageArg1.data).to.deep.equal({
       url: 'https://abc.com/oppty-one',
       ctr: '0.12',
-      siteAgerageCtr: '0.25',
+      siteAverageCtr: '0.25',
     });
 
     const [queueArg2, messageArg2] = context.sqs.sendMessage.secondCall.args;
@@ -196,7 +196,7 @@ describe('Experimentation Opportunities Tests', () => {
     expect(messageArg2.data).to.deep.equal({
       url: 'https://abc.com/oppty-two',
       ctr: '0.08',
-      siteAgerageCtr: '0.22',
+      siteAverageCtr: '0.22',
     });
   });
 


### PR DESCRIPTION
Updated the variable name from 'siteAgerageCtr' to 'siteAverageCtr' in both the handler and test files to ensure consistency and accuracy in data handling.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
