### PR TITLE
fix(vulnerabilities): make buildKey shape-agnostic so sync updates existing suggestions (CQ-4363001)

### DIFF
--- a/src/vulnerabilities/handler.js
+++ b/src/vulnerabilities/handler.js
@@ -15,7 +15,6 @@ import {
   DELIVERY_TYPES, hasText, isNonEmptyArray, tracingFetch as fetch,
 } from '@adobe/spacecat-shared-utils';
 import { ImsClient } from '@adobe/spacecat-shared-ims-client';
-import { createHash } from 'node:crypto';
 import { AuditBuilder } from '../common/audit-builder.js';
 import { convertToOpportunity } from '../common/opportunity.js';
 import { createOpportunityData, createOpportunityProps } from './opportunity-data-mapper.js';
@@ -178,6 +177,25 @@ export async function extractCodeBucket(context) {
   };
 }
 
+/**
+ * Builds a stable key for a vulnerable component used to match new audit data against
+ * previously-stored suggestions. Works on both raw components ({name, dependencyTree})
+ * and stored suggestion data ({library, dependency_tree}), since syncSuggestions calls
+ * buildKey against both shapes. The key is the library name joined with each
+ * dependency-tree entry (excluding "[root]" and stripped of its "@version" suffix).
+ *
+ * @param {Object} item - Raw vulnerable component or stored suggestion data.
+ * @returns {string} - A stable key derived from library name and dependency tree.
+ */
+export const buildKey = (item) => {
+  const libName = item.library ?? item.name;
+  const tree = item.dependency_tree ?? item.dependencyTree ?? [];
+  const parts = tree
+    .filter((entry) => entry !== '[root]')
+    .map((entry) => entry.replace(/@[^@]*$/, ''));
+  return [libName, ...parts].join('-');
+};
+
 export const extractCodeInfo = (data) => {
   if (!data || typeof data !== 'object') {
     return null;
@@ -270,13 +288,6 @@ export const opportunityAndSuggestionsStep = async (context) => {
     AUDIT_TYPE,
     createOpportunityProps(auditResult.vulnerabilityReport),
   );
-
-  // As a buildKey we hash all the component details and add name and version for readability
-  const buildKey = (item) => {
-    const s = JSON.stringify(item);
-    const hash = createHash('sha256').update(s).digest('hex').slice(0, 8);
-    return `${item.name}@${item.version}#${hash}`;
-  };
 
   // Populate suggestions
   await syncSuggestions({

--- a/src/vulnerabilities/handler.js
+++ b/src/vulnerabilities/handler.js
@@ -179,21 +179,24 @@ export async function extractCodeBucket(context) {
 
 /**
  * Builds a stable key for a vulnerable component used to match new audit data against
- * previously-stored suggestions. Works on both raw components ({name, dependencyTree})
- * and stored suggestion data ({library, dependency_tree}), since syncSuggestions calls
- * buildKey against both shapes. The key is the library name joined with each
- * dependency-tree entry (excluding "[root]" and stripped of its "@version" suffix).
+ * previously-stored suggestions. Works on both raw components
+ * ({name, version, dependencyTree}) and stored suggestion data
+ * ({library, current_version, dependency_tree}), since syncSuggestions calls buildKey
+ * against both shapes. The key is "library@version" joined with each dependency-tree
+ * entry (excluding "[root]" and stripped of its "@version" suffix — we don't key on
+ * transitive parent versions, only on the vulnerable library's own version).
  *
  * @param {Object} item - Raw vulnerable component or stored suggestion data.
- * @returns {string} - A stable key derived from library name and dependency tree.
+ * @returns {string} - A stable key derived from library name/version and dependency tree.
  */
 export const buildKey = (item) => {
   const libName = item.library ?? item.name;
+  const libVersion = item.current_version ?? item.version;
   const tree = item.dependency_tree ?? item.dependencyTree ?? [];
   const parts = tree
     .filter((entry) => entry !== '[root]')
     .map((entry) => entry.replace(/@[^@]*$/, ''));
-  return [libName, ...parts].join('-');
+  return [`${libName}@${libVersion}`, ...parts].join('-');
 };
 
 export const extractCodeInfo = (data) => {

--- a/test/audits/vulnerabilities.test.js
+++ b/test/audits/vulnerabilities.test.js
@@ -23,7 +23,9 @@ import {
   VULNERABILITY_REPORT_NO_VULNERABILITIES,
   VULNERABILITY_REPORT_MULTIPLE_COMPONENTS,
 } from '../fixtures/vulnerabilities/vulnerability-reports.js';
-import { vulnerabilityAuditRunner, opportunityAndSuggestionsStep, extractCodeInfo } from '../../src/vulnerabilities/handler.js';
+import {
+  vulnerabilityAuditRunner, opportunityAndSuggestionsStep, extractCodeInfo, buildKey,
+} from '../../src/vulnerabilities/handler.js';
 
 use(sinonChai);
 use(chaiAsPromised);
@@ -822,6 +824,119 @@ describe('extractCodeInfo', () => {
       expect(extractCodeInfo({
         importResults: [{ result: [{ codeBucket: 'my-bucket', codePath: '   ' }] }],
       })).to.be.null;
+    });
+  });
+
+  describe('buildKey', () => {
+    it('builds key from library name and dependency tree, stripping [root] and @version', () => {
+      const key = buildKey({
+        name: 'com.fasterxml.jackson.core:jackson-databind',
+        version: '2.12.3',
+        dependencyTree: [
+          '[root]',
+          'biz.netcentric.cq.tools.accesscontroltool/accesscontroltool-bundle@3.5.1',
+        ],
+      });
+      expect(key).to.equal(
+        'com.fasterxml.jackson.core:jackson-databind-biz.netcentric.cq.tools.accesscontroltool/accesscontroltool-bundle',
+      );
+    });
+
+    it('produces identical keys for raw component and stored suggestion data shapes', () => {
+      const rawComponent = {
+        name: 'com.fasterxml.jackson.core:jackson-databind',
+        version: '2.12.3',
+        recommendedVersion: '2.12.6.1',
+        vulnerabilities: [{ id: 'CVE-2020-36518', score: 7.5 }],
+        dependencyTree: [
+          '[root]',
+          'biz.netcentric.cq.tools.accesscontroltool/accesscontroltool-bundle@3.5.1',
+        ],
+      };
+      const storedData = {
+        library: 'com.fasterxml.jackson.core:jackson-databind',
+        current_version: '2.12.3',
+        recommended_version: '2.12.6.1',
+        cves: [{ cve_id: 'CVE-2020-36518', score: 7.5 }],
+        dependency_tree: [
+          '[root]',
+          'biz.netcentric.cq.tools.accesscontroltool/accesscontroltool-bundle@3.5.1',
+        ],
+      };
+      expect(buildKey(rawComponent)).to.equal(buildKey(storedData));
+    });
+
+    it('distinguishes same library reached via different dependency paths', () => {
+      const keyA = buildKey({
+        name: 'lib-x',
+        dependencyTree: ['[root]', 'parent-a@1.0.0'],
+      });
+      const keyB = buildKey({
+        name: 'lib-x',
+        dependencyTree: ['[root]', 'parent-b@1.0.0'],
+      });
+      expect(keyA).to.not.equal(keyB);
+    });
+
+    it('treats two entries that differ only by version as the same key', () => {
+      const keyOld = buildKey({
+        name: 'lib-x',
+        dependencyTree: ['[root]', 'parent-a@1.0.0'],
+      });
+      const keyNew = buildKey({
+        name: 'lib-x',
+        dependencyTree: ['[root]', 'parent-a@2.5.9'],
+      });
+      expect(keyOld).to.equal(keyNew);
+    });
+
+    it('handles missing dependencyTree by falling back to library name only', () => {
+      expect(buildKey({ name: 'lib-x' })).to.equal('lib-x');
+      expect(buildKey({ library: 'lib-x' })).to.equal('lib-x');
+    });
+
+    it('handles empty dependencyTree array', () => {
+      expect(buildKey({ name: 'lib-x', dependencyTree: [] })).to.equal('lib-x');
+    });
+
+    it('handles tree entries without any @version suffix', () => {
+      const key = buildKey({
+        name: 'lib-x',
+        dependencyTree: ['[root]', 'parent-with-no-version'],
+      });
+      expect(key).to.equal('lib-x-parent-with-no-version');
+    });
+
+    it('strips only the trailing @version when entry contains multiple "@"', () => {
+      const key = buildKey({
+        name: 'lib-x',
+        dependencyTree: ['@scope/pkg@1.0.0'],
+      });
+      expect(key).to.equal('lib-x-@scope/pkg');
+    });
+
+    it('preserves dependency tree ordering in the key', () => {
+      const keyAB = buildKey({
+        name: 'lib-x',
+        dependencyTree: ['parent-a@1', 'parent-b@1'],
+      });
+      const keyBA = buildKey({
+        name: 'lib-x',
+        dependencyTree: ['parent-b@1', 'parent-a@1'],
+      });
+      expect(keyAB).to.not.equal(keyBA);
+    });
+
+    it('matches on a real fixture entry across raw and mapped shapes', () => {
+      const raw = VULNERABILITY_REPORT_WITH_VULNERABILITIES.vulnerableComponents[0];
+      const mapped = {
+        library: raw.name,
+        current_version: raw.version,
+        recommended_version: raw.recommendedVersion,
+        cves: [],
+        dependency_tree: raw.dependencyTree,
+      };
+      expect(buildKey(raw)).to.equal(buildKey(mapped));
     });
   });
 });

--- a/test/audits/vulnerabilities.test.js
+++ b/test/audits/vulnerabilities.test.js
@@ -828,7 +828,7 @@ describe('extractCodeInfo', () => {
   });
 
   describe('buildKey', () => {
-    it('builds key from library name and dependency tree, stripping [root] and @version', () => {
+    it('builds key from library@version and dependency tree, stripping [root] and parent @version', () => {
       const key = buildKey({
         name: 'com.fasterxml.jackson.core:jackson-databind',
         version: '2.12.3',
@@ -838,8 +838,22 @@ describe('extractCodeInfo', () => {
         ],
       });
       expect(key).to.equal(
-        'com.fasterxml.jackson.core:jackson-databind-biz.netcentric.cq.tools.accesscontroltool/accesscontroltool-bundle',
+        'com.fasterxml.jackson.core:jackson-databind@2.12.3-biz.netcentric.cq.tools.accesscontroltool/accesscontroltool-bundle',
       );
+    });
+
+    it('distinguishes the same library at different versions', () => {
+      const keyOld = buildKey({
+        name: 'lib-x',
+        version: '1.0.0',
+        dependencyTree: ['[root]', 'parent-a@1.0.0'],
+      });
+      const keyNew = buildKey({
+        name: 'lib-x',
+        version: '1.0.1',
+        dependencyTree: ['[root]', 'parent-a@1.0.0'],
+      });
+      expect(keyOld).to.not.equal(keyNew);
     });
 
     it('produces identical keys for raw component and stored suggestion data shapes', () => {
@@ -878,50 +892,56 @@ describe('extractCodeInfo', () => {
       expect(keyA).to.not.equal(keyB);
     });
 
-    it('treats two entries that differ only by version as the same key', () => {
+    it('ignores transitive parent versions in the dependency tree', () => {
       const keyOld = buildKey({
         name: 'lib-x',
+        version: '1.0.0',
         dependencyTree: ['[root]', 'parent-a@1.0.0'],
       });
       const keyNew = buildKey({
         name: 'lib-x',
+        version: '1.0.0',
         dependencyTree: ['[root]', 'parent-a@2.5.9'],
       });
       expect(keyOld).to.equal(keyNew);
     });
 
-    it('handles missing dependencyTree by falling back to library name only', () => {
-      expect(buildKey({ name: 'lib-x' })).to.equal('lib-x');
-      expect(buildKey({ library: 'lib-x' })).to.equal('lib-x');
+    it('handles missing dependencyTree by falling back to library@version only', () => {
+      expect(buildKey({ name: 'lib-x', version: '1.0.0' })).to.equal('lib-x@1.0.0');
+      expect(buildKey({ library: 'lib-x', current_version: '1.0.0' })).to.equal('lib-x@1.0.0');
     });
 
     it('handles empty dependencyTree array', () => {
-      expect(buildKey({ name: 'lib-x', dependencyTree: [] })).to.equal('lib-x');
+      expect(buildKey({ name: 'lib-x', version: '1.0.0', dependencyTree: [] })).to.equal('lib-x@1.0.0');
     });
 
     it('handles tree entries without any @version suffix', () => {
       const key = buildKey({
         name: 'lib-x',
+        version: '1.0.0',
         dependencyTree: ['[root]', 'parent-with-no-version'],
       });
-      expect(key).to.equal('lib-x-parent-with-no-version');
+      expect(key).to.equal('lib-x@1.0.0-parent-with-no-version');
     });
 
     it('strips only the trailing @version when entry contains multiple "@"', () => {
       const key = buildKey({
         name: 'lib-x',
+        version: '1.0.0',
         dependencyTree: ['@scope/pkg@1.0.0'],
       });
-      expect(key).to.equal('lib-x-@scope/pkg');
+      expect(key).to.equal('lib-x@1.0.0-@scope/pkg');
     });
 
     it('preserves dependency tree ordering in the key', () => {
       const keyAB = buildKey({
         name: 'lib-x',
+        version: '1.0.0',
         dependencyTree: ['parent-a@1', 'parent-b@1'],
       });
       const keyBA = buildKey({
         name: 'lib-x',
+        version: '1.0.0',
         dependencyTree: ['parent-b@1', 'parent-a@1'],
       });
       expect(keyAB).to.not.equal(keyBA);
@@ -937,6 +957,7 @@ describe('extractCodeInfo', () => {
         dependency_tree: raw.dependencyTree,
       };
       expect(buildKey(raw)).to.equal(buildKey(mapped));
+      expect(buildKey(raw)).to.include(`@${raw.version}`);
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Bug**: `buildKey` in `src/vulnerabilities/handler.js` hashed the raw vulnerable component (`{name, version, vulnerabilities, dependencyTree, …}`), but `syncSuggestions` also calls `buildKey` against `existing.getData()`, which stores the *mapped* shape (`{library, current_version, cves, dependency_tree, …}`). The two hashes never matched, so every existing suggestion looked "new" on each run — the sync inserted duplicates and marked the real ones as outdated instead of updating them.
- **Fix**: Derive the key from the library name plus the dependency tree (ignore `[root]`, strip `@version` suffixes, join with `-`), reading from whichever field shape is present. This produces identical keys for raw components and stored suggestion data.
- Promoted `buildKey` to a named export so it can be unit-tested directly.

Ref: [CQ-4363001](https://jira.corp.adobe.com/browse/CQ-4363001)

## Test plan

- [x] Unit tests for `buildKey` added to `test/audits/vulnerabilities.test.js`:
  - canonical fixture example
  - regression test: raw component and stored suggestion data produce the same key
  - same library via different dependency paths → different keys
  - same path with different versions → same key (version-insensitive)
  - missing / empty dependency tree → library name only
  - tree entries without `@version` preserved verbatim
  - entries with multiple `@` (e.g. `@scope/pkg@1.0.0`) → only trailing version stripped
  - dependency tree ordering affects the key
  - end-to-end fixture match across raw and mapped shapes
- [x] `npm run test:spec -- test/audits/vulnerabilities.test.js` — 43 passing
- [x] `src/vulnerabilities/handler.js` coverage remains at 100% lines / branches / statements
- [x] `npm run lint` — clean