### PR TITLE
fix: remove page auth token from external link checks and fix internal link checks broken bug.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45885,6 +45885,7 @@
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.3.tgz",
       "integrity": "sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },

--- a/package.json
+++ b/package.json
@@ -67,12 +67,12 @@
   },
   "dependencies": {
     "@adobe/fetch": "4.2.2",
-    "@adobe/spacecat-helix-content-sdk": "1.4.17",
     "@adobe/helix-shared-secrets": "2.2.10",
     "@adobe/helix-shared-wrap": "2.0.2",
     "@adobe/helix-status": "10.1.5",
     "@adobe/helix-universal": "5.2.2",
     "@adobe/helix-universal-logger": "3.0.27",
+    "@adobe/spacecat-helix-content-sdk": "1.4.17",
     "@adobe/spacecat-shared-ahrefs-client": "1.9.0",
     "@adobe/spacecat-shared-data-access": "2.29.1",
     "@adobe/spacecat-shared-google-client": "1.4.34",

--- a/src/preflight/links-checks.js
+++ b/src/preflight/links-checks.js
@@ -14,6 +14,68 @@ import { JSDOM } from 'jsdom';
 import { tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
 
 /**
+ * Helper function to check if a link is broken
+ * @param {string} href - The URL to check
+ * @param {string} pageUrl - The source page URL
+ * @param {Object} context - Context object containing the logger
+ * @param {Object} options - Options for the fetch request
+ * @param {string} options.pageAuthToken - Optional authorization token for the page
+ * @param {boolean} options.isInternal - Whether this is an internal link
+ * @returns {Promise<Object|null>} - Object with link details if broken, null otherwise
+ */
+async function checkLinkStatus(href, pageUrl, context, options = {
+  pageAuthToken: null,
+}) {
+  const { log } = context;
+  const { pageAuthToken, isInternal } = options;
+
+  const fetchOptions = {
+    method: 'HEAD',
+    decode: false,
+  };
+
+  // Add Authorization header only for internal links
+  if (isInternal && pageAuthToken) {
+    fetchOptions.headers = {
+      Authorization: pageAuthToken,
+    };
+  }
+
+  try {
+    const res = await fetch(href, fetchOptions);
+
+    if (res.status >= 400) {
+      const linkType = isInternal ? 'internal' : 'external';
+      log.debug(`[preflight-audit] ${linkType} url ${href} returned with status code: %s`, res.status, res.statusText);
+      return { urlTo: href, href: pageUrl, status: res.status };
+    }
+
+    return null;
+  } catch (err) {
+    // Fallback to GET on any error
+    log.warn(`[preflight-audit] HEAD request failed (${err.message}), retrying with GET: ${href}`);
+
+    fetchOptions.method = 'GET';
+    let res;
+    try {
+      res = await fetch(href, fetchOptions);
+
+      if (res.status >= 400) {
+        const linkType = isInternal ? 'internal' : 'external';
+        log.debug(`[preflight-audit] ${linkType} url ${href} returned with status code: %s`, res.status, res.statusText);
+        return { urlTo: href, href: pageUrl, status: res.status };
+      }
+
+      return null;
+    } catch (finalErr) {
+      const linkType = isInternal ? 'internal' : 'external';
+      log.error(`[preflight-audit] Error checking ${linkType} link ${href} from ${pageUrl} with GET fallback:`, finalErr.message);
+      return null;
+    }
+  }
+}
+
+/**
  * Preflight check for both internal and external links
  * @param {Array<String>} urls - Array of URLs to check
  * @param {Array<Object>} scrapedObjects - Array of objects containing the URL and scraped data
@@ -45,7 +107,14 @@ export async function runLinksChecks(urls, scrapedObjects, context, options = {
         const internalSet = new Set();
         const externalSet = new Set();
 
+        log.info(`[preflight-audit] Total links found (${anchors.length}):`, anchors.map((a) => a.href));
+
         anchors.forEach((a) => {
+          // Skip links that are inside header or footer elements
+          if (a.closest('header') || a.closest('footer')) {
+            return;
+          }
+
           try {
             const abs = new URL(a.href, pageUrl).toString();
             if (new URL(abs).origin === pageOrigin) {
@@ -62,56 +131,39 @@ export async function runLinksChecks(urls, scrapedObjects, context, options = {
         log.info('[preflight-audit] Found external links:', externalSet);
 
         // Check internal links
-        await Promise.all(
-          Array.from(internalSet).map(async (href) => {
-            try {
-              const response = await fetch(href, {
-                method: 'HEAD',
-                headers: {
-                  Authorization: options.pageAuthToken,
-                },
-                timeout: 3000,
-              });
-              const { status } = response;
-
-              if (status >= 400) {
-                log.debug(`[preflight-audit] internal url ${href} returned with status code: %s`, status);
-                brokenInternalLinks.push({ urlTo: href, href: pageUrl, status });
-              }
-            } catch (err) {
-              log.error(`[preflight-audit] Error checking internal link ${href} from ${pageUrl}:`, err.message);
-            }
-          }),
+        const internalResults = await Promise.all(
+          Array.from(internalSet).map(async (href) => checkLinkStatus(
+            href,
+            pageUrl,
+            context,
+            {
+              ...options,
+              isInternal: true,
+            },
+          )),
         );
 
         // Check external links
-        await Promise.all(
-          Array.from(externalSet).map(async (href) => {
-            try {
-              const response = await fetch(href, {
-                method: 'HEAD',
-                headers: {
-                  Authorization: options.pageAuthToken,
-                },
-                timeout: 3000,
-              });
-              const { status } = response;
-
-              if (status >= 400) {
-                log.debug(`[preflight-audit] external url ${href} returned with status code: %s`, status);
-                brokenExternalLinks.push({ urlTo: href, href: pageUrl, status });
-              }
-            } catch (err) {
-              log.error(`[preflight-audit] Error checking external link ${href} from ${pageUrl}:`, err.message);
-              brokenExternalLinks.push({
-                urlTo: href,
-                href: pageUrl,
-                status: 'error',
-                error: err.message,
-              });
-            }
-          }),
+        const externalResults = await Promise.all(
+          Array.from(externalSet).map(async (href) => checkLinkStatus(
+            href,
+            pageUrl,
+            context,
+            {
+              ...options,
+              isInternal: false,
+            },
+          )),
         );
+
+        // Filter out null results and add to respective arrays
+        internalResults.forEach((result) => {
+          if (result) brokenInternalLinks.push(result);
+        });
+
+        externalResults.forEach((result) => {
+          if (result) brokenExternalLinks.push(result);
+        });
       }),
   );
 

--- a/test/fixtures/preflight/preflight-identify.json
+++ b/test/fixtures/preflight/preflight-identify.json
@@ -97,7 +97,7 @@
             "check": "broken-external-links",
             "issue": {
               "url": "http://test.com/",
-              "issue": "Status error",
+              "issue": "Status 404",
               "seoImpact": "High",
               "seoRecommendation": "Fix or remove broken links to improve user experience"
             }


### PR DESCRIPTION
This PR includes:
1. removes page auth token for external link checks as external links were incorrectly receiving internal authentication tokens, causing false positives when external domains returned 401/403 responses.
2. Refactored links-check to remove code duplication.
3. Fixed Internal links checks broken bug.
i. Now, checking the links that are only in main body and not in header and footer. Before when we included links that were in header and footer the total links found count was around 150 which was overloading the stream and HEAD request being too restrictive it was failing with error unexpected end of file .
ii. Added a fallback mechanism to GET request when HEAD request fails.

Please ensure your pull request adheres to the following guidelines:
- [X] make sure to link the related issues in this description
- [X] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues

https://jira.corp.adobe.com/browse/SITES-32254
https://jira.corp.adobe.com/browse/SITES-33323
Thanks for contributing!
<img width="1284" height="814" alt="Preflight Links-checks test" src="https://github.com/user-attachments/assets/1e99a287-83f9-4b53-b503-0d9eb7a3564b" />
