### PR TITLE
fea: meta-tags language info

### DIFF
--- a/src/metatags/handler.js
+++ b/src/metatags/handler.js
@@ -12,6 +12,7 @@
 
 import RUMAPIClient from '@adobe/spacecat-shared-rum-api-client';
 import { Audit, Suggestion as SuggestionModel } from '@adobe/spacecat-shared-data-access';
+import { hasText } from '@adobe/spacecat-shared-utils';
 import { calculateCPCValue } from '../support/utils.js';
 import { getObjectFromKey } from '../utils/s3-utils.js';
 import SeoChecks from './seo-checks.js';
@@ -149,6 +150,8 @@ export async function fetchAndProcessPageObject(s3Client, bucketName, url, key, 
 
   const pageUrl = object.finalUrl ? new URL(object.finalUrl).pathname
     : new URL(url).pathname;
+  const lang = tags.lang ?? object.scrapeResult.language;
+
   // handling for homepage
   return {
     [pageUrl]: {
@@ -156,6 +159,7 @@ export async function fetchAndProcessPageObject(s3Client, bucketName, url, key, 
       description: trimTagValue(object.scrapeResult.tags.description),
       h1: trimTagValue(object.scrapeResult.tags.h1) || [],
       s3key: key,
+      ...(hasText(lang) ? { language: lang } : {}),
     },
   };
 }

--- a/src/metatags/seo-checks.js
+++ b/src/metatags/seo-checks.js
@@ -71,6 +71,7 @@ class SeoChecks {
    * @param {object} pageTags - An object containing the tags of the page.
    */
   checkForTagsLength(urlPath, pageTags) {
+    const { language } = pageTags;
     const getLengthSuggestion = (tagName) => {
       if (TITLE === tagName.toLowerCase()) {
         return TITLE_LENGTH_SUGGESTION;
@@ -128,6 +129,7 @@ class SeoChecks {
           [ISSUE_DETAILS]: issueDetails,
           [SEO_RECOMMENDATION]: recommendation,
           ...(tagContent && { tagContent }),
+          ...(language && { language }),
         });
       } else {
         this.healthyTags[tagName].push(tagContent);

--- a/test/detect-cdn/cdn-detector.test.js
+++ b/test/detect-cdn/cdn-detector.test.js
@@ -194,6 +194,17 @@ describe('cdn-detector', () => {
   });
 
   describe('detectCdnFromUrl', () => {
+    // Avoid mocha timeout by mocking instant DNS failure.
+    function mockDnsForFastFallback() {
+      return {
+        promises: {
+          resolve: sinon.stub().rejects(Object.assign(new Error('ENODATA'), { code: 'ENODATA' })),
+          resolve4: sinon.stub().resolves([]),
+          reverse: sinon.stub().resolves([]),
+        },
+      };
+    }
+
     it('returns CDN from response headers when fetch succeeds', async () => {
       const headers = new Map([
         ['cf-ray', 'abc123'],
@@ -219,6 +230,9 @@ describe('cdn-detector', () => {
     });
 
     it('returns error when both HEAD and GET throw', async () => {
+      const detector = await esmock('../../src/detect-cdn/cdn-detector.js', {
+        'node:dns': mockDnsForFastFallback(),
+      });
       let n = 0;
       const fetchFn = sinon.stub().callsFake(() => {
         n += 1;
@@ -227,7 +241,7 @@ describe('cdn-detector', () => {
         }
         return Promise.resolve({ ok: true, json: () => Promise.resolve({ Answer: [] }) });
       });
-      const result = await detectCdnFromUrl('https://example.com', fetchFn);
+      const result = await detector.detectCdnFromUrl('https://example.com', fetchFn);
       expect(result.cdn).to.equal('unknown');
       expect(result.error).to.equal('network error');
       expect(fetchFn.firstCall.args[1].method).to.equal('HEAD');
@@ -275,6 +289,9 @@ describe('cdn-detector', () => {
     });
 
     it('returns error message as string when both HEAD and GET throw with no .message', async () => {
+      const detector = await esmock('../../src/detect-cdn/cdn-detector.js', {
+        'node:dns': mockDnsForFastFallback(),
+      });
       let n = 0;
       const fetchFn = sinon.stub().callsFake(() => {
         n += 1;
@@ -285,7 +302,7 @@ describe('cdn-detector', () => {
         }
         return Promise.resolve({ ok: true, json: () => Promise.resolve({ Answer: [] }) });
       });
-      const result = await detectCdnFromUrl('https://example.com', fetchFn);
+      const result = await detector.detectCdnFromUrl('https://example.com', fetchFn);
       expect(result.cdn).to.equal('unknown');
       expect(result.error).to.equal('plain string error');
       expect(fetchFn.callCount).to.be.at.least(2);

--- a/test/metatags/metatags.test.js
+++ b/test/metatags/metatags.test.js
@@ -151,6 +151,29 @@ describe('Meta Tags', () => {
         expect(seoChecks.getDetectedTags()[url][TITLE].issueDetails)
           .to.equal(`${aboveIdealTitle.length - TAG_LENGTHS[TITLE].idealMaxLength} chars above ideal maximum`);
       });
+
+      it('should include page language on detected tag objects (seo-checks language spread)', () => {
+        const url = 'https://example.com';
+        const pageTags = {
+          language: 'es',
+          [TITLE]: '',
+          [DESCRIPTION]: 'x'.repeat(150),
+          [H1]: ['Fine'],
+        };
+        seoChecks.checkForTagsLength(url, pageTags);
+        expect(seoChecks.getDetectedTags()[url][TITLE].language).to.equal('es');
+      });
+
+      it('should not include page language on detected tag objects if not present', () => {
+        const url = 'https://example.com';
+        const pageTags = {
+          [TITLE]: '',
+          [DESCRIPTION]: 'x'.repeat(150),
+          [H1]: ['Fine'],
+        };
+        seoChecks.checkForTagsLength(url, pageTags);
+        expect(seoChecks.getDetectedTags()[url][TITLE].language).to.be.undefined;
+      });
     });
 
     // check disabled, to be included in later iterations
@@ -668,6 +691,84 @@ describe('Meta Tags', () => {
             description: 'Test Description',
             h1: ['Test H1'],
             s3key: 'scrapes/site-id/page1/scrape.json',
+          },
+        });
+      });
+
+      it('should include language when scrape tags include lang', async () => {
+        const mockScrapeResult = {
+          finalUrl: 'http://example.com/page1',
+          scrapeResult: {
+            tags: {
+              title: 'Test Page',
+              description: 'Test Description',
+              h1: ['Test H1'],
+              lang: 'de',
+            },
+          },
+        };
+
+        s3ClientStub.send.resolves({
+          Body: {
+            transformToString: () => JSON.stringify(mockScrapeResult),
+          },
+          ContentType: 'application/json',
+        });
+
+        const result = await fetchAndProcessPageObject(
+          s3ClientStub,
+          'test-bucket',
+          'http://example.com/page1',
+          'scrapes/site-id/page1/scrape.json',
+          logStub,
+        );
+
+        expect(result).to.deep.equal({
+          '/page1': {
+            title: 'Test Page',
+            description: 'Test Description',
+            h1: ['Test H1'],
+            s3key: 'scrapes/site-id/page1/scrape.json',
+            language: 'de',
+          },
+        });
+      });
+
+      it('should use scrapeResult.language when tags.lang is absent', async () => {
+        const mockScrapeResult = {
+          finalUrl: 'http://example.com/page1',
+          scrapeResult: {
+            language: 'fr',
+            tags: {
+              title: 'Test Page',
+              description: 'Test Description',
+              h1: ['Test H1'],
+            },
+          },
+        };
+
+        s3ClientStub.send.resolves({
+          Body: {
+            transformToString: () => JSON.stringify(mockScrapeResult),
+          },
+          ContentType: 'application/json',
+        });
+
+        const result = await fetchAndProcessPageObject(
+          s3ClientStub,
+          'test-bucket',
+          'http://example.com/page1',
+          'scrapes/site-id/page1/scrape.json',
+          logStub,
+        );
+
+        expect(result).to.deep.equal({
+          '/page1': {
+            title: 'Test Page',
+            description: 'Test Description',
+            h1: ['Test H1'],
+            s3key: 'scrapes/site-id/page1/scrape.json',
+            language: 'fr',
           },
         });
       });


### PR DESCRIPTION
meta-tags audit now collect page language info and pass the info to mystique.

added auto test for new behavior

updated cdn-detector test to fixes flakiness.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
