### PR TITLE
fix: prerender saving final audit result & handling no opp case

### DIFF
--- a/src/prerender/handler.js
+++ b/src/prerender/handler.js
@@ -1115,6 +1115,7 @@ export async function processContentAndGenerateOpportunities(context) {
       const { LatestAudit } = dataAccess;
 
       await LatestAudit.create({
+        auditId: audit.getId(),
         siteId,
         auditType: AUDIT_TYPE,
         auditResult,
@@ -1122,6 +1123,7 @@ export async function processContentAndGenerateOpportunities(context) {
         auditedAt: audit.getAuditedAt(),
         isLive: site.getIsLive(),
         isError: false,
+        invocationId: audit.getInvocationId(),
       });
 
       log.info(`Prerender - Updated LatestAudit with detailed results. baseUrl=${site.getBaseURL()}, siteId=${siteId}`);

--- a/src/prerender/handler.js
+++ b/src/prerender/handler.js
@@ -1015,7 +1015,39 @@ export async function processContentAndGenerateOpportunities(context) {
         scrapeJobId,
       }, context);
     } else {
+      // No opportunities found - check if there are existing suggestions to mark as outdated
       log.info(`Prerender - No opportunity found. baseUrl=${site.getBaseURL()}, siteId=${siteId}, scrapeForbidden=${scrapeForbidden}`);
+
+      try {
+        const { dataAccess } = context;
+        const { Opportunity } = dataAccess;
+        const opportunities = await Opportunity.allBySiteIdAndStatus(siteId, 'NEW');
+        const existingOpportunity = opportunities.find((o) => o.getType() === AUDIT_TYPE);
+
+        if (existingOpportunity) {
+          log.info(`Prerender - Found existing opportunity with no new prerender needs, marking suggestions as outdated. baseUrl=${site.getBaseURL()}, siteId=${siteId}, opportunityId=${existingOpportunity.getId()}`);
+
+          // Get all suggestions for this opportunity
+          const suggestions = await existingOpportunity.getSuggestions();
+
+          // Mark only NEW, PENDING_VALIDATION, and SKIPPED suggestions as outdated
+          if (suggestions && suggestions.length > 0) {
+            const suggestionsToUpdate = suggestions.filter((s) => [
+              Suggestion.STATUSES.NEW,
+              Suggestion.STATUSES.PENDING_VALIDATION,
+              Suggestion.STATUSES.SKIPPED,
+            ].includes(s.getStatus()));
+
+            if (suggestionsToUpdate.length > 0) {
+              await Suggestion.bulkUpdateStatus(suggestionsToUpdate, Suggestion.STATUSES.OUTDATED);
+              log.info(`Prerender - Marked ${suggestionsToUpdate.length} suggestions as outdated. baseUrl=${site.getBaseURL()}, siteId=${siteId}, opportunityId=${existingOpportunity.getId()}`);
+            }
+          }
+        }
+      } catch (error) {
+        log.error(`Prerender - Failed to update existing suggestions to outdated: ${error.message}. baseUrl=${site.getBaseURL()}, siteId=${siteId}`, error);
+        // Don't throw - this is a cleanup step and shouldn't fail the audit
+      }
     }
 
     const endTime = process.hrtime(startTime);
