### PR TITLE
fix: add static file for llm error pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
       "src/cdn-analysis/sql",
       "src/cdn-logs-report/sql",
       "src/llmo-referral-traffic/sql",
-      "src/page-intent/sql"
+      "src/page-intent/sql",
+      "src/llm-error-pages/sql"
     ]
   },
   "repository": {


### PR DESCRIPTION
Adding the missing static file so that audit can run in spacecat envs.
