### PR TITLE
fix: llm-error-pages enabled only when cdn-config present

### DIFF
--- a/src/llmo-customer-analysis/cdn-config-handler.js
+++ b/src/llmo-customer-analysis/cdn-config-handler.js
@@ -169,6 +169,7 @@ export async function handleCdnBucketConfigChanges(context, data) {
     const configuration = await Configuration.findLatest();
     configuration.disableHandlerForSite('cdn-logs-analysis', site);
     configuration.disableHandlerForSite('cdn-logs-report', site);
+    configuration.disableHandlerForSite('llm-error-pages', site);
     configuration.disableHandlerForSite('page-citability', site);
     await configuration.save();
     throw new Error('CDN provider is required for CDN configuration');
@@ -218,6 +219,7 @@ export async function handleCdnBucketConfigChanges(context, data) {
   const configuration = await Configuration.findLatest();
   configuration.enableHandlerForSite('cdn-logs-analysis', site);
   configuration.enableHandlerForSite('cdn-logs-report', site);
+  configuration.enableHandlerForSite('llm-error-pages', site);
   configuration.enableHandlerForSite('page-citability', site);
   await configuration.save();
 

--- a/src/llmo-customer-analysis/handler.js
+++ b/src/llmo-customer-analysis/handler.js
@@ -322,7 +322,6 @@ export async function runLlmoCustomerAnalysis(finalUrl, context, site, auditCont
       'scrape-top-pages',
       'headings',
       'llm-blocked',
-      'llm-error-pages',
       'summarization',
       REFERRAL_TRAFFIC_AUDIT,
       'readability',

--- a/test/audits/llmo-customer-analysis-cdn-config.test.js
+++ b/test/audits/llmo-customer-analysis-cdn-config.test.js
@@ -330,6 +330,7 @@ describe('CDN Config Handler', () => {
       expect(mockSite.save).to.have.been.called;
       expect(mockConfiguration.disableHandlerForSite).to.have.been.calledWith('cdn-logs-analysis', mockSite);
       expect(mockConfiguration.disableHandlerForSite).to.have.been.calledWith('cdn-logs-report', mockSite);
+      expect(mockConfiguration.disableHandlerForSite).to.have.been.calledWith('llm-error-pages', mockSite);
       expect(mockConfiguration.disableHandlerForSite).to.have.been.calledWith('page-citability', mockSite);
       expect(mockConfiguration.save).to.have.been.called;
       expect(context.log.warn).to.have.been.calledWith(
@@ -413,6 +414,7 @@ describe('CDN Config Handler', () => {
       expect(mockSite.save).to.have.been.called;
       expect(mockConfiguration.enableHandlerForSite).to.have.been.calledWith('cdn-logs-analysis', mockSite);
       expect(mockConfiguration.enableHandlerForSite).to.have.been.calledWith('cdn-logs-report', mockSite);
+      expect(mockConfiguration.enableHandlerForSite).to.have.been.calledWith('llm-error-pages', mockSite);
       expect(mockConfiguration.enableHandlerForSite).to.have.been.calledWith('page-citability', mockSite);
       expect(context.log.info).to.have.been.calledWith(
         'CDN_CONFIG_CHANGED: CDN bucket configuration updated',

--- a/test/audits/llmo-customer-analysis.test.js
+++ b/test/audits/llmo-customer-analysis.test.js
@@ -1241,7 +1241,6 @@ describe('LLMO Customer Analysis Handler', () => {
         'scrape-top-pages',
         'headings',
         'llm-blocked',
-        'llm-error-pages',
         'summarization',
         'llmo-referral-traffic',
         'readability',


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
