### PR TITLE
fix: Catch errors from SDA validator

### DIFF
--- a/src/structured-data/lib.js
+++ b/src/structured-data/lib.js
@@ -192,9 +192,14 @@ export async function getIssuesFromScraper(context, pages, scrapeCache) {
     );
 
     const validator = new StructuredDataValidator(schemaOrgPath);
-    const validatorIssues = (await validator.validate(waeResult))
-      // For now, ignore issues with severity lower than ERROR
-      .filter((issue) => issue.severity === 'ERROR');
+    let validatorIssues = [];
+    try {
+      validatorIssues = (await validator.validate(waeResult))
+        // For now, ignore issues with severity lower than ERROR
+        .filter((issue) => issue.severity === 'ERROR');
+    } catch (e) {
+      log.error(`SDA: Failed to validate structured data for ${page}.`, e);
+    }
     for (const issue of validatorIssues) {
       // Only add if same issue for the same source does not exist already.
       // This can happen e.g. if a field is missing for every item in a list.


### PR DESCRIPTION
* Improve robustness of structured data audit by catching potential errors from the structured data validation.
* If the validation fails for one page, this won't make the whole audit fail anymore.
* Added unit test.
* See SITES-33683 for more details.
