### PR TITLE
feat(referral-traffic): apply subpath filter to Athena results (LLMO-4249)

### DIFF
--- a/src/llmo-referral-traffic/handler.js
+++ b/src/llmo-referral-traffic/handler.js
@@ -13,14 +13,13 @@
 /* eslint-disable no-param-reassign */
 /* c8 ignore start */
 
-import {
-  getStaticContent, getWeekInfo, isoCalendarWeek,
-} from '@adobe/spacecat-shared-utils';
+import { getStaticContent, getWeekInfo, isoCalendarWeek } from '@adobe/spacecat-shared-utils';
 import { AWSAthenaClient } from '@adobe/spacecat-shared-athena-client';
 import { Audit } from '@adobe/spacecat-shared-data-access';
 import ExcelJS from 'exceljs';
 import { AuditBuilder } from '../common/audit-builder.js';
 import { wwwUrlResolver } from '../common/index.js';
+import { filterByAuditScope } from '../internal-links/subpath-filter.js';
 import { createLLMOSharepointClient, saveExcelReport } from '../utils/report-uploader.js';
 import { DEFAULT_COUNTRY_PATTERNS } from '../common/country-patterns.js';
 
@@ -87,10 +86,7 @@ export async function triggerTrafficAnalysisImport(context) {
     ({ week, year } = isoCalendarWeek(yesterday));
   }
 
-  log.info(
-    `[llmo-referral-traffic] Triggering traffic-analysis import for site: ${siteId}, `
-    + `week: ${week}, year: ${year}`,
-  );
+  log.info(`[llmo-referral-traffic] Triggering traffic-analysis import for site: ${siteId}, week: ${week}, year: ${year}`);
 
   return {
     type: 'traffic-analysis',
@@ -121,10 +117,7 @@ export async function referralTrafficRunner(context) {
   const siteId = site.getSiteId();
   const baseURL = site.getBaseURL();
 
-  log.info(
-    `[llmo-referral-traffic] Starting referral traffic extraction for site: ${siteId}, `
-    + `week: ${week}, year: ${year}`,
-  );
+  log.info(`[llmo-referral-traffic] Starting referral traffic extraction for site: ${siteId}, week: ${week}, year: ${year}`);
 
   // constants
   const tempLocation = `s3://${importerBucket}/rum-metrics-compact/temp/out/`;
@@ -155,6 +148,9 @@ export async function referralTrafficRunner(context) {
     };
   }
 
+  // filter results by audit scope (subpath)
+  const scopedResults = filterByAuditScope(results, baseURL, { urlProperty: 'path' }, log);
+
   log.info('[llmo-referral-traffic] Enriching data with page intents and region information');
   const pageIntents = await site.getPageIntents();
   log.info(`[llmo-referral-traffic] Retrieved ${pageIntents.length} page intents for site ${siteId}`);
@@ -164,16 +160,16 @@ export async function referralTrafficRunner(context) {
   }, {});
 
   // enrich with extra fields
