### PR TITLE
fix: store suggestion ID in data for correct syncSuggestions deduplication

### DIFF
--- a/src/reddit-analysis/guidance-handler.js
+++ b/src/reddit-analysis/guidance-handler.js
@@ -114,12 +114,15 @@ export default async function handler(message, context) {
       context,
       opportunity,
       newData: suggestions,
-      buildKey: (suggestion) => `reddit::${suggestion.id}`,
+      buildKey: (suggestion) => `reddit::${suggestion.redditSuggestionId || suggestion.id}`,
       mapNewSuggestion: (suggestion) => ({
         opportunityId: opportunity.getId(),
         type: suggestion.type || 'CONTENT_UPDATE',
         rank: suggestion.rank,
-        data: suggestion.data,
+        data: {
+          ...suggestion.data,
+          redditSuggestionId: suggestion.id,
+        },
       }),
     });
 

--- a/src/youtube-analysis/guidance-handler.js
+++ b/src/youtube-analysis/guidance-handler.js
@@ -112,12 +112,15 @@ export default async function handler(message, context) {
       context,
       opportunity,
       newData: suggestions,
-      buildKey: (suggestion) => `youtube::${suggestion.id}`,
+      buildKey: (suggestion) => `youtube::${suggestion.youtubeSuggestionId || suggestion.id}`,
       mapNewSuggestion: (suggestion) => ({
         opportunityId: opportunity.getId(),
         type: suggestion.type || 'CONTENT_UPDATE',
         rank: suggestion.rank,
-        data: suggestion.data,
+        data: {
+          ...suggestion.data,
+          youtubeSuggestionId: suggestion.id,
+        },
       }),
     });
 

--- a/test/audits/reddit-analysis/guidance-handler.test.js
+++ b/test/audits/reddit-analysis/guidance-handler.test.js
@@ -412,12 +412,12 @@ describe('Reddit Analysis Guidance Handler', () => {
       const mapped0 = mapNewSuggestion(newData[0]);
       expect(mapped0.rank).to.equal(1);
       expect(mapped0.type).to.equal('CONTENT_UPDATE');
-      expect(mapped0.data).to.deep.equal({ suggestionValue: 'Analysis A' });
+      expect(mapped0.data).to.deep.equal({ suggestionValue: 'Analysis A', redditSuggestionId: 'sug_a' });
 
       const mapped1 = mapNewSuggestion(newData[1]);
       expect(mapped1.rank).to.equal(2);
       expect(mapped1.type).to.equal('METADATA_UPDATE');
-      expect(mapped1.data).to.deep.equal({ suggestionValue: 'Analysis B' });
+      expect(mapped1.data).to.deep.equal({ suggestionValue: 'Analysis B', redditSuggestionId: 'sug_b' });
     });
 
     it('should default type to CONTENT_UPDATE when not provided', async () => {
@@ -447,7 +447,7 @@ describe('Reddit Analysis Guidance Handler', () => {
       expect(mapped.type).to.equal('CONTENT_UPDATE');
     });
 
-    it('should use correct buildKey function', async () => {
+    it('should use correct buildKey function with id', async () => {
       const message = {
         siteId,
         auditId,
@@ -468,6 +468,29 @@ describe('Reddit Analysis Guidance Handler', () => {
       const key = buildKey({ id: 'my_suggestion_id' });
 
       expect(key).to.equal('reddit::my_suggestion_id');
+    });
+
+    it('should use redditSuggestionId in buildKey when available (existing suggestion data)', async () => {
+      const message = {
+        siteId,
+        auditId,
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            suggestions: [
+              { id: 'my_suggestion_id', priority: 'HIGH', title: 'My Title', description: 'Desc' },
+            ],
+          },
+        },
+      };
+
+      await handler.default(message, context);
+
+      const syncCall = syncSuggestionsStub.firstCall;
+      const { buildKey } = syncCall.args[0];
+      const key = buildKey({ redditSuggestionId: 'stored_id', suggestionValue: 'some value' });
+
+      expect(key).to.equal('reddit::stored_id');
     });
   });
 

--- a/test/audits/youtube-analysis/guidance-handler.test.js
+++ b/test/audits/youtube-analysis/guidance-handler.test.js
@@ -473,12 +473,12 @@ describe('YouTube Analysis Guidance Handler', () => {
       const mapped0 = mapNewSuggestion(newData[0]);
       expect(mapped0.rank).to.equal(1);
       expect(mapped0.type).to.equal('CONTENT_UPDATE');
-      expect(mapped0.data).to.deep.equal({ suggestionValue: 'Analysis A' });
+      expect(mapped0.data).to.deep.equal({ suggestionValue: 'Analysis A', youtubeSuggestionId: 'sug-1' });
 
       const mapped1 = mapNewSuggestion(newData[1]);
       expect(mapped1.rank).to.equal(2);
       expect(mapped1.type).to.equal('METADATA_UPDATE');
-      expect(mapped1.data).to.deep.equal({ suggestionValue: 'Analysis B' });
+      expect(mapped1.data).to.deep.equal({ suggestionValue: 'Analysis B', youtubeSuggestionId: 'sug-2' });
     });
 
     it('should default type to CONTENT_UPDATE when not provided', async () => {
@@ -509,7 +509,7 @@ describe('YouTube Analysis Guidance Handler', () => {
       expect(mapped.type).to.equal('CONTENT_UPDATE');
     });
 
-    it('should use correct buildKey function', async () => {
+    it('should use correct buildKey function with id', async () => {
       const message = {
         siteId,
         auditId,
@@ -530,6 +530,29 @@ describe('YouTube Analysis Guidance Handler', () => {
       const key = buildKey({ id: 'my_suggestion_id' });
 
       expect(key).to.equal('youtube::my_suggestion_id');
+    });
+
+    it('should use youtubeSuggestionId in buildKey when available (existing suggestion data)', async () => {
+      const message = {
+        siteId,
+        auditId,
+        data: {
+          analysis: {
+            suggestions: [
+              { id: 'my_suggestion_id', priority: 'HIGH', title: 'Test', description: 'Test' },
+            ],
+          },
+          companyName: 'Example Corp',
+        },
+      };
+
+      await guidanceHandler.default(message, context);
+
+      const syncCall = mockSyncSuggestions.firstCall;
+      const { buildKey } = syncCall.args[0];
+      const key = buildKey({ youtubeSuggestionId: 'stored_id', suggestionValue: 'some value' });
+
+      expect(key).to.equal('youtube::stored_id');
     });
 
     it('should save full analysis data to opportunity', async () => {


### PR DESCRIPTION
## Summary

- Fixes Reddit and YouTube guidance handlers to store the original suggestion ID inside the `data` payload (`redditSuggestionId` / `youtubeSuggestionId`)
- Updates `buildKey` to prefer the stored ID over the top-level `id`

**Root cause:** `syncSuggestions` calls `buildKey(s.getData())` for existing records, but `getData()` returns only the `data` sub-object which lacks the suggestion `id` field. This caused all existing keys to resolve to `reddit::undefined` (or `youtube::undefined`), marking every suggestion as OUTDATED on every re-run and creating duplicates.
