### PR TITLE
fix:geo brand presence daily oppty type fix

### DIFF
--- a/src/geo-brand-presence/handler.js
+++ b/src/geo-brand-presence/handler.js
@@ -288,7 +288,9 @@ export async function sendToMystique(context, getPresignedUrl = getSignedUrl) {
   }
 
   // Determine opportunity types based on cadence
-  const opptyTypes = isDaily ? [GEO_BRAND_PRESENCE_DAILY_OPPTY_TYPE] : OPPTY_TYPES;
+  const opptyTypes = isDaily
+    ? [GEO_BRAND_PRESENCE_DAILY_OPPTY_TYPE]
+    : [GEO_BRAND_PRESENCE_OPPTY_TYPE];
 
   // Send messages for each combination of opportunity type and web search provider
   await Promise.all(


### PR DESCRIPTION
## Fix: Add daily opportunity type to validation for geo-brand-presence

### Problem
Daily geo-brand-presence audits were failing to upload files to SharePoint with error:
`GEO BRAND PRESENCE: Unsupported subtype: detect:geo-brand-presence-daily`

### Root Cause
The detection handler only validated `detect:geo-brand-presence` but not the daily variant `detect:geo-brand-presence-daily` that Mystique was sending back.

### Solution
- Added `GEO_BRAND_PRESENCE_DAILY_OPPTY_TYPE` constant
- Included it in the `OPPTY_TYPES` validation array
- Refactored to use constant instead of hardcoded string for consistency

### Testing
- [ ] Daily audit now successfully uploads files to SharePoint
- [ ] Files are placed in correct weekly folders (e.g., `brand-presence/w01`)