### PR TITLE
fix: calculate week number from date in daily geo-brand-presence handler

### DIFF
--- a/src/geo-brand-presence-daily/detect-geo-brand-presence-handler.js
+++ b/src/geo-brand-presence-daily/detect-geo-brand-presence-handler.js
@@ -11,6 +11,7 @@
  */
 /* c8 ignore start */
 
+import { isoCalendarWeek } from '@adobe/spacecat-shared-utils';
 import baseHandler from '../geo-brand-presence/detect-geo-brand-presence-handler.js';
 
 /**
@@ -18,8 +19,14 @@ import baseHandler from '../geo-brand-presence/detect-geo-brand-presence-handler
  * Extends the base handler with daily-specific path logic
  */
 export default async function handler(message, context) {
-  // Extract daily-specific information
-  const weekNumber = message.week ? String(message.week).padStart(2, '0') : '01';
+  // Extract daily-specific information from the data object
+  // Calculate week number from the date field since Mystique preserves date reliably
+  let weekNumber = '01'; // fallback
+  if (message.data?.date) {
+    const date = new Date(message.data.date);
+    const { week } = isoCalendarWeek(date);
+    weekNumber = String(week).padStart(2, '0');
+  }
 
   // Create a modified context with daily-specific path logic
   const dailyContext = {


### PR DESCRIPTION
## Fix: Calculate week number from date in daily geo-brand-presence handler

### Problem
The daily geo-brand-presence handler was using `message.week` which is not preserved by Mystique. This caused all daily reports to fall back to week "01" instead of using the actual ISO week number.

### Solution
Calculate the ISO week number from `message.data.date` field using the `isoCalendarWeek()` utility, since Mystique reliably preserves the date field.

### Changes
- Added import of `isoCalendarWeek` from `@adobe/spacecat-shared-utils`
- Changed logic to calculate week from `message.data.date` instead of `message.week`
- Week calculation handles edge cases (year boundaries) correctly

### Testing
- ✅ ESLint validation passed
- ✅ Syntax validation passed
- ✅ Logic tested with actual Mystique data: `2025-10-13` → week `42`
- ✅ Edge cases tested (year boundaries)

### Result
Daily reports will now be correctly organized in SharePoint paths like `/brand-presence/w42` instead of defaulting to `/brand-presence/w01`.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
