### PR TITLE
feat: broken external links check.

### DIFF
--- a/src/external-links/handler.js
+++ b/src/external-links/handler.js
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import RUMAPIClient from '@adobe/spacecat-shared-rum-api-client';
+import { Audit, Opportunity as Oppty, Suggestion as SuggestionDataAccess } from '@adobe/spacecat-shared-data-access';
+import { isNonEmptyArray } from '@adobe/spacecat-shared-utils';
+import { AuditBuilder } from '../common/audit-builder.js';
+import { syncSuggestions } from '../utils/data-access.js';
+import { convertToOpportunity } from '../common/opportunity.js';
+import { createOpportunityData } from './opportunity-data-mapper.js';
+import { generateSuggestionData } from './suggestions-generator.js';
+import { wwwUrlResolver } from '../common/index.js';
+import {
+  calculateKpiDeltasForAudit,
+  isLinkInaccessible,
+  calculatePriority,
+} from './helpers.js';
+
+const { AUDIT_STEP_DESTINATIONS } = Audit;
+const INTERVAL = 30; // days
+const AUDIT_TYPE = Audit.AUDIT_TYPES.BROKEN_EXTERNAL_LINKS;
+
+/**
+ * Perform an audit to check which external links for domain are broken.
+ *
+ * @async
+ * @param {string} baseURL - The URL to run audit against
+ * @param {Object} context - The context object containing configurations, services,
+ * and environment variables.
+ * @returns {Response} - Returns a response object indicating the result of the audit process.
+ */
+export async function externalLinksAuditRunner(auditUrl, context) {
+  const { log, site } = context;
+  const finalUrl = await wwwUrlResolver(site, context);
+
+  try {
+    // 1. Create RUM API client
+    const rumAPIClient = RUMAPIClient.createFrom(context);
+
+    // 2. Prepare query options
+    const options = {
+      domain: finalUrl,
+      interval: INTERVAL,
+      granularity: 'hourly',
+    };
+
+    // 3. Query for external links
+    const externalLinks = await rumAPIClient.query('external-links', options);
+
+    // 4. Check accessibility in parallel before transformation
+    const accessibilityResults = await Promise.all(
+      externalLinks.map(async (link) => ({
+        link,
+        inaccessible: await isLinkInaccessible(link.url_to, log),
+      })),
+    );
+
+    // 5. Filter only inaccessible links and transform for further processing
+    const inaccessibleLinks = accessibilityResults
+      .filter((result) => result.inaccessible)
+      .map((result) => ({
+        urlFrom: result.link.url_from,
+        urlTo: result.link.url_to,
+        trafficDomain: result.link.traffic_domain,
+      }));
+
+    // 6. Prioritize links
+    const prioritizedLinks = calculatePriority(inaccessibleLinks);
+
+    log.info(`[${AUDIT_TYPE}] [Site: ${site.getId()}] found: ${prioritizedLinks.length} broken external links`);
+
+    // 7. Build and return audit result
+    return {
+      auditResult: {
+        brokenExternalLinks: prioritizedLinks,
+        fullAuditRef: auditUrl,
+        finalUrl,
+        auditContext: { interval: INTERVAL },
+      },
+      fullAuditRef: auditUrl,
+    };
+  } catch (error) {
+    log.error(`[${AUDIT_TYPE}] [Site: ${site.getId()}] audit failed with error: ${error.message}`);
+    return {
+      fullAuditRef: auditUrl,
+      auditResult: {
+        finalUrl: auditUrl,
+        error: `[${AUDIT_TYPE}] [Site: ${site.getId()}] audit failed with error: ${error.message}`,
+        success: false,
+      },
+    };
+  }
+}
+
+export async function runAuditAndImportTopPagesStep(context) {
+  const { site, log, finalUrl } = context;
+  log.info(`[${AUDIT_TYPE}] [Site: ${site.getId()}] starting audit`);
+  const externalLinksAuditRunnerResult = await externalLinksAuditRunner(
+    finalUrl,
+    context,
+  );
+
+  return {
+    auditResult: externalLinksAuditRunnerResult.auditResult,
+    fullAuditRef: finalUrl,
+    type: 'top-pages',
+    siteId: site.getId(),
+  };
+}
+
+export async function prepareScrapingStep(context) {
+  const {
+    log, site, dataAccess,
+  } = context;
+  const { SiteTopPage } = dataAccess;
+  const topPages = await SiteTopPage.allBySiteIdAndSourceAndGeo(site.getId(), 'ahrefs', 'global');
+
+  log.info(`[${AUDIT_TYPE}] [Site: ${site.getId()}] found ${topPages.length} top pages`);
+
+  const urls = topPages.map((page) => ({ url: page.getUrl() }));
+  return {
+    urls,
+    siteId: site.getId(),
+    type: 'broken-external-links',
+  };
+}
+
+export async function opportunityAndSuggestionsStep(
+  context,
+  generateSuggestionDataImpl = generateSuggestionData,
+) {
+  const {
+    log, site, finalUrl, audit, dataAccess,
+  } = context;
+
+  let { brokenExternalLinks } = audit.getAuditResult();
+
+  // generate suggestions
+  try {
+    brokenExternalLinks = await generateSuggestionDataImpl(
+      finalUrl,
+      audit,
+      context,
+      site,
+    );
+  } catch (error) {
+    log.error(`[${AUDIT_TYPE}] [Site: ${site.getId()}] suggestion generation error: ${error.message}`);
+  }
+
+  const kpiDeltas = calculateKpiDeltasForAudit(brokenExternalLinks);
+
+  if (!isNonEmptyArray(brokenExternalLinks)) {
+    // no broken external links found
+    // fetch opportunity
+    const { Opportunity } = dataAccess;
+    let opportunity;
+    try {
+      const opportunities = await Opportunity
+        .allBySiteIdAndStatus(site.getId(), Oppty.STATUSES.NEW);
+      opportunity = opportunities.find((oppty) => oppty.getType() === AUDIT_TYPE);
+    } catch (e) {
+      log.error(`Fetching opportunities for siteId ${site.getId()} failed with error: ${e.message}`);
+      throw new Error(`Failed to fetch opportunities for siteId ${site.getId()}: ${e.message}`);
+    }
+
+    if (!opportunity) {
+      log.info(`[${AUDIT_TYPE}] [Site: ${site.getId()}] no broken external links found, skipping opportunity creation`);
+    } else {
+      try {
+        // no broken external links found, update opportunity status to RESOLVED
+        log.info(`[${AUDIT_TYPE}] [Site: ${site.getId()}] no broken external links found, but found opportunity, updating status to RESOLVED`);
+        await opportunity.setStatus(Oppty.STATUSES.RESOLVED);
+
+        // We also need to update all suggestions inside this opportunity
+        // Get all suggestions for this opportunity
+        const suggestions = await opportunity.getSuggestions();
+
+        // If there are suggestions, update their status to outdated
+        if (isNonEmptyArray(suggestions)) {
+          const { Suggestion } = dataAccess;
+          await Suggestion.bulkUpdateStatus(suggestions, SuggestionDataAccess.STATUSES.OUTDATED);
+        }
+        opportunity.setUpdatedBy('system');
+        await opportunity.save();
+      } catch (error) {
+        log.error(`[${AUDIT_TYPE}] [Site: ${site.getId()}] Failed to update opportunity status: ${error.message}`);
+        throw error;
+      }
+    }
+    return {
+      status: 'complete',
+    };
+  }
+
+  try {
+    const opportunity = await convertToOpportunity(
+      finalUrl,
+      { siteId: site.getId(), id: audit.getId() },
+      context,
+      createOpportunityData,
+      AUDIT_TYPE,
+      {
+        kpiDeltas,
+      },
+    );
+
+    const buildKey = (item) => `${item.urlFrom}-${item.urlTo}`;
+    await syncSuggestions({
+      opportunity,
+      newData: brokenExternalLinks,
+      context,
+      buildKey,
+      mapNewSuggestion: (entry) => ({
+        opportunityId: opportunity.getId(),
+        type: 'CONTENT_UPDATE',
+        rank: entry.trafficDomain,
+        data: {
+          title: entry.title,
+          urlFrom: entry.urlFrom,
+          urlTo: entry.urlTo,
+          urlsSuggested: entry.urlsSuggested || [],
+          aiRationale: entry.aiRationale || '',
+          trafficDomain: entry.trafficDomain,
+        },
+      }),
+      log,
+    });
+    return {
+      status: 'complete',
+    };
+  } catch (error) {
+    log.error(`[${AUDIT_TYPE}] [Site: ${site.getId()}] Failed to create opportunity or sync suggestions: ${error.message}`);
+    throw error;
+  }
+}
+
+export default new AuditBuilder()
+  .withUrlResolver(wwwUrlResolver)
+  .addStep(
+    'runAuditAndImportTopPages',
+    runAuditAndImportTopPagesStep,
+    AUDIT_STEP_DESTINATIONS.IMPORT_WORKER,
+  )
+  .addStep(
+    'prepareScraping',
+    prepareScrapingStep,
+    AUDIT_STEP_DESTINATIONS.CONTENT_SCRAPER,
+  )
+  .addStep('opportunityAndSuggestions', opportunityAndSuggestionsStep)
+  .build();

