### PR TITLE
feat(llmo): trigger daily DB backfill for Adobe-managed Fastly

### DIFF
--- a/src/llmo-customer-analysis/cdn-config-handler.js
+++ b/src/llmo-customer-analysis/cdn-config-handler.js
@@ -32,6 +32,8 @@ function getAdobeFastlyBackfillDays(referenceDate = new Date()) {
       year,
       month,
       day,
+      // cdn-logs-report daily runs treat auditContext.date as the reference date
+      // and then export the previous UTC day, so we send next-day midnight here.
       reportDate: new Date(Date.UTC(year, month - 1, day + 1)).toISOString(),
     });
   }

--- a/src/llmo-customer-analysis/cdn-config-handler.js
+++ b/src/llmo-customer-analysis/cdn-config-handler.js
@@ -17,6 +17,27 @@ import { getImsOrgId } from '../utils/data-access.js';
 import { SERVICE_PROVIDER_TYPES } from '../utils/cdn-utils.js';
 
 const CDN_LOGS_ANALYSIS_DELAY_SECONDS = 5;
+const CDN_LOGS_REPORT_DELAY_SECONDS = 900;
+
+function getAdobeFastlyBackfillDays(referenceDate = new Date()) {
+  const lastMonday = startOfWeek(subWeeks(referenceDate, 1), { weekStartsOn: 1 });
+  const backfillDays = [];
+
+  for (let date = new Date(lastMonday); !isAfter(date, referenceDate); date = addDays(date, 1)) {
+    const year = date.getUTCFullYear();
+    const month = date.getUTCMonth() + 1;
+    const day = date.getUTCDate();
+
+    backfillDays.push({
+      year,
+      month,
+      day,
+      reportDate: new Date(Date.UTC(year, month - 1, day + 1)).toISOString(),
+    });
+  }
+
+  return backfillDays;
+}
 
 /**
  * Fetches commerce-fastly service for given domain
@@ -75,6 +96,7 @@ async function handleAdobeFastly(
 ) {
   const config = await Configuration.findLatest();
   const auditQueue = config.getQueues().audits;
+  const backfillDays = getAdobeFastlyBackfillDays();
 
   // Skip CDN analysis if current site already has cdn-logs-analysis with fullAuditRef
   const cdnLogsAnalysis = await LatestAudit.findBySiteIdAndAuditType(siteId, 'cdn-logs-analysis');
@@ -85,25 +107,19 @@ async function handleAdobeFastly(
   if (hasCdnAnalysisWithResults) {
     log.info(`Skipping CDN analysis for site ${siteId} - site already has cdn-logs-analysis with results`);
   } else {
-    // Queue CDN analysis from last Monday until today
-    const lastMonday = startOfWeek(subWeeks(new Date(), 1), { weekStartsOn: 1 });
-    const today = new Date();
-
     const analysisPromises = [];
-    let delaySeconds = 0;
-    for (let date = new Date(lastMonday); !isAfter(date, today); date = addDays(date, 1)) {
+    for (const [index, backfillDay] of backfillDays.entries()) {
       analysisPromises.push(sqs.sendMessage(auditQueue, {
         type: 'cdn-logs-analysis',
         siteId,
         auditContext: {
-          year: date.getUTCFullYear(),
-          month: date.getUTCMonth() + 1,
-          day: date.getUTCDate(),
+          year: backfillDay.year,
+          month: backfillDay.month,
+          day: backfillDay.day,
           hour: 8,
           processFullDay: true,
         },
-      }, null, delaySeconds));
-      delaySeconds += CDN_LOGS_ANALYSIS_DELAY_SECONDS;
+      }, null, index * CDN_LOGS_ANALYSIS_DELAY_SECONDS));
     }
 
     await Promise.all(analysisPromises);
@@ -114,7 +130,17 @@ async function handleAdobeFastly(
     type: 'cdn-logs-report',
     siteId,
     auditContext: { weekOffset: -1 },
-  }, null, 900);
+  }, null, CDN_LOGS_REPORT_DELAY_SECONDS);
+
+  const reportPromises = backfillDays.map((backfillDay, index) => sqs.sendMessage(auditQueue, {
+    type: 'cdn-logs-report',
+    siteId,
+    auditContext: {
+      date: backfillDay.reportDate,
+    },
+  }, null, CDN_LOGS_REPORT_DELAY_SECONDS + (index * CDN_LOGS_ANALYSIS_DELAY_SECONDS)));
+
+  await Promise.all(reportPromises);
 }
 
 async function handleBucketConfiguration(

--- a/test/audits/llmo-customer-analysis-cdn-config.test.js
+++ b/test/audits/llmo-customer-analysis-cdn-config.test.js
@@ -272,6 +272,27 @@ describe('CDN Config Handler', () => {
     let mockSiteConfig;
     let mockConfiguration;
 
+    const getCdnLogsAnalysisCalls = () => context.sqs.sendMessage.getCalls()
+      .filter((call) => call.args[1].type === 'cdn-logs-analysis');
+
+    const getCdnLogsReportCalls = () => context.sqs.sendMessage.getCalls()
+      .filter((call) => call.args[1].type === 'cdn-logs-report');
+
+    const getWeeklyReportCalls = () => getCdnLogsReportCalls()
+      .filter((call) => call.args[1].auditContext?.weekOffset !== undefined);
+
+    const getDailyReportCalls = () => getCdnLogsReportCalls()
+      .filter((call) => call.args[1].auditContext?.date);
+
+    const getExpectedReportDate = (analysisCall) => {
+      const {
+        year,
+        month,
+        day,
+      } = analysisCall.args[1].auditContext;
+      return new Date(Date.UTC(year, month - 1, day + 1)).toISOString();
+    };
+
     beforeEach(() => {
       // Mock Config.toDynamoItem static method
       sandbox.stub(Config, 'toDynamoItem').returns({});
@@ -385,16 +406,29 @@ describe('CDN Config Handler', () => {
       await cdnConfigHandler.handleCdnBucketConfigChanges(context, data);
 
       expect(context.sqs.sendMessage).to.have.been.called;
-      const cdnLogsAnalysisCalls = context.sqs.sendMessage.getCalls()
-        .filter((call) => call.args[1].type === 'cdn-logs-analysis');
+      const cdnLogsAnalysisCalls = getCdnLogsAnalysisCalls();
+      const weeklyReportCalls = getWeeklyReportCalls();
+      const dailyReportCalls = getDailyReportCalls();
+
       expect(cdnLogsAnalysisCalls.length).to.be.greaterThan(0);
-      expect(context.sqs.sendMessage).to.have.been.calledWith(
-        sinon.match.any,
-        sinon.match({ type: 'cdn-logs-report' }),
-      );
+      expect(weeklyReportCalls).to.have.length(1);
+      expect(weeklyReportCalls[0].args[1].auditContext).to.deep.equal({ weekOffset: -1 });
+      expect(weeklyReportCalls[0].args[3]).to.equal(900);
+      expect(dailyReportCalls).to.have.length(cdnLogsAnalysisCalls.length);
+
+      dailyReportCalls.forEach((call, index) => {
+        expect(call.args[1].auditContext).to.deep.equal({
+          date: getExpectedReportDate(cdnLogsAnalysisCalls[index]),
+        });
+        expect(call.args[3]).to.equal(900 + (index * 5));
+      });
     });
 
     it('should not run Fastly analysis for commerce-fastly provider when pathId is not resolved', async () => {
+      nock('https://main--project-elmo-ui-data--adobe.aem.live')
+        .get('/adobe-managed-domains/commerce-fastly-domains.json?limit=10000')
+        .reply(200, { data: [] });
+
       const data = { bucketName: 'test-bucket', cdnProvider: 'commerce-fastly' };
 
       await cdnConfigHandler.handleCdnBucketConfigChanges(context, data);
@@ -403,6 +437,10 @@ describe('CDN Config Handler', () => {
     });
 
     it('should handle bucket configuration when bucketName provided', async () => {
+      nock('https://main--project-elmo-ui-data--adobe.aem.live')
+        .get('/adobe-managed-domains/commerce-fastly-domains.json?limit=10000')
+        .reply(200, { data: [] });
+
       const data = { bucketName: 'test-bucket', cdnProvider: 'commerce-fastly' };
 
       await cdnConfigHandler.handleCdnBucketConfigChanges(context, data);
@@ -425,6 +463,10 @@ describe('CDN Config Handler', () => {
     });
 
     it('should handle bucket configuration when allowedPaths provided', async () => {
+      nock('https://main--project-elmo-ui-data--adobe.aem.live')
+        .get('/adobe-managed-domains/commerce-fastly-domains.json?limit=10000')
+        .reply(200, { data: [] });
+
       const data = { allowedPaths: ['test-org/path1', 'test-org/path2'], cdnProvider: 'commerce-fastly' };
 
       await cdnConfigHandler.handleCdnBucketConfigChanges(context, data);
@@ -434,6 +476,10 @@ describe('CDN Config Handler', () => {
     });
 
     it('should handle bucket configuration when both bucketName and allowedPaths provided', async () => {
+      nock('https://main--project-elmo-ui-data--adobe.aem.live')
+        .get('/adobe-managed-domains/commerce-fastly-domains.json?limit=10000')
+        .reply(200, { data: [] });
+
       const data = { bucketName: 'test-bucket', allowedPaths: ['test-org/path1'], cdnProvider: 'commerce-fastly' };
 
       await cdnConfigHandler.handleCdnBucketConfigChanges(context, data);
@@ -446,6 +492,10 @@ describe('CDN Config Handler', () => {
     });
 
     it('should persist region in bucket configuration when provided', async () => {
+      nock('https://main--project-elmo-ui-data--adobe.aem.live')
+        .get('/adobe-managed-domains/commerce-fastly-domains.json?limit=10000')
+        .reply(200, { data: [] });
+
       const data = { bucketName: 'test-bucket', region: 'eu-west-1', cdnProvider: 'commerce-fastly' };
 
       await cdnConfigHandler.handleCdnBucketConfigChanges(context, data);
@@ -458,6 +508,7 @@ describe('CDN Config Handler', () => {
     });
 
     it('should handle aem-cs-fastly provider', async () => {
+      const clock = sandbox.useFakeTimers(new Date('2025-01-10T12:00:00Z'));
       context.dataAccess.LatestAudit.findBySiteIdAndAuditType.resolves({ getAuditResult: () => ({}), getFullAuditRef: () => '' });
 
       const data = { cdnProvider: 'aem-cs-fastly' };
@@ -466,33 +517,45 @@ describe('CDN Config Handler', () => {
 
       expect(context.sqs.sendMessage).to.have.been.called;
       // Should send multiple cdn-logs-analysis messages (one per day from last Monday to today)
-      const cdnLogsAnalysisCalls = context.sqs.sendMessage.getCalls().filter(call => call.args[1].type === 'cdn-logs-analysis');
+      const cdnLogsAnalysisCalls = getCdnLogsAnalysisCalls();
+      const weeklyReportCalls = getWeeklyReportCalls();
+      const dailyReportCalls = getDailyReportCalls();
+
       expect(cdnLogsAnalysisCalls.length).to.be.greaterThan(0);
-      // Should also send cdn-logs-report
-      expect(context.sqs.sendMessage).to.have.been.calledWith(
-        sinon.match.any,
-        sinon.match({ type: 'cdn-logs-report' })
-      );
+      expect(weeklyReportCalls).to.have.length(1);
+      expect(dailyReportCalls).to.have.length(cdnLogsAnalysisCalls.length);
+
+      clock.restore();
     });
 
-    it('should stagger aem-cs-fastly cdn-logs-analysis messages by 5 seconds per day', async () => {
+    it('should stagger aem-cs-fastly analysis and date-based report messages by 5 seconds per day', async () => {
+      const clock = sandbox.useFakeTimers(new Date('2025-01-10T12:00:00Z'));
       context.dataAccess.LatestAudit.findBySiteIdAndAuditType.resolves({ getAuditResult: () => ({}), getFullAuditRef: () => '' });
 
       const data = { cdnProvider: 'aem-cs-fastly' };
 
       await cdnConfigHandler.handleCdnBucketConfigChanges(context, data);
 
-      const cdnLogsAnalysisCalls = context.sqs.sendMessage
-        .getCalls()
-        .filter((call) => call.args[1].type === 'cdn-logs-analysis');
+      const cdnLogsAnalysisCalls = getCdnLogsAnalysisCalls();
+      const dailyReportCalls = getDailyReportCalls();
 
       expect(cdnLogsAnalysisCalls.length).to.be.greaterThan(0);
       cdnLogsAnalysisCalls.forEach((call, index) => {
         expect(call.args[3]).to.equal(index * 5);
       });
+      expect(dailyReportCalls).to.have.length(cdnLogsAnalysisCalls.length);
+      dailyReportCalls.forEach((call, index) => {
+        expect(call.args[1].auditContext).to.deep.equal({
+          date: getExpectedReportDate(cdnLogsAnalysisCalls[index]),
+        });
+        expect(call.args[3]).to.equal(900 + (index * 5));
+      });
+
+      clock.restore();
     });
 
     it('should skip aem-cs-fastly processing when site already has cdn-logs-analysis with fullAuditRef', async () => {
+      const clock = sandbox.useFakeTimers(new Date('2025-01-10T12:00:00Z'));
       context.dataAccess.LatestAudit.findBySiteIdAndAuditType.resolves({ 
         getAuditResult: () => ({ providers: ['fastly'] }), 
         getFullAuditRef: () => 'some-audit-ref' 
@@ -502,17 +565,25 @@ describe('CDN Config Handler', () => {
 
       await cdnConfigHandler.handleCdnBucketConfigChanges(context, data);
 
-      // Should only send CDN logs report, not cdn-logs-analysis since fullAuditRef already exists for this site
-      expect(context.sqs.sendMessage).to.have.been.calledOnce;
-      expect(context.sqs.sendMessage).to.have.been.calledWith(
-        sinon.match.any,
-        sinon.match({ type: 'cdn-logs-report' })
-      );
+      const cdnLogsAnalysisCalls = getCdnLogsAnalysisCalls();
+      const weeklyReportCalls = getWeeklyReportCalls();
+      const dailyReportCalls = getDailyReportCalls();
+
+      expect(cdnLogsAnalysisCalls).to.have.length(0);
+      expect(weeklyReportCalls).to.have.length(1);
+      expect(weeklyReportCalls[0].args[1].auditContext).to.deep.equal({ weekOffset: -1 });
+      expect(dailyReportCalls.length).to.be.greaterThan(0);
+      dailyReportCalls.forEach((call, index) => {
+        expect(call.args[1].auditContext.date).to.match(/T00:00:00\.000Z$/);
+        expect(call.args[3]).to.equal(900 + (index * 5));
+      });
       // Verify it checked for cdn-logs-analysis
       expect(context.dataAccess.LatestAudit.findBySiteIdAndAuditType).to.have.been.calledWith(
         'site-123',
         'cdn-logs-analysis'
       );
+
+      clock.restore();
     });
 
     it('should skip commerce-fastly processing when site already has cdn-logs-analysis with fullAuditRef', async () => {
@@ -535,11 +606,17 @@ describe('CDN Config Handler', () => {
 
       await cdnConfigHandler.handleCdnBucketConfigChanges(context, data);
 
-      expect(context.sqs.sendMessage).to.have.been.calledOnce;
-      expect(context.sqs.sendMessage).to.have.been.calledWith(
-        sinon.match.any,
-        sinon.match({ type: 'cdn-logs-report' }),
-      );
+      const cdnLogsAnalysisCalls = getCdnLogsAnalysisCalls();
+      const weeklyReportCalls = getWeeklyReportCalls();
+      const dailyReportCalls = getDailyReportCalls();
+
+      expect(cdnLogsAnalysisCalls).to.have.length(0);
+      expect(weeklyReportCalls).to.have.length(1);
+      expect(dailyReportCalls.length).to.be.greaterThan(0);
+      dailyReportCalls.forEach((call, index) => {
+        expect(call.args[1].auditContext.date).to.match(/T00:00:00\.000Z$/);
+        expect(call.args[3]).to.equal(900 + (index * 5));
+      });
       expect(context.dataAccess.LatestAudit.findBySiteIdAndAuditType).to.have.been.calledWith(
         'site-123',
         'cdn-logs-analysis',


### PR DESCRIPTION
## Summary

This change adds DB backfill support for Adobe-managed Fastly onboarding and replay flows.

Today `handleAdobeFastly()` only fans out the weekly `cdn-logs-report` message used for the SharePoint workbook flow. That means the DB/export path is not backfilled alongside the Fastly analysis replay. This update keeps the existing weekly SharePoint trigger and adds one extra `cdn-logs-report` message per replayed day using `auditContext.date`, so the existing daily DB/export logic also runs for the same Adobe-managed Fastly window.

## What Changed

- kept the existing Adobe Fastly `cdn-logs-analysis` day fan-out as the source of truth for the replay window
- kept the weekly SharePoint `cdn-logs-report` trigger with `auditContext.weekOffset = -1`
- added one daily DB/export `cdn-logs-report` trigger per replayed day using next-day-midnight UTC in `auditContext.date`
- left the `cdn-logs-report` handler contract unchanged and reused its existing semantics:
  - `weekOffset` continues to drive the weekly SharePoint workbook flow
  - `date` continues to drive the daily DB/export flow
- added a code comment explaining why the `date` payload is intentionally offset by one UTC day

## Why The Date Is Offset

`runDailyAgenticExport()` treats `auditContext.date` as a reference date and then exports the previous UTC day. Because of that, if we want DB backfill for `2026-04-03`, we must send `2026-04-04T00:00:00.000Z`.

## Scope

- only Adobe-managed Fastly handling in `handleAdobeFastly()`
- no change to category-change triggering in `llmo-customer-analysis/handler.js`
- no new payload fields or handler modes introduced

## Testing

- `./node_modules/.bin/mocha test/audits/llmo-customer-analysis-cdn-config.test.js`
- `./node_modules/.bin/c8 --reporter=text --all --include=src/llmo-customer-analysis/cdn-config-handler.js ./node_modules/.bin/mocha test/audits/llmo-customer-analysis-cdn-config.test.js`

## Coverage

- `src/llmo-customer-analysis/cdn-config-handler.js`: 100% statements, 100% branches, 100% functions, 100% lines

## Notes

- DB report messages are staggered after the analysis wave using the existing 5-second cadence on top of the 900-second report delay
- this keeps weekly SharePoint backfill and daily DB backfill aligned to the same Adobe-managed Fastly replay days