-  results.forEach((result) => {
+  scopedResults.forEach((result) => {
     result.page_intent = pageIntentMap[result.path] || '';
     result.region = extractCountryCode(result.path);
   });
-  log.info(`[llmo-referral-traffic] Data enrichment completed for ${results.length} rows`);
+  log.info(`[llmo-referral-traffic] Data enrichment completed for ${scopedResults.length} rows`);
 
   // upload to sharepoint & publish via hlx admin api
   const sharepointClient = await createLLMOSharepointClient(context);
 
-  const workbook = await createWorkbook(results);
+  const workbook = await createWorkbook(scopedResults);
   const llmoFolder = site.getConfig()?.getLlmoDataFolder();
   const outputLocation = `${llmoFolder}/referral-traffic`;
   const filename = `referral-traffic-w${String(week).padStart(2, '0')}-${year}.xlsx`;
@@ -190,7 +186,7 @@ export async function referralTrafficRunner(context) {
     auditResult: {
       filename,
       outputLocation,
-      rowCount: results.length,
+      rowCount: scopedResults.length,
     },
     fullAuditRef: `${outputLocation}/${filename}`,
   };
@@ -198,14 +194,7 @@ export async function referralTrafficRunner(context) {
 
 export default new AuditBuilder()
   .withUrlResolver(wwwUrlResolver)
-  .addStep(
-    'trigger-traffic-analysis-import',
-    triggerTrafficAnalysisImport,
-    AUDIT_STEP_DESTINATIONS.IMPORT_WORKER,
-  )
-  .addStep(
-    'run-referral-traffic',
-    referralTrafficRunner,
-  )
+  .addStep('trigger-traffic-analysis-import', triggerTrafficAnalysisImport, AUDIT_STEP_DESTINATIONS.IMPORT_WORKER)
+  .addStep('run-referral-traffic', referralTrafficRunner)
   .build();
 /* c8 ignore end */

--- a/test/audits/llmo-referral-traffic.test.js
+++ b/test/audits/llmo-referral-traffic.test.js
@@ -147,9 +147,7 @@ describe('LLMO Referral Traffic Handler', () => {
         { path: '/de/page2', trf_type: 'earned' },
       ];
 
-      const mockPageIntents = [
-        { getUrl: () => 'https://example.com/us/page1', getPageIntent: () => 'purchase' },
-      ];
+      const mockPageIntents = [{ getUrl: () => 'https://example.com/us/page1', getPageIntent: () => 'purchase' }];
 
       site.getPageIntents.resolves(mockPageIntents);
       mockAthenaClient.query.resolves(mockTrafficData);
@@ -161,15 +159,50 @@ describe('LLMO Referral Traffic Handler', () => {
     });
 
     it('should extract the country from bare country/language paths', async () => {
-      const mockTrafficData = [
-        { path: 'cz/cs/page1', trf_type: 'earned' },
-      ];
+      const mockTrafficData = [{ path: 'cz/cs/page1', trf_type: 'earned' }];
 
       mockAthenaClient.query.resolves(mockTrafficData);
 
       await handlerModule.referralTrafficRunner(context);
 
       expect(mockTrafficData[0].region).to.equal('CZ');
+    });
+
+    it('should filter results by subpath when baseURL has a subpath', async () => {
+      site.getBaseURL.returns('https://example.com/uk');
+
+      const mockTrafficData = [
+        { path: '/uk/page1', trf_type: 'earned' },
+        { path: '/uk/page2', trf_type: 'earned' },
+        { path: '/us/page3', trf_type: 'earned' },
+        { path: '/de/page4', trf_type: 'earned' },
+      ];
+
+      mockAthenaClient.query.resolves(mockTrafficData);
+
+      const result = await handlerModule.referralTrafficRunner(context);
+
+      // Only /uk/ paths should remain after filtering
+      expect(result.auditResult.rowCount).to.equal(2);
+      expect(saveExcelReportStub).to.have.been.calledOnce;
+    });
+
+    it('should pass through all results when baseURL has no subpath', async () => {
+      site.getBaseURL.returns('https://example.com');
+
+      const mockTrafficData = [
+        { path: '/us/page1', trf_type: 'earned' },
+        { path: '/de/page2', trf_type: 'earned' },
+        { path: '/page3', trf_type: 'earned' },
+      ];
+
+      mockAthenaClient.query.resolves(mockTrafficData);
+
+      const result = await handlerModule.referralTrafficRunner(context);
+
+      // All results should pass through when no subpath
+      expect(result.auditResult.rowCount).to.equal(3);
+      expect(saveExcelReportStub).to.have.been.calledOnce;
     });
   });
 });


### PR DESCRIPTION
## Summary

- Wire `filterByAuditScope` into `referralTrafficRunner` to scope Athena referral traffic results to the site's registered subpath
- Uses the existing battle-tested `subpath-filter.js` utility (same as internal-links and backlinks audits)
- Results filtered via `{ urlProperty: 'path' }` — relative paths handled correctly

## Test plan

- [x] Results filtered when `baseURL` has a subpath (e.g., `example.com/uk`)
- [x] Results pass through unfiltered when `baseURL` has no subpath (root domain)
- [x] Existing subpath-filter tests still pass (34 total)
- [ ] Deploy and verify with Sacramento Kings test site

**Companion PR:** adobe-rnd/llmo-data-retrieval-service#1305 (DRS subpath support)
**Jira:** [LLMO-4249](https://jira.corp.adobe.com/browse/LLMO-4249)

🤖 Generated with [Claude Code](https://claude.com/claude-code)