--- a/src/external-links/helpers.js
+++ b/src/external-links/helpers.js
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+const LINK_TIMEOUT = 3000; // 3 seconds
+const MAX_LINKS_TO_CONSIDER = 10;
+const TRAFFIC_MULTIPLIER = 0.1;
+
+/**
+ * Resolves the CPC (Cost Per Click) value for KPI calculations
+ * @returns {number} The CPC value
+ */
+export const resolveCpcValue = () => 1.0; // Default value, can be configured
+
+/**
+ * Calculates KPI deltas based on broken external links audit data
+ * @param {Object} auditData - The audit data containing results
+ * @returns {Object} KPI delta calculations
+ */
+export const calculateKpiDeltasForAudit = (brokenExternalLinks) => {
+  const cpcValue = resolveCpcValue();
+
+  // Sort all links by traffic domain in descending order
+  const sortedLinks = [...brokenExternalLinks].sort((a, b) => b.trafficDomain - a.trafficDomain);
+
+  // Take only the top MAX_LINKS_TO_CONSIDER links
+  const topLinks = sortedLinks.slice(0, MAX_LINKS_TO_CONSIDER);
+
+  // Calculate projected traffic lost
+  const projectedTrafficLost = topLinks.reduce(
+    (acc, link) => acc + link.trafficDomain * TRAFFIC_MULTIPLIER,
+    0,
+  );
+
+  return {
+    projectedTrafficLost: Math.round(projectedTrafficLost),
+    projectedTrafficValue: Math.round(projectedTrafficLost * cpcValue),
+  };
+};
+
+/**
+ * Checks if a URL is inaccessible/not reachable by attempting to fetch it.
+ * A URL is considered inaccessible if:
+ * - The fetch request fails (network errors or timeouts)
+ * - The response status code is >= 400 (400-499)
+ * The check will timeout after LINK_TIMEOUT milliseconds.
+ * Non-404 client errors (400-499) will log a warning.
+ * All errors (network, timeout etc) will log an error and return true.
+ * @param {string} url - The URL to validate
+ * @returns {Promise<boolean>} True if the URL is inaccessible, times out, or errors
+ * false if reachable/accessible
+ */
+export async function isLinkInaccessible(url, log) {
+  try {
+    const response = await fetch(url, {
+      method: 'HEAD',
+      timeout: LINK_TIMEOUT,
+    });
+    const { status } = response;
+
+    if (status === 404) {
+      log.warn(`Client error (404) for URL: ${url}`);
+    } else if (status >= 400 && status < 500) {
+      log.warn(`Client error (${status}) for URL: ${url}`);
+    } else if (status >= 500) {
+      log.error(`Server error (${status}) for URL: ${url}`);
+    }
+
+    return status >= 400;
+  } catch {
+    log.error(`Error checking URL: ${url}`);
+    return true;
+  }
+}
+
+/**
+ * Classifies links into priority categories based on views
+ * High: top 25%, Medium: next 25%, Low: bottom 50%
+ * @param {Array} links - Array of objects with views property
+ * @returns {Array} - Links with priority classifications included
+ */
+export function calculatePriority(links) {
+  // Sort links by views in descending order
+  const sortedLinks = [...links].sort((a, b) => b.views - a.views);
+
+  // Calculate indices for the 25% and 50% marks
+  const quarterIndex = Math.ceil(sortedLinks.length * 0.25);
+  const halfIndex = Math.ceil(sortedLinks.length * 0.5);
+
+  // Map through sorted links and assign priority
+  return sortedLinks.map((link, index) => {
+    let priority;
+
+    if (index < quarterIndex) {
+      priority = 'high';
+    } else if (index < halfIndex) {
+      priority = 'medium';
+    } else {
+      priority = 'low';
+    }
+
+    return {
+      ...link,
+      priority,
+    };
+  });
+}

--- a/src/external-links/opportunity-data-mapper.js
+++ b/src/external-links/opportunity-data-mapper.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { DATA_SOURCES } from '../common/constants.js';
+
+/**
+ * Creates an opportunity data object for the broken external links audit.
+ * @param {Object} props - The properties for the opportunity data object.
+ * @param {Object} props.kpiDeltas - The KPI deltas for the audit.
+ * @returns {Object} The opportunity data object.
+ */
+export function createOpportunityData({ kpiDeltas }) {
+  return {
+    runbook: 'https://adobe.sharepoint.com/sites/aemsites-engineering/Shared%20Documents/3%20-%20Experience%20Success/SpaceCat/Runbooks/Experience_Success_Studio_Broken_External_Links_Runbook.docx?web=1',
+    origin: 'AUTOMATION',
+    title: 'Broken external links are impairing user experience and SEO crawlability',
+    description: 'We\'ve detected broken external links on your website. Broken external links can negatively impact user experience, SEO, and your site\'s credibility. Please review and fix these links to ensure smooth navigation and maintain trust with your users.',
+    guidance: {
+      steps: [
+        'Update each broken external link to valid URLs or remove them if no longer relevant.',
+        'Test the implemented changes manually to ensure they are working as expected.',
+        'Monitor external links for 404 errors in RUM tool over time to ensure they are functioning correctly.',
+        'Consider implementing a link checking system to proactively monitor external link health.',
+      ],
+    },
+    tags: [
+      'Traffic acquisition',
+      'Engagement',
+      'User Experience',
+    ],
+    data: {
+      ...kpiDeltas,
+      dataSources: [DATA_SOURCES.AHREFS, DATA_SOURCES.RUM, DATA_SOURCES.SITE],
+    },
+  };
+}

