### PR TITLE
fix: A11y modify the placement of sentCount metric computation

### DIFF
--- a/test/audits/accessibility/generate-individual-opportunities.test.js
+++ b/test/audits/accessibility/generate-individual-opportunities.test.js
@@ -3146,7 +3146,18 @@ describe('handleAccessibilityRemediationGuidance', () => {
 
   beforeEach(async () => {
     sandbox = sinon.createSandbox();
-    testModule = await import('../../../src/accessibility/utils/generate-individual-opportunities.js');
+    testModule = await esmock('../../../src/accessibility/utils/generate-individual-opportunities.js', {
+      '../../../src/accessibility/guidance-utils/mystique-data-processing.js': {
+        processSuggestionsForMystique: sandbox.stub().returns([
+          {
+            url: 'https://example.com/page1',
+            issuesList: [
+              { suggestionId: 'sugg-789' },
+            ],
+          },
+        ]),
+      },
+    });
     mockLog = {
       info: sandbox.stub(),
       debug: sandbox.stub(),
@@ -3909,10 +3920,21 @@ describe('handleAccessibilityRemediationGuidance', () => {
   });
 
   it('should log success message when metrics are saved successfully (line 889 coverage)', async () => {
-    // Mock the scrape-utils module to ensure saveMystiqueValidationMetricsToS3 succeeds
+    // Mock both the scrape-utils and mystique-data-processing modules
+    // to ensure saveMystiqueValidationMetricsToS3 succeeds
     const mockScrapeUtils = await esmock('../../../src/accessibility/utils/generate-individual-opportunities.js', {
       '../../../src/accessibility/utils/scrape-utils.js': {
         saveMystiqueValidationMetricsToS3: sandbox.stub().resolves(),
+      },
+      '../../../src/accessibility/guidance-utils/mystique-data-processing.js': {
+        processSuggestionsForMystique: sandbox.stub().returns([
+          {
+            url: 'https://example.com/page1',
+            issuesList: [
+              { suggestionId: 'sugg-789' },
+            ],
+          },
+        ]),
       },
     });
 


### PR DESCRIPTION
The purpose of this PR is to move the counting logic of the total sent suggestions before the logic responsible for updating the received suggestions with enhanced issues containing remediation details. Before, when were the suggestions counted, some of them were excluded, because they were already marked as having guidance. Now, we count the suggestions before any of them is marked as having guidance.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
