### PR TITLE
fix: forward 100% BrightData-resolved backlinks to Mystique for bridge enrichment

### DIFF
--- a/src/backlinks/handler.js
+++ b/src/backlinks/handler.js
@@ -527,12 +527,7 @@ export const generateSuggestionData = async (context) => {
 
   // Validate before sending to Mystique
   if (brokenLinksForMystique.length === 0) {
-    log.info('All broken links resolved via Bright Data. Skipping Mystique.');
-    opportunity.setLastAuditedAt(new Date().toISOString());
-    await opportunity.save();
-    return {
-      status: 'complete',
-    };
+    log.info('All broken links resolved via Bright Data. Forwarding to Mystique.');
   }
 
   if (alternativeUrls.length === 0) {

--- a/test/audits/backlinks.test.js
+++ b/test/audits/backlinks.test.js
@@ -1361,6 +1361,48 @@ describe('Backlinks Tests', function () {
 
       expect(context.log.info).to.have.been.calledWith(sinon.match(/maxResults=5/));
     });
+
+    it('should forward to Mystique with empty brokenLinks when all links resolved via Bright Data', async () => {
+      context.env.BRIGHT_DATA_API_KEY = 'test-api-key';
+      context.env.BRIGHT_DATA_ZONE = 'test-zone';
+
+      // Bright Data successfully resolves the suggestion
+      mockBrightDataClient.googleSearchWithFallback.resolves({
+        results: [{ link: 'https://example.com/suggested-page', title: 'Suggested Page' }],
+        query: 'site:example.com broken page',
+        keywords: 'broken page',
+      });
+
+      context.audit.getAuditResult.returns({
+        success: true,
+        brokenBacklinks: auditDataMock.auditResult.brokenBacklinks,
+      });
+
+      const mockSuggestion = {
+        getId: () => 'test-suggestion-bd-all',
+        getData: () => ({
+          url_from: 'https://from.com/page',
+          url_to: 'https://example.com/broken-page',
+        }),
+        setData: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+      context.dataAccess.Suggestion.allByOpportunityIdAndStatus.resolves([mockSuggestion]);
+      context.dataAccess.Suggestion.findById = sinon.stub().resolves(mockSuggestion);
+      context.dataAccess.SiteTopPage.allBySiteIdAndSourceAndGeo.resolves(topPages);
+
+      const result = await mockedGenerateSuggestionData(context);
+
+      expect(result.status).to.equal('complete');
+      // Must still forward to Mystique so the bridge can enrich the BrightData suggestions
+      expect(context.sqs.sendMessage).to.have.been.calledOnce;
+      const sentMessage = context.sqs.sendMessage.getCall(0).args[1];
+      expect(sentMessage.data.brokenLinks).to.deep.equal([]);
+      // Log must say Forwarding, not Skipping
+      expect(context.log.info).to.have.been.calledWith(
+        'All broken links resolved via Bright Data. Forwarding to Mystique.',
+      );
+    });
   });
 
   describe('calculateKpiMetrics', () => {


### PR DESCRIPTION
⚠️ Merge after https://git.corp.adobe.com/experience-platform/mystique/pull/1592

## Summary

- Removes the early return when all broken backlinks are resolved by Bright Data
- Instead forwards the message to Mystique with an empty `brokenLinks` array
- Mystique's companion fast path (adobe/mystique#companion) detects the empty array, skips the LLM crew, and runs bridge enrichment via Subset 2 over the BrightData suggestions already in SpaceCat

**Root cause:** ~0.7% of broken-backlinks audits (37/5290 over 7 days in prod) hit the 100% BrightData path and skipped Mystique entirely, leaving `fixable`/`fixabilityReason` unset on those suggestions.

**No breaking change.** The message shape is unchanged. Mystique receives `brokenLinks: []` — the companion PR handles this case.

**Deploy order:** Mystique companion PR must be deployed first. If this lands before Mystique, the old task receives `brokenLinks: []`, logs an error, and runs the LLM crew with empty input (no crash, just wasteful). Correct order: Mystique → audit-worker.

## Test plan

- [x] New test: `should forward to Mystique with empty brokenLinks when all links resolved via Bright Data` — verifies `sendMessage` is called with `brokenLinks: []` and logs "Forwarding to Mystique"
- [x] Existing 65 tests all pass
- [ ] After deploy: search Coralogix prod for `"Forwarding to Mystique"` to confirm the path fires
- [ ] Verify BrightData-only sites gain `fixable`/`fixabilityReason` on their suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)