### PR TITLE
feat: byocdn-imperva cdn audits

### DIFF
--- a/src/cdn-analysis/handler.js
+++ b/src/cdn-analysis/handler.js
@@ -335,7 +335,11 @@ export async function processCdnLogs(auditUrl, context, site, auditContext) {
     const cdnType = mapServiceToCdnProvider(serviceProvider);
 
     const cdnTypeLower = cdnType.toLowerCase();
-    const hasDailyPartitioningOnly = [CDN_TYPES.CLOUDFLARE, CDN_TYPES.OTHER].includes(cdnTypeLower);
+    const hasDailyPartitioningOnly = [
+      CDN_TYPES.CLOUDFLARE,
+      CDN_TYPES.IMPERVA,
+      CDN_TYPES.OTHER,
+    ].includes(cdnTypeLower);
 
     // Skip providers with daily partitioning only (no hourly partitions) unless hour=23
     if (hasDailyPartitioningOnly && hour !== '23') {
@@ -404,6 +408,10 @@ export async function processCdnLogs(auditUrl, context, site, auditContext) {
         }
         if (cdnTypeLower === CDN_TYPES.OTHER) {
           return `${paths.rawLocation}${year}/${month}/${day}/`;
+        }
+        if (cdnTypeLower === CDN_TYPES.IMPERVA) {
+          // Imperva raw files are delivered flat at the rawLocation prefix (no date/hour subdirs)
+          return paths.rawLocation;
         }
         return `${paths.rawLocation}${year}/${month}/${day}/${hour}/`;
       })();

--- a/src/cdn-analysis/sql/imperva/create-database.sql
+++ b/src/cdn-analysis/sql/imperva/create-database.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE IF NOT EXISTS {{database}};

--- a/src/cdn-analysis/sql/imperva/create-raw-table.sql
+++ b/src/cdn-analysis/sql/imperva/create-raw-table.sql
@@ -1,0 +1,63 @@
+CREATE EXTERNAL TABLE IF NOT EXISTS {{database}}.{{rawTable}} (
+  date string,
+  time string,
+  cs_vid string,
+  cs_clapp string,
+  cs_browsertype string,
+  cs_js_support string,
+  cs_co_support string,
+  cs_clappsig string,
+  s_capsupport string,
+  s_suid string,
+  cs_user_agent string,
+  cs_sessionid string,
+  s_siteid string,
+  cs_countrycode string,
+  s_tag string,
+  cs_cicode string,
+  s_computername string,
+  cs_lat string,
+  cs_long string,
+  s_accountname string,
+  sr_pop string,
+  s_sitetag string,
+  cs_uri string,
+  cs_postbody string,
+  cs_version string,
+  sc_action string,
+  s_externalid string,
+  cs_referrer string,
+  s_ip string,
+  s_port string,
+  cs_method string,
+  cs_uri_query string,
+  sc_status string,
+  s_xff string,
+  cs_bytes string,
+  cs_start string,
+  c_port string,
+  cs_rule string,
+  c_ip string,
+  cs_protver string,
+  cs_end string,
+  cs_additionalReqHeaders string,
+  cs_additionalResHeaders string,
+  cs_severity string,
+  cs_attacktype string,
+  cs_attackid string,
+  s_ruleName string,
+  cs_ruleInfo string
+)
+ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.OpenCSVSerde'
+WITH SERDEPROPERTIES (
+  'separatorChar' = ' ',
+  'quoteChar'     = '"',
+  'escapeChar'    = '\\'
+)
+LOCATION '{{rawLocation}}'
+TBLPROPERTIES (
+  'schema_version'            = '1',
+  'skip.header.line.count'    = '4',
+  'projection.enabled'        = 'false',
+  'has_encrypted_data'        = 'false'
+);