--- a/src/external-links/suggestions-generator.js
+++ b/src/external-links/suggestions-generator.js
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { getPrompt, isNonEmptyArray } from '@adobe/spacecat-shared-utils';
+import { FirefallClient } from '@adobe/spacecat-shared-gpt-client';
+import { Audit } from '@adobe/spacecat-shared-data-access';
+import { getScrapedDataForSiteId } from '../support/utils.js';
+
+const AUDIT_TYPE = Audit.AUDIT_TYPES.BROKEN_EXTERNAL_LINKS;
+
+export const generateSuggestionData = async (finalUrl, audit, context, site) => {
+  const { dataAccess, log } = context;
+  const { Configuration } = dataAccess;
+  const { FIREFALL_MODEL } = context.env;
+  const { brokenExternalLinks } = audit.getAuditResult();
+
+  if (audit.getAuditResult().success === false) {
+    log.info(`[${AUDIT_TYPE}] [Site: ${site.getId()}] Audit failed, skipping suggestions generation`);
+    return brokenExternalLinks;
+  }
+
+  const configuration = await Configuration.findLatest();
+  if (!configuration.isHandlerEnabledForSite('broken-external-links-auto-suggest', site)) {
+    log.info(`[${AUDIT_TYPE}] [Site: ${site.getId()}] Auto-suggest is disabled for site`);
+    return brokenExternalLinks;
+  }
+
+  log.info(`[${AUDIT_TYPE}] [Site: ${site.getId()}] Generating suggestions for site ${finalUrl}`);
+
+  const firefallClient = FirefallClient.createFrom(context);
+  const firefallOptions = { responseFormat: 'json_object', model: FIREFALL_MODEL };
+  const BATCH_SIZE = 300;
+
+  const data = await getScrapedDataForSiteId(site, context);
+  const { siteData, headerLinks } = data;
+  const totalBatches = Math.ceil(siteData.length / BATCH_SIZE);
+  const dataBatches = Array.from(
+    { length: totalBatches },
+    (_, i) => siteData.slice(i * BATCH_SIZE, (i + 1) * BATCH_SIZE),
+  );
+
+  // return early if site data is not found
+  if (!isNonEmptyArray(siteData)) {
+    log.info(`[${AUDIT_TYPE}] [Site: ${site.getId()}] No site data found, skipping suggestions generation`);
+    return brokenExternalLinks;
+  }
+
+  log.info(`[${AUDIT_TYPE}] [Site: ${site.getId()}] Processing ${siteData.length} alternative URLs in ${totalBatches} batches of ${BATCH_SIZE}...`);
+
+  const processBatches = async (batches, brokenUrl) => {
+    const batchResults = await Promise.all(
+      batches.map(async (batch) => {
+        try {
+          const requestBody = await getPrompt(
+            {
+              alternative_urls: batch,
+              broken_url: brokenUrl,
+            },
+            'broken-external-links',
+            log,
+          );
+          const response = await firefallClient.fetchChatCompletion(requestBody, firefallOptions);
+          if (!response.choices || response.choices[0].finish_reason !== 'stop') {
+            log.error(`[${AUDIT_TYPE}] [Site: ${site.getId()}] No suggestions found for ${brokenUrl}`);
+            return null;
+          }
+          return JSON.parse(response.choices[0].message.content);
+        } catch (error) {
+          log.error(`[${AUDIT_TYPE}] [Site: ${site.getId()}] Batch processing error: ${error.message}`);
+          return null;
+        }
+      }),
+    );
+    return batchResults.filter(Boolean);
+  };
+
+  /**
+   * Process a broken external link to generate URL suggestions
+   * @param {Object} link - The broken external link object containing urlTo and other properties
+   * @param {Object} headerSuggestions - Suggestions generated from header links
+   * @returns {Promise<Object>} Updated link object with suggested URLs and AI rationale
+   */
+  const processLink = async (link, headerSuggestions) => {
+    log.info(`[${AUDIT_TYPE}] [Site: ${site.getId()}] Processing link: ${link.urlTo}`);
+    const suggestions = await processBatches(dataBatches, link.urlTo);
+
+    if (totalBatches > 1) {
+      log.info(
+        `[${AUDIT_TYPE}] [Site: ${site.getId()}] Compiling final suggestions for: ${link.urlTo}`,
+      );
+      try {
+        const finalRequestBody = await getPrompt(
+          {
+            suggested_urls: suggestions,
+            header_links: headerSuggestions,
+            broken_url: link.urlTo,
+          },
+          'broken-external-links-followup',
+          log,
+        );
+        const finalResponse = await firefallClient
+          .fetchChatCompletion(finalRequestBody, firefallOptions);
+
+        if (!finalResponse.choices || finalResponse.choices[0].finish_reason !== 'stop') {
+          log.error(`[${AUDIT_TYPE}] [Site: ${site.getId()}] No final suggestions found for ${link.urlTo}`);
+          return { ...link };
+        }
+
+        const answer = JSON.parse(finalResponse.choices[0].message.content);
+
+        log.info(`[${AUDIT_TYPE}] [Site: ${site.getId()}] Final suggestion for ${link.urlTo}:, ${JSON.stringify(answer)}`, answer);
+        const urlsSuggested = Array.isArray(answer.suggested_urls)
+          && answer.suggested_urls.length > 0
+          ? answer.suggested_urls
+          : [finalUrl];
+
+        const aiRationale = typeof answer.aiRationale === 'string'
+          && answer.aiRationale.trim().length > 0
+          ? answer.aiRationale
+          : 'No suitable suggestions found';
+
+        return {
+          ...link,
+          urlsSuggested,
+          aiRationale,
+        };
+      } catch (error) {
+        log.error(`[${AUDIT_TYPE}] [Site: ${site.getId()}] Final suggestion error for ${link.urlTo}: ${error.message}`);
+        return { ...link };
+      }
+    }
+
+    log.info(`[${AUDIT_TYPE}] [Site: ${site.getId()}] Suggestions for ${link.urlTo}: ${JSON.stringify(suggestions[0]?.suggested_urls)}`);
+    return {
+      ...link,
+      urlsSuggested:
+        suggestions[0]?.suggested_urls?.length > 0 ? suggestions[0]?.suggested_urls : [finalUrl],
+      aiRationale:
+        suggestions[0]?.aiRationale?.length > 0 ? suggestions[0]?.aiRationale : 'No suitable suggestions found',
+    };
+  };
+
+  // Process all header suggestions in parallel
+  const headerSuggestionsPromises = brokenExternalLinks.map(async (link) => {
+    try {
+      const requestBody = await getPrompt(
+        { alternative_urls: headerLinks, broken_url: link.urlTo },
+        'broken-external-links',
+        log,
+      );
+      const response = await firefallClient.fetchChatCompletion(requestBody, firefallOptions);
+      if (response.choices?.length >= 1 && response.choices[0].finish_reason !== 'stop') {
+        log.error(`[${AUDIT_TYPE}] [Site: ${site.getId()}] No header suggestions for ${link.urlTo}`);
+        return null;
+      }
+      return JSON.parse(response.choices[0].message.content);
+    } catch (error) {
+      log.error(`[${AUDIT_TYPE}] [Site: ${site.getId()}] Header suggestion error: ${error.message}`);
+      return null;
+    }
+  });
+
+  const headerSuggestions = await Promise.all(headerSuggestionsPromises);
+
+  // Process all links in parallel
+  const updatedExternalLinks = await Promise.all(
+    brokenExternalLinks.map(async (link, index) => {
+      const headerSuggestion = headerSuggestions[index];
+      return processLink(link, headerSuggestion);
+    }),
+  );
+
+  log.info(`[${AUDIT_TYPE}] [Site: ${site.getId()}] Suggestions generation complete.`);
+
+  return updatedExternalLinks;
+};

--- a/src/preflight/external-links.js
+++ b/src/preflight/external-links.js
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2024 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { JSDOM } from 'jsdom';
+
+/**
+ * Preflight check for external links
+ * @param {Array<Object>} scrapedObjects - Array of objects containing the URL and scraped data
+ * @param {Object} context - Context object containing the logger
+ * @returns {Promise<Object>} - Object containing the audit result with broken external links
+ */
+export async function runExternalLinkChecks(scrapedObjects, context) {
+  const { log } = context;
+  const brokenExternalLinks = [];
+
+  await Promise.all(
+    scrapedObjects.map(async ({ data }) => {
+      const html = data.scrapeResult.rawBody;
+      const pageUrl = data.finalUrl;
+      const dom = new JSDOM(html);
+
+      const doc = dom.window.document;
+      const anchors = Array.from(doc.querySelectorAll('a[href]'));
+      const pageOrigin = new URL(pageUrl).origin;
+      const externalSet = new Set();
+
+      anchors.forEach((a) => {
+        const abs = new URL(a.href, pageUrl).toString();
+        if (new URL(abs).origin !== pageOrigin) {
+          externalSet.add(abs);
+        }
+      });
+
+      log.info('[preflight-audit] Found external links:', externalSet);
+
+      // Check external links
+      await Promise.all(
+        Array.from(externalSet).map(async (href) => {
+          try {
+            const res = await fetch(href, {
+              method: 'HEAD',
+              timeout: 3000, // 3 second timeout for external links
+            });
+            if (res.status >= 400) {
+              brokenExternalLinks.push({
+                check: 'broken-external-links',
+                issue: [{
+                  url: href,
+                  issue: `Link returning ${res.status} status code`,
+                  seoImpact: 'High',
+                  seoRecommendation: 'Fix or remove broken links to improve user experience',
+                }],
+              });
+            }
+          } catch {
+            brokenExternalLinks.push({
+              check: 'broken-external-links',
+              issue: [{
+                url: href,
+                issue: 'Link is unreachable',
+                seoImpact: 'High',
+                seoRecommendation: 'Fix or remove broken links to improve user experience',
+              }],
+            });
+          }
+        }),
+      );
+    }),
+  );
+
+  return {
+    auditResult: {
+      brokenExternalLinks,
+    },
+  };
+}

