### PR TITLE
Sites 31808

### DIFF
--- a/src/accessibility/handler.js
+++ b/src/accessibility/handler.js
@@ -19,6 +19,7 @@ import {
   getRemainingUrls,
   getExistingUrlsFromFailedAudits,
   updateStatusToIgnored,
+  saveA11yMetricsToS3,
 } from './utils/scrape-utils.js';
 import { createAccessibilityIndividualOpportunities } from './utils/generate-individual-opportunities.js';
 
@@ -186,6 +187,18 @@ export async function processAccessibilityOpportunities(context) {
       context,
     );
     log.debug('[A11yAudit] Individual opportunities created successfully');
+  } catch (error) {
+    log.error(`[A11yAudit] Error creating individual opportunities: ${error.message}`, error);
+    return {
+      status: 'PROCESSING_FAILED',
+      error: error.message,
+    };
+  }
+
+  // step 3 save a11y metrics to s3
+  try {
+    await saveA11yMetricsToS3(aggregationResult.finalResultFiles.current, context);
+    log.debug('[A11yAudit] Saving a11y metrics to s3');
   } catch (error) {
     log.error(`[A11yAudit] Error creating individual opportunities: ${error.message}`, error);
     return {

--- a/src/accessibility/utils/scrape-utils.js
+++ b/src/accessibility/utils/scrape-utils.js
@@ -176,21 +176,18 @@ export async function saveA11yMetricsToS3(reportData, context) {
 
   // Extract a11y metrics needed in the JSON structure
   const { overall } = reportData;
-  const totalViolations = overall?.violations?.total || 0;
-  const criticalViolations = overall?.violations?.critical?.count || 0;
-  const seriousViolations = overall?.violations?.serious?.count || 0;
-
-  // Calculate passed (assuming total represents all checks)
-  const failedChecks = criticalViolations + seriousViolations;
-  const totalChecks = Math.max(totalViolations, failedChecks);
+  // Calculate compliance metrics
+  const totalChecks = 50; // Fixed total representing number of accessibility issues checked
+  const criticalItemsCount = Object.keys(overall?.violations?.critical?.items || {}).length;
+  const seriousItemsCount = Object.keys(overall?.violations?.serious?.items || {}).length;
+  const failedChecks = criticalItemsCount + seriousItemsCount;
   const passedChecks = totalChecks - failedChecks;
 
   // Calculate top offenders from individual URL data
   const topOffenders = [];
   for (const [url, urlData] of Object.entries(reportData)) {
     if (url !== 'overall' && urlData.violations) {
-      const urlViolationCount = (urlData.violations.critical?.count || 0)
-                               + (urlData.violations.serious?.count || 0);
+      const urlViolationCount = urlData.violations.total || 0;
       if (urlViolationCount > 0) {
         topOffenders.push({ url, count: urlViolationCount });
       }

--- a/src/accessibility/utils/scrape-utils.js
+++ b/src/accessibility/utils/scrape-utils.js
@@ -164,3 +164,23 @@ export async function updateStatusToIgnored(dataAccess, siteId, log) {
     };
   }
 }
+
+export async function saveA11yMetricsToS3(reportData, context) {
+  const { log, env } = context;
+  const bucketName = env.S3_IMPORTER_BUCKET_NAME;
+
+  // TODO: extract a11y metrics needed in the JSON structure
+
+  // TODO: read existing a11y-audit.json file from s3
+
+  // TODO: create s3 file path > metrics/{siteId}/xcore/a11y-audit.json
+
+  // TODO: save new metrics to s3 a11y-audit.json file
+
+  log.info(`[A11yAudit] Saving a11y metrics to s3: ${JSON.stringify(reportData, null, 2)}`);
+  log.info(`[A11yAudit] Bucket name: ${bucketName}`);
+  return {
+    success: true,
+    message: 'A11y metrics saved to s3',
+  };
+}

--- a/test/audits/accessibility/scrape-utils.test.js
+++ b/test/audits/accessibility/scrape-utils.test.js
@@ -538,18 +538,32 @@ describe('Scrape Utils', () => {
         overall: {
           violations: {
             total: 10,
-            critical: { count: 5 },
-            serious: { count: 3 },
+            critical: {
+              count: 5,
+              items: {
+                'color-contrast': { count: 3 },
+                'missing-alt': { count: 2 },
+              },
+            },
+            serious: {
+              count: 3,
+              items: {
+                'link-name': { count: 1 },
+                'form-label': { count: 2 },
+              },
+            },
           },
         },
         'https://example.com/page1': {
           violations: {
+            total: 8,
             critical: { count: 3 },
             serious: { count: 2 },
           },
         },
         'https://example.com/page2': {
           violations: {
+            total: 5,
             critical: { count: 2 },
             serious: { count: 1 },
           },
@@ -576,15 +590,15 @@ describe('Scrape Utils', () => {
         name: 'a11y-audit',
         time: '2024-07-24T10:00:00.000Z',
         compliance: {
-          total: 10,
-          failed: 8,
-          passed: 2,
+          total: 50,
+          failed: 4,
+          passed: 46,
         },
       });
       expect(result.metricsData.topOffenders).to.have.lengthOf(2);
       expect(result.metricsData.topOffenders[0]).to.deep.equal({
         url: 'https://example.com/page1',
-        count: 5,
+        count: 8,
       });
 
       expect(mockS3Client.send).to.have.been.calledOnce;
@@ -608,12 +622,23 @@ describe('Scrape Utils', () => {
         overall: {
           violations: {
             total: 5,
-            critical: { count: 2 },
-            serious: { count: 1 },
+            critical: {
+              count: 2,
+              items: {
+                'color-contrast': { count: 2 },
+              },
+            },
+            serious: {
+              count: 1,
+              items: {
+                'link-name': { count: 1 },
+              },
+            },
           },
         },
         'https://example.com/page1': {
           violations: {
+            total: 3,
             critical: { count: 2 },
             serious: { count: 1 },
           },
@@ -658,9 +683,9 @@ describe('Scrape Utils', () => {
       // Assert
       expect(result.success).to.be.true;
       expect(result.metricsData.compliance).to.deep.equal({
-        total: 0,
+        total: 50,
         failed: 0,
-        passed: 0,
+        passed: 50,
       });
       expect(result.metricsData.topOffenders).to.be.an('array').that.is.empty;
     });
@@ -669,7 +694,24 @@ describe('Scrape Utils', () => {
       // Arrange
       const reportData = {
         overall: {
-          violations: { total: 50, critical: { count: 25 }, serious: { count: 20 } },
+          violations: {
+            total: 50,
+            critical: {
+              count: 25,
+              items: {
+                'color-contrast': { count: 10 },
+                'missing-alt': { count: 8 },
+                'keyboard-nav': { count: 7 },
+              },
+            },
+            serious: {
+              count: 20,
+              items: {
+                'link-name': { count: 12 },
+                'form-label': { count: 8 },
+              },
+            },
+          },
         },
       };
 
@@ -677,6 +719,7 @@ describe('Scrape Utils', () => {
       for (let i = 1; i <= 15; i += 1) {
         reportData[`https://example.com/page${i}`] = {
           violations: {
+            total: i * 2, // Use total instead of critical + serious
             critical: { count: i },
             serious: { count: i - 1 },
           },
@@ -696,11 +739,11 @@ describe('Scrape Utils', () => {
       expect(result.metricsData.topOffenders).to.have.lengthOf(10);
       expect(result.metricsData.topOffenders[0]).to.deep.equal({
         url: 'https://example.com/page15',
-        count: 29, // 15 + 14
+        count: 30, // 15 * 2
       });
       expect(result.metricsData.topOffenders[9]).to.deep.equal({
         url: 'https://example.com/page6',
-        count: 11, // 6 + 5
+        count: 12, // 6 * 2
       });
     });
 
@@ -708,7 +751,21 @@ describe('Scrape Utils', () => {
       // Arrange
       const reportData = {
         overall: {
-          violations: { total: 5, critical: { count: 2 }, serious: { count: 1 } },
+          violations: {
+            total: 5,
+            critical: {
+              count: 2,
+              items: {
+                'color-contrast': { count: 2 },
+              },
+            },
+            serious: {
+              count: 1,
+              items: {
+                'link-name': { count: 1 },
+              },
+            },
+          },
         },
       };
 

--- a/test/audits/accessibility/scrape-utils.test.js
+++ b/test/audits/accessibility/scrape-utils.test.js
@@ -623,15 +623,15 @@ describe('Scrape Utils', () => {
           violations: {
             total: 5,
             critical: {
-              count: 2,
+              count: 3,
               items: {
-                'color-contrast': { count: 2 },
+                'color-contrast': { count: 3 },
               },
             },
             serious: {
-              count: 1,
+              count: 2,
               items: {
-                'link-name': { count: 1 },
+                'link-name': { count: 2 },
               },
             },
           },
@@ -866,22 +866,39 @@ describe('Scrape Utils', () => {
       // Arrange
       const reportData = {
         overall: {
-          violations: { total: 5, critical: { count: 3 }, serious: { count: 2 } },
+          violations: {
+            total: 5,
+            critical: {
+              count: 3,
+              items: {
+                'color-contrast': { count: 3 },
+              },
+            },
+            serious: {
+              count: 2,
+              items: {
+                'link-name': { count: 2 },
+              },
+            },
+          },
         },
         'https://example.com/page1': {
           violations: {
+            total: 3,
             critical: { count: 3 },
             serious: { count: 0 },
           },
         },
         'https://example.com/page2': {
           violations: {
+            total: 0,
             critical: { count: 0 },
             serious: { count: 0 },
           },
         },
         'https://example.com/page3': {
           violations: {
+            total: 2,
             critical: { count: 0 },
             serious: { count: 2 },
           },


### PR DESCRIPTION
### Jira Ticket

https://jira.corp.adobe.com/browse/SITES-31808

### Changes Description

Implemented saveA11yMetricsToS3 function with proper metrics extraction from accessibility reports
Added S3 read/write operations for historical metrics tracking at metrics/{siteId}/xcore/a11y-audit.json

Example metrics json structure:

`{
  "siteId": "site-id",
  "url": "https://example.com", 
  "source": "xcore",
  "time": "2024-07-24T10:00:00.000Z",
  "compliance": { "total": 50, "failed": 4, "passed": 46 },
  "topOffenders": [
    { "url": "https://example.com/page1", "count": 8 }
  ]
}`