### PR TITLE
feat: support just Google user agent

### DIFF
--- a/src/cdn-analysis/sql/akamai/unload-aggregated.sql
+++ b/src/cdn-analysis/sql/akamai/unload-aggregated.sql
@@ -23,7 +23,7 @@ UNLOAD (
     AND hour  = '{{hour}}'
 
     -- match known LLM-related user-agents
-    AND REGEXP_LIKE(ua, '(?i)ChatGPT|GPTBot|OAI-SearchBot|Perplexity|Claude|Anthropic|Gemini|Copilot|Googlebot|bingbot')
+    AND REGEXP_LIKE(ua, '(?i)(ChatGPT|GPTBot|OAI-SearchBot|Perplexity|Claude|Anthropic|Gemini|Copilot|Googlebot|bingbot|^Google$)')
 
     -- only count text/html responses with robots.txt and sitemaps
     AND (

--- a/src/cdn-analysis/sql/cloudflare/unload-aggregated.sql
+++ b/src/cdn-analysis/sql/cloudflare/unload-aggregated.sql
@@ -20,7 +20,7 @@ UNLOAD (
     -- The 'hour' column in output provides hourly breakdown within the daily aggregation
 
     -- match known LLM-related user-agents
-    AND REGEXP_LIKE(ClientRequestUserAgent, '(?i)ChatGPT|GPTBot|OAI-SearchBot|Perplexity|Claude|Anthropic|Gemini|Copilot|Googlebot|bingbot')
+    AND REGEXP_LIKE(ClientRequestUserAgent, '(?i)(ChatGPT|GPTBot|OAI-SearchBot|Perplexity|Claude|Anthropic|Gemini|Copilot|Googlebot|bingbot|^Google$)')
 
     -- only count text/html responses with robots.txt and sitemaps
     AND (

--- a/src/cdn-analysis/sql/fastly/unload-aggregated.sql
+++ b/src/cdn-analysis/sql/fastly/unload-aggregated.sql
@@ -15,7 +15,7 @@ UNLOAD (
     AND hour  = '{{hour}}'
     
      -- match known LLM-related user-agents
-    AND REGEXP_LIKE(request_user_agent, '(?i)ChatGPT|GPTBot|OAI-SearchBot|Perplexity|Claude|Anthropic|Gemini|Copilot|Googlebot|bingbot')
+    AND REGEXP_LIKE(request_user_agent, '(?i)(ChatGPT|GPTBot|OAI-SearchBot|Perplexity|Claude|Anthropic|Gemini|Copilot|Googlebot|bingbot|^Google$)')
 
     -- only count text/html responses with robots.txt and sitemaps
     AND (

--- a/src/cdn-logs-report/constants/user-agent-patterns.js
+++ b/src/cdn-logs-report/constants/user-agent-patterns.js
@@ -13,7 +13,7 @@ export const PROVIDER_USER_AGENT_PATTERNS = {
   chatgpt: '(?i)ChatGPT|GPTBot|OAI-SearchBot',
   perplexity: '(?i)Perplexity',
   claude: '(?i)Claude|Anthropic',
-  gemini: '(?i)Gemini',
+  gemini: '(?i)Gemini|Gemini-Deep-Research',
   copilot: '(?i)Copilot',
   google: '(?i)Googlebot',
   bing: '(?i)Bingbot',


### PR DESCRIPTION
support just Google user agent

> Use the user agent “Google” in case they don’t have a cached copy from the Googlebot indexing process - it’s really a small % that isn’t cached.. but still at least some indication of visibility