--- a/test/audits/external-links/handler.test.js
+++ b/test/audits/external-links/handler.test.js
@@ -1,0 +1,554 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import nock from 'nock';
+import esmock from 'esmock';
+import { Audit, Opportunity as Oppty, Suggestion as SuggestionDataAccess } from '@adobe/spacecat-shared-data-access';
+import { MockContextBuilder } from '../../shared.js';
+import { opportunityAndSuggestionsStep } from '../../../src/external-links/handler.js';
+
+use(sinonChai);
+
+const AUDIT_TYPE = Audit.AUDIT_TYPES.BROKEN_EXTERNAL_LINKS;
+
+// Define mockLogger for use in tests
+const mockLogger = {
+  info: sinon.stub(),
+  error: sinon.stub(),
+  warn: sinon.stub(),
+  debug: sinon.stub(),
+};
+
+before(() => {
+  sinon.stub(Oppty, 'STATUSES').value({ RESOLVED: 'RESOLVED', NEW: 'NEW' });
+  sinon.stub(SuggestionDataAccess, 'STATUSES').value({ OUTDATED: 'OUTDATED', NEW: 'NEW' });
+});
+
+describe('External Links Handler', () => {
+  let context;
+  let handler;
+  let sandbox;
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    // Reset mockLogger stubs
+    Object.values(mockLogger).forEach((stub) => stub.reset());
+
+    context = new MockContextBuilder()
+      .withSandbox(sandbox)
+      .withOverrides({
+        runtime: { name: 'aws-lambda', region: 'us-east-1' },
+        func: { package: 'spacecat-services', version: 'ci', name: 'test' },
+        finalUrl: 'https://example.com',
+        site: {
+          getId: () => 'test-site-id',
+          getBaseURL: () => 'https://example.com',
+          getConfig: sandbox.stub().returns({
+            get: () => 'https://example.com',
+            getFetchConfig: () => ({
+              headers: {},
+              timeout: 5000,
+            }),
+          }),
+        },
+        dataAccess: {
+          SiteTopPage: {
+            allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([]),
+          },
+          Opportunity: {
+            allBySiteIdAndStatus: sandbox.stub().resolves([]),
+            create: sandbox.stub().resolves({
+              addSuggestions: sandbox.stub().resolves({ createdItems: [], errorItems: [] }),
+              getSuggestions: sandbox.stub().resolves([]),
+              setAuditId: sandbox.stub(),
+              save: sandbox.stub().resolves(),
+              setData: () => {},
+              getData: () => {},
+              setUpdatedBy: sandbox.stub().returnsThis(),
+              getType: () => Audit.AUDIT_TYPES.BROKEN_EXTERNAL_LINKS,
+              getId: () => 'oppty-id-1',
+              getSiteId: () => 'test-site-id',
+            }),
+          },
+          Suggestion: {
+            bulkUpdateStatus: sandbox.stub().resolves(),
+          },
+          Configuration: {
+            findLatest: () => ({
+              isHandlerEnabledForSite: () => true,
+            }),
+          },
+        },
+        env: {
+          FIREFALL_MODEL: 'test-model',
+        },
+      })
+      .build();
+    context.log = {
+      warn: sandbox.stub(),
+      info: sandbox.stub(),
+      error: sandbox.stub(),
+    };
+
+    handler = await esmock('../../../src/external-links/handler.js', {
+      '@adobe/spacecat-shared-rum-api-client': {
+        default: {
+          createFrom: () => ({
+            query: async () => ([{
+              url_from: 'https://example.com/page1',
+              url_to: 'https://external.com/broken',
+              traffic_domain: 'example.com',
+            }]),
+          }),
+        },
+      },
+      '../../../src/external-links/helpers.js': {
+        isLinkInaccessible: async () => true,
+        calculatePriority: (links) => links,
+        calculateKpiDeltasForAudit: () => ({}),
+      },
+      '../../../src/external-links/suggestions-generator.js': {
+        generateSuggestionData: () => [{
+          urlFrom: 'https://example.com',
+          urlTo: 'https://example.com/broken',
+          trafficDomain: 100,
+          urlsSuggested: ['https://example.com/suggested'],
+          aiRationale: 'Test rationale',
+        }],
+      },
+    });
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    sandbox.restore();
+  });
+
+  describe('externalLinksAuditRunner', () => {
+    it('should return audit result with broken external links', async () => {
+      const result = await handler.externalLinksAuditRunner('https://example.com', context);
+      expect(result).to.have.property('auditResult');
+      expect(result.auditResult).to.have.property('brokenExternalLinks');
+      expect(result.auditResult.brokenExternalLinks).to.be.an('array');
+      expect(result.auditResult.brokenExternalLinks).to.have.lengthOf(1);
+      expect(result.auditResult.brokenExternalLinks[0]).to.deep.include({
+        urlFrom: 'https://example.com/page1',
+        urlTo: 'https://external.com/broken',
+        trafficDomain: 'example.com',
+      });
+    });
+
+    it('should handle errors gracefully', async () => {
+      handler = await esmock('../../../src/external-links/handler.js', {
+        '@adobe/spacecat-shared-rum-api-client': {
+          default: {
+            createFrom: () => ({
+              query: async () => { throw new Error('RUM API error'); },
+            }),
+          },
+        },
+        '../../../src/external-links/helpers.js': {
+          isLinkInaccessible: async () => true,
+          calculatePriority: (links) => links,
+          calculateKpiDeltasForAudit: () => ({}),
+        },
+        '../../../src/external-links/suggestions-generator.js': {
+          generateSuggestionData: () => [{
+            urlFrom: 'https://example.com',
+            urlTo: 'https://example.com/broken',
+            trafficDomain: 100,
+            urlsSuggested: ['https://example.com/suggested'],
+            aiRationale: 'Test rationale',
+          }],
+        },
+      });
+
+      const result = await handler.externalLinksAuditRunner('https://example.com', context);
+      expect(result.auditResult.success).to.be.false;
+    });
+  });
+
+  describe('runAuditAndImportTopPagesStep', () => {
+    it('should run audit and return result', async () => {
+      const result = await handler.runAuditAndImportTopPagesStep(context);
+      expect(result).to.have.property('auditResult');
+    });
+  });
+
+  describe('prepareScrapingStep', () => {
+    it('should prepare scraping step with top pages', async () => {
+      const result = await handler.prepareScrapingStep(context);
+      expect(result).to.have.property('urls');
+    });
+  });
+
+  describe('opportunityAndSuggestionsStep', () => {
+    it('should handle no broken external links and update existing opportunity to RESOLVED', async () => {
+      const setStatusStub = sinon.stub().resolves();
+      const getSuggestionsStub = sinon.stub().resolves([]);
+      const setUpdatedByStub = sinon.stub().returnsThis();
+      const saveStub = sinon.stub().resolves();
+      const mockOpportunity = {
+        setStatus: setStatusStub,
+        getType: () => Audit.AUDIT_TYPES.BROKEN_EXTERNAL_LINKS,
+        getSuggestions: getSuggestionsStub,
+        setUpdatedBy: setUpdatedByStub,
+        save: saveStub,
+        getId: () => 'oppty-id-1',
+      };
+      const allBySiteIdAndStatusStub = sinon.stub()
+        .callsFake(() => Promise.resolve([mockOpportunity]));
+      const testContext = {
+        log: { info: sinon.stub(), error: sinon.stub() },
+        dataAccess: {
+          Opportunity: {
+            allBySiteIdAndStatus: allBySiteIdAndStatusStub,
+          },
+          Suggestion: {
+            bulkUpdateStatus: sinon.stub().resolves(),
+          },
+        },
+        site: { getId: () => 'test-site-id' },
+        audit: {
+          getAuditResult: () => ({ brokenExternalLinks: [] }),
+          fullAuditRef: {},
+        },
+        finalUrl: 'https://example.com',
+      };
+      const result = await opportunityAndSuggestionsStep(testContext);
+      expect(result).to.deep.equal({ status: 'complete' });
+      expect(setStatusStub.calledWith('RESOLVED')).to.be.true;
+      expect(setUpdatedByStub).to.have.been.calledWith('system');
+      expect(saveStub).to.have.been.calledOnce;
+    });
+
+    it('should handle error when updating opportunity status', async () => {
+      const setStatusStub = sinon.stub().rejects(new Error('Update error'));
+      const getSuggestionsStub = sinon.stub().resolves([]);
+      const setUpdatedByStub = sinon.stub().returnsThis();
+      const saveStub = sinon.stub().resolves();
+      const mockOpportunity = {
+        setStatus: setStatusStub,
+        getType: () => Audit.AUDIT_TYPES.BROKEN_EXTERNAL_LINKS,
+        getSuggestions: getSuggestionsStub,
+        setUpdatedBy: setUpdatedByStub,
+        save: saveStub,
+        getId: () => 'oppty-id-1',
+      };
+      const allBySiteIdAndStatusStub = sinon.stub()
+        .callsFake(() => Promise.resolve([mockOpportunity]));
+      const testContext = {
+        log: { error: sinon.stub(), info: sinon.stub() },
+        site: { getId: () => 'test-site-id' },
+        finalUrl: 'https://example.com',
+        audit: {
+          getAuditResult: () => ({ brokenExternalLinks: [] }),
+          getId: () => 'test-audit-id',
+        },
+        dataAccess: {
+          Opportunity: {
+            allBySiteIdAndStatus: allBySiteIdAndStatusStub,
+          },
+          Suggestion: {
+            bulkUpdateStatus: sinon.stub().resolves(),
+          },
+        },
+      };
+      await expect(opportunityAndSuggestionsStep(testContext))
+        .to.be.rejectedWith('Update error');
+    });
+
+    it('should handle error when fetching opportunities fails', async () => {
+      const allBySiteIdAndStatusStub = sinon.stub().rejects(new Error('Fetch error'));
+      const mockDataAccess = {
+        Opportunity: {
+          allBySiteIdAndStatus: allBySiteIdAndStatusStub,
+        },
+      };
+
+      const testContext = {
+        log: mockLogger,
+        site: { getId: () => 'test-site' },
+        finalUrl: 'https://example.com',
+        audit: {
+          getAuditResult: () => ({ brokenExternalLinks: [] }),
+          getId: () => 'audit-id',
+        },
+        dataAccess: mockDataAccess,
+      };
+
+      await expect(opportunityAndSuggestionsStep(testContext))
+        .to.be.rejectedWith('Failed to fetch opportunities for siteId test-site: Fetch error');
+    });
+
+    it('should handle error when syncing suggestions fails', async () => {
+      const mockOpportunity = {
+        getId: () => 'opportunity-id',
+        getType: () => Audit.AUDIT_TYPES.BROKEN_EXTERNAL_LINKS,
+        setStatus: sinon.stub().resolves(),
+        getSuggestions: sinon.stub().resolves([]),
+        save: sinon.stub().resolves(),
+        setUpdatedBy: sinon.stub().returnsThis(),
+        setAuditId: sinon.stub().returnsThis(),
+        getData: () => ({}),
+        setData: () => {},
+        addSuggestions: sinon.stub().resolves({ createdItems: [], errorItems: [] }),
+      };
+      const allBySiteIdAndStatusStub = sinon.stub().resolves([mockOpportunity]);
+      const mockDataAccess = {
+        Opportunity: {
+          allBySiteIdAndStatus: allBySiteIdAndStatusStub,
+        },
+        Suggestion: {
+          bulkUpdateStatus: sinon.stub().rejects(new Error('Sync error')),
+        },
+      };
+
+      const testContext = {
+        log: mockLogger,
+        site: { getId: () => 'test-site' },
+        finalUrl: 'https://example.com',
+        audit: {
+          getAuditResult: () => ({
+            brokenExternalLinks: [{
+              urlFrom: 'https://example.com/from',
+              urlTo: 'https://example.com/to',
+              trafficDomain: 100,
+            }],
+          }),
+          getId: () => 'audit-id',
+        },
+        dataAccess: mockDataAccess,
+      };
+
+      const result = await opportunityAndSuggestionsStep(testContext);
+      expect(result).to.deep.equal({ status: 'complete' });
+    });
+
+    it('should handle error when creating opportunity fails', async () => {
+      const mockDataAccess = {
+        Opportunity: {
+          allBySiteIdAndStatus: sinon.stub().resolves([]),
+          create: sinon.stub().rejects(new Error('Create error')),
+        },
+      };
+
+      const testContext = {
+        log: mockLogger,
+        site: { getId: () => 'test-site' },
+        finalUrl: 'https://example.com',
+        audit: {
+          getAuditResult: () => ({
+            brokenExternalLinks: [{
+              urlFrom: 'https://example.com/from',
+              urlTo: 'https://example.com/to',
+            }],
+          }),
+          getId: () => 'audit-id',
+        },
+        dataAccess: mockDataAccess,
+      };
+
+      await expect(opportunityAndSuggestionsStep(testContext))
+        .to.be.rejectedWith('Create error');
+    });
+
+    it('should handle no broken external links and no existing opportunity', async () => {
+      const allBySiteIdAndStatusStub = sinon.stub().resolves([]);
+      const mockDataAccess = {
+        Opportunity: {
+          allBySiteIdAndStatus: allBySiteIdAndStatusStub,
+        },
+      };
+
+      const testContext = {
+        log: mockLogger,
+        site: { getId: () => 'test-site' },
+        finalUrl: 'https://example.com',
+        env: { FIREFALL_MODEL: 'test-model' },
+        audit: {
+          getAuditResult: () => ({ brokenExternalLinks: [] }),
+          getId: () => 'audit-id',
+        },
+        dataAccess: mockDataAccess,
+      };
+
+      const result = await opportunityAndSuggestionsStep(testContext);
+      expect(result).to.deep.equal({ status: 'complete' });
+      expect(mockLogger.info).to.have.been.calledWith(`[${AUDIT_TYPE}] [Site: test-site] no broken external links found, skipping opportunity creation`);
+    });
+
+    it('should update suggestions to OUTDATED when no broken external links and existing opportunity has suggestions', async () => {
+      const setStatusStub = sinon.stub().resolves();
+      const getSuggestionsStub = sinon.stub().resolves([{ id: 'suggestion-1' }]);
+      const setUpdatedByStub = sinon.stub().returnsThis();
+      const saveStub = sinon.stub().resolves();
+      const mockOpportunity = {
+        setStatus: setStatusStub,
+        getType: () => Audit.AUDIT_TYPES.BROKEN_EXTERNAL_LINKS,
+        getSuggestions: getSuggestionsStub,
+        setUpdatedBy: setUpdatedByStub,
+        save: saveStub,
+        getId: () => 'oppty-id-coverage',
+      };
+      const allBySiteIdAndStatusStub = sinon.stub().resolves([mockOpportunity]);
+      const bulkUpdateStatusStub = sinon.stub().resolves();
+      const mockDataAccess = {
+        Opportunity: { allBySiteIdAndStatus: allBySiteIdAndStatusStub },
+        Suggestion: { bulkUpdateStatus: bulkUpdateStatusStub },
+      };
+      const mockContext = {
+        log: { info: sinon.stub(), error: sinon.stub() },
+        site: { getId: () => 'site-id' },
+        finalUrl: 'https://example.com',
+        audit: { getAuditResult: () => ({ brokenExternalLinks: [] }) },
+        dataAccess: mockDataAccess,
+      };
+      // Patch SuggestionDataAccess.STATUSES.OUTDATED if needed
+      global.SuggestionDataAccess = { STATUSES: { OUTDATED: 'OUTDATED' } };
+      await opportunityAndSuggestionsStep(mockContext);
+      sinon.assert.calledOnce(bulkUpdateStatusStub);
+      sinon.assert.calledWith(bulkUpdateStatusStub, [{ id: 'suggestion-1' }], 'OUTDATED');
+    });
+
+    it('should handle error when suggestion generation fails (coverage for line 152)', async () => {
+      const mockDataAccess = {
+        Opportunity: {
+          allBySiteIdAndStatus: sinon.stub().resolves([]),
+          create: sinon.stub().resolves({
+            getId: () => 'new-opportunity-id',
+            setStatus: sinon.stub().resolves(),
+            getSuggestions: sinon.stub().resolves([]),
+            save: sinon.stub().resolves(),
+            setUpdatedBy: sinon.stub().returnsThis(),
+            setAuditId: sinon.stub().returnsThis(),
+            getData: () => ({}),
+            setData: () => {},
+            addSuggestions: sinon.stub().resolves({ createdItems: [], errorItems: [] }),
+          }),
+        },
+        Configuration: {
+          findLatest: sinon.stub().resolves({
+            isHandlerEnabledForSite: () => true,
+          }),
+        },
+      };
+
+      const testContext = {
+        log: mockLogger,
+        site: { getId: () => 'test-site' },
+        finalUrl: 'https://example.com',
+        env: { FIREFALL_MODEL: 'test-model' },
+        audit: {
+          getAuditResult: () => ({
+            success: true,
+            brokenExternalLinks: [{ urlFrom: 'https://example.com', urlTo: 'https://broken.com' }],
+          }),
+          getId: () => 'audit-id',
+        },
+        dataAccess: mockDataAccess,
+      };
+
+      // Pass a stub that throws
+      const throwingGenerateSuggestionData = sinon.stub()
+        .rejects(new Error('Test error'));
+      const result = await opportunityAndSuggestionsStep(
+        testContext,
+        throwingGenerateSuggestionData,
+      );
+      expect(mockLogger.error).to.have.been.calledWith(
+        '[undefined] [Site: test-site] suggestion generation error: Test error',
+      );
+      expect(result).to.deep.equal({ status: 'complete' });
+    });
+
+    it('should run generateSuggestionDataImpl successfully without error', async () => {
+      const mockData = [{
+        urlFrom: 'https://example.com',
+        urlTo: 'https://broken-link.com',
+        trafficDomain: 100,
+      }];
+
+      const testContext = {
+        log: { info: sinon.stub(), error: sinon.stub() },
+        site: { getId: () => 'test-site' },
+        finalUrl: 'https://example.com',
+        audit: {
+          getAuditResult: () => ({ brokenExternalLinks: [] }),
+          getId: () => 'audit-id',
+        },
+        dataAccess: {
+          Opportunity: {
+            allBySiteIdAndStatus: sinon.stub().resolves([]),
+            create: sinon.stub().resolves({
+              getId: () => 'oppty-id-123',
+              addSuggestions: sinon.stub().resolves({ createdItems: [], errorItems: [] }),
+              getSuggestions: sinon.stub().resolves([]),
+              setAuditId: sinon.stub().returnsThis(),
+              save: sinon.stub().resolves(),
+              setData: () => {},
+              getData: () => {},
+              setUpdatedBy: sinon.stub().returnsThis(),
+              getType: () => Audit.AUDIT_TYPES.BROKEN_EXTERNAL_LINKS,
+              getSiteId: () => 'test-site',
+            }),
+          },
+          Suggestion: {
+            bulkUpdateStatus: sinon.stub().resolves(),
+          },
+        },
+      };
+
+      const mockGenerateSuggestionData = sinon.stub().resolves(mockData);
+
+      const result = await opportunityAndSuggestionsStep(testContext, mockGenerateSuggestionData);
+
+      expect(result).to.deep.equal({ status: 'complete' });
+    });
+
+    it('should log an error when generateSuggestionDataImpl throws', async () => {
+      const error = new Error('Failed');
+
+      const testContext = {
+        log: { info: sinon.stub(), error: sinon.stub() },
+        site: { getId: () => 'test-site' },
+        finalUrl: 'https://example.com',
+        audit: {
+          getAuditResult: () => ({ brokenExternalLinks: [] }),
+          getId: () => 'audit-id',
+        },
+        dataAccess: {
+          Opportunity: { allBySiteIdAndStatus: sinon.stub().resolves([]) },
+          Suggestion: { bulkUpdateStatus: sinon.stub().resolves() },
+        },
+      };
+
+      const failingGenerateSuggestionData = sinon.stub().rejects(error);
+
+      const result = await opportunityAndSuggestionsStep(
+        testContext,
+        failingGenerateSuggestionData,
+      );
+
+      expect(testContext.log.error).to.have.been.calledWithMatch(
+        `[${AUDIT_TYPE}] [Site: test-site] suggestion generation error: ${error.message}`,
+      );
+
+      expect(result).to.deep.equal({ status: 'complete' });
+    });
+  });
+});

