### PR TITLE
feat: verify scraped pages before Mystique summarization

### DIFF
--- a/src/summarization/handler.js
+++ b/src/summarization/handler.js
@@ -17,7 +17,7 @@ import { wwwUrlResolver } from '../common/index.js';
 const { AUDIT_STEP_DESTINATIONS } = Audit;
 const SCRAPE_AVAILABILITY_THRESHOLD = 0.5; // 50%
 const MAX_TOP_PAGES = 200;
-const MAX_TOP_PAGES_TO_SEND = 100;
+const MAX_PAGES_TO_MYSTIQUE = 100;
 
 /**
  * Step 1: Import top pages from Ahrefs
@@ -89,7 +89,7 @@ export async function submitForScraping(context) {
     log.warn('[SUMMARIZATION] No top pages to submit for scraping');
     throw new Error('No top pages to submit for scraping');
   }
-  const topPagesToScrape = topPages.slice(0, MAX_TOP_PAGES_TO_SEND);
+  const topPagesToScrape = topPages.slice(0, MAX_TOP_PAGES);
 
   log.info(`[SUMMARIZATION] Submitting ${topPagesToScrape.length} pages for scraping`);
 
@@ -151,7 +151,7 @@ export async function sendToMystique(context) {
 
   // Use URLs from scrapeResultPaths Map (these are the URLs that actually have scrape data)
   const scrapedUrls = Array.from(scrapeResultPaths.keys());
-  const scrapedUrlsToSend = scrapedUrls.slice(0, MAX_TOP_PAGES_TO_SEND);
+  const scrapedUrlsToSend = scrapedUrls.slice(0, MAX_PAGES_TO_MYSTIQUE);
   const topPagesPayload = scrapedUrlsToSend.map((url) => ({
     page_url: url,
     keyword: '',

--- a/test/audits/summarization/handler.test.js
+++ b/test/audits/summarization/handler.test.js
@@ -183,17 +183,17 @@ describe('Summarization Handler', () => {
       expect(log.info).to.have.been.calledWith('[SUMMARIZATION] Submitting 3 pages for scraping');
     });
 
-    it('should limit to 100 pages when submitting for scraping', async () => {
+    it('should limit to 200 pages when submitting for scraping', async () => {
       audit.getAuditResult.returns({ success: true });
-      const manyPages = Array.from({ length: 150 }, (_, i) => ({
+      const manyPages = Array.from({ length: 250 }, (_, i) => ({
         getUrl: () => `https://adobe.com/page${i}`,
       }));
       dataAccess.SiteTopPage.allBySiteIdAndSourceAndGeo.resolves(manyPages);
 
       const result = await submitForScraping(context);
 
-      expect(result.urls).to.have.lengthOf(100);
-      expect(log.info).to.have.been.calledWith('[SUMMARIZATION] Submitting 100 pages for scraping');
+      expect(result.urls).to.have.lengthOf(200);
+      expect(log.info).to.have.been.calledWith('[SUMMARIZATION] Submitting 200 pages for scraping');
     });
 
     it('should throw error when audit failed', async () => {


### PR DESCRIPTION
The scrape step can fail sometimes. When it does, the audit should not proceed if a certain limit of pages are not yet scraped.