### PR TITLE
feat: ensure Sitemap audit can go gracefully into "slow mode"

### DIFF
--- a/src/sitemap/common.js
+++ b/src/sitemap/common.js
@@ -33,18 +33,17 @@ export const PAGE_URL_TIMEOUT_MS = 10000; // 10 seconds
 
 // "Fast" batching when fetching/validating page URLs
 export const FAST_MAX_PAGE_URLS_PROBED = 10000; // max total, proportioned across sitemaps
-export const FAST_PAGE_URL_BATCH_SIZE = 700; // must stay under 1000
+export const FAST_PAGE_URL_BATCH_SIZE = 700; // must stay under 1000 per SpaceCat arch
 export const FAST_PAGE_URL_BATCH_DELAY_MS = 0; // none
 
 // Dynamic switch from fast → slow page-URL batching when 'otherStatus' dominates
 export const PAGE_URL_OTHER_STATUS_SLOWDOWN_MIN_URLS = 10; // min probes before evaluating the ratio
 export const PAGE_URL_OTHER_STATUS_SLOWDOWN_RATIO = 0.6; // once we hit 60%+ we switch
+export const SLOW_MODE_ENTRY_DELAY_MS = 300_000; // long pause for WAF when switching into slow mode
 
 // "Slow" batching when fetching/validating page URLs
-//   ex: approx 10 probes per second, and assuming 0.5 seconds per probe to complete,
-//       then 1000 probes will take about 8.3 minutes (which is 8 min and 20 sec)
 export const SLOW_MAX_PAGE_URLS_PROBED = 1000; // smaller set to use when running slow
-export const SLOW_PAGE_URL_BATCH_SIZE = 1; // must stay under 1000
+export const SLOW_PAGE_URL_BATCH_SIZE = 4; // must stay under 1000 per SpaceCat arch
 export const SLOW_PAGE_URL_BATCH_DELAY_MS = 100; // 0.1 of a second delay between batches
 
 // ----- internal constants ----------------------------------------------------
