### PR TITLE
fix(deps): Update @adobe/structured-data-validator to 1.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@adobe/spacecat-shared-rum-api-client": "2.31.0",
         "@adobe/spacecat-shared-rum-api-client-v1": "npm:@adobe/spacecat-shared-rum-api-client@1.8.4",
         "@adobe/spacecat-shared-utils": "1.41.3",
-        "@adobe/structured-data-validator": "1.2.1",
+        "@adobe/structured-data-validator": "1.2.3",
         "@aws-sdk/client-athena": "3.844.0",
         "@aws-sdk/client-lambda": "3.844.0",
         "@aws-sdk/client-s3": "3.844.0",
@@ -23860,9 +23860,9 @@
       }
     },
     "node_modules/@adobe/structured-data-validator": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@adobe/structured-data-validator/-/structured-data-validator-1.2.1.tgz",
-      "integrity": "sha512-XWkfhNvRjb7VHkeyiNgUwZpwgy9+gE2672JdXJBkFjnG7QGWt4wnoSk5o05fntQF8c1HqWbIAMfF3TGDEoixfw==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@adobe/structured-data-validator/-/structured-data-validator-1.2.3.tgz",
+      "integrity": "sha512-x+xftXBgmxE1eaPg251ghWtXoXVndZIQZ1QO6QFg8JuVlpMASFgFs7GJacO7rZ6BLJ5MKI8h2X+BDUc0imYvOw==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "@adobe/spacecat-shared-rum-api-client": "2.31.0",
     "@adobe/spacecat-shared-rum-api-client-v1": "npm:@adobe/spacecat-shared-rum-api-client@1.8.4",
     "@adobe/spacecat-shared-utils": "1.41.3",
-    "@adobe/structured-data-validator": "1.2.1",
+    "@adobe/structured-data-validator": "1.2.3",
     "@aws-sdk/client-athena": "3.844.0",
     "@aws-sdk/client-lambda": "3.844.0",
     "@aws-sdk/client-s3": "3.844.0",


### PR DESCRIPTION
* Manually upgrading the `@adobe/structured-data-validator` dependency to 1.2.3.
* Includes the following fixes:
    * https://github.com/adobe/structured-data-validator/pull/26
    * https://github.com/adobe/structured-data-validator/pull/27
    * https://github.com/adobe/structured-data-validator/pull/29