### PR TITLE
fix(deps): upgrade @adobe/mysticat-shared-seo-client to 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@adobe/helix-shared-wrap": "2.0.2",
         "@adobe/helix-status": "10.1.5",
         "@adobe/helix-universal-logger": "3.0.29",
-        "@adobe/mysticat-shared-seo-client": "1.1.3",
+        "@adobe/mysticat-shared-seo-client": "1.2.0",
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
         "@adobe/spacecat-shared-athena-client": "1.9.11",
         "@adobe/spacecat-shared-data-access": "3.48.0",
@@ -925,9 +925,9 @@
       }
     },
     "node_modules/@adobe/mysticat-shared-seo-client": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@adobe/mysticat-shared-seo-client/-/mysticat-shared-seo-client-1.1.3.tgz",
-      "integrity": "sha512-fj/mwWOU7ka7Ul8D7zPrjGw6Ut8siqAZ6FIhr0oNeT7HBxywVSQRhOhDe9iMfxOGp6qcJyOseAj9Fq2UQszmuw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@adobe/mysticat-shared-seo-client/-/mysticat-shared-seo-client-1.2.0.tgz",
+      "integrity": "sha512-0OzpPOFl/mx3Ozr/Ftv3I6pc9deI0jRxzu64+zcq+yUipHh//aGYwwsUULLHdawtqWZuXEXS2LUOTvn4osI+Jw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@adobe/helix-shared-wrap": "2.0.2",
     "@adobe/helix-status": "10.1.5",
     "@adobe/helix-universal-logger": "3.0.29",
-    "@adobe/mysticat-shared-seo-client": "1.1.3",
+    "@adobe/mysticat-shared-seo-client": "1.2.0",
     "@adobe/spacecat-helix-content-sdk": "1.4.33",
     "@adobe/spacecat-shared-athena-client": "1.9.11",
     "@adobe/spacecat-shared-data-access": "3.48.0",


### PR DESCRIPTION
## Summary

Bumps `@adobe/mysticat-shared-seo-client` from **1.1.3** to **1.2.0**.

## Breaking changes in 1.2.0

Positional parameters replaced with options objects across several methods:

| Method | Before | After |
|--------|--------|-------|
| `getTopPages` | `(url, limit)` | `(url, { limit, region })` |
| `getPaidPages` | `(url, date, limit, mode)` | `(url, { date, limit, region })` — `mode` removed |
| `getMetrics` | `(url, date)` | `(url, { date, region })` |
| `getOrganicTraffic` | `(url, startDate, endDate)` | `(url, { startDate, endDate, region })` |
| `getMetricsByCountry` | signature unchanged | default date changed from `todayISO()` to `lastMonthISO()` |

All methods now accept an optional `region` (ISO 3166-1 alpha-2) to scope queries to a specific market. Pass `site.getRegion()` when set; omit it to fan out across the default 30 big markets.

## Impact on this repo

No source changes required. This codebase only calls `seoClient.getBrokenBacklinks()`, which is unaffected by the above signature changes.

## Test plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)