### PR TITLE
fix: disable variation edit in high organic low ctr opportunity in ASO UI

### DIFF
--- a/src/experimentation-opportunities/guidance-high-organic-low-ctr-handler.js
+++ b/src/experimentation-opportunities/guidance-high-organic-low-ctr-handler.js
@@ -27,13 +27,16 @@ function hasManuallyModifiedSuggestions(suggestions) {
 }
 
 /**
- * remove variationEditPageUrl from the variations
+ * remove variationEditPageUrl from the variations other than Original
  * @param {Array} variations - Array of variation objects
  * @returns {Array} - updated Array of variation objects
  */
 function updateVariations(variations) {
   if (isNonEmptyArray(variations)) {
     return variations.map((variation) => {
+      if (variation?.name === 'Original') {
+        return variation;
+      }
       // eslint-disable-next-line no-unused-vars
       const { variationEditPageUrl, ...variationWithOutEditUrl } = variation;
       return variationWithOutEditUrl;

--- a/test/fixtures/experimentation-opportunities/high-organic-low-ctr-guidance.json
+++ b/test/fixtures/experimentation-opportunities/high-organic-low-ctr-guidance.json
@@ -17,7 +17,7 @@
       {
         "name": "Original",
         "changes": [],
-        "variationEditPageUrl": "",
+        "variationEditPageUrl": "https://example.com/edit/original",
         "id": "original",
         "variationPageUrl": "https://main--wknd--hlxsites.hlx.live/",
         "explanation": "",

--- a/test/guidance-handlers/high-organic-low-ctr.test.js
+++ b/test/guidance-handlers/high-organic-low-ctr.test.js
@@ -148,7 +148,11 @@ describe('high-organic-low-ctr guidance handler tests', () => {
       guidanceMsgFromMystique.data.suggestions.length,
     );
     suggestionArg.data.variations.forEach((variation, index) => {
-      expect(variation).to.not.have.property('variationEditPageUrl');
+      if (variation.name !== 'Original') {
+        expect(variation).to.not.have.property('variationEditPageUrl');
+      } else {
+        expect(variation).to.have.property('variationEditPageUrl');
+      }
       expect(variation.id).to.equal(guidanceMsgFromMystique.data.suggestions[index].id);
       expect(variation.name).to.equal(guidanceMsgFromMystique.data.suggestions[index].name);
     });
@@ -364,7 +368,7 @@ describe('high-organic-low-ctr guidance handler tests', () => {
     expect(Suggestion.create).to.have.been.calledOnce;
   });
 
-  it('should remove variationEditPageUrl when saving suggestions', async () => {
+  it('should remove variationEditPageUrl when saving suggestions for variations other than Original', async () => {
     Opportunity.allBySiteId.resolves([]);
     const message = {
       auditId: 'audit-id',
@@ -387,6 +391,12 @@ describe('high-organic-low-ctr guidance handler tests', () => {
 
     // Verify that variationEditPageUrl is removed from all variations
     suggestionArg.data.variations.forEach((variation) => {
+      if (variation.name === 'Original') {
+        expect(
+          variation.variationEditPageUrl,
+        ).to.equal(guidanceMsgFromMystique.data.suggestions[0].variationEditPageUrl);
+        return;
+      }
       expect(variation).to.not.have.property('variationEditPageUrl');
       // Verify other properties are still present
       expect(variation).to.have.property('name');


### PR DESCRIPTION
Fixes [SKYOPS-121236](https://jira.corp.adobe.com/browse/SKYOPS-121236)

As per the [discussion](https://cq-dev.slack.com/archives/C08QT805FS9/p1761744363723039?thread_ts=1759443821.665269&cid=C08QT805FS9) disabling the Edit for variations
>While we can expose an Edit button for a clone, we lack functionality to regenerate the json patch when the user clicks apply in ASO (the patch is the diff between the original and the suggestion, if one modifies the suggestion then the patch is no longer an exact diff and needs to be recreated. Similar situation if the original changes, but let't ignore that now)
Hence the suggestion to hide the Edit button.

- removed variationEditPageUrl from the variations sent by Mystique before creating Suggestions