### PR TITLE
fix(llmo-customer-analysis): remove config changes from audit result

### DIFF
--- a/src/llmo-customer-analysis/handler.js
+++ b/src/llmo-customer-analysis/handler.js
@@ -252,6 +252,8 @@ export async function runLlmoCustomerAnalysis(finalUrl, context, site, auditCont
         configChangesDetected: true,
         message: 'All audits triggered (no config version provided)',
         triggeredSteps,
+        previousConfigVersion,
+        configVersion,
       },
       fullAuditRef: finalUrl,
     };
@@ -340,6 +342,8 @@ export async function runLlmoCustomerAnalysis(finalUrl, context, site, auditCont
         status: 'completed',
         configChangesDetected: true,
         triggeredSteps,
+        previousConfigVersion,
+        configVersion,
       },
       fullAuditRef: finalUrl,
     };
@@ -351,6 +355,8 @@ export async function runLlmoCustomerAnalysis(finalUrl, context, site, auditCont
     auditResult: {
       status: 'completed',
       configChangesDetected: false,
+      previousConfigVersion,
+      configVersion,
     },
     fullAuditRef: finalUrl,
   };


### PR DESCRIPTION
Addresses the issue of item sizes being too large for DynamoDB while running the `llmo-customer-analysis` audit

Previously, the LLMO config diff was saved in the audit result, which could be large for certain domains.

This PR removes it. The audit result will now only contain the triggered steps. The config diff is not used anywhere else.