### PR TITLE
fix: Support legacy URL-based aggregation and code fix flow

### DIFF
--- a/test/audits/accessibility/mystique-aggregation-e2e.test.js
+++ b/test/audits/accessibility/mystique-aggregation-e2e.test.js
@@ -517,7 +517,8 @@ describe('Accessibility Suggestion Aggregation - End-to-End', () => {
         }),
       };
 
-      const result = processSuggestionsForMystique([suggestionWithGuidance, suggestionWithoutGuidance]);
+      // Use legacy flow (useCodeFixFlow = false) to skip issues with guidance
+      const result = processSuggestionsForMystique([suggestionWithGuidance, suggestionWithoutGuidance], false);
 
       // Should only process the suggestion without guidance
       expect(result).to.have.length(1);

--- a/test/audits/accessibility/mystique-data-processing.test.js
+++ b/test/audits/accessibility/mystique-data-processing.test.js
@@ -55,6 +55,37 @@ describe('mystique-data-processing', () => {
       expect(result).to.be.an('array').that.is.empty;
     });
 
+    it('should use legacy aggregation when useCodeFixFlow is false', () => {
+      const mockSuggestion = {
+        getData: () => ({
+          url: 'https://example.com',
+          issues: [
+            {
+              type: 'aria-allowed-attr',
+              htmlWithIssues: [
+                {
+                  update_from: '<dt aria-level="3">Term</dt>',
+                  target_selector: 'dt',
+                },
+              ],
+              description: 'ARIA attribute not allowed on this element',
+            },
+          ],
+        }),
+        getId: () => 'sugg-1',
+        getStatus: () => 'NEW',
+      };
+
+      // Call with useCodeFixFlow = false to trigger legacy aggregation
+      const result = processSuggestionsForMystique([mockSuggestion], false);
+
+      expect(result).to.have.length(1);
+      expect(result[0]).to.have.property('url', 'https://example.com');
+      // In legacy mode, aggregationKey should be just the URL
+      expect(result[0]).to.have.property('aggregationKey', 'https://example.com');
+      expect(result[0].issuesList).to.have.length(1);
+    });
+
     it('should return empty array when suggestions is empty', () => {
       const mockSuggestion = {
         getData: () => ({ issues: [] }),
@@ -491,6 +522,269 @@ describe('mystique-data-processing', () => {
         issueDescription: '', // Should default to empty string
         suggestionId: 'sugg-1',
       });
+    });
+
+    it('should skip issues that already have guidance in legacy flow', () => {
+      const mockSuggestion = {
+        getData: () => ({
+          url: 'https://example.com',
+          issues: [
+            {
+              type: 'aria-allowed-attr',
+              htmlWithIssues: [
+                {
+                  update_from: '<dt aria-level="3">Term</dt>',
+                  target_selector: 'dt',
+                  guidance: {
+                    generalSuggestion: 'Remove aria-level',
+                    updateTo: '<dt>Term</dt>',
+                    userImpact: 'Screen readers will...',
+                  },
+                },
+              ],
+              description: 'ARIA attribute not allowed on this element',
+            },
+          ],
+        }),
+        getId: () => 'sugg-1',
+        getStatus: () => 'NEW',
+      };
+
+      // Use legacy flow (useCodeFixFlow = false)
+      const result = processSuggestionsForMystique([mockSuggestion], false);
+
+      // Should not include this suggestion since it already has guidance
+      expect(result).to.have.length(0);
+    });
+
+    it('should resend issues with guidance but no codefix when useCodeFixFlow is true', () => {
+      const mockSuggestion = {
+        getData: () => ({
+          url: 'https://example.com',
+          isCodeChangeAvailable: false, // No code fix available
+          issues: [
+            {
+              type: 'aria-allowed-attr',
+              htmlWithIssues: [
+                {
+                  update_from: '<dt aria-level="3">Term</dt>',
+                  target_selector: 'dt',
+                  guidance: {
+                    generalSuggestion: 'Remove aria-level',
+                    updateTo: '<dt>Term</dt>',
+                    userImpact: 'Screen readers will...',
+                  },
+                },
+              ],
+              description: 'ARIA attribute not allowed on this element',
+            },
+          ],
+        }),
+        getId: () => 'sugg-1',
+        getStatus: () => 'NEW',
+      };
+
+      // Call with useCodeFixFlow = true
+      const result = processSuggestionsForMystique([mockSuggestion], true);
+
+      // Should resend because code fix is not available
+      expect(result).to.have.length(1);
+      expect(result[0].issuesList).to.have.length(1);
+    });
+
+    it('should skip issues with both guidance and codefix when useCodeFixFlow is true', () => {
+      const mockSuggestion = {
+        getData: () => ({
+          url: 'https://example.com',
+          isCodeChangeAvailable: true, // Code fix is available
+          issues: [
+            {
+              type: 'aria-allowed-attr',
+              htmlWithIssues: [
+                {
+                  update_from: '<dt aria-level="3">Term</dt>',
+                  target_selector: 'dt',
+                  guidance: {
+                    generalSuggestion: 'Remove aria-level',
+                    updateTo: '<dt>Term</dt>',
+                    userImpact: 'Screen readers will...',
+                  },
+                },
+              ],
+              description: 'ARIA attribute not allowed on this element',
+            },
+          ],
+        }),
+        getId: () => 'sugg-1',
+        getStatus: () => 'NEW',
+      };
+
+      // Call with useCodeFixFlow = true
+      const result = processSuggestionsForMystique([mockSuggestion], true);
+
+      // Should not resend because both guidance and code fix are available
+      expect(result).to.have.length(0);
+    });
+
+    it('should aggregate multiple issues by URL in legacy flow', () => {
+      const mockSuggestion1 = {
+        getData: () => ({
+          url: 'https://example.com',
+          issues: [
+            {
+              type: 'aria-allowed-attr',
+              htmlWithIssues: [
+                {
+                  update_from: '<dt aria-level="3">Term</dt>',
+                  target_selector: 'dt',
+                },
+              ],
+              description: 'ARIA attribute not allowed',
+            },
+          ],
+        }),
+        getId: () => 'sugg-1',
+        getStatus: () => 'NEW',
+      };
+
+      const mockSuggestion2 = {
+        getData: () => ({
+          url: 'https://example.com',
+          issues: [
+            {
+              type: 'button-name',
+              htmlWithIssues: [
+                {
+                  update_from: '<button></button>',
+                  target_selector: 'button',
+                },
+              ],
+              description: 'Button needs name',
+            },
+          ],
+        }),
+        getId: () => 'sugg-2',
+        getStatus: () => 'NEW',
+      };
+
+      // Call with useCodeFixFlow = false for legacy aggregation
+      const result = processSuggestionsForMystique([mockSuggestion1, mockSuggestion2], false);
+
+      // In legacy mode, all issues for the same URL should be grouped together
+      expect(result).to.have.length(1);
+      expect(result[0].url).to.equal('https://example.com');
+      expect(result[0].aggregationKey).to.equal('https://example.com');
+      expect(result[0].issuesList).to.have.length(2);
+    });
+
+    it('should group by URL only in legacy flow, ignoring issue type and selector', () => {
+      // Create multiple suggestions with different issue types and selectors for the same URL
+      const mockSuggestion1 = {
+        getData: () => ({
+          url: 'https://example.com/page1',
+          issues: [
+            {
+              type: 'aria-allowed-attr',
+              htmlWithIssues: [
+                {
+                  update_from: '<dt aria-level="3">Term 1</dt>',
+                  target_selector: 'dt.first',
+                },
+              ],
+              description: 'ARIA attribute not allowed',
+            },
+          ],
+        }),
+        getId: () => 'sugg-1',
+        getStatus: () => 'NEW',
+      };
+
+      const mockSuggestion2 = {
+        getData: () => ({
+          url: 'https://example.com/page1',
+          issues: [
+            {
+              type: 'aria-allowed-attr',
+              htmlWithIssues: [
+                {
+                  update_from: '<dt aria-level="2">Term 2</dt>',
+                  target_selector: 'dt.second', // Different selector
+                },
+              ],
+              description: 'ARIA attribute not allowed',
+            },
+          ],
+        }),
+        getId: () => 'sugg-2',
+        getStatus: () => 'NEW',
+      };
+
+      const mockSuggestion3 = {
+        getData: () => ({
+          url: 'https://example.com/page1',
+          issues: [
+            {
+              type: 'button-name', // Different issue type
+              htmlWithIssues: [
+                {
+                  update_from: '<button></button>',
+                  target_selector: 'button.submit',
+                },
+              ],
+              description: 'Button needs name',
+            },
+          ],
+        }),
+        getId: () => 'sugg-3',
+        getStatus: () => 'NEW',
+      };
+
+      const mockSuggestion4 = {
+        getData: () => ({
+          url: 'https://example.com/page2', // Different URL
+          issues: [
+            {
+              type: 'aria-allowed-attr',
+              htmlWithIssues: [
+                {
+                  update_from: '<dt aria-level="1">Term</dt>',
+                  target_selector: 'dt',
+                },
+              ],
+              description: 'ARIA attribute not allowed',
+            },
+          ],
+        }),
+        getId: () => 'sugg-4',
+        getStatus: () => 'NEW',
+      };
+
+      // Call with useCodeFixFlow = false for legacy aggregation
+      const result = processSuggestionsForMystique(
+        [mockSuggestion1, mockSuggestion2, mockSuggestion3, mockSuggestion4],
+        false,
+      );
+
+      // Should have 2 messages (one per URL)
+      expect(result).to.have.length(2);
+
+      // Find the message for page1
+      const page1Message = result.find((msg) => msg.url === 'https://example.com/page1');
+      expect(page1Message).to.exist;
+      expect(page1Message.aggregationKey).to.equal('https://example.com/page1');
+      // All 3 suggestions for page1 should be grouped together
+      expect(page1Message.issuesList).to.have.length(3);
+      
+      // Verify all three issues are present
+      const suggestionIds = page1Message.issuesList.map((item) => item.suggestionId);
+      expect(suggestionIds).to.include.members(['sugg-1', 'sugg-2', 'sugg-3']);
+
+      // Find the message for page2
+      const page2Message = result.find((msg) => msg.url === 'https://example.com/page2');
+      expect(page2Message).to.exist;
+      expect(page2Message.aggregationKey).to.equal('https://example.com/page2');
+      expect(page2Message.issuesList).to.have.length(1);
+      expect(page2Message.issuesList[0].suggestionId).to.equal('sugg-4');
     });
   });
 });


### PR DESCRIPTION
### Changes

**Refactored Mystique message processing to support two aggregation strategies:**

1. **Code Fix Flow** (when `a11y-mystique-auto-fix` is enabled): Uses granular aggregation by issue type, URL, and selector
2. **Legacy Flow** (default): Groups all issues by URL only, ignoring issue type and selector

**Key modifications:**

- Moved `useCodeFixFlow` determination logic to `sendMessageToMystiqueForRemediation()` so it can control aggregation strategy
- Added `useCodeFixFlow` parameter to `processSuggestionsForMystique()` to switch between aggregation modes
- Created `shouldSendIssueToMystique()` function to centralize filtering logic
- Updated filtering to resend issues that lack **either** guidance **or** code fix (when code fix flow is enabled)
