### PR TITLE
feat: redirect-chains audit

### DIFF
--- a/src/redirect-chains/opportunity-data-mapper.js
+++ b/src/redirect-chains/opportunity-data-mapper.js
@@ -12,8 +12,8 @@
 
 import { DATA_SOURCES } from '../common/constants.js';
 
-export function createOpportunityData(projectedTrafficMetrics = {}) {
-  const { projectedTrafficLost, projectedTrafficValue } = projectedTrafficMetrics;
+export function createOpportunityData(params = {}) {
+  const { projectedTrafficLost, projectedTrafficValue, auditScopeUrl } = params;
 
   return {
     runbook: 'https://adobe.sharepoint.com/:w:/r/sites/aemsites-engineering/Shared%20Documents/3%20-%20Experience%20Success/SpaceCat/Runbooks/Acquisition%20-%20SEO/Experience_Success_Studio_Redirect_Chains_Runbook.docx?d=w15b25d46a5124cf29543ed08acf6caae&csf=1&web=1&e=Kiosk9',
@@ -30,6 +30,7 @@ export function createOpportunityData(projectedTrafficMetrics = {}) {
       dataSources: [DATA_SOURCES.SITE],
       projectedTrafficLost: projectedTrafficLost || 0,
       projectedTrafficValue: projectedTrafficValue || 0,
+      auditScopeUrl: auditScopeUrl || '',
     },
   };
 }

--- a/src/redirect-chains/opportunity-utils.js
+++ b/src/redirect-chains/opportunity-utils.js
@@ -134,7 +134,7 @@ export function ensureFullUrl(url, domain = '') {
       // Neither has a slash, so add one
       reasonableUrl = `${domain}/${reasonableUrl}`;
     } else {
-      // One has a slash, so concatenate directly
+      // Only one has a slash, so concatenate directly
       reasonableUrl = domain + reasonableUrl;
     }
     addWwwSubdomain = true; // add 'www.' if needed


### PR DESCRIPTION
 + added support when a site has been onboarded with a subpath
 + the created opportunity data object will now remember the `auditScopeUrl` used to filter the site's Source URLs

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
