### PR TITLE
hotfix: rename money-pages SQS message type from detect:money-pages to money-pages

### DIFF
--- a/src/money-pages/handler.js
+++ b/src/money-pages/handler.js
@@ -27,7 +27,7 @@ export async function sendToMystiqueForGeneration(context) {
 
   try {
     const message = {
-      type: 'detect:money-pages',
+      type: 'money-pages',
       siteId: site.getId(),
       auditId: audit.getId(),
       time: new Date().toISOString(),

--- a/test/audits/money-pages/handler.test.js
+++ b/test/audits/money-pages/handler.test.js
@@ -87,7 +87,7 @@ describe('Money pages audit', () => {
       expect(mockSqs.sendMessage).to.have.been.calledOnce;
 
       const messageArg = mockSqs.sendMessage.getCall(0).args[1];
-      expect(messageArg).to.have.property('type', 'detect:money-pages');
+      expect(messageArg).to.have.property('type', 'money-pages');
       expect(messageArg).to.have.property('siteId', 'site-id-1');
       expect(messageArg).to.have.property('auditId', 'audit-id-1');
       expect(messageArg).to.not.have.property('deliveryType');


### PR DESCRIPTION
## Summary
- Renames the outbound SQS message type sent to Mystique from `detect:money-pages` to `money-pages` to keep a single consistent name across all projects

## Test plan
- [ ] Existing unit tests updated and passing