### PR TITLE
fix: exclude OTF and php extensions

### DIFF
--- a/src/cdn-analysis/sql/frontdoor/unload-aggregated-referral.sql
+++ b/src/cdn-analysis/sql/frontdoor/unload-aggregated-referral.sql
@@ -73,7 +73,7 @@ UNLOAD (
 
       -- exclude static assets, but always include HTML
       AND (
-        NOT REGEXP_LIKE(url_extract_path(properties.requestUri), '(?i)\.(css|js|png|jpg|jpeg|gif|webp|svg|ico|woff|woff2|ttf|eot|mp4|mp3|avi|mov|zip|tar|gz|json|xml|pdf|txt)(\?.*)?$')
+        NOT REGEXP_LIKE(url_extract_path(properties.requestUri), '(?i)\.(css|js|png|jpg|jpeg|gif|webp|php|svg|ico|woff|woff2|otf|ttf|eot|mp4|mp3|avi|mov|zip|tar|gz|json|xml|pdf|txt)(\?.*)?$')
         OR url_extract_path(properties.requestUri) LIKE '%.htm%'
       )
   

--- a/src/cdn-analysis/sql/frontdoor/unload-aggregated.sql
+++ b/src/cdn-analysis/sql/frontdoor/unload-aggregated.sql
@@ -19,7 +19,7 @@ UNLOAD (
 
     -- exclude static assets, but always include HTML, PDF, robots.txt, and sitemaps
     AND (
-        NOT REGEXP_LIKE(url_extract_path(properties.requestUri), '(?i)\.(css|js|png|jpg|jpeg|gif|webp|svg|ico|woff|woff2|ttf|eot|mp4|mp3|avi|mov|zip|tar|gz|json|xml|txt)(\?.*)?$')
+        NOT REGEXP_LIKE(url_extract_path(properties.requestUri), '(?i)\.(css|js|png|jpg|jpeg|gif|webp|php|svg|ico|woff|woff2|otf|ttf|eot|mp4|mp3|avi|mov|zip|tar|gz|json|xml|txt)(\?.*)?$')
         OR REGEXP_LIKE(url_extract_path(properties.requestUri), '(?i)(\.htm|\.pdf|robots\.txt|sitemap)')
     )
 

--- a/test/audits/cdn-logs-report/handler.test.js
+++ b/test/audits/cdn-logs-report/handler.test.js
@@ -240,6 +240,10 @@ describe('CDN Logs Report Handler', function test() {
 
   describe('Cdn logs report audit handler', () => {
     it('successfully processes CDN logs report', async () => {
+      const clock = sinon.useFakeTimers({
+        now: new Date('2025-01-07'),
+        toFake: ['Date']
+      });
       const auditContext = createAuditContext(sandbox);
       const result = await handler.runner('https://example.com', context, site, auditContext);
 
@@ -256,6 +260,7 @@ describe('CDN Logs Report Handler', function test() {
         expect(reportResult).to.have.property('customer').that.is.a('string');
       });
 
+      clock.restore();
       // Verify logging calls
       expect(context.log.info).to.have.been.calledWith('Starting CDN logs report audit for https://example.com');
 


### PR DESCRIPTION
exclude OTF and php extensions for Frontdoor