### PR TITLE
fix: skip chrome links for sites using ARIA landmarks or AEM XFs (SITES-43574)

### DIFF
--- a/src/preflight/links-checks.js
+++ b/src/preflight/links-checks.js
@@ -32,6 +32,11 @@ const HEAD_FALLBACK_STATUSES = new Set([400, 401, 403, 405, 429, 451]);
  *   - AEM Experience Fragment wrappers: `cmp-experiencefragment--header` /
  *     `cmp-experiencefragment--footer`, emitted by AEM XFs on many enterprise sites
  *     (including OneWalmart) that don't render semantic header/footer tags at all.
+ *
+ * Intentionally excluded: `<nav>` and `role="navigation"`. Navigation links point at real
+ * in-site destinations that we want to verify, so treating them as chrome would hide
+ * genuine broken links. Keep this list conservative — ambiguous wrappers like `.nav`,
+ * `.menu`, `.sidebar`, or generic `class*="header"` risk false-skipping content links.
  */
 const CHROME_ANCESTOR_SELECTOR = [
   'header',
@@ -40,6 +45,7 @@ const CHROME_ANCESTOR_SELECTOR = [
   '[role="contentinfo"]',
   '.cmp-experiencefragment--header',
   '.cmp-experiencefragment--footer',
+  // Do not add broader class-matchers here without evidence — see docblock above.
 ].join(', ');
 
 /**

--- a/src/preflight/links-checks.js
+++ b/src/preflight/links-checks.js
@@ -22,6 +22,27 @@ import { DEFAULT_USER_AGENT } from '../internal-links/helpers.js';
 const HEAD_FALLBACK_STATUSES = new Set([400, 401, 403, 405, 429, 451]);
 
 /**
+ * Ancestor selectors identifying page chrome (site header / footer). Anchors inside these
+ * are skipped because they are typically repeated across every page — checking them per
+ * page multiplies traffic to the same URLs and produces noisy, non-actionable findings.
+ *
+ * Covers three shapes seen in practice:
+ *   - Semantic HTML5 tags: `<header>`, `<footer>`
+ *   - ARIA landmarks: `role="banner"` (site header), `role="contentinfo"` (site footer)
+ *   - AEM Experience Fragment wrappers: `cmp-experiencefragment--header` /
+ *     `cmp-experiencefragment--footer`, emitted by AEM XFs on many enterprise sites
+ *     (including OneWalmart) that don't render semantic header/footer tags at all.
+ */
+const CHROME_ANCESTOR_SELECTOR = [
+  'header',
+  'footer',
+  '[role="banner"]',
+  '[role="contentinfo"]',
+  '.cmp-experiencefragment--header',
+  '.cmp-experiencefragment--footer',
+].join(', ');
+
+/**
  * Returns true only for status codes that definitively indicate a broken link.
  *
  * 404 (Not Found) and 410 (Gone) mean the content does not exist — unambiguously broken.
@@ -147,8 +168,8 @@ export async function runLinksChecks(urls, scrapedObjects, context, options = {
 
         anchors.each((i, a) => {
           const $a = $(a);
-          // Skip links that are inside header or footer elements
-          if ($a.closest('header').length || $a.closest('footer').length) {
+          // Skip links inside page chrome (site header / footer). See CHROME_ANCESTOR_SELECTOR.
+          if ($a.closest(CHROME_ANCESTOR_SELECTOR).length) {
             return;
           }
 

--- a/test/preflight/links-checks.test.js
+++ b/test/preflight/links-checks.test.js
@@ -412,7 +412,7 @@ describe('preflight/links-checks - runLinksChecks', () => {
   it('skips links inside AEM experience-fragment header/footer wrappers', async () => {
     fetchStub.resolves(makeResponse(404));
 
-    await runLinksChecks(
+    const result = await runLinksChecks(
       [pageUrl],
       makeScrapedObjects(`
         <div class="cmp-experiencefragment cmp-experiencefragment--header">
@@ -433,5 +433,7 @@ describe('preflight/links-checks - runLinksChecks', () => {
     // Only the <main> content link should be fetched — XF header/footer links are skipped.
     expect(fetchStub.callCount).to.equal(1);
     expect(fetchStub.firstCall.args[0]).to.equal('https://other.com/article');
+    expect(result.auditResult.brokenExternalLinks).to.have.lengthOf(1);
+    expect(result.auditResult.brokenExternalLinks[0].urlTo).to.equal('https://other.com/article');
   });
 });

--- a/test/preflight/links-checks.test.js
+++ b/test/preflight/links-checks.test.js
@@ -392,4 +392,46 @@ describe('preflight/links-checks - runLinksChecks', () => {
     expect(fetchStub.callCount).to.equal(0);
     expect(result.auditResult.brokenExternalLinks).to.have.lengthOf(0);
   });
+
+  it('skips links inside ARIA banner and contentinfo landmarks', async () => {
+    fetchStub.resolves(makeResponse(404));
+
+    const result = await runLinksChecks(
+      [pageUrl],
+      makeScrapedObjects(`
+        <div role="banner"><a href="https://other.com/nav">nav</a></div>
+        <div role="contentinfo"><a href="https://other.com/footer">footer</a></div>
+      `),
+      context,
+    );
+
+    expect(fetchStub.callCount).to.equal(0);
+    expect(result.auditResult.brokenExternalLinks).to.have.lengthOf(0);
+  });
+
+  it('skips links inside AEM experience-fragment header/footer wrappers', async () => {
+    fetchStub.resolves(makeResponse(404));
+
+    await runLinksChecks(
+      [pageUrl],
+      makeScrapedObjects(`
+        <div class="cmp-experiencefragment cmp-experiencefragment--header">
+          <div class="header">
+            <a href="https://outlook.example.com/owa/">email</a>
+          </div>
+        </div>
+        <div class="cmp-experiencefragment cmp-experiencefragment--footer">
+          <div class="footer">
+            <a href="https://x.com/example">social</a>
+          </div>
+        </div>
+        <main><a href="https://other.com/article">content</a></main>
+      `),
+      context,
+    );
+
+    // Only the <main> content link should be fetched — XF header/footer links are skipped.
+    expect(fetchStub.callCount).to.equal(1);
+    expect(fetchStub.firstCall.args[0]).to.equal('https://other.com/article');
+  });
 });


### PR DESCRIPTION
## Summary

- The preflight links audit skips anchors inside page chrome so repeated header/footer links don't get checked on every page. The previous guard used `closest('header') || closest('footer')`, which only matches semantic HTML5 tags — so sites expressing chrome with other markup (AEM Experience Fragments, ARIA landmarks) bypassed the skip and had every chrome link link-checked as if it were content.
- On the OneWalmart intranet (`one.walmart.com`), the page renders no semantic `<header>` or `<footer>` at all — the chrome is a pair of AEM XF wrappers (`.cmp-experiencefragment--header` / `--footer`) around `<div class="header">` / `<div class="footer">`. Social links, SSO gateways (`pfedprod.wal-mart.com`), the OWA email link, etc. were all being fetched server-side, and several of those return 4xx/5xx to non-browser UAs.
- Broaden the skip to cover three shapes: semantic tags, ARIA landmarks (`role="banner"` / `role="contentinfo"`), and AEM XF header/footer classes. Shape list is kept explicit in `CHROME_ANCESTOR_SELECTOR` with comments explaining each.

Fixes [SITES-43574](https://jira.corp.adobe.com/browse/SITES-43574).

Related prior work:
- #2207 (v1.388.3) — stopped 400/401 from being classified as broken; still the right call, but didn't address pages where chrome links were being checked in the first place.
- #1007 — introduced the original semantic-tag skip.

## Test plan

- [x] Existing `skips links inside header and footer elements` test still passes
- [x] New test: `skips links inside ARIA banner and contentinfo landmarks`
- [x] New test: `skips links inside AEM experience-fragment header/footer wrappers` — uses Walmart-representative markup, asserts only the main-body link is fetched
- [x] `npm run test:spec -- test/preflight/links-checks.test.js` — 23 passing, 100% coverage on `src/preflight/links-checks.js`
- [x] `npx eslint src/preflight/links-checks.js test/preflight/links-checks.test.js` — clean
- [ ] Post-merge: re-run preflight against a one.walmart.com page and confirm chrome links no longer appear in the Links section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
