### PR TITLE
feat:create-jira-ticket

### DIFF
--- a/src/accessibility/utils/generate-individual-opportunities.js
+++ b/src/accessibility/utils/generate-individual-opportunities.js
@@ -366,6 +366,7 @@ export async function createIndividualOpportunitySuggestions(
           url: urlData.url,
           type: urlData.type,
           issues: urlData.issues, // Array of formatted accessibility issues
+          isCreateTicketClicked: false,
         },
       }),
       log,

--- a/test/audits/accessibility/generate-individual-opportunities.test.js
+++ b/test/audits/accessibility/generate-individual-opportunities.test.js
@@ -763,6 +763,7 @@ describe('createIndividualOpportunitySuggestions', () => {
             occurrences: 3,
           },
         ],
+        isCreateTicketClicked: false,
       },
     });
   });


### PR DESCRIPTION
Added a new flag to suggesstion data object called `isCreateTicketClicked` to track if a user clicked on jira button to create a jira ticket