### PR TITLE
fix: set logs to debug or remove

### DIFF
--- a/src/accessibility/handler.js
+++ b/src/accessibility/handler.js
@@ -60,7 +60,7 @@ export async function scrapeAccessibilityData(context) {
       error: errorMsg,
     };
   }
-  log.info(`[A11yAudit] Step 1: Preparing content scrape for accessibility audit for ${site.getBaseURL()} with siteId ${siteId}`);
+  log.debug(`[A11yAudit] Step 1: Preparing content scrape for accessibility audit for ${site.getBaseURL()} with siteId ${siteId}`);
 
   let urlsToScrape = [];
   urlsToScrape = await getUrlsForAudit(s3Client, bucketName, siteId, log);
@@ -68,7 +68,7 @@ export async function scrapeAccessibilityData(context) {
   if (urlsToScrape.length === 0) {
     const { SiteTopPage } = dataAccess;
     const topPages = await SiteTopPage.allBySiteIdAndSourceAndGeo(site.getId(), 'ahrefs', 'global');
-    log.info(`[A11yAudit] Found ${topPages?.length || 0} top pages for site ${site.getBaseURL()}: ${JSON.stringify(topPages || [], null, 2)}`);
+    log.debug(`[A11yAudit] Found ${topPages?.length || 0} top pages for site ${site.getBaseURL()}: ${JSON.stringify(topPages || [], null, 2)}`);
     if (!isNonEmptyArray(topPages)) {
       log.info(`[A11yAudit] No top pages found for site ${siteId} (${site.getBaseURL()}), skipping audit`);
       return {
@@ -81,7 +81,7 @@ export async function scrapeAccessibilityData(context) {
       .map((page) => ({ url: page.getUrl(), traffic: page.getTraffic(), urlId: page.getId() }))
       .sort((a, b) => b.traffic - a.traffic)
       .slice(0, 100);
-    log.info(`[A11yAudit] Top 100 pages for site ${siteId} (${site.getBaseURL()}): ${JSON.stringify(urlsToScrape, null, 2)}`);
+    log.debug(`[A11yAudit] Top 100 pages for site ${siteId} (${site.getBaseURL()}): ${JSON.stringify(urlsToScrape, null, 2)}`);
   }
 
   const existingObjectKeys = await getExistingObjectKeysFromFailedAudits(
@@ -90,16 +90,15 @@ export async function scrapeAccessibilityData(context) {
     siteId,
     log,
   );
-  log.info(`[A11yAudit] Found existing files from failed audits for site ${siteId} (${site.getBaseURL()}): ${existingObjectKeys}`);
+
   const existingUrls = await getExistingUrlsFromFailedAudits(
     s3Client,
     bucketName,
     log,
     existingObjectKeys,
   );
-  log.info(`[A11yAudit] Found existing URLs from failed audits for site ${siteId} (${site.getBaseURL()}): ${existingUrls}`);
+
   const remainingUrls = getRemainingUrls(urlsToScrape, existingUrls);
-  log.info(`[A11yAudit] Remaining URLs to scrape for site ${siteId} (${site.getBaseURL()}): ${JSON.stringify(remainingUrls, null, 2)}`);
 
   // The first step MUST return auditResult and fullAuditRef.
   // fullAuditRef could point to where the raw scraped data will be stored (e.g., S3 path).
@@ -138,7 +137,7 @@ export async function processAccessibilityOpportunities(context) {
     };
   }
 
-  log.info(`[A11yAudit] Step 2: Processing scraped data for site ${siteId} (${site.getBaseURL()})`);
+  log.debug(`[A11yAudit] Step 2: Processing scraped data for site ${siteId} (${site.getBaseURL()})`);
 
   // Use the accessibility aggregator to process data
   let aggregationResult;
@@ -232,7 +231,7 @@ export async function processAccessibilityOpportunities(context) {
   // Subtract 1 for the 'overall' key to get actual URL count
   const urlsProcessed = Object.keys(aggregationResult.finalResultFiles.current).length - 1;
 
-  log.info(`[A11yAudit] Found ${totalIssues} issues across ${urlsProcessed} unique URLs for site ${siteId} (${site.getBaseURL()})`);
+  log.info(`[A11yAudit] Found ${totalIssues} issues across ${urlsProcessed} unique URLs for site ${siteId} (${site.getBaseURL()})`); // debug?
 
   // Return the final audit result with metrics and status
   return {

--- a/src/accessibility/utils/scrape-utils.js
+++ b/src/accessibility/utils/scrape-utils.js
@@ -39,7 +39,6 @@ export async function getExistingObjectKeysFromFailedAudits(s3Client, bucketName
       return [];
     }
 
-    log.info(`[A11yAudit] Found ${objectKeys.length} existing URLs from failed audits for site ${siteId}.`);
     return objectKeys;
   } catch (error) {
     log.error(`[A11yAudit][A11yProcessingError] Error getting existing URLs from failed audits for site ${siteId}: ${error.message}`);
@@ -128,14 +127,13 @@ export async function updateStatusToIgnored(
   try {
     const { Opportunity } = dataAccess;
     const opportunities = await Opportunity.allBySiteIdAndStatus(siteId, 'NEW');
-    log.info(`[A11yAudit] Found ${opportunities.length} opportunities for site ${siteId}`);
 
     if (opportunities.length === 0) {
       return { success: true, updatedCount: 0 };
     }
 
     const accessibilityOppties = filterOpportunities(opportunities);
-    log.info(`[A11yAudit] Found ${accessibilityOppties.length} opportunities to update to IGNORED for site ${siteId}`);
+    log.debug(`[A11yAudit] Found ${accessibilityOppties.length} opportunities to update to IGNORED for site ${siteId}`);
 
     if (accessibilityOppties.length === 0) {
       return { success: true, updatedCount: 0 };
@@ -208,7 +206,7 @@ export async function saveMystiqueValidationMetricsToS3(
     receivedCount: validationData.receivedCount || 0,
   };
 
-  log.info(`[A11yValidation] Mystique validation metrics for site ${siteId}, opportunity ${opportunityId}, page ${validationData.pageUrl} - Sent: ${newValidationEntry.sentCount}, Received: ${newValidationEntry.receivedCount}`);
+  log.debug(`[A11yValidation] Mystique validation metrics for site ${siteId}, opportunity ${opportunityId}, page ${validationData.pageUrl} - Sent: ${newValidationEntry.sentCount}, Received: ${newValidationEntry.receivedCount}`);
 
   // Read existing a11y-suggestions-validation.json file from S3
   const s3Key = `metrics/${siteId}/mystique/a11y-suggestions-validation.json`;
@@ -218,10 +216,10 @@ export async function saveMystiqueValidationMetricsToS3(
     const existingData = await getObjectFromKey(s3Client, bucketName, s3Key, log);
     if (existingData && Array.isArray(existingData)) {
       existingMetrics = existingData;
-      log.info(`[A11yValidation] Found existing mystique validation file with ${existingMetrics.length} entries for site ${siteId}`);
+      log.debug(`[A11yValidation] Found existing mystique validation file with ${existingMetrics.length} entries for site ${siteId}`);
     }
   } catch (error) {
-    log.info(`[A11yValidation] No existing mystique validation file found for site ${siteId}, creating new one: ${error.message}`);
+    log.error(`[A11yValidation] No existing mystique validation file found for site ${siteId}, creating new one: ${error.message}`);
   }
 
   // Check if entry already exists for this audit + opportunity + page combination
@@ -232,11 +230,11 @@ export async function saveMystiqueValidationMetricsToS3(
   if (existingIndex >= 0) {
     // Update existing entry
     existingMetrics[existingIndex] = newValidationEntry;
-    log.info(`[A11yValidation] Updated existing mystique validation entry for page ${validationData.pageUrl}`);
+    log.debug(`[A11yValidation] Updated existing mystique validation entry for page ${validationData.pageUrl}`); // remove instead?
   } else {
     // Add new entry
     existingMetrics.push(newValidationEntry);
-    log.info(`[A11yValidation] Added new mystique validation entry for page ${validationData.pageUrl}`);
+    log.debug(`[A11yValidation] Added new mystique validation entry for page ${validationData.pageUrl}`); // remove instead?
   }
 
   try {
@@ -247,7 +245,7 @@ export async function saveMystiqueValidationMetricsToS3(
       ContentType: 'application/json',
     }));
 
-    log.info(`[A11yValidation] Successfully saved mystique validation metrics to S3: ${s3Key} for site ${siteId}, opportunity ${opportunityId}`);
+    log.debug(`[A11yValidation] Successfully saved mystique validation metrics to S3: ${s3Key} for site ${siteId}, opportunity ${opportunityId}`); // remove instead?
 
     return {
       success: true,

--- a/src/apex/handler.js
+++ b/src/apex/handler.js
@@ -28,7 +28,7 @@ async function probeUrlConnection(baseUrl, log) {
   try {
     resp = await fetch(baseUrl, { redirect: 'manual' });
   } catch (e) {
-    log.info(`Request to ${baseUrl} fails for an unknown reason. Code: ${e.code}`, e);
+    log.error(`Request to ${baseUrl} fails for an unknown reason. Code: ${e.code}`, e);
     return {
       url: baseUrl,
       success: false,

--- a/src/backlinks/handler.js
+++ b/src/backlinks/handler.js
@@ -49,8 +49,6 @@ async function filterOutValidBacklinks(backlinks, log) {
 
   const backlinkStatuses = [];
   for (const backlink of backlinks) {
-    log.info(`Checking backlink: ${backlink.url_to}`);
-
     // eslint-disable-next-line no-await-in-loop
     const result = await isStillBrokenBacklink(backlink);
     backlinkStatuses.push(result);
@@ -70,7 +68,7 @@ export async function brokenBacklinksAuditRunner(auditUrl, context, site) {
       result,
       fullAuditRef,
     } = await ahrefsAPIClient.getBrokenBacklinks(auditUrl);
-    log.info(`Found ${result?.backlinks?.length} broken backlinks for siteId: ${siteId} and url ${auditUrl}`);
+    log.debug(`Found ${result?.backlinks?.length} broken backlinks for siteId: ${siteId} and url ${auditUrl}`);
     const excludedURLs = site.getConfig().getExcludedURLs('broken-backlinks');
     const filteredBacklinks = result?.backlinks?.filter(
       (backlink) => !excludedURLs?.includes(backlink.url_to),

--- a/src/broken-links-guidance/guidance-handler.js
+++ b/src/broken-links-guidance/guidance-handler.js
@@ -20,7 +20,7 @@ export default async function handler(message, context) {
   const {
     brokenLinks, opportunityId,
   } = data;
-  log.info(`Message received in broken-links suggestion handler: ${JSON.stringify(message, null, 2)}`);
+  log.debug(`Message received in broken-links suggestion handler: ${JSON.stringify(message, null, 2)}`);
 
   const site = await Site.findById(siteId);
   if (!site) {

--- a/src/cdn-analysis/handler.js
+++ b/src/cdn-analysis/handler.js
@@ -85,7 +85,7 @@ export async function cdnLogAnalysisRunner(auditUrl, context, site, auditContext
     ? await discoverCdnProviders(s3Client, bucketName, { year, month, day, hour })
     : providers;
 
-  log.info(`Processing ${serviceProviders.length} service provider(s) in bucket: ${bucketName}`);
+  log.debug(`Processing ${serviceProviders.length} service provider(s) in bucket: ${bucketName}`);
 
   const database = `cdn_logs_${customerDomain}`;
   const results = [];

--- a/src/cdn-logs-report/handler.js
+++ b/src/cdn-logs-report/handler.js
@@ -35,7 +35,7 @@ async function runCdnLogsReport(url, context, site, auditContext) {
     };
   }
 
-  log.info(`Starting CDN logs report audit for ${url}`);
+  log.debug(`Starting CDN logs report audit for ${url}`);
 
   const sharepointClient = await createLLMOSharepointClient(
     context,
@@ -57,7 +57,7 @@ async function runCdnLogsReport(url, context, site, auditContext) {
   for (const reportConfig of reportConfigs) {
     await ensureTableExists(athenaClient, s3Config.databaseName, reportConfig, log);
 
-    log.info(`Running weekly report: ${reportConfig.name}...`);
+    log.debug(`Running weekly report: ${reportConfig.name}...`);
     const weekOffset = auditContext?.weekOffset || -1;
     await runWeeklyReport({
       athenaClient,

--- a/src/cdn-logs-report/utils/report-runner.js
+++ b/src/cdn-logs-report/utils/report-runner.js
@@ -28,7 +28,7 @@ export async function runReport(reportConfig, athenaClient, s3Config, log, optio
   const periodEnd = week.endDate;
   const periodIdentifier = generatePeriodIdentifier(periodStart, periodEnd);
 
-  log.info(`Running ${reportConfig.name} report for ${periodIdentifier} (week offset: ${weekOffset})`);
+  log.debug(`Running ${reportConfig.name} report for ${periodIdentifier} (week offset: ${weekOffset})`);
   const llmoFolder = site.getConfig()?.getLlmoDataFolder();
   const outputLocation = `${llmoFolder}/${reportConfig.folderSuffix}`;
 
@@ -87,13 +87,13 @@ export async function runWeeklyReport({
   weekOffset,
 }) {
   try {
-    log.info(`Starting ${reportConfig.name} report for week offset: ${weekOffset}...`);
+    log.debug(`Starting ${reportConfig.name} report for week offset: ${weekOffset}...`);
     await runReport(reportConfig, athenaClient, s3Config, log, {
       site,
       sharepointClient,
       weekOffset,
     });
-    log.info(`Successfully completed ${reportConfig.name} report`);
+    log.debug(`Successfully completed ${reportConfig.name} report`);
   } catch (error) {
     log.error(`Failed to generate ${reportConfig.name} report: ${error.message}`);
   }

--- a/src/cdn-logs-report/utils/report-utils.js
+++ b/src/cdn-logs-report/utils/report-utils.js
@@ -77,11 +77,11 @@ export async function ensureTableExists(athenaClient, databaseName, reportConfig
       aggregatedLocation,
     });
 
-    log.info(`Creating or checking table: ${tableName}`);
+    log.debug(`Creating or checking table: ${tableName}`);
     const sqlCreateTableDescription = `[Athena Query] Create table ${databaseName}.${tableName}`;
     await athenaClient.execute(createTableQuery, databaseName, sqlCreateTableDescription);
 
-    log.info(`Table ${tableName} is ready`);
+    log.debug(`Table ${tableName} is ready`);
   } catch (error) {
     log.error(`Failed to ensure table exists: ${error.message}`);
     throw error;

--- a/src/common/async-job-runner.js
+++ b/src/common/async-job-runner.js
@@ -53,7 +53,7 @@ export class AsyncJobRunner extends StepAudit {
     const payload = destination.formatPayload(stepResult, auditContext, context);
     await sendContinuationMessage({ queueUrl, payload }, context);
 
-    log.info(`Step ${step.name} completed for job ${job.getId()} of type ${type}, message sent to ${step.destination}`);
+    log.debug(`Step ${step.name} completed for job ${job.getId()} of type ${type}, message sent to ${step.destination}`);
 
     return stepResult;
   }
@@ -106,7 +106,7 @@ export class AsyncJobRunner extends StepAudit {
       const promiseToken = message.promiseToken || message.auditContext?.promiseToken;
       if (promiseToken) {
         updatedStepContext.promiseToken = promiseToken;
-        log.info(`site: ${siteId}. Promise token added to step context`);
+        log.debug(`site: ${siteId}. Promise token added to step context`);
       }
 
       const stepResult = await step.handler(updatedStepContext);

--- a/src/common/audit-utils.js
+++ b/src/common/audit-utils.js
@@ -36,7 +36,7 @@ export async function sendContinuationMessage(message, context) {
 
   try {
     const { sqs } = context;
-    log.info(`sending continuation message ${JSON.stringify(payload, null, 2)}`);
+    log.debug(`sending continuation message ${JSON.stringify(payload, null, 2)}`);
     await sqs.sendMessage(queueUrl, payload);
   } catch (e) {
     log.error(`Failed to send message to queue ${queueUrl}`, e);

--- a/src/common/base-audit.js
+++ b/src/common/base-audit.js
@@ -73,7 +73,7 @@ export async function wwwUrlResolver(site, context) {
   const subdomain = uri.subdomain();
 
   if (hasText(subdomain) && subdomain !== 'www') {
-    log.info(`Resolved URL ${hostname} since ${baseURL} contains subdomain`);
+    log.debug(`Resolved URL ${hostname} since ${baseURL} contains subdomain`); // delete?
     return hostname;
   }
 
@@ -82,22 +82,22 @@ export async function wwwUrlResolver(site, context) {
   try {
     const wwwToggledHostname = toggleWWWHostname(hostname);
     await rumApiClient.retrieveDomainkey(wwwToggledHostname);
-    log.info(`Resolved URL ${wwwToggledHostname} for ${baseURL} using RUM API Client`);
+    log.debug(`Resolved URL ${wwwToggledHostname} for ${baseURL} using RUM API Client`); // delete?
     return wwwToggledHostname;
   } catch (e) {
-    log.info(`Could not retrieved RUM domainkey for ${hostname}: ${e.message}`);
+    log.error(`Could not retrieved RUM domainkey for ${hostname}: ${e.message}`);
   }
 
   try {
     await rumApiClient.retrieveDomainkey(hostname);
-    log.info(`Resolved URL ${hostname} for ${baseURL} using RUM API Client`);
+    log.debug(`Resolved URL ${hostname} for ${baseURL} using RUM API Client`); // delete?
     return hostname;
   } catch (e) {
-    log.info(`Could not retrieved RUM domainkey for ${hostname}: ${e.message}`);
+    log.error(`Could not retrieved RUM domainkey for ${hostname}: ${e.message}`);
   }
 
   const fallback = hostname.startsWith('www.') ? hostname : `www.${hostname}`;
-  log.info(`Fallback to ${fallback} for URL resolution for ${baseURL}`);
+  log.debug(`Fallback to ${fallback} for URL resolution for ${baseURL}`);
   return fallback;
 }
 

--- a/src/common/step-audit.js
+++ b/src/common/step-audit.js
@@ -77,9 +77,9 @@ export class StepAudit extends BaseAudit {
     if (step.destination === AUDIT_STEP_DESTINATIONS.SCRAPE_CLIENT) {
       const scrapeClient = ScrapeClient.createFrom(context);
       const payload = destination.formatPayload(stepResult, auditContext, context);
-      log.info(`Creating new scrapeJob with the ScrapeClient. Payload: ${JSON.stringify(payload)}`);
+      log.info(`Creating new scrapeJob with the ScrapeClient. Payload: ${JSON.stringify(payload)}`); // remove or set to debug when done
       const scrapeJob = await scrapeClient.createScrapeJob(payload);
-      log.info(`Crated scrapeJob: ${scrapeJob}`);
+      log.info(`Crated scrapeJob: ${scrapeJob}`); // remove or set to debug when done
       return stepResult;
     } else {
       const queueUrl = destination.getQueueUrl(context);
@@ -87,7 +87,7 @@ export class StepAudit extends BaseAudit {
       await sendContinuationMessage({ queueUrl, payload }, context);
     }
 
-    log.info(`Step ${step.name} completed for audit ${audit.getId()} of type ${audit.getAuditType()}, message sent to ${step.destination}`);
+    log.debug(`Step ${step.name} completed for audit ${audit.getId()} of type ${audit.getAuditType()}, message sent to ${step.destination}`);
 
     return stepResult;
   }

--- a/src/csp/csp.js
+++ b/src/csp/csp.js
@@ -126,7 +126,7 @@ export async function cspOpportunityAndSuggestions(auditUrl, auditData, context,
   const { Configuration } = dataAccess;
   const configuration = await Configuration.findLatest();
   if (!configuration.isHandlerEnabledForSite('security-csp', site)) {
-    log.info(`[${AUDIT_TYPE}] [Site: ${site.getId()}] audit is disabled for site`);
+    log.debug(`[${AUDIT_TYPE}] [Site: ${site.getId()}] audit is disabled for site`);
     return { ...auditData };
   }
 

--- a/src/experimentation-ess/all.js
+++ b/src/experimentation-ess/all.js
@@ -57,7 +57,8 @@ export async function essExperimentationAllAuditRunner(auditUrl, context, site) 
     days = Math.ceil((Date.now() - new Date(oldestExperiment.getStartDate()).getTime())
     / (1000 * 60 * 60 * 24));
   }
-  log.info(`ESS Experimentation All Audit will run for ${days} days`);
+
+  log.debug(`ESS Experimentation All Audit will run for ${days} days`);
   const auditData = await processAudit(
     auditUrl,
     context,
@@ -65,13 +66,11 @@ export async function essExperimentationAllAuditRunner(auditUrl, context, site) 
     days,
   );
 
-  log.info(`ESS Experimentation All Audit data size: ${JSON.stringify(auditData).length}`);
-
   const endTime = process.hrtime(startTime);
   const elapsedSeconds = endTime[0] + endTime[1] / 1e9;
   const formattedElapsed = elapsedSeconds.toFixed(2);
 
-  log.info(`ESS Experimentation All Audit completed in ${formattedElapsed} seconds for ${auditUrl}`);
+  log.debug(`ESS Experimentation All Audit completed in ${formattedElapsed} seconds for ${auditUrl}`);
 
   return {
     auditResult: auditData,

--- a/src/experimentation-ess/common.js
+++ b/src/experimentation-ess/common.js
@@ -388,11 +388,11 @@ async function addPValues(experimentData) {
       };
     }
   }
-  log.info('Lambda Payload: ', JSON.stringify(lambdaPayload, null, 2));
+  log.debug('Lambda Payload: ', JSON.stringify(lambdaPayload, null, 2));
   let lambdaResult;
   try {
     const lambdaResponse = await invokeLambdaFunction(lambdaPayload);
-    log.info('Lambda Response: ', JSON.stringify(lambdaResponse, null, 2));
+    log.debug('Lambda Response: ', JSON.stringify(lambdaResponse, null, 2));
     const lambdaResponseBody = typeof (lambdaResponse.body) === 'string' ? JSON.parse(lambdaResponse.body) : lambdaResponse.body;
     lambdaResult = lambdaResponseBody.result;
   } catch (error) {
@@ -612,7 +612,7 @@ function filterMultiPageExperimentsByThreshold(
       const dailyViews = Math.ceil(experimentViews / experimentDays);
       if (multiPageExperimentNames.includes(id)
         && dailyViews < threshold) {
-        log.info(`Filtering out experiment ${id} from url ${url} as daily views ${dailyViews} are less than threshold ${threshold}`);
+        log.debug(`Filtering out experiment ${id} from url ${url} as daily views ${dailyViews} are less than threshold ${threshold}`);
       } else {
         newUrlInsights.push(exp);
       }
@@ -629,12 +629,12 @@ function filterMultiPageExperimentsByThreshold(
 
 async function processExperimentRUMData(experimentInsights, context, days) {
   if (Object.keys(experimentInsights).length === 0) {
-    log.info('No Experiment Insights found');
+    log.debug('No Experiment Insights found');
     return [];
   }
-  log.info('Experiment Insights: ', JSON.stringify(experimentInsights, null, 2));
+  log.debug('Experiment Insights: ', JSON.stringify(experimentInsights, null, 2));
   const multiPageExperimentNames = getMultiPageExperimentNames(experimentInsights);
-  log.info('Multi-Page Experiment Names: ', multiPageExperimentNames.join(', '));
+  log.debug('Multi-Page Experiment Names: ', multiPageExperimentNames.join(', '));
   const dailyPageViewsThreshold = context.env.MULTIPAGE_EXPERIMENT_DAILY_PAGE_VIEWS_THRESHOLD
   || DEFAULT_MULTIPAGE_EXPERIMENT_DAILY_PAGE_VIEWS_THRESHOLD;
   filterMultiPageExperimentsByThreshold(
@@ -650,7 +650,7 @@ async function processExperimentRUMData(experimentInsights, context, days) {
 
 export async function processAudit(auditURL, context, site, days) {
   log = context.log;
-  log.info(`Processing ESS Experimentation audit for ${auditURL}`);
+  log.debug(`Processing ESS Experimentation audit for ${auditURL}`);
   const rumAPIClient = RUMAPIClient.createFrom(context);
   const options = {
     domain: auditURL,

--- a/src/experimentation-ess/daily.js
+++ b/src/experimentation-ess/daily.js
@@ -34,7 +34,7 @@ export async function essExperimentationDailyAuditRunner(auditUrl, context, site
   const elapsedSeconds = endTime[0] + endTime[1] / 1e9;
   const formattedElapsed = elapsedSeconds.toFixed(2);
 
-  log.info(`ESS Experimentation Daily Audit completed in ${formattedElapsed} seconds for ${auditUrl}`);
+  log.debug(`ESS Experimentation Daily Audit completed in ${formattedElapsed} seconds for ${auditUrl}`);
 
   return {
     auditResult: auditData,

--- a/src/experimentation-opportunities/guidance-high-organic-low-ctr-handler.js
+++ b/src/experimentation-opportunities/guidance-high-organic-low-ctr-handler.js
@@ -18,7 +18,7 @@ export default async function handler(message, context) {
   const { Audit, Opportunity, Suggestion } = dataAccess;
   const { auditId, siteId, data } = message;
   const { url, guidance, suggestions } = data;
-  log.info(`Message received in high-organic-low-ctr handler: ${JSON.stringify(message, null, 2)}`);
+  log.debug(`Message received in high-organic-low-ctr handler: ${JSON.stringify(message, null, 2)}`);
 
   const audit = await Audit.findById(auditId);
   if (!audit) {
@@ -45,10 +45,8 @@ export default async function handler(message, context) {
   );
 
   if (!opportunity) {
-    log.info(`No existing Opportunity found for page: ${url}. Creating a new one.`);
     opportunity = await Opportunity.create(entity);
   } else {
-    log.info(`Existing Opportunity found for page: ${url}. Updating it with new data.`);
     opportunity.setAuditId(auditId);
     opportunity.setData({
       ...opportunity.getData(),

--- a/src/experimentation-opportunities/handler.js
+++ b/src/experimentation-opportunities/handler.js
@@ -58,7 +58,7 @@ export async function generateOpportunityAndSuggestions(context) {
     log, sqs, env, site, audit,
   } = context;
   const auditResult = audit.getAuditResult();
-  log.info('auditResult in generateOpportunityAndSuggestions: ', JSON.stringify(auditResult, null, 2));
+  log.debug('auditResult in generateOpportunityAndSuggestions: ', JSON.stringify(auditResult, null, 2));
 
   const messages = auditResult?.experimentationOpportunities?.filter(
     (oppty) => oppty.type === HIGH_ORGANIC_LOW_CTR_OPPTY_TYPE,
@@ -83,7 +83,7 @@ export async function generateOpportunityAndSuggestions(context) {
   for (const message of messages) {
     // eslint-disable-next-line no-await-in-loop
     await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, message);
-    log.info(`Message sent to Mystique: ${JSON.stringify(message)}`);
+    log.debug(`Message sent to Mystique: ${JSON.stringify(message)}`);
   }
 }
 
@@ -160,7 +160,7 @@ export async function experimentOpportunitiesAuditRunner(auditUrl, context) {
   const queryResults = await rumAPIClient.queryMulti(OPPTY_QUERIES, options);
   const experimentationOpportunities = Object.values(queryResults).flatMap((oppty) => oppty);
   processRageClickOpportunities(experimentationOpportunities);
-  log.info(`Found ${experimentationOpportunities.length} experimentation opportunites for ${auditUrl}`);
+  log.debug(`Found ${experimentationOpportunities.length} experimentation opportunites for ${auditUrl}`);
 
   // Handle custom URLs if provided via audit context
   const { data } = context;
@@ -241,19 +241,19 @@ export async function organicKeywordsStep(context) {
   const {
     site, log, finalUrl, audit, s3Client,
   } = context;
-  log.info(`Organic keywords step started for ${finalUrl}`);
+  log.debug(`Organic keywords step started for ${finalUrl}`);
   let organicKeywordsImportEnabled = false;
   const bucketName = context.env.S3_SCRAPER_BUCKET_NAME;
   const s3BucketPrefix = `scrapes/${site.getId()}`;
   const auditResult = audit.getAuditResult();
   const urls = getHighOrganicLowCtrOpportunity(auditResult.experimentationOpportunities)
     .map((oppty) => oppty.page);
-  log.info(`Organic keywords step for ${finalUrl}, found ${urls.length} urls`);
+  log.debug(`Organic keywords step for ${finalUrl}, found ${urls.length} urls`);
   const siteConfig = site.getConfig();
   const imports = siteConfig?.getImports() || [];
-  log.info(`Site config exists: ${!!siteConfig}, imports count: ${imports.length}`);
+  log.debug(`Site config exists: ${!!siteConfig}, imports count: ${imports.length}`);
   if (!isImportEnabled(IMPORT_ORGANIC_KEYWORDS, imports)) {
-    log.info(`Enabling ${IMPORT_ORGANIC_KEYWORDS} for site ${site.getId()}`);
+    log.debug(`Enabling ${IMPORT_ORGANIC_KEYWORDS} for site ${site.getId()}`);
     await toggleImport(site, IMPORT_ORGANIC_KEYWORDS, true, log);
     organicKeywordsImportEnabled = true;
   }
@@ -272,15 +272,15 @@ export async function organicKeywordsStep(context) {
       urlObj.pathname,
       log,
     );
-    log.info(`Lang for ${url} is ${lang}`);
+    log.debug(`Lang for ${url} is ${lang}`);
     const geo = getCountryCodeFromLang(lang);
     return { url, geo };
   }));
   urlConfigs = urlConfigs.filter(Boolean);
-  log.info(`Url configs: ${JSON.stringify(urlConfigs, null, 2)}`);
+  log.debug(`Url configs: ${JSON.stringify(urlConfigs, null, 2)}`);
   if (organicKeywordsImportEnabled) {
     // disable the import after the step is done, if it was enabled in the beginning
-    log.info(`Disabling ${IMPORT_ORGANIC_KEYWORDS} for site ${site.getId()}`);
+    log.debug(`Disabling ${IMPORT_ORGANIC_KEYWORDS} for site ${site.getId()}`);
     await toggleImport(site, IMPORT_ORGANIC_KEYWORDS, false, log);
   }
   return {
@@ -294,7 +294,7 @@ export function importAllTrafficStep(context) {
   const {
     site, log, finalUrl,
   } = context;
-  log.info(`Import all traffic step for ${finalUrl}`);
+  log.debug(`Import all traffic step for ${finalUrl}`);
   return {
     type: 'all-traffic',
     siteId: site.getId(),

--- a/src/forms-opportunities/form-details-handler/detect-form-details.js
+++ b/src/forms-opportunities/form-details-handler/detect-form-details.js
@@ -20,15 +20,12 @@ export default async function handler(message, context) {
   } = context;
   const { Opportunity } = dataAccess;
   const { data, auditId: id } = message;
-  log.info(`Message received in form details handler : ${JSON.stringify(message, null, 2)}`);
   const { form_details: formDetails } = data;
 
   const opportunity = await Opportunity.findById(id);
   if (opportunity) {
-    log.info(`Opportunity found in form details handler: ${JSON.stringify(opportunity)}`);
     if (opportunity.getType() === FORM_OPPORTUNITY_TYPES.FORM_A11Y) {
       const opportunityData = opportunity.getData();
-      log.info(`Opportunity found accessibility data in form details handler: ${JSON.stringify(opportunityData)}`);
       const updatedAccessibility = opportunityData.accessibility.map((item) => {
         // eslint-disable-next-line max-len
         const matchingFormDetail = formDetails.find((detail) => detail.url === item.form && detail.form_source === item.formSource);
@@ -62,7 +59,6 @@ export default async function handler(message, context) {
 
     opportunity.setUpdatedBy('system');
     await opportunity.save();
-    log.info(`Updated opportunity with form details: ${JSON.stringify(opportunity, null, 2)}`);
     await sendMessageToMystiqueForGuidance(context, opportunity);
   }
   return ok();

--- a/src/forms-opportunities/guidance-handlers/guidance-accessibility.js
+++ b/src/forms-opportunities/guidance-handlers/guidance-accessibility.js
@@ -17,7 +17,7 @@ export default async function handler(message, context) {
   const { auditId, siteId, data } = message;
   const { opportunityId, a11y: a11yGuidanceOfIssues } = data;
   const { Opportunity } = dataAccess;
-  log.info(`Message received in accessibility guidance handler: ${JSON.stringify(message, null, 2)}`);
+  log.debug(`Message received in accessibility guidance handler: ${JSON.stringify(message, null, 2)}`);
   const opportunity = await Opportunity.findById(opportunityId);
   if (!opportunity) {
     log.error(`[Form Opportunity] [Site Id: ${siteId}] A11y opportunity not found`);
@@ -48,6 +48,6 @@ export default async function handler(message, context) {
     accessibility: a11yData,
   });
   await opportunity.save();
-  log.info(`[Form Opportunity] [Site Id: ${siteId}] A11y opportunity updated with guidance`);
+  log.debug(`[Form Opportunity] [Site Id: ${siteId}] A11y opportunity updated with guidance`);
   return ok();
 }

--- a/src/forms-opportunities/guidance-handlers/guidance-high-form-views-low-conversions.js
+++ b/src/forms-opportunities/guidance-handlers/guidance-high-form-views-low-conversions.js
@@ -18,7 +18,7 @@ export default async function handler(message, context) {
   const { Opportunity } = dataAccess;
   const { auditId, siteId, data } = message;
   const { url, guidance, form_source: formsource } = data;
-  log.info(`Message received in high-form-views-low-conversions guidance handler: ${JSON.stringify(message, null, 2)}`);
+  log.debug(`Message received in high-form-views-low-conversions guidance handler: ${JSON.stringify(message, null, 2)}`);
 
   const existingOpportunities = await Opportunity.allBySiteId(siteId);
   const opportunity = existingOpportunities
@@ -28,14 +28,14 @@ export default async function handler(message, context) {
       && oppty.getData()?.origin !== ORIGINS.ESS_OPS);
 
   if (opportunity) {
-    log.info(`Existing Opportunity found for page: ${url}. Updating it with new data.`);
+    log.debug(`Existing Opportunity found for page: ${url}. Updating it with new data.`);
     opportunity.setAuditId(auditId);
     // Wrap the guidance data under the recommendation key
     const wrappedGuidance = { recommendations: guidance };
     opportunity.setGuidance(wrappedGuidance);
     opportunity.setUpdatedBy('system');
     await opportunity.save();
-    log.info(`high-form-views-low-conversions guidance updated oppty : ${JSON.stringify(opportunity, null, 2)}`);
+    log.debug(`high-form-views-low-conversions guidance updated oppty : ${JSON.stringify(opportunity, null, 2)}`);
   }
 
   return ok();

--- a/src/forms-opportunities/guidance-handlers/guidance-high-page-views-low-form-nav.js
+++ b/src/forms-opportunities/guidance-handlers/guidance-high-page-views-low-form-nav.js
@@ -18,7 +18,7 @@ export default async function handler(message, context) {
   const { Opportunity } = dataAccess;
   const { auditId, siteId, data } = message;
   const { url, guidance, form_source: formsource } = data;
-  log.info(`Message received in high-page-views-low-form-nav guidance handler: ${JSON.stringify(message, null, 2)}`);
+  log.debug(`Message received in high-page-views-low-form-nav guidance handler: ${JSON.stringify(message, null, 2)}`);
 
   const existingOpportunities = await Opportunity.allBySiteId(siteId);
   const opportunity = existingOpportunities
@@ -28,14 +28,14 @@ export default async function handler(message, context) {
       && oppty.getData()?.origin !== ORIGINS.ESS_OPS);
 
   if (opportunity) {
-    log.info(`Existing Opportunity found for page: ${url}. Updating it with new data.`);
+    log.debug(`Existing Opportunity found for page: ${url}. Updating it with new data.`);
     opportunity.setAuditId(auditId);
     // Wrap the guidance data under the recommendation key
     const wrappedGuidance = { recommendations: guidance };
     opportunity.setGuidance(wrappedGuidance);
     opportunity.setUpdatedBy('system');
     await opportunity.save();
-    log.info(`high-page-views-low-form-nav guidance updated oppty : ${JSON.stringify(opportunity, null, 2)}`);
+    log.debug(`high-page-views-low-form-nav guidance updated oppty : ${JSON.stringify(opportunity, null, 2)}`);
   }
 
   return ok();

--- a/src/forms-opportunities/guidance-handlers/guidance-high-page-views-low-form-views.js
+++ b/src/forms-opportunities/guidance-handlers/guidance-high-page-views-low-form-views.js
@@ -18,7 +18,7 @@ export default async function handler(message, context) {
   const { Opportunity } = dataAccess;
   const { auditId, siteId, data } = message;
   const { url, form_source: formsource, guidance } = data;
-  log.info(`Message received in high-page-views-low-form-views guidance handler: ${JSON.stringify(message, null, 2)}`);
+  log.debug(`Message received in high-page-views-low-form-views guidance handler: ${JSON.stringify(message, null, 2)}`);
 
   const existingOpportunities = await Opportunity.allBySiteId(siteId);
   const opportunity = existingOpportunities
@@ -28,14 +28,14 @@ export default async function handler(message, context) {
       && oppty.getData()?.origin !== ORIGINS.ESS_OPS);
 
   if (opportunity) {
-    log.info(`Existing Opportunity found for page: ${url}. Updating it with new data.`);
+    log.debug(`Existing Opportunity found for page: ${url}. Updating it with new data.`);
     opportunity.setAuditId(auditId);
     // Wrap the guidance data under the recommendation key
     const wrappedGuidance = { recommendations: guidance };
     opportunity.setGuidance(wrappedGuidance);
     opportunity.setUpdatedBy('system');
     await opportunity.save();
-    log.info(`high-page-views-low-form-views guidance updated oppty 2 : ${JSON.stringify(opportunity, null, 2)}`);
+    log.debug(`high-page-views-low-form-views guidance updated oppty 2 : ${JSON.stringify(opportunity, null, 2)}`);
   }
 
   return ok();

--- a/src/forms-opportunities/handler.js
+++ b/src/forms-opportunities/handler.js
@@ -58,7 +58,7 @@ export async function runAuditAndSendUrlsForScrapingStep(context) {
   const { SiteTopForm } = dataAccess;
   const topForms = await SiteTopForm.allBySiteId(site.getId());
 
-  log.info(`[Form Opportunity] [Site Id: ${site.getId()}] starting audit`);
+  log.debug(`[Form Opportunity] [Site Id: ${site.getId()}] starting audit`);
   const formsAuditRunnerResult = await formsAuditRunner(finalUrl, context);
   const { formVitals } = formsAuditRunnerResult.auditResult;
 
@@ -114,7 +114,7 @@ export async function runAuditAndSendUrlsForScrapingStep(context) {
     fullAuditRef: formsAuditRunnerResult.fullAuditRef,
   };
 
-  log.info(`[Form Opportunity] [Site Id: ${site.getId()}] finished audit and sending urls for scraping`);
+  log.debug(`[Form Opportunity] [Site Id: ${site.getId()}] finished audit and sending urls for scraping`);
   return result;
 }
 
@@ -125,7 +125,7 @@ export async function sendA11yUrlsForScrapingStep(context) {
   const { SiteTopForm } = dataAccess;
   const topForms = await SiteTopForm.allBySiteId(site.getId());
 
-  log.info(`[Form Opportunity] [Site Id: ${site.getId()}] getting scraped data for a11y audit`);
+  log.debug(`[Form Opportunity] [Site Id: ${site.getId()}] getting scraped data for a11y audit`);
   const scrapedData = await getScrapedDataForSiteId(site, context);
   const latestAudit = await site.getLatestAuditByAuditType('forms-opportunities');
   const { formVitals } = latestAudit.getAuditResult();
@@ -167,7 +167,7 @@ export async function sendA11yUrlsForScrapingStep(context) {
     siteId: site.getId(),
   };
 
-  log.info(`[Form Opportunity] [Site Id: ${site.getId()}] sending urls for form-accessibility audit`);
+  log.debug(`[Form Opportunity] [Site Id: ${site.getId()}] sending urls for form-accessibility audit`);
   return result;
 }
 
@@ -176,7 +176,7 @@ export async function processOpportunityStep(context) {
     log, site, finalUrl,
   } = context;
 
-  log.info(`[Form Opportunity] [Site Id: ${site.getId()}] processing opportunity`);
+  log.debug(`[Form Opportunity] [Site Id: ${site.getId()}] processing opportunity`);
   const scrapedData = await getScrapedDataForSiteId(site, context);
   const latestAudit = await site.getLatestAuditByAuditType('forms-opportunities');
   const excludeForms = new Set();
@@ -184,7 +184,7 @@ export async function processOpportunityStep(context) {
   await createLowViewsOpportunities(finalUrl, latestAudit, scrapedData, context, excludeForms);
   await createLowConversionOpportunities(finalUrl, latestAudit, scrapedData, context, excludeForms);
   await createAccessibilityOpportunity(latestAudit, context);
-  log.info(`[Form Opportunity] [Site Id: ${site.getId()}] opportunity identified`);
+  log.debug(`[Form Opportunity] [Site Id: ${site.getId()}] opportunity identified`);
   return {
     status: 'complete',
   };

--- a/src/forms-opportunities/oppty-handlers/accessibility-handler.js
+++ b/src/forms-opportunities/oppty-handlers/accessibility-handler.js
@@ -41,13 +41,13 @@ async function createOrUpdateOpportunity(auditId, siteId, a11yData, context, opp
     }
 
     if (a11yData?.length === 0) {
-      log.info(`[Form Opportunity] [Site Id: ${siteId}] No a11y data found to create or update opportunity `);
+      log.debug(`[Form Opportunity] [Site Id: ${siteId}] No a11y data found to create or update opportunity `);
       return opportunity;
     }
 
     const filteredA11yData = a11yData.filter((a11y) => a11y.a11yIssues?.length > 0);
     if (filteredA11yData.length === 0) {
-      log.info(`[Form Opportunity] [Site Id: ${siteId}] No a11y issues found to create or update opportunity`);
+      log.debug(`[Form Opportunity] [Site Id: ${siteId}] No a11y issues found to create or update opportunity`);
       return opportunity;
     }
 
@@ -122,7 +122,7 @@ async function createOrUpdateOpportunity(auditId, siteId, a11yData, context, opp
         },
       };
       opportunity = await Opportunity.create(opportunityData);
-      log.info(`[Form Opportunity] [Site Id: ${siteId}] Created new a11y opportunity`);
+      log.debug(`[Form Opportunity] [Site Id: ${siteId}] Created new a11y opportunity`);
     }
   } catch (e) {
     log.error(`[Form Opportunity] [Site Id: ${siteId}] Failed to create/update a11y opportunity with error: ${e.message}`);
@@ -265,7 +265,7 @@ export async function createAccessibilityOpportunity(auditData, context) {
     };
 
     await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, mystiqueMessage);
-    log.info(`[Form Opportunity] [Site Id: ${site.getId()}] a11y opportunity created (if issues found) and sent to mystique`);
+    log.debug(`[Form Opportunity] [Site Id: ${site.getId()}] a11y opportunity created (if issues found) and sent to mystique`);
   } catch (error) {
     log.error(`[Form Opportunity] [Site Id: ${site.getId()}] Error creating a11y issues: ${error.message}`);
   }
@@ -275,7 +275,7 @@ export default async function handler(message, context) {
   const { log } = context;
   const { auditId, siteId, data } = message;
   const { opportunityId, a11y } = data;
-  log.info(`[Form Opportunity] [Site Id: ${siteId}] Received message in accessibility handler: ${JSON.stringify(message, null, 2)}`);
+  log.debug(`[Form Opportunity] [Site Id: ${siteId}] Received message in accessibility handler: ${JSON.stringify(message, null, 2)}`);
   try {
     const opportunity = await createOrUpdateOpportunity(
       auditId,

--- a/src/forms-opportunities/oppty-handlers/low-conversion-handler.js
+++ b/src/forms-opportunities/oppty-handlers/low-conversion-handler.js
@@ -100,7 +100,6 @@ export default async function createLowConversionOpportunities(auditUrl, auditDa
 
   // eslint-disable-next-line no-param-reassign
   const auditData = JSON.parse(JSON.stringify(auditDataObject));
-  log.info(`Syncing opportunity high form views low conversion for ${auditData.siteId}`);
   let opportunities;
 
   try {
@@ -117,7 +116,7 @@ export default async function createLowConversionOpportunities(auditUrl, auditDa
   log.debug(`forms opportunities ${JSON.stringify(formOpportunities, null, 2)}`);
   const filteredOpportunities = filterForms(formOpportunities, scrapedData, log, excludeForms);
   filteredOpportunities.forEach((oppty) => excludeForms.add(oppty.form + oppty.formsource));
-  log.info(`filtered opportunties high form views low conversion for form ${JSON.stringify(filteredOpportunities, null, 2)}`);
+  log.debug(`filtered opportunties high form views low conversion for form ${JSON.stringify(filteredOpportunities, null, 2)}`);
 
   try {
     for (const opptyData of filteredOpportunities) {
@@ -145,7 +144,7 @@ export default async function createLowConversionOpportunities(auditUrl, auditDa
         guidance: generateDefaultGuidance(scrapedData, opptyData),
       };
 
-      log.info(`Forms Opportunity high form views low conversion ${JSON.stringify(opportunityData, null, 2)}`);
+      log.debug(`Forms Opportunity high form views low conversion ${JSON.stringify(opportunityData, null, 2)}`);
       let formsList = [];
 
       if (!highFormViewsLowConversionsOppty) {
@@ -192,5 +191,5 @@ export default async function createLowConversionOpportunities(auditUrl, auditDa
   } catch (e) {
     log.error(`Creating Forms opportunity for siteId ${auditData.siteId} failed with error: ${e.message}`, e);
   }
-  log.info(`Successfully synced Opportunity for site: ${auditData.siteId} and high-form-views-low-conversions audit type.`);
+  log.debug(`Successfully synced Opportunity for site: ${auditData.siteId} and high-form-views-low-conversions audit type.`);
 }

--- a/src/forms-opportunities/oppty-handlers/low-navigation-handler.js
+++ b/src/forms-opportunities/oppty-handlers/low-navigation-handler.js
@@ -36,7 +36,7 @@ export default async function createLowNavigationOpportunities(auditUrl, auditDa
 
   // eslint-disable-next-line no-param-reassign
   const auditData = JSON.parse(JSON.stringify(auditDataObject));
-  log.info(`Syncing high page views low form nav opportunity for ${auditData.siteId}`);
+  log.debug(`Syncing high page views low form nav opportunity for ${auditData.siteId}`);
   let opportunities;
 
   try {
@@ -64,7 +64,7 @@ export default async function createLowNavigationOpportunities(auditUrl, auditDa
     excludeForms,
   );
   filteredOpportunities.forEach((oppty) => excludeForms.add(oppty.form + oppty.formsource));
-  log.info(`filtered opportunities: high-page-views-low-form-navigations:  ${JSON.stringify(filteredOpportunities, null, 2)}`);
+  log.debug(`filtered opportunities: high-page-views-low-form-navigations:  ${JSON.stringify(filteredOpportunities, null, 2)}`);
   try {
     for (const opptyData of filteredOpportunities) {
       let highPageViewsLowFormNavOppty = opportunities.find(
@@ -100,7 +100,7 @@ export default async function createLowNavigationOpportunities(auditUrl, auditDa
         },
       };
 
-      log.info(`Forms Opportunity created high page views low form nav ${JSON.stringify(opportunityData, null, 2)}`);
+      log.debug(`Forms Opportunity created high page views low form nav ${JSON.stringify(opportunityData, null, 2)}`);
       let formsList = [];
 
       if (!highPageViewsLowFormNavOppty) {
@@ -119,9 +119,9 @@ export default async function createLowNavigationOpportunities(auditUrl, auditDa
       } else {
         const data = highPageViewsLowFormNavOppty.getData();
         const { formDetails } = data;
-        log.info(`Form details available for data  ${JSON.stringify(data, null, 2)}`);
+        log.debug(`Form details available for data  ${JSON.stringify(data, null, 2)}`);
         formsList = (formDetails !== undefined && isNonEmptyObject(formDetails))
-          ? (log.info('Form details available for opportunity, not sending it to mystique'), [])
+          ? (log.debug('Form details available for opportunity, not sending it to mystique'), [])
           : [{ form: opportunityData.data.form, formSource: opportunityData.data.formsource }];
 
         highPageViewsLowFormNavOppty.setAuditId(auditData.auditId);
@@ -146,5 +146,5 @@ export default async function createLowNavigationOpportunities(auditUrl, auditDa
   } catch (e) {
     log.error(`Creating Forms opportunity for high page views low form nav for siteId ${auditData.siteId} failed with error: ${e.message}`, e);
   }
-  log.info(`Successfully synced Opportunity for site: ${auditData.siteId} and high page views low form nav audit type.`);
+  log.debug(`Successfully synced Opportunity for site: ${auditData.siteId} and high page views low form nav audit type.`);
 }

--- a/src/forms-opportunities/utils.js
+++ b/src/forms-opportunities/utils.js
@@ -35,7 +35,7 @@ function getS3PathPrefix(url, site) {
 async function getPresignedUrl(fileName, context, url, site) {
   const { log, s3Client: s3ClientObj } = context;
   const screenshotPath = `${getS3PathPrefix(url, site)}/${fileName}`;
-  log.info(`Generating presigned URL for ${screenshotPath}`);
+  log.debug(`Generating presigned URL for ${screenshotPath}`);
 
   const command = new GetObjectCommand({
     Bucket: process.env.S3_BUCKET_NAME,
@@ -470,7 +470,7 @@ export async function calculateProjectedConversionValue(context, siteId, opportu
 
   try {
     const cpcValue = await calculateCPCValue(context, siteId);
-    log.info(`Calculated CPC value: ${cpcValue} for site: ${siteId}`);
+    log.debug(`Calculated CPC value: ${cpcValue} for site: ${siteId}`);
 
     const originalTraffic = opportunityData.pageViews;
     // traffic is calculated for 15 days - extrapolating for a year
@@ -495,7 +495,7 @@ export async function sendMessageToFormsQualityAgent(context, opportunity, forms
       log, sqs, site, env,
     } = context;
 
-    log.info(`Received forms quality agent message for mystique : ${JSON.stringify(opportunity)}`);
+    log.debug(`Received forms quality agent message for mystique : ${JSON.stringify(opportunity)}`);
     const opportunityData = JSON.parse(JSON.stringify(opportunity));
 
     const data = {
@@ -517,7 +517,7 @@ export async function sendMessageToFormsQualityAgent(context, opportunity, forms
 
     // eslint-disable-next-line no-await-in-loop
     await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, mystiqueFormsQualityAgentMessage);
-    log.info(`Forms quality agent message sent to mystique: ${JSON.stringify(mystiqueFormsQualityAgentMessage)}`);
+    log.debug(`Forms quality agent message sent to mystique: ${JSON.stringify(mystiqueFormsQualityAgentMessage)}`);
   }
 }
 
@@ -527,7 +527,7 @@ export async function sendMessageToMystiqueForGuidance(context, opportunity) {
   } = context;
 
   if (opportunity) {
-    log.info(`Received forms opportunity for guidance: ${JSON.stringify(opportunity)}`);
+    log.debug(`Received forms opportunity for guidance: ${JSON.stringify(opportunity)}`);
     const opptyData = JSON.parse(JSON.stringify(opportunity));
     // Normalize type: convert forms-accessibility → forms-a11y
     const normalizedType = opptyData.type === 'form-accessibility' ? 'forms-a11y' : opptyData.type;
@@ -562,7 +562,7 @@ export async function sendMessageToMystiqueForGuidance(context, opportunity) {
 
     // eslint-disable-next-line no-await-in-loop
     await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, mystiqueMessage);
-    log.info(`Forms opportunity sent to mystique for guidance: ${JSON.stringify(mystiqueMessage)}`);
+    log.debug(`Forms opportunity sent to mystique for guidance: ${JSON.stringify(mystiqueMessage)}`);
   }
 }
 

--- a/src/geo-brand-presence/detect-geo-brand-presence-handler.js
+++ b/src/geo-brand-presence/detect-geo-brand-presence-handler.js
@@ -23,7 +23,7 @@ export default async function handler(message, context) {
     auditId, siteId, type: subType, data,
   } = message;
 
-  log.info('GEO BRAND PRESENCE: Message received:', message);
+  log.debug('GEO BRAND PRESENCE: Message received:', message);
 
   if (!subType || !OPPTY_TYPES.includes(subType)) {
     log.error(`GEO BRAND PRESENCE: Unsupported subtype: ${subType}`);

--- a/src/geo-brand-presence/handler.js
+++ b/src/geo-brand-presence/handler.js
@@ -55,7 +55,7 @@ export async function sendToMystique(context, getPresignedUrl = getSignedUrl) {
   }
   /* c8 ignore stop */
 
-  log.info('GEO BRAND PRESENCE: sending data to mystique for site id %s (%s)', siteId, baseURL);
+  log.debug('GEO BRAND PRESENCE: sending data to mystique for site id %s (%s)', siteId, baseURL);
 
   const bucket = context.env?.S3_IMPORTER_BUCKET_NAME ?? /* c8 ignore next */ '';
   const recordSets = await Promise.all(
@@ -67,7 +67,7 @@ export async function sendToMystique(context, getPresignedUrl = getSignedUrl) {
     x.origin = x.source; // TODO(aurelio): remove when we decided which one to pick
   }
 
-  log.info('GEO BRAND PRESENCE: Found %d keyword prompts for site id %s (%s)', prompts.length, siteId, baseURL);
+  log.debug('GEO BRAND PRESENCE: Found %d keyword prompts for site id %s (%s)', prompts.length, siteId, baseURL);
   /* c8 ignore next 4 */
   if (prompts.length === 0) {
     log.warn('GEO BRAND PRESENCE: No keyword prompts found for site id %s (%s), skipping message to mystique', siteId, baseURL);
@@ -75,7 +75,7 @@ export async function sendToMystique(context, getPresignedUrl = getSignedUrl) {
   }
 
   const url = await asPresignedJsonUrl(prompts, bucket, { ...context, getPresignedUrl });
-  log.info('GEO BRAND PRESENCE: Presigned URL for prompts for site id %s (%s): %s', siteId, baseURL, url);
+  log.debug('GEO BRAND PRESENCE: Presigned URL for prompts for site id %s (%s): %s', siteId, baseURL, url);
   await Promise.all(OPPTY_TYPES.map(async (opptyType) => {
     const message = {
       type: opptyType,
@@ -89,7 +89,7 @@ export async function sendToMystique(context, getPresignedUrl = getSignedUrl) {
       data: { url },
     };
     await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, message);
-    log.info('GEO BRAND PRESENCE: %s Message sent to Mystique for site id %s (%s):', opptyType, siteId, baseURL, message);
+    log.debug('GEO BRAND PRESENCE: %s Message sent to Mystique for site id %s (%s):', opptyType, siteId, baseURL, message);
   }));
 }
 
@@ -126,7 +126,7 @@ async function asPresignedJsonUrl(data, bucketName, context) {
     ContentType: 'application/json',
   }));
 
-  log.info('GEO BRAND PRESENCE: Data uploaded to S3 at s3://%s/%s', bucketName, key);
+  log.debug('GEO BRAND PRESENCE: Data uploaded to S3 at s3://%s/%s', bucketName, key);
   return getPresignedUrl(
     s3Client,
     new GetObjectCommand({ Bucket: bucketName, Key: key }),
@@ -146,7 +146,7 @@ export async function keywordPromptsImportStep(context) {
   const endDate = Date.parse(data) ? data : undefined;
   /* c8 ignore stop */
 
-  log.info('GEO BRAND PRESENCE: Keyword prompts import step for %s with endDate: %s', finalUrl, endDate);
+  log.debug('GEO BRAND PRESENCE: Keyword prompts import step for %s with endDate: %s', finalUrl, endDate);
   return {
     type: LLMO_QUESTIONS_IMPORT_TYPE,
     endDate,

--- a/src/headings/handler.js
+++ b/src/headings/handler.js
@@ -145,7 +145,6 @@ export async function validatePageHeadings(url, log) {
   }
 
   try {
-    log.info(`Checking headings for URL: ${url}`);
     const response = await fetch(url);
     const html = await response.text();
     const dom = new JSDOM(html);
@@ -163,7 +162,7 @@ export async function validatePageHeadings(url, log) {
         explanation: HEADINGS_CHECKS.HEADING_MISSING_H1.explanation,
         suggestion: HEADINGS_CHECKS.HEADING_MISSING_H1.suggestion,
       });
-      log.info(`Missing h1 element detected at ${url}`);
+      log.info(`Missing h1 element detected at ${url}`); // debug?
     } else if (h1Elements.length > 1) {
       checks.push({
         check: HEADINGS_CHECKS.HEADING_MULTIPLE_H1.check,
@@ -172,7 +171,7 @@ export async function validatePageHeadings(url, log) {
         suggestion: HEADINGS_CHECKS.HEADING_MULTIPLE_H1.suggestion,
         count: h1Elements.length,
       });
-      log.info(`Multiple h1 elements detected at ${url}: ${h1Elements.length} found`);
+      log.info(`Multiple h1 elements detected at ${url}: ${h1Elements.length} found`); // debug?
     }
 
     // Check for empty headings and collect text content for duplicate detection
@@ -187,7 +186,7 @@ export async function validatePageHeadings(url, log) {
           suggestion: HEADINGS_CHECKS.HEADING_EMPTY.suggestion,
           tagName: heading.tagName,
         });
-        log.info(`Empty heading detected (${heading.tagName}) at ${url}`);
+        log.info(`Empty heading detected (${heading.tagName}) at ${url}`); // debug?
       } else {
         // Track heading text content for duplicate detection
         const lowerText = text.toLowerCase();
@@ -215,7 +214,7 @@ export async function validatePageHeadings(url, log) {
           duplicates: headingsWithSameText.map((h) => h.tagName),
           count: headingsWithSameText.length,
         });
-        log.info(`Duplicate heading text detected at ${url}: "${headingsWithSameText[0].text}" found in ${headingsWithSameText.map((h) => h.tagName).join(', ')}`);
+        log.info(`Duplicate heading text detected at ${url}: "${headingsWithSameText[0].text}" found in ${headingsWithSameText.map((h) => h.tagName).join(', ')}`); // debug? > 1k logs in 7d
       }
     }
 
@@ -233,7 +232,7 @@ export async function validatePageHeadings(url, log) {
           heading: currentHeading.tagName,
           nextHeading: nextHeading.tagName,
         });
-        log.info(`Heading without content detected at ${url}: ${currentHeading.tagName} has no content before ${nextHeading.tagName}`);
+        log.info(`Heading without content detected at ${url}: ${currentHeading.tagName} has no content before ${nextHeading.tagName}`); // debug? > 5.8k logs in 7d
       }
     }
 
@@ -252,7 +251,7 @@ export async function validatePageHeadings(url, log) {
             previous: `h${prevLevel}`,
             current: `h${curLevel}`,
           });
-          log.info(`Heading level jump detected at ${url}: h${prevLevel} → h${curLevel}`);
+          log.info(`Heading level jump detected at ${url}: h${prevLevel} → h${curLevel}`);// debug? ~500 logs in 7d
         }
       }
     }
@@ -277,14 +276,13 @@ export async function validatePageHeadings(url, log) {
 export async function headingsAuditRunner(baseURL, context, site) {
   const siteId = site.getId();
   const { log, dataAccess } = context;
-  log.info(`Starting Headings Audit with siteId: ${siteId}`);
 
   try {
     // Get top 200 pages
     const allTopPages = await getTopPagesForSiteId(dataAccess, siteId, context, log);
     const topPages = allTopPages.slice(0, 200);
 
-    log.info(`Processing ${topPages.length} top pages for headings audit (limited to 200)`);
+    log.debug(`Processing ${topPages.length} top pages for headings audit (limited to 200)`);
 
     if (topPages.length === 0) {
       log.info('No top pages found, ending audit.');
@@ -334,7 +332,7 @@ export async function headingsAuditRunner(baseURL, context, site) {
       }
     });
 
-    log.info(`Successfully completed Headings Audit for site: ${baseURL}. Found ${totalIssuesFound} issues across ${Object.keys(aggregatedResults).length} check types.`);
+    log.debug(`Successfully completed Headings Audit for site: ${baseURL}. Found ${totalIssuesFound} issues across ${Object.keys(aggregatedResults).length} check types.`);
 
     // Return success if no issues found, otherwise return the aggregated results
     if (totalIssuesFound === 0) {
@@ -381,7 +379,7 @@ export function generateSuggestions(auditUrl, auditData, context) {
     }
   });
 
-  log.info(`Generated ${suggestions.length} headings suggestions for ${auditUrl}`);
+  log.info(`Generated ${suggestions.length} headings suggestions for ${auditUrl}`); // debug?
   return { ...auditData, suggestions };
 }
 
@@ -437,7 +435,7 @@ export async function opportunityAndSuggestions(auditUrl, auditData, context) {
     log,
   });
 
-  log.info(`Headings opportunity created and ${auditData.suggestions.length} suggestions synced for ${auditUrl}`);
+  log.info(`Headings opportunity created and ${auditData.suggestions.length} suggestions synced for ${auditUrl}`); // debug?
   return { ...auditData };
 }
 

--- a/src/hreflang/handler.js
+++ b/src/hreflang/handler.js
@@ -60,7 +60,6 @@ export async function validatePageHreflang(url, log) {
   }
 
   try {
-    log.info(`Checking hreflang for URL: ${url}`);
     const response = await fetch(url);
 
     if (!response.ok) {
@@ -82,7 +81,7 @@ export async function validatePageHreflang(url, log) {
       return { url, checks: [] }; // Return empty checks - no issues to report
     }
 
-    log.info(`Found ${hreflangLinks.length} hreflang tags for URL: ${url}, validating implementation quality`);
+    log.debug(`Found ${hreflangLinks.length} hreflang tags for URL: ${url}, validating implementation quality`);
 
     if (hreflangLinks.length > 0) {
       let hasXDefault = false;
@@ -158,14 +157,14 @@ export async function validatePageHreflang(url, log) {
 export async function hreflangAuditRunner(baseURL, context, site) {
   const siteId = site.getId();
   const { log, dataAccess } = context;
-  log.info(`Starting Hreflang Audit with siteId: ${siteId}`);
+  log.debug(`Starting Hreflang Audit with siteId: ${siteId}`);
 
   try {
     // Get top 200 pages
     const allTopPages = await getTopPagesForSiteId(dataAccess, siteId, context, log);
     const topPages = allTopPages.slice(0, 200);
 
-    log.info(`Processing ${topPages.length} top pages for hreflang audit (limited to 200)`);
+    log.debug(`Processing ${topPages.length} top pages for hreflang audit (limited to 200)`);
 
     if (topPages.length === 0) {
       log.info('No top pages found, ending audit.');
@@ -205,7 +204,7 @@ export async function hreflangAuditRunner(baseURL, context, site) {
       return acc;
     }, {});
 
-    log.info(`Successfully completed Hreflang Audit for site: ${baseURL}`);
+    log.debug(`Successfully completed Hreflang Audit for site: ${baseURL}`);
 
     // All checks passed
     if (Object.keys(aggregatedResults).length === 0) {
@@ -345,7 +344,7 @@ export async function opportunityAndSuggestions(auditUrl, auditData, context) {
     }),
   });
 
-  log.info(`Hreflang opportunity created and ${auditData.suggestions.length} suggestions synced for ${auditUrl}`);
+  log.info(`Hreflang opportunity created and ${auditData.suggestions.length} suggestions synced for ${auditUrl}`); // debug?
   return { ...auditData };
 }
 

--- a/src/image-alt-text/handler.js
+++ b/src/image-alt-text/handler.js
@@ -36,7 +36,7 @@ export async function processAltTextWithMystique(context) {
     log, site, audit, dataAccess,
   } = context;
 
-  log.info(`[${AUDIT_TYPE}]: Processing alt-text with Mystique for site ${site.getId()}`);
+  log.debug(`[${AUDIT_TYPE}]: Processing alt-text with Mystique for site ${site.getId()}`);
 
   try {
     const { Opportunity } = dataAccess;
@@ -74,9 +74,9 @@ export async function processAltTextWithMystique(context) {
       };
       altTextOppty.setData(resetData);
       await altTextOppty.save();
-      log.info(`[${AUDIT_TYPE}]: Updated opportunity data for new audit run`);
+      log.debug(`[${AUDIT_TYPE}]: Updated opportunity data for new audit run`);
     } else {
-      log.info(`[${AUDIT_TYPE}]: Creating new opportunity for site ${siteId}`);
+      log.debug(`[${AUDIT_TYPE}]: Creating new opportunity for site ${siteId}`);
       const opportunityDTO = {
         siteId,
         auditId: audit.getId(),
@@ -112,7 +112,7 @@ export async function processAltTextWithMystique(context) {
       };
 
       altTextOppty = await Opportunity.create(opportunityDTO);
-      log.info(`[${AUDIT_TYPE}]: Created new opportunity with ID ${altTextOppty.getId()}`);
+      log.debug(`[${AUDIT_TYPE}]: Created new opportunity with ID ${altTextOppty.getId()}`);
     }
 
     await sendAltTextOpportunityToMystique(
@@ -123,7 +123,7 @@ export async function processAltTextWithMystique(context) {
       context,
     );
 
-    log.info(`[${AUDIT_TYPE}]: Sent ${pageUrls.length} pages to Mystique for generating alt-text suggestions`);
+    log.debug(`[${AUDIT_TYPE}]: Sent ${pageUrls.length} pages to Mystique for generating alt-text suggestions`);
 
     // Clean up outdated suggestions
     // Small delay to ensure no concurrent operations

--- a/src/image-alt-text/opportunityHandler.js
+++ b/src/image-alt-text/opportunityHandler.js
@@ -76,7 +76,6 @@ export const getProjectedMetrics = async ({
 
   try {
     finalUrl = await getRUMUrl(auditUrl);
-    log.info(`[${AUDIT_TYPE}]: RUM URL: ${finalUrl}`);
     const rumAPIClient = RUMAPIClient.createFrom(context);
     const options = {
       domain: finalUrl,
@@ -160,7 +159,7 @@ export async function sendAltTextOpportunityToMystique(
     // Batch the URLs to avoid sending too many at once
     const urlBatches = chunkArray(pageUrls, MYSTIQUE_BATCH_SIZE);
 
-    log.info(`[${AUDIT_TYPE}]: Sending ${pageUrls.length} URLs to Mystique in ${urlBatches.length} batch(es)`);
+    log.debug(`[${AUDIT_TYPE}]: Sending ${pageUrls.length} URLs to Mystique in ${urlBatches.length} batch(es)`);
 
     // Send each batch as a separate message
     for (let i = 0; i < urlBatches.length; i += 1) {
@@ -180,11 +179,11 @@ export async function sendAltTextOpportunityToMystique(
       };
       // eslint-disable-next-line no-await-in-loop
       await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, mystiqueMessage);
-      log.info(`[${AUDIT_TYPE}]: Batch ${i + 1}/${urlBatches.length} sent to Mystique with ${batch.length} URLs`);
-      log.info(`[${AUDIT_TYPE}]: Message sent to Mystique: ${JSON.stringify(mystiqueMessage)}`);
+      log.debug(`[${AUDIT_TYPE}]: Batch ${i + 1}/${urlBatches.length} sent to Mystique with ${batch.length} URLs`);
+      log.debug(`[${AUDIT_TYPE}]: Message sent to Mystique: ${JSON.stringify(mystiqueMessage)}`);
     }
 
-    log.info(`[${AUDIT_TYPE}]: All ${urlBatches.length} batches sent to Mystique successfully`);
+    log.debug(`[${AUDIT_TYPE}]: All ${urlBatches.length} batches sent to Mystique successfully`);
   } catch (error) {
     log.error(`[${AUDIT_TYPE}]: Failed to send alt-text opportunity to Mystique: ${error.message}`);
     throw error;
@@ -261,7 +260,7 @@ export async function addAltTextSuggestions({ opportunity, newSuggestionDTOs, lo
     }
   }
 
-  log.info(`[${AUDIT_TYPE}]: Added ${newSuggestionDTOs.length} new suggestions`);
+  log.debug(`[${AUDIT_TYPE}]: Added ${newSuggestionDTOs.length} new suggestions`);
 }
 
 /**
@@ -279,9 +278,9 @@ export async function cleanupOutdatedSuggestions(opportunity, log) {
 
     if (outdatedSuggestions.length > 0) {
       await Promise.all(outdatedSuggestions.map((suggestion) => suggestion.remove()));
-      log.info(`[${AUDIT_TYPE}]: Cleaned up ${outdatedSuggestions.length} OUTDATED suggestions`);
+      log.info(`[${AUDIT_TYPE}]: Cleaned up ${outdatedSuggestions.length} OUTDATED suggestions`); // debug?
     } else {
-      log.info(`[${AUDIT_TYPE}]: No OUTDATED suggestions to clean up`);
+      log.info(`[${AUDIT_TYPE}]: No OUTDATED suggestions to clean up`); // debug?
     }
   } catch (error) {
     log.error(`[${AUDIT_TYPE}]: Failed to cleanup OUTDATED suggestions: ${error.message}`);

--- a/src/internal-links/handler.js
+++ b/src/internal-links/handler.js
@@ -75,8 +75,6 @@ export async function internalLinksAuditRunner(auditUrl, context) {
     // 6. Prioritize links
     const prioritizedLinks = calculatePriority(inaccessibleLinks);
 
-    log.info(`[${AUDIT_TYPE}] [Site: ${site.getId()}] found: ${prioritizedLinks.length} broken internal links`);
-
     // 7. Build and return audit result
     return {
       auditResult: {
@@ -103,7 +101,7 @@ export async function internalLinksAuditRunner(auditUrl, context) {
 
 export async function runAuditAndImportTopPagesStep(context) {
   const { site, log, finalUrl } = context;
-  log.info(`[${AUDIT_TYPE}] [Site: ${site.getId()}] starting audit`);
+  log.debug(`[${AUDIT_TYPE}] [Site: ${site.getId()}] starting audit`); // remove?
   const internalLinksAuditRunnerResult = await internalLinksAuditRunner(
     finalUrl,
     context,
@@ -236,7 +234,7 @@ export const opportunityAndSuggestionsStep = async (context) => {
       },
     };
     await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, message);
-    log.info(`Message sent to Mystique: ${JSON.stringify(message)}`);
+    log.debug(`Message sent to Mystique: ${JSON.stringify(message)}`);
   }
   return {
     status: 'complete',

--- a/src/internal-links/helpers.js
+++ b/src/internal-links/helpers.js
@@ -82,13 +82,13 @@ export async function isLinkInaccessible(url, log) {
 
     // Log non-404, non-200 status codes
     if (status >= 400 && status < 500 && status !== 404) {
-      log.info(`broken-internal-links audit: Warning: ${url} returned client error: ${status}`);
+      log.warn(`broken-internal-links audit: Warning: ${url} returned client error: ${status}`);
     }
 
     // URL is valid if status code is less than 400, otherwise it is invalid
     return status >= 400;
   } catch (error) {
-    log.info(`broken-internal-links audit: Error checking ${url}: ${error.code === 'ETIMEOUT' ? `Request timed out after ${LINK_TIMEOUT}ms` : error.message}`);
+    log.error(`broken-internal-links audit: Error checking ${url}: ${error.code === 'ETIMEOUT' ? `Request timed out after ${LINK_TIMEOUT}ms` : error.message}`);
     // Any error means the URL is inaccessible
     return true;
   }

--- a/src/lhs/lib.js
+++ b/src/lhs/lib.js
@@ -279,7 +279,7 @@ async function lhsAuditRunner(baseURL, strategy, context, site) {
   const elapsedSeconds = endTime[0] + endTime[1] / 1e9;
   const formattedElapsed = elapsedSeconds.toFixed(2);
 
-  log.info(`LHS Audit of type ${strategy} completed in ${formattedElapsed} seconds for ${baseURL}`);
+  log.debug(`LHS Audit of type ${strategy} completed in ${formattedElapsed} seconds for ${baseURL}`); // remove? > 2.5k logs in 7d
 
   return auditData;
 }

--- a/src/llm-blocked/handler.js
+++ b/src/llm-blocked/handler.js
@@ -23,7 +23,7 @@ const { AUDIT_STEP_DESTINATIONS } = Audit;
 export async function importTopPages(context) {
   const { site, finalUrl, log } = context;
 
-  log.info(`Importing top pages for ${finalUrl}`);
+  log.debug(`Importing top pages for ${finalUrl}`);
 
   return {
     type: 'top-pages',
@@ -37,7 +37,7 @@ export async function importTopPages(context) {
 export async function getRobotsTxt(context) {
   try {
     const { finalUrl, log } = context;
-    log.info(`Fetching https://${finalUrl}/robots.txt`);
+    log.debug(`Fetching https://${finalUrl}/robots.txt`);
     const robotsTxt = await fetch(`https://${finalUrl}/robots.txt`);
     const robotsTxtContent = await robotsTxt.text();
 
@@ -64,7 +64,7 @@ export async function checkLLMBlocked(context) {
     throw new Error('No top pages found for site');
   }
 
-  log.info(`Checking top URLs for blocked AI bots, finalUrl: ${finalUrl}`);
+  log.debug(`Checking top URLs for blocked AI bots, finalUrl: ${finalUrl}`);
 
   const agentsWithRationale = {
     'ClaudeBot/1.0': 'Unblock ClaudeBot/1.0 to allow Anthropic’s Claude to access your site when assisting users.',

--- a/src/llm-error-pages/guidance-handler.js
+++ b/src/llm-error-pages/guidance-handler.js
@@ -94,7 +94,7 @@ export default async function handler(message, context) {
             '',
           ];
           row.commit();
-          log.info(`Updated row ${i} for URL: ${pathOnlyUrl} with broken URL data`);
+          log.debug(`Updated row ${i} for URL: ${pathOnlyUrl} with broken URL data`);
         }
       }
     }
@@ -103,7 +103,7 @@ export default async function handler(message, context) {
     const buffer = await workbook.xlsx.writeBuffer();
     await uploadToSharePoint(buffer, filename, outputDir, sharepointClient, log);
     await publishToAdminHlx(filename, outputDir, log);
-    log.info(`Updated Excel 404 file with Mystique guidance: ${filename}`);
+    log.debug(`Updated Excel 404 file with Mystique guidance: ${filename}`);
   } catch (e) {
     log.error(`Failed to update 404 Excel on Mystique callback: ${e.message}`);
     return badRequest('Failed to persist guidance');

--- a/src/llm-error-pages/handler.js
+++ b/src/llm-error-pages/handler.js
@@ -34,8 +34,8 @@ async function runLlmErrorPagesAudit(url, context, site) {
   } = context;
   const s3Config = await getS3Config(site, context);
 
-  log.info(`Starting LLM error pages audit for ${url}`);
-  log.info(`Running LLM error pages audit ${audit}`);
+  log.debug(`Starting LLM error pages audit for ${url}`);
+  log.debug(`Running LLM error pages audit ${audit}`);
 
   try {
     const athenaClient = AWSAthenaClient.fromContext(context, s3Config.getAthenaTempLocation());
@@ -44,7 +44,7 @@ async function runLlmErrorPagesAudit(url, context, site) {
     const { startDate } = week;
     const { endDate } = week;
     const periodIdentifier = `w${week.weekNumber}-${week.year}`;
-    log.info(`Running weekly audit for ${periodIdentifier}`);
+    log.debug(`Running weekly audit for ${periodIdentifier}`);
 
     // Get site configuration
     const filters = site.getConfig()?.getLlmoCdnlogsFilter?.() || [];
@@ -60,7 +60,7 @@ async function runLlmErrorPagesAudit(url, context, site) {
       siteFilters,
     });
 
-    log.info('Executing LLM error pages query...');
+    log.debug('Executing LLM error pages query...');
     const sqlQueryDescription = '[Athena Query] LLM error pages analysis';
     const results = await athenaClient.query(
       query,
@@ -107,7 +107,7 @@ async function runLlmErrorPagesAudit(url, context, site) {
         sharepointClient,
         filename,
       });
-      log.info(`Uploaded Excel for ${code}: ${filename} (${sorted.length} rows)`);
+      log.debug(`Uploaded Excel for ${code}: ${filename} (${sorted.length} rows)`);
     };
 
     // Generate and upload Excel files for each category
@@ -117,7 +117,7 @@ async function runLlmErrorPagesAudit(url, context, site) {
       writeCategoryExcel('5xx', categorizedResults['5xx']),
     ]);
 
-    log.info(`Found ${processedResults.totalErrors} total errors across ${processedResults.summary.uniqueUrls} unique URLs`);
+    log.debug(`Found ${processedResults.totalErrors} total errors across ${processedResults.summary.uniqueUrls} unique URLs`);
 
     const auditResult = {
       success: true,
@@ -228,7 +228,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     };
 
     await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, message);
-    log.info(`Queued ${urlToUserAgentsMap.size} consolidated 404 URLs to Mystique for AI processing`);
+    log.debug(`Queued ${urlToUserAgentsMap.size} consolidated 404 URLs to Mystique for AI processing`);
   } catch (error) {
     log.error(`Failed to send Mystique message: ${error.message}`);
   }

--- a/src/llmo-customer-analysis/domain-analysis.js
+++ b/src/llmo-customer-analysis/domain-analysis.js
@@ -121,7 +121,7 @@ ${JSON.stringify(products, null, 2)}
           url: product.url,
         }));
 
-      log.info(`Concentrated ${products.length} products into ${validatedProducts.length} products`);
+      log.debug(`Concentrated ${products.length} products into ${validatedProducts.length} products`);
       return { products: validatedProducts, usage: promptResponse.usage };
     }
   } catch (err) {
@@ -180,13 +180,13 @@ Example outputs:
 
 []`;
 
-  log.info(`Starting domain analysis for ${domain}`);
+  log.debug(`Starting domain analysis for ${domain}`);
 
   for (const scrape of scrapes) {
     // eslint-disable-next-line no-await-in-loop
     const data = await getObjectFromKey(s3Client, S3_SCRAPER_BUCKET_NAME, scrape);
     const { scrapeResult } = data;
-    log.info('Scrape retrieved; starting analysis');
+    log.debug('Scrape retrieved; starting analysis');
 
     // Build an object containing only the requested fields from scrapeResult if they exist
     // TODO:: Create a handler in spacecat-content-scraper
@@ -268,7 +268,7 @@ ${stringified}
               log.warn(`Invalid product object structure obtained during extraction: ${JSON.stringify(product)}`);
             }
           });
-          log.info(`Extracted ${productArray.length} products from scrape.`);
+          log.debug(`Extracted ${productArray.length} products from scrape.`);
         } else {
           log.info('No products found in this scrape.');
         }
@@ -288,7 +288,7 @@ ${stringified}
   }
 
   // Log total token usage before returning
-  log.info(`Total token usage for domain analysis: ${JSON.stringify(totalTokenUsage)}`);
+  log.debug(`Total token usage for domain analysis: ${JSON.stringify(totalTokenUsage)}`);
 
   return concentratedInsights.products;
 }

--- a/src/llmo-customer-analysis/handler.js
+++ b/src/llmo-customer-analysis/handler.js
@@ -37,8 +37,8 @@ async function runReferralTrafficStep(context) {
   const configuration = await Configuration.findLatest();
   const siteId = site.getSiteId();
 
-  log.info(`Starting llmo-customer-analysis audit for site: ${siteId}}`);
-  log.info('Referral Traffic Step: Initiating OpTel import for the last 4 full calendar weeks');
+  log.debug(`Starting llmo-customer-analysis audit for site: ${siteId}}`);
+  log.debug('Referral Traffic Step: Initiating OpTel import for the last 4 full calendar weeks');
 
   const last4Weeks = getLastNumberOfWeeks(4);
 
@@ -76,7 +76,7 @@ async function runAgenticTrafficStep(context) {
     audit, env, site, log,
   } = context;
 
-  log.info('Agentic Traffic Step: Extracting product and page type information');
+  log.debug('Agentic Traffic Step: Extracting product and page type information');
 
   const lastFourWeeks = getLastNumberOfWeeks(4);
 
@@ -106,11 +106,11 @@ async function runAgenticTrafficStep(context) {
   const productRegexes = await analyzeProducts(domain, paths.map((p) => p.path), context);
   const pagetypeRegexes = await analyzePageTypes(domain, paths.map((p) => p.path), context);
 
-  log.info('Agentic Traffic Step: Extraction complete; uploading results');
+  log.debug('Agentic Traffic Step: Extraction complete; uploading results');
 
   await uploadPatternsWorkbook(productRegexes, pagetypeRegexes, site, context);
 
-  log.info('Agentic Traffic Step: Upload complete; initiating scrap');
+  log.debug('Agentic Traffic Step: Upload complete; initiating scrap');
 
   const urls = paths.slice(0, 20).map((p) => ({ url: `https://${audit.getFullAuditRef()}${p.path}` }));
 
@@ -135,15 +135,15 @@ async function runBrandPresenceStep(context) {
   const results = [...scrapeResultPaths.values()];
 
   try {
-    log.info('Brand Presence Step: Scrapes received; starting analysis');
+    log.debug('Brand Presence Step: Scrapes received; starting analysis');
 
     const domainInsights = await analyzeDomain(domain, results, context);
 
-    log.info('Brand Presence Step: analysis complete; uploading results');
+    log.debug('Brand Presence Step: analysis complete; uploading results');
 
     await uploadUrlsWorkbook(domainInsights, site, context);
 
-    log.info('Brand Presence Step: Upload complete; triggering geo-brand-presence audit');
+    log.debug('Brand Presence Step: Upload complete; triggering geo-brand-presence audit');
 
     const geoBrandPresenceMessage = {
       type: 'geo-brand-presence',

--- a/src/llmo-customer-analysis/page-type-analysis.js
+++ b/src/llmo-customer-analysis/page-type-analysis.js
@@ -144,14 +144,14 @@ URL Paths:
 ${JSON.stringify(paths, null, 2)}`;
 
   try {
-    log.info('Extracting page types from URL paths');
+    log.debug('Extracting page types from URL paths');
     const promptResponse = await prompt(systemPrompt, userPrompt, env);
     if (promptResponse && promptResponse.content) {
       const { paths: parsedPaths } = JSON.parse(promptResponse.content);
-      log.info('Successfully extracted page types from URL paths');
+      log.debug('Successfully extracted page types from URL paths');
       return { paths: parsedPaths, usage: promptResponse.usage };
     } else {
-      log.info('No content received; defaulting all paths to "other"');
+      log.debug('No content received; defaulting all paths to "other"');
       return { paths: paths.map((path) => ({ path, pageType: 'other' })), usage: null };
     }
   } catch (error) {
@@ -222,12 +222,12 @@ Grouped Paths:
 ${JSON.stringify(groupedPaths, null, 2)}`;
 
   try {
-    log.info('Generating regex patterns for page types');
+    log.debug('Generating regex patterns for page types');
     const promptResponse = await prompt(systemPrompt, userPrompt, env);
     if (promptResponse && promptResponse.content) {
       const parsed = JSON.parse(promptResponse.content);
       if (parsed && typeof parsed === 'object') {
-        log.info('Successfully generated regex patterns for page types');
+        log.debug('Successfully generated regex patterns for page types');
         return { regexes: parsed, usage: promptResponse.usage };
       }
 
@@ -264,7 +264,7 @@ ${JSON.stringify(groupedPaths, null, 2)}`;
 export async function analyzePageTypes(domain, paths, context) {
   const { log } = context;
 
-  log.info(`Starting page type analysis for domain: ${domain}`);
+  log.debug(`Starting page type analysis for domain: ${domain}`);
 
   const totalTokenUsage = {
     prompt_tokens: 0,
@@ -293,9 +293,9 @@ export async function analyzePageTypes(domain, paths, context) {
     }
 
     // Log total token usage
-    log.info(`Total token usage for page type analysis: ${JSON.stringify(totalTokenUsage)}`);
+    log.debug(`Total token usage for page type analysis: ${JSON.stringify(totalTokenUsage)}`);
 
-    log.info(`Page type analysis complete for domain: ${domain}`);
+    log.debug(`Page type analysis complete for domain: ${domain}`);
     return regexPatterns.regexes;
   } catch (error) {
     log.error(`Failed to complete page type analysis: ${error.message}`);

--- a/src/llmo-customer-analysis/product-analysis.js
+++ b/src/llmo-customer-analysis/product-analysis.js
@@ -173,14 +173,13 @@ PATHS:
 ${JSON.stringify(paths, null, 2)}`;
 
   try {
-    log.info('Extracting products from URL paths');
     const promptResponse = await prompt(systemPrompt, userPrompt, env);
     if (promptResponse && promptResponse.content) {
       const { paths: parsedPaths } = JSON.parse(promptResponse.content);
-      log.info('Successfully extracted products from URL paths');
+      log.debug('Successfully extracted products from URL paths');
       return { paths: parsedPaths, usage: promptResponse.usage };
     } else {
-      log.info('No content received; defaulting to unknown products');
+      log.debug('No content received; defaulting to unknown products');
       return { paths: paths.map((path) => ({ path, product: 'unknown' })), usage: null };
     }
   } catch (error) {
@@ -263,12 +262,11 @@ GROUPED PATHS BY PRODUCT:
 ${JSON.stringify(groupedPaths)}`;
 
   try {
-    log.info('Generating regex patterns for products');
     const promptResponse = await prompt(systemPrompt, userPrompt, env);
     if (promptResponse && promptResponse.content) {
       const parsed = JSON.parse(promptResponse.content);
       if (parsed && typeof parsed === 'object') {
-        log.info('Successfully generated regex patterns for products');
+        log.debug('Successfully generated regex patterns for products');
         return { patterns: parsed, usage: promptResponse.usage };
       }
       log.warn('Unexpected format received; defaulting to fallback regexes');
@@ -309,7 +307,7 @@ export async function analyzeProducts(domain, paths, context) {
     total_tokens: 0,
   };
 
-  log.info(`Starting product analysis for domain: ${domain}`);
+  log.debug(`Starting product analysis for domain: ${domain}`);
 
   try {
     const pathClassifications = await deriveProductsForPaths(domain, paths, context);
@@ -356,8 +354,8 @@ export async function analyzeProducts(domain, paths, context) {
     // Remove "unknown" key if it exists
     delete combinedPatterns.unknown;
 
-    log.info(`Completed product analysis for domain: ${domain}`);
-    log.info(`Total token usage for product analysis: ${JSON.stringify(totalTokenUsage)}`);
+    log.debug(`Completed product analysis for domain: ${domain}`);
+    log.debug(`Total token usage for product analysis: ${JSON.stringify(totalTokenUsage)}`);
     return combinedPatterns;
   } catch (error) {
     log.error(`Product analysis failed: ${error.message}`);

--- a/src/metatags/metatags-auto-suggest.js
+++ b/src/metatags/metatags-auto-suggest.js
@@ -54,7 +54,7 @@ export default async function metatagsAutoSuggest(allTags, context, site, option
   const { Configuration } = dataAccess;
   const configuration = await Configuration.findLatest();
   if (!forceAutoSuggest && !configuration.isHandlerEnabledForSite('meta-tags-auto-suggest', site)) {
-    log.info('Metatags auto-suggest is disabled for site');
+    log.info('Metatags auto-suggest is disabled for site'); // debug?
     return detectedTags;
   }
   log.debug('Generating suggestions for Meta-tags using Genvar.');
@@ -98,6 +98,6 @@ export default async function metatagsAutoSuggest(allTags, context, site, option
       }
     }
   }
-  log.info('Generated AI suggestions for Meta-tags using Genvar.');
+  log.debug('Generated AI suggestions for Meta-tags using Genvar.');
   return updatedDetectedTags;
 }

--- a/src/notfound/handler.js
+++ b/src/notfound/handler.js
@@ -40,7 +40,7 @@ function process404Response(data) {
 export async function audit404Runner(baseURL, context) {
   const { log } = context;
 
-  log.info(`Received audit req for domain: ${baseURL}`);
+  log.debug(`Received audit req for domain: ${baseURL}`);
   const finalUrl = await getRUMUrl(baseURL);
 
   const rumAPIClient = RUMAPIClient.createFrom(context);

--- a/src/optimization-report/handler.js
+++ b/src/optimization-report/handler.js
@@ -22,7 +22,7 @@ async function optimizationReportCallback(message, context) {
   const { data } = message;
   const { siteId, reportId } = data;
 
-  log.info(`Processing optimization report callback for site: ${siteId} with report id: ${reportId}`);
+  log.debug(`Processing optimization report callback for site: ${siteId} with report id: ${reportId}`);
 
   try {
     // Get the report jobs queue URL from environment variables
@@ -35,7 +35,7 @@ async function optimizationReportCallback(message, context) {
     // Send the message to the report jobs queue without modification
     await sqs.sendMessage(reportJobsQueueUrl, message);
 
-    log.info(`Successfully sent message to report jobs queue for site: ${siteId} and report id: ${reportId}`);
+    log.debug(`Successfully sent message to report jobs queue for site: ${siteId} and report id: ${reportId}`);
   } catch (error) {
     log.error(`Failed to send message to report jobs queue for site: ${siteId} and report id: ${reportId}`, error);
     throw error;

--- a/src/paid-cookie-consent/guidance-handler.js
+++ b/src/paid-cookie-consent/guidance-handler.js
@@ -27,14 +27,14 @@ export default async function handler(message, context) {
   const { auditId, siteId, data } = message;
   const { url, guidance } = data;
 
-  log.info(`Message received for guidance:paid-cookie-consent handler site: ${siteId} url: ${url} message: ${JSON.stringify(message)}`);
+  log.debug(`Message received for guidance:paid-cookie-consent handler site: ${siteId} url: ${url} message: ${JSON.stringify(message)}`);
 
   const audit = await Audit.findById(auditId);
   if (!audit) {
     log.warn(`No audit found for auditId: ${auditId}`);
     return notFound();
   }
-  log.info(`Fetched Audit ${JSON.stringify(message)}`);
+  log.debug(`Fetched Audit ${JSON.stringify(message)}`);
 
   // Check for low severity and skip if so
   const guidanceParsed = getGuidanceObj(guidance);
@@ -45,7 +45,7 @@ export default async function handler(message, context) {
 
   const entity = mapToPaidOpportunity(siteId, url, audit, guidanceParsed);
   // Always create a new opportunity
-  log.info(`Creating new paid-cookie-consent opportunity for ${siteId} page: ${url}`);
+  log.debug(`Creating new paid-cookie-consent opportunity for ${siteId} page: ${url}`);
 
   const opportunity = await Opportunity.create(entity);
   // Create suggestion for the new opportunity first
@@ -57,7 +57,7 @@ export default async function handler(message, context) {
     guidanceParsed,
   );
   await Suggestion.create(suggestionData);
-  log.info(`Created suggestion for opportunity ${opportunity.getId()}`);
+  log.debug(`Created suggestion for opportunity ${opportunity.getId()}`);
 
   // Only after suggestion is successfully created,
   // find and mark existing NEW system opportunities as IGNORED
@@ -69,7 +69,7 @@ export default async function handler(message, context) {
     .filter((oppty) => oppty.getId() !== opportunity.getId()); // Exclude the newly created one
 
   if (existingMatches.length > 0) {
-    log.info(`Found ${existingMatches.length} existing NEW system opportunities for page ${url}. Marking them as IGNORED.`);
+    log.debug(`Found ${existingMatches.length} existing NEW system opportunities for page ${url}. Marking them as IGNORED.`);
     await Promise.all(existingMatches.map(async (oldOppty) => {
       oldOppty.setStatus('IGNORED');
       await oldOppty.save();
@@ -77,7 +77,7 @@ export default async function handler(message, context) {
     }));
   }
 
-  log.info(`paid-cookie-consent  opportunity succesfully added for site: ${siteId} page: ${url} audit: ${auditId}  opportunity: ${JSON.stringify(opportunity, null, 2)}`);
+  log.debug(`paid-cookie-consent  opportunity succesfully added for site: ${siteId} page: ${url} audit: ${auditId}  opportunity: ${JSON.stringify(opportunity, null, 2)}`);
 
   return ok();
 }

--- a/src/paid-traffic-analysis/cache-warmer.js
+++ b/src/paid-traffic-analysis/cache-warmer.js
@@ -146,11 +146,11 @@ export async function warmCacheForSite(context, log, env, site, temporalParams) 
 
   const { yearInt, weekInt, monthInt } = temporalParams;
 
-  log.info(`Starting cache warming for site ${siteId} - Year: ${yearInt}, Week: ${weekInt}, Month: ${monthInt}`);
-  log.info(`Using max concurrent requests: ${config.maxConcurrentRequests}`);
+  log.debug(`Starting cache warming for site ${siteId} - Year: ${yearInt}, Week: ${weekInt}, Month: ${monthInt}`);
+  log.debug(`Using max concurrent requests: ${config.maxConcurrentRequests}`);
 
   // Check which queries need cache warming
-  log.info(`Checking cache existence for ${QUERIES.length} queries...`);
+  log.debug(`Checking cache existence for ${QUERIES.length} queries...`);
   const checkTasks = QUERIES.map(
     (queryConfig) => () => checkCacheExists(
       context,
@@ -168,10 +168,10 @@ export async function warmCacheForSite(context, log, env, site, temporalParams) 
   const queriesToWarm = cacheChecks.filter((check) => !check.exists);
   const cachedQueries = cacheChecks.filter((check) => check.exists);
 
-  log.info(`Found ${cachedQueries.length} cached queries, ${queriesToWarm.length} queries need warming`);
+  log.debug(`Found ${cachedQueries.length} cached queries, ${queriesToWarm.length} queries need warming`);
 
   if (queriesToWarm.length === 0) {
-    log.info(`All caches already exist for site ${siteId}. No warming needed.`);
+    log.debug(`All caches already exist for site ${siteId}. No warming needed.`);
     return {
       success: true,
       results: cachedQueries.map(
@@ -193,7 +193,7 @@ export async function warmCacheForSite(context, log, env, site, temporalParams) 
     cacheKey: check.cacheKey,
   })));
 
-  log.info(`Processing ${queriesToWarm.length} queries with max ${config.maxConcurrentRequests} concurrent...`);
+  log.debug(`Processing ${queriesToWarm.length} queries with max ${config.maxConcurrentRequests} concurrent...`);
 
   const warmingTasks = queriesToWarm.map(({ queryConfig }) => () => (async () => {
     try {
@@ -222,7 +222,7 @@ export async function warmCacheForSite(context, log, env, site, temporalParams) 
   results.push(...warmingResults);
 
   const successCount = results.filter((r) => r.success).length;
-  log.info(`Cache warming completed for site ${siteId}. Success: ${successCount}/${results.length}`);
+  log.debug(`Cache warming completed for site ${siteId}. Success: ${successCount}/${results.length}`);
 
   return {
     success: true, results, successCount, totalCount: results.length,
@@ -260,7 +260,7 @@ export async function warmCacheForQuery(
   const query = getTrafficAnalysisQuery(queryParams);
   const { cacheKey, outPrefix } = getCacheKey(siteId, query, config.cacheLocation);
 
-  log.info(`Warming cache for dimensions [${dimensions.join(', ')}]: ${cacheKey}`);
+  log.debug(`Warming cache for dimensions [${dimensions.join(', ')}]: ${cacheKey}`);
 
   const resultLocation = `${config.athenaTemp}/${outPrefix}`;
   const athenaClient = AWSAthenaClient.fromContext(context, resultLocation);

--- a/src/paid-traffic-analysis/caching-helper.js
+++ b/src/paid-traffic-analysis/caching-helper.js
@@ -46,7 +46,7 @@ export async function addResultJsonToCache(s3, cacheKey, data, log) {
     });
 
     await s3.send(command);
-    log.info(`Successfully cached result to: ${cacheKey}`);
+    log.debug(`Successfully cached result to: ${cacheKey}`);
   } catch (error) {
     log.error(`Failed to cache result to: ${cacheKey}.  Ignoring error and proceeding with next steps`, error);
   }

--- a/src/paid-traffic-analysis/guidance-handler.js
+++ b/src/paid-traffic-analysis/guidance-handler.js
@@ -75,12 +75,12 @@ async function ignorePreviousOpportunitiesForPeriod(Opportunity, siteId, _period
     const weekVal = data?.week;
     const monthVal = data?.month;
     const id = oppty.getId();
-    log.info(`Setting existing paid-traffic opportunity id=${id} title="${title}" week=${weekVal} month=${monthVal} to IGNORED`);
+    log.debug(`Setting existing paid-traffic opportunity id=${id} title="${title}" week=${weekVal} month=${monthVal} to IGNORED`);
     oppty.setStatus('IGNORED');
     oppty.setUpdatedBy('system');
     await oppty.save();
   }));
-  log.info(`Ignored ${candidates.length} existing paid-traffic opportunities for siteId=${siteId}`);
+  log.debug(`Ignored ${candidates.length} existing paid-traffic opportunities for siteId=${siteId}`);
 }
 
 export default async function handler(message, context) {
@@ -91,7 +91,7 @@ export default async function handler(message, context) {
     url, guidance,
   } = data;
 
-  log.info(`Message received for ${GUIDANCE_TYPE} handler site: ${siteId} url: ${url} message: ${JSON.stringify(message)}`);
+  log.debug(`Message received for ${GUIDANCE_TYPE} handler site: ${siteId} url: ${url} message: ${JSON.stringify(message)}`);
   const audit = await Audit.findById(auditId);
   if (!audit) {
     log.warn(`No audit found for auditId: ${auditId}`);
@@ -126,6 +126,6 @@ export default async function handler(message, context) {
     opportunity.getId(),
   );
 
-  log.info(`Finished mapping [${GUIDANCE_TYPE}] -> OpportunityType [${TRAFFIC_OPP_TYPE}] for site: ${siteId} period: ${period.week != null ? `W${period.week}/Y${period.year}` : `M${period.month}/Y${period.year}`} opportunityId: ${opportunity.getId?.()}`);
+  log.debug(`Finished mapping [${GUIDANCE_TYPE}] -> OpportunityType [${TRAFFIC_OPP_TYPE}] for site: ${siteId} period: ${period.week != null ? `W${period.week}/Y${period.year}` : `M${period.month}/Y${period.year}`} opportunityId: ${opportunity.getId?.()}`);
   return ok();
 }

--- a/src/paid-traffic-analysis/handler.js
+++ b/src/paid-traffic-analysis/handler.js
@@ -43,7 +43,7 @@ export async function prepareTrafficAnalysisRequest(auditUrl, context, site, per
   const { log, env } = context;
   const siteId = site.getSiteId();
 
-  log.info(`[traffic-analysis-audit-${period}] Preparing mystique traffic-analysis-audit request parameters for [siteId: ${siteId}] and baseUrl: ${auditUrl}`);
+  log.debug(`[traffic-analysis-audit-${period}] Preparing mystique traffic-analysis-audit request parameters for [siteId: ${siteId}] and baseUrl: ${auditUrl}`);
 
   let auditResult;
 
@@ -78,10 +78,10 @@ export async function prepareTrafficAnalysisRequest(auditUrl, context, site, per
     monthInt: auditResult.month,
   };
 
-  log.info(`[cache-warming-${period}] Starting cache warming for site: ${siteId}`);
+  log.debug(`[cache-warming-${period}] Starting cache warming for site: ${siteId}`);
   await warmCacheForSite(context, log, env, site, temporalParams);
-  log.info(`[cache-warming-${period}] Completed cache warming for site: ${siteId}`);
-  log.info(`[traffic-analysis-audit-${period}] Request parameters: ${JSON.stringify(auditResult)} set for [siteId: ${siteId}] and baseUrl: ${auditUrl}`);
+  log.debug(`[cache-warming-${period}] Completed cache warming for site: ${siteId}`);
+  log.debug(`[traffic-analysis-audit-${period}] Request parameters: ${JSON.stringify(auditResult)} set for [siteId: ${siteId}] and baseUrl: ${auditUrl}`);
 
   return {
     auditResult,
@@ -96,9 +96,9 @@ export async function sendRequestToMystique(auditUrl, auditData, context, site) 
   } = context;
   const mystiqueMessage = buildMystiqueMessage(site, id, auditUrl, auditResult);
 
-  log.info(`[traffic-analysis-audit] [siteId:  ${siteId}] and [baseUrl:${auditUrl}] with message ${JSON.stringify(mystiqueMessage, 2)} evaluation to mystique`);
+  log.debug(`[traffic-analysis-audit] [siteId:  ${siteId}] and [baseUrl:${auditUrl}] with message ${JSON.stringify(mystiqueMessage, 2)} evaluation to mystique`);
   await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, mystiqueMessage);
-  log.info(`[traffic-analysis-audit] [siteId: ${auditUrl}] [baseUrl:${auditUrl}] Completed mystique evaluation step`);
+  log.debug(`[traffic-analysis-audit] [siteId: ${auditUrl}] [baseUrl:${auditUrl}] Completed mystique evaluation step`);
 }
 
 const createWeeklyRunner = () => (auditUrl, context, site, auditContext) => prepareTrafficAnalysisRequest(auditUrl, context, site, 'weekly', auditContext);

--- a/src/preflight/accessibility.js
+++ b/src/preflight/accessibility.js
@@ -68,7 +68,7 @@ export async function scrapeAccessibilityData(context, auditContext) {
     return;
   }
 
-  log.info(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. Step 1: Preparing accessibility scrape`);
+  log.debug(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. Step 1: Preparing accessibility scrape`);
 
   // Create accessibility audit entries for all pages
   previewUrls.forEach((url) => {
@@ -82,13 +82,13 @@ export async function scrapeAccessibilityData(context, auditContext) {
 
   // Use the URLs from the preflight job request directly
   const urlsToScrape = previewUrls.map((url) => ({ url }));
-  log.info(`[preflight-audit] Using preview URLs for accessibility audit: ${JSON.stringify(urlsToScrape, null, 2)}`);
+  log.debug(`[preflight-audit] Using preview URLs for accessibility audit: ${JSON.stringify(urlsToScrape, null, 2)}`);
 
   // Force re-scrape all URLs regardless of existing data
-  log.info(`[preflight-audit] Force re-scraping all ${urlsToScrape.length} URLs for accessibility audit`);
+  log.debug(`[preflight-audit] Force re-scraping all ${urlsToScrape.length} URLs for accessibility audit`);
 
   if (urlsToScrape.length > 0) {
-    log.info(`[preflight-audit] Sending ${urlsToScrape.length} URLs to content scraper for accessibility audit`);
+    log.debug(`[preflight-audit] Sending ${urlsToScrape.length} URLs to content scraper for accessibility audit`);
 
     try {
       const scrapeMessage = {
@@ -115,9 +115,9 @@ export async function scrapeAccessibilityData(context, auditContext) {
       log.debug(`[preflight-audit] Completion queue: ${scrapeMessage.completionQueueUrl}`);
 
       // Send to content scraper queue
-      log.info(`[preflight-audit] Sending to queue: ${env.CONTENT_SCRAPER_QUEUE_URL}`);
+      log.debug(`[preflight-audit] Sending to queue: ${env.CONTENT_SCRAPER_QUEUE_URL}`);
       await sqs.sendMessage(env.CONTENT_SCRAPER_QUEUE_URL, scrapeMessage);
-      log.info(
+      log.debug(
         `[preflight-audit] Sent accessibility scraping request to content scraper for ${urlsToScrape.length} URLs`,
       );
     } catch (error) {
@@ -158,7 +158,7 @@ export async function processAccessibilityOpportunities(context, auditContext) {
     return;
   }
 
-  log.info(`[preflight-audit] Processing individual accessibility result files for ${site.getBaseURL()}`);
+  log.debug(`[preflight-audit] Processing individual accessibility result files for ${site.getBaseURL()}`);
 
   try {
     // Process each preview URL's accessibility result file
@@ -168,7 +168,7 @@ export async function processAccessibilityOpportunities(context, auditContext) {
         const filename = generateAccessibilityFilename(url);
 
         const fileKey = `accessibility-preflight/${siteId}/${filename}`;
-        log.info(`[preflight-audit] Processing accessibility file: ${fileKey}`);
+        log.debug(`[preflight-audit] Processing accessibility file: ${fileKey}`);
 
         // Get the accessibility result file from S3 using existing utility
         // eslint-disable-next-line no-await-in-loop
@@ -178,7 +178,7 @@ export async function processAccessibilityOpportunities(context, auditContext) {
           log.warn(`[preflight-audit] No accessibility data found for ${url} at key: ${fileKey}`);
           // Skip to next URL if no data found
         } else {
-          log.info(`[preflight-audit] Successfully loaded accessibility data for ${url}`);
+          log.debug(`[preflight-audit] Successfully loaded accessibility data for ${url}`);
 
           // Get the page result for this URL
           const pageResult = audits.get(url);
@@ -235,7 +235,7 @@ export async function processAccessibilityOpportunities(context, auditContext) {
               });
             }
 
-            log.info(`[preflight-audit] Accessibility audit details for ${url}:`, JSON.stringify(accessibilityAudit, null, 2));
+            log.debug(`[preflight-audit] Accessibility audit details for ${url}:`, JSON.stringify(accessibilityAudit, null, 2));
           } else {
             log.warn(`[preflight-audit] No accessibility audit found for URL: ${url}`);
           }
@@ -265,7 +265,7 @@ export async function processAccessibilityOpportunities(context, auditContext) {
     const accessibilityElapsed = ((accessibilityEndTime - accessibilityStartTime) / 1000)
       .toFixed(2);
 
-    log.info(
+    log.debug(
       `[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}.
 Accessibility audit completed in ${accessibilityElapsed} seconds`,
     );
@@ -286,7 +286,7 @@ Accessibility audit completed in ${accessibilityElapsed} seconds`,
         return `accessibility-preflight/${siteId}/${filename}`;
       });
 
-      log.info(`[preflight-audit] Cleaning up ${filesToDelete.length} individual accessibility files`);
+      log.debug(`[preflight-audit] Cleaning up ${filesToDelete.length} individual accessibility files`);
 
       const deleteCommand = new DeleteObjectsCommand({
         Bucket: bucketName,
@@ -297,7 +297,7 @@ Accessibility audit completed in ${accessibilityElapsed} seconds`,
       });
 
       await s3Client.send(deleteCommand);
-      log.info(`[preflight-audit] Successfully cleaned up ${filesToDelete.length} accessibility files`);
+      log.debug(`[preflight-audit] Successfully cleaned up ${filesToDelete.length} accessibility files`);
     } catch (cleanupError) {
       log.warn(`[preflight-audit] Failed to clean up accessibility files: ${cleanupError.message}`);
       // Don't fail the entire audit if cleanup fails
@@ -362,7 +362,7 @@ export default async function accessibility(context, auditContext) {
     // Generate expected filenames based on preview URLs
     const expectedFiles = previewUrls.map((url) => generateAccessibilityFilename(url));
 
-    log.info(`[preflight-audit] Expected files: ${JSON.stringify(expectedFiles)}`);
+    log.debug(`[preflight-audit] Expected files: ${JSON.stringify(expectedFiles)}`);
 
     // Recursive polling function to check for accessibility files
     const pollForAccessibilityFiles = async () => {
@@ -372,7 +372,7 @@ export default async function accessibility(context, auditContext) {
       }
 
       try {
-        log.info(`[preflight-audit] Polling attempt - checking S3 bucket: ${bucketName}`);
+        log.debug(`[preflight-audit] Polling attempt - checking S3 bucket: ${bucketName}`); // remove completely? > 60k in 7d
 
         // Check if accessibility data files exist in S3 using helper function
         const objectKeys = await getObjectKeysUsingPrefix(
@@ -395,7 +395,7 @@ export default async function accessibility(context, auditContext) {
         });
 
         if (foundFiles && foundFiles.length >= expectedFiles.length) {
-          log.info(`[preflight-audit] Found ${foundFiles.length} accessibility files out of ${expectedFiles.length} expected, accessibility processing complete`);
+          log.debug(`[preflight-audit] Found ${foundFiles.length} accessibility files out of ${expectedFiles.length} expected, accessibility processing complete`);
 
           // Log the found files for debugging
           foundFiles.forEach((key) => {
@@ -404,8 +404,8 @@ export default async function accessibility(context, auditContext) {
           return;
         }
 
-        log.info(`[preflight-audit] Found ${foundFiles.length} out of ${expectedFiles.length} expected accessibility files, continuing to wait...`);
-        log.info('[preflight-audit] No accessibility data yet, waiting...');
+        log.debug(`[preflight-audit] Found ${foundFiles.length} out of ${expectedFiles.length} expected accessibility files, continuing to wait...`); // delete? > 50k in 7d
+        log.debug('[preflight-audit] No accessibility data yet, waiting...'); // delete? > 50k in 7d
         await sleep(pollInterval);
 
         // Recursively call to continue polling
@@ -427,7 +427,7 @@ export default async function accessibility(context, auditContext) {
     const scrapeEndTimestamp = new Date().toISOString();
     const scrapeElapsed = ((scrapeEndTime - scrapeStartTime) / 1000).toFixed(2);
 
-    log.info(`[preflight-audit] site: ${site.getId()}, job: ${job?.getId()}, step: ${auditContext.step}. Accessibility scraping process completed in ${scrapeElapsed} seconds`);
+    log.debug(`[preflight-audit] site: ${site.getId()}, job: ${job?.getId()}, step: ${auditContext.step}. Accessibility scraping process completed in ${scrapeElapsed} seconds`);
 
     timeExecutionBreakdown.push({
       name: 'accessibility-scraping',
@@ -436,7 +436,7 @@ export default async function accessibility(context, auditContext) {
       endTime: scrapeEndTimestamp,
     });
 
-    log.info('[preflight-audit] Polling completed, proceeding to process accessibility data');
+    log.debug('[preflight-audit] Polling completed, proceeding to process accessibility data');
 
     // Step 2: Process scraped data and create opportunities
     await processAccessibilityOpportunities(context, auditContext);

--- a/src/preflight/canonical.js
+++ b/src/preflight/canonical.js
@@ -45,7 +45,7 @@ export default async function canonical(context, auditContext) {
         } = await validateCanonicalTag(url, log, authHeader, true);
         const allChecks = [...tagChecks];
         if (canonicalUrl) {
-          log.info(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Found Canonical URL: ${canonicalUrl}`);
+          log.debug(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Found Canonical URL: ${canonicalUrl}`);
           allChecks.push(...validateCanonicalFormat(canonicalUrl, previewBaseURL, log, true));
         }
         return { url, checks: allChecks.filter((c) => !c.success) };
@@ -54,7 +54,7 @@ export default async function canonical(context, auditContext) {
     const canonicalEndTime = Date.now();
     const canonicalEndTimestamp = new Date().toISOString();
     const canonicalElapsed = ((canonicalEndTime - canonicalStartTime) / 1000).toFixed(2);
-    log.info(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Canonical audit completed in ${canonicalElapsed} seconds`);
+    log.debug(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Canonical audit completed in ${canonicalElapsed} seconds`);
 
     timeExecutionBreakdown.push({
       name: 'canonical',

--- a/src/preflight/handler.js
+++ b/src/preflight/handler.js
@@ -107,7 +107,7 @@ export const preflightAudit = async (context) => {
     return stripTrailingSlash(url);
   });
 
-  log.info(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. Preflight audit started.`);
+  log.debug(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. Preflight audit started.`);
 
   if (job.getStatus() !== AsyncJob.Status.IN_PROGRESS) {
     throw new Error(`[preflight-audit] site: ${site.getId()}. Job not in progress for jobId: ${job.getId()}. Status: ${job.getStatus()}`);
@@ -213,7 +213,7 @@ export const preflightAudit = async (context) => {
       const domEndTime = Date.now();
       const domEndTimestamp = new Date().toISOString();
       const domElapsed = ((domEndTime - domStartTime) / 1000).toFixed(2);
-      log.info(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. DOM-based audit completed in ${domElapsed} seconds`);
+      log.debug(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. DOM-based audit completed in ${domElapsed} seconds`);
 
       timeExecutionBreakdown.push({
         name: 'dom',
@@ -263,7 +263,7 @@ export const preflightAudit = async (context) => {
       },
     }));
 
-    log.info(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. resultWithProfiling: ${JSON.stringify(resultWithProfiling)}`);
+    log.debug(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. resultWithProfiling: ${JSON.stringify(resultWithProfiling)}`);
 
     const jobEntity = await AsyncJobEntity.findById(jobId);
     const anyProcessing = handlerResults.some((r) => r && r.processing === true);
@@ -292,7 +292,7 @@ export const preflightAudit = async (context) => {
     throw error;
   }
 
-  log.info(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. Preflight audit completed.`);
+  log.debug(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. Preflight audit completed.`);
 };
 
 export default new AuditBuilder()

--- a/src/preflight/links-checks.js
+++ b/src/preflight/links-checks.js
@@ -107,7 +107,7 @@ export async function runLinksChecks(urls, scrapedObjects, context, options = {
         const internalSet = new Set();
         const externalSet = new Set();
 
-        log.info(`[preflight-audit] Total links found (${anchors.length}):`, anchors.map((a) => a.href));
+        log.debug(`[preflight-audit] Total links found (${anchors.length}):`, anchors.map((a) => a.href));
 
         anchors.forEach((a) => {
           // Skip links that are inside header or footer elements
@@ -127,8 +127,8 @@ export async function runLinksChecks(urls, scrapedObjects, context, options = {
           }
         });
 
-        log.info('[preflight-audit] Found internal links:', internalSet);
-        log.info('[preflight-audit] Found external links:', externalSet);
+        log.debug('[preflight-audit] Found internal links:', internalSet);
+        log.debug('[preflight-audit] Found external links:', externalSet);
 
         // Check internal links
         const internalResults = await Promise.all(

--- a/src/preflight/links.js
+++ b/src/preflight/links.js
@@ -149,7 +149,7 @@ export default async function links(context, auditContext) {
     const linksEndTime = Date.now();
     const linksEndTimestamp = new Date().toISOString();
     const linksElapsed = ((linksEndTime - linksStartTime) / 1000).toFixed(2);
-    log.info(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Links audit completed in ${linksElapsed} seconds`);
+    log.debug(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Links audit completed in ${linksElapsed} seconds`);
 
     timeExecutionBreakdown.push({
       name: 'links',

--- a/src/preflight/metatags.js
+++ b/src/preflight/metatags.js
@@ -72,7 +72,7 @@ export default async function metatags(context, auditContext) {
     const metatagsEndTime = Date.now();
     const metatagsEndTimestamp = new Date().toISOString();
     const metatagsElapsed = ((metatagsEndTime - metatagsStartTime) / 1000).toFixed(2);
-    log.info(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Meta tags audit completed in ${metatagsElapsed} seconds`);
+    log.debug(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Meta tags audit completed in ${metatagsElapsed} seconds`);
 
     timeExecutionBreakdown.push({
       name: 'metatags',

--- a/src/preflight/utils.js
+++ b/src/preflight/utils.js
@@ -22,7 +22,7 @@ export async function saveIntermediateResults(context, result, auditName) {
     const jobEntity = await AsyncJob.findById(job.getId());
     jobEntity.setResult(result);
     await jobEntity.save();
-    log.info(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. ${auditName}: Intermediate results saved successfully`);
+    log.debug(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. ${auditName}: Intermediate results saved successfully`); // remove? ~60k in last 7d
   } catch (error) {
     log.warn(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. ${auditName}: Failed to save intermediate results: ${error.message}`);
   }

--- a/src/readability/async-mystique.js
+++ b/src/readability/async-mystique.js
@@ -47,7 +47,7 @@ export async function sendReadabilityToMystique(
     throw new Error('Missing SQS context or queue configuration');
   }
 
-  log.info(`[readability-suggest async] Sending ${readabilityIssues.length} readability issues to Mystique queue: ${env.QUEUE_SPACECAT_TO_MYSTIQUE}`);
+  log.debug(`[readability-suggest async] Sending ${readabilityIssues.length} readability issues to Mystique queue: ${env.QUEUE_SPACECAT_TO_MYSTIQUE}`);
 
   try {
     const site = await dataAccess.Site.findById(siteId);
@@ -80,7 +80,7 @@ export async function sendReadabilityToMystique(
       },
     });
     await jobEntity.save();
-    log.info(`[readability-suggest async] Stored readability metadata in job ${jobId}`);
+    log.debug(`[readability-suggest async] Stored readability metadata in job ${jobId}`);
 
     // Send each readability issue as a separate message to Mystique
     const messagePromises = readabilityIssues.map((issue, index) => {
@@ -134,7 +134,7 @@ export async function sendReadabilityToMystique(
       throw new Error(`Failed to send ${failedMessages.length} out of ${readabilityIssues.length} messages to Mystique`);
     }
 
-    log.info(`[readability-suggest async] Successfully sent ${successfulMessages.length} messages to Mystique for processing`);
+    log.debug(`[readability-suggest async] Successfully sent ${successfulMessages.length} messages to Mystique for processing`);
   } catch (error) {
     log.error(`[readability-suggest async] Failed to send readability issues to Mystique: ${error.message}`);
     throw error;

--- a/src/readability/handler.js
+++ b/src/readability/handler.js
@@ -281,7 +281,7 @@ export default async function readability(context, auditContext) {
         }
       });
 
-      log.info(
+      log.debug( // remove? ~8k
         `[readability-suggest handler] readability: Processed ${processedElements} text element(s) on `
         + `${normalizedFinalUrl}, found ${poorReadabilityCount} with poor readability`,
       );
@@ -324,7 +324,7 @@ export default async function readability(context, auditContext) {
             .filter((opp) => opp.suggestionStatus === 'processing').length;
 
           if (stillProcessing > 0) {
-            log.info(
+            log.debug(
               `[readability-suggest handler] readability: Sending ${stillProcessing} readability issues `
               + 'to Mystique for async processing...',
             );
@@ -338,7 +338,7 @@ export default async function readability(context, auditContext) {
               context,
             );
 
-            log.info(`[readability-suggest handler] readability: Successfully sent ${allReadabilityIssues.length} `
+            log.debug(`[readability-suggest handler] readability: Successfully sent ${allReadabilityIssues.length} `
               + 'readability issues to Mystique for processing');
             // Indicate to preflight runner that we are still processing
             isProcessing = true;
@@ -388,7 +388,7 @@ export default async function readability(context, auditContext) {
           }
         }
       } else {
-        log.info('[readability-suggest handler] readability: No readability issues found to send to Mystique');
+        log.debug('[readability-suggest handler] readability: No readability issues found to send to Mystique');
       }
     }
 
@@ -396,7 +396,8 @@ export default async function readability(context, auditContext) {
     const readabilityEndTimestamp = new Date().toISOString();
     const readabilityElapsed = ((readabilityEndTime - readabilityStartTime) / 1000).toFixed(2);
     const auditStepName = step === 'suggest' ? 'readability-suggestions' : 'readability';
-    log.info(
+
+    log.debug( // remove? ~8k
       `[readability-suggest handler] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. `
       + `Readability audit completed in ${readabilityElapsed} seconds`,
     );

--- a/src/site-detection/handler.js
+++ b/src/site-detection/handler.js
@@ -187,12 +187,12 @@ export async function siteDetectionRunner(_, context) {
     .filter((candidate) => !knownHosts.has(candidate.domain))
     .filter((candidate) => isValidCandidate(config, candidate.domain, log));
 
-  log.info(`Out of ${unfilteredCandidates.length} candidates, found ${candidates.length} valid candidates`);
+  log.debug(`Out of ${unfilteredCandidates.length} candidates, found ${candidates.length} valid candidates`);
 
   // TODO: replace the HOOK call with a proper post-processing step
   for (const candidate of candidates) {
     try {
-      log.info(`Re-feeding ${candidate.domain}; x-fw: ${candidate.xFwHost}, v: ${candidate.hlxVersion}`);
+      log.info(`Re-feeding ${candidate.domain}; x-fw: ${candidate.xFwHost}, v: ${candidate.hlxVersion}`); // debug? ~80k last 7d
       // eslint-disable-next-line no-await-in-loop
       await refeed(candidate.xFwHost, candidate.hlxVersion, siteDetectionWebHook);
     } catch (e) {

--- a/src/sitemap/handler.js
+++ b/src/sitemap/handler.js
@@ -501,7 +501,7 @@ export async function sitemapAuditRunner(baseURL, context) {
   const { log } = context;
   const startTime = process.hrtime();
 
-  log.info(`Starting sitemap audit for ${baseURL}`);
+  log.debug(`Starting sitemap audit for ${baseURL}`);
 
   const auditResult = await findSitemap(baseURL);
 
@@ -509,7 +509,7 @@ export async function sitemapAuditRunner(baseURL, context) {
   const elapsedSeconds = endTime[0] + endTime[1] / 1e9;
   const formattedElapsed = elapsedSeconds.toFixed(2);
 
-  log.info(`Sitemap audit for ${baseURL} completed in ${formattedElapsed} seconds`);
+  log.debug(`Sitemap audit for ${baseURL} completed in ${formattedElapsed} seconds`);
 
   return {
     fullAuditRef: baseURL,
@@ -566,7 +566,7 @@ export function generateSuggestions(auditUrl, auditData, context) {
         : 'Make sure your sitemaps only include URLs that return the 200 (OK) response code.',
     }));
 
-  log.info(`Generated ${suggestions.length} suggestions for ${auditUrl}`);
+  log.debug(`Generated ${suggestions.length} suggestions for ${auditUrl}`);
   return { ...auditData, suggestions };
 }
 
@@ -574,12 +574,12 @@ export async function opportunityAndSuggestions(auditUrl, auditData, context) {
   const { log } = context;
 
   if (auditData.auditResult.success === false) {
-    log.info('Sitemap audit failed, skipping opportunity and suggestions creation');
+    log.debug('Sitemap audit failed, skipping opportunity and suggestions creation');
     return { ...auditData };
   }
 
   if (!auditData.suggestions?.length) {
-    log.info('No sitemap issues found, skipping opportunity creation');
+    log.debug('No sitemap issues found, skipping opportunity creation');
     return { ...auditData };
   }
 

--- a/src/structured-data/guidance-handler.js
+++ b/src/structured-data/guidance-handler.js
@@ -19,7 +19,7 @@ export default async function handler(message, context) {
   const {
     suggestionId, opportunityId, remediations,
   } = data;
-  log.info(`Message received in broken-links suggestion handler: ${JSON.stringify(message, null, 2)}`);
+  log.debug(`Message received in broken-links suggestion handler: ${JSON.stringify(message, null, 2)}`);
 
   const site = await Site.findById(siteId);
   if (!site) {

--- a/src/structured-data/handler.js
+++ b/src/structured-data/handler.js
@@ -58,7 +58,7 @@ export async function processStructuredData(finalUrl, context, pages, scrapeCach
     scraperPagesWithIssues,
   );
 
-  log.info(`SDA: ${gscPagesWithIssues.length} issues from GSC, ${scraperPagesWithIssues.length} issues from scrape. ${pagesWithIssues.length} issues after deduplication`);
+  log.debug(`SDA: ${gscPagesWithIssues.length} issues from GSC, ${scraperPagesWithIssues.length} issues from scrape. ${pagesWithIssues.length} issues after deduplication`);
   log.debug('SDA: Deduplicated issues', JSON.stringify(pagesWithIssues));
 
   // Abort early if no issues are found
@@ -145,7 +145,7 @@ export async function opportunityAndSuggestions(auditUrl, auditData, context) {
 export async function importTopPages(context) {
   const { site, finalUrl, log } = context;
 
-  log.info(`SDA: Importing top pages for ${finalUrl}`);
+  log.debug(`SDA: Importing top pages for ${finalUrl}`);
 
   const s3BucketPath = `scrapes/${site.getId()}/`;
   return {
@@ -170,7 +170,7 @@ export async function submitForScraping(context) {
     throw new Error('No top pages found for site');
   }
 
-  log.info(`SDA: Submitting for scraping ${topPages.length} top pages for site ${site.getId()}, finalUrl: ${finalUrl}`);
+  log.debug(`SDA: Submitting for scraping ${topPages.length} top pages for site ${site.getId()}, finalUrl: ${finalUrl}`);
 
   return {
     urls: topPages.map((topPage) => ({ url: topPage.getUrl() })),
@@ -237,7 +237,7 @@ export async function runAuditAndGenerateSuggestions(context) {
     const endTime = process.hrtime(startTime);
     const elapsedSeconds = endTime[0] + endTime[1] / 1e9;
     const formattedElapsed = elapsedSeconds.toFixed(2);
-    log.info(`SDA: Structured data audit completed in ${formattedElapsed} seconds for ${finalUrl}`);
+    log.debug(`SDA: Structured data audit completed in ${formattedElapsed} seconds for ${finalUrl}`);
 
     return {
       fullAuditRef: finalUrl,

--- a/src/support/psi-client.js
+++ b/src/support/psi-client.js
@@ -115,7 +115,7 @@ function PSIClient(config, log = console) {
         return formattedURL;
       }
 
-      log.info(`Redirect detected from '${formattedURL}' to '${finalUrl}'`);
+      log.debug(`Redirect detected from '${formattedURL}' to '${finalUrl}'`);
       return finalUrl;
     } catch (error) {
       log.error(`Error happened while following redirects: ${error}. Falling back to original url: ${url}`);
@@ -144,7 +144,7 @@ function PSIClient(config, log = console) {
     const strategyEndTime = process.hrtime(strategyStartTime);
     const strategyElapsedTime = (strategyEndTime[0] + strategyEndTime[1] / 1e9).toFixed(2);
 
-    log.info(`Audited ${finalUrl} for ${strategy} strategy in ${strategyElapsedTime} seconds`);
+    log.debug(`Audited ${finalUrl} for ${strategy} strategy in ${strategyElapsedTime} seconds`);
 
     psiResult.finalUrl = finalUrl;
 

--- a/src/support/sqs.js
+++ b/src/support/sqs.js
@@ -37,7 +37,7 @@ class SQS {
 
     try {
       const data = await this.sqsClient.send(msgCommand);
-      this.log.info(`Success, message sent. MessageID:  ${data.MessageId}`);
+      this.log.debug(`Success, message sent. MessageID:  ${data.MessageId}`); // remove? ~212k in last 7d
     } catch (e) {
       const { type, code, message: msg } = e;
       this.log.error(`Message send failed. Type: ${type}, Code: ${code}, Message: ${msg}`, { length: asJSON.length }, e);

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -352,10 +352,8 @@ export const getScrapedDataForSiteId = async (site, context) => {
     log,
   );
   const headerLinks = extractLinksFromHeader(indexFileContent, site.getBaseURL(), log);
-  log.info(`siteData: ${JSON.stringify(extractedData)}`);
 
   let scrapedFormData;
-  log.info(`all files: ${JSON.stringify(allFiles)}`);
   if (allFiles) {
     const formFiles = allFiles.filter((file) => file.Key.endsWith('forms/scrape.json'));
     scrapedFormData = await fetchContentOfFiles(formFiles);

--- a/src/utils/report-uploader.js
+++ b/src/utils/report-uploader.js
@@ -60,7 +60,7 @@ export async function readFromSharePoint(filename, outputLocation, sharepointCli
     const documentPath = `/sites/elmo-ui-data/${outputLocation}/${filename}`;
     const sharepointDoc = sharepointClient.getDocument(documentPath);
     const buffer = await sharepointDoc.getDocumentContent();
-    log.info(`Document successfully downloaded from SharePoint: ${documentPath}`);
+    log.debug(`Document successfully downloaded from SharePoint: ${documentPath}`);
     return buffer;
   } catch (error) {
     log.error(`Failed to read from SharePoint: ${error.message}`);
@@ -84,7 +84,7 @@ export async function publishToAdminHlx(filename, outputLocation, log) {
     ];
 
     for (const [index, endpoint] of endpoints.entries()) {
-      log.info(`Publishing Excel report via admin API (${endpoint.name}): ${endpoint.url}`);
+      log.debug(`Publishing Excel report via admin API (${endpoint.name}): ${endpoint.url}`);
 
       // eslint-disable-next-line no-await-in-loop
       const response = await fetch(endpoint.url, { method: 'POST', headers });
@@ -93,10 +93,10 @@ export async function publishToAdminHlx(filename, outputLocation, log) {
         throw new Error(`${endpoint.name} failed: ${response.status} ${response.statusText}`);
       }
 
-      log.info(`Excel report successfully published to ${endpoint.name}`);
+      log.debug(`Excel report successfully published to ${endpoint.name}`);
 
       if (index === 0) {
-        log.info('Waiting 2 seconds before publishing to live...');
+        log.debug('Waiting 2 seconds before publishing to live...');
         // eslint-disable-next-line no-await-in-loop
         await sleep(2000);
       }
@@ -111,7 +111,7 @@ export async function uploadToSharePoint(buffer, filename, outputLocation, share
     const documentPath = `/sites/elmo-ui-data/${outputLocation}/${filename}`;
     const sharepointDoc = sharepointClient.getDocument(documentPath);
     await sharepointDoc.uploadRawDocument(buffer);
-    log.info(`Excel report successfully uploaded to SharePoint: ${documentPath}`);
+    log.debug(`Excel report successfully uploaded to SharePoint: ${documentPath}`);
   } catch (error) {
     log.error(`Failed to upload to SharePoint: ${error.message}`);
     throw error;

--- a/src/utils/s3-utils.js
+++ b/src/utils/s3-utils.js
@@ -48,7 +48,7 @@ export async function getObjectKeysUsingPrefix(
       });
       continuationToken = data?.NextContinuationToken;
     } while (continuationToken);
-    log.info(
+    log.debug( // remove? ~85k in last 7d
       `Fetched ${objectKeys.length} keys from S3 for bucket ${bucketName} and prefix ${prefix}`,
     );
   } catch (err) {


### PR DESCRIPTION
This PR removes unnecessary logs that were cluttering the output and causing us to hit the limit in Coralogix. Only essential logs are kept to ensure clearer debugging and reduced noise.

EPIC: [SITES-34661](https://jira.corp.adobe.com/browse/SITES-34661)