### PR TITLE
fix: repurpose the  security-vulnerabilities-auto-suggest handler to call mystique 

### DIFF
--- a/src/vulnerabilities/suggestion-data-mapper.js
+++ b/src/vulnerabilities/suggestion-data-mapper.js
@@ -40,7 +40,7 @@ function highestScore(vulnerabilities) {
  * @param {boolean} generateSuggestions - Whether to generate version recommendations
  * @return {Object} A suggestion object providing a structured representation of the vulnerability
  */
-export function mapVulnerabilityToSuggestion(opportunity, vulnerability, generateSuggestions) {
+export function mapVulnerabilityToSuggestion(opportunity, vulnerability) {
   const {
     name, version, recommendedVersion, vulnerabilities,
   } = vulnerability;
@@ -55,7 +55,7 @@ export function mapVulnerabilityToSuggestion(opportunity, vulnerability, generat
     data: {
       library: name,
       current_version: version,
-      recommended_version: generateSuggestions ? recommendedVersion : '',
+      recommended_version: recommendedVersion,
       cves: safeVulnerabilities.sort((a, b) => b.score - a.score).map((vuln) => ({
         cve_id: vuln.id,
         score: vuln.score,

--- a/test/audits/vulnerabilities.test.js
+++ b/test/audits/vulnerabilities.test.js
@@ -522,53 +522,14 @@ describe('Vulnerabilities Handler Integration Tests', () => {
       expect(springSuggestion.data.cves[1].score).to.equal(5.5);
     });
 
-    it('should handle disabled auto-suggest configuration', async () => {
+    it('should handle auto suggest to trigger mystique', async () => {
       const configuration = {
         isHandlerEnabledForSite: sandbox.stub(),
       };
       context.dataAccess.Configuration.findLatest.resolves(configuration);
 
-      // Enable main handler but disable auto-suggest
-      configuration.isHandlerEnabledForSite.withArgs('security-vulnerabilities').returns(true);
-      configuration.isHandlerEnabledForSite.withArgs('security-vulnerabilities-auto-suggest').returns(false);
-
-      context.audit = {
-        getAuditResult: () => ({
-          vulnerabilityReport: VULNERABILITY_REPORT_WITH_VULNERABILITIES,
-          success: true,
-        }),
-        getId: () => 'test-audit-id',
-      };
-
-      const result = await opportunityAndSuggestionsStep(context);
-
-      expect(result).to.deep.equal({ status: 'complete' });
-      expect(context.dataAccess.Opportunity.create).to.have.been.calledOnce;
-      expect(context.log.debug).to.have.been.calledWithMatch(
-        /security-vulnerabilities-auto-suggest not configured, skipping version recommendations/,
-      );
-
-      // Verify opportunity was created and addSuggestions was called
-      const createdOpportunity = await context.dataAccess.Opportunity.create.getCall(0).returnValue;
-      expect(createdOpportunity.addSuggestions).to.have.been.calledOnce;
-
-      // Verify suggestions were created with empty recommended_version (generateSuggestions=false)
-      const suggestionsCall = createdOpportunity.addSuggestions.getCall(0);
-      const suggestions = suggestionsCall.args[0];
-      expect(suggestions).to.be.an('array');
-      expect(suggestions[0].data.recommended_version).to.equal('');
-    });
-
-    it('should handle code fixt to trigger mystique', async () => {
-      const configuration = {
-        isHandlerEnabledForSite: sandbox.stub(),
-      };
-      context.dataAccess.Configuration.findLatest.resolves(configuration);
-
-      // Enable main handler but disable auto-suggest
       configuration.isHandlerEnabledForSite.withArgs('security-vulnerabilities').returns(true);
       configuration.isHandlerEnabledForSite.withArgs('security-vulnerabilities-auto-suggest').returns(true);
-      configuration.isHandlerEnabledForSite.withArgs('security-vulnerabilities-auto-fix').returns(true);
 
       context.audit = {
         getAuditResult: () => ({

--- a/test/audits/vulnerabilities/suggestion-data-mapper.test.js
+++ b/test/audits/vulnerabilities/suggestion-data-mapper.test.js
@@ -67,7 +67,7 @@ describe('Vulnerabilities Suggestion Data Mapper', () => {
   describe('mapVulnerabilityToSuggestion', () => {
     it('should map vulnerability to suggestion with single vulnerability', () => {
       const vulnerability = createVulnerability();
-      const result = mapVulnerabilityToSuggestion(mockOpportunity, vulnerability, true);
+      const result = mapVulnerabilityToSuggestion(mockOpportunity, vulnerability);
 
       expect(result).to.deep.equal({
         opportunityId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
@@ -99,7 +99,7 @@ describe('Vulnerabilities Suggestion Data Mapper', () => {
         ]),
       });
 
-      const result = mapVulnerabilityToSuggestion(mockOpportunity, vulnerability, true);
+      const result = mapVulnerabilityToSuggestion(mockOpportunity, vulnerability);
 
       expect(result.rank).to.equal(9.5);
       expect(result.data.cves).to.have.lengthOf(3);
@@ -120,7 +120,7 @@ describe('Vulnerabilities Suggestion Data Mapper', () => {
 
       testCases.forEach(({ vulnerabilities }) => {
         const vulnerability = createVulnerability({ vulnerabilities });
-        const result = mapVulnerabilityToSuggestion(mockOpportunity, vulnerability, true);
+        const result = mapVulnerabilityToSuggestion(mockOpportunity, vulnerability);
 
         expect(result.rank).to.equal(0);
         expect(result.data.cves).to.deep.equal([]);
@@ -140,7 +140,7 @@ describe('Vulnerabilities Suggestion Data Mapper', () => {
         ]),
       });
 
-      const result = mapVulnerabilityToSuggestion(mockOpportunity, vulnerability, true);
+      const result = mapVulnerabilityToSuggestion(mockOpportunity, vulnerability);
 
       expect(result.data.library).to.equal('test-library');
       expect(result.data.current_version).to.equal('1.0.0');
@@ -162,7 +162,7 @@ describe('Vulnerabilities Suggestion Data Mapper', () => {
         ]),
       });
 
-      const result = mapVulnerabilityToSuggestion(mockOpportunity, vulnerability, true);
+      const result = mapVulnerabilityToSuggestion(mockOpportunity, vulnerability);
 
       expect(result.rank).to.equal(7.5);
       expect(result.data.cves).to.have.lengthOf(3);
@@ -199,31 +199,12 @@ describe('Vulnerabilities Suggestion Data Mapper', () => {
         ],
       });
 
-      const result = mapVulnerabilityToSuggestion(mockOpportunity, vulnerability, true);
+      const result = mapVulnerabilityToSuggestion(mockOpportunity, vulnerability);
 
       expect(result.data.cves).to.have.lengthOf(3);
       expect(result.data.cves[0].url).to.equal('https://example.com/cve');
       expect(result.data.cves[1].url).to.equal(''); // null URL should become empty string
       expect(result.data.cves[2].url).to.equal(''); // undefined URL should become empty string
-    });
-
-    it('should handle generateSuggestions=false by setting empty recommended_version', () => {
-      const vulnerability = createVulnerability({
-        name: 'test-library',
-        version: '1.0.0',
-        recommendedVersion: '2.0.0',
-        vulnerabilities: createVulnerabilities([
-          { score: 7.5, severity: 'High' },
-        ]),
-      });
-
-      const result = mapVulnerabilityToSuggestion(mockOpportunity, vulnerability, false);
-
-      expect(result.data.library).to.equal('test-library');
-      expect(result.data.current_version).to.equal('1.0.0');
-      expect(result.data.recommended_version).to.equal(''); // Should be empty when generateSuggestions=false
-      expect(result.rank).to.equal(7.5);
-      expect(result.data.cves).to.have.lengthOf(1);
     });
   });
 });


### PR DESCRIPTION
This PR changes the behavior of the `security-vulnerabilities-auto-suggest` handler.
New behavior:
* recommended version is always added to the opportunity
* the handler determines if we should generate code suggestions using mystique
* removed `security-vulnerabilities-auto-fix`