@@ -97,6 +96,29 @@ function delay(ms) {
 }
 
 /**
+ * Returns a function that enforces a minimum interval between the start of consecutive requests.
+ * When in slowdown mode, this allows us to honor the slower rate of requests to the webserver.
+ * Note that a given probe of a page URL might use a HEAD request, followed by a GET request.
+ *
+ * @param {number} intervalMs
+ * @returns {(() => Promise<void>) | null}
+ */
+function createPageUrlHttpRequestThrottle(intervalMs) {
+  if (intervalMs == null || intervalMs <= 0) {
+    return null;
+  }
+  let nextAllowedAt = 0;
+  return async function beforeHttpRequest() {
+    const now = Date.now();
+    const waitMs = Math.max(0, nextAllowedAt - now);
+    if (waitMs > 0) {
+      await delay(waitMs);
+    }
+    nextAllowedAt = Date.now() + intervalMs;
+  };
+}
+
+/**
  * After {@link applyPageUrlProbeSampling}, further cap how many page URLs we probe per sitemap
  * while in slow mode: floor(length * SLOW_MAX / FAST_MAX), at least 1 when non-empty.
  *
@@ -115,14 +137,29 @@ export function slicePageUrlsForSlowProbeSampling(urls) {
 /**
  * Helper function to initially try a HEAD request.
  * If HEAD returns a status code that is in our "fallback" list, then retry with GET.
- * Uses `options.timeout` to bound these requests.
+ *
+ * `options`
+ * - `options.beforeRequest` if present, is invoked before each outbound request (HEAD, with a
+ *   possible GET fallback) so callers can enforce spacing between requests when probing page URLs.
+ * - `options.timeout` max wait for each request to finish (default {@link PAGE_URL_TIMEOUT_MS}).
+ *
+ * @returns {Promise<Response>} A promise that resolves to the Response from the HEAD request
+ *   unless the HEAD response status is in the configured fallback list (e.g. 403, 404, 405, 501),
+ *   in which case this function will attempt a GET and resolve with that GET Response instead.
+ *
+ *   Notes on what is returned:
+ *   - If the initial HEAD call throws (network error / timeout), the promise will reject with
+ *     that error (the error is not caught inside this function).
+ *   - If HEAD returns a fallback status but the GET attempt throws, this function will return
+ *     the original HEAD Response object (so callers can inspect the original status code).
  */
 export async function fetchWithHeadFallback(url, options = {}) {
-  // Ensure we only wait a limited amount of time for the response to our request.
-  const timeout = options.timeout ?? PAGE_URL_TIMEOUT_MS;
-  const fetchOptions = { ...options, timeout };
+  const { beforeRequest, ...rest } = options; // the `beforeRequest` function
+  const timeout = rest.timeout ?? PAGE_URL_TIMEOUT_MS;
+  const fetchOptions = { ...rest, timeout }; // ensure our `timeout` is used
 
-  // note: this could throw an exception for network errors
+  await beforeRequest?.(); // if present, deliberately wait before sending this request
+  // note: the `fetch` could throw an exception for network errors or for timing out
   const headResponse = await fetch(url, {
     ...fetchOptions,
     method: 'HEAD',
@@ -131,6 +168,7 @@ export async function fetchWithHeadFallback(url, options = {}) {
   // If HEAD fails with a known "fallback" status code, retry with GET
   if (HEAD_FALLBACK_STATUSES.includes(headResponse.status)) {
     try {
+      await beforeRequest?.(); // if present, deliberately wait before sending this request
       // return whatever we receive from GET
       return await fetch(url, {
         ...fetchOptions,
@@ -193,6 +231,8 @@ export function formatUrlProbeErrorDetail(err) {
  * @param {null} [pageUrlBatchOptions] - Optional page-URL probe batching parameters
  * @param {number} [pageUrlBatchOptions.pageUrlBatchSize] - defaults to use "fast" value
  * @param {number} [pageUrlBatchOptions.pageUrlBatchDelayMs] - defaults to use "fast" value
+ * @param {number} [pageUrlBatchOptions.pageUrlHttpRequestIntervalMs] - when set, minimum spacing
+ *        between each HTTP request made while probing (HEAD, GET fallback, redirect checks)
  *
  * @returns {Promise<{
  *   ok: string[], // Array of URLs
@@ -217,10 +257,17 @@ export async function filterValidUrls(
     return results; // empty
   }
 
+  // if specified, build the `beforeRequest` callback to force a delay between HTTP requests
+  const beforeRequest = createPageUrlHttpRequestThrottle(
+    pageUrlBatchOptions?.pageUrlHttpRequestIntervalMs,
+  );
+  const probeFetchOpts = beforeRequest ? { beforeRequest } : {};
+
   // callback to validate a specific URL
   const checkUrl = async (url) => {
     try {
       const response = await fetchWithHeadFallback(url, {
+        ...probeFetchOpts, // == beforeRequest: callbackFunction
         redirect: 'manual', // so we can watch if we go to an auth or a login page
         timeout: timeoutMs,
       });
@@ -259,7 +306,8 @@ export async function filterValidUrls(
           return {
             type: 'notOk',
             url,
-            statusCode: response.status,
+            statusCode: response.status, // redirected
+            urlsSuggested: '', // no reasonable suggestion available
           };
         }
 
@@ -270,6 +318,7 @@ export async function filterValidUrls(
           redirectResponse = await fetchWithHeadFallback(firstHopUrl, {
             redirect: 'follow',
             timeout: timeoutMs,
+            ...probeFetchOpts,
           });
 
           const resolvedUrl = redirectResponse.url?.trim();
@@ -306,14 +355,14 @@ export async function filterValidUrls(
 
         if (firstHopDiffersFromProbed && !terminalClearlyBad) {
           log?.debug(
-            `Sitemap: recommending first-hop redirect target instead of validated terminal URL for ${url}; `
+            `Sitemap: recommending first-hop redirect target instead of terminal URL for ${url}; `
             + `first hop: ${firstHopUrl}, terminal candidate: ${terminalUrl}, `
             + `terminal response status: ${redirectResponse?.status ?? 'error'}.`,
           );
           return {
             type: 'notOk',
             url,
-            statusCode: response.status,
+            statusCode: response.status, // redirected
             urlsSuggested: firstHopUrl, // suggest a reasonable URL
           };
         }

--- a/src/sitemap/handler.js
+++ b/src/sitemap/handler.js
@@ -22,11 +22,13 @@ import {
   PAGE_URL_OTHER_STATUS_SLOWDOWN_MIN_URLS,
   PAGE_URL_OTHER_STATUS_SLOWDOWN_RATIO,
   PAGE_URL_TIMEOUT_MS,
+  SLOW_MODE_ENTRY_DELAY_MS,
   SLOW_PAGE_URL_BATCH_DELAY_MS,
   SLOW_PAGE_URL_BATCH_SIZE,
   slicePageUrlsForSlowProbeSampling,
 } from './common.js';
 import { AuditBuilder } from '../common/audit-builder.js';
+import { sleep } from '../support/utils.js';
 import { noopUrlResolver } from '../common/base-audit.js';
 import { syncSuggestions } from '../utils/data-access.js';
 import { convertToOpportunity } from '../common/opportunity.js';
@@ -39,6 +41,7 @@ const TRACKED_STATUS_CODES = Object.freeze([301, 302, 404]);
 const SLOW_PAGE_URL_BATCH_OPTIONS = Object.freeze({
   pageUrlBatchSize: SLOW_PAGE_URL_BATCH_SIZE,
   pageUrlBatchDelayMs: SLOW_PAGE_URL_BATCH_DELAY_MS,
+  pageUrlHttpRequestIntervalMs: SLOW_PAGE_URL_BATCH_DELAY_MS,
 });
 
 /**
@@ -125,15 +128,19 @@ export async function findSitemap(inputUrl, log) {
             useSlowPageUrlProbing = true;
             // inform about this decision to slow down and echo the stats that triggered it
             const pct = (slowdownStats.ratio * 100).toFixed(0);
-            log?.info(`* Sitemap: slowing down page URL probing starting with sitemap ${sitemapUrl} due to high count of 'otherStatus' codes: ${slowdownStats.otherCount} out of ${slowdownStats.total} (${pct}%)`);
+            log?.warn(`* Sitemap: slowing down page URL probing starting with sitemap ${sitemapUrl} due to high count of 'otherStatus' codes: ${slowdownStats.otherCount} out of ${slowdownStats.total} (${pct}%)`);
             urlsToProbe = slicePageUrlsForSlowProbeSampling(urlsFromSampling); // re-do current set
             const slowCapRetainPct = urlsFromSampling.length > 0
               ? ((100 * urlsToProbe.length) / urlsFromSampling.length).toFixed(0)
               : '0';
-            log?.info(`* Sitemap: since we are going slower, the slow probe uses ~${slowCapRetainPct}% of our original "fast" sampled page URLs (${urlsToProbe.length} of ${urlsFromSampling.length})`);
+            log?.warn(`* Sitemap: since we are going slower, the slow probe uses ~${slowCapRetainPct}% of our original "fast" sampled page URLs (ex: ${urlsToProbe.length} of ${urlsFromSampling.length} from this current sitemap)`);
+            log?.warn(`* Sitemap: pausing ${SLOW_MODE_ENTRY_DELAY_MS / 1000}s for anticipated WAF rules before slow page URL re-probe for sitemap ${sitemapUrl}`);
+            // eslint-disable-next-line no-await-in-loop
+            await sleep(SLOW_MODE_ENTRY_DELAY_MS); // allow any WAF blockage to cool off
+            log?.warn(`* Sitemap: slow pausing complete; resuming page URL re-probe for sitemap ${sitemapUrl}`);
             // eslint-disable-next-line no-await-in-loop
             existingPages = await filterValidUrls(
-              urlsToProbe, // now using the "slow probe" set
+              urlsToProbe, // re-do, but now using the smaller "slow probe" set
               log,
               PAGE_URL_TIMEOUT_MS,
               SLOW_PAGE_URL_BATCH_OPTIONS,

--- a/test/audits/sitemap.test.js
+++ b/test/audits/sitemap.test.js
@@ -41,6 +41,7 @@ import {
   FAST_PAGE_URL_BATCH_DELAY_MS,
   SLOW_PAGE_URL_BATCH_SIZE,
   SLOW_PAGE_URL_BATCH_DELAY_MS,
+  SLOW_MODE_ENTRY_DELAY_MS,
   urlLooksLike404Page,
   formatUrlProbeErrorDetail,
 } from '../../src/sitemap/common.js';
@@ -272,6 +273,16 @@ describe('Sitemap Audit', () => {
 
       const response = await fetchWithHeadFallback(`${url}/head-501`, {});
       expect(response.status).to.equal(200);
+    });
+
+    it('should call beforeRequest before HEAD and before GET fallback', async () => {
+      nock(url).head('/spaced').reply(404);
+      nock(url).get('/spaced').reply(200);
+
+      const beforeRequest = sandbox.spy(async () => {});
+      const response = await fetchWithHeadFallback(`${url}/spaced`, { beforeRequest });
+      expect(response.status).to.equal(200);
+      expect(beforeRequest).to.have.been.calledTwice;
     });
   });
 
@@ -818,6 +829,7 @@ describe('Sitemap Audit', () => {
       const slowBatchOpts = {
         pageUrlBatchSize: SLOW_PAGE_URL_BATCH_SIZE,
         pageUrlBatchDelayMs: SLOW_PAGE_URL_BATCH_DELAY_MS,
+        pageUrlHttpRequestIntervalMs: SLOW_PAGE_URL_BATCH_DELAY_MS,
       };
 
       it('re-probes with slow batching when otherStatus share is >= 60% with at least 10 URLs', async () => {
@@ -848,6 +860,7 @@ describe('Sitemap Audit', () => {
           otherStatusCodes: [],
         });
 
+        const sleepStub = sandbox.stub().resolves();
         const { findSitemap: findSitemapMocked } = await esmock('../../src/sitemap/handler.js', {
           '../../src/sitemap/common.js': {
             applyPageUrlProbeSampling,
@@ -858,11 +871,18 @@ describe('Sitemap Audit', () => {
             slicePageUrlsForSlowProbeSampling,
             SLOW_PAGE_URL_BATCH_DELAY_MS,
             SLOW_PAGE_URL_BATCH_SIZE,
+            SLOW_MODE_ENTRY_DELAY_MS,
+          },
+          '../../src/support/utils.js': {
+            sleep: sleepStub,
           },
         });
 
-        const result = await findSitemapMocked(url, { info: () => {}, debug: () => {} });
+        const result = await findSitemapMocked(url, {
+          info: () => {}, debug: () => {}, warn: () => {},
+        });
         expect(result.success).to.equal(true);
+        expect(sleepStub).to.have.been.calledOnceWith(SLOW_MODE_ENTRY_DELAY_MS);
         expect(filterStub).to.have.been.calledTwice;
         expect(filterStub.firstCall.args[3]).to.equal(null);
         expect(filterStub.secondCall.args[0]).to.deep.equal([tenUrls[0]]);
@@ -904,6 +924,7 @@ describe('Sitemap Audit', () => {
 
         const log = { info: sandbox.stub(), warn: sandbox.stub(), debug: sandbox.stub(), error: sandbox.stub() };
 
+        const sleepStub = sandbox.stub().resolves();
         const { findSitemap: findSitemapMocked } = await esmock('../../src/sitemap/handler.js', {
           '../../src/sitemap/common.js': {
             applyPageUrlProbeSampling,
@@ -914,21 +935,28 @@ describe('Sitemap Audit', () => {
             slicePageUrlsForSlowProbeSampling,
             SLOW_PAGE_URL_BATCH_DELAY_MS,
             SLOW_PAGE_URL_BATCH_SIZE,
+            SLOW_MODE_ENTRY_DELAY_MS,
+          },
+          '../../src/support/utils.js': {
+            sleep: sleepStub,
           },
         });
 
         await findSitemapMocked(url, log);
+        expect(sleepStub).to.have.been.calledOnceWith(SLOW_MODE_ENTRY_DELAY_MS);
         expect(filterStub).to.have.been.calledThrice;
         expect(filterStub.secondCall.args[0]).to.deep.equal([tenUrlsA[0]]);
         expect(filterStub.thirdCall.args[0]).to.have.length(10);
         expect(filterStub.thirdCall.args[3]).to.deep.equal(slowBatchOpts);
         const summaryMsg = log.info.getCalls().map((c) => c.args[0]).find((m) => typeof m === 'string' && m.includes('slow page URL probing summary'));
         expect(summaryMsg).to.include('otherStatus codes: 6 of 11 page URLs probed slowly (55%)');
-        expect(log.warn).to.have.been.calledOnce;
-        expect(log.warn.firstCall.args[0]).to.include(sitemapB);
-        expect(log.warn.firstCall.args[0]).to.include(`'otherStatus' count=6`);
-        expect(log.warn.firstCall.args[0]).to.include('total count=10');
-        expect(log.warn.firstCall.args[0]).to.include('(60%)');
+        const highOtherWarns = log.warn.getCalls().filter((c) => typeof c.args[0] === 'string'
+          && c.args[0].includes('remains high')
+          && c.args[0].includes(sitemapB));
+        expect(highOtherWarns).to.have.lengthOf(1);
+        expect(highOtherWarns[0].args[0]).to.include(`'otherStatus' count=6`);
+        expect(highOtherWarns[0].args[0]).to.include('total count=10');
+        expect(highOtherWarns[0].args[0]).to.include('(60%)');
       });
 
       it('does not switch to slow when fewer than 10 URLs are probed', async () => {
@@ -995,6 +1023,7 @@ describe('Sitemap Audit', () => {
 
         const log = { info: sandbox.stub(), warn: sandbox.stub(), debug: sandbox.stub(), error: sandbox.stub() };
 
+        const sleepStub = sandbox.stub().resolves();
         const { findSitemap: findSitemapMocked } = await esmock('../../src/sitemap/handler.js', {
           '../../src/sitemap/common.js': {
             applyPageUrlProbeSampling,
@@ -1005,13 +1034,21 @@ describe('Sitemap Audit', () => {
             slicePageUrlsForSlowProbeSampling,
             SLOW_PAGE_URL_BATCH_DELAY_MS,
             SLOW_PAGE_URL_BATCH_SIZE,
+            SLOW_MODE_ENTRY_DELAY_MS,
+          },
+          '../../src/support/utils.js': {
+            sleep: sleepStub,
           },
         });
 
         await findSitemapMocked(url, log);
+        expect(sleepStub).to.have.been.calledOnceWith(SLOW_MODE_ENTRY_DELAY_MS);
         expect(filterStub).to.have.been.calledTwice;
         expect(filterStub.secondCall.args[0]).to.have.length(10);
-        expect(log.warn).to.have.been.calledOnce;
+        const stillHighWarns = log.warn.getCalls().filter((c) => typeof c.args[0] === 'string'
+          && c.args[0].includes('remains high')
+          && c.args[0].includes('still.xml'));
+        expect(stillHighWarns).to.have.lengthOf(1);
         const summaryMsg = log.info.getCalls().map((c) => c.args[0]).find((m) => typeof m === 'string' && m.includes('slow page URL probing summary'));
         expect(summaryMsg).to.include('otherStatus codes: 6 of 10 page URLs probed slowly (60%)');
       });
@@ -1054,6 +1091,7 @@ describe('Sitemap Audit', () => {
           otherStatusCodes: [],
         });
 
+        const sleepStub = sandbox.stub().resolves();
         const { findSitemap: findSitemapMocked } = await esmock('../../src/sitemap/handler.js', {
           '../../src/sitemap/common.js': {
             applyPageUrlProbeSampling,
@@ -1064,10 +1102,15 @@ describe('Sitemap Audit', () => {
             slicePageUrlsForSlowProbeSampling,
             SLOW_PAGE_URL_BATCH_DELAY_MS,
             SLOW_PAGE_URL_BATCH_SIZE,
+            SLOW_MODE_ENTRY_DELAY_MS,
+          },
+          '../../src/support/utils.js': {
+            sleep: sleepStub,
           },
         });
 
         await findSitemapMocked(url, { info: () => {}, warn: sandbox.stub(), debug: () => {} });
+        expect(sleepStub).to.have.been.calledOnceWith(SLOW_MODE_ENTRY_DELAY_MS);
         expect(filterStub).to.have.been.calledThrice;
         expect(filterStub.secondCall.args[0]).to.deep.equal([tenUrlsA[0]]);
         expect(filterStub.thirdCall.args[0]).to.have.length(10);
@@ -2027,6 +2070,7 @@ describe('filterValidUrls with redirect handling', () => {
       .head('/redirect-to-404')
       .reply(301, '', { Location: 'https://example.com/not-found' });
     nock('https://example.com').head('/not-found').reply(404);
+    nock('https://example.com').get('/not-found').reply(404);
 
     // Redirect to a page that returns 200
     nock('https://example.com')
@@ -2045,6 +2089,7 @@ describe('filterValidUrls with redirect handling', () => {
       .head('/redirect-to-404')
       .reply(302, '', { Location: 'https://subdomain.example.com/not-found' });
     nock('https://subdomain.example.com').head('/not-found').reply(404);
+    nock('https://subdomain.example.com').get('/not-found').reply(404);
 
     const result = await filterValidUrls(urls);
 
@@ -2080,7 +2125,7 @@ describe('filterValidUrls with redirect handling', () => {
       .head('/broken-redirect')
       .reply(301, '', { Location: 'https://example.com/error' });
 
-    // Second request fails with network error (suggests invalid URL)
+    // Follow-up to validate redirect target fails before a usable terminal URL is known
     nock('https://example.com')
       .head('/error')
       .replyWithError('Network error');
@@ -2275,7 +2320,7 @@ describe('filterValidUrls with redirect handling', () => {
     });
   });
 
-  it('should omit urlsSuggested for redirects with no Location header', async () => {
+  it('should set urlsSuggested to empty string when redirect has no Location header', async () => {
     const urls = ['https://example.com/redirect-no-location'];
     nock('https://example.com')
       .head('/redirect-no-location')
@@ -2286,6 +2331,7 @@ describe('filterValidUrls with redirect handling', () => {
       {
         url: 'https://example.com/redirect-no-location',
         statusCode: 301,
+        urlsSuggested: '',
       },
     ]);
   });
@@ -2471,14 +2517,18 @@ describe('filterValidUrls with status code tracking', () => {
 
     // Mock validation requests for redirect targets
     nock('https://example.com').head('/404.html').reply(404);
+    nock('https://example.com').get('/404.html').reply(404);
     nock('https://example.com').head('/404/not-found').reply(404);
+    nock('https://example.com').get('/404/not-found').reply(404);
     nock('https://example.com').head('/errors/404/page').reply(404);
+    nock('https://example.com').get('/errors/404/page').reply(404);
     nock('https://example.com').head('/valid-page').reply(200);
 
     const result = await filterValidUrls(urls);
 
     expect(result.notOk).to.have.length(4);
 
+    // Redirects to clear 404 targets: no safe replacement URL
     const redirectsTo404 = result.notOk.filter(
       (item) => item.url.includes('redirect-to-404')
         || item.url.includes('redirect-to-errors-404'),
@@ -2544,7 +2594,7 @@ describe('filterValidUrls with HEAD to GET fallback', () => {
     expect(result.otherStatusCodes).to.be.empty;
   });
 
-  it('should record otherStatus when HEAD returns 403 and GET also returns 403', async () => {
+  it('should use GET fallback when HEAD returns 403 and classify final 403 as otherStatus', async () => {
     const urls = ['https://example.com/head-403'];
 
     nock('https://example.com').head('/head-403').reply(403);
@@ -2677,5 +2727,24 @@ describe('filterValidUrls with HEAD to GET fallback', () => {
 
     expect(result.networkErrors).to.have.length(1);
     expect(log.debug).to.have.been.calledWith(sinon.match(/network error/i));
+  });
+
+  it('should space HEAD and GET fallback when pageUrlHttpRequestIntervalMs is set', async () => {
+    const urls = ['https://example.com/slow-head-get'];
+    const intervalMs = 40;
+
+    nock('https://example.com').head('/slow-head-get').reply(404);
+    nock('https://example.com').get('/slow-head-get').reply(200);
+
+    const started = Date.now();
+    const result = await filterValidUrls(urls, undefined, PAGE_URL_TIMEOUT_MS, {
+      pageUrlBatchSize: SLOW_PAGE_URL_BATCH_SIZE,
+      pageUrlBatchDelayMs: SLOW_PAGE_URL_BATCH_DELAY_MS,
+      pageUrlHttpRequestIntervalMs: intervalMs,
+    });
+    const elapsed = Date.now() - started;
+
+    expect(result.ok).to.deep.equal(['https://example.com/slow-head-get']);
+    expect(elapsed).to.be.at.least(intervalMs - 5);
   });
 });


### PR DESCRIPTION
 * ensure proper pacing between HTTP requests
 * allow websites some time to "cool off" after they think the Sitemap audit is attacking them