@@ -1044,6 +1076,19 @@ export async function processContentAndGenerateOpportunities(context) {
 
     // Upload status summary to S3 (post-processing)
     await uploadStatusSummaryToS3(site.getBaseURL(), auditData, context);
+
+    // Update the audit record with the detailed results from step 3
+    try {
+      if (audit) {
+        audit.setAuditResult(auditResult);
+        await audit.save();
+        log.info(`Prerender - Saved detailed audit result for auditId: ${audit.getId()}. baseUrl=${site.getBaseURL()}, siteId=${siteId}`);
+      } else {
+        log.warn(`Prerender - Audit not available to save results. baseUrl=${site.getBaseURL()}, siteId=${siteId}`);
+      }
+    } catch (error) {
+      log.error(`Prerender - Failed to save audit result for auditId: ${audit?.getId()}: ${error.message}. baseUrl=${site.getBaseURL()}, siteId=${siteId}`, error);
+    }
 
     return {
       status: 'complete',

--- a/src/prerender/utils/constants.js
+++ b/src/prerender/utils/constants.js
@@ -11,6 +11,6 @@
  */
 
 export const CONTENT_GAIN_THRESHOLD = 1.1;
-export const TOP_AGENTIC_URLS_LIMIT = 200;
-export const TOP_ORGANIC_URLS_LIMIT = 200;
+export const TOP_AGENTIC_URLS_LIMIT = 5;
+export const TOP_ORGANIC_URLS_LIMIT = 5;
 export const MODE_AI_ONLY = 'ai-only';

--- a/src/prerender/utils/constants.js
+++ b/src/prerender/utils/constants.js
@@ -11,6 +11,6 @@
  */
 
 export const CONTENT_GAIN_THRESHOLD = 1.1;
-export const TOP_AGENTIC_URLS_LIMIT = 2;
-export const TOP_ORGANIC_URLS_LIMIT = 2;
+export const TOP_AGENTIC_URLS_LIMIT = 200;
+export const TOP_ORGANIC_URLS_LIMIT = 200;
 export const MODE_AI_ONLY = 'ai-only';

--- a/src/prerender/utils/constants.js
+++ b/src/prerender/utils/constants.js
@@ -11,6 +11,6 @@
  */
 
 export const CONTENT_GAIN_THRESHOLD = 1.1;
-export const TOP_AGENTIC_URLS_LIMIT = 5;
-export const TOP_ORGANIC_URLS_LIMIT = 5;
+export const TOP_AGENTIC_URLS_LIMIT = 2;
+export const TOP_ORGANIC_URLS_LIMIT = 2;
 export const MODE_AI_ONLY = 'ai-only';

--- a/test/audits/prerender/handler.test.js
+++ b/test/audits/prerender/handler.test.js
@@ -247,7 +247,11 @@ describe('Prerender Audit', () => {
             getBaseURL: () => 'https://example.com',
             getConfig: () => ({ getIncludedURLs: () => [] }),
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: { info: sandbox.stub(), debug: sandbox.stub() },
           env: {
             S3_SCRAPER_BUCKET_NAME: 'test-bucket',
@@ -280,7 +284,11 @@ describe('Prerender Audit', () => {
             getBaseURL: () => 'https://example.com',
             getConfig: () => ({ getIncludedURLs: () => [] }),
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: { info: sandbox.stub(), debug: sandbox.stub() },
           env: {
             S3_SCRAPER_BUCKET_NAME: 'test-bucket',
@@ -325,7 +333,11 @@ describe('Prerender Audit', () => {
             getBaseURL: () => 'https://example.com',
             getConfig: () => ({ getIncludedURLs: (auditType) => (auditType === 'prerender' ? ['https://example.com/special'] : []) }),
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: { info: sandbox.stub(), debug: sandbox.stub() },
         };
         const result = await mockHandler.submitForScraping(context);
@@ -353,7 +365,11 @@ describe('Prerender Audit', () => {
             getBaseURL: () => 'https://example.com',
             getConfig: () => ({ getIncludedURLs: () => [] }),
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: { info: sandbox.stub(), debug: sandbox.stub() },
         };
         const result = await mockHandler.submitForScraping(context);
@@ -387,7 +403,11 @@ describe('Prerender Audit', () => {
             getBaseURL: () => 'https://example.com',
             getConfig: () => ({ getIncludedURLs: () => [] }),
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: { info: sandbox.stub(), debug: sandbox.stub() },
         };
         const out = await mockHandler.submitForScraping(context);
@@ -548,7 +568,11 @@ describe('Prerender Audit', () => {
             getBaseURL: () => 'https://example.com',
             getConfig: () => ({ getIncludedURLs: () => [] }),
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: { info: sandbox.stub(), debug: sandbox.stub(), warn: sandbox.stub() },
         };
 
@@ -576,7 +600,11 @@ describe('Prerender Audit', () => {
           audit: {
             getId: () => 'audit-id',
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: {
             info: sandbox.stub(),
             error: sandbox.stub(),
@@ -613,7 +641,11 @@ describe('Prerender Audit', () => {
           audit: {
             getId: () => 'audit-id',
           },
-          dataAccess: { SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().rejects(new Error('Database error')) } },
+          dataAccess: {
+            SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().rejects(new Error('Database error')) },
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: { info: sandbox.stub(), debug: sandbox.stub(), error: sandbox.stub(), warn: sandbox.stub() },
           scrapeResultPaths: new Map(),
           s3Client: {},
@@ -655,6 +687,8 @@ describe('Prerender Audit', () => {
               // No top pages, we don't want to exercise that path here
               allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([]),
             },
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
           },
           log: {
             info: sandbox.stub(),
@@ -703,7 +737,11 @@ describe('Prerender Audit', () => {
           audit: {
             getId: () => 'audit-id',
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: {
             info: sandbox.stub(),
             debug: sandbox.stub(),
@@ -736,7 +774,11 @@ describe('Prerender Audit', () => {
           audit: {
             getId: () => 'audit-id',
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: {
             info: sandbox.stub(),
             debug: sandbox.stub(),
@@ -952,53 +994,28 @@ describe('Prerender Audit', () => {
     });
 
     describe('No Opportunity Found - Outdated Suggestions', () => {
-      it('should mark existing suggestions as outdated when no prerender opportunity is found', async () => {
-        const { Suggestion: SuggestionDataAccess } = await import('@adobe/spacecat-shared-data-access');
+      // Note: Suggestion syncing is now handled by the well-tested syncSuggestions() utility function.
+      // These tests verify the behavior when no new prerender needs are found.
 
-        // Create mock suggestions with different statuses
-        const mockSuggestions = [
-          {
-            getId: () => 'suggestion-1',
-            getStatus: () => 'NEW',
-            getData: () => ({ url: 'https://example.com/page1' }),
-          },
-          {
-            getId: () => 'suggestion-2',
-            getStatus: () => 'PENDING_VALIDATION',
-            getData: () => ({ url: 'https://example.com/page2' }),
-          },
-          {
-            getId: () => 'suggestion-3',
-            getStatus: () => 'SKIPPED',
-            getData: () => ({ url: 'https://example.com/page3' }),
-          },
-          {
-            getId: () => 'suggestion-4',
-            getStatus: () => 'OUTDATED', // Already outdated - should not be updated
-            getData: () => ({ url: 'https://example.com/page4' }),
-          },
-          {
-            getId: () => 'suggestion-5',
-            getStatus: () => 'FIXED', // Already fixed - should not be updated
-            getData: () => ({ url: 'https://example.com/page5' }),
-          },
-        ];
-
+      it('should call syncSuggestions with empty array when existing opportunity is found', async () => {
         const mockOpportunity = {
           getId: () => 'existing-opportunity-id',
           getType: () => 'prerender',
-          getSuggestions: sandbox.stub().resolves(mockSuggestions),
+          getSuggestions: sandbox.stub().resolves([
+            {
+              getId: () => 'suggestion-1',
+              getStatus: () => 'NEW',
+              getData: () => ({ url: 'https://example.com/page1' }),
+            },
+          ]),
         };
 
-        const bulkUpdateStatusStub = sandbox.stub().resolves();
         const allBySiteIdAndStatusStub = sandbox.stub().resolves([mockOpportunity]);
+        const syncSuggestionsStub = sandbox.stub().resolves();
 
         const mockHandler = await esmock('../../../src/prerender/handler.js', {
-          '@adobe/spacecat-shared-data-access': {
-            Suggestion: {
-              bulkUpdateStatus: bulkUpdateStatusStub,
-              STATUSES: SuggestionDataAccess.STATUSES,
-            },
+          '../../../src/utils/data-access.js': {
+            syncSuggestions: syncSuggestionsStub,
           },
         });
 
@@ -1009,6 +1026,9 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
+            getFullAuditRef: () => 'https://example.com',
+            getAuditedAt: () => '2024-01-01T00:00:00Z',
+            getInvocationId: () => 'invocation-123',
           },
           dataAccess: {
             Opportunity: {
@@ -1036,285 +1056,45 @@ describe('Prerender Audit', () => {
 
         const result = await mockHandler.processContentAndGenerateOpportunities(context);
 
+        // Should complete successfully
         expect(result.status).to.equal('complete');
         expect(result.auditResult.urlsNeedingPrerender).to.equal(0);
 
         // Verify that we checked for existing opportunities
         expect(allBySiteIdAndStatusStub).to.have.been.calledWith('test-site-id', 'NEW');
 
-        // Verify that suggestions were fetched
-        expect(mockOpportunity.getSuggestions).to.have.been.called;
+        // Verify that syncSuggestions was called with correct parameters
+        expect(syncSuggestionsStub).to.have.been.calledOnce;
+        const syncCall = syncSuggestionsStub.firstCall.args[0];
+        expect(syncCall.opportunity).to.equal(mockOpportunity);
+        expect(syncCall.newData).to.deep.equal([]); // Empty array to mark all as outdated
+        expect(syncCall.context).to.equal(context);
+        expect(syncCall.buildKey).to.be.a('function');
+        expect(syncCall.mapNewSuggestion).to.be.a('function');
 
-        // Verify that bulkUpdateStatus was called with NEW, PENDING_VALIDATION, and SKIPPED suggestions
-        // (OUTDATED and FIXED suggestions should not be updated)
-        expect(bulkUpdateStatusStub).to.have.been.calledOnce;
-        const suggestionsToUpdate = bulkUpdateStatusStub.firstCall.args[0];
-        expect(suggestionsToUpdate).to.have.length(3);
-        expect(suggestionsToUpdate[0].getId()).to.equal('suggestion-1');
-        expect(suggestionsToUpdate[1].getId()).to.equal('suggestion-2');
-        expect(suggestionsToUpdate[2].getId()).to.equal('suggestion-3');
+        // Test the buildKey function
+        expect(syncCall.buildKey({ url: 'https://test.com' })).to.equal('https://test.com');
 
-        // Verify the status we're updating to
-        expect(bulkUpdateStatusStub.firstCall.args[1]).to.equal(SuggestionDataAccess.STATUSES.OUTDATED);
-
-        // Verify log message
-        const infoLogs = context.log.info.args.map(call => call[0]);
-        expect(infoLogs.some(msg => msg.includes('Marked 3 suggestions as outdated'))).to.be.true;
-      });
-
-      it('should handle errors gracefully when marking suggestions as outdated', async () => {
-        const mockOpportunity = {
-          getId: () => 'existing-opportunity-id',
-          getType: () => 'prerender',
-          getSuggestions: sandbox.stub().rejects(new Error('Database error')),
-        };
-
-        const allBySiteIdAndStatusStub = sandbox.stub().resolves([mockOpportunity]);
-
-        const mockHandler = await esmock('../../../src/prerender/handler.js');
-
-        const context = {
-          site: {
-            getId: () => 'test-site-id',
-            getBaseURL: () => 'https://example.com',
-          },
-          audit: {
-            getId: () => 'audit-id',
-          },
-          dataAccess: {
-            Opportunity: {
-              allBySiteIdAndStatus: allBySiteIdAndStatusStub,
-            },
-            LatestAudit: {
-              create: sandbox.stub().resolves(),
-            },
-          },
-          log: {
-            info: sandbox.stub(),
-            debug: sandbox.stub(),
-            warn: sandbox.stub(),
-            error: sandbox.stub(),
-          },
-          s3Client: {
-            send: sandbox.stub().resolves({
-              Body: { transformToString: () => Promise.resolve('') },
-            }),
-          },
-          env: { S3_SCRAPER_BUCKET_NAME: 'test-bucket' },
-          auditContext: { scrapeJobId: 'test-job-id' },
-          scrapeResultPaths: new Map([['https://example.com/test', '/tmp/test']]),
-        };
-
-        const result = await mockHandler.processContentAndGenerateOpportunities(context);
-
-        // Should still complete successfully despite the error
-        expect(result.status).to.equal('complete');
-
-        // Verify error was logged
-        expect(context.log.error).to.have.been.called;
-        const errorLogs = context.log.error.args.map(call => call[0]);
-        expect(errorLogs.some(msg => msg.includes('Failed to update existing suggestions to outdated'))).to.be.true;
-      });
-
-      it('should not attempt to update suggestions when no existing opportunity is found', async () => {
-        const allBySiteIdAndStatusStub = sandbox.stub().resolves([]);
-
-        const mockHandler = await esmock('../../../src/prerender/handler.js');
-
-        const context = {
-          site: {
-            getId: () => 'test-site-id',
-            getBaseURL: () => 'https://example.com',
-          },
-          audit: {
-            getId: () => 'audit-id',
-          },
-          dataAccess: {
-            Opportunity: {
-              allBySiteIdAndStatus: allBySiteIdAndStatusStub,
-            },
-            LatestAudit: {
-              create: sandbox.stub().resolves(),
-            },
-          },
-          log: {
-            info: sandbox.stub(),
-            debug: sandbox.stub(),
-            warn: sandbox.stub(),
-            error: sandbox.stub(),
-          },
-          s3Client: {
-            send: sandbox.stub().resolves({
-              Body: { transformToString: () => Promise.resolve('') },
-            }),
-          },
-          env: { S3_SCRAPER_BUCKET_NAME: 'test-bucket' },
-          auditContext: { scrapeJobId: 'test-job-id' },
-          scrapeResultPaths: new Map([['https://example.com/test', '/tmp/test']]),
-        };
-
-        const result = await mockHandler.processContentAndGenerateOpportunities(context);
-
-        // Should complete successfully
-        expect(result.status).to.equal('complete');
+        // Test the mapNewSuggestion function
+        expect(syncCall.mapNewSuggestion()).to.deep.equal({});
 
         // Verify log message indicates no opportunity was found
         const infoLogs = context.log.info.args.map(call => call[0]);
         expect(infoLogs.some(msg => msg.includes('No opportunity found'))).to.be.true;
-
-        // Should not log about marking suggestions as outdated
-        expect(infoLogs.some(msg => msg.includes('marking suggestions as outdated'))).to.be.false;
       });
 
-      it('should handle existing opportunity with null suggestions', async () => {
+      it('should not call syncSuggestions when existing opportunity is not prerender type', async () => {
         const mockOpportunity = {
           getId: () => 'existing-opportunity-id',
-          getType: () => 'prerender',
-          getSuggestions: sandbox.stub().resolves(null), // null suggestions
+          getType: () => 'cwv', // Different type, not prerender
         };
 
         const allBySiteIdAndStatusStub = sandbox.stub().resolves([mockOpportunity]);
-
-        const mockHandler = await esmock('../../../src/prerender/handler.js');
-
-        const context = {
-          site: {
-            getId: () => 'test-site-id',
-            getBaseURL: () => 'https://example.com',
-          },
-          audit: {
-            getId: () => 'audit-id',
-          },
-          dataAccess: {
-            Opportunity: {
-              allBySiteIdAndStatus: allBySiteIdAndStatusStub,
-            },
-            LatestAudit: {
-              create: sandbox.stub().resolves(),
-            },
-          },
-          log: {
-            info: sandbox.stub(),
-            debug: sandbox.stub(),
-            warn: sandbox.stub(),
-            error: sandbox.stub(),
-          },
-          s3Client: {
-            send: sandbox.stub().resolves({
-              Body: { transformToString: () => Promise.resolve('') },
-            }),
-          },
-          env: { S3_SCRAPER_BUCKET_NAME: 'test-bucket' },
-          auditContext: { scrapeJobId: 'test-job-id' },
-          scrapeResultPaths: new Map([['https://example.com/test', '/tmp/test']]),
-        };
-
-        const result = await mockHandler.processContentAndGenerateOpportunities(context);
-
-        // Should complete successfully
-        expect(result.status).to.equal('complete');
-
-        // Should log about finding opportunity
-        const infoLogs = context.log.info.args.map(call => call[0]);
-        expect(infoLogs.some(msg => msg.includes('Found existing opportunity with no new prerender needs'))).to.be.true;
-
-        // Should not log about marking suggestions (no suggestions to mark)
-        expect(infoLogs.some(msg => msg.includes('Marked'))).to.be.false;
-      });
-
-      it('should handle existing opportunity with empty suggestions array', async () => {
-        const mockOpportunity = {
-          getId: () => 'existing-opportunity-id',
-          getType: () => 'prerender',
-          getSuggestions: sandbox.stub().resolves([]), // empty array
-        };
-
-        const allBySiteIdAndStatusStub = sandbox.stub().resolves([mockOpportunity]);
-
-        const mockHandler = await esmock('../../../src/prerender/handler.js');
-
-        const context = {
-          site: {
-            getId: () => 'test-site-id',
-            getBaseURL: () => 'https://example.com',
-          },
-          audit: {
-            getId: () => 'audit-id',
-          },
-          dataAccess: {
-            Opportunity: {
-              allBySiteIdAndStatus: allBySiteIdAndStatusStub,
-            },
-            LatestAudit: {
-              create: sandbox.stub().resolves(),
-            },
-          },
-          log: {
-            info: sandbox.stub(),
-            debug: sandbox.stub(),
-            warn: sandbox.stub(),
-            error: sandbox.stub(),
-          },
-          s3Client: {
-            send: sandbox.stub().resolves({
-              Body: { transformToString: () => Promise.resolve('') },
-            }),
-          },
-          env: { S3_SCRAPER_BUCKET_NAME: 'test-bucket' },
-          auditContext: { scrapeJobId: 'test-job-id' },
-          scrapeResultPaths: new Map([['https://example.com/test', '/tmp/test']]),
-        };
-
-        const result = await mockHandler.processContentAndGenerateOpportunities(context);
-
-        // Should complete successfully
-        expect(result.status).to.equal('complete');
-
-        // Should log about finding opportunity
-        const infoLogs = context.log.info.args.map(call => call[0]);
-        expect(infoLogs.some(msg => msg.includes('Found existing opportunity with no new prerender needs'))).to.be.true;
-
-        // Should not log about marking suggestions (no suggestions to mark)
-        expect(infoLogs.some(msg => msg.includes('Marked'))).to.be.false;
-      });
-
-      it('should handle existing opportunity where all suggestions are already OUTDATED or FIXED', async () => {
-        const { Suggestion: SuggestionDataAccess } = await import('@adobe/spacecat-shared-data-access');
-
-        // All suggestions already have non-updatable statuses
-        const mockSuggestions = [
-          {
-            getId: () => 'suggestion-1',
-            getStatus: () => 'OUTDATED',
-            getData: () => ({ url: 'https://example.com/page1' }),
-          },
-          {
-            getId: () => 'suggestion-2',
-            getStatus: () => 'FIXED',
-            getData: () => ({ url: 'https://example.com/page2' }),
-          },
-          {
-            getId: () => 'suggestion-3',
-            getStatus: () => 'APPROVED',
-            getData: () => ({ url: 'https://example.com/page3' }),
-          },
-        ];
-
-        const mockOpportunity = {
-          getId: () => 'existing-opportunity-id',
-          getType: () => 'prerender',
-          getSuggestions: sandbox.stub().resolves(mockSuggestions),
-        };
-
-        const bulkUpdateStatusStub = sandbox.stub().resolves();
-        const allBySiteIdAndStatusStub = sandbox.stub().resolves([mockOpportunity]);
+        const syncSuggestionsStub = sandbox.stub().resolves();
 
         const mockHandler = await esmock('../../../src/prerender/handler.js', {
-          '@adobe/spacecat-shared-data-access': {
-            Suggestion: {
-              bulkUpdateStatus: bulkUpdateStatusStub,
-              STATUSES: SuggestionDataAccess.STATUSES,
-            },
+          '../../../src/utils/data-access.js': {
+            syncSuggestions: syncSuggestionsStub,
           },
         });
 
@@ -1325,6 +1105,9 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
+            getFullAuditRef: () => 'https://example.com',
+            getAuditedAt: () => '2024-01-01T00:00:00Z',
+            getInvocationId: () => 'invocation-123',
           },
           dataAccess: {
             Opportunity: {
@@ -1355,15 +1138,70 @@ describe('Prerender Audit', () => {
         // Should complete successfully
         expect(result.status).to.equal('complete');
 
-        // Should log about finding opportunity
+        // Verify that syncSuggestions was NOT called since opportunity is not prerender type
+        expect(syncSuggestionsStub).to.not.have.been.called;
+
+        // Verify log message indicates no opportunity was found
         const infoLogs = context.log.info.args.map(call => call[0]);
-        expect(infoLogs.some(msg => msg.includes('Found existing opportunity with no new prerender needs'))).to.be.true;
+        expect(infoLogs.some(msg => msg.includes('No opportunity found'))).to.be.true;
+      });
 
-        // bulkUpdateStatus should NOT be called since no suggestions need updating
-        expect(bulkUpdateStatusStub).to.not.have.been.called;
+      it('should not attempt to update suggestions when no existing opportunity is found', async () => {
+        const allBySiteIdAndStatusStub = sandbox.stub().resolves([]);
+        const syncSuggestionsStub = sandbox.stub().resolves();
 
-        // Should not log about marking suggestions (no eligible suggestions)
-        expect(infoLogs.some(msg => msg.includes('Marked'))).to.be.false;
+        const mockHandler = await esmock('../../../src/prerender/handler.js', {
+          '../../../src/utils/data-access.js': {
+            syncSuggestions: syncSuggestionsStub,
+          },
+        });
+
+        const context = {
+          site: {
+            getId: () => 'test-site-id',
+            getBaseURL: () => 'https://example.com',
+          },
+          audit: {
+            getId: () => 'audit-id',
+            getFullAuditRef: () => 'https://example.com',
+            getAuditedAt: () => '2024-01-01T00:00:00Z',
+            getInvocationId: () => 'invocation-123',
+          },
+          dataAccess: {
+            Opportunity: {
+              allBySiteIdAndStatus: allBySiteIdAndStatusStub,
+            },
+            LatestAudit: {
+              create: sandbox.stub().resolves(),
+            },
+          },
+          log: {
+            info: sandbox.stub(),
+            debug: sandbox.stub(),
+            warn: sandbox.stub(),
+            error: sandbox.stub(),
+          },
+          s3Client: {
+            send: sandbox.stub().resolves({
+              Body: { transformToString: () => Promise.resolve('') },
+            }),
+          },
+          env: { S3_SCRAPER_BUCKET_NAME: 'test-bucket' },
+          auditContext: { scrapeJobId: 'test-job-id' },
+          scrapeResultPaths: new Map([['https://example.com/test', '/tmp/test']]),
+        };
+
+        const result = await mockHandler.processContentAndGenerateOpportunities(context);
+
+        // Should complete successfully
+        expect(result.status).to.equal('complete');
+
+        // Verify that syncSuggestions was NOT called since no existing opportunity was found
+        expect(syncSuggestionsStub).to.not.have.been.called;
+
+        // Verify log message indicates no opportunity was found
+        const infoLogs = context.log.info.args.map(call => call[0]);
+        expect(infoLogs.some(msg => msg.includes('No opportunity found'))).to.be.true;
       });
 
       it('should successfully update LatestAudit with detailed results', async () => {
@@ -3016,6 +2854,8 @@ describe('Prerender Audit', () => {
               { getUrl: () => 'https://example.com/top1' },
             ]),
           },
+          Opportunity: { allBySiteIdAndStatus: sinon.stub().resolves([]) },
+          LatestAudit: { create: sinon.stub().resolves() },
         },
         log: { info, warn: sinon.stub(), debug: sinon.stub(), error: sinon.stub() },
         s3Client: { send: sinon.stub().resolves({}) },
@@ -3384,7 +3224,11 @@ describe('Prerender Audit', () => {
           audit: {
             getId: () => 'audit-id',
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: {
             info: sandbox.stub(),
             debug: sandbox.stub(),
@@ -3438,7 +3282,11 @@ describe('Prerender Audit', () => {
           audit: {
             getId: () => 'audit-id',
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           auditContext: { scrapeJobId: 'test-job-id' },
         };
 
@@ -3475,7 +3323,11 @@ describe('Prerender Audit', () => {
           audit: {
             getId: () => 'audit-id',
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: {
             info: sandbox.stub(),
             debug: sandbox.stub(),
@@ -3528,7 +3380,11 @@ describe('Prerender Audit', () => {
           audit: {
             getId: () => 'audit-id',
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: {
             info: sandbox.stub(),
             debug: sandbox.stub(),
@@ -3612,7 +3468,11 @@ describe('Prerender Audit', () => {
           audit: {
             getId: () => 'audit-id',
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: {
             info: sandbox.stub(),
             debug: sandbox.stub(),
@@ -3664,7 +3524,11 @@ describe('Prerender Audit', () => {
           audit: {
             getId: () => 'audit-id',
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: {
             info: sandbox.stub(),
             debug: sandbox.stub(),
@@ -3696,7 +3560,11 @@ describe('Prerender Audit', () => {
             getBaseURL: () => 'https://example.com',
             getConfig: () => null, // No config
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: { info: sandbox.stub(), debug: sandbox.stub() },
         };
 
@@ -3717,7 +3585,11 @@ describe('Prerender Audit', () => {
             getBaseURL: () => 'https://example.com',
             getConfig: () => ({}), // Config without getIncludedURLs
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: { info: sandbox.stub(), debug: sandbox.stub() },
         };
 
@@ -3952,7 +3824,11 @@ describe('Prerender Audit', () => {
           audit: {
             getId: () => 'audit-id',
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: {
             info: sandbox.stub(),
             debug: sandbox.stub(),
@@ -3998,7 +3874,11 @@ describe('Prerender Audit', () => {
           audit: {
             getId: () => 'audit-id',
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: {
             info: sandbox.stub(),
             debug: sandbox.stub(),
@@ -4050,7 +3930,11 @@ describe('Prerender Audit', () => {
           audit: {
             getId: () => 'audit-id',
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: {
             info: sandbox.stub(),
             debug: sandbox.stub(),
@@ -4335,7 +4219,11 @@ describe('Prerender Audit', () => {
           audit: {
             getId: () => 'audit-id',
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: {
             info: sandbox.stub(),
             debug: sandbox.stub(),
@@ -4386,7 +4274,11 @@ describe('Prerender Audit', () => {
           audit: {
             getId: () => 'audit-id',
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: {
             info: sandbox.stub(),
             debug: sandbox.stub(),
@@ -4437,7 +4329,11 @@ describe('Prerender Audit', () => {
           audit: {
             getId: () => 'audit-id',
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: {
             info: sandbox.stub(),
             debug: sandbox.stub(),
@@ -4490,7 +4386,11 @@ describe('Prerender Audit', () => {
           audit: {
             getId: () => 'audit-id',
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: {
             info: sandbox.stub(),
             debug: sandbox.stub(),
@@ -4542,7 +4442,11 @@ describe('Prerender Audit', () => {
           audit: {
             getId: () => 'audit-id',
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: {
             info: sandbox.stub(),
             warn: sandbox.stub(),
@@ -4589,7 +4493,11 @@ describe('Prerender Audit', () => {
           audit: {
             getId: () => 'audit-id',
           },
-          dataAccess: { SiteTopPage: mockSiteTopPage },
+          dataAccess: {
+            SiteTopPage: mockSiteTopPage,
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: {
             info: sandbox.stub(),
             warn: sandbox.stub(),
@@ -4631,9 +4539,13 @@ describe('Prerender Audit', () => {
           audit: {
             getId: () => 'audit-id',
           },
-          dataAccess: { SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([
-            { getUrl: () => 'https://example.com/page1', getTraffic: () => 100 },
-          ]) } },
+          dataAccess: {
+            SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([
+              { getUrl: () => 'https://example.com/page1', getTraffic: () => 100 },
+            ]) },
+            Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+            LatestAudit: { create: sandbox.stub().resolves() },
+          },
           log: { info: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub(), debug: sandbox.stub() },
           s3Client: { send: sandbox.stub().resolves({}) },
           env: { S3_SCRAPER_BUCKET_NAME: 'test-bucket' },

--- a/test/audits/prerender/handler.test.js
+++ b/test/audits/prerender/handler.test.js
@@ -575,8 +575,6 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: { SiteTopPage: mockSiteTopPage },
           log: {
@@ -614,8 +612,6 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: { SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().rejects(new Error('Database error')) } },
           log: { info: sandbox.stub(), debug: sandbox.stub(), error: sandbox.stub(), warn: sandbox.stub() },
@@ -653,8 +649,6 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: {
             SiteTopPage: {
@@ -708,8 +702,6 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: { SiteTopPage: mockSiteTopPage },
           log: {
@@ -743,8 +735,6 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: { SiteTopPage: mockSiteTopPage },
           log: {
@@ -808,8 +798,6 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: {
             SiteTopPage: mockSiteTopPage,
@@ -889,8 +877,6 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: {
             SiteTopPage: mockSiteTopPage,
@@ -1023,12 +1009,13 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: {
             Opportunity: {
               allBySiteIdAndStatus: allBySiteIdAndStatusStub,
+            },
+            LatestAudit: {
+              create: sandbox.stub().resolves(),
             },
           },
           log: {
@@ -1093,12 +1080,13 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: {
             Opportunity: {
               allBySiteIdAndStatus: allBySiteIdAndStatusStub,
+            },
+            LatestAudit: {
+              create: sandbox.stub().resolves(),
             },
           },
           log: {
@@ -1140,12 +1128,13 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: {
             Opportunity: {
               allBySiteIdAndStatus: allBySiteIdAndStatusStub,
+            },
+            LatestAudit: {
+              create: sandbox.stub().resolves(),
             },
           },
           log: {
@@ -1195,12 +1184,13 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: {
             Opportunity: {
               allBySiteIdAndStatus: allBySiteIdAndStatusStub,
+            },
+            LatestAudit: {
+              create: sandbox.stub().resolves(),
             },
           },
           log: {
@@ -1250,12 +1240,13 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: {
             Opportunity: {
               allBySiteIdAndStatus: allBySiteIdAndStatusStub,
+            },
+            LatestAudit: {
+              create: sandbox.stub().resolves(),
             },
           },
           log: {
@@ -1334,12 +1325,13 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: {
             Opportunity: {
               allBySiteIdAndStatus: allBySiteIdAndStatusStub,
+            },
+            LatestAudit: {
+              create: sandbox.stub().resolves(),
             },
           },
           log: {
@@ -1372,51 +1364,6 @@ describe('Prerender Audit', () => {
 
         // Should not log about marking suggestions (no eligible suggestions)
         expect(infoLogs.some(msg => msg.includes('Marked'))).to.be.false;
-      });
-
-      it('should handle errors when saving audit results', async () => {
-        const mockHandler = await esmock('../../../src/prerender/handler.js');
-
-        const context = {
-          site: {
-            getId: () => 'test-site-id',
-            getBaseURL: () => 'https://example.com',
-          },
-          audit: {
-            getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().rejects(new Error('Database save failed')),
-          },
-          dataAccess: {
-            Opportunity: {
-              allBySiteIdAndStatus: sandbox.stub().resolves([]),
-            },
-          },
-          log: {
-            info: sandbox.stub(),
-            debug: sandbox.stub(),
-            warn: sandbox.stub(),
-            error: sandbox.stub(),
-          },
-          s3Client: {
-            send: sandbox.stub().resolves({
-              Body: { transformToString: () => Promise.resolve('') },
-            }),
-          },
-          env: { S3_SCRAPER_BUCKET_NAME: 'test-bucket' },
-          auditContext: { scrapeJobId: 'test-job-id' },
-          scrapeResultPaths: new Map([['https://example.com/test', '/tmp/test']]),
-        };
-
-        const result = await mockHandler.processContentAndGenerateOpportunities(context);
-
-        // Should complete successfully despite save error
-        expect(result.status).to.equal('complete');
-
-        // Should log error about save failure
-        expect(context.log.error).to.have.been.calledWith(
-          sinon.match(/Failed to save audit result/)
-        );
       });
     });
 
@@ -2398,8 +2345,6 @@ describe('Prerender Audit', () => {
         },
         audit: {
           getId: () => 'a',
-          setAuditResult: sinon.stub(),
-          save: sinon.stub().resolves(),
         },
         dataAccess: {
           Opportunity: {
@@ -2522,8 +2467,6 @@ describe('Prerender Audit', () => {
         },
         audit: {
           getId: () => 'a',
-          setAuditResult: sinon.stub(),
-          save: sinon.stub().resolves(),
         },
         dataAccess: {
           Opportunity: {
@@ -2580,8 +2523,6 @@ describe('Prerender Audit', () => {
         },
         audit: {
           getId: () => 'a',
-          setAuditResult: sinon.stub(),
-          save: sinon.stub().resolves(),
         },
         dataAccess: {
           Opportunity: {
@@ -2635,8 +2576,6 @@ describe('Prerender Audit', () => {
         },
         audit: {
           getId: () => 'a',
-          setAuditResult: sinon.stub(),
-          save: sinon.stub().resolves(),
         },
         dataAccess: {
           Opportunity: {
@@ -2720,8 +2659,6 @@ describe('Prerender Audit', () => {
         site: { getId: () => 'site', getBaseURL: () => 'https://example.com', getConfig: () => ({ getIncludedURLs: () => [] }) },
         audit: {
           getId: () => 'a',
-          setAuditResult: sinon.stub(),
-          save: sinon.stub().resolves(),
         },
         dataAccess: {
           Opportunity: {
@@ -2776,8 +2713,6 @@ describe('Prerender Audit', () => {
         },
         audit: {
           getId: () => 'a',
-          setAuditResult: sinon.stub(),
-          save: sinon.stub().resolves(),
         },
         log: { info: sinon.stub(), warn, debug: sinon.stub(), error: err },
         s3Client: { send: sinon.stub().resolves({}) },
@@ -2961,8 +2896,6 @@ describe('Prerender Audit', () => {
         },
         audit: {
           getId: () => 'a',
-          setAuditResult: sinon.stub(),
-          save: sinon.stub().resolves(),
         },
         dataAccess: {
           SiteTopPage: {
@@ -3337,8 +3270,6 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: { SiteTopPage: mockSiteTopPage },
           log: {
@@ -3393,8 +3324,6 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: { SiteTopPage: mockSiteTopPage },
           auditContext: { scrapeJobId: 'test-job-id' },
@@ -3432,8 +3361,6 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: { SiteTopPage: mockSiteTopPage },
           log: {
@@ -3487,8 +3414,6 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: { SiteTopPage: mockSiteTopPage },
           log: {
@@ -3573,8 +3498,6 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: { SiteTopPage: mockSiteTopPage },
           log: {
@@ -3627,8 +3550,6 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: { SiteTopPage: mockSiteTopPage },
           log: {
@@ -3917,8 +3838,6 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: { SiteTopPage: mockSiteTopPage },
           log: {
@@ -3965,8 +3884,6 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: { SiteTopPage: mockSiteTopPage },
           log: {
@@ -4019,8 +3936,6 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: { SiteTopPage: mockSiteTopPage },
           log: {
@@ -4306,8 +4221,6 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: { SiteTopPage: mockSiteTopPage },
           log: {
@@ -4359,8 +4272,6 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: { SiteTopPage: mockSiteTopPage },
           log: {
@@ -4412,8 +4323,6 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: { SiteTopPage: mockSiteTopPage },
           log: {
@@ -4467,8 +4376,6 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: { SiteTopPage: mockSiteTopPage },
           log: {
@@ -4521,8 +4428,6 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: { SiteTopPage: mockSiteTopPage },
           log: {
@@ -4570,8 +4475,6 @@ describe('Prerender Audit', () => {
           },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: { SiteTopPage: mockSiteTopPage },
           log: {
@@ -4614,8 +4517,6 @@ describe('Prerender Audit', () => {
           site: { getId: () => 'test-site', getBaseURL: () => 'https://example.com' },
           audit: {
             getId: () => 'audit-id',
-            setAuditResult: sandbox.stub(),
-            save: sandbox.stub().resolves(),
           },
           dataAccess: { SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([
             { getUrl: () => 'https://example.com/page1', getTraffic: () => 100 },

--- a/test/audits/prerender/handler.test.js
+++ b/test/audits/prerender/handler.test.js
@@ -1380,6 +1380,7 @@ describe('Prerender Audit', () => {
             getId: () => 'audit-id',
             getFullAuditRef: () => 'https://example.com',
             getAuditedAt: () => '2024-01-01T00:00:00Z',
+            getInvocationId: () => 'invocation-123',
           },
           dataAccess: {
             Opportunity: {
@@ -1413,12 +1414,15 @@ describe('Prerender Audit', () => {
         // Should call LatestAudit.create with correct data
         expect(latestAuditCreateStub).to.have.been.calledOnce;
         const createCall = latestAuditCreateStub.firstCall.args[0];
+        expect(createCall).to.have.property('auditId', 'audit-id');
         expect(createCall).to.have.property('siteId', 'test-site-id');
         expect(createCall).to.have.property('auditType', 'prerender');
         expect(createCall).to.have.property('auditResult');
         expect(createCall).to.have.property('fullAuditRef', 'https://example.com');
+        expect(createCall).to.have.property('auditedAt', '2024-01-01T00:00:00Z');
         expect(createCall).to.have.property('isLive', true);
         expect(createCall).to.have.property('isError', false);
+        expect(createCall).to.have.property('invocationId', 'invocation-123');
 
         // Should log success message
         const infoLogs = context.log.info.args.map(call => call[0]);
@@ -1438,6 +1442,7 @@ describe('Prerender Audit', () => {
             getId: () => 'audit-id',
             getFullAuditRef: () => 'https://example.com',
             getAuditedAt: () => '2024-01-01T00:00:00Z',
+            getInvocationId: () => 'invocation-123',
           },
           dataAccess: {
             Opportunity: {


### PR DESCRIPTION
### 1. Opportunity Health View on LLMO UI

Updating `LatestAudit` entity in final audit step, capturing URL wise audit result. Attached screenshots for 3 cases -

<img width="1728" height="1042" alt="image" src="https://github.com/user-attachments/assets/afa7f49f-b2b0-4a96-9752-125af2eb0370" />


<img width="1728" height="1034" alt="image" src="https://github.com/user-attachments/assets/82e1a65d-6534-41e6-9d2c-9d6d4749a5e6" />

<img width="1728" height="1037" alt="image" src="https://github.com/user-attachments/assets/125e57ee-0fa3-4592-8a6c-cce062e9bc4b" />

---
### 2. Handling - No opportunity found case

Move suggestions from last audit to "OUTDATED"

---
Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Divyansh Pratap", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```