--- a/src/cdn-analysis/sql/imperva/insert-aggregated-referral.sql
+++ b/src/cdn-analysis/sql/imperva/insert-aggregated-referral.sql
@@ -1,0 +1,125 @@
+INSERT INTO {{database}}.{{aggregatedTable}}
+WITH hosts AS (
+  -- first, identify the hosts from the cdn logs so that self-referrals can be filtered out later on
+  SELECT DISTINCT s_computername AS host
+  FROM {{database}}.{{rawTable}}
+  WHERE date = '{{year}}-{{month}}-{{day}}'
+),
+
+base AS (
+  -- normalize key fields and construct a full URL from path + query
+  SELECT
+    CASE
+      WHEN cs_uri_query IS NOT NULL AND cs_uri_query <> ''
+        THEN CONCAT(cs_uri, '?', cs_uri_query)
+      ELSE cs_uri
+    END AS url,
+    s_computername AS host,
+    cs_referrer AS referer_raw,
+    cs_user_agent AS user_agent
+  FROM {{database}}.{{rawTable}}
+  WHERE date = '{{year}}-{{month}}-{{day}}'
+),
+
+referrals_raw AS (
+  SELECT
+    url,
+    host,
+    try(url_extract_host(referer_raw)) AS referrer,
+    url_extract_parameter(url, 'utm_source') AS utm_source,
+    url_extract_parameter(url, 'utm_medium') AS utm_medium,
+
+    -- only the tracking_param, not the value (no PII)
+    -- for the tracking_param list, please refer to https://github.com/adobe/helix-rum-enhancer/blob/main/plugins/martech.js#L13-L22
+    -- list is limited to have feature parity with rum-enhancer
+    CASE
+      WHEN REGEXP_LIKE(
+        url,
+        '(?i)(gclid|gclsrc|wbraid|gbraid|dclid|msclkid|fb(?:cl|ad_|pxl_)id|tw(?:clid|src|term)|li_fat_id|epik|ttclid)'
+      ) THEN 'paid'
+      WHEN REGEXP_LIKE(
+        url,
+        '(?i)(mc_(?:c|e)id|mkt_tok)'
+      ) THEN 'email'
+      ELSE NULL
+    END AS tracking_param,
+    
+    -- device bucket from User-Agent
+    CASE
+      WHEN regexp_like(coalesce(user_agent, ''),
+        '(?i)(mobi|iphone|ipod|ipad|android(?!.*tv)|windows phone|blackberry|bb10|opera mini|fennec|ucbrowser|silk|kindle|playbook|tablet)'
+      )
+        THEN 'mobile'
+      ELSE 'desktop'
+    END AS device,
+    '{{serviceProvider}}' AS cdn_provider,
+
+    CONCAT('{{year}}', '-', '{{month}}', '-', '{{day}}') as date
+
+  FROM base
+  WHERE
+    -- referral traffic definition
+    (
+      -- case 1: IF URL contains utm_source OR utm_medium
+      (
+        (url_extract_parameter(url, 'utm_source') IS NOT NULL AND url_extract_parameter(url, 'utm_source') <> '')
+        OR
+        (url_extract_parameter(url, 'utm_medium') IS NOT NULL AND url_extract_parameter(url, 'utm_medium') <> '')
+      )
+
+      -- case 2: IF URL contains a known tracking param
+      OR REGEXP_LIKE(
+        url,
+        -- for the tracking_param list, please refer to https://github.com/adobe/helix-rum-enhancer/blob/main/plugins/martech.js#L13-L22
+        -- list is limited to have feature parity with rum-enhancer
+        '(?i)(gclid|gclsrc|wbraid|gbraid|dclid|msclkid|fbclid|fbad_id|fbpxl_id|twclid|twsrc|twterm|li_fat_id|epik|ttclid)'
+      )
+
+      -- case 3: IF cdn log contains external referrer (not one of first party hosts)
+      OR (
+        referer_raw IS NOT NULL
+        AND try(url_extract_host(referer_raw)) NOT IN (SELECT host FROM hosts)
+      )
+    )
+
+    -- only count HTML page views
+    AND REGEXP_LIKE(lower(url_extract_path(url)), '(?i)((\.html)(\?.*)?)$')
+
+    -- basic filtering on user_agent for bots, crawlers, programmatic clients
+    AND NOT REGEXP_LIKE(
+      COALESCE(user_agent, ''),
+      '(?i)(
+         bot|crawler|crawl|spider|slurp|archiver|fetch|monitor|pingdom|preview|scanner|scrapy|httpclient|urlgrabber|
+         ahrefs|semrush|mj12bot|dotbot|rogerbot|seznambot|linkdex|blexbot|screaming frog|
+         googlebot|bingbot|duckduckbot|baiduspider|yandex(bot|images)|sogou|exabot|
+         twitterbot|facebookexternalhit|linkedinbot|pinterest|quora link preview|whatsapp|telegrambot|discordbot|
+         curl|wget|python|httpie|okhttp|aiohttp|libwww-perl|lwp::simple|
+         java|go-http-client|php|ruby|perl|axios|node|synthetics|probe|ahc
+      )'
+    )
+)
+
+SELECT 
+  url_extract_path(url) as url,
+  host,
+  referrer,
+  utm_source,
+  utm_medium,
+  tracking_param,
+  device,
+  date,
+  cdn_provider,
+  COALESCE(host, '') as x_forwarded_host,
+  
+  -- Add partition columns as regular columns
+  '{{year}}' AS year,
+  '{{month}}' AS month,
+  '{{day}}' AS day,
+  '{{hour}}' AS hour
+FROM referrals_raw
+WHERE COALESCE(
+  NULLIF(utm_source, ''),
+  NULLIF(utm_medium, ''),
+  NULLIF(referrer, ''),
+  NULLIF(tracking_param, '')
+) IS NOT NULL;

