### PR TITLE
feat(prerender): skip Mystique AI summary request for suggestions with existing valuable AI summary

### DIFF
--- a/src/prerender/handler.js
+++ b/src/prerender/handler.js
@@ -581,6 +581,16 @@ async function sendPrerenderGuidanceRequestToMystique(auditUrl, auditData, oppor
           return;
         }
 
+        // Skip suggestions that already have a valid AI summary and are marked as valuable —
+        // sending them to Mystique again would be wasteful with no benefit.
+        const hasValidAiSummary = data?.aiSummary
+          && data.aiSummary.toLowerCase() !== 'not available';
+        if (hasValidAiSummary && data?.valuable === true) {
+          log.debug(`${LOG_PREFIX} Skipping suggestion for url=${data.url}: already has a valid `
+            + `AI summary. baseUrl=${baseUrl}, siteId=${siteId}`);
+          return;
+        }
+
         const suggestionId = s.getId();
 
         // Resolve the scrapeJobId in priority order:
@@ -1185,10 +1195,31 @@ export async function processOpportunityAndSuggestions(
     suggestions=${preRenderSuggestions.length},
     totalSuggestions=${allSuggestions.length},`);
 
+  // Build a set of URLs whose suggestions already carry a valid AI summary marked as valuable.
+  // These do not need to be re-sent to Mystique — the summary is already present and useful.
+  const syncedSuggestions = await opportunity.getSuggestions();
+  const urlsWithValidAiSummary = new Set(
+    syncedSuggestions
+      .filter((s) => {
+        const d = s.getData();
+        const hasValidAiSummary = d?.aiSummary && d.aiSummary.toLowerCase() !== 'not available';
+        return hasValidAiSummary && d?.valuable === true;
+      })
+      .map((s) => s.getData()?.url)
+      .filter(Boolean),
+  );
+
+  if (urlsWithValidAiSummary.size > 0) {
+    log.info(`${LOG_PREFIX} Skipping ${urlsWithValidAiSummary.size} suggestion(s) from Mystique request: already have a valid AI summary. baseUrl=${auditUrl}, siteId=${auditData.siteId}`);
+  }
+
   // Build Mystique candidates from individual URLs (domain-wide excluded).
   // The guidance handler matches Mystique responses back to suggestions by URL,
   // so sending the URL as suggestionId is sufficient and avoids a post-sync DB fetch.
   const auditRunCandidates = preRenderSuggestions.reduce((acc, s) => {
+    if (urlsWithValidAiSummary.has(s.url)) {
+      return acc; // Already has a valid AI summary — skip re-generation
+    }
     try {
       acc.push({
         suggestionId: s.url,

--- a/test/audits/prerender/ai-only-mode.test.js
+++ b/test/audits/prerender/ai-only-mode.test.js
@@ -448,6 +448,74 @@ describe('Prerender AI-Only Mode', () => {
       );
     });
 
+    it('should skip suggestions that already have a valid AI summary and are valuable', async () => {
+      mockSuggestions[0].getData.returns({
+        url: 'https://example.com/page1',
+        isDomainWide: false,
+        scrapeJobId: 'test-scrape-job',
+        aiSummary: 'This page benefits greatly from prerendering.',
+        valuable: true,
+      });
+
+      const result = await importTopPages(context);
+
+      expect(result.auditResult.suggestionCount).to.equal(1); // Only page2 sent
+      const message = mockSqs.sendMessage.getCall(0).args[1];
+      expect(message.data.suggestions).to.have.lengthOf(1);
+      expect(message.data.suggestions[0].url).to.equal('https://example.com/page2');
+    });
+
+    it('should not skip suggestions with aiSummary "not available" even if valuable', async () => {
+      mockSuggestions[0].getData.returns({
+        url: 'https://example.com/page1',
+        isDomainWide: false,
+        scrapeJobId: 'test-scrape-job',
+        aiSummary: 'not available',
+        valuable: true,
+      });
+
+      const result = await importTopPages(context);
+
+      expect(result.auditResult.suggestionCount).to.equal(2); // Both sent
+    });
+
+    it('should not skip suggestions with valid aiSummary but valuable=false', async () => {
+      mockSuggestions[0].getData.returns({
+        url: 'https://example.com/page1',
+        isDomainWide: false,
+        scrapeJobId: 'test-scrape-job',
+        aiSummary: 'This page benefits greatly from prerendering.',
+        valuable: false,
+      });
+
+      const result = await importTopPages(context);
+
+      expect(result.auditResult.suggestionCount).to.equal(2); // Both sent
+    });
+
+    it('should return 0 if all suggestions have valid AI summaries and are valuable', async () => {
+      mockSuggestions[0].getData.returns({
+        url: 'https://example.com/page1',
+        isDomainWide: false,
+        scrapeJobId: 'test-scrape-job',
+        aiSummary: 'Prerendering is recommended.',
+        valuable: true,
+      });
+      mockSuggestions[1].getData.returns({
+        url: 'https://example.com/page2',
+        isDomainWide: false,
+        scrapeJobId: 'test-scrape-job',
+        aiSummary: 'Great candidate for prerendering.',
+        valuable: true,
+      });
+
+      const result = await importTopPages(context);
+
+      expect(result.auditResult.suggestionCount).to.equal(0);
+      expect(context.log.info).to.have.been.calledWith(
+        sinon.match(/No eligible suggestions to send to Mystique/),
+      );
+    });
 
     it('should handle missing getDeliveryType method', async () => {
       context.site.getDeliveryType = undefined;
@@ -653,9 +721,9 @@ describe('Prerender AI-Only Mode', () => {
       );
 
       expect(opportunity).to.equal(mockOpportunityNormal);
-      // getSuggestions is called once by findPreservableDomainWideSuggestion only —
-      // suggestionId is now the URL itself, no post-sync DB fetch needed.
-      expect(getSuggestionsStub).to.have.been.calledOnce;
+      // getSuggestions is called twice: once by findPreservableDomainWideSuggestion and once
+      // after syncSuggestions to filter out candidates that already have a valid AI summary.
+      expect(getSuggestionsStub).to.have.been.calledTwice;
       // One candidate per URL in the current batch — plain objects with S3 keys and suggestionId
       expect(auditRunCandidates).to.have.lengthOf(1);
       expect(auditRunCandidates[0].suggestionId).to.equal('https://example.com/page1');

--- a/test/audits/prerender/handler.test.js
+++ b/test/audits/prerender/handler.test.js
@@ -7138,6 +7138,191 @@ describe('Prerender Audit', () => {
       expect(auditRunCandidates[0].suggestionId).to.equal('https://example.com/page1');
       expect(auditRunCandidates[0].url).to.equal('https://example.com/page1');
     });
+
+    it('should exclude URLs with valid AI summary and valuable=true from auditRunCandidates', async () => {
+      const savedSuggestion = {
+        getStatus: () => 'NEW',
+        getId: () => 'saved-suggestion-id',
+        getData: () => ({
+          url: 'https://example.com/page1',
+          aiSummary: 'This page benefits greatly from prerendering.',
+          valuable: true,
+        }),
+      };
+
+      const mockOpportunity = {
+        getId: () => 'test-opp-id',
+        getSuggestions: sandbox.stub().resolves([savedSuggestion]),
+      };
+
+      const syncSuggestionsStub = sandbox.stub().resolves();
+      const mockIsPaidLLMOCustomer = sandbox.stub().resolves(true);
+
+      const mockHandler = await esmock('../../../src/prerender/handler.js', {
+        '../../../src/common/opportunity.js': {
+          convertToOpportunity: sandbox.stub().resolves(mockOpportunity),
+        },
+        '../../../src/utils/data-access.js': {
+          syncSuggestions: syncSuggestionsStub,
+        },
+        '../../../src/prerender/utils/utils.js': {
+          isPaidLLMOCustomer: mockIsPaidLLMOCustomer,
+        },
+      });
+
+      const auditData = {
+        siteId: 'test-site',
+        auditId: 'audit-123',
+        scrapeJobId: 'job-123',
+        auditResult: {
+          urlsNeedingPrerender: 1,
+          results: [{
+            url: 'https://example.com/page1',
+            needsPrerender: true,
+            contentGainRatio: 2.5,
+            wordCountBefore: 100,
+            wordCountAfter: 250,
+          }],
+        },
+      };
+
+      const context = {
+        log: {
+          info: sandbox.stub(), debug: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub(),
+        },
+      };
+
+      const result = await mockHandler.processOpportunityAndSuggestions('https://example.com', auditData, context);
+
+      expect(result).to.not.be.null;
+      const { auditRunCandidates } = result;
+      expect(auditRunCandidates).to.be.an('array').with.lengthOf(0);
+      expect(context.log.info).to.have.been.calledWith(
+        sinon.match(/Skipping 1 suggestion\(s\) from Mystique request: already have a valid AI summary/),
+      );
+    });
+
+    it('should include URL with aiSummary "not available" in auditRunCandidates even if valuable', async () => {
+      const savedSuggestion = {
+        getStatus: () => 'NEW',
+        getId: () => 'saved-suggestion-id',
+        getData: () => ({
+          url: 'https://example.com/page1',
+          aiSummary: 'not available',
+          valuable: true,
+        }),
+      };
+
+      const mockOpportunity = {
+        getId: () => 'test-opp-id',
+        getSuggestions: sandbox.stub().resolves([savedSuggestion]),
+      };
+
+      const syncSuggestionsStub = sandbox.stub().resolves();
+      const mockIsPaidLLMOCustomer = sandbox.stub().resolves(true);
+
+      const mockHandler = await esmock('../../../src/prerender/handler.js', {
+        '../../../src/common/opportunity.js': {
+          convertToOpportunity: sandbox.stub().resolves(mockOpportunity),
+        },
+        '../../../src/utils/data-access.js': {
+          syncSuggestions: syncSuggestionsStub,
+        },
+        '../../../src/prerender/utils/utils.js': {
+          isPaidLLMOCustomer: mockIsPaidLLMOCustomer,
+        },
+      });
+
+      const auditData = {
+        siteId: 'test-site',
+        auditId: 'audit-123',
+        scrapeJobId: 'job-123',
+        auditResult: {
+          urlsNeedingPrerender: 1,
+          results: [{
+            url: 'https://example.com/page1',
+            needsPrerender: true,
+            contentGainRatio: 2.5,
+            wordCountBefore: 100,
+            wordCountAfter: 250,
+          }],
+        },
+      };
+
+      const context = {
+        log: {
+          info: sandbox.stub(), debug: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub(),
+        },
+      };
+
+      const result = await mockHandler.processOpportunityAndSuggestions('https://example.com', auditData, context);
+
+      expect(result).to.not.be.null;
+      const { auditRunCandidates } = result;
+      expect(auditRunCandidates).to.be.an('array').with.lengthOf(1);
+      expect(auditRunCandidates[0].url).to.equal('https://example.com/page1');
+    });
+
+    it('should include URL with valid aiSummary but valuable=false in auditRunCandidates', async () => {
+      const savedSuggestion = {
+        getStatus: () => 'NEW',
+        getId: () => 'saved-suggestion-id',
+        getData: () => ({
+          url: 'https://example.com/page1',
+          aiSummary: 'Prerendering recommended.',
+          valuable: false,
+        }),
+      };
+
+      const mockOpportunity = {
+        getId: () => 'test-opp-id',
+        getSuggestions: sandbox.stub().resolves([savedSuggestion]),
+      };
+
+      const syncSuggestionsStub = sandbox.stub().resolves();
+      const mockIsPaidLLMOCustomer = sandbox.stub().resolves(true);
+
+      const mockHandler = await esmock('../../../src/prerender/handler.js', {
+        '../../../src/common/opportunity.js': {
+          convertToOpportunity: sandbox.stub().resolves(mockOpportunity),
+        },
+        '../../../src/utils/data-access.js': {
+          syncSuggestions: syncSuggestionsStub,
+        },
+        '../../../src/prerender/utils/utils.js': {
+          isPaidLLMOCustomer: mockIsPaidLLMOCustomer,
+        },
+      });
+
+      const auditData = {
+        siteId: 'test-site',
+        auditId: 'audit-123',
+        scrapeJobId: 'job-123',
+        auditResult: {
+          urlsNeedingPrerender: 1,
+          results: [{
+            url: 'https://example.com/page1',
+            needsPrerender: true,
+            contentGainRatio: 2.5,
+            wordCountBefore: 100,
+            wordCountAfter: 250,
+          }],
+        },
+      };
+
+      const context = {
+        log: {
+          info: sandbox.stub(), debug: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub(),
+        },
+      };
+
+      const result = await mockHandler.processOpportunityAndSuggestions('https://example.com', auditData, context);
+
+      expect(result).to.not.be.null;
+      const { auditRunCandidates } = result;
+      expect(auditRunCandidates).to.be.an('array').with.lengthOf(1);
+      expect(auditRunCandidates[0].url).to.equal('https://example.com/page1');
+    });
   });
 
   describe('getScrapeJobStats', () => {


### PR DESCRIPTION
## Problem

Every prerender audit run unconditionally sends all eligible suggestions to Mystique for AI summary generation — even when a suggestion already has a valid, valuable AI summary from a prior run. This wastes Mystique capacity and adds latency with no benefit.

## Solution

Skip sending a suggestion to Mystique if it already has a valid `aiSummary` (non-empty and not `"not available"`) **and** is marked as `valuable: true`. The summary is already present and useful, so re-generating it is unnecessary.

The optimization is applied in **two places**:

### 1. Normal audit run (`processOpportunityAndSuggestions`)
After `syncSuggestions` merges the new scraping results into the DB, the updated suggestions are fetched and a set of URLs with existing valuable AI summaries is built. Those URLs are then excluded from `auditRunCandidates` before the batch is forwarded to `sendPrerenderGuidanceRequestToMystique`.

### 2. AI-only mode (`sendPrerenderGuidanceRequestToMystique` — ai-only path)
When deriving candidates from existing DB suggestions (ai-only mode), suggestions that already have a valid AI summary and `valuable: true` are skipped with a `debug` log entry.

## Behaviour preserved

- Suggestions with `aiSummary: "not available"` are still sent (the summary is invalid).
- Suggestions with a valid `aiSummary` but `valuable: false` are still sent (they may need re-evaluation).
- All other existing skip conditions (OUTDATED, SKIPPED, FIXED, edgeDeployed, domain-wide) are unchanged.

## Testing

- 7 new unit tests covering the optimization: partial and full skipping, edge cases (`"not available"`, `valuable: false`).
- Updated one existing assertion that expected `getSuggestions` to be called once — it is now correctly called twice (once by `findPreservableDomainWideSuggestion`, once for the AI summary check).
- All 273 prerender tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)