### PR TITLE
fix: import worker by explicitly call import worker with allow cache false

### DIFF
--- a/src/vulnerabilities/handler.js
+++ b/src/vulnerabilities/handler.js
@@ -170,6 +170,7 @@ export async function extractCodeBucket(context) {
 
   return {
     type: 'code',
+    allowCache: false,
     siteId: site.getId(),
     auditResult: result.auditResult,
     fullAuditRef: result.fullAuditRef,


### PR DESCRIPTION
This pr prevents the import worker from returning empty results by explicitly setting cache to false