### PR TITLE
fix: should not remove fixed suggestions

### DIFF
--- a/src/image-alt-text/opportunityHandler.js
+++ b/src/image-alt-text/opportunityHandler.js
@@ -35,8 +35,9 @@ const AUDIT_TYPE = AuditModel.AUDIT_TYPES.ALT_TEXT;
 export async function syncAltTextSuggestions({ opportunity, newSuggestionDTOs, log }) {
   const existingSuggestions = await opportunity.getSuggestions();
 
+  const IGNORED_STATUSES = [SuggestionModel.STATUSES.SKIPPED, SuggestionModel.STATUSES.FIXED];
   const ignoredSuggestions = existingSuggestions.filter(
-    (s) => s.getStatus() === SuggestionModel.STATUSES.SKIPPED,
+    (s) => IGNORED_STATUSES.includes(s.getStatus()),
   );
   const ignoredSuggestionIds = ignoredSuggestions.map((s) => s.getData().recommendations[0].id);
 


### PR DESCRIPTION
Update the `syncAltTextSuggestions` function so that it won't remove the suggestions that have FIXED status. 
Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues
[ASSETS-54507](https://jira.corp.adobe.com/browse/ASSETS-54507)

Thanks for contributing!
