### PR TITLE
fix(prerender): keep valuable flag in sync with aiSummary in guidance handler

### DIFF
--- a/src/prerender/guidance-handler.js
+++ b/src/prerender/guidance-handler.js
@@ -175,8 +175,8 @@ export default async function handler(message, context) {
         ...currentData,
         // Use new summary if valid; otherwise preserve existing (don't overwrite with empty)
         aiSummary: hasValidAiSummary ? aiSummary : (currentData.aiSummary ?? ''),
-        // Default to true if not provided, but respect explicit boolean from Mystique
-        valuable: isValuable,
+        // Keep valuable in sync with aiSummary — only update when new AI response is valid
+        valuable: hasValidAiSummary ? isValuable : (currentData.valuable ?? true),
       };
 
       warnOnInvalidSuggestionData(updatedData, opportunity.getType(), log);

--- a/test/audits/prerender/guidance-handler.test.js
+++ b/test/audits/prerender/guidance-handler.test.js
@@ -754,6 +754,47 @@ describe('Prerender Guidance Handler (Presigned URL)', () => {
       );
     });
 
+    it('should preserve existing valuable flag when aiSummary is invalid', async () => {
+      // Suggestion already has valuable=false and a valid aiSummary from a previous run
+      mockSuggestions[0].getData.returns({
+        url: 'https://example.com/page1',
+        isDomainWide: false,
+        aiSummary: 'Previous valid summary',
+        valuable: false,
+      });
+
+      mockFetchSuccess({
+        opportunityId: 'opportunity-123',
+        suggestions: [
+          {
+            url: 'https://example.com/page1',
+            aiSummary: null, // Invalid — should preserve existing
+            valuable: true, // New value — should NOT overwrite
+          },
+        ],
+      });
+
+      const message = {
+        siteId: 'site-123',
+        auditId: 'audit-123',
+        data: {
+          presignedUrl: 'https://s3.amazonaws.com/bucket/path?X-Amz-Signature=...',
+          opportunityId: 'opportunity-123',
+        },
+      };
+
+      await handler.default(message, context);
+
+      expect(Suggestion.saveMany).to.have.been.calledOnce;
+      const savedSuggestions = Suggestion.saveMany.getCall(0).args[0];
+      expect(savedSuggestions[0].setData).to.have.been.calledWith(
+        sinon.match({
+          aiSummary: 'Previous valid summary', // Preserved
+          valuable: false, // Preserved (not overwritten with true)
+        }),
+      );
+    });
+
     it('should treat "Not available" aiSummary as empty string (case-insensitive)', async () => {
       mockFetchSuccess({
         opportunityId: 'opportunity-123',


### PR DESCRIPTION
## Problem

In `guidance-handler.js`, when updating suggestion data from Mystique AI responses:

- `aiSummary` is conditionally updated — only when the new value is valid (not null, undefined, or "Not available"). Otherwise the existing value is preserved.
- `valuable` was **always** overwritten with the new value, regardless of whether `aiSummary` was valid.

This meant: if a suggestion had `valuable: false` and a valid `aiSummary` from a previous run, and the next Mystique response had no valid summary (`aiSummary: null`), the `valuable` flag would be overwritten with `true` (the default) while `aiSummary` was correctly preserved. The two fields fell out of sync.

## Fix

```js
// Before
valuable: isValuable,  // Always overwrites

// After
valuable: hasValidAiSummary ? isValuable : (currentData.valuable ?? true),
```

Now `valuable` follows the same pattern as `aiSummary` — only updates when the new AI response has a valid summary.

## Test plan

- [x] New test: preserves existing `valuable: false` when `aiSummary` is null
- [x] Existing tests pass (29 passing, 0 failing)
- [x] 100% coverage on guidance-handler.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)