### PR TITLE
fix: removing helix-universal from run time dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@adobe/helix-shared-secrets": "2.3.0",
         "@adobe/helix-shared-wrap": "2.0.2",
         "@adobe/helix-status": "10.1.5",
-        "@adobe/helix-universal": "5.3.0",
         "@adobe/helix-universal-logger": "3.0.28",
         "@adobe/spacecat-helix-content-sdk": "1.4.28",
         "@adobe/spacecat-shared-ahrefs-client": "1.10.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "@adobe/helix-shared-secrets": "2.3.0",
     "@adobe/helix-shared-wrap": "2.0.2",
     "@adobe/helix-status": "10.1.5",
-    "@adobe/helix-universal": "5.3.0",
     "@adobe/helix-universal-logger": "3.0.28",
     "@adobe/spacecat-helix-content-sdk": "1.4.28",
     "@adobe/spacecat-shared-ahrefs-client": "1.10.1",


### PR DESCRIPTION
As per cursor

When @adobe/helix-universal is included as a runtime dependency:
- The package gets bundled into the Lambda deployment
- This creates a conflict with the adapter code that @adobe/helix-deploy generates during the build process
- The module initialization chain (init_src85()) fails because there are competing/conflicting versions of the helix-universal adapter code
- Result: main is never properly initialized, causing main2 to be undefined when Lambda tries to invoke it