### PR TITLE
test: stabilize CDN logs report date-sensitive specs

### DIFF
--- a/test/audits/cdn-logs-report/handler.test.js
+++ b/test/audits/cdn-logs-report/handler.test.js
@@ -341,7 +341,7 @@ describe('CDN Logs Report Handler', function test() {
         'https://example.com',
         context,
         site,
-        createAuditContext(sandbox, { categoriesUpdated: false }),
+        createAuditContext(sandbox, { weekOffset: 0, categoriesUpdated: false }),
       );
 
       expect(fetchRemotePatternsStub).to.have.been.calledOnce;
@@ -412,7 +412,7 @@ describe('CDN Logs Report Handler', function test() {
         'https://example.com',
         context,
         site,
-        createAuditContext(sandbox, { categoriesUpdated: false }),
+        createAuditContext(sandbox, { weekOffset: 0, categoriesUpdated: false }),
       );
 
       expect(fetchRemotePatternsStub).to.have.been.calledOnce;
@@ -610,6 +610,10 @@ describe('CDN Logs Report Handler', function test() {
     });
 
     it('skips daily export when the agentic report config is missing', async () => {
+      const clock = sinon.useFakeTimers({
+        now: new Date('2025-01-07'),
+        toFake: ['Date'],
+      });
       const runWeeklyReportStub = sandbox.stub().resolves({ success: true, uploadResult: null });
       const runDailyAgenticExportStub = sandbox.stub().resolves();
       const localHandler = await esmock('../../../src/cdn-logs-report/handler.js', {
@@ -666,12 +670,17 @@ describe('CDN Logs Report Handler', function test() {
         },
       });
 
-      const result = await localHandler.runner(
-        'https://example.com',
-        context,
-        site,
-        createAuditContext(sandbox, { categoriesUpdated: false }),
-      );
+      let result;
+      try {
+        result = await localHandler.runner(
+          'https://example.com',
+          context,
+          site,
+          createAuditContext(sandbox, { categoriesUpdated: false }),
+        );
+      } finally {
+        clock.restore();
+      }
 
       expect(runDailyAgenticExportStub).to.not.have.been.called;
       expect(result.dailyAgenticExport).to.equal(undefined);


### PR DESCRIPTION
## Summary
This fixes flaky CDN logs report specs that depended on the current day.

## What changed
- pin two specs to `weekOffset: 0` so they only assert a single weekly run
- freeze the missing-agentic-config spec to a non-Monday date
- restore the fake clock in a `finally` block

## Verification
- `npm test`