### PR TITLE
feat: treat HTTP/2 stream errors as transient, not broken

### DIFF
--- a/src/internal-links/helpers.js
+++ b/src/internal-links/helpers.js
@@ -83,19 +83,25 @@ function isTimeoutError(error) {
 }
 
 /**
- * Checks if an error is a transient HTTP/2 stream error (e.g. REFUSED_STREAM).
- * Servers/CDNs sometimes refuse HTTP/2 streams under load or for Range requests
- * while the resource is actually available; treat as accessible to avoid false positives.
+ * Checks if an error is transient (network/HTTP glitch) rather than a truly broken link.
+ * Servers/CDNs under load, proxies mangling headers, or brief connection resets can cause
+ * these while the resource is actually available; treat as accessible to avoid false positives.
  * @param {Error} error - The error to check
- * @returns {boolean} True if it's a transient HTTP/2 stream error
+ * @returns {boolean} True if it's a transient error
  */
-function isTransientOrHttp2Error(error) {
+function isTransientNetworkError(error) {
   const message = error?.message || '';
   const code = (error?.code || '').toLowerCase();
-  return code === 'err_http2_stream_error'
+  return (
+    code === 'err_http2_stream_error'
     || message.includes('NGHTTP2_REFUSED_STREAM')
     || message.includes('NGHTTP2_INTERNAL_ERROR')
-    || message.includes('NGHTTP2_CONNECT_ERROR');
+    || message.includes('NGHTTP2_CONNECT_ERROR')
+    || code === 'econnreset'
+    || code === 'hpe_invalid_header_token'
+    || message.includes('HPE_INVALID_HEADER_TOKEN')
+    || message.includes('Invalid header token')
+  );
 }
 
 /**
@@ -190,7 +196,7 @@ async function checkLinkWithGet(url, isAsset, log) {
       return false;
     }
 
-    if (isTransientOrHttp2Error(getError)) {
+    if (isTransientNetworkError(getError)) {
       log.info(`⏱ TRANSIENT: ${url} (${getError.code || getError.message}, assuming accessible)`);
       return false;
     }

--- a/src/internal-links/helpers.js
+++ b/src/internal-links/helpers.js
@@ -83,6 +83,22 @@ function isTimeoutError(error) {
 }
 
 /**
+ * Checks if an error is a transient HTTP/2 stream error (e.g. REFUSED_STREAM).
+ * Servers/CDNs sometimes refuse HTTP/2 streams under load or for Range requests
+ * while the resource is actually available; treat as accessible to avoid false positives.
+ * @param {Error} error - The error to check
+ * @returns {boolean} True if it's a transient HTTP/2 stream error
+ */
+function isTransientOrHttp2Error(error) {
+  const message = error?.message || '';
+  const code = (error?.code || '').toLowerCase();
+  return code === 'err_http2_stream_error'
+    || message.includes('NGHTTP2_REFUSED_STREAM')
+    || message.includes('NGHTTP2_INTERNAL_ERROR')
+    || message.includes('NGHTTP2_CONNECT_ERROR');
+}
+
+/**
  * Checks if a URL points to a static asset
  * @param {string} url - The URL to check
  * @returns {boolean} True if it's a static asset (image, SVG, CSS, JS, etc.)
@@ -171,6 +187,11 @@ async function checkLinkWithGet(url, isAsset, log) {
   } catch (getError) {
     if (isTimeoutError(getError)) {
       log.info(`⏱ TIMEOUT: ${url} (GET request timed out after ${LINK_TIMEOUT}ms, assuming accessible)`);
+      return false;
+    }
+
+    if (isTransientOrHttp2Error(getError)) {
+      log.info(`⏱ TRANSIENT: ${url} (${getError.code || getError.message}, assuming accessible)`);
       return false;
     }
 

--- a/test/audits/internal-links/helpers.test.js
+++ b/test/audits/internal-links/helpers.test.js
@@ -373,6 +373,38 @@ describe('isLinkInaccessible', () => {
       sinon.match(/\[siteId=test-site-id\].*⏱ TIMEOUT.*GET request timed out/),
     )).to.be.true;
   });
+
+  it('should treat HTTP/2 stream error (NGHTTP2_REFUSED_STREAM) as accessible', async function call() {
+    this.timeout(15000);
+    const http2Error = new Error('Stream closed with error code NGHTTP2_REFUSED_STREAM');
+    http2Error.code = 'ERR_HTTP2_STREAM_ERROR';
+    http2Error.type = 'system';
+
+    nock('https://example.com')
+      .get('/image.jpg')
+      .replyWithError(http2Error);
+
+    const result = await isLinkInaccessible('https://example.com/image.jpg', mockLog, 'test-site-id');
+    expect(result).to.be.false;
+    expect(mockLog.info.calledWith(
+      sinon.match(/\[siteId=test-site-id\].*⏱ TRANSIENT.*assuming accessible/),
+    )).to.be.true;
+  });
+
+  it('should treat GET error with NGHTTP2_REFUSED_STREAM in message as accessible', async function call() {
+    this.timeout(15000);
+    const http2Error = new Error('Stream closed with error code NGHTTP2_REFUSED_STREAM');
+
+    nock('https://example.com')
+      .get('/asset.png')
+      .replyWithError(http2Error);
+
+    const result = await isLinkInaccessible('https://example.com/asset.png', mockLog, 'test-site-id');
+    expect(result).to.be.false;
+    expect(mockLog.info.calledWith(
+      sinon.match(/⏱ TRANSIENT.*assuming accessible/),
+    )).to.be.true;
+  });
 });
 
 describe('calculatePriority', () => {

--- a/test/audits/internal-links/helpers.test.js
+++ b/test/audits/internal-links/helpers.test.js
@@ -156,10 +156,10 @@ describe('isLinkInaccessible', () => {
     expect(mockLog.error.calledOnce).to.be.true;
   });
 
-  it('should handle error with code property', async function call() {
+  it('should handle error with code property (non-transient code reported as broken)', async function call() {
     this.timeout(15000);
     const codeError = new Error('Connection failed');
-    codeError.code = 'ECONNRESET';
+    codeError.code = 'ENOTFOUND';
 
     nock('https://example.com')
       .head('/code-err')
@@ -400,6 +400,40 @@ describe('isLinkInaccessible', () => {
       .replyWithError(http2Error);
 
     const result = await isLinkInaccessible('https://example.com/asset.png', mockLog, 'test-site-id');
+    expect(result).to.be.false;
+    expect(mockLog.info.calledWith(
+      sinon.match(/⏱ TRANSIENT.*assuming accessible/),
+    )).to.be.true;
+  });
+
+  it('should treat ECONNRESET as transient (assume accessible)', async function call() {
+    this.timeout(15000);
+    const resetError = new Error('read ECONNRESET');
+    resetError.code = 'ECONNRESET';
+
+    nock('https://example.com')
+      .get('/page.html')
+      .replyWithError(resetError);
+
+    const result = await isLinkInaccessible('https://example.com/page.html', mockLog, 'test-site-id');
+    expect(result).to.be.false;
+    expect(mockLog.info.calledWith(
+      sinon.match(/⏱ TRANSIENT.*assuming accessible/),
+    )).to.be.true;
+  });
+
+  it('should treat HPE_INVALID_HEADER_TOKEN as transient (assume accessible)', async function call() {
+    this.timeout(15000);
+    const parseError = new Error('Parse Error: Invalid header token');
+    parseError.code = 'HPE_INVALID_HEADER_TOKEN';
+
+    nock('https://example.com')
+      .head('/casino-credit-application.html')
+      .reply(403)
+      .get('/casino-credit-application.html')
+      .replyWithError(parseError);
+
+    const result = await isLinkInaccessible('https://example.com/casino-credit-application.html', mockLog, 'test-site-id');
     expect(result).to.be.false;
     expect(mockLog.info.calledWith(
       sinon.match(/⏱ TRANSIENT.*assuming accessible/),


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
