### PR TITLE
feat: Adding auto-detect for publish during broken backlinks audits run

### DIFF
--- a/src/utils/data-access.js
+++ b/src/utils/data-access.js
@@ -309,6 +309,8 @@ export const defaultMergeStatusFunction = (existing, newDataItem, context) => {
  * @param {Function} [params.mergeStatusFunction] - Function to determine the status of
  *   existing suggestions.
  * @param {string} [params.statusToSetForOutdated] - Status to set for outdated suggestions.
+ * @param {Array} [params.existingSuggestions] - Pre-fetched suggestions to avoid duplicate
+ *   DB query. If not provided, will be fetched from opportunity.
  * @returns {Promise<void>} - Resolves when the synchronization is complete.
  */
 export async function syncSuggestions({
@@ -321,13 +323,15 @@ export async function syncSuggestions({
   mergeStatusFunction = defaultMergeStatusFunction,
   statusToSetForOutdated = SuggestionDataAccess.STATUSES.OUTDATED,
   scrapedUrlsSet = null,
+  existingSuggestions: prefetchedSuggestions = null,
 }) {
   if (!context) {
     return;
   }
   const { log } = context;
   const newDataKeys = new Set(newData.map(buildKey));
-  const existingSuggestions = await opportunity.getSuggestions();
+  // Use pre-fetched suggestions if provided, otherwise fetch from DB
+  const existingSuggestions = prefetchedSuggestions ?? await opportunity.getSuggestions();
 
   // Pre-compute Maps for O(1) lookups instead of O(N*M)
   const newDataByKey = new Map(newData.map((data) => [buildKey(data), data]));
@@ -705,7 +709,7 @@ export async function syncSuggestionsWithPublishDetection({
     });
   }
 
-  // Step 3: Delegate to base syncSuggestions
+  // Step 3: Delegate to base syncSuggestions, passing pre-fetched suggestions to avoid double query
   await syncSuggestions({
     context,
     opportunity,
@@ -716,5 +720,6 @@ export async function syncSuggestionsWithPublishDetection({
     mergeStatusFunction,
     statusToSetForOutdated,
     scrapedUrlsSet,
+    existingSuggestions,
   });
 }

--- a/src/utils/data-access.js
+++ b/src/utils/data-access.js
@@ -10,7 +10,26 @@
  * governing permissions and limitations under the License.
  */
 import { isNonEmptyArray, isObject } from '@adobe/spacecat-shared-utils';
-import { Suggestion as SuggestionDataAccess } from '@adobe/spacecat-shared-data-access';
+import {
+  Suggestion as SuggestionDataAccess,
+  FixEntity as FixEntityDataAccess,
+} from '@adobe/spacecat-shared-data-access';
+import { limitConcurrencyAllSettled } from '../support/utils.js';
+
+// Max concurrent HTTP calls to prevent Lambda timeout (15 min)
+const MAX_CONCURRENT_CHECKS = 5;
+
+/**
+ * Opportunity types that only make changes in the author environment (no publish state).
+ * For these types:
+ * - Fix entities are created directly in DEPLOYED state (final state)
+ * - Skip the publish step (publishDeployedFixEntities)
+ * - Regression checks look for DEPLOYED fix entities instead of PUBLISHED
+ */
+export const AUTHOR_ONLY_OPPORTUNITY_TYPES = [
+  'security-permissions-redundant',
+  'security-permissions',
+];
 
 /**
  * Safely stringify an object for logging, truncating large arrays to prevent
@@ -310,6 +329,12 @@ export async function syncSuggestions({
   const newDataKeys = new Set(newData.map(buildKey));
   const existingSuggestions = await opportunity.getSuggestions();
 
+  // Pre-compute Maps for O(1) lookups instead of O(N*M)
+  const newDataByKey = new Map(newData.map((data) => [buildKey(data), data]));
+  const existingSuggestionKeys = new Set(
+    existingSuggestions.map((s) => buildKey(s.getData())),
+  );
+
   // Update outdated suggestions
   await handleOutdatedSuggestions({
     existingSuggestions,
@@ -322,7 +347,7 @@ export async function syncSuggestions({
 
   log.debug(`Existing suggestions = ${existingSuggestions.length}: ${safeStringify(existingSuggestions)}`);
 
-  // Update existing suggestions
+  // Update existing suggestions - O(N) with Map lookup
   await Promise.all(
     existingSuggestions
       .filter((existing) => {
@@ -330,7 +355,8 @@ export async function syncSuggestions({
         return newDataKeys.has(existingKey);
       })
       .map((existing) => {
-        const newDataItem = newData.find((data) => buildKey(data) === buildKey(existing.getData()));
+        const existingKey = buildKey(existing.getData());
+        const newDataItem = newDataByKey.get(existingKey);
         existing.setData(mergeDataFunction(existing.getData(), newDataItem));
 
         // Use the merge status function to determine if status should change
@@ -345,13 +371,11 @@ export async function syncSuggestions({
   );
   log.debug(`Updated existing suggestions = ${existingSuggestions.length}: ${safeStringify(existingSuggestions)}`);
 
-  // Prepare new suggestions
+  // Prepare new suggestions - O(N) with Set lookup
   const { site } = context;
   const requiresValidation = Boolean(site?.requiresValidation);
   const newSuggestions = newData
-    .filter((data) => !existingSuggestions.some(
-      (existing) => buildKey(existing.getData()) === buildKey(data),
-    ))
+    .filter((data) => !existingSuggestionKeys.has(buildKey(data)))
     .map((data) => {
       const suggestion = mapNewSuggestion(data);
       return {
@@ -394,4 +418,303 @@ export async function syncSuggestions({
       log.debug(`Successfully created ${suggestions.createdItems?.length || suggestions.length} suggestions for siteId ${siteId}`);
     }
   }
+}
+
+/**
+ * Computes suggestions that have "disappeared" from the current audit data.
+ * A suggestion is considered disappeared if its key is no longer present in newDataKeys.
+ *
+ * @param {Array} existingSuggestions - The existing suggestions from the opportunity.
+ * @param {Set} newDataKeys - Set of keys from current audit data.
+ * @param {Function} buildKey - Function to generate a unique key from suggestion data.
+ * @returns {Array} - Suggestions whose keys are not in newDataKeys.
+ */
+export function getDisappearedSuggestions(existingSuggestions, newDataKeys, buildKey) {
+  return existingSuggestions.filter(
+    (suggestion) => !newDataKeys.has(buildKey(suggestion.getData())),
+  );
+}
+
+/**
+ * Reconciles disappeared suggestions by checking if issues were fixed externally.
+ * For suggestions in NEW status that have disappeared from audit data, this function
+ * checks if the issue was resolved using the AI suggestion and marks them as FIXED.
+ *
+ * @param {Object} params - The parameters object.
+ * @param {Object} params.opportunity - The opportunity object with addFixEntities method.
+ * @param {Array} params.disappearedSuggestions - Suggestions no longer in audit data.
+ * @param {Object} params.log - Logger object.
+ * @param {Function} params.isIssueFixedWithAISuggestion - Async callback to verify fix.
+ * @param {Function} params.buildFixEntityPayload - Function to build fix entity payload.
+ * @param {boolean} [params.isAuthorOnly=false] - If true, this is an author-only opportunity.
+ * @returns {Promise<void>}
+ */
+export async function reconcileDisappearedSuggestions({
+  opportunity,
+  disappearedSuggestions,
+  log,
+  isIssueFixedWithAISuggestion,
+  buildFixEntityPayload,
+  isAuthorOnly = false,
+}) {
+  try {
+    const newStatus = SuggestionDataAccess?.STATUSES?.NEW;
+
+    // From disappeared suggestions, only process those in NEW status
+    const candidates = disappearedSuggestions.filter((s) => {
+      if (!newStatus || s?.getStatus?.() !== newStatus) {
+        return false;
+      }
+      return true;
+    });
+
+    if (candidates.length === 0) {
+      return;
+    }
+
+    // Use bounded concurrency for HTTP checks to prevent Lambda timeout
+    const checkTasks = candidates.map((suggestion) => async () => {
+      const isFixed = await isIssueFixedWithAISuggestion?.(suggestion);
+      return { suggestion, isFixed };
+    });
+
+    const checkResults = await limitConcurrencyAllSettled(checkTasks, MAX_CONCURRENT_CHECKS);
+    const fixedSuggestions = checkResults.filter((r) => r?.isFixed).map((r) => r.suggestion);
+
+    const fixEntityObjects = [];
+
+    // Process fixed suggestions (DB operations are fast, no concurrency limit needed)
+    for (const suggestion of fixedSuggestions) {
+      log.debug(`[reconcileDisappearedSuggestions] Marking suggestion ${suggestion?.getId?.()} as FIXED`);
+      let suggestionMarkedFixed = false;
+      try {
+        suggestion.setStatus?.(SuggestionDataAccess.STATUSES.FIXED);
+        suggestion.setUpdatedBy?.('system');
+        // eslint-disable-next-line no-await-in-loop
+        await suggestion.save?.();
+        suggestionMarkedFixed = true;
+      } catch (e) {
+        log.warn(`Failed to mark suggestion ${suggestion?.getId?.()} as FIXED: ${e.message}`);
+      }
+
+      if (suggestionMarkedFixed && typeof buildFixEntityPayload === 'function') {
+        try {
+          const fixEntity = buildFixEntityPayload(suggestion, opportunity, isAuthorOnly);
+          if (fixEntity) {
+            fixEntityObjects.push(fixEntity);
+          }
+        } catch (e) {
+          log.warn(`Failed building fix entity for suggestion ${suggestion?.getId?.()}: ${e.message}`);
+        }
+      }
+    }
+
+    if (fixEntityObjects.length > 0 && typeof opportunity.addFixEntities === 'function') {
+      try {
+        await opportunity.addFixEntities(fixEntityObjects);
+        log.info(`Added ${fixEntityObjects.length} fix entities for opportunity ${opportunity.getId?.()}`);
+      } catch (e) {
+        log.warn(`Failed to add fix entities on opportunity ${opportunity.getId?.()}: ${e.message}`);
+      }
+    }
+  } catch (e) {
+    log.warn(`Failed reconciliation for disappeared suggestions: ${e.message}`);
+  }
+}
+
+/**
+ * Publishes DEPLOYED fix entities to PUBLISHED when verified on production.
+ * Skipped for author-only opportunity types where DEPLOYED is final.
+ *
+ * @param {Object} params - The parameters object.
+ * @param {string} params.opportunityId - The opportunity ID.
+ * @param {Object} params.context - Context object with dataAccess and log.
+ * @param {Function} params.isIssueResolvedOnProduction - Async predicate for verification.
+ * @param {Array} [params.currentAuditData] - Current audit data for fast-path optimization.
+ * @param {Function} [params.buildKey] - Function to build unique key from data.
+ * @returns {Promise<void>}
+ */
+export async function publishDeployedFixEntities({
+  opportunityId,
+  context,
+  isIssueResolvedOnProduction,
+  currentAuditData,
+  buildKey,
+}) {
+  if (!context) {
+    return;
+  }
+  const { dataAccess, log } = context;
+  try {
+    const { FixEntity, Suggestion } = dataAccess || {};
+    if (!FixEntity?.allByOpportunityIdAndStatus || !Suggestion?.getFixEntitiesBySuggestionId) {
+      log.debug('FixEntity APIs not available; skipping publish.');
+      return;
+    }
+
+    const deployedStatus = FixEntityDataAccess.STATUSES.DEPLOYED;
+    const publishedStatus = FixEntityDataAccess.STATUSES.PUBLISHED;
+
+    const deployedFixEntities = await FixEntity.allByOpportunityIdAndStatus(
+      opportunityId,
+      deployedStatus,
+    );
+    if (!Array.isArray(deployedFixEntities) || deployedFixEntities.length === 0) {
+      return;
+    }
+
+    // Build set of current audit data keys for fast-path check
+    const currentDataKeys = currentAuditData && buildKey
+      ? new Set(currentAuditData.map(buildKey))
+      : null;
+
+    // Helper to check a single fix entity with bounded HTTP calls
+    const checkFixEntity = async (fixEntity) => {
+      const suggestionIds = fixEntity.getSuggestionIds?.() || [];
+      if (suggestionIds.length === 0) {
+        return { fixEntity, allResolved: false };
+      }
+
+      // Fetch all suggestions first (DB calls)
+      const suggestionResults = await Promise.all(
+        suggestionIds.map(async (suggestionId) => {
+          const { data: suggestions = [] } = await Suggestion.getFixEntitiesBySuggestionId(
+            suggestionId,
+          );
+          return suggestions[0];
+        }),
+      );
+
+      // Fast-path check using current audit data (no HTTP)
+      for (const suggestion of suggestionResults) {
+        if (!suggestion) {
+          return { fixEntity, allResolved: false };
+        }
+        if (currentDataKeys && buildKey) {
+          const key = buildKey(suggestion.getData?.());
+          if (currentDataKeys.has(key)) {
+            return { fixEntity, allResolved: false };
+          }
+        }
+      }
+
+      // HTTP verification with bounded concurrency
+      const httpCheckTasks = suggestionResults.map((suggestion) => async () => {
+        const resolved = await isIssueResolvedOnProduction?.(suggestion);
+        return resolved;
+      });
+
+      const httpResults = await limitConcurrencyAllSettled(httpCheckTasks, MAX_CONCURRENT_CHECKS);
+      const allResolved = httpResults.every((r) => r === true);
+      return { fixEntity, allResolved };
+    };
+
+    // Process fix entities with bounded concurrency
+    const fixEntityTasks = deployedFixEntities.map((fe) => async () => checkFixEntity(fe));
+    const results = await limitConcurrencyAllSettled(fixEntityTasks, MAX_CONCURRENT_CHECKS);
+
+    // Update resolved fix entities
+    for (const result of results) {
+      if (result?.allResolved) {
+        try {
+          result.fixEntity.setStatus?.(publishedStatus);
+          // eslint-disable-next-line no-await-in-loop
+          await result.fixEntity.save?.();
+          log.info(`Published fix entity ${result.fixEntity.getId?.()}`);
+        } catch (e) {
+          log.debug(`Failed to save fix entity: ${e.message}`);
+        }
+      }
+    }
+  } catch (e) {
+    log.warn(`Failed to publish deployed fix entities: ${e.message}`);
+  }
+}
+
+/**
+ * Wrapper that orchestrates publish detection before delegating to syncSuggestions.
+ * This separates the publish detection logic from the core sync functionality.
+ *
+ * Steps:
+ * 1. Reconcile disappeared suggestions (mark externally fixed as FIXED)
+ * 2. Publish deployed fix entities (verify on production)
+ * 3. Delegate to base syncSuggestions
+ *
+ * @param {Object} params - All parameters from syncSuggestions plus publish detection params.
+ * @param {Function} [params.isIssueFixedWithAISuggestion] - Callback for reconcile step.
+ * @param {Function} [params.buildFixEntityPayload] - Function to build fix entity payload.
+ * @param {Function} [params.isIssueResolvedOnProduction] - Callback for publish step.
+ * @returns {Promise<void>}
+ */
+export async function syncSuggestionsWithPublishDetection({
+  context,
+  opportunity,
+  newData,
+  buildKey,
+  mapNewSuggestion,
+  mergeDataFunction,
+  mergeStatusFunction,
+  statusToSetForOutdated,
+  scrapedUrlsSet,
+  // Publish detection params
+  isIssueFixedWithAISuggestion,
+  buildFixEntityPayload,
+  isIssueResolvedOnProduction,
+}) {
+  if (!context) {
+    return;
+  }
+  const { log } = context;
+
+  // Determine if this is an author-only opportunity type
+  const opportunityType = opportunity.getType?.();
+  const isAuthorOnly = AUTHOR_ONLY_OPPORTUNITY_TYPES.includes(opportunityType);
+
+  // Compute disappeared suggestions for reconcile step
+  const newDataKeys = new Set(newData.map(buildKey));
+  const existingSuggestions = await opportunity.getSuggestions();
+  const disappearedSuggestions = getDisappearedSuggestions(
+    existingSuggestions,
+    newDataKeys,
+    buildKey,
+  );
+
+  // Step 1: Reconcile disappeared suggestions
+  if (typeof isIssueFixedWithAISuggestion === 'function'
+      && typeof buildFixEntityPayload === 'function') {
+    await reconcileDisappearedSuggestions({
+      opportunity,
+      disappearedSuggestions,
+      log,
+      isIssueFixedWithAISuggestion,
+      buildFixEntityPayload,
+      isAuthorOnly,
+    });
+  }
+
+  // Step 2: Publish deployed fix entities (skip for author-only)
+  if (isAuthorOnly) {
+    log.debug('[syncSuggestionsWithPublishDetection] Skipping publish for author-only type');
+  } else if (typeof isIssueResolvedOnProduction === 'function') {
+    await publishDeployedFixEntities({
+      opportunityId: opportunity.getId(),
+      context,
+      currentAuditData: newData,
+      buildKey,
+      isIssueResolvedOnProduction,
+    });
+  }
+
+  // Step 3: Delegate to base syncSuggestions
+  await syncSuggestions({
+    context,
+    opportunity,
+    newData,
+    buildKey,
+    mapNewSuggestion,
+    mergeDataFunction,
+    mergeStatusFunction,
+    statusToSetForOutdated,
+    scrapedUrlsSet,
+  });
 }

--- a/src/utils/url-utils.js
+++ b/src/utils/url-utils.js
@@ -200,3 +200,48 @@ export function joinBaseAndPath(baseURL, path) {
 
   return `${normalizedBase}${normalizedPath}`;
 }
+
+/**
+ * Strips query string from a URL, keeping only the origin and path.
+ * @param {string} url - The URL to strip.
+ * @returns {string} - URL without query string.
+ */
+export function stripQueryString(url) {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Normalizes a URL for comparison (lowercase, strip trailing slashes).
+ * @param {string} url - The URL to normalize.
+ * @returns {string} - Normalized URL.
+ */
+export function normalizeUrlForComparison(url) {
+  try {
+    return url?.toLowerCase().replace(/\/+$/, '');
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Checks if two URLs match (with or without query strings).
+ * Compares normalized URLs and also tries without query strings.
+ * @param {string} url1 - First URL.
+ * @param {string} url2 - Second URL.
+ * @returns {boolean} - True if URLs match.
+ */
+export function urlsMatch(url1, url2) {
+  const norm1 = normalizeUrlForComparison(url1);
+  const norm2 = normalizeUrlForComparison(url2);
+  if (norm1 === norm2) return true;
+
+  // Also try without query strings
+  const stripped1 = normalizeUrlForComparison(stripQueryString(url1));
+  const stripped2 = normalizeUrlForComparison(stripQueryString(url2));
+  return stripped1 === stripped2;
+}

--- a/test/utils/data-access.test.js
+++ b/test/utils/data-access.test.js
@@ -20,10 +20,15 @@ import { Suggestion as SuggestionDataAccess } from '@adobe/spacecat-shared-data-
 import {
   retrieveSiteBySiteId,
   syncSuggestions,
+  syncSuggestionsWithPublishDetection,
   getImsOrgId,
   retrieveAuditById,
   keepSameDataFunction,
   keepLatestMergeDataFunction,
+  getDisappearedSuggestions,
+  reconcileDisappearedSuggestions,
+  publishDeployedFixEntities,
+  AUTHOR_ONLY_OPPORTUNITY_TYPES,
 } from '../../src/utils/data-access.js';
 import { MockContextBuilder } from '../shared.js';
 
@@ -1737,6 +1742,641 @@ describe('data-access', () => {
       expect(result).to.not.have.property('oldProperty');
       expect(result).to.have.property('newProperty', 'newValue');
       expect(result).to.have.property('sharedProperty', 'newValue');
+    });
+  });
+
+  describe('AUTHOR_ONLY_OPPORTUNITY_TYPES', () => {
+    it('should contain expected opportunity types', () => {
+      expect(AUTHOR_ONLY_OPPORTUNITY_TYPES).to.include('security-permissions-redundant');
+      expect(AUTHOR_ONLY_OPPORTUNITY_TYPES).to.include('security-permissions');
+    });
+  });
+
+  describe('getDisappearedSuggestions', () => {
+    it('should return suggestions whose keys are not in newDataKeys', () => {
+      const existingSuggestions = [
+        { getData: () => ({ key: '1' }) },
+        { getData: () => ({ key: '2' }) },
+        { getData: () => ({ key: '3' }) },
+      ];
+      const newDataKeys = new Set(['1', '3']);
+      const buildKey = (data) => data.key;
+
+      const result = getDisappearedSuggestions(existingSuggestions, newDataKeys, buildKey);
+
+      expect(result).to.have.lengthOf(1);
+      expect(result[0].getData().key).to.equal('2');
+    });
+
+    it('should return empty array when all suggestions exist in newDataKeys', () => {
+      const existingSuggestions = [
+        { getData: () => ({ key: '1' }) },
+        { getData: () => ({ key: '2' }) },
+      ];
+      const newDataKeys = new Set(['1', '2']);
+      const buildKey = (data) => data.key;
+
+      const result = getDisappearedSuggestions(existingSuggestions, newDataKeys, buildKey);
+
+      expect(result).to.have.lengthOf(0);
+    });
+  });
+
+  describe('reconcileDisappearedSuggestions', () => {
+    let mockLogger;
+    let mockOpportunity;
+
+    beforeEach(() => {
+      mockLogger = {
+        info: sinon.stub(),
+        warn: sinon.stub(),
+        debug: sinon.stub(),
+        error: sinon.stub(),
+      };
+      mockOpportunity = {
+        getId: sinon.stub().returns('opp-id'),
+        addFixEntities: sinon.stub().resolves({ createdItems: [], errorItems: [] }),
+      };
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should mark NEW suggestions as FIXED when isIssueFixedWithAISuggestion returns true', async () => {
+      const suggestion = {
+        getId: sinon.stub().returns('sugg-1'),
+        getData: sinon.stub().returns({ key: '1' }),
+        getStatus: sinon.stub().returns(SuggestionDataAccess.STATUSES.NEW),
+        getType: sinon.stub().returns('TEST_TYPE'),
+        setStatus: sinon.stub(),
+        setUpdatedBy: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      await reconcileDisappearedSuggestions({
+        opportunity: mockOpportunity,
+        disappearedSuggestions: [suggestion],
+        log: mockLogger,
+        isIssueFixedWithAISuggestion: sinon.stub().resolves(true),
+        buildFixEntityPayload: (s, opp) => ({
+          opportunityId: opp.getId(),
+          status: 'PUBLISHED',
+          suggestions: [s.getId()],
+        }),
+      });
+
+      expect(suggestion.setStatus).to.have.been.calledWith(SuggestionDataAccess.STATUSES.FIXED);
+      expect(suggestion.save).to.have.been.called;
+      expect(mockOpportunity.addFixEntities).to.have.been.called;
+    });
+
+    it('should skip suggestions not in NEW status', async () => {
+      const suggestion = {
+        getId: sinon.stub().returns('sugg-1'),
+        getData: sinon.stub().returns({ key: '1' }),
+        getStatus: sinon.stub().returns(SuggestionDataAccess.STATUSES.APPROVED),
+        setStatus: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      await reconcileDisappearedSuggestions({
+        opportunity: mockOpportunity,
+        disappearedSuggestions: [suggestion],
+        log: mockLogger,
+        isIssueFixedWithAISuggestion: sinon.stub().resolves(true),
+        buildFixEntityPayload: sinon.stub(),
+      });
+
+      expect(suggestion.setStatus).to.not.have.been.called;
+      expect(mockOpportunity.addFixEntities).to.not.have.been.called;
+    });
+
+    it('should pass isAuthorOnly to buildFixEntityPayload', async () => {
+      const suggestion = {
+        getId: sinon.stub().returns('sugg-1'),
+        getData: sinon.stub().returns({ key: '1' }),
+        getStatus: sinon.stub().returns(SuggestionDataAccess.STATUSES.NEW),
+        getType: sinon.stub().returns('TEST_TYPE'),
+        setStatus: sinon.stub(),
+        setUpdatedBy: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      const buildFixEntityPayloadStub = sinon.stub().returns({
+        opportunityId: 'opp-id',
+        status: 'DEPLOYED',
+        suggestions: ['sugg-1'],
+      });
+
+      await reconcileDisappearedSuggestions({
+        opportunity: mockOpportunity,
+        disappearedSuggestions: [suggestion],
+        log: mockLogger,
+        isIssueFixedWithAISuggestion: sinon.stub().resolves(true),
+        buildFixEntityPayload: buildFixEntityPayloadStub,
+        isAuthorOnly: true,
+      });
+
+      expect(buildFixEntityPayloadStub).to.have.been.calledWith(
+        suggestion,
+        mockOpportunity,
+        true,
+      );
+    });
+
+    it('should log warning when suggestion.save() throws', async () => {
+      const suggestion = {
+        getId: sinon.stub().returns('sugg-1'),
+        getData: sinon.stub().returns({ key: '1' }),
+        getStatus: sinon.stub().returns(SuggestionDataAccess.STATUSES.NEW),
+        setStatus: sinon.stub(),
+        setUpdatedBy: sinon.stub(),
+        save: sinon.stub().rejects(new Error('DB error')),
+      };
+
+      await reconcileDisappearedSuggestions({
+        opportunity: mockOpportunity,
+        disappearedSuggestions: [suggestion],
+        log: mockLogger,
+        isIssueFixedWithAISuggestion: sinon.stub().resolves(true),
+        buildFixEntityPayload: sinon.stub(),
+      });
+
+      expect(mockLogger.warn).to.have.been.calledWith(
+        'Failed to mark suggestion sugg-1 as FIXED: DB error',
+      );
+    });
+
+    it('should log warning when buildFixEntityPayload throws', async () => {
+      const suggestion = {
+        getId: sinon.stub().returns('sugg-2'),
+        getData: sinon.stub().returns({ key: '2' }),
+        getStatus: sinon.stub().returns(SuggestionDataAccess.STATUSES.NEW),
+        setStatus: sinon.stub(),
+        setUpdatedBy: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      await reconcileDisappearedSuggestions({
+        opportunity: mockOpportunity,
+        disappearedSuggestions: [suggestion],
+        log: mockLogger,
+        isIssueFixedWithAISuggestion: sinon.stub().resolves(true),
+        buildFixEntityPayload: sinon.stub().throws(new Error('Payload error')),
+      });
+
+      expect(mockLogger.warn).to.have.been.calledWith(
+        'Failed building fix entity for suggestion sugg-2: Payload error',
+      );
+    });
+
+    it('should log warning when opportunity.addFixEntities throws', async () => {
+      const suggestion = {
+        getId: sinon.stub().returns('sugg-3'),
+        getData: sinon.stub().returns({ key: '3' }),
+        getStatus: sinon.stub().returns(SuggestionDataAccess.STATUSES.NEW),
+        setStatus: sinon.stub(),
+        setUpdatedBy: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      mockOpportunity.addFixEntities.rejects(new Error('Add fix entities error'));
+
+      await reconcileDisappearedSuggestions({
+        opportunity: mockOpportunity,
+        disappearedSuggestions: [suggestion],
+        log: mockLogger,
+        isIssueFixedWithAISuggestion: sinon.stub().resolves(true),
+        buildFixEntityPayload: sinon.stub().returns({ id: 'fix-1' }),
+      });
+
+      expect(mockLogger.warn).to.have.been.calledWith(
+        'Failed to add fix entities on opportunity opp-id: Add fix entities error',
+      );
+    });
+
+    it('should log warning on outer catch when unexpected error occurs', async () => {
+      const suggestion = {
+        getId: sinon.stub().returns('sugg-4'),
+        getData: sinon.stub().returns({ key: '4' }),
+        getStatus: sinon.stub().throws(new Error('Unexpected error')),
+      };
+
+      await reconcileDisappearedSuggestions({
+        opportunity: mockOpportunity,
+        disappearedSuggestions: [suggestion],
+        log: mockLogger,
+        isIssueFixedWithAISuggestion: sinon.stub().resolves(true),
+        buildFixEntityPayload: sinon.stub(),
+      });
+
+      expect(mockLogger.warn).to.have.been.calledWith(
+        'Failed reconciliation for disappeared suggestions: Unexpected error',
+      );
+    });
+
+    it('should skip when isIssueFixedWithAISuggestion returns false', async () => {
+      const suggestion = {
+        getId: sinon.stub().returns('sugg-5'),
+        getData: sinon.stub().returns({ key: '5' }),
+        getStatus: sinon.stub().returns(SuggestionDataAccess.STATUSES.NEW),
+        setStatus: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      await reconcileDisappearedSuggestions({
+        opportunity: mockOpportunity,
+        disappearedSuggestions: [suggestion],
+        log: mockLogger,
+        isIssueFixedWithAISuggestion: sinon.stub().resolves(false),
+        buildFixEntityPayload: sinon.stub(),
+      });
+
+      expect(suggestion.setStatus).to.not.have.been.called;
+      expect(mockOpportunity.addFixEntities).to.not.have.been.called;
+    });
+  });
+
+  describe('publishDeployedFixEntities', () => {
+    let mockLogger;
+    let mockDataAccess;
+
+    beforeEach(() => {
+      mockLogger = {
+        info: sinon.stub(),
+        warn: sinon.stub(),
+        debug: sinon.stub(),
+        error: sinon.stub(),
+      };
+      mockDataAccess = {
+        FixEntity: {
+          allByOpportunityIdAndStatus: sinon.stub().resolves([]),
+        },
+        Suggestion: {
+          getFixEntitiesBySuggestionId: sinon.stub().resolves({ data: [] }),
+        },
+      };
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should skip when FixEntity APIs not available', async () => {
+      await publishDeployedFixEntities({
+        opportunityId: 'opp-id',
+        context: { dataAccess: {}, log: mockLogger },
+        isIssueResolvedOnProduction: sinon.stub().resolves(true),
+      });
+
+      expect(mockLogger.debug).to.have.been.calledWith('FixEntity APIs not available; skipping publish.');
+    });
+
+    it('should handle when context is falsy', async () => {
+      // This should not throw - just return early
+      await publishDeployedFixEntities({
+        opportunityId: 'opp-id',
+        context: null,
+        isIssueResolvedOnProduction: sinon.stub().resolves(true),
+      });
+      // No assertions needed - just ensure no error thrown
+    });
+
+    it('should handle when dataAccess is undefined in context', async () => {
+      await publishDeployedFixEntities({
+        opportunityId: 'opp-id',
+        context: { log: mockLogger },
+        isIssueResolvedOnProduction: sinon.stub().resolves(true),
+      });
+
+      expect(mockLogger.debug).to.have.been.calledWith('FixEntity APIs not available; skipping publish.');
+    });
+
+    it('should handle fix entity with getSuggestionIds returning undefined', async () => {
+      const fixEntity = {
+        getId: sinon.stub().returns('fix-undefined'),
+        getSuggestionIds: sinon.stub().returns(undefined),
+        setStatus: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      mockDataAccess.FixEntity.allByOpportunityIdAndStatus.resolves([fixEntity]);
+
+      await publishDeployedFixEntities({
+        opportunityId: 'opp-id',
+        context: { dataAccess: mockDataAccess, log: mockLogger },
+        isIssueResolvedOnProduction: sinon.stub().resolves(true),
+      });
+
+      // Should not publish since suggestionIds is empty after || []
+      expect(fixEntity.setStatus).to.not.have.been.called;
+    });
+
+    it('should skip when no deployed fix entities found', async () => {
+      mockDataAccess.FixEntity.allByOpportunityIdAndStatus.resolves([]);
+
+      await publishDeployedFixEntities({
+        opportunityId: 'opp-id',
+        context: { dataAccess: mockDataAccess, log: mockLogger },
+        isIssueResolvedOnProduction: sinon.stub().resolves(true),
+      });
+
+      expect(mockDataAccess.FixEntity.allByOpportunityIdAndStatus).to.have.been.called;
+    });
+
+    it('should skip fix entity with empty suggestionIds', async () => {
+      const fixEntity = {
+        getId: sinon.stub().returns('fix-1'),
+        getSuggestionIds: sinon.stub().returns([]),
+        setStatus: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      mockDataAccess.FixEntity.allByOpportunityIdAndStatus.resolves([fixEntity]);
+
+      await publishDeployedFixEntities({
+        opportunityId: 'opp-id',
+        context: { dataAccess: mockDataAccess, log: mockLogger },
+        isIssueResolvedOnProduction: sinon.stub().resolves(true),
+      });
+
+      expect(fixEntity.setStatus).to.not.have.been.called;
+    });
+
+    it('should not publish when suggestion not found', async () => {
+      const fixEntity = {
+        getId: sinon.stub().returns('fix-2'),
+        getSuggestionIds: sinon.stub().returns(['sugg-1']),
+        setStatus: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      mockDataAccess.FixEntity.allByOpportunityIdAndStatus.resolves([fixEntity]);
+      mockDataAccess.Suggestion.getFixEntitiesBySuggestionId.resolves({ data: [] });
+
+      await publishDeployedFixEntities({
+        opportunityId: 'opp-id',
+        context: { dataAccess: mockDataAccess, log: mockLogger },
+        isIssueResolvedOnProduction: sinon.stub().resolves(true),
+      });
+
+      expect(fixEntity.setStatus).to.not.have.been.called;
+    });
+
+    it('should not publish when key exists in currentAuditData (fast-path)', async () => {
+      const suggestion = {
+        getData: sinon.stub().returns({ key: 'existing-key' }),
+      };
+
+      const fixEntity = {
+        getId: sinon.stub().returns('fix-3'),
+        getSuggestionIds: sinon.stub().returns(['sugg-1']),
+        setStatus: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      mockDataAccess.FixEntity.allByOpportunityIdAndStatus.resolves([fixEntity]);
+      mockDataAccess.Suggestion.getFixEntitiesBySuggestionId.resolves({ data: [suggestion] });
+
+      await publishDeployedFixEntities({
+        opportunityId: 'opp-id',
+        context: { dataAccess: mockDataAccess, log: mockLogger },
+        isIssueResolvedOnProduction: sinon.stub().resolves(true),
+        currentAuditData: [{ key: 'existing-key' }],
+        buildKey: (d) => d?.key,
+      });
+
+      expect(fixEntity.setStatus).to.not.have.been.called;
+    });
+
+    it('should not publish when isIssueResolvedOnProduction returns false', async () => {
+      const suggestion = {
+        getData: sinon.stub().returns({ key: 'resolved-key' }),
+      };
+
+      const fixEntity = {
+        getId: sinon.stub().returns('fix-4'),
+        getSuggestionIds: sinon.stub().returns(['sugg-1']),
+        setStatus: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      mockDataAccess.FixEntity.allByOpportunityIdAndStatus.resolves([fixEntity]);
+      mockDataAccess.Suggestion.getFixEntitiesBySuggestionId.resolves({ data: [suggestion] });
+
+      await publishDeployedFixEntities({
+        opportunityId: 'opp-id',
+        context: { dataAccess: mockDataAccess, log: mockLogger },
+        isIssueResolvedOnProduction: sinon.stub().resolves(false),
+      });
+
+      expect(fixEntity.setStatus).to.not.have.been.called;
+    });
+
+    it('should publish fix entity when all suggestions resolved', async () => {
+      const suggestion = {
+        getData: sinon.stub().returns({ key: 'resolved-key' }),
+      };
+
+      const fixEntity = {
+        getId: sinon.stub().returns('fix-5'),
+        getSuggestionIds: sinon.stub().returns(['sugg-1']),
+        setStatus: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      mockDataAccess.FixEntity.allByOpportunityIdAndStatus.resolves([fixEntity]);
+      mockDataAccess.Suggestion.getFixEntitiesBySuggestionId.resolves({ data: [suggestion] });
+
+      await publishDeployedFixEntities({
+        opportunityId: 'opp-id',
+        context: { dataAccess: mockDataAccess, log: mockLogger },
+        isIssueResolvedOnProduction: sinon.stub().resolves(true),
+      });
+
+      expect(fixEntity.setStatus).to.have.been.called;
+      expect(fixEntity.save).to.have.been.called;
+      expect(mockLogger.info).to.have.been.calledWith('Published fix entity fix-5');
+    });
+
+    it('should log debug when fixEntity.save() throws', async () => {
+      const suggestion = {
+        getData: sinon.stub().returns({ key: 'resolved-key' }),
+      };
+
+      const fixEntity = {
+        getId: sinon.stub().returns('fix-6'),
+        getSuggestionIds: sinon.stub().returns(['sugg-1']),
+        setStatus: sinon.stub(),
+        save: sinon.stub().rejects(new Error('Save error')),
+      };
+
+      mockDataAccess.FixEntity.allByOpportunityIdAndStatus.resolves([fixEntity]);
+      mockDataAccess.Suggestion.getFixEntitiesBySuggestionId.resolves({ data: [suggestion] });
+
+      await publishDeployedFixEntities({
+        opportunityId: 'opp-id',
+        context: { dataAccess: mockDataAccess, log: mockLogger },
+        isIssueResolvedOnProduction: sinon.stub().resolves(true),
+      });
+
+      expect(mockLogger.debug).to.have.been.calledWith('Failed to save fix entity: Save error');
+    });
+
+    it('should log warning on outer catch when unexpected error occurs', async () => {
+      mockDataAccess.FixEntity.allByOpportunityIdAndStatus.rejects(new Error('DB error'));
+
+      await publishDeployedFixEntities({
+        opportunityId: 'opp-id',
+        context: { dataAccess: mockDataAccess, log: mockLogger },
+        isIssueResolvedOnProduction: sinon.stub().resolves(true),
+      });
+
+      expect(mockLogger.warn).to.have.been.calledWith(
+        'Failed to publish deployed fix entities: DB error',
+      );
+    });
+  });
+
+  describe('syncSuggestionsWithPublishDetection', () => {
+    let mockLogger;
+    let mockOpportunity;
+    let context;
+    const buildKey = (d) => d?.key;
+    const mapNewSuggestion = (d) => ({ type: 'TEST', data: d });
+
+    beforeEach(() => {
+      mockLogger = {
+        info: sinon.stub(),
+        warn: sinon.stub(),
+        debug: sinon.stub(),
+        error: sinon.stub(),
+      };
+      mockOpportunity = {
+        getId: sinon.stub().returns('opp-id'),
+        getSiteId: sinon.stub().returns('site-id'),
+        getSuggestions: sinon.stub().resolves([]),
+        addSuggestions: sinon.stub().resolves({ createdItems: [], errorItems: [] }),
+        addFixEntities: sinon.stub().resolves({ createdItems: [], errorItems: [] }),
+        getType: sinon.stub().returns('broken-backlinks'),
+      };
+      context = {
+        dataAccess: {
+          Suggestion: {
+            bulkUpdateStatus: sinon.stub().resolves(),
+            getFixEntitiesBySuggestionId: sinon.stub().resolves({ data: [] }),
+          },
+          FixEntity: {
+            allByOpportunityIdAndStatus: sinon.stub().resolves([]),
+          },
+        },
+        log: mockLogger,
+        site: {
+          getDeliveryType: sinon.stub().returns('aem_edge'),
+          requiresValidation: false,
+        },
+      };
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('should call reconcile when callbacks provided', async () => {
+      const newData = [];
+      const disappearedSuggestion = {
+        getId: sinon.stub().returns('sugg-1'),
+        getData: sinon.stub().returns({ key: '1' }),
+        getStatus: sinon.stub().returns(SuggestionDataAccess.STATUSES.NEW),
+        getType: sinon.stub().returns('TEST'),
+        setStatus: sinon.stub(),
+        setUpdatedBy: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      mockOpportunity.getSuggestions.resolves([disappearedSuggestion]);
+
+      const isIssueFixedStub = sinon.stub().resolves(true);
+      const buildFixEntityStub = sinon.stub().returns({
+        opportunityId: 'opp-id',
+        status: 'PUBLISHED',
+        suggestions: ['sugg-1'],
+      });
+
+      await syncSuggestionsWithPublishDetection({
+        context,
+        opportunity: mockOpportunity,
+        newData,
+        buildKey,
+        mapNewSuggestion,
+        isIssueFixedWithAISuggestion: isIssueFixedStub,
+        buildFixEntityPayload: buildFixEntityStub,
+      });
+
+      expect(isIssueFixedStub).to.have.been.called;
+      expect(disappearedSuggestion.setStatus).to.have.been.calledWith(
+        SuggestionDataAccess.STATUSES.FIXED,
+      );
+    });
+
+    it('should skip publish step for author-only opportunity types', async () => {
+      mockOpportunity.getType.returns('security-permissions-redundant');
+
+      await syncSuggestionsWithPublishDetection({
+        context,
+        opportunity: mockOpportunity,
+        newData: [{ key: '1' }],
+        buildKey,
+        mapNewSuggestion,
+        isIssueResolvedOnProduction: sinon.stub().resolves(true),
+      });
+
+      expect(mockLogger.debug).to.have.been.calledWith(
+        '[syncSuggestionsWithPublishDetection] Skipping publish for author-only type',
+      );
+    });
+
+    it('should call publish step for non-author-only types', async () => {
+      mockOpportunity.getType.returns('broken-backlinks');
+
+      await syncSuggestionsWithPublishDetection({
+        context,
+        opportunity: mockOpportunity,
+        newData: [{ key: '1' }],
+        buildKey,
+        mapNewSuggestion,
+        isIssueResolvedOnProduction: sinon.stub().resolves(true),
+      });
+
+      // Should have called allByOpportunityIdAndStatus for publish step
+      expect(context.dataAccess.FixEntity.allByOpportunityIdAndStatus).to.have.been.called;
+    });
+
+    it('should return early when context is falsy', async () => {
+      await syncSuggestionsWithPublishDetection({
+        context: null,
+        opportunity: mockOpportunity,
+        newData: [{ key: '1' }],
+        buildKey,
+        mapNewSuggestion,
+      });
+
+      // Should not have called any methods on opportunity
+      expect(mockOpportunity.getSuggestions).to.not.have.been.called;
+    });
+
+    it('should return early when context is undefined', async () => {
+      await syncSuggestionsWithPublishDetection({
+        context: undefined,
+        opportunity: mockOpportunity,
+        newData: [{ key: '1' }],
+        buildKey,
+        mapNewSuggestion,
+      });
+
+      // Should not have called any methods on opportunity
+      expect(mockOpportunity.getSuggestions).to.not.have.been.called;
     });
   });
 });

--- a/test/utils/data-access.test.js
+++ b/test/utils/data-access.test.js
@@ -1611,6 +1611,36 @@ describe('data-access', () => {
         expect(e.message).to.include('Sample error: Unknown error');
       }
     });
+
+    it('should use pre-fetched suggestions when provided to avoid double DB query', async () => {
+      const suggestionsData = [{ key: '1', title: 'existing' }];
+      const prefetchedSuggestions = [{
+        id: '1',
+        data: suggestionsData[0],
+        getData: sinon.stub().returns(suggestionsData[0]),
+        setData: sinon.stub(),
+        save: sinon.stub(),
+        getStatus: sinon.stub().returns('NEW'),
+        setUpdatedBy: sinon.stub().returnsThis(),
+      }];
+      const newData = [{ key: '1', title: 'updated' }];
+
+      // Pass existingSuggestions directly - getSuggestions should NOT be called
+      await syncSuggestions({
+        opportunity: mockOpportunity,
+        newData,
+        context,
+        buildKey,
+        mapNewSuggestion,
+        existingSuggestions: prefetchedSuggestions,
+      });
+
+      // Verify getSuggestions was NOT called since we provided pre-fetched suggestions
+      expect(mockOpportunity.getSuggestions).to.not.have.been.called;
+      // Verify the pre-fetched suggestions were used
+      expect(prefetchedSuggestions[0].setData).to.have.been.calledOnceWith(newData[0]);
+      expect(prefetchedSuggestions[0].save).to.have.been.calledOnce;
+    });
   });
 
   describe('getImsOrgId', () => {
@@ -2377,6 +2407,31 @@ describe('data-access', () => {
 
       // Should not have called any methods on opportunity
       expect(mockOpportunity.getSuggestions).to.not.have.been.called;
+    });
+
+    it('should only call getSuggestions once to avoid duplicate DB queries', async () => {
+      const existingSuggestion = {
+        id: '1',
+        getData: sinon.stub().returns({ key: '1' }),
+        getStatus: sinon.stub().returns('NEW'),
+        setData: sinon.stub(),
+        save: sinon.stub(),
+        setUpdatedBy: sinon.stub().returnsThis(),
+      };
+      mockOpportunity.getSuggestions.resolves([existingSuggestion]);
+      mockOpportunity.getType.returns('broken-backlinks');
+
+      await syncSuggestionsWithPublishDetection({
+        context,
+        opportunity: mockOpportunity,
+        newData: [{ key: '1', title: 'updated' }],
+        buildKey,
+        mapNewSuggestion,
+      });
+
+      // Verify getSuggestions is only called ONCE, not twice
+      // (once in wrapper, passed to syncSuggestions to avoid double query)
+      expect(mockOpportunity.getSuggestions).to.have.been.calledOnce;
     });
   });
 });

--- a/test/utils/url-utils.test.js
+++ b/test/utils/url-utils.test.js
@@ -335,3 +335,113 @@ describe('joinBaseAndPath', () => {
     expect(utils.joinBaseAndPath('https://example.com/base/', 'page')).to.equal('https://example.com/base/page');
   });
 });
+
+describe('stripQueryString', () => {
+  it('should remove query string from URL', () => {
+    expect(utils.stripQueryString('https://example.com/page?foo=bar'))
+      .to.equal('https://example.com/page');
+  });
+
+  it('should remove multiple query parameters', () => {
+    expect(utils.stripQueryString('https://example.com/page?foo=bar&baz=qux'))
+      .to.equal('https://example.com/page');
+  });
+
+  it('should handle URLs without query strings', () => {
+    expect(utils.stripQueryString('https://example.com/page'))
+      .to.equal('https://example.com/page');
+  });
+
+  it('should handle root URLs', () => {
+    expect(utils.stripQueryString('https://example.com/'))
+      .to.equal('https://example.com/');
+  });
+
+  it('should return original value for invalid URLs', () => {
+    expect(utils.stripQueryString('not-a-url')).to.equal('not-a-url');
+    expect(utils.stripQueryString('')).to.equal('');
+  });
+});
+
+describe('normalizeUrlForComparison', () => {
+  it('should lowercase URL', () => {
+    expect(utils.normalizeUrlForComparison('HTTPS://EXAMPLE.COM/Page'))
+      .to.equal('https://example.com/page');
+  });
+
+  it('should strip trailing slashes', () => {
+    expect(utils.normalizeUrlForComparison('https://example.com/page/'))
+      .to.equal('https://example.com/page');
+  });
+
+  it('should strip multiple trailing slashes', () => {
+    expect(utils.normalizeUrlForComparison('https://example.com/page///'))
+      .to.equal('https://example.com/page');
+  });
+
+  it('should handle undefined', () => {
+    expect(utils.normalizeUrlForComparison(undefined)).to.be.undefined;
+  });
+
+  it('should handle null', () => {
+    expect(utils.normalizeUrlForComparison(null)).to.be.undefined;
+  });
+
+  it('should return original value when toLowerCase throws', () => {
+    const badUrl = {
+      toLowerCase: () => { throw new Error('Cannot lowercase'); },
+    };
+    expect(utils.normalizeUrlForComparison(badUrl)).to.equal(badUrl);
+  });
+});
+
+describe('urlsMatch', () => {
+  it('should match identical URLs', () => {
+    expect(utils.urlsMatch(
+      'https://example.com/page',
+      'https://example.com/page',
+    )).to.be.true;
+  });
+
+  it('should match URLs with different cases', () => {
+    expect(utils.urlsMatch(
+      'https://example.com/Page',
+      'https://example.com/page',
+    )).to.be.true;
+  });
+
+  it('should match URLs with/without trailing slash', () => {
+    expect(utils.urlsMatch(
+      'https://example.com/page/',
+      'https://example.com/page',
+    )).to.be.true;
+  });
+
+  it('should match URLs ignoring query strings', () => {
+    expect(utils.urlsMatch(
+      'https://example.com/page?foo=bar',
+      'https://example.com/page',
+    )).to.be.true;
+  });
+
+  it('should match URLs with different query strings', () => {
+    expect(utils.urlsMatch(
+      'https://example.com/page?foo=bar',
+      'https://example.com/page?baz=qux',
+    )).to.be.true;
+  });
+
+  it('should not match different URLs', () => {
+    expect(utils.urlsMatch(
+      'https://example.com/page1',
+      'https://example.com/page2',
+    )).to.be.false;
+  });
+
+  it('should not match URLs with different hosts', () => {
+    expect(utils.urlsMatch(
+      'https://example.com/page',
+      'https://other.com/page',
+    )).to.be.false;
+  });
+});


### PR DESCRIPTION
This PR replaces https://github.com/adobe/spacecat-audit-worker/pull/1730

Implements these -

1. Automated detection of Publish for Broken Backlinks opportunity
2. Updates common utility data-access#syncSuggestions method to:
  -  optionally receive `isIssueFixedByAISuggestion` & `isIssueResolvedOnProduction` from opportunity handlers
  - update a NEW Suggestion to Fixed & creating its FixEntity as Published, if `isIssueFixedByAISuggestion` is true
  - updated a Deployed FixEntity to Published, if `isIssueResolvedOnProduction` is true for all Suggestions of the FixEntity
  - not ever update already Fixed Suggestions (whether published or not), if the same issue re-appears
  - create a New Suggestion, if same issue re-appears and previous Suggestions were Deployed+Published


----

Strategies for publish auto-detection is mentioned in https://wiki.corp.adobe.com/pages/viewpage.action?spaceKey=AEMSites&title=AEM+Sites+Optimizer+%7C+Auto-detect+Publish#AEMSitesOptimizer|AutodetectPublish-Strategies

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Kanishka", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```