### PR TITLE
feat: added LLM-404-blocked audit

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ import { helixStatus } from '@adobe/helix-status';
 import secrets from '@adobe/helix-shared-secrets';
 import dataAccess from '@adobe/spacecat-shared-data-access';
 import { resolveSecretsName, sqsEventAdapter } from '@adobe/spacecat-shared-utils';
-import { internalServerError, notFound, ok } from '@adobe/spacecat-shared-http-utils';
+import { internalServerError, notFound } from '@adobe/spacecat-shared-http-utils';
 
 import sqs from './support/sqs.js';
 import s3Client from './support/s3-client.js';
@@ -52,6 +52,9 @@ import formAccessibilityGuidance from './forms-opportunities/guidance-handlers/g
 import mystiqueDetectedFormAccessibilityOpportunity from './forms-opportunities/oppty-handlers/accessibility-handler.js';
 import cdnAnalysis from './cdn-analysis/handler.js';
 import cdnLogsReport from './cdn-logs-report/handler.js';
+import llm404Blocked from './llm-404-blocked/handler.js';
+import llm404BlockedGuidance from './llm-404-blocked/guidance-handler.js';
+import llm404BlockedReport from './llm-404-blocked/report-handler.js';
 
 const HANDLERS = {
   accessibility,
@@ -88,7 +91,9 @@ const HANDLERS = {
   preflight,
   'cdn-analysis': cdnAnalysis,
   'cdn-logs-report': cdnLogsReport,
-  dummy: (message) => ok(message),
+  'llm-404-blocked': llm404Blocked,
+  'guidance:llm-404-blocked': llm404BlockedGuidance,
+  'llm-404-blocked-report': llm404BlockedReport,
 };
 
 function getElapsedSeconds(startTime) {

--- a/src/llm-404-blocked/constants.js
+++ b/src/llm-404-blocked/constants.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export const LLM_404_BLOCKED_AUDIT = 'llm-404-blocked';
+
+export const API_BASE_URL = 'https://d1vm7168yg1w6d.cloudfront.net';
+export const REFERER_URL = 'https://dev.d2ikwb7s634epv.amplifyapp.com/';
+export const REQUEST_TIMEOUT = 30000; // 30 seconds
+
+export const MYSTIQUE_MESSAGE_TYPE = 'detect:llm-404-blocked';
+
+export const MIN_404_COUNT_THRESHOLD = 5;
+export const MAX_URLS_LIMIT = 200;
+
+export const REPORT_HANDLER_SQS_TYPE = 'llm-404-blocked-report';
+
+// Suggestion types used across audits
+export const SUGGESTION_TYPES = {
+  REDIRECT_UPDATE: 'REDIRECT_UPDATE',
+};

--- a/src/llm-404-blocked/guidance-handler.js
+++ b/src/llm-404-blocked/guidance-handler.js
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { ok, notFound } from '@adobe/spacecat-shared-http-utils';
+import { LLM_404_BLOCKED_AUDIT, REPORT_HANDLER_SQS_TYPE } from './constants.js';
+
+async function atomicIncrementReceived(AuditModel, auditId, log) {
+  if (typeof AuditModel.update === 'function') {
+    try {
+      await AuditModel.update(auditId, { $ADD: { 'data.mystique.received': 1 } });
+      return;
+    } catch (err) {
+      log.warn(`[${LLM_404_BLOCKED_AUDIT}] Atomic $ADD failed (falling back): ${err.message}`);
+    }
+  }
+  const audit = await AuditModel.findById(auditId);
+  if (!audit) {
+    return;
+  }
+  const mystiqueData = audit.getData()?.mystique || { expected: 0, received: 0 };
+  audit.setDataValue('mystique', {
+    ...mystiqueData,
+    received: (mystiqueData.received || 0) + 1,
+  });
+  await audit.save();
+}
+
+async function processSuggestionResponse(context, opportunity) {
+  const {
+    log, dataAccess, sqs, env,
+  } = context;
+  const { Audit } = dataAccess;
+  const auditId = opportunity.getAuditId();
+
+  try {
+    const audit = await Audit.getByID(auditId);
+    if (!audit) {
+      log.warn(`[${LLM_404_BLOCKED_AUDIT}] Audit ${auditId} not found when trying to trigger report.`);
+      return;
+    }
+
+    const mystiqueData = audit.getData()?.mystique || { expected: 0, received: 0 };
+    const expected = mystiqueData.expected || 0;
+
+    await atomicIncrementReceived(Audit, auditId, log);
+
+    const newReceived = (mystiqueData.received || 0) + 1; // optimistic display
+
+    log.info(`[${LLM_404_BLOCKED_AUDIT}] Suggestion count for audit ${auditId}: ${newReceived}/${expected}`);
+
+    if (expected > 0 && newReceived >= expected) {
+      log.info(`[${LLM_404_BLOCKED_AUDIT}] All suggestions received for audit ${auditId}. Triggering report generation.`);
+      const message = {
+        type: REPORT_HANDLER_SQS_TYPE,
+        auditId,
+        siteId: opportunity.getSiteId(),
+      };
+      await sqs.sendMessage(env.QUEUE_SPACECAT, message);
+    }
+  } catch (error) {
+    log.error(`[${LLM_404_BLOCKED_AUDIT}] Failed to check/trigger report for audit ${auditId}: ${error.message}`, error);
+  }
+}
+
+export default async function handler(message, context) {
+  const { log, dataAccess } = context;
+  const { Opportunity, Suggestion } = dataAccess;
+  const { siteId, data } = message;
+  const {
+    suggestionId,
+    broken_url, // eslint-disable-line camelcase
+    suggested_urls, // eslint-disable-line camelcase
+    aiRationale,
+  } = data;
+
+  log.info(`[${LLM_404_BLOCKED_AUDIT}] Message received in guidance handler for site: ${siteId}, URL: ${broken_url}`); // eslint-disable-line camelcase
+
+  const suggestion = await Suggestion.findById(suggestionId);
+  if (!suggestion) {
+    log.warn(`[${LLM_404_BLOCKED_AUDIT}] No suggestion found for suggestionId: ${suggestionId}`);
+    return notFound();
+  }
+
+  const opportunity = await Opportunity.findById(suggestion.getOpportunityId());
+  if (!opportunity) {
+    log.warn(`[${LLM_404_BLOCKED_AUDIT}] No opportunity found for suggestion ${suggestionId}`);
+    return notFound();
+  }
+
+  if (opportunity.getSiteId() !== siteId) {
+    log.warn(`[${LLM_404_BLOCKED_AUDIT}] SiteId mismatch: expected ${opportunity.getSiteId()}, got ${siteId}`);
+    return { status: 400, body: 'SiteId mismatch' };
+  }
+
+  if (message.auditId && opportunity.getAuditId() !== message.auditId) {
+    log.warn(`[${LLM_404_BLOCKED_AUDIT}] AuditId mismatch: expected ${opportunity.getAuditId()}, got ${message.auditId}`);
+    return { status: 400, body: 'AuditId mismatch' };
+  }
+
+  log.info(`[${LLM_404_BLOCKED_AUDIT}] Found suggestion ${suggestionId}, processing AI guidance for URL: ${broken_url}`); // eslint-disable-line camelcase
+
+  const currentData = suggestion.getData();
+  suggestion.setData({
+    ...currentData,
+    urlsSuggested: suggested_urls || [], // eslint-disable-line camelcase
+    aiRationale: aiRationale || '',
+    aiResponseReceived: true,
+    aiResponseTimestamp: new Date().toISOString(),
+  });
+  suggestion.setUpdatedBy('system');
+  await suggestion.save();
+
+  log.info(`[${LLM_404_BLOCKED_AUDIT}] Successfully processed guidance for suggestion ${suggestionId}, URL: ${broken_url}, suggestions: ${suggested_urls?.length || 0}`); // eslint-disable-line camelcase
+
+  await processSuggestionResponse(context, opportunity);
+
+  return ok();
+}

--- a/src/llm-404-blocked/handler.js
+++ b/src/llm-404-blocked/handler.js
@@ -1,0 +1,308 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
+import { AuditBuilder } from '../common/audit-builder.js';
+import { noopUrlResolver } from '../common/index.js';
+import {
+  LLM_404_BLOCKED_AUDIT, REFERER_URL, REQUEST_TIMEOUT, MIN_404_COUNT_THRESHOLD, MAX_URLS_LIMIT,
+} from './constants.js';
+import { calculateCurrentWeek, buildApiUrl, convertPathsToFullUrls } from './utils.js';
+import llm404PostProcessor from './opportunity-data-mapper.js';
+
+async function fetchLLM404Data(apiUrl, log) {
+  try {
+    log.info(`[${LLM_404_BLOCKED_AUDIT}] Fetching data from: ${apiUrl}`);
+
+    const response = await fetch(apiUrl, {
+      method: 'GET',
+      headers: {
+        Referer: REFERER_URL,
+        Accept: 'application/json',
+        'User-Agent': 'SpaceCat-Audit-Worker/1.0',
+      },
+      timeout: REQUEST_TIMEOUT,
+    });
+
+    if (!response.ok) {
+      const errorMsg = `HTTP ${response.status}: ${response.statusText}`;
+      log.error(`[${LLM_404_BLOCKED_AUDIT}] API request failed: ${errorMsg}`);
+      return {
+        success: false,
+        error: `API request failed: ${errorMsg}`,
+        statusCode: response.status,
+      };
+    }
+
+    const contentType = response.headers.get('content-type');
+    if (!contentType || !contentType.includes('application/json')) {
+      log.error(`[${LLM_404_BLOCKED_AUDIT}] Invalid content type: ${contentType}`);
+      return {
+        success: false,
+        error: `Invalid content type: ${contentType}`,
+      };
+    }
+
+    try {
+      const data = await response.json();
+      log.info(`[${LLM_404_BLOCKED_AUDIT}] Successfully fetched data from API`);
+
+      return {
+        success: true,
+        data,
+      };
+    } catch (jsonError) {
+      log.error(`[${LLM_404_BLOCKED_AUDIT}] Failed to parse JSON: ${jsonError.message}`);
+      return {
+        success: false,
+        error: `Failed to parse JSON: ${jsonError.message}`,
+      };
+    }
+  } catch (error) {
+    const errorMsg = error.code === 'ETIMEOUT'
+      ? `Request timeout after ${REQUEST_TIMEOUT}ms`
+      : error.message;
+
+    log.error(`[${LLM_404_BLOCKED_AUDIT}] Network error: ${errorMsg}`);
+    return {
+      success: false,
+      error: `Network error: ${errorMsg}`,
+    };
+  }
+}
+
+function processApiData(data, siteBaseUrl, log) {
+  try {
+    const urlsContainer = data['404_all_urls'];
+
+    if (!urlsContainer || typeof urlsContainer !== 'object') {
+      log.warn(`[${LLM_404_BLOCKED_AUDIT}] 404_all_urls field missing or invalid`);
+      return {
+        blocked404Urls: [],
+        fullUrls: [],
+        totalCount: 0,
+        dataQuality: 'missing_field',
+      };
+    }
+
+    const urlsData = urlsContainer.data;
+    if (!Array.isArray(urlsData)) {
+      log.warn(`[${LLM_404_BLOCKED_AUDIT}] 404_all_urls.data is not an array, got: ${typeof urlsData}`);
+      return {
+        blocked404Urls: [],
+        fullUrls: [],
+        totalCount: 0,
+        dataQuality: 'invalid_format',
+      };
+    }
+
+    if (urlsData.length === 0) {
+      log.info(`[${LLM_404_BLOCKED_AUDIT}] No 404 URLs found in data`);
+      return {
+        blocked404Urls: [],
+        fullUrls: [],
+        totalCount: 0,
+        dataQuality: 'no_data',
+      };
+    }
+
+    const parsedData = urlsData.map((item) => {
+      const count = parseInt(item['Number of 404s'] || '0', 10);
+      return {
+        ...item,
+        count_404s: Number.isNaN(count) ? 0 : count,
+      };
+    }).filter((item) => item.count_404s > 0) // Only include items with valid counts > 0
+      .sort((a, b) => b.count_404s - a.count_404s);
+
+    // Only apply threshold filtering if we have more than MAX_URLS_LIMIT URLs
+    // Otherwise, return all URLs as-is (no capping)
+    let selectedUrls;
+    if (parsedData.length <= MAX_URLS_LIMIT) {
+      // Few enough URLs - return all of them, no threshold filtering
+      selectedUrls = parsedData;
+    } else {
+      // Too many URLs - apply threshold filter, return all that meet threshold
+      const urlsWithThreshold = parsedData.filter(
+        (item) => item.count_404s >= MIN_404_COUNT_THRESHOLD,
+      );
+      if (urlsWithThreshold.length > 0) {
+        // Some URLs meet threshold - return all of them
+        selectedUrls = urlsWithThreshold;
+      } else {
+        // No URLs meet threshold - fall back to top 200 by count
+        selectedUrls = parsedData.slice(0, MAX_URLS_LIMIT);
+      }
+    }
+
+    let filterType;
+    if (parsedData.length <= MAX_URLS_LIMIT) {
+      filterType = 'all_urls';
+    } else {
+      const urlsWithThreshold = parsedData.filter(
+        (item) => item.count_404s >= MIN_404_COUNT_THRESHOLD,
+      );
+      filterType = urlsWithThreshold.length > 0 ? 'threshold_filtered' : 'top_200_fallback';
+    }
+    log.info(`[${LLM_404_BLOCKED_AUDIT}] Filtering results: ${parsedData.length} total URLs, selected ${selectedUrls.length} URLs (${filterType})`);
+
+    const urlPaths = selectedUrls.map((item) => item.URL).filter(Boolean);
+
+    const fullUrls = convertPathsToFullUrls(urlPaths, siteBaseUrl, log);
+
+    log.info(`[${LLM_404_BLOCKED_AUDIT}] Found ${selectedUrls.length} filtered 404 URL entries, converted ${fullUrls.length} to valid full URLs`);
+
+    return {
+      blocked404Urls: selectedUrls, // Keep original filtered data for audit result
+      fullUrls, // Full URLs for Mystique
+      totalCount: selectedUrls.length,
+      validUrlCount: fullUrls.length,
+      originalTotalCount: urlsData.length,
+      filterCriteria: (() => {
+        if (filterType === 'all_urls') return `all_${parsedData.length}_urls`;
+        if (filterType === 'threshold_filtered') return `threshold_${MIN_404_COUNT_THRESHOLD}_404s`;
+        return `top_${MAX_URLS_LIMIT}_fallback`;
+      })(),
+      dataQuality: 'valid',
+    };
+  } catch (error) {
+    log.error(`[${LLM_404_BLOCKED_AUDIT}] Error processing API data: ${error.message}`);
+    return {
+      blocked404Urls: [],
+      fullUrls: [],
+      totalCount: 0,
+      dataQuality: 'processing_error',
+      processingError: error.message,
+    };
+  }
+}
+
+export async function llm404BlockedAuditRunner(baseURL, context, site) {
+  const { log } = context;
+  const siteId = site.getId();
+  const siteBaseUrl = site.getBaseURL();
+  const currentWeek = calculateCurrentWeek();
+
+  log.info(`[${LLM_404_BLOCKED_AUDIT}] Starting audit for site: ${siteId}, base URL: ${siteBaseUrl}, week period: ${currentWeek}`);
+
+  try {
+    const cdnLogsConfig = site.getConfig()?.getCdnLogsConfig?.();
+    const outputLocation = cdnLogsConfig?.outputLocation;
+
+    if (!cdnLogsConfig) {
+      const errorMsg = `CDN logs configuration not found for site: ${siteId}`;
+      log.error(`[${LLM_404_BLOCKED_AUDIT}] ${errorMsg}`);
+      return {
+        auditResult: {
+          finalUrl: baseURL,
+          domain: 'unknown',
+          currentWeek,
+          apiUrl: 'unavailable',
+          blocked404Urls: [],
+          fullUrls: [],
+          totalCount: 0,
+          success: false,
+          error: errorMsg,
+          auditedAt: new Date().toISOString(),
+        },
+        fullAuditRef: baseURL,
+      };
+    }
+
+    if (!outputLocation || typeof outputLocation !== 'string' || outputLocation.trim() === '') {
+      const errorMsg = `Missing or invalid cdnLogsConfig.outputLocation. Site: ${siteId}, Config: ${JSON.stringify(cdnLogsConfig)}`;
+      log.error(`[${LLM_404_BLOCKED_AUDIT}] ${errorMsg}`);
+      return {
+        auditResult: {
+          finalUrl: baseURL,
+          domain: 'unknown',
+          currentWeek,
+          apiUrl: 'unavailable',
+          blocked404Urls: [],
+          fullUrls: [],
+          totalCount: 0,
+          success: false,
+          error: 'Configuration error: cdnLogsConfig.outputLocation is required but missing or invalid',
+          auditedAt: new Date().toISOString(),
+        },
+        fullAuditRef: baseURL,
+      };
+    }
+
+    const domain = outputLocation.trim();
+    log.info(`[${LLM_404_BLOCKED_AUDIT}] Using outputLocation from cdnLogsConfig: ${domain} (Site: ${siteId})`);
+
+    const apiUrl = buildApiUrl(domain, currentWeek);
+
+    const apiResult = await fetchLLM404Data(apiUrl, log);
+
+    if (!apiResult.success) {
+      log.warn(`[${LLM_404_BLOCKED_AUDIT}] API call failed, returning empty result`);
+      return {
+        auditResult: {
+          finalUrl: baseURL,
+          domain,
+          currentWeek,
+          apiUrl,
+          blocked404Urls: [],
+          fullUrls: [],
+          totalCount: 0,
+          success: false,
+          error: apiResult.error,
+          ...(apiResult.statusCode && { statusCode: apiResult.statusCode }),
+        },
+        fullAuditRef: apiUrl,
+      };
+    }
+
+    const processedData = processApiData(apiResult.data, siteBaseUrl, log);
+
+    const auditResult = {
+      finalUrl: baseURL,
+      domain,
+      currentWeek,
+      apiUrl,
+      ...processedData,
+      success: true,
+      auditedAt: new Date().toISOString(),
+    };
+
+    log.info(`[${LLM_404_BLOCKED_AUDIT}] Audit completed successfully for site: ${siteId}, found ${processedData.totalCount} blocked URLs`);
+
+    return {
+      auditResult,
+      fullAuditRef: apiUrl,
+    };
+  } catch (error) {
+    log.error(`[${LLM_404_BLOCKED_AUDIT}] Unexpected error during audit: ${error.message}`, error);
+
+    return {
+      auditResult: {
+        finalUrl: baseURL,
+        domain: 'unknown',
+        currentWeek: calculateCurrentWeek(),
+        blocked404Urls: [],
+        fullUrls: [],
+        totalCount: 0,
+        success: false,
+        error: `Unexpected error: ${error.message}`,
+      },
+      fullAuditRef: baseURL,
+    };
+  }
+}
+
+export default new AuditBuilder()
+  .withUrlResolver(noopUrlResolver)
+  .withRunner(llm404BlockedAuditRunner)
+  .withPostProcessors([llm404PostProcessor])
+  .build();

--- a/src/llm-404-blocked/opportunity-data-mapper.js
+++ b/src/llm-404-blocked/opportunity-data-mapper.js
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { randomUUID } from 'crypto';
+import { LLM_404_BLOCKED_AUDIT, MYSTIQUE_MESSAGE_TYPE, SUGGESTION_TYPES } from './constants.js';
+import { convertToOpportunity } from '../common/opportunity.js';
+import { syncSuggestions } from '../utils/data-access.js';
+import { sleep } from '../support/utils.js';
+
+function createOpportunityData() {
+  return {
+    runbook: 'https://wiki.corp.adobe.com/display/AEMSites/404+Agentic+Traffic',
+    origin: 'AUTOMATION',
+    title: 'Agentic Traffic - 404 Blocked URLs',
+    description: 'When AI hits a 404, the page visit is unutilized. This is a problem because it means that the AI is not able scrape data and surface it, which leads to potential traffic loss.',
+    guidance: {
+      steps: [
+        'Review the list of 404 URLs and their corresponding redirect suggestions.',
+      ],
+    },
+    tags: ['isElmo'],
+    data: {},
+  };
+}
+
+/**
+ * Send 404 URLs to Mystique and create suggestions
+ * @param {Object} context - Audit context
+ * @param {Object} opportunity - The single opportunity object
+ * @param {Array} urlsWithCounts - Array of {url, count} objects
+ * @returns {Promise<Object>} Statistics about messages sent
+ */
+async function sendToMystique(
+  context,
+  site,
+  auditId,
+  urlsWithCounts,
+  opportunityId,
+  suggestionIdMap,
+) {
+  const { log, sqs, env } = context;
+
+  if (!sqs || !env.QUEUE_SPACECAT_TO_MYSTIQUE) {
+    log.warn(`[${LLM_404_BLOCKED_AUDIT}] SQS or queue configuration missing, skipping Mystique integration`);
+    return { messagesSent: 0, successfulMessages: 0, failedMessages: 0 };
+  }
+
+  log.info(`[${LLM_404_BLOCKED_AUDIT}] Sending ${urlsWithCounts.length} URLs to Mystique and creating opportunities`);
+
+  const baseMessage = {
+    type: MYSTIQUE_MESSAGE_TYPE,
+    siteId: site.getId(),
+    auditId,
+    deliveryType: site.getDeliveryType(),
+    time: new Date().toISOString(),
+  };
+
+  let successfulMessages = 0;
+  let failedMessages = 0;
+  const BATCH_SIZE = 10;
+
+  for (let i = 0; i < urlsWithCounts.length; i += BATCH_SIZE) {
+    const batch = urlsWithCounts.slice(i, Math.min(i + BATCH_SIZE, urlsWithCounts.length));
+    // eslint-disable-next-line no-loop-func
+    const batchPromises = batch.map(async (urlData) => {
+      const messageId = randomUUID();
+      const suggestionId = suggestionIdMap.get(urlData.path) || randomUUID();
+
+      try {
+        // Send message to Mystique (suggestion will be created later)
+        const message = {
+          MessageId: messageId,
+          Body: JSON.stringify({
+            ...baseMessage,
+            data: {
+              broken_url: urlData.fullUrl,
+              alternative_urls: [],
+              opportunity_id: opportunityId,
+              suggestion_id: suggestionId,
+            },
+          }),
+        };
+
+        await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, message);
+        return { success: true, url: urlData.path, suggestionId };
+      } catch (error) {
+        log.error(`[${LLM_404_BLOCKED_AUDIT}] Failed to process URL ${urlData.fullUrl}: ${error.message}`);
+        return { success: false, url: urlData.path, error: error.message };
+      }
+    });
+
+    // eslint-disable-next-line no-await-in-loop
+    const batchResults = await Promise.allSettled(batchPromises);
+
+    for (const result of batchResults) {
+      if (result.status === 'fulfilled' && result.value.success) {
+        successfulMessages += 1;
+      } else {
+        failedMessages += 1;
+      }
+    }
+
+    if (i + BATCH_SIZE < urlsWithCounts.length) {
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(50);
+    }
+  }
+
+  const messageStats = {
+    messagesSent: urlsWithCounts.length,
+    successfulMessages,
+    failedMessages,
+  };
+
+  log.info(`[${LLM_404_BLOCKED_AUDIT}] Mystique integration complete: ${successfulMessages} messages sent, ${failedMessages} failed`);
+
+  return messageStats;
+}
+
+export default async function llm404PostProcessor(auditUrl, auditData, context, site) {
+  const { log } = context;
+  const { siteId, id: auditId, auditResult } = auditData;
+
+  try {
+    // Only process if audit was successful and has blocked URLs
+    if (
+      !auditResult.success || !auditResult.blocked404Urls || auditResult.blocked404Urls.length === 0
+    ) {
+      log.info(`[${LLM_404_BLOCKED_AUDIT}] No valid URLs to process for site ${siteId}`);
+      return auditData;
+    }
+
+    const { blocked404Urls } = auditResult;
+    const siteBaseUrl = site.getBaseURL();
+
+    const urlsWithCounts = blocked404Urls.map((item) => {
+      const itemPath = item.URL?.startsWith('/') ? item.URL : `/${item.URL || ''}`;
+      const fullUrl = new URL(itemPath, siteBaseUrl).href;
+      return {
+        fullUrl,
+        path: itemPath,
+        count_404s: item.count_404s || 0,
+      };
+    });
+
+    log.info(`[${LLM_404_BLOCKED_AUDIT}] Processing ${urlsWithCounts.length} URLs for opportunities and Mystique integration`);
+
+    const opportunity = await convertToOpportunity(
+      auditUrl,
+      { siteId, id: auditId },
+      context,
+      createOpportunityData,
+      LLM_404_BLOCKED_AUDIT,
+    );
+
+    const buildKey = (data) => data.path;
+    await syncSuggestions({
+      opportunity,
+      newData: urlsWithCounts,
+      context,
+      buildKey,
+      mapNewSuggestion: (urlData) => ({
+        opportunityId: opportunity.getId(),
+        type: SUGGESTION_TYPES.REDIRECT_UPDATE,
+        rank: urlData.count_404s,
+        status: 'NEW',
+        data: {
+          url: urlData.path,
+          count_404s: urlData.count_404s,
+          full_url: urlData.fullUrl,
+          siteDomain: new URL(site.getBaseURL()).hostname,
+        },
+      }),
+      log,
+    });
+
+    const suggestions = await opportunity.getSuggestions();
+    const suggestionIdMap = new Map();
+    suggestions.forEach((s) => {
+      const d = s.getData();
+      if (d.url) {
+        suggestionIdMap.set(d.url, s.getId());
+      }
+    });
+
+    const mystiqueStats = await sendToMystique(
+      context,
+      site,
+      auditId,
+      urlsWithCounts,
+      opportunity.getId(),
+      suggestionIdMap,
+    );
+
+    const { audit } = context;
+    if (audit && mystiqueStats.messagesSent > 0) {
+      audit.setDataValue('mystique', {
+        expected: mystiqueStats.messagesSent,
+        received: 0,
+      });
+      await audit.save();
+      log.info(`[${LLM_404_BLOCKED_AUDIT}] Audit ${auditId} updated with expected suggestion count: ${mystiqueStats.messagesSent}`);
+    }
+
+    const updatedAuditData = {
+      ...auditData,
+      auditResult: {
+        ...auditResult,
+        mystiqueIntegration: {
+          messagesSent: mystiqueStats.messagesSent,
+          successfulMessages: mystiqueStats.successfulMessages,
+          failedMessages: mystiqueStats.failedMessages,
+          opportunityCreated: 1,
+          suggestionsCreated: urlsWithCounts.length,
+          successRate: mystiqueStats.messagesSent > 0
+            ? `${((mystiqueStats.successfulMessages / mystiqueStats.messagesSent) * 100).toFixed(1)}%` : '0%',
+        },
+      },
+    };
+
+    log.info(`[${LLM_404_BLOCKED_AUDIT}] Post-processing complete for site ${siteId}: 1 opportunity updated with ${urlsWithCounts.length} suggestions, ${mystiqueStats.messagesSent} messages sent to Mystique`);
+
+    return updatedAuditData;
+  } catch (error) {
+    log.error(`[${LLM_404_BLOCKED_AUDIT}] Error in post-processor for site ${siteId}: ${error.message}`, error);
+    return auditData;
+  }
+}

--- a/src/llm-404-blocked/report-handler.js
+++ b/src/llm-404-blocked/report-handler.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { ok, notFound } from '@adobe/spacecat-shared-http-utils';
+import { createFrom } from '@adobe/spacecat-helix-content-sdk';
+import { LLM_404_BLOCKED_AUDIT } from './constants.js';
+import {
+  createExcelReport, getWeekRange, generatePeriodIdentifier, saveExcelReport,
+} from './utils.js';
+
+async function prepareReportData(opportunities) {
+  if (opportunities.length === 0) {
+    return [];
+  }
+
+  const opportunity = opportunities[0];
+  const suggestions = await opportunity.getSuggestions();
+  const reportData = [];
+
+  // Process all suggestions for the single opportunity
+  for (const suggestion of suggestions) {
+    const suggestionData = suggestion.getData();
+
+    reportData.push({
+      url: suggestionData.url,
+      count_404s: suggestionData.count_404s,
+      suggestions: suggestionData.urlsSuggested || [],
+      status: suggestionData.aiResponseReceived ? 'Suggestion Received' : 'Pending Suggestion',
+      aiRationale: suggestionData.aiRationale || '',
+    });
+  }
+
+  return reportData;
+}
+
+export default async function reportHandler(message, context) {
+  const { log, dataAccess, env } = context;
+  const { auditId, siteId } = message;
+
+  log.info(`[${LLM_404_BLOCKED_AUDIT}] Report handler received for audit ${auditId}`);
+
+  const { Audit, Opportunity, Site } = dataAccess;
+
+  const audit = await Audit.getByID(auditId);
+  if (!audit) {
+    log.error(`[${LLM_404_BLOCKED_AUDIT}] Audit ${auditId} not found for reporting.`);
+    return notFound('Audit not found');
+  }
+
+  const site = await Site.getByID(siteId);
+  if (!site) {
+    log.error(`[${LLM_404_BLOCKED_AUDIT}] Site ${siteId} not found for reporting.`);
+    return notFound('Site not found');
+  }
+
+  const allOpportunities = await Opportunity.allBySiteId(siteId);
+  const opportunities = allOpportunities.filter((opp) => (
+    opp.getAuditId() === auditId && opp.getType() === LLM_404_BLOCKED_AUDIT
+  ));
+
+  log.info(`[${LLM_404_BLOCKED_AUDIT}] Filtered ${allOpportunities.length} total opportunities to ${opportunities.length} llm-404-blocked opportunities for audit ${auditId}`);
+
+  if (opportunities.length === 0) {
+    log.warn(`[${LLM_404_BLOCKED_AUDIT}] No opportunity found for audit ${auditId}. Skipping report generation.`);
+    return ok();
+  }
+
+  log.info(`[${LLM_404_BLOCKED_AUDIT}] Found llm-404-blocked opportunity for audit ${auditId}. Generating report.`);
+
+  const reportData = await prepareReportData(opportunities);
+
+  const excelWorkbook = await createExcelReport(reportData);
+
+  const SHAREPOINT_URL = 'https://adobe.sharepoint.com/:x:/r/sites/HelixProjects/Shared%20Documents/sites/elmo-ui-data';
+  const sharepointClient = await createFrom({
+    clientId: env.SHAREPOINT_CLIENT_ID,
+    clientSecret: env.SHAREPOINT_CLIENT_SECRET,
+    authority: env.SHAREPOINT_AUTHORITY,
+    domainId: env.SHAREPOINT_DOMAIN_ID,
+  }, { url: SHAREPOINT_URL, type: 'onedrive' });
+
+  const { weekStart, weekEnd } = getWeekRange(-1); // Assuming report for last week
+  const periodIdentifier = generatePeriodIdentifier(weekStart, weekEnd);
+  const domain = new URL(site.getBaseURL()).hostname.replace('www.', '');
+  const excelFilename = `llm-404-blocked-${domain}-${periodIdentifier}.xlsx`;
+
+  const outputLocation = site.getConfig()?.getCdnLogsConfig()?.outputLocation || domain;
+
+  await saveExcelReport({
+    workbook: excelWorkbook,
+    outputLocation,
+    log,
+    sharepointClient,
+    filename: excelFilename,
+  });
+
+  log.info(`[${LLM_404_BLOCKED_AUDIT}] Report for audit ${auditId} generated and uploaded successfully.`);
+
+  return ok();
+}

--- a/src/llm-404-blocked/utils.js
+++ b/src/llm-404-blocked/utils.js
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import ExcelJS from 'exceljs';
+import { tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
+import { API_BASE_URL, LLM_404_BLOCKED_AUDIT } from './constants.js';
+import { sleep } from '../support/utils.js';
+
+/**
+ * Convert URL paths to full URLs using site base URL
+ * @param {Array} urlPaths - Array of URL paths (e.g., ["/404.html", "/page"])
+ * @param {string} siteBaseUrl - Site base URL
+ * @param {Object} log - Logger instance
+ * @returns {Array} Array of full URLs
+ */
+export function convertPathsToFullUrls(urlPaths, siteBaseUrl, log) {
+  const fullUrls = [];
+
+  for (const path of urlPaths) {
+    try {
+      const fullUrl = new URL(path, siteBaseUrl).href;
+      fullUrls.push(fullUrl);
+    } catch {
+      log.warn(`[${LLM_404_BLOCKED_AUDIT}] Invalid URL path: ${path}, skipping`);
+    }
+  }
+
+  return fullUrls;
+}
+
+// Moved after function definitions below
+
+export function buildApiUrl(outputLocation, weekPeriod) {
+  return `${API_BASE_URL}/${outputLocation}/agentictraffic-chatgpt-${weekPeriod}.json`;
+}
+
+// Excel generation utilities
+const EXCEL_CONFIG = {
+  DEFAULT_COLUMN_WIDTH: 30,
+  NUMBER_FORMAT: '#,##0',
+  FONT: {
+    bold: true,
+    size: 11,
+    color: { argb: 'FF000000' },
+  },
+};
+
+function styleHeaders(worksheet) {
+  const headerRow = worksheet.getRow(1);
+  headerRow.font = EXCEL_CONFIG.FONT;
+}
+
+function formatColumns(worksheet) {
+  worksheet.columns.forEach((column, index) => {
+    let maxLength = 0;
+    column.eachCell({ includeEmpty: true }, (cell) => {
+      const cellLength = cell.value ? cell.value.toString().length : 10;
+      if (cellLength > maxLength) {
+        maxLength = cellLength;
+      }
+    });
+    // eslint-disable-next-line no-param-reassign
+    column.width = Math.min(Math.max(maxLength, 15), 60);
+
+    if (index === 1) { // 'Number of 404s' column
+      // eslint-disable-next-line no-param-reassign
+      column.numFmt = EXCEL_CONFIG.NUMBER_FORMAT;
+    }
+  });
+}
+
+export async function createExcelReport(reportData) {
+  const workbook = new ExcelJS.Workbook();
+  workbook.creator = 'SpaceCat';
+  workbook.created = new Date();
+
+  const worksheet = workbook.addWorksheet('LLM-404-Blocked-Suggestions');
+
+  worksheet.columns = [
+    { header: 'URL', key: 'url', width: 60 },
+    { header: 'Number of 404s', key: 'count404s', width: 20 },
+    { header: 'Suggestions', key: 'suggestions', width: 60 },
+  ];
+
+  styleHeaders(worksheet);
+
+  reportData.forEach((row) => {
+    worksheet.addRow({
+      url: row.url,
+      count404s: row.count_404s,
+      suggestions: row.suggestions.join(', '),
+    });
+  });
+
+  formatColumns(worksheet);
+
+  return workbook;
+}
+
+const TIME_CONSTANTS = {
+  ISO_MONDAY: 1,
+  ISO_SUNDAY: 0,
+  DAYS_PER_WEEK: 7,
+};
+
+export function formatDateString(date) {
+  return date.toISOString().split('T')[0];
+}
+
+function getWeekNumber(date) {
+  const d = new Date(date);
+  d.setUTCHours(0, 0, 0, 0);
+  d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  return Math.ceil(((d - yearStart) / 86400000 + 1) / 7);
+}
+
+export function getWeekRange(offsetWeeks = 0, referenceDate = new Date()) {
+  const refDate = new Date(referenceDate);
+  const isSunday = refDate.getUTCDay() === TIME_CONSTANTS.ISO_SUNDAY;
+  const daysToMonday = isSunday ? 6 : refDate.getUTCDay() - TIME_CONSTANTS.ISO_MONDAY;
+
+  const weekStart = new Date(refDate);
+  const totalOffset = daysToMonday - (offsetWeeks * TIME_CONSTANTS.DAYS_PER_WEEK);
+  weekStart.setUTCDate(refDate.getUTCDate() - totalOffset);
+  weekStart.setUTCHours(0, 0, 0, 0);
+
+  const weekEnd = new Date(weekStart);
+  weekEnd.setUTCDate(weekStart.getUTCDate() + 6);
+  weekEnd.setUTCHours(23, 59, 59, 999);
+
+  return { weekStart, weekEnd };
+}
+
+export function generatePeriodIdentifier(startDate, endDate) {
+  const start = formatDateString(startDate);
+  const end = formatDateString(endDate);
+
+  const diffDays = Math.ceil((endDate - startDate) / (24 * 60 * 60 * 1000));
+  if (diffDays === 7) {
+    const year = startDate.getUTCFullYear();
+    const weekNum = getWeekNumber(startDate);
+    return `w${String(weekNum).padStart(2, '0')}-${year}`;
+  }
+
+  return `${start}_to_${end}`;
+}
+
+export function calculateCurrentWeek() {
+  // Get last week's range (offset -1)
+  const { weekStart, weekEnd } = getWeekRange(-1);
+
+  // Generate period identifier in format "w28-2025"
+  return generatePeriodIdentifier(weekStart, weekEnd);
+}
+
+// Report upload functions
+async function publishToAdminHlx(filename, outputLocation, log) {
+  try {
+    const org = 'adobe';
+    const site = 'project-elmo-ui-data';
+    const ref = 'main';
+    const jsonFilename = `${filename.replace(/\.[^/.]+$/, '')}.json`;
+    const path = `${outputLocation}/${jsonFilename}`;
+    const headers = { Cookie: `auth_token=${process.env.ADMIN_HLX_API_KEY}` };
+
+    const baseUrl = 'https://admin.hlx.page';
+    const endpoints = [
+      { name: 'preview', url: `${baseUrl}/preview/${org}/${site}/${ref}/${path}` },
+      { name: 'live', url: `${baseUrl}/live/${org}/${site}/${ref}/${path}` },
+    ];
+
+    for (const [index, endpoint] of endpoints.entries()) {
+      log.info(`Publishing Excel report via admin API (${endpoint.name}): ${endpoint.url}`);
+
+      // eslint-disable-next-line no-await-in-loop
+      const response = await fetch(endpoint.url, { method: 'POST', headers });
+
+      if (!response.ok) {
+        throw new Error(`${endpoint.name} failed: ${response.status} ${response.statusText}`);
+      }
+
+      log.info(`Excel report successfully published to ${endpoint.name}`);
+
+      if (index === 0) {
+        log.info('Waiting 2 seconds before publishing to live...');
+        // eslint-disable-next-line no-await-in-loop
+        await sleep(2000);
+      }
+    }
+  } catch (publishError) {
+    log.error(`Failed to publish via admin.hlx.page: ${publishError.message}`);
+  }
+}
+
+async function uploadToSharePoint(buffer, filename, outputLocation, sharepointClient, log) {
+  try {
+    const documentPath = `/sites/elmo-ui-data/${outputLocation}/${filename}`;
+    const sharepointDoc = sharepointClient.getDocument(documentPath);
+    await sharepointDoc.uploadRawDocument(buffer);
+    log.info(`Excel report successfully uploaded to SharePoint: ${documentPath}`);
+  } catch (error) {
+    log.error(`Failed to upload to SharePoint: ${error.message}`);
+    throw error;
+  }
+}
+
+export async function saveExcelReport({
+  workbook,
+  outputLocation,
+  log,
+  sharepointClient,
+  filename,
+}) {
+  try {
+    const buffer = await workbook.xlsx.writeBuffer();
+    if (sharepointClient) {
+      await uploadToSharePoint(buffer, filename, outputLocation, sharepointClient, log);
+      await publishToAdminHlx(filename, outputLocation, log);
+    }
+  } catch (error) {
+    log.error(`Failed to save Excel report: ${error.message}`);
+    throw error;
+  }
+}


### PR DESCRIPTION
## Overview
Implements a new audit type that identifies 404 URLs being accessed by AI agents and generates redirect suggestions via Mystique.

## Key Features  
- **API Integration**: Fetches 404 data from CloudFront
- **Smart Filtering**: Threshold-based filtering ( more than 5 agentic hits) with fallback to top-N URLs
- **AI Integration**: Sends URLs to Mystique for AI suggestions
- **Excel Reports**: Generates excel reports and uploads them to sharepoint

## Files Added
Core Audit Module
- src/llm-404-blocked/handler.js - Main audit runner, fetches 404 data from CloudFront API
- src/llm-404-blocked/opportunity-data-mapper.js - Post-processor that creates opportunities and queues Mystique messages
- src/llm-404-blocked/guidance-handler.js - Processes AI responses from Mystique and updates suggestions
- src/llm-404-blocked/report-handler.js - Generates and distributes Excel reports
- src/llm-404-blocked/constants.js - Configuration constants and thresholds
- src/llm-404-blocked/utils.js - Utility functions (date handling, Excel generation, report upload)
## Integration
- src/index.js - Registered new handlers: llm-404-blocked, guidance:llm-404-blocked, llm-404-blocked-report