### PR TITLE
feat: add error label in the error logs for easier query

### DIFF
--- a/src/accessibility/guidance-handlers/guidance-accessibility-remediation.js
+++ b/src/accessibility/guidance-handlers/guidance-accessibility-remediation.js
@@ -21,14 +21,14 @@ export default async function handler(message, context) {
     const result = await handleAccessibilityRemediationGuidance(message, context);
 
     if (!result.success) {
-      log.error(`[A11yIndividual] Failed to process guidance: ${result.error}`);
+      log.error(`[A11yIndividual][A11yProcessingError] Failed to process guidance: ${result.error}`);
       return ok(); // Still return ok to avoid retries
     }
 
     log.info('Successfully processed accessibility remediation guidance');
     return ok();
   } catch (error) {
-    log.error(`[A11yIndividual] Error processing accessibility remediation guidance: ${error.message}`);
+    log.error(`[A11yIndividual][A11yProcessingError] Error processing accessibility remediation guidance: ${error.message}`);
     return ok(); // Return ok to avoid retries
   }
 }

--- a/src/accessibility/handler.js
+++ b/src/accessibility/handler.js
@@ -76,7 +76,7 @@ export async function scrapeAccessibilityData(context) {
   const bucketName = env.S3_SCRAPER_BUCKET_NAME;
   if (!bucketName) {
     const errorMsg = 'Missing S3 bucket configuration for accessibility audit';
-    log.error(errorMsg);
+    log.error(`[A11yProcessingError] ${errorMsg}`);
     return {
       status: 'PROCESSING_FAILED',
       error: errorMsg,
@@ -153,7 +153,7 @@ export async function processAccessibilityOpportunities(context) {
   const bucketName = env.S3_SCRAPER_BUCKET_NAME;
   if (!bucketName) {
     const errorMsg = 'Missing S3 bucket configuration for accessibility audit';
-    log.error(errorMsg);
+    log.error(`[A11yProcessingError] ${errorMsg}`);
     return {
       status: 'PROCESSING_FAILED',
       error: errorMsg,
@@ -176,14 +176,14 @@ export async function processAccessibilityOpportunities(context) {
     );
 
     if (!aggregationResult.success) {
-      log.error(`[A11yAudit] No data aggregated for site ${siteId} (${site.getBaseURL()}): ${aggregationResult.message}`);
+      log.error(`[A11yAudit][A11yProcessingError] No data aggregated for site ${siteId} (${site.getBaseURL()}): ${aggregationResult.message}`);
       return {
         status: 'NO_OPPORTUNITIES',
         message: aggregationResult.message,
       };
     }
   } catch (error) {
-    log.error(`[A11yAudit] Error processing accessibility data for site ${siteId} (${site.getBaseURL()}): ${error.message}`, error);
+    log.error(`[A11yAudit][A11yProcessingError] Error processing accessibility data for site ${siteId} (${site.getBaseURL()}): ${error.message}`, error);
     return {
       status: 'PROCESSING_FAILED',
       error: error.message,
@@ -201,7 +201,7 @@ export async function processAccessibilityOpportunities(context) {
       AUDIT_TYPE_ACCESSIBILITY,
     );
   } catch (error) {
-    log.error(`[A11yAudit] Error generating report opportunities for site ${siteId} (${site.getBaseURL()}): ${error.message}`, error);
+    log.error(`[A11yAudit][A11yProcessingError] Error generating report opportunities for site ${siteId} (${site.getBaseURL()}): ${error.message}`, error);
     return {
       status: 'PROCESSING_FAILED',
       error: error.message,
@@ -216,7 +216,7 @@ export async function processAccessibilityOpportunities(context) {
     );
     log.debug(`[A11yAudit] Individual opportunities created successfully for site ${siteId} (${site.getBaseURL()})`);
   } catch (error) {
-    log.error(`[A11yAudit] Error creating individual opportunities for site ${siteId} (${site.getBaseURL()}): ${error.message}`, error);
+    log.error(`[A11yAudit][A11yProcessingError] Error creating individual opportunities for site ${siteId} (${site.getBaseURL()}): ${error.message}`, error);
     return {
       status: 'PROCESSING_FAILED',
       error: error.message,
@@ -233,7 +233,7 @@ export async function processAccessibilityOpportunities(context) {
     );
     log.debug(`[A11yAudit] Saved a11y metrics for site ${siteId} - Result:`, metricsResult);
   } catch (error) {
-    log.error(`[A11yAudit] Error saving a11y metrics to s3 for site ${siteId} (${site.getBaseURL()}): ${error.message}`, error);
+    log.error(`[A11yAudit][A11yProcessingError] Error saving a11y metrics to s3 for site ${siteId} (${site.getBaseURL()}): ${error.message}`, error);
     return {
       status: 'PROCESSING_FAILED',
       error: error.message,

--- a/src/accessibility/utils/generate-individual-opportunities.js
+++ b/src/accessibility/utils/generate-individual-opportunities.js
@@ -105,7 +105,7 @@ async function sendMystiqueMessage({
     };
   } catch (error) {
     log.error(
-      `[A11yIndividual] Failed to send message to Mystique for url ${url}, message: ${JSON.stringify(message, null, 2)} with error: ${error.message}`,
+      `[A11yIndividual][A11yProcessingError] Failed to send message to Mystique for url ${url}, message: ${JSON.stringify(message, null, 2)} with error: ${error.message}`,
     );
     return {
       success: false,
@@ -338,7 +338,7 @@ export async function createIndividualOpportunity(opportunityInstance, auditData
     log.debug(`[A11yIndividual] Created opportunity with ID: ${opportunity.getId()}`);
     return { opportunity };
   } catch (e) {
-    log.error(`Failed to create new opportunity for siteId ${auditData.siteId} and auditId ${auditData.auditId}: ${e.message}`);
+    log.error(`[A11yProcessingError] Failed to create new opportunity for siteId ${auditData.siteId} and auditId ${auditData.auditId}: ${e.message}`);
     throw new Error(e.message);
   }
 }
@@ -442,7 +442,7 @@ export async function createIndividualOpportunitySuggestions(
 
     // Validate required context objects before proceeding
     if (!sqs || !env || !env.QUEUE_SPACECAT_TO_MYSTIQUE) {
-      log.error(`[A11yIndividual] Missing required context - sqs: ${!!sqs}, env: ${!!env}, queue: ${env?.QUEUE_SPACECAT_TO_MYSTIQUE || 'undefined'}`);
+      log.error(`[A11yIndividual][A11yProcessingError] Missing required context - sqs: ${!!sqs}, env: ${!!env}, queue: ${env?.QUEUE_SPACECAT_TO_MYSTIQUE || 'undefined'}`);
       return { success: false, error: 'Missing SQS context or queue configuration' };
     }
 
@@ -476,7 +476,7 @@ export async function createIndividualOpportunitySuggestions(
 
     return { success: true };
   } catch (e) {
-    log.error(`Failed to create suggestions for opportunity ${opportunity.getId()}: ${e.message}`);
+    log.error(`[A11yProcessingError] Failed to create suggestions for opportunity ${opportunity.getId()}: ${e.message}`);
     throw new Error(e.message);
   }
 }
@@ -616,7 +616,7 @@ export async function createAccessibilityIndividualOpportunities(accessibilityDa
           if (!creatorFunc) {
             const availableCreators = Object.keys(opportunityCreators).join(', ');
             log.error(
-              `[A11yIndividual] No opportunity creator found for type: ${opportunityType}. Available creators: ${availableCreators}`,
+              `[A11yIndividual][A11yProcessingError] No opportunity creator found for type: ${opportunityType}. Available creators: ${availableCreators}`,
             );
             throw new Error(`No opportunity creator found for type: ${opportunityType}`);
           }
@@ -633,7 +633,7 @@ export async function createAccessibilityIndividualOpportunities(accessibilityDa
             );
           } catch (error) {
             log.error(
-              `Failed to find or create individual accessibility opportunity for ${opportunityType}: ${error.message}`,
+              `[A11yProcessingError] Failed to find or create individual accessibility opportunity for ${opportunityType}: ${error.message}`,
             );
             throw new Error(error.message);
           }
@@ -651,7 +651,7 @@ export async function createAccessibilityIndividualOpportunities(accessibilityDa
             );
           } catch (error) {
             const errorMsg = `Failed to update individual accessibility opportunity suggestions for ${opportunityType}: ${error.message}`;
-            log.error(errorMsg);
+            log.error(`[A11yProcessingError] ${errorMsg}`);
             throw new Error(error.message);
           }
 
@@ -689,7 +689,7 @@ export async function createAccessibilityIndividualOpportunities(accessibilityDa
       ...aggregatedData,
     };
   } catch (error) {
-    log.error(`[A11yIndividual] Error processing accessibility opportunities: ${error.message}`, error);
+    log.error(`[A11yIndividual][A11yProcessingError] Error processing accessibility opportunities: ${error.message}`, error);
     return {
       status: 'OPPORTUNITIES_FAILED',
       error: error.message,
@@ -753,13 +753,13 @@ export async function handleAccessibilityRemediationGuidance(message, context) {
     const opportunity = await Opportunity.findById(opportunityId);
 
     if (!opportunity) {
-      log.error(`[A11yRemediationGuidance] site ${siteId}, audit ${auditId}, page ${pageUrl}, opportunity ${opportunityId}: Opportunity not found`);
+      log.error(`[A11yRemediationGuidance][A11yProcessingError] site ${siteId}, audit ${auditId}, page ${pageUrl}, opportunity ${opportunityId}: Opportunity not found`);
       return { success: false, error: 'Opportunity not found' };
     }
 
     // Verify the opportunity belongs to the correct site
     if (opportunity.getSiteId() !== siteId) {
-      log.error(`[A11yRemediationGuidance] site ${siteId}, audit ${auditId}, page ${pageUrl}, opportunity ${opportunityId}: Site ID mismatch. Expected: ${siteId}, Found: ${opportunity.getSiteId()}`);
+      log.error(`[A11yRemediationGuidance][A11yProcessingError] site ${siteId}, audit ${auditId}, page ${pageUrl}, opportunity ${opportunityId}: Site ID mismatch. Expected: ${siteId}, Found: ${opportunity.getSiteId()}`);
       return { success: false, error: 'Site ID mismatch' };
     }
 
@@ -849,7 +849,7 @@ export async function handleAccessibilityRemediationGuidance(message, context) {
     saveResults.forEach((result, index) => {
       if (result.status === 'rejected') {
         failedSuggestionIds.push(processingPromises[index].suggestionId);
-        log.error(`[A11yRemediationGuidance] site ${siteId}, audit ${auditId}, page ${pageUrl}, opportunity ${opportunityId}: Failed to save suggestion ${processingPromises[index].suggestionId}: ${result.reason}`);
+        log.error(`[A11yRemediationGuidance][A11yProcessingError] site ${siteId}, audit ${auditId}, page ${pageUrl}, opportunity ${opportunityId}: Failed to save suggestion ${processingPromises[index].suggestionId}: ${result.reason}`);
       } else {
         successfulSaves += 1;
       }
@@ -904,7 +904,7 @@ export async function handleAccessibilityRemediationGuidance(message, context) {
       );
       log.info(`[A11yRemediationGuidance] Saved complete Mystique validation metrics for opportunity ${opportunityId}, page ${pageUrl}: sent=${sentCount}, received=${receivedCount}`);
     } catch (error) {
-      log.error(`[A11yRemediationGuidance] Failed to save Mystique validation metrics for opportunity ${opportunityId}, page ${pageUrl}: ${error.message}`);
+      log.error(`[A11yRemediationGuidance][A11yProcessingError] Failed to save Mystique validation metrics for opportunity ${opportunityId}, page ${pageUrl}: ${error.message}`);
     }
 
     return {
@@ -916,7 +916,7 @@ export async function handleAccessibilityRemediationGuidance(message, context) {
       failedSuggestionIds,
     };
   } catch (error) {
-    log.error(`[A11yRemediationGuidance] site ${siteId}, audit ${auditId}, page ${pageUrl}, opportunity ${opportunityId}: Failed to process accessibility remediation guidance: ${error.message}`);
+    log.error(`[A11yRemediationGuidance][A11yProcessingError] site ${siteId}, audit ${auditId}, page ${pageUrl}, opportunity ${opportunityId}: Failed to process accessibility remediation guidance: ${error.message}`);
     return { success: false, error: error.message };
   }
 }

--- a/src/accessibility/utils/scrape-utils.js
+++ b/src/accessibility/utils/scrape-utils.js
@@ -43,7 +43,7 @@ export async function getExistingObjectKeysFromFailedAudits(s3Client, bucketName
     log.info(`[A11yAudit] Found ${objectKeys.length} existing URLs from failed audits for site ${siteId}.`);
     return objectKeys;
   } catch (error) {
-    log.error(`[A11yAudit] Error getting existing URLs from failed audits for site ${siteId}: ${error.message}`);
+    log.error(`[A11yAudit][A11yProcessingError] Error getting existing URLs from failed audits for site ${siteId}: ${error.message}`);
     return []; // Return empty array on error to prevent downstream issues
   }
 }
@@ -154,7 +154,7 @@ export async function updateStatusToIgnored(
     const failedUpdates = updateResults.filter((result) => result.status === 'rejected');
 
     if (failedUpdates.length > 0) {
-      log.error(`[A11yAudit] Failed to update ${failedUpdates.length} opportunities for site ${siteId}: ${JSON.stringify(failedUpdates)}`);
+      log.error(`[A11yAudit][A11yProcessingError] Failed to update ${failedUpdates.length} opportunities for site ${siteId}: ${JSON.stringify(failedUpdates)}`);
     }
 
     return {
@@ -163,7 +163,7 @@ export async function updateStatusToIgnored(
       error: failedUpdates.length > 0 ? 'Some updates failed' : undefined,
     };
   } catch (error) {
-    log.error(`[A11yAudit] Error updating opportunities to IGNORED for site ${siteId}: ${error.message}`);
+    log.error(`[A11yAudit][A11yProcessingError] Error updating opportunities to IGNORED for site ${siteId}: ${error.message}`);
     return {
       success: false,
       updatedCount: 0,
@@ -300,7 +300,7 @@ export async function saveA11yMetricsToS3(reportData, context) {
       s3Key,
     };
   } catch (error) {
-    log.error(`[A11yAudit] Error saving metrics to S3 for site ${siteId} (${baseUrl}): ${error.message}`);
+    log.error(`[A11yAudit][A11yProcessingError] Error saving metrics to S3 for site ${siteId} (${baseUrl}): ${error.message}`);
     return {
       success: false,
       message: `Failed to save a11y metrics to S3: ${error.message}`,
@@ -394,7 +394,7 @@ export async function saveMystiqueValidationMetricsToS3(
       s3Key,
     };
   } catch (error) {
-    log.error(`[A11yValidation] Error saving mystique validation metrics to S3 for site ${siteId}, opportunity ${opportunityId}: ${error.message}`);
+    log.error(`[A11yValidation][A11yProcessingError] Error saving mystique validation metrics to S3 for site ${siteId}, opportunity ${opportunityId}: ${error.message}`);
     return {
       success: false,
       message: `Failed to save mystique validation metrics to S3: ${error.message}`,

--- a/test/audits/accessibility.test.js
+++ b/test/audits/accessibility.test.js
@@ -161,7 +161,7 @@ describe('Accessibility Audit Handler', () => {
 
       // Assert
       expect(mockContext.log.error).to.have.been.calledWith(
-        'Missing S3 bucket configuration for accessibility audit',
+        '[A11yProcessingError] Missing S3 bucket configuration for accessibility audit',
       );
 
       expect(result).to.deep.equal({
@@ -841,7 +841,7 @@ describe('Accessibility Audit Handler', () => {
 
       // Assert
       expect(mockContext.log.error).to.have.been.calledWith(
-        '[A11yAudit] Error creating individual opportunities for site test-site-id (https://example.com): Failed to create individual opportunities',
+        '[A11yAudit][A11yProcessingError] Error creating individual opportunities for site test-site-id (https://example.com): Failed to create individual opportunities',
         error,
       );
 
@@ -901,7 +901,7 @@ describe('Accessibility Audit Handler', () => {
 
       // Assert
       expect(mockContext.log.error).to.have.been.calledWith(
-        'Missing S3 bucket configuration for accessibility audit',
+        '[A11yProcessingError] Missing S3 bucket configuration for accessibility audit',
       );
 
       expect(result).to.deep.equal({
@@ -926,7 +926,7 @@ describe('Accessibility Audit Handler', () => {
 
       // Assert
       expect(mockContext.log.error).to.have.been.calledWith(
-        '[A11yAudit] No data aggregated for site test-site-id (https://example.com): No accessibility data found',
+        '[A11yAudit][A11yProcessingError] No data aggregated for site test-site-id (https://example.com): No accessibility data found',
       );
 
       expect(result).to.deep.equal({
@@ -948,7 +948,7 @@ describe('Accessibility Audit Handler', () => {
 
       // Assert
       expect(mockContext.log.error).to.have.been.calledWith(
-        '[A11yAudit] Error processing accessibility data for site test-site-id (https://example.com): S3 connection failed',
+        '[A11yAudit][A11yProcessingError] Error processing accessibility data for site test-site-id (https://example.com): S3 connection failed',
         error,
       );
 
@@ -991,7 +991,7 @@ describe('Accessibility Audit Handler', () => {
 
       // Assert
       expect(mockContext.log.error).to.have.been.calledWith(
-        '[A11yAudit] Error generating report opportunities for site test-site-id (https://example.com): Failed to create opportunity',
+        '[A11yAudit][A11yProcessingError] Error generating report opportunities for site test-site-id (https://example.com): Failed to create opportunity',
         error,
       );
 
@@ -1205,7 +1205,7 @@ describe('Accessibility Audit Handler', () => {
       );
 
       expect(mockContext.log.error).to.have.been.calledWith(
-        '[A11yAudit] Error saving a11y metrics to s3 for site test-site-id (https://example.com): S3 upload failed',
+        '[A11yAudit][A11yProcessingError] Error saving a11y metrics to s3 for site test-site-id (https://example.com): S3 upload failed',
         error,
       );
 

--- a/test/audits/accessibility/data-processing.test.js
+++ b/test/audits/accessibility/data-processing.test.js
@@ -114,7 +114,7 @@ describe('data-processing utility functions', () => {
       const result = await deleteOriginalFiles(mockS3Client, 'test-bucket', objectKeys, mockLog);
 
       expect(result).to.equal(0);
-      expect(mockLog.error.calledWith('Error deleting original files', error)).to.be.true;
+      expect(mockLog.error.calledWith('[A11yProcessingError] Error deleting original files', error)).to.be.true;
     });
 
     it('should handle errors for multiple files', async () => {
@@ -125,7 +125,7 @@ describe('data-processing utility functions', () => {
       const result = await deleteOriginalFiles(mockS3Client, 'test-bucket', objectKeys, mockLog);
 
       expect(result).to.equal(0);
-      expect(mockLog.error.calledWith('Error deleting original files', error)).to.be.true;
+      expect(mockLog.error.calledWith('[A11yProcessingError] Error deleting original files', error)).to.be.true;
     });
   });
 
@@ -263,7 +263,7 @@ describe('data-processing utility functions', () => {
         expect.fail('Should have thrown an error');
       } catch (thrownError) {
         expect(thrownError).to.equal(error);
-        expect(mockLog.error.calledWith('Error while fetching S3 object keys using bucket test-bucket and prefix accessibility/site1/ with delimiter /', error)).to.be.true;
+        expect(mockLog.error.calledWith('[A11yProcessingError] Error while fetching S3 object keys using bucket test-bucket and prefix accessibility/site1/ with delimiter /', error)).to.be.true;
       }
     });
 
@@ -975,7 +975,7 @@ describe('data-processing utility functions', () => {
         expect.fail('Should have thrown an error');
       } catch (thrownError) {
         expect(thrownError.message).to.equal('Database connection failed');
-        expect(mockLog.error.calledWith('Failed to create new opportunity for siteId test-site-123 and auditId audit-456: Database connection failed')).to.be.true;
+        expect(mockLog.error.calledWith('[A11yProcessingError] Failed to create new opportunity for siteId test-site-123 and auditId audit-456: Database connection failed')).to.be.true;
       }
     });
 
@@ -1093,7 +1093,7 @@ describe('data-processing utility functions', () => {
         const suggestion = await opportunity.addSuggestions(suggestions);
         return { suggestion };
       } catch (e) {
-        log.error(`Failed to create new suggestion for siteId ${auditData.siteId} and auditId ${auditData.auditId}: ${e.message}`);
+        log.error(`[A11yProcessingError] Failed to create new suggestion for siteId ${auditData.siteId} and auditId ${auditData.auditId}: ${e.message}`);
         throw new Error(e.message);
       }
     };
@@ -1141,7 +1141,7 @@ describe('data-processing utility functions', () => {
         expect.fail('Should have thrown an error');
       } catch (thrownError) {
         expect(thrownError.message).to.equal('Failed to add suggestions');
-        expect(mockLog.error.calledWith('Failed to create new suggestion for siteId test-site-123 and auditId audit-456: Failed to add suggestions')).to.be.true;
+        expect(mockLog.error.calledWith('[A11yProcessingError] Failed to create new suggestion for siteId test-site-123 and auditId audit-456: Failed to add suggestions')).to.be.true;
       }
     });
 
@@ -1227,7 +1227,7 @@ describe('data-processing utility functions', () => {
         );
         expect.fail('Should have thrown an error');
       } catch {
-        expect(mockLog.error.calledWith('Failed to create new suggestion for siteId different-site and auditId different-audit: Validation failed')).to.be.true;
+        expect(mockLog.error.calledWith('[A11yProcessingError] Failed to create new suggestion for siteId different-site and auditId different-audit: Validation failed')).to.be.true;
       }
     });
 
@@ -1283,7 +1283,7 @@ describe('data-processing utility functions', () => {
 
         // Test line 486: log.error with specific format
         expect(mockLog.error.calledWith(
-          'Failed to create new suggestion for siteId test-site-456 and auditId audit-789: Database connection failed',
+          '[A11yProcessingError] Failed to create new suggestion for siteId test-site-456 and auditId audit-789: Database connection failed',
         )).to.be.true;
       } finally {
         // Restore the original function
@@ -1307,7 +1307,7 @@ describe('data-processing utility functions', () => {
       expect(result.success).to.be.false;
       expect(result.aggregatedData).to.be.null;
       expect(result.message).to.equal('Missing required parameters for aggregateAccessibilityData');
-      expect(mockLog.error.calledWith('Missing required parameters for aggregateAccessibilityData')).to.be.true;
+      expect(mockLog.error.calledWith('[A11yProcessingError] Missing required parameters for aggregateAccessibilityData')).to.be.true;
     });
 
     it('should return error when bucketName is missing', async () => {
@@ -1465,7 +1465,7 @@ describe('data-processing utility functions', () => {
       expect(result.success).to.be.false;
       expect(result.aggregatedData).to.be.null;
       expect(result.message).to.equal('[A11yAudit] No files could be processed successfully for site test-site');
-      expect(mockLog.error.calledWith('[A11yAudit] No files could be processed successfully for site test-site')).to.be.true;
+      expect(mockLog.error.calledWith('[A11yProcessingError] [A11yAudit] No files could be processed successfully for site test-site')).to.be.true;
     });
 
     it('should successfully aggregate data with single file', async () => {
@@ -1712,7 +1712,7 @@ describe('data-processing utility functions', () => {
       expect(result.aggregatedData).to.be.null;
       expect(result.message).to.equal('Error: S3 save failed');
       // The main catch block in aggregateAccessibilityData logs a generic error
-      expect(mockLog.error.calledWith('[A11yAudit] Error aggregating accessibility data for site test-site')).to.be.true;
+      expect(mockLog.error.calledWith('[A11yAudit][A11yProcessingError] Error aggregating accessibility data for site test-site')).to.be.true;
     });
 
     it('should handle lastWeekFile logging correctly', async () => {
@@ -2051,7 +2051,7 @@ describe('data-processing utility functions', () => {
       expect(result.success).to.be.false;
       expect(result.aggregatedData).to.be.null;
       expect(result.message).to.equal('[FormsA11yAudit] No files could be processed successfully for site test-site');
-      expect(mockLog.error.calledWith('[FormsA11yAudit] No files could be processed successfully for site test-site')).to.be.true;
+      expect(mockLog.error.calledWith('[A11yProcessingError] [FormsA11yAudit] No files could be processed successfully for site test-site')).to.be.true;
     });
 
     it('should handle forms-opportunities audit type error with correct log identifier', async () => {
@@ -2094,7 +2094,7 @@ describe('data-processing utility functions', () => {
       expect(result.aggregatedData).to.be.null;
       expect(result.message).to.equal('Error: S3 save failed');
       // Verify the correct log identifier is used in error message
-      expect(mockLog.error.calledWith('[FormsA11yAudit] Error aggregating accessibility data for site test-site')).to.be.true;
+      expect(mockLog.error.calledWith('[FormsA11yAudit][A11yProcessingError] Error aggregating accessibility data for site test-site')).to.be.true;
     });
   });
 
@@ -2327,7 +2327,7 @@ describe('data-processing utility functions', () => {
           'Retrying file failing-file.json (attempt 1/1): Persistent S3 error',
         );
         expect(mockLog.error).to.have.been.calledWith(
-          'Failed to process file failing-file.json after 1 retries: Persistent S3 error',
+          '[A11yProcessingError] Failed to process file failing-file.json after 1 retries: Persistent S3 error',
         );
         expect(mockLog.warn).to.have.been.calledWith(
           '1 out of 1 files failed to process, continuing with 0 successful files',
@@ -2377,7 +2377,7 @@ describe('data-processing utility functions', () => {
           'Retrying file retry-success-file.json (attempt 1/1): Temporary failure',
         );
         expect(mockLog.error).to.have.been.calledWith(
-          'Failed to process file fail-file.json after 1 retries: Permanent failure',
+          '[A11yProcessingError] Failed to process file fail-file.json after 1 retries: Permanent failure',
         );
         expect(mockLog.warn).to.have.been.calledWith(
           '1 out of 3 files failed to process, continuing with 2 successful files',
@@ -2406,7 +2406,7 @@ describe('data-processing utility functions', () => {
           'Retrying file default-retry-file.json (attempt 1/1): Error for default retry test',
         );
         expect(mockLog.error).to.have.been.calledWith(
-          'Failed to process file default-retry-file.json after 1 retries: Error for default retry test',
+          '[A11yProcessingError] Failed to process file default-retry-file.json after 1 retries: Error for default retry test',
         );
       });
     });
@@ -2502,7 +2502,7 @@ describe('data-processing utility functions', () => {
           sinon.match(/Retrying file/),
         );
         expect(mockLog.error).to.have.been.calledWith(
-          'Failed to process file no-retry-file.json after 0 retries: No retry error',
+          '[A11yProcessingError] Failed to process file no-retry-file.json after 0 retries: No retry error',
         );
       });
 
@@ -2936,7 +2936,7 @@ describe('data-processing utility functions', () => {
         expect(result).to.be.an('array');
         expect(result).to.have.length(0);
         expect(mockLogForAudit.error.calledWith(
-          '[A11yAudit] No final result files found for no-files-site',
+          '[A11yProcessingError] [A11yAudit] No final result files found for no-files-site',
         )).to.be.true;
       });
 
@@ -2969,7 +2969,7 @@ describe('data-processing utility functions', () => {
         expect(result).to.be.an('array');
         expect(result).to.have.length(0);
         expect(mockLogForAudit.error.calledWith(
-          '[A11yAudit] Error getting final result files for error-site: S3 access denied',
+          '[A11yAudit][A11yProcessingError] Error getting final result files for error-site: S3 access denied',
         )).to.be.true;
       });
 
@@ -3001,7 +3001,7 @@ describe('data-processing utility functions', () => {
         expect(result).to.be.an('array');
         expect(result).to.have.length(0);
         expect(mockLogForAudit.error.calledWith(
-          '[A11yAudit] No latest final result file found for null-file-site',
+          '[A11yProcessingError] [A11yAudit] No latest final result file found for null-file-site',
         )).to.be.true;
       });
 
@@ -3034,7 +3034,7 @@ describe('data-processing utility functions', () => {
         expect(result).to.be.an('array');
         expect(result).to.have.length(0);
         expect(mockLogForAudit.error.calledWith(
-          '[A11yAudit] Error getting latest final result file for get-object-error-site: Failed to get object from S3',
+          '[A11yAudit][A11yProcessingError] Error getting latest final result file for get-object-error-site: Failed to get object from S3',
         )).to.be.true;
       });
 
@@ -3072,7 +3072,7 @@ describe('data-processing utility functions', () => {
         expect(result).to.be.an('array');
         expect(result).to.have.length(0);
         expect(mockLogForAudit.error.calledWith(
-          '[A11yAudit] No URLs found for no-urls-site',
+          '[A11yProcessingError] [A11yAudit] No URLs found for no-urls-site',
         )).to.be.true;
       });
 
@@ -3102,7 +3102,7 @@ describe('data-processing utility functions', () => {
         expect(result).to.be.an('array');
         expect(result).to.have.length(0);
         expect(mockLogForAudit.error.calledWith(
-          '[A11yAudit] No URLs found for only-overall-site',
+          '[A11yProcessingError] [A11yAudit] No URLs found for only-overall-site',
         )).to.be.true;
       });
     });
@@ -3130,7 +3130,7 @@ describe('data-processing utility functions', () => {
         expect(result).to.be.an('array');
         expect(result).to.have.length(0);
         expect(mockLogForAudit.error.calledWith(
-          '[A11yAudit] No URLs found for empty-file-site',
+          '[A11yProcessingError] [A11yAudit] No URLs found for empty-file-site',
         )).to.be.true;
       });
 
@@ -3641,7 +3641,7 @@ describe('data-processing utility functions', () => {
         } catch (error) {
           expect(error.message).to.equal('Database connection failed');
           expect(mockLog.error.calledWith(
-            'Failed to create report opportunity for Error Test Report',
+            '[A11yProcessingError] Failed to create report opportunity for Error Test Report',
             'Database connection failed',
           )).to.be.true;
         }
@@ -3685,7 +3685,7 @@ describe('data-processing utility functions', () => {
         } catch (error) {
           expect(error.message).to.equal('Failed to add suggestions');
           expect(mockLog.error.calledWith(
-            'Failed to create report opportunity suggestion for Suggestion Error Report',
+            '[A11yProcessingError] Failed to create report opportunity suggestion for Suggestion Error Report',
             'Failed to add suggestions',
           )).to.be.true;
           expect(mockDataAccess.Opportunity.create.calledOnce).to.be.true;
@@ -4014,7 +4014,7 @@ describe('data-processing utility functions', () => {
         } catch (error) {
           expect(error.message).to.include('Database connection failed');
           expect(mockLog.error.calledWith(
-            'Failed to generate in-depth report opportunity',
+            '[A11yProcessingError] Failed to generate in-depth report opportunity',
             'Database connection failed',
           )).to.be.true;
         }
@@ -4043,7 +4043,7 @@ describe('data-processing utility functions', () => {
         } catch (error) {
           expect(error.message).to.include('Failed to create suggestions');
           expect(mockLog.error.calledWith(
-            'Failed to generate in-depth report opportunity',
+            '[A11yProcessingError] Failed to generate in-depth report opportunity',
             'Failed to create suggestions',
           )).to.be.true;
         }
@@ -4218,7 +4218,7 @@ describe('data-processing utility functions', () => {
         } catch (error) {
           expect(error.message).to.include('Enhanced report creation failed');
           expect(mockLog.error.calledWith(
-            'Failed to generate enhanced report opportunity',
+            '[A11yProcessingError] Failed to generate enhanced report opportunity',
             'Enhanced report creation failed',
           )).to.be.true;
         }
@@ -4259,7 +4259,7 @@ describe('data-processing utility functions', () => {
         } catch (error) {
           expect(error.message).to.include('Enhanced suggestions failed');
           expect(mockLog.error.calledWith(
-            'Failed to generate enhanced report opportunity',
+            '[A11yProcessingError] Failed to generate enhanced report opportunity',
             'Enhanced suggestions failed',
           )).to.be.true;
         }
@@ -4363,7 +4363,7 @@ describe('data-processing utility functions', () => {
         } catch (error) {
           expect(error.message).to.include('Enhanced report database error');
           expect(mockLog.error.calledWith(
-            'Failed to generate enhanced report opportunity',
+            '[A11yProcessingError] Failed to generate enhanced report opportunity',
             'Enhanced report database error',
           )).to.be.true;
         }
@@ -4480,7 +4480,7 @@ describe('data-processing utility functions', () => {
         } catch (error) {
           expect(error.message).to.include('Fixed vs new report creation failed');
           expect(mockLog.error.calledWith(
-            'Failed to generate fixed vs new report opportunity',
+            '[A11yProcessingError] Failed to generate fixed vs new report opportunity',
             'Fixed vs new report creation failed',
           )).to.be.true;
         }
@@ -4530,7 +4530,7 @@ describe('data-processing utility functions', () => {
         } catch (error) {
           expect(error.message).to.include('Fixed vs new suggestions failed');
           expect(mockLog.error.calledWith(
-            'Failed to generate fixed vs new report opportunity',
+            '[A11yProcessingError] Failed to generate fixed vs new report opportunity',
             'Fixed vs new suggestions failed',
           )).to.be.true;
         }
@@ -4685,7 +4685,7 @@ describe('data-processing utility functions', () => {
         } catch (error) {
           expect(error.message).to.include('Fixed vs new database error');
           expect(mockLog.error.calledWith(
-            'Failed to generate fixed vs new report opportunity',
+            '[A11yProcessingError] Failed to generate fixed vs new report opportunity',
             'Fixed vs new database error',
           )).to.be.true;
         }
@@ -4844,7 +4844,7 @@ describe('data-processing utility functions', () => {
         } catch (error) {
           expect(error.message).to.include('Base report creation failed');
           expect(mockLog.error.calledWith(
-            'Failed to generate base report opportunity',
+            '[A11yProcessingError] Failed to generate base report opportunity',
             'Base report creation failed',
           )).to.be.true;
         }
@@ -4885,7 +4885,7 @@ describe('data-processing utility functions', () => {
         } catch (error) {
           expect(error.message).to.include('Base report suggestions failed');
           expect(mockLog.error.calledWith(
-            'Failed to generate base report opportunity',
+            '[A11yProcessingError] Failed to generate base report opportunity',
             'Base report suggestions failed',
           )).to.be.true;
         }
@@ -4987,7 +4987,7 @@ describe('data-processing utility functions', () => {
         } catch (error) {
           expect(error.message).to.include('Base report database error');
           expect(mockLog.error.calledWith(
-            'Failed to generate base report opportunity',
+            '[A11yProcessingError] Failed to generate base report opportunity',
             'Base report database error',
           )).to.be.true;
         }

--- a/test/audits/accessibility/generate-individual-opportunities.test.js
+++ b/test/audits/accessibility/generate-individual-opportunities.test.js
@@ -1211,7 +1211,7 @@ describe('createIndividualOpportunity', () => {
     await expect(createIndividualOpportunity(opportunityInstance, auditData, mockContext))
       .to.be.rejectedWith('Test error');
     expect(mockContext.log.error).to.have.been.calledWith(
-      'Failed to create new opportunity for siteId test-site and auditId test-audit: Test error',
+      '[A11yProcessingError] Failed to create new opportunity for siteId test-site and auditId test-audit: Test error',
     );
   });
 });
@@ -1360,7 +1360,7 @@ describe('createIndividualOpportunitySuggestions', () => {
       mockLog,
     )).to.be.rejectedWith('Test error');
     expect(mockContext.log.error).to.have.been.calledWith(
-      'Failed to create suggestions for opportunity test-id: Test error',
+      '[A11yProcessingError] Failed to create suggestions for opportunity test-id: Test error',
     );
   });
 
@@ -2685,7 +2685,7 @@ describe('sendMystiqueMessage', () => {
       log: fakeLog,
     });
     expect(fakeSqs.sendMessage).to.have.been.calledOnce;
-    expect(fakeLog.error).to.have.been.calledWithMatch('[A11yIndividual] Failed to send message to Mystique');
+    expect(fakeLog.error).to.have.been.calledWithMatch('[A11yIndividual][A11yProcessingError] Failed to send message to Mystique');
     expect(result).to.deep.include({ success: false, url: 'https://example.com' });
     expect(result.error).to.equal('SQS error');
   });
@@ -2712,7 +2712,7 @@ describe('sendMystiqueMessage error path (coverage)', () => {
     expect(result.url).to.equal('https://example.com');
     expect(result.error).to.equal('Simulated SQS failure');
     expect(fakeLog.error).to.have.been.calledWithMatch(
-      '[A11yIndividual] Failed to send message to Mystique for url https://example.com',
+      '[A11yIndividual][A11yProcessingError] Failed to send message to Mystique for url https://example.com',
     );
   });
 });
@@ -2890,7 +2890,7 @@ describe('createIndividualOpportunitySuggestions missing SQS context coverage', 
     // Should return failure due to missing SQS context
     expect(result.success).to.be.false;
     expect(result.error).to.equal('Missing SQS context or queue configuration');
-    expect(mockLog.error).to.have.been.calledWithMatch('[A11yIndividual] Missing required context');
+    expect(mockLog.error).to.have.been.calledWithMatch('[A11yIndividual][A11yProcessingError] Missing required context');
   });
 
   it('should handle missing env.QUEUE_SPACECAT_TO_MYSTIQUE', async () => {
@@ -2914,7 +2914,7 @@ describe('createIndividualOpportunitySuggestions missing SQS context coverage', 
     // Should return failure due to missing queue name
     expect(result.success).to.be.false;
     expect(result.error).to.equal('Missing SQS context or queue configuration');
-    expect(mockLog.error).to.have.been.calledWithMatch('[A11yIndividual] Missing required context');
+    expect(mockLog.error).to.have.been.calledWithMatch('[A11yIndividual][A11yProcessingError] Missing required context');
   });
 });
 
@@ -3103,7 +3103,7 @@ describe('sendMystiqueMessage error handling', () => {
 
     // Should log the error
     expect(fakeLog.error).to.have.been.calledWithMatch(
-      '[A11yIndividual] Failed to send message to Mystique for url https://example.com',
+      '[A11yIndividual][A11yProcessingError] Failed to send message to Mystique for url https://example.com',
     );
   });
 
@@ -3134,7 +3134,7 @@ describe('sendMystiqueMessage error handling', () => {
 
     // Should log the error
     expect(fakeLog.error).to.have.been.calledWithMatch(
-      '[A11yIndividual] Failed to send message to Mystique for url https://test.com',
+      '[A11yIndividual][A11yProcessingError] Failed to send message to Mystique for url https://test.com',
     );
   });
 });
@@ -3274,7 +3274,7 @@ describe('handleAccessibilityRemediationGuidance', () => {
     });
 
     expect(mockLog.error).to.have.been.calledWith(
-      '[A11yRemediationGuidance] site site-456, audit audit-123, page https://example.com/page1, opportunity oppty-nonexistent: Opportunity not found',
+      '[A11yRemediationGuidance][A11yProcessingError] site site-456, audit audit-123, page https://example.com/page1, opportunity oppty-nonexistent: Opportunity not found',
     );
   });
 
@@ -3313,7 +3313,7 @@ describe('handleAccessibilityRemediationGuidance', () => {
     });
 
     expect(mockLog.error).to.have.been.calledWith(
-      '[A11yRemediationGuidance] site site-456, audit audit-123, page https://example.com/page1, opportunity oppty-123: Site ID mismatch. Expected: site-456, Found: site-different',
+      '[A11yRemediationGuidance][A11yProcessingError] site site-456, audit audit-123, page https://example.com/page1, opportunity oppty-123: Site ID mismatch. Expected: site-456, Found: site-different',
     );
   });
 
@@ -3498,7 +3498,7 @@ describe('handleAccessibilityRemediationGuidance', () => {
     });
 
     expect(mockLog.error).to.have.been.calledWith(
-      '[A11yRemediationGuidance] site site-456, audit audit-123, page https://example.com/page1, opportunity oppty-123: Failed to process accessibility remediation guidance: Database connection failed',
+      '[A11yRemediationGuidance][A11yProcessingError] site site-456, audit audit-123, page https://example.com/page1, opportunity oppty-123: Failed to process accessibility remediation guidance: Database connection failed',
     );
   });
 
@@ -3898,7 +3898,7 @@ describe('handleAccessibilityRemediationGuidance', () => {
     });
 
     expect(mockLog.error).to.have.been.calledWith(
-      '[A11yRemediationGuidance] site site-456, audit audit-123, page https://example.com/page1, opportunity oppty-123: Failed to save suggestion sugg-789: Error: Database connection failed',
+      '[A11yRemediationGuidance][A11yProcessingError] site site-456, audit audit-123, page https://example.com/page1, opportunity oppty-123: Failed to save suggestion sugg-789: Error: Database connection failed',
     );
     expect(mockLog.warn).to.have.been.calledWith(
       '[A11yRemediationGuidance] site site-456, audit audit-123, page https://example.com/page1, opportunity oppty-123: 1 suggestions failed to save: sugg-789',

--- a/test/audits/accessibility/guidance-accessibility-remidiation.test.js
+++ b/test/audits/accessibility/guidance-accessibility-remidiation.test.js
@@ -133,7 +133,7 @@ describe('guidance-accessibility-remediation handler', () => {
     expect(mockContext.log.info).to.have.been.calledWith(expectedLogMessage);
     // eslint-disable-next-line max-len
     expect(mockContext.log.error).to.have.been.calledWith(
-      '[A11yIndividual] Failed to process guidance: Opportunity not found',
+      '[A11yIndividual][A11yProcessingError] Failed to process guidance: Opportunity not found',
     );
     expect(mockHandleAccessibilityRemediationGuidance).to.have.been.calledWith(
       mockMessage,
@@ -177,7 +177,7 @@ describe('guidance-accessibility-remediation handler', () => {
     )}`;
     expect(mockContext.log.info).to.have.been.calledWith(expectedLogMessage);
     expect(mockContext.log.error).to.have.been.calledWith(
-      '[A11yIndividual] Error processing accessibility remediation guidance: Database connection failed',
+      '[A11yIndividual][A11yProcessingError] Error processing accessibility remediation guidance: Database connection failed',
     );
     expect(mockHandleAccessibilityRemediationGuidance).to.have.been.calledWith(
       mockMessage,

--- a/test/audits/accessibility/scrape-utils.test.js
+++ b/test/audits/accessibility/scrape-utils.test.js
@@ -308,7 +308,7 @@ describe('Scrape Utils', () => {
       const keys = await getKeys(mockS3Client, 'test-bucket', 'site1', mockLog);
 
       expect(keys).to.deep.equal([]);
-      expect(mockLog.error).to.have.been.calledWith(`[A11yAudit] Error getting existing URLs from failed audits for site site1: ${error.message}`);
+      expect(mockLog.error).to.have.been.calledWith(`[A11yAudit][A11yProcessingError] Error getting existing URLs from failed audits for site site1: ${error.message}`);
     });
 
     it('returns all keys even if some are malformed', async () => {
@@ -463,7 +463,7 @@ describe('Scrape Utils', () => {
         error: 'Some updates failed',
       });
       expect(mockLog.error).to.have.been.calledWith(
-        '[A11yAudit] Failed to update 1 opportunities for site site1: [{"status":"rejected","reason":{}}]',
+        '[A11yAudit][A11yProcessingError] Failed to update 1 opportunities for site site1: [{"status":"rejected","reason":{}}]',
       );
     });
 
@@ -476,7 +476,7 @@ describe('Scrape Utils', () => {
         updatedCount: 0,
         error: 'Fetch failed',
       });
-      expect(mockLog.error).to.have.been.calledWith('[A11yAudit] Error updating opportunities to IGNORED for site site1: Fetch failed');
+      expect(mockLog.error).to.have.been.calledWith('[A11yAudit][A11yProcessingError] Error updating opportunities to IGNORED for site site1: Fetch failed');
     });
   });
 
@@ -809,7 +809,7 @@ describe('Scrape Utils', () => {
       expect(result.success).to.be.false;
       expect(result.message).to.equal('Failed to save a11y metrics to S3: S3 write error');
       expect(result.error).to.equal('S3 write error');
-      expect(mockLog.error).to.have.been.calledWith('[A11yAudit] Error saving metrics to S3 for site test-site-id (https://example.com): S3 write error');
+      expect(mockLog.error).to.have.been.calledWith('[A11yAudit][A11yProcessingError] Error saving metrics to S3 for site test-site-id (https://example.com): S3 write error');
     });
 
     it('should use correct S3 key format', async () => {
@@ -1421,7 +1421,7 @@ describe('Scrape Utils', () => {
       expect(result.message).to.equal('Failed to save mystique validation metrics to S3: S3 save failed');
       expect(result.error).to.equal('S3 save failed');
       expect(mockLog.error).to.have.been.calledWith(
-        '[A11yValidation] Error saving mystique validation metrics to S3 for site site-456, opportunity oppty-123: S3 save failed',
+        '[A11yValidation][A11yProcessingError] Error saving mystique validation metrics to S3 for site site-456, opportunity oppty-123: S3 save failed',
       );
     });
 


### PR DESCRIPTION
Add the label [A11yProcessingError] to each error log in order to have a easy query in Coralogix logs and for alerts query.
Jira ticket: https://jira.corp.adobe.com/browse/SITES-34576