### PR TITLE
fix: simplify period identifier and timezone issue

### DIFF
--- a/src/cdn-logs-report/utils/report-runner.js
+++ b/src/cdn-logs-report/utils/report-runner.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { generatePeriodIdentifier, generateReportingPeriods } from './report-utils.js';
+import { generateReportingPeriods } from './report-utils.js';
 import { saveExcelReport } from '../../utils/report-uploader.js';
 import { createExcelReport } from './excel-generator.js';
 
@@ -23,10 +23,7 @@ export async function runReport(reportConfig, athenaClient, s3Config, log, optio
 
   const referenceDate = new Date();
   const periods = generateReportingPeriods(referenceDate, weekOffset);
-  const week = periods.weeks[0];
-  const periodStart = week.startDate;
-  const periodEnd = week.endDate;
-  const periodIdentifier = generatePeriodIdentifier(periodStart, periodEnd);
+  const { periodIdentifier } = periods;
 
   log.info(`Running ${reportConfig.name} report for ${periodIdentifier} (week offset: ${weekOffset})`);
   const llmoFolder = site.getConfig()?.getLlmoDataFolder();

--- a/src/cdn-logs-report/utils/report-utils.js
+++ b/src/cdn-logs-report/utils/report-utils.js
@@ -12,10 +12,8 @@
 
 import { getStaticContent } from '@adobe/spacecat-shared-utils';
 import {
-  format,
   getWeek,
   getYear,
-  differenceInDays,
 } from 'date-fns';
 import {
   extractCustomerDomain,
@@ -89,27 +87,10 @@ export async function ensureTableExists(athenaClient, databaseName, reportConfig
 }
 
 /**
- * Generates period identifier. 7-day periods return week format (w01-2024).
- * @param {Date} startDate - Period start date
- * @param {Date} endDate - Period end date
- * @returns {string} Period identifier
- * @example generatePeriodIdentifier(new Date('2024-12-16'), new Date('2024-12-22')) // 'w51-2024'
- */
-export function generatePeriodIdentifier(startDate, endDate) {
-  if (differenceInDays(endDate, startDate) + 1 === 7) {
-    const weekNum = getWeek(startDate, { weekStartsOn: 1 });
-    const year = getYear(startDate);
-    return `w${String(weekNum).padStart(2, '0')}-${year}`;
-  }
-
-  return `${format(startDate, 'yyyy-MM-dd')}_to_${format(endDate, 'yyyy-MM-dd')}`;
-}
-
-/**
  * Generates reporting periods data for past weeks
  * @param {number|Date} [offsetOrDate=-1] - If number: weeks offset. If Date: reference date
  * @param {Date} [referenceDate=new Date()] - Reference date (when first param is number)
- * @returns {Object} Object with weeks array and columns
+ * @returns {Object} Object with weeks array and periodIdentifier
  */
 export function generateReportingPeriods(refDate = new Date(), offsetWeeks = -1) {
   const refUTC = new Date(Date.UTC(
@@ -129,14 +110,21 @@ export function generateReportingPeriods(refDate = new Date(), offsetWeeks = -1)
   weekEnd.setUTCDate(weekStart.getUTCDate() + 6);
   weekEnd.setUTCHours(23, 59, 59, 999);
 
-  const weekNumber = getWeek(weekStart, { weekStartsOn: 1 });
-  const year = getYear(weekStart);
+  const localDate = new Date(
+    weekStart.getUTCFullYear(),
+    weekStart.getUTCMonth(),
+    weekStart.getUTCDate(),
+  );
+  const weekNumber = getWeek(localDate, { weekStartsOn: 1, firstWeekContainsDate: 4 });
+  const year = getYear(localDate);
+
+  const periodIdentifier = `w${String(weekNumber).padStart(2, '0')}-${year}`;
 
   return {
     weeks: [{
       startDate: weekStart, endDate: weekEnd, weekNumber, year, weekLabel: `Week ${weekNumber}`,
     }],
-    columns: [`Week ${weekNumber}`],
+    periodIdentifier,
   };
 }
 

--- a/test/audits/cdn-logs-report/report-utils.test.js
+++ b/test/audits/cdn-logs-report/report-utils.test.js
@@ -89,25 +89,6 @@ describe('CDN Logs Report Utils', () => {
       expect(tempLocation).to.equal('s3://test-bucket/temp/athena-results/');
     });
   });
-
-  describe('generatePeriodIdentifier', () => {
-    it('generates week format for 7-day periods', () => {
-      const startDate = new Date('2025-01-06');
-      const endDate = new Date('2025-01-12');
-
-      const identifier = reportUtils.generatePeriodIdentifier(startDate, endDate);
-      expect(identifier).to.equal('w02-2025');
-    });
-
-    it('generates date range format for non-7-day periods', () => {
-      const startDate = new Date('2025-01-06');
-      const endDate = new Date('2025-01-20');
-
-      const identifier = reportUtils.generatePeriodIdentifier(startDate, endDate);
-      expect(identifier).to.equal('2025-01-06_to_2025-01-20');
-    });
-  });
-
   describe('generateReportingPeriods', () => {
     it('generates week periods with offset', () => {
       const refDate = new Date('2025-01-15');
@@ -115,11 +96,12 @@ describe('CDN Logs Report Utils', () => {
       const periods = reportUtils.generateReportingPeriods(refDate, -1);
 
       expect(periods).to.have.property('weeks').that.is.an('array');
-      expect(periods.weeks).to.have.length(1);
-      expect(periods.weeks[0]).to.have.property('startDate');
-      expect(periods.weeks[0]).to.have.property('endDate');
-      expect(periods.weeks[0]).to.have.property('weekLabel');
-      expect(periods).to.have.property('columns').that.is.an('array');
+      expect(periods.weeks[0].startDate.toISOString()).to.equal('2025-01-06T00:00:00.000Z');
+      expect(periods.weeks[0].endDate.toISOString()).to.equal('2025-01-12T23:59:59.999Z');
+      expect(periods.weeks[0].weekLabel).to.equal('Week 2');
+      expect(periods.weeks[0].weekNumber).to.equal(2);
+      expect(periods.weeks[0].year).to.equal(2025);
+      expect(periods.periodIdentifier).to.equal('w02-2025');
     });
 
     it('handles Sunday reference date correctly', () => {


### PR DESCRIPTION
Simplify period identifier and timezone issue

PST timezone have failures due to date-fns getWeek uses local dates. so set them to UTC first