### PR TITLE
fix(cdn-logs-report): add dispatch log correlation context

### DIFF
--- a/src/cdn-logs-report/agentic-daily-export.js
+++ b/src/cdn-logs-report/agentic-daily-export.js
@@ -275,7 +275,7 @@ export async function runDailyAgenticExport({
     throw error;
   }
 
-  log.info(`[cdn-logs-report] Daily agentic export dispatched for ${site.getId()} on ${trafficDate}. Rows: ${trafficRows.length}, classifications: ${classificationRows.length}`);
+  log.info(`[cdn-logs-report] Daily agentic export dispatched for ${site.getId()} (${site.getBaseURL()}) on ${trafficDate}. batchId: ${batchId}, Rows: ${trafficRows.length}, classifications: ${classificationRows.length}`);
 
   return {
     enabled: true,

--- a/test/audits/cdn-logs-report/agentic-daily-export.test.js
+++ b/test/audits/cdn-logs-report/agentic-daily-export.test.js
@@ -170,6 +170,9 @@ describe('agentic daily export', () => {
       classificationCount: 1,
       bundleUri: 's3://spacecat-dev-importer/agentic-traffic-daily-export/9ae8877a-bbf3-407d-9adb-d6a72ce3c5e3/agentic-traffic/2026/03/31/20260401T100000000Z/',
     });
+    expect(context.log.info).to.have.been.calledWith(
+      '[cdn-logs-report] Daily agentic export dispatched for 9ae8877a-bbf3-407d-9adb-d6a72ce3c5e3 (https://www.example.com) on 2026-03-31. batchId: batch-123, Rows: 1, classifications: 1',
+    );
   });
 
   it('logs a warning when cleanup after failure also fails', async () => {


### PR DESCRIPTION
## Summary
- add `batchId` to the daily agentic export dispatch log so it matches the outbound analytics `correlationId`
- include `site.getBaseURL()` in the same log line for easier log filtering and correlation
- assert the updated log output in the focused agentic daily export test

## Testing
- `npx mocha --require test/setup-env.js test/audits/cdn-logs-report/agentic-daily-export.test.js`