### PR TITLE
fix(deps): update @adobe/structured-data-validator to v1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@adobe/spacecat-shared-rum-api-client": "2.31.0",
         "@adobe/spacecat-shared-rum-api-client-v1": "npm:@adobe/spacecat-shared-rum-api-client@1.8.4",
         "@adobe/spacecat-shared-utils": "1.41.3",
-        "@adobe/structured-data-validator": "1.1.0",
+        "@adobe/structured-data-validator": "1.2.1",
         "@aws-sdk/client-athena": "3.839.0",
         "@aws-sdk/client-lambda": "3.839.0",
         "@aws-sdk/client-s3": "3.839.0",
@@ -23860,13 +23860,10 @@
       }
     },
     "node_modules/@adobe/structured-data-validator": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@adobe/structured-data-validator/-/structured-data-validator-1.1.0.tgz",
-      "integrity": "sha512-MOeb2T95H1ofS+1Fmbl6dOEuPQxI0cnB6e0EqZh4orsmX+5Wt127GdO1pzABs83Rw5Rz7U23RNoWOvc7aZqt2A==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@adobe/structured-data-validator/-/structured-data-validator-1.2.1.tgz",
+      "integrity": "sha512-XWkfhNvRjb7VHkeyiNgUwZpwgy9+gE2672JdXJBkFjnG7QGWt4wnoSk5o05fntQF8c1HqWbIAMfF3TGDEoixfw==",
       "license": "Apache-2.0",
-      "dependencies": {
-        "@marbec/web-auto-extractor": "^2.0.0-beta.12"
-      },
       "engines": {
         "node": ">=18.0.0"
       }
@@ -29783,15 +29780,6 @@
       "dependencies": {
         "@json2csv/formatters": "^7.0.6",
         "@streamparser/json": "^0.0.20"
-      }
-    },
-    "node_modules/@marbec/web-auto-extractor": {
-      "version": "2.0.0-beta.12",
-      "resolved": "https://registry.npmjs.org/@marbec/web-auto-extractor/-/web-auto-extractor-2.0.0-beta.12.tgz",
-      "integrity": "sha512-7m4K2ipmgc379chTwDXMFaTfHQMKKleQ2hA199cI6NknM6uJVRR31gpAbM9ltFvQeMk+Mf1hg0T3xKkf8kGedA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@microsoft/microsoft-graph-client": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@adobe/spacecat-shared-rum-api-client": "2.31.0",
     "@adobe/spacecat-shared-rum-api-client-v1": "npm:@adobe/spacecat-shared-rum-api-client@1.8.4",
     "@adobe/spacecat-shared-utils": "1.41.3",
-    "@adobe/structured-data-validator": "1.1.0",
+    "@adobe/structured-data-validator": "1.2.1",
     "@aws-sdk/client-athena": "3.839.0",
     "@aws-sdk/client-lambda": "3.839.0",
     "@aws-sdk/client-s3": "3.839.0",


### PR DESCRIPTION
* Manually update dependency, as renovate PR is stuck with failing tests.

## Related Issues
* https://github.com/adobe/structured-data-validator/pull/24
* https://github.com/adobe/structured-data-validator/pull/22

Thanks for contributing!
