### PR TITLE
feat: add multi-provider support for geo-brand-presence audit

### DIFF
--- a/src/geo-brand-presence/handler.js
+++ b/src/geo-brand-presence/handler.js
@@ -95,7 +95,7 @@ export async function sendToMystique(context, getPresignedUrl = getSignedUrl) {
   // Get aiPlatform from the audit result
   const auditResult = audit?.getAuditResult();
   const aiPlatform = auditResult?.aiPlatform;
-  const providersToUse = isString(aiPlatform) ? [aiPlatform] : WEB_SEARCH_PROVIDERS;
+  const providersToUse = WEB_SEARCH_PROVIDERS.includes(aiPlatform) ? [aiPlatform] : WEB_SEARCH_PROVIDERS;
   log.info('GEO BRAND PRESENCE: aiPlatform: %s for site id %s (%s). Will use providers: %j', aiPlatform, siteId, baseURL, providersToUse);
 
   if (success === false) {

--- a/src/geo-brand-presence/handler.js
+++ b/src/geo-brand-presence/handler.js
@@ -44,45 +44,6 @@ export const WEB_SEARCH_PROVIDERS = [
  * @import { S3Client } from '@aws-sdk/client-s3';
  */
 
-/**
- * Creates a message object for sending to Mystique.
- * @param {object} params - Message parameters
- * @param {string} params.opptyType - The opportunity type
- * @param {string} params.siteId - The site ID
- * @param {string} params.baseURL - The base URL
- * @param {string} params.auditId - The audit ID
- * @param {string} params.deliveryType - The delivery type
- * @param {object} params.calendarWeek - The calendar week object
- * @param {string} params.url - The presigned URL for data
- * @param {string} params.webSearchProvider - The web search provider
- * @returns {object} The message object
- */
-function createMystiqueMessage({
-  opptyType,
-  siteId,
-  baseURL,
-  auditId,
-  deliveryType,
-  calendarWeek,
-  url,
-  webSearchProvider,
-}) {
-  return {
-    type: opptyType,
-    siteId,
-    url: baseURL,
-    auditId,
-    deliveryType,
-    time: new Date().toISOString(),
-    week: calendarWeek.week,
-    year: calendarWeek.year,
-    data: {
-      url,
-      web_search_provider: webSearchProvider,
-    },
-  };
-}
-
 export async function sendToMystique(context, getPresignedUrl = getSignedUrl) {
   const {
     auditContext, log, sqs, env, site, audit, s3Client,
@@ -95,7 +56,9 @@ export async function sendToMystique(context, getPresignedUrl = getSignedUrl) {
   // Get aiPlatform from the audit result
   const auditResult = audit?.getAuditResult();
   const aiPlatform = auditResult?.aiPlatform;
-  const providersToUse = WEB_SEARCH_PROVIDERS.includes(aiPlatform) ? [aiPlatform] : WEB_SEARCH_PROVIDERS;
+  const providersToUse = WEB_SEARCH_PROVIDERS.includes(aiPlatform)
+    ? [aiPlatform]
+    : WEB_SEARCH_PROVIDERS;
   log.info('GEO BRAND PRESENCE: aiPlatform: %s for site id %s (%s). Will use providers: %j', aiPlatform, siteId, baseURL, providersToUse);
 
   if (success === false) {
@@ -239,6 +202,45 @@ export async function keywordPromptsImportStep(context) {
     // auditResult can't be empty, so sending empty array and include aiPlatform
     auditResult: { keywordQuestions: [], aiPlatform },
     fullAuditRef: finalUrl,
+  };
+}
+
+/**
+ * Creates a message object for sending to Mystique.
+ * @param {object} params - Message parameters
+ * @param {string} params.opptyType - The opportunity type
+ * @param {string} params.siteId - The site ID
+ * @param {string} params.baseURL - The base URL
+ * @param {string} params.auditId - The audit ID
+ * @param {string} params.deliveryType - The delivery type
+ * @param {object} params.calendarWeek - The calendar week object
+ * @param {string} params.url - The presigned URL for data
+ * @param {string} params.webSearchProvider - The web search provider
+ * @returns {object} The message object
+ */
+function createMystiqueMessage({
+  opptyType,
+  siteId,
+  baseURL,
+  auditId,
+  deliveryType,
+  calendarWeek,
+  url,
+  webSearchProvider,
+}) {
+  return {
+    type: opptyType,
+    siteId,
+    url: baseURL,
+    auditId,
+    deliveryType,
+    time: new Date().toISOString(),
+    week: calendarWeek.week,
+    year: calendarWeek.year,
+    data: {
+      url,
+      web_search_provider: webSearchProvider,
+    },
   };
 }
 

--- a/src/geo-brand-presence/handler.js
+++ b/src/geo-brand-presence/handler.js
@@ -94,7 +94,7 @@ export async function sendToMystique(context, getPresignedUrl = getSignedUrl) {
   // Get aiPlatform from the audit result
   const auditResult = audit?.getAuditResult();
   const aiPlatform = auditResult?.aiPlatform;
-  log.info('GEO BRAND PRESENCE: aiPlatform: %s', aiPlatform);
+  log.info('GEO BRAND PRESENCE: aiPlatform: %s for site id %s (%s)', aiPlatform, siteId, baseURL);
   /* c8 ignore start */
   if (success === false) {
     log.error('GEO BRAND PRESENCE: Received the following errors for site id %s (%s). Cannot send data to Mystique', siteId, baseURL, auditContext);
@@ -133,7 +133,7 @@ export async function sendToMystique(context, getPresignedUrl = getSignedUrl) {
   log.info('GEO BRAND PRESENCE: Presigned URL for prompts for site id %s (%s): %s', siteId, baseURL, url);
 
   // Determine which providers to use
-  const providersToUse = aiPlatform ? [aiPlatform] : WEB_SEARCH_PROVIDERS;
+  const providersToUse = aiPlatform !== undefined ? [aiPlatform] : WEB_SEARCH_PROVIDERS;
 
   /* c8 ignore next 4 */
   if (!providersToUse || providersToUse.length === 0) {

--- a/test/audits/geo-brand-presence.test.js
+++ b/test/audits/geo-brand-presence.test.js
@@ -17,7 +17,7 @@ import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { parquetWriteBuffer } from 'hyparquet-writer';
-import { keywordPromptsImportStep, sendToMystique } from '../../src/geo-brand-presence/handler.js';
+import { keywordPromptsImportStep, sendToMystique, WEB_SEARCH_PROVIDERS } from '../../src/geo-brand-presence/handler.js';
 
 use(sinonChai);
 
@@ -158,7 +158,7 @@ describe('Geo Brand Presence Handler', () => {
     );
   });
 
-  it('should send message to Mystique for all opportunity types when keywordQuestions are found', async () => {
+  it('should send message to Mystique using aiPlatform when provided', async () => {
     // Mock S3 client method used by getStoredMetrics (AWS SDK v3 style)
     fakeS3Response(fakeData());
 
@@ -171,7 +171,7 @@ describe('Geo Brand Presence Handler', () => {
         parquetFiles: ['some/parquet/file/data.parquet'],
       },
     }, getPresignedUrl);
-    // two messages are sent to Mystique, one for brand presence and one for faq
+    // When aiPlatform is provided (chatgpt), only one message is sent per opportunity type
     expect(sqs.sendMessage).to.have.been.calledOnce;
     const [brandPresenceQueue, brandPresenceMessage] = sqs.sendMessage.firstCall.args;
     expect(brandPresenceQueue).to.equal('spacecat-to-mystique');
@@ -186,20 +186,43 @@ describe('Geo Brand Presence Handler', () => {
       web_search_provider: 'chatgpt',
       url: 'https://example.com/presigned-url',
     });
+  });
 
-    // TODO(aurelio): check that we write the right file to s3
-    // const expectedPrompts = fakeData((x) => ({ ...x, market: x.region, origin: x.source }));
+  // TODO(aurelio): check that we write the right file to s3
+  it('should send messages to Mystique for all web search providers when no aiPlatform is provided', async () => {
+    // Remove aiPlatform from audit result
+    audit.getAuditResult = () => ({});
+    
+    fakeS3Response(fakeData());
+    getPresignedUrl.resolves('https://example.com/presigned-url');
 
-    // const [faqQueue, faqMessage] = sqs.sendMessage.secondCall.args;
-    // expect(faqQueue).to.equal('spacecat-to-mystique');
-    // expect(faqMessage).to.include({
-    //   type: 'guidance:geo-faq',
-    //   siteId: site.getId(),
-    //   url: site.getBaseURL(),
-    //   auditId: audit.getId(),
-    //   deliveryType: site.getDeliveryType(),
-    // });
-    // expect(faqMessage.data).deep.equal({ url: 'https://example.com/presigned-url' });
+    await sendToMystique({
+      ...context,
+      auditContext: {
+        calendarWeek: { year: 2025, week: 33 },
+        parquetFiles: ['some/parquet/file/data.parquet'],
+      },
+    }, getPresignedUrl);
+
+    // Should send messages equal to the number of configured providers
+    expect(sqs.sendMessage).to.have.callCount(WEB_SEARCH_PROVIDERS.length);
+    
+    // Verify each message has the correct provider
+    WEB_SEARCH_PROVIDERS.forEach((provider, index) => {
+      const [queue, message] = sqs.sendMessage.getCall(index).args;
+      expect(queue).to.equal('spacecat-to-mystique');
+      expect(message).to.include({
+        type: 'detect:geo-brand-presence',
+        siteId: site.getId(),
+        url: site.getBaseURL(),
+        auditId: audit.getId(),
+        deliveryType: site.getDeliveryType(),
+      });
+      expect(message.data).deep.equal({
+        web_search_provider: provider,
+        url: 'https://example.com/presigned-url',
+      });
+    });
   });
 
   it('should skip sending message to Mystique when no keywordQuestions', async () => {
@@ -212,6 +235,38 @@ describe('Geo Brand Presence Handler', () => {
       },
     }, getPresignedUrl);
     expect(sqs.sendMessage).to.not.have.been.called;
+  });
+
+  it('should skip sending message to Mystique when aiPlatform is undefined (simulating empty providers)', async () => {
+    // Set aiPlatform to undefined to simulate empty provider scenario
+    audit.getAuditResult = () => ({ aiPlatform: undefined });
+    
+    fakeS3Response(fakeData());
+    getPresignedUrl.resolves('https://example.com/presigned-url');
+
+    // Temporarily empty the providers array
+    const originalProviders = [...WEB_SEARCH_PROVIDERS];
+    WEB_SEARCH_PROVIDERS.splice(0, WEB_SEARCH_PROVIDERS.length);
+
+    try {
+      await sendToMystique({
+        ...context,
+        auditContext: {
+          calendarWeek: { year: 2025, week: 33 },
+          parquetFiles: ['some/parquet/file/data.parquet'],
+        },
+      }, getPresignedUrl);
+
+      expect(sqs.sendMessage).to.not.have.been.called;
+      expect(log.warn).to.have.been.calledWith(
+        'GEO BRAND PRESENCE: No web search providers configured for site id %s (%s), skipping message to mystique',
+        site.getId(),
+        site.getBaseURL(),
+      );
+    } finally {
+      // Restore original providers
+      WEB_SEARCH_PROVIDERS.push(...originalProviders);
+    }
   });
 
   function fakeS3Response(response) {

--- a/test/audits/geo-brand-presence.test.js
+++ b/test/audits/geo-brand-presence.test.js
@@ -145,10 +145,9 @@ describe('Geo Brand Presence Handler', () => {
       auditResult: { keywordQuestions: [], aiPlatform: undefined },
       fullAuditRef: finalUrl,
     });
-    expect(log.error).to.have.been.calledWith(
-      'GEO BRAND PRESENCE:failed to parse %s as JSON',
+    expect(log.warn).to.have.been.calledWith(
+      'GEO BRAND PRESENCE: Could not parse data as JSON or date string: %s',
       invalidJson,
-      sinon.match.instanceOf(Error),
     );
     expect(log.info).to.have.been.calledWith(
       'GEO BRAND PRESENCE: Keyword prompts import step for %s with endDate: %s, aiPlatform: %s',


### PR DESCRIPTION
- Add configurable WEB_SEARCH_PROVIDERS array for sending to multiple providers
- Maintain backward compatibility: use specific aiPlatform if provided
- Extract message creation to createMystiqueMessage helper to reduce duplication
- Add safeguard for empty provider configuration
- Update tests to dynamically validate against provider array
- Export WEB_SEARCH_PROVIDERS constant for test reusability

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