--- a/test/audits/external-links/helpers.test.js
+++ b/test/audits/external-links/helpers.test.js
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import nock from 'nock';
+import {
+  isLinkInaccessible,
+  resolveCpcValue,
+  calculateKpiDeltasForAudit,
+  calculatePriority,
+} from '../../../src/external-links/helpers.js';
+
+use(sinonChai);
+
+describe('External Links Helpers', () => {
+  let log;
+
+  beforeEach(() => {
+    log = {
+      warn: sinon.stub(),
+      error: sinon.stub(),
+    };
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  describe('isLinkInaccessible', () => {
+    it('returns false for accessible links (200 response)', async () => {
+      nock('https://example.com')
+        .head('/valid')
+        .reply(200);
+
+      const result = await isLinkInaccessible('https://example.com/valid', log);
+      expect(result).to.be.false;
+    });
+
+    it('returns true for 404 responses', async () => {
+      nock('https://example.com')
+        .head('/not-found')
+        .reply(404);
+
+      const result = await isLinkInaccessible('https://example.com/not-found', log);
+      expect(result).to.be.true;
+      expect(log.warn).to.have.been.calledWith('Client error (404) for URL: https://example.com/not-found');
+    });
+
+    it('returns true for other 4xx responses', async () => {
+      nock('https://example.com')
+        .head('/forbidden')
+        .reply(403);
+
+      const result = await isLinkInaccessible('https://example.com/forbidden', log);
+      expect(result).to.be.true;
+      expect(log.warn).to.have.been.calledWith('Client error (403) for URL: https://example.com/forbidden');
+    });
+
+    it('returns true for 5xx responses', async () => {
+      nock('https://example.com')
+        .head('/server-error')
+        .reply(500);
+
+      const result = await isLinkInaccessible('https://example.com/server-error', log);
+      expect(result).to.be.true;
+      expect(log.error).to.have.been.calledWith('Server error (500) for URL: https://example.com/server-error');
+    });
+
+    it('returns true for network errors', async () => {
+      nock('https://example.com')
+        .head('/network-error')
+        .replyWithError('network error');
+
+      const result = await isLinkInaccessible('https://example.com/network-error', log);
+      expect(result).to.be.true;
+      expect(log.error).to.have.been.calledWith('Error checking URL: https://example.com/network-error');
+    });
+
+    it('returns true for timeout errors', async () => {
+      nock('https://example.com')
+        .head('/timeout')
+        .delay(100) // Shorter delay to avoid test timeout
+        .replyWithError({ code: 'ETIMEOUT' });
+
+      const result = await isLinkInaccessible('https://example.com/timeout', log);
+      expect(result).to.be.true;
+      expect(log.error).to.have.been.calledWith('Error checking URL: https://example.com/timeout');
+    });
+  });
+
+  describe('resolveCpcValue', () => {
+    it('returns the default CPC value', () => {
+      expect(resolveCpcValue()).to.equal(1.0);
+    });
+  });
+
+  describe('calculateKpiDeltasForAudit', () => {
+    it('calculates KPI deltas for broken external links', () => {
+      const brokenLinks = [
+        { urlTo: 'https://example.com/1', trafficDomain: 100 },
+        { urlTo: 'https://example.com/1', trafficDomain: 200 },
+        { urlTo: 'https://example.com/2', trafficDomain: 300 },
+      ];
+
+      const result = calculateKpiDeltasForAudit(brokenLinks);
+      expect(result).to.deep.equal({
+        projectedTrafficLost: 60, // (100 + 200 + 300) * 0.1
+        projectedTrafficValue: 60, // 60 * 1.0
+      });
+    });
+
+    it('limits the number of links considered to MAX_LINKS_TO_CONSIDER', () => {
+      const brokenLinks = Array.from({ length: 15 }, (_, i) => ({
+        urlTo: `https://example.com/${i}`,
+        trafficDomain: 100 * (i + 1),
+      }));
+
+      const result = calculateKpiDeltasForAudit(brokenLinks);
+      // Should only consider top 10 links by traffic domain
+      expect(result.projectedTrafficLost).to.equal(1050); // Sum of top 10 traffic domains * 0.1
+      expect(result.projectedTrafficValue).to.equal(1050); // 1050 * 1.0
+    });
+
+    it('handles empty array of broken links', () => {
+      const result = calculateKpiDeltasForAudit([]);
+      expect(result).to.deep.equal({
+        projectedTrafficLost: 0,
+        projectedTrafficValue: 0,
+      });
+    });
+  });
+
+  describe('calculatePriority', () => {
+    it('classifies links into priority categories based on views', () => {
+      const links = [
+        { url: 'https://example.com/1', views: 1000 },
+        { url: 'https://example.com/2', views: 800 },
+        { url: 'https://example.com/3', views: 600 },
+        { url: 'https://example.com/4', views: 400 },
+        { url: 'https://example.com/5', views: 200 },
+      ];
+
+      const result = calculatePriority(links);
+      expect(result).to.deep.equal([
+        { url: 'https://example.com/1', views: 1000, priority: 'high' },
+        { url: 'https://example.com/2', views: 800, priority: 'high' },
+        { url: 'https://example.com/3', views: 600, priority: 'medium' },
+        { url: 'https://example.com/4', views: 400, priority: 'low' },
+        { url: 'https://example.com/5', views: 200, priority: 'low' },
+      ]);
+    });
+
+    it('handles empty array of links', () => {
+      const result = calculatePriority([]);
+      expect(result).to.deep.equal([]);
+    });
+
+    it('handles array with single link', () => {
+      const result = calculatePriority([{ url: 'https://example.com/1', views: 1000 }]);
+      expect(result).to.deep.equal([
+        { url: 'https://example.com/1', views: 1000, priority: 'high' },
+      ]);
+    });
+
+    it('handles array with two links', () => {
+      const result = calculatePriority([
+        { url: 'https://example.com/1', views: 1000 },
+        { url: 'https://example.com/2', views: 500 },
+      ]);
+      expect(result).to.deep.equal([
+        { url: 'https://example.com/1', views: 1000, priority: 'high' },
+        { url: 'https://example.com/2', views: 500, priority: 'low' },
+      ]);
+    });
+  });
+});

--- a/test/audits/external-links/opportunity-data-mapper.test.js
+++ b/test/audits/external-links/opportunity-data-mapper.test.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import { expect } from 'chai';
+import { createOpportunityData } from '../../../src/external-links/opportunity-data-mapper.js';
+
+describe('Opportunity Data Mapper', () => {
+  describe('createOpportunityData', () => {
+    it('should create opportunity data with correct structure', () => {
+      const kpiDeltas = { projectedTrafficLost: 100, projectedTrafficValue: 200 };
+      const result = createOpportunityData({ kpiDeltas });
+      expect(result).to.have.property('runbook');
+      expect(result).to.have.property('origin', 'AUTOMATION');
+      expect(result).to.have.property('title');
+      expect(result).to.have.property('description');
+      expect(result).to.have.property('guidance');
+      expect(result).to.have.property('tags');
+      expect(result.data).to.deep.include(kpiDeltas);
+    });
+  });
+});

--- a/test/audits/external-links/suggestions-generator.test.js
+++ b/test/audits/external-links/suggestions-generator.test.js
@@ -1,0 +1,466 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { FirefallClient } from '@adobe/spacecat-shared-gpt-client';
+import esmock from 'esmock';
+
+describe('External Links Suggestions Generator', () => {
+  let sandbox;
+  let mockContext;
+  let mockSite;
+  let mockAudit;
+  let mockConfiguration;
+  let mockFirefallClient;
+  let mockDataAccess;
+  let generateSuggestionData;
+  let mockUtils;
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+
+    const mockAuditType = 'BROKEN_EXTERNAL_LINKS';
+
+    mockSite = { getId: () => 'test-site-id' };
+
+    mockAudit = {
+      getAuditResult: () => ({
+        success: true,
+        brokenExternalLinks: [
+          {
+            urlFrom: 'https://example.com/page1',
+            urlTo: 'https://broken-link.com',
+            trafficDomain: 100,
+          },
+        ],
+      }),
+    };
+
+    mockConfiguration = {
+      isHandlerEnabledForSite: sandbox.stub().returns(true),
+    };
+
+    mockFirefallClient = {
+      fetchChatCompletion: sandbox.stub(),
+    };
+
+    mockDataAccess = {
+      Configuration: {
+        findLatest: sandbox.stub().resolves(mockConfiguration),
+      },
+    };
+
+    mockContext = {
+      dataAccess: mockDataAccess,
+      log: {
+        info: sandbox.stub(),
+        error: sandbox.stub(),
+      },
+      env: {
+        FIREFALL_MODEL: 'test-model',
+      },
+    };
+
+    mockUtils = {
+      getScrapedDataForSiteId: sandbox.stub(),
+    };
+
+    generateSuggestionData = (await esmock(
+      '../../../src/external-links/suggestions-generator.js',
+      {
+        '@adobe/spacecat-shared-utils': {
+          getPrompt: sandbox.stub().resolves({
+            messages: [{ role: 'user', content: 'Mocked prompt' }],
+          }),
+          isNonEmptyArray: (arr) => Array.isArray(arr) && arr.length > 0,
+        },
+        '@adobe/spacecat-shared-data-access': {
+          Audit: {
+            AUDIT_TYPES: {
+              BROKEN_EXTERNAL_LINKS: mockAuditType,
+            },
+          },
+        },
+        '../../../src/support/utils.js': mockUtils,
+      },
+    )).generateSuggestionData;
+
+    sandbox.stub(FirefallClient, 'createFrom').returns(mockFirefallClient);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    sinon.restore();
+  });
+
+  it('should return original links if audit failed', async () => {
+    mockAudit.getAuditResult = () => ({
+      success: false,
+      brokenExternalLinks: [{ urlFrom: 'test', urlTo: 'test' }],
+    });
+
+    const result = await generateSuggestionData('https://example.com', mockAudit, mockContext, mockSite);
+    expect(result).to.deep.equal([{ urlFrom: 'test', urlTo: 'test' }]);
+  });
+
+  it('should return original links if auto-suggest is disabled', async () => {
+    mockConfiguration.isHandlerEnabledForSite.returns(false);
+
+    const result = await generateSuggestionData('https://example.com', mockAudit, mockContext, mockSite);
+    expect(result).to.deep.equal(mockAudit.getAuditResult().brokenExternalLinks);
+  });
+
+  it('should handle empty site data', async () => {
+    mockUtils.getScrapedDataForSiteId.resolves({ siteData: [], headerLinks: [] });
+
+    const result = await generateSuggestionData('https://example.com', mockAudit, mockContext, mockSite);
+    expect(result).to.deep.equal(mockAudit.getAuditResult().brokenExternalLinks);
+  });
+
+  it('should process single batch of suggestions successfully', async () => {
+    const mockSiteData = Array(100).fill('https://example.com/page');
+    const mockHeaderLinks = ['https://example.com/header1'];
+    mockUtils.getScrapedDataForSiteId.resolves(
+      {
+        siteData: mockSiteData,
+        headerLinks: mockHeaderLinks,
+      },
+    );
+
+    mockFirefallClient.fetchChatCompletion.resolves({
+      choices: [{
+        finish_reason: 'stop',
+        message: {
+          content: JSON.stringify({
+            suggested_urls: ['https://example.com/suggested1'],
+            aiRationale: 'Test rationale',
+          }),
+        },
+      }],
+    });
+
+    const result = await generateSuggestionData('https://example.com', mockAudit, mockContext, mockSite);
+    expect(result[0].urlsSuggested).to.deep.equal(['https://example.com/suggested1']);
+    expect(result[0].aiRationale).to.equal('Test rationale');
+  });
+
+  it('should handle multiple batches of suggestions', async () => {
+    const mockSiteData = Array(400).fill('https://example.com/page');
+    const mockHeaderLinks = ['https://example.com/header1'];
+    mockUtils.getScrapedDataForSiteId.resolves(
+      {
+        siteData: mockSiteData,
+        headerLinks: mockHeaderLinks,
+      },
+    );
+
+    mockFirefallClient.fetchChatCompletion.resolves({
+      choices: [{
+        finish_reason: 'stop',
+        message: {
+          content: JSON.stringify({
+            suggested_urls: ['https://example.com/suggested1'],
+            aiRationale: 'Test rationale',
+          }),
+        },
+      }],
+    });
+
+    const result = await generateSuggestionData('https://example.com', mockAudit, mockContext, mockSite);
+    expect(result[0].urlsSuggested).to.deep.equal(['https://example.com/suggested1']);
+    expect(result[0].aiRationale).to.equal('Test rationale');
+  });
+
+  it('should handle Firefall API errors gracefully', async () => {
+    const mockSiteData = Array(100).fill('https://example.com/page');
+    const mockHeaderLinks = ['https://example.com/header1'];
+    mockUtils.getScrapedDataForSiteId.resolves(
+      {
+        siteData: mockSiteData,
+        headerLinks: mockHeaderLinks,
+      },
+    );
+
+    mockFirefallClient.fetchChatCompletion.rejects(new Error('API Error'));
+
+    const result = await generateSuggestionData('https://example.com', mockAudit, mockContext, mockSite);
+    expect(result[0].urlsSuggested).to.deep.equal(['https://example.com']);
+    expect(result[0].aiRationale).to.equal('No suitable suggestions found');
+  });
+
+  it('should handle invalid Firefall responses', async () => {
+    const mockSiteData = Array(100).fill('https://example.com/page');
+    const mockHeaderLinks = ['https://example.com/header1'];
+    mockUtils.getScrapedDataForSiteId.resolves(
+      {
+        siteData: mockSiteData,
+        headerLinks: mockHeaderLinks,
+      },
+    );
+
+    mockFirefallClient.fetchChatCompletion.resolves({
+      choices: [{
+        finish_reason: 'length',
+        message: {
+          content: 'invalid json',
+        },
+      }],
+    });
+
+    const result = await generateSuggestionData('https://example.com', mockAudit, mockContext, mockSite);
+    expect(result[0].urlsSuggested).to.deep.equal(['https://example.com']);
+    expect(result[0].aiRationale).to.equal('No suitable suggestions found');
+  });
+
+  it('should handle finish_reason not being stop in final suggestions (lines 108-110)', async () => {
+    const mockSiteData = Array(400).fill('https://example.com/page');
+    const mockHeaderLinks = ['https://example.com/header1'];
+    mockUtils.getScrapedDataForSiteId.resolves(
+      {
+        siteData: mockSiteData,
+        headerLinks: mockHeaderLinks,
+      },
+    );
+
+    mockFirefallClient.fetchChatCompletion.onCall(0).resolves({
+      choices: [{
+        finish_reason: 'stop',
+        message: { content: JSON.stringify({ suggested_urls: ['https://header-suggestion.com'], aiRationale: 'Header rationale' }) },
+      }],
+    });
+
+    mockFirefallClient.fetchChatCompletion.onCall(1).resolves({
+      choices: [{
+        finish_reason: 'stop',
+        message: { content: JSON.stringify({ suggested_urls: ['https://batch-suggestion.com'], aiRationale: 'Batch rationale' }) },
+      }],
+    });
+
+    mockFirefallClient.fetchChatCompletion.onCall(2).resolves({
+      choices: [{
+        finish_reason: 'length',
+        message: { content: JSON.stringify({ suggested_urls: ['https://final-suggestion.com'], aiRationale: 'Final rationale' }) },
+      }],
+    });
+
+    const result = await generateSuggestionData('https://example.com', mockAudit, mockContext, mockSite);
+    expect(result[0]).to.deep.include({
+      urlFrom: 'https://example.com/page1',
+      urlTo: 'https://broken-link.com',
+      trafficDomain: 100,
+    });
+  });
+
+  it('should return original link if final Firefall response finish_reason is not stop', async () => {
+    const mockSiteData = Array(400).fill('https://example.com/page');
+    const mockHeaderLinks = ['https://example.com/header1'];
+
+    const getPromptStub = sinon.stub().resolves({
+      messages: [{ role: 'user', content: 'Mocked prompt' }],
+    });
+
+    let callCount = 0;
+    mockFirefallClient = {
+      fetchChatCompletion: sinon.stub().callsFake(() => {
+        const responses = [
+          {
+            choices: [{
+              finish_reason: 'stop',
+              message: {
+                content: JSON.stringify({
+                  suggested_urls: ['https://header-suggestion.com'],
+                  aiRationale: 'Header rationale',
+                }),
+              },
+            }],
+          },
+          {
+            choices: [{
+              finish_reason: 'stop',
+              message: {
+                content: JSON.stringify({
+                  suggested_urls: ['https://batch-suggestion.com'],
+                  aiRationale: 'Batch rationale',
+                }),
+              },
+            }],
+          },
+          {
+            choices: [{
+              finish_reason: 'length',
+              message: {
+                content: JSON.stringify({
+                  suggested_urls: ['https://final-suggestion.com'],
+                  aiRationale: 'Final rationale',
+                }),
+              },
+            }],
+          },
+        ];
+        const result = responses[callCount] || responses[2];
+        callCount += 1;
+        return Promise.resolve(result);
+      }),
+    };
+
+    mockContext = {
+      log: {
+        error: sinon.stub(),
+        info: sinon.stub(),
+      },
+      env: { FIREFALL_MODEL: 'gpt-test' },
+      dataAccess: {
+        Configuration: {
+          findLatest: sinon.stub().resolves({
+            isHandlerEnabledForSite: () => true,
+          }),
+        },
+      },
+    };
+
+    mockAudit = {
+      getAuditResult: () => ({
+        success: true,
+        brokenExternalLinks: [
+          {
+            urlFrom: 'https://example.com/page1',
+            urlTo: 'https://broken-link.com',
+            trafficDomain: 100,
+          },
+        ],
+      }),
+    };
+
+    mockSite = {
+      getId: () => 'test-site-id',
+    };
+
+    generateSuggestionData = (await esmock(
+      '../../../src/external-links/suggestions-generator.js',
+      {
+        '@adobe/spacecat-shared-utils': {
+          getPrompt: getPromptStub,
+          isNonEmptyArray: (arr) => Array.isArray(arr) && arr.length > 0,
+        },
+        '@adobe/spacecat-shared-data-access': {
+          Audit: {
+            AUDIT_TYPES: {
+              BROKEN_EXTERNAL_LINKS: 'BROKEN_EXTERNAL_LINKS',
+            },
+          },
+        },
+        '../../../src/support/utils.js': {
+          getScrapedDataForSiteId: sinon.stub().resolves({
+            siteData: mockSiteData,
+            headerLinks: mockHeaderLinks,
+          }),
+        },
+        '@adobe/spacecat-shared-gpt-client': {
+          FirefallClient: {
+            createFrom: () => mockFirefallClient,
+          },
+        },
+      },
+    )).generateSuggestionData;
+
+    const result = await generateSuggestionData('https://example.com', mockAudit, mockContext, mockSite);
+
+    expect(result[0]).to.deep.equal({
+      urlFrom: 'https://example.com/page1',
+      urlTo: 'https://broken-link.com',
+      trafficDomain: 100,
+    });
+
+    const errorCalls = mockContext.log.error.getCalls();
+    const matched = errorCalls.some((call) => call.args[0]?.includes('[BROKEN_EXTERNAL_LINKS] [Site: test-site-id] No final suggestions found for https://broken-link.com'));
+    expect(matched).to.be.true;
+  });
+  it('should use fallback values if suggested_urls or aiRationale are missing or empty', async () => {
+    const mockSiteData = Array(400).fill('https://example.com/page');
+    const mockHeaderLinks = ['https://example.com/header1'];
+
+    generateSuggestionData = (await esmock(
+      '../../../src/external-links/suggestions-generator.js',
+      {
+        '@adobe/spacecat-shared-utils': {
+          getPrompt: sinon.stub().resolves({
+            messages: [{ role: 'user', content: 'Mocked prompt' }],
+          }),
+          isNonEmptyArray: (arr) => Array.isArray(arr) && arr.length > 0,
+        },
+        '@adobe/spacecat-shared-data-access': {
+          Audit: {
+            AUDIT_TYPES: {
+              BROKEN_EXTERNAL_LINKS: 'BROKEN_EXTERNAL_LINKS',
+            },
+          },
+        },
+        '../../../src/support/utils.js': {
+          getScrapedDataForSiteId: sinon.stub().resolves({
+            siteData: mockSiteData,
+            headerLinks: mockHeaderLinks,
+          }),
+        },
+        '@adobe/spacecat-shared-gpt-client': {
+          FirefallClient: {
+            createFrom: () => ({
+              fetchChatCompletion: sinon.stub().resolves({
+                choices: [{
+                  finish_reason: 'stop',
+                  message: {
+                    content: JSON.stringify({}),
+                  },
+                }],
+              }),
+            }),
+          },
+        },
+      },
+    )).generateSuggestionData;
+
+    mockContext = {
+      log: { info: sinon.stub(), error: sinon.stub() },
+      env: { FIREFALL_MODEL: 'gpt-test' },
+      dataAccess: {
+        Configuration: {
+          findLatest: sinon.stub().resolves({
+            isHandlerEnabledForSite: () => true,
+          }),
+        },
+      },
+    };
+
+    mockAudit = {
+      getAuditResult: () => ({
+        success: true,
+        brokenExternalLinks: [
+          {
+            urlFrom: 'https://example.com/page1',
+            urlTo: 'https://broken-link.com',
+            trafficDomain: 100,
+          },
+        ],
+      }),
+    };
+
+    mockSite = {
+      getId: () => 'test-site-id',
+    };
+
+    const result = await generateSuggestionData('https://example.com', mockAudit, mockContext, mockSite);
+    expect(result[0].urlsSuggested).to.deep.equal(['https://example.com']);
+    expect(result[0].aiRationale).to.equal('No suitable suggestions found');
+  });
+});


### PR DESCRIPTION
# Broken External Links Check

## Description
Implements functionality to check for broken external links in SpaceCat audit system.

## Changes
- Added functionality to detect broken external links
- Integrated with Firefall for AI-powered link suggestions
- Added test coverage for the new functionality

## Testing
- Added unit tests covering various scenarios (empty links, multiple links, API errors)

Please ensure your pull request adheres to the following guidelines:
- [X] make sure to link the related issues in this description
- [X] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues
https://jira.corp.adobe.com/browse/SITES-32254

Thanks for contributing!
