### PR TITLE
feat: broken external links check in preflight.

### DIFF
--- a/src/preflight/links-checks.js
+++ b/src/preflight/links-checks.js
@@ -11,21 +11,23 @@
  */
 
 import { JSDOM } from 'jsdom';
+import { tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
 
 /**
- * Preflight check for internal links
+ * Preflight check for both internal and external links
  * @param {Array<String>} urls - Array of URLs to check
  * @param {Array<Object>} scrapedObjects - Array of objects containing the URL and scraped data
  * @param {Object} context - Context object containing the logger
  * @param {RequestOptions} options - Options for to pass to the fetch request
  * @param {String} options.pageAuthToken - Optional authorization token for the page
- * @returns {Promise<Array<Object>>} - Array of objects containing the page URL and link status
+ * @returns {Promise<Object>} - Object containing both broken internal and external links
  */
-export async function runInternalLinkChecks(urls, scrapedObjects, context, options = {
+export async function runLinksChecks(urls, scrapedObjects, context, options = {
   pageAuthToken: null,
 }) {
   const { log } = context;
   const brokenInternalLinks = [];
+  const brokenExternalLinks = [];
 
   const urlSet = new Set(urls);
 
@@ -41,12 +43,15 @@ export async function runInternalLinkChecks(urls, scrapedObjects, context, optio
         const anchors = Array.from(doc.querySelectorAll('a[href]'));
         const pageOrigin = new URL(pageUrl).origin;
         const internalSet = new Set();
+        const externalSet = new Set();
 
         anchors.forEach((a) => {
           try {
             const abs = new URL(a.href, pageUrl).toString();
             if (new URL(abs).origin === pageOrigin) {
               internalSet.add(abs);
+            } else {
+              externalSet.add(abs);
             }
           } catch {
             // skip invalid hrefs
@@ -54,22 +59,56 @@ export async function runInternalLinkChecks(urls, scrapedObjects, context, optio
         });
 
         log.info('[preflight-audit] Found internal links:', internalSet);
+        log.info('[preflight-audit] Found external links:', externalSet);
 
+        // Check internal links
         await Promise.all(
           Array.from(internalSet).map(async (href) => {
             try {
-              const res = await fetch(href, {
+              const response = await fetch(href, {
                 method: 'HEAD',
                 headers: {
                   Authorization: options.pageAuthToken,
                 },
+                timeout: 3000,
               });
-              if (res.status >= 400) {
-                log.debug(`[preflight-audit] url ${href} returned with status code: %s`, res.status, res.statusText);
-                brokenInternalLinks.push({ urlTo: href, href: pageUrl, status: res.status });
+              const { status } = response;
+
+              if (status >= 400) {
+                log.debug(`[preflight-audit] internal url ${href} returned with status code: %s`, status);
+                brokenInternalLinks.push({ urlTo: href, href: pageUrl, status });
               }
             } catch (err) {
               log.error(`[preflight-audit] Error checking internal link ${href} from ${pageUrl}:`, err.message);
+            }
+          }),
+        );
+
+        // Check external links
+        await Promise.all(
+          Array.from(externalSet).map(async (href) => {
+            try {
+              const response = await fetch(href, {
+                method: 'HEAD',
+                headers: {
+                  Authorization: options.pageAuthToken,
+                },
+                timeout: 3000,
+              });
+              const { status } = response;
+
+              if (status >= 400) {
+                log.debug(`[preflight-audit] external url ${href} returned with status code: %s`, status);
+                brokenExternalLinks.push({ urlTo: href, href: pageUrl, status });
+              }
+            } catch (err) {
+              log.error(`[preflight-audit] Error checking external link ${href} from ${pageUrl}:`, err.message);
+              brokenExternalLinks.push({
+                urlTo: href,
+                href: pageUrl,
+                status: 'error',
+                error: err.message,
+              });
             }
           }),
         );
@@ -77,9 +116,12 @@ export async function runInternalLinkChecks(urls, scrapedObjects, context, optio
   );
 
   log.debug(`[preflight-audit] Broken internal links found: ${JSON.stringify(brokenInternalLinks)}`);
+  log.debug(`[preflight-audit] Broken external links found: ${JSON.stringify(brokenExternalLinks)}`);
+
   return {
     auditResult: {
       brokenInternalLinks,
+      brokenExternalLinks,
     },
   };
 }

--- a/test/fixtures/preflight/preflight-identify.json
+++ b/test/fixtures/preflight/preflight-identify.json
@@ -94,6 +94,15 @@
             }
           },
           {
+            "check": "broken-external-links",
+            "issue": {
+              "url": "http://test.com/",
+              "issue": "Status error",
+              "seoImpact": "High",
+              "seoRecommendation": "Fix or remove broken links to improve user experience"
+            }
+          },
+          {
             "check": "bad-links",
             "issue": [
               {


### PR DESCRIPTION
This PR adds broken external link detection to the preflight audit. When a webpage is scraped, all external links are automatically validated using HEAD requests. Broken external links (404s, network errors, timeouts) are now reported with high SEO impact and actionable recommendations.

The links audit in preflight will now return opportunities in this format:
```
{
  "name": "links",
  "type": "seo", 
  "opportunities": [
    {
      "check": "broken-internal-links",
      "issue": {
        "url": "https://example.com/broken-page",
        "issue": "Status 404",
        "seoImpact": "High",
        "seoRecommendation": "Fix or remove broken links to improve user experience and SEO"
      }
    },
    {
      "check": "broken-external-links", 
      "issue": {
        "url": "https://external-site.com/broken",
        "issue": "Status error",
        "seoImpact": "High",
        "seoRecommendation": "Fix or remove broken links to improve user experience"
      }
    },
    {
      "check": "bad-links",
      "issue": [
        {
          "url": "http://insecure-site.com",
          "issue": "Link using HTTP instead of HTTPS",
          "seoImpact": "High", 
          "seoRecommendation": "Update all links to use HTTPS protocol"
        }
      ]
    }
  ]
}
```

Please ensure your pull request adheres to the following guidelines:
- [X] make sure to link the related issues in this description
- [X] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues
https://jira.corp.adobe.com/browse/SITES-32254

Thanks for contributing!
