### PR TITLE
fix: prevent glued hosts while resolving paths

### DIFF
--- a/src/llm-error-pages/handler.js
+++ b/src/llm-error-pages/handler.js
@@ -220,7 +220,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
       return auditData;
     }
 
-    const base = site.getBaseURL?.() || '';
+    const messageBaseUrl = site.getBaseURL?.() || '';
     const consolidated404 = consolidateErrorsByUrl(errors404);
     const sorted404 = sortErrorsByTrafficVolume(consolidated404).slice(0, 50);
     const { SiteTopPage } = dataAccess;
@@ -229,8 +229,8 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     // Consolidate by URL and combine user agents
     const urlToUserAgentsMap = new Map();
     sorted404.forEach((errorPage) => {
-      const path = toPathOnly(errorPage.url, base);
-      const fullUrl = base ? new URL(path, base).toString() : path;
+      const path = toPathOnly(errorPage.url, messageBaseUrl);
+      const fullUrl = messageBaseUrl ? new URL(path, messageBaseUrl).toString() : path;
       if (!urlToUserAgentsMap.has(fullUrl)) {
         urlToUserAgentsMap.set(fullUrl, new Set());
       }

--- a/src/llm-error-pages/handler.js
+++ b/src/llm-error-pages/handler.js
@@ -26,6 +26,7 @@ import {
   downloadExistingCdnSheet,
   matchErrorsWithCdnData,
   SPREADSHEET_COLUMNS,
+  toPathOnly,
 } from './utils.js';
 import { wwwUrlResolver } from '../common/index.js';
 import { createLLMOSharepointClient, saveExcelReport, readFromSharePoint } from '../utils/report-uploader.js';
@@ -219,7 +220,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
       return auditData;
     }
 
-    const messageBaseUrl = site.getBaseURL?.() || '';
+    const base = site.getBaseURL?.() || '';
     const consolidated404 = consolidateErrorsByUrl(errors404);
     const sorted404 = sortErrorsByTrafficVolume(consolidated404).slice(0, 50);
     const { SiteTopPage } = dataAccess;
@@ -228,7 +229,8 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     // Consolidate by URL and combine user agents
     const urlToUserAgentsMap = new Map();
     sorted404.forEach((errorPage) => {
-      const fullUrl = messageBaseUrl ? `${messageBaseUrl}${errorPage.url}` : errorPage.url;
+      const path = toPathOnly(errorPage.url, base);
+      const fullUrl = base ? new URL(path, base).toString() : path;
       if (!urlToUserAgentsMap.has(fullUrl)) {
         urlToUserAgentsMap.set(fullUrl, new Set());
       }


### PR DESCRIPTION
**Summary**: 
Normalize and resolve LLM error‑page URLs against the site base to prevent “glued host” URLs in Mystique payloads and ensure the 404 Excel file updates correctly.

**Problem**: 
We were concatenating base + rawUrl, so paths without a leading slash produced malformed URLs like https://adobe.comcreativecloud/..., which the updater couldn’t match to the sheet’s URL column.

**Fix**:
Build full URLs via resolver instead of string concatenation.
Normalize the log URL to a path before resolving against the site base.

**Example:**
Input: base https://www.adobe.com, raw creativecloud/photography/discover/bokeh.html
Old: https://www.adobe.comcreativecloud/photography/discover/bokeh.html
New: https://www.adobe.com/creativecloud/photography/discover/bokeh.html