--- a/src/cdn-analysis/sql/imperva/insert-aggregated-referral.sql
+++ b/src/cdn-analysis/sql/imperva/insert-aggregated-referral.sql
@@ -82,8 +82,11 @@ referrals_raw AS (
       )
     )
 
-    -- only count HTML page views
-    AND REGEXP_LIKE(lower(url_extract_path(url)), '(?i)((\.html)(\?.*)?)$')
+    -- only count HTML page views with negative pattern matching on static assets
+    AND (
+      NOT REGEXP_LIKE(url_extract_path(url), '(?i)\.(pdf|md|css|js|png|jpg|jpeg|gif|webp|php|svg|ico|woff|woff2|otf|ttf|eot|mp4|mp3|avi|mov|zip|tar|gz|json|xml|txt)$')
+      OR REGEXP_LIKE(url_extract_path(url), '(?i)(\.html?)$')
+    )
 
     -- basic filtering on user_agent for bots, crawlers, programmatic clients
     AND NOT REGEXP_LIKE(

--- a/src/cdn-analysis/sql/imperva/insert-aggregated.sql
+++ b/src/cdn-analysis/sql/imperva/insert-aggregated.sql
@@ -1,0 +1,44 @@
+INSERT INTO {{database}}.{{aggregatedTable}}
+SELECT
+  url_extract_path(cs_uri) AS url,
+  cs_user_agent AS user_agent,
+  COALESCE(try_cast(NULLIF(sc_status, '') AS INTEGER), 0) AS status,
+  try(url_extract_host(cs_referrer)) AS referer,
+  s_computername AS host,
+  0.0 AS time_to_first_byte,
+  COUNT(*) AS count,
+  '{{serviceProvider}}' AS cdn_provider,
+  '' AS x_forwarded_host,
+
+  '{{year}}' AS year,
+  '{{month}}' AS month,
+  '{{day}}' AS day,
+  '{{hour}}' AS hour
+
+FROM {{database}}.{{rawTable}}
+
+WHERE 
+  date = '{{year}}-{{month}}-{{day}}'
+
+  -- match known LLM-related user-agents
+  AND REGEXP_LIKE(cs_user_agent, '(?i)(ChatGPT|GPTBot|OAI-SearchBot|Perplexity|Claude|Anthropic|Gemini|Copilot|MistralAI-User|Google-NotebookLM|GoogleAgent|Google-Extended|Googlebot|bingbot|Amzn-User|^Google$)')
+
+  -- only count HTML/PDF/Markdown responses, plus .md paths, robots.txt and sitemaps
+  AND (
+    REGEXP_LIKE(lower(url_extract_path(cs_uri)), '(?i)((\.html|\.pdf|\.md)(\?.*)?)$')
+    OR cs_uri LIKE '%robots.txt'
+    OR cs_uri LIKE '%sitemap%'
+  )
+
+  -- agentic and LLM-attributed traffic never has self-referer
+  AND NOT REGEXP_LIKE(COALESCE(cs_referrer, ''), '{{host}}')
+
+GROUP BY
+  url_extract_path(cs_uri),
+  cs_user_agent,
+  COALESCE(try_cast(NULLIF(sc_status, '') AS INTEGER), 0),
+  try(url_extract_host(cs_referrer)),
+  s_computername,
+  0.0,
+  '{{serviceProvider}}',
+  '';

--- a/src/cdn-analysis/sql/imperva/insert-aggregated.sql
+++ b/src/cdn-analysis/sql/imperva/insert-aggregated.sql
@@ -8,7 +8,7 @@ SELECT
   0.0 AS time_to_first_byte,
   COUNT(*) AS count,
   '{{serviceProvider}}' AS cdn_provider,
-  '' AS x_forwarded_host,
+  COALESCE(s_computername, '') as x_forwarded_host,
 
   '{{year}}' AS year,
   '{{month}}' AS month,
@@ -25,9 +25,8 @@ WHERE
 
   -- only count HTML/PDF/Markdown responses, plus .md paths, robots.txt and sitemaps
   AND (
-    REGEXP_LIKE(lower(url_extract_path(cs_uri)), '(?i)((\.html|\.pdf|\.md)(\?.*)?)$')
-    OR cs_uri LIKE '%robots.txt'
-    OR cs_uri LIKE '%sitemap%'
+    NOT REGEXP_LIKE(url_extract_path(cs_uri), '(?i)\.(css|js|png|jpg|jpeg|gif|webp|php|svg|ico|woff|woff2|otf|ttf|eot|mp4|mp3|avi|mov|zip|tar|gz|json|xml|txt)$')
+    OR REGEXP_LIKE(url_extract_path(cs_uri), '(?i)((\.html?|\.pdf|\.md|robots\.txt)$|sitemap)')
   )
 
   -- agentic and LLM-attributed traffic never has self-referer

--- a/src/utils/cdn-utils.js
+++ b/src/utils/cdn-utils.js
@@ -28,6 +28,7 @@ export const CDN_TYPES = {
   CLOUDFLARE: 'cloudflare',
   CLOUDFRONT: 'cloudfront',
   FRONTDOOR: 'frontdoor',
+  IMPERVA: 'imperva',
   OTHER: 'other',
 };
 
@@ -39,6 +40,7 @@ export const SERVICE_PROVIDER_TYPES = {
   BYOCDN_CLOUDFLARE: 'byocdn-cloudflare',
   BYOCDN_CLOUDFRONT: 'byocdn-cloudfront',
   BYOCDN_FRONTDOOR: 'byocdn-frontdoor',
+  BYOCDN_IMPERVA: 'byocdn-imperva',
   BYOCDN_OTHER: 'byocdn-other',
   AMS_CLOUDFRONT: 'ams-cloudfront',
   AMS_FRONTDOOR: 'ams-frontdoor',
@@ -53,6 +55,7 @@ export const SERVICE_TO_CDN_MAPPING = {
   [SERVICE_PROVIDER_TYPES.BYOCDN_CLOUDFLARE]: CDN_TYPES.CLOUDFLARE,
   [SERVICE_PROVIDER_TYPES.BYOCDN_CLOUDFRONT]: CDN_TYPES.CLOUDFRONT,
   [SERVICE_PROVIDER_TYPES.BYOCDN_FRONTDOOR]: CDN_TYPES.FRONTDOOR,
+  [SERVICE_PROVIDER_TYPES.BYOCDN_IMPERVA]: CDN_TYPES.IMPERVA,
   [SERVICE_PROVIDER_TYPES.BYOCDN_OTHER]: CDN_TYPES.OTHER,
   [SERVICE_PROVIDER_TYPES.AMS_CLOUDFRONT]: CDN_TYPES.CLOUDFRONT,
   [SERVICE_PROVIDER_TYPES.AMS_FRONTDOOR]: CDN_TYPES.FRONTDOOR,
@@ -221,9 +224,13 @@ export function buildCdnPaths(bucketName, serviceProvider, timeParts, pathId = n
   } = timeParts;
 
   // New standardized bucket structure: cdn-logs-adobe-{env}/{pathId}/raw/{serviceProvider}/
+  // For byocdn-imperva, pathId, 'raw', and serviceProvider are joined with underscores
   if (isStandardAdobeCdnBucket(bucketName) && pathId) {
+    const rawLocation = serviceProvider.includes('byocdn-imperva')
+      ? `s3://${bucketName}/${pathId}_raw_${serviceProvider}/`
+      : `s3://${bucketName}/${pathId}/raw/${serviceProvider}/`;
     return {
-      rawLocation: `s3://${bucketName}/${pathId}/raw/${serviceProvider}/`,
+      rawLocation,
       aggregatedLocation: `s3://${bucketName}/${pathId}/aggregated/`,
       aggregatedOutput: `s3://${bucketName}/${pathId}/aggregated/${year}/${month}/${day}/${hour}/`,
       aggregatedReferralLocation: `s3://${bucketName}/${pathId}/aggregated-referral/`,
@@ -313,6 +320,24 @@ export async function getBucketInfo(s3Client, bucketName, pathId = null) {
       providers = (response.CommonPrefixes || [])
         .map((prefix) => prefix.Prefix.replace(`${pathId}/raw/`, '').replace('/', ''))
         .filter((provider) => provider && provider.length > 0);
+
+      // Also discover providers using the underscore layout: {pathId}_raw_{provider}/
+      // Imperva logs are delivered with pathId, "raw", and provider joined by underscores
+      // instead of slashes, so a separate listing is needed to find them.
+      const underscoreResponse = await s3Client.send(new ListObjectsV2Command({
+        Bucket: bucketName,
+        Prefix: `${pathId}_raw_`,
+        Delimiter: '/',
+        MaxKeys: 10,
+      }));
+
+      const underscorePrefix = `${pathId}_raw_`;
+      const underscoreProviders = (underscoreResponse.CommonPrefixes || [])
+        .filter((prefix) => prefix.Prefix.startsWith(underscorePrefix))
+        .map((prefix) => prefix.Prefix.slice(underscorePrefix.length).replace(/\/$/, ''))
+        .filter((provider) => provider && provider.length > 0);
+
+      providers = [...providers, ...underscoreProviders];
 
       return { isLegacy: isLegacyBucketStructure(providers), providers };
     }

--- a/test/audits/cdn-analysis/handler.test.js
+++ b/test/audits/cdn-analysis/handler.test.js
@@ -55,6 +55,13 @@ function createS3MockForCdnType(cdnType, options = {}) {
       keyPath: `${orgId}/raw/byocdn-other/${year}/${month}/${day}/file1.log`,
       prefix: `${orgId}/raw/byocdn-other/`,
     },
+    imperva: {
+      logSample: null,
+      keyPath: `${orgId}_raw_byocdn-imperva/somefile.log`,
+      // underscore-layout prefix used for both provider discovery and raw data check
+      prefix: `${orgId}_raw_byocdn-imperva/`,
+      underscoreLayout: true,
+    },
   };
 
   const config = cdnConfigs[cdnType];
@@ -70,6 +77,17 @@ function createS3MockForCdnType(cdnType, options = {}) {
       const { Prefix = '' } = command.input || {};
       if (Prefix.includes('aggregated')) {
         return Promise.resolve({ Contents: [] });
+      }
+      if (config.underscoreLayout) {
+        // Slash-layout listing (getBucketInfo first call) returns no providers;
+        // underscore-layout listing and raw data check both use the underscore prefix.
+        if (Prefix.endsWith('/raw/')) {
+          return Promise.resolve({ Contents: [], CommonPrefixes: [] });
+        }
+        return Promise.resolve({
+          Contents: [{ Key: config.keyPath }],
+          CommonPrefixes: [{ Prefix: config.prefix }],
+        });
       }
       return Promise.resolve({
         Contents: [{ Key: config.keyPath }],
@@ -197,6 +215,30 @@ describe('CDN Analysis Handler', () => {
       expect(result23.auditResult.providers[0]).to.have.property('cdnType', 'cloudflare');
 
       // Test CloudFlare at hour 22 (should skip CloudFlare if bucket exists)
+      const result22 = await cdnLogsAnalysisRunner('https://example.com', context, site, auditContext22);
+      expect(result22.auditResult.providers).to.be.an('array').with.length(0);
+    });
+
+    it('handles Imperva processing: daily-only and flat rawDataPath', async () => {
+      const auditContext23 = {
+        year: 2025, month: 6, day: 15, hour: 23,
+      };
+      const auditContext22 = {
+        year: 2025, month: 6, day: 15, hour: 22,
+      };
+
+      context.s3Client.send.callsFake(createS3MockForCdnType('imperva'));
+
+      // At hour 23: should process imperva and use flat rawLocation as rawDataPath
+      const result23 = await cdnLogsAnalysisRunner('https://example.com', context, site, auditContext23);
+      expect(result23.auditResult.providers).to.be.an('array').with.length.greaterThan(0);
+      const impervaResult = result23.auditResult.providers[0];
+      expect(impervaResult).to.have.property('cdnType', 'imperva');
+      expect(impervaResult).to.have.property('serviceProvider', 'byocdn-imperva');
+      // rawDataPath must equal rawLocation exactly (no year/month/day/hour appended)
+      expect(impervaResult.rawDataPath).to.equal(impervaResult.rawDataPath.replace(/\d{4}\/\d{2}\/\d{2}/, ''));
+
+      // At hour 22: should skip (daily-only provider)
       const result22 = await cdnLogsAnalysisRunner('https://example.com', context, site, auditContext22);
       expect(result22.auditResult.providers).to.be.an('array').with.length(0);
     });

--- a/test/utils/cdn-utils.test.js
+++ b/test/utils/cdn-utils.test.js
@@ -51,6 +51,7 @@ describe('CDN Utils', () => {
         CLOUDFLARE: 'cloudflare',
         CLOUDFRONT: 'cloudfront',
         FRONTDOOR: 'frontdoor',
+        IMPERVA: 'imperva',
         OTHER: 'other',
       });
     });
@@ -226,14 +227,27 @@ describe('CDN Utils', () => {
     });
 
     it('returns modern bucket info when byocdn-other prefix exists', async () => {
-      s3Client.send.resolves({
+      s3Client.send.onFirstCall().resolves({
         CommonPrefixes: [{ Prefix: `${pathId}/raw/byocdn-other/` }],
       });
+      s3Client.send.onSecondCall().resolves({ CommonPrefixes: [] });
 
       const result = await getBucketInfo(s3Client, bucketName, pathId);
 
       expect(result.isLegacy).to.be.false;
       expect(result.providers).to.deep.equal(['byocdn-other']);
+    });
+
+    it('returns modern bucket info when byocdn-imperva prefix exists', async () => {
+      s3Client.send.onFirstCall().resolves({ CommonPrefixes: [] });
+      s3Client.send.onSecondCall().resolves({
+        CommonPrefixes: [{ Prefix: `${pathId}_raw_byocdn-imperva/` }],
+      });
+
+      const result = await getBucketInfo(s3Client, bucketName, pathId);
+
+      expect(result.isLegacy).to.be.false;
+      expect(result.providers).to.deep.equal(['byocdn-imperva']);
     });
   });
 


### PR DESCRIPTION
byocdn-imperva CDN support wires Imperva logs into the existing CDN analysis pipeline. Three things make it different from other providers:

- S3 path layout — raw logs land at {pathId}_raw_byocdn-imperva/ (underscores, not slashes). buildCdnPaths emits this format; getBucketInfo runs a second ListObjectsV2 scan with Prefix: "{pathId}_raw_" to discover it alongside the normal slash-layout providers.

- Daily-only processing — Imperva SQL filters by date only (no hourly partition), so it joins Cloudflare/Other in hasDailyPartitioningOnly and is skipped at every hour except 23.

- Flat raw location — files land directly at the prefix with no date/hour subdirs, so rawDataPath = paths.rawLocation with nothing appended.

Everything else (SQL execution, aggregation, Athena table management) flows through the existing pipeline unchanged via CDN_TYPES.IMPERVA → sql/imperva/.