### PR TITLE
fix: resolve duplicate suggestions in structured data audit

### DIFF
--- a/src/structured-data/handler.js
+++ b/src/structured-data/handler.js
@@ -111,7 +111,7 @@ export async function opportunityAndSuggestions(auditUrl, auditData, context) {
   // Temporarily group issues by pageUrl as the UI does not support displaying
   // the same page multiple times or displaying issues grouped by rootType
   const issuesByPageUrl = auditData.auditResult.issues.reduce((acc, issue) => {
-    const existingIssue = acc.find((i) => i.pageUrl === issue.pageUrl);
+    const existingIssue = acc.find((i) => (i.url || i.pageUrl) === issue.pageUrl);
     if (!existingIssue) {
       acc.push(issue);
     } else {


### PR DESCRIPTION
Fix buildKey function to handle both pageUrl and url
   Prevents duplicate suggestions for same URL by ensuring proper key matching
   Maintains backward compatibility with existing data structures
   
 Error
<img width="1719" height="984" alt="image" src="https://github.com/user-attachments/assets/50f03f3d-b05d-49d8-ab6e-18297218ba27" />
<img width="1188" height="958" alt="image" src="https://github.com/user-attachments/assets/e941da69-b572-4f9f-b756-08cfe9b713b3" />


After fix
The previous bug was fixed but created all the outdated as new

Another bug

<img width="1674" height="910" alt="image" src="https://github.com/user-attachments/assets/2042e8b4-9793-45c4-9bfc-08cf809c76f9" />



Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
