### PR TITLE
feat: disable HOTLCTR v1 flow

### DIFF
--- a/src/experimentation-opportunities/handler.js
+++ b/src/experimentation-opportunities/handler.js
@@ -30,6 +30,10 @@ export const HIGH_ORGANIC_LOW_CTR_OPPTY_TYPE = 'high-organic-low-ctr';
 export const RAGECLICK_OPPTY_TYPE = 'rageclick';
 export const HIGH_INORGANIC_HIGH_BOUNCE_RATE_OPPTY_TYPE = 'high-inorganic-high-bounce-rate';
 
+// KILL SWITCH: when true, HOTLCTR opportunities are not dispatched to Mystique
+// for any site. Flip to false (or revert this change) to re-enable.
+const HOTLCTR_DISABLED = true;
+
 const OPPTY_QUERIES = [
   RAGECLICK_OPPTY_TYPE,
   HIGH_INORGANIC_HIGH_BOUNCE_RATE_OPPTY_TYPE,
@@ -57,6 +61,11 @@ export async function generateOpportunityAndSuggestions(context) {
   const {
     log, sqs, env, site, audit,
   } = context;
+  if (HOTLCTR_DISABLED) {
+    log.info(`HOTLCTR is disabled — skipping Mystique dispatch for site ${site.getId()}, audit ${audit.getId()}`);
+    return;
+  }
+  /* c8 ignore start */
   const auditResult = audit.getAuditResult();
   log.debug('auditResult in generateOpportunityAndSuggestions: ', JSON.stringify(auditResult, null, 2));
 
@@ -85,6 +94,7 @@ export async function generateOpportunityAndSuggestions(context) {
     await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, message);
     log.debug(`Message sent to Mystique: ${JSON.stringify(message)}`);
   }
+  /* c8 ignore stop */
 }
 
 export function getHighOrganicLowCtrOpportunity(experimentationOpportunities) {

--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,10 @@ import deliveryConfigWriter from './delivery-config-writer/handler.js';
 import highFormViewsLowConversionsGuidance from './forms-opportunities/guidance-handlers/guidance-high-form-views-low-conversions.js';
 import highPageViewsLowFormNavGuidance from './forms-opportunities/guidance-handlers/guidance-high-page-views-low-form-nav.js';
 import highPageViewsLowFormViewsGuidance from './forms-opportunities/guidance-handlers/guidance-high-page-views-low-form-views.js';
-import highOrganicLowCtrGuidance from './experimentation-opportunities/guidance-high-organic-low-ctr-handler.js';
+// KILL SWITCH: HOTLCTR is disabled platform-wide; do not accept Mystique callbacks.
+// Re-enable by uncommenting this import and the HANDLERS entry below.
+// eslint-disable-next-line max-len
+// import highOrganicLowCtrGuidance from './experimentation-opportunities/guidance-high-organic-low-ctr-handler.js';
 import paidConsentGuidance from './paid-cookie-consent/guidance-handler.js';
 import noCTAAboveTheFoldGuidance from './no-cta-above-the-fold/guidance-handler.js';
 import paidTrafficAnalysisGuidance from './paid-traffic-analysis/guidance-handler.js';
@@ -149,7 +152,8 @@ const HANDLERS = {
   'llm-blocked': llmBlocked,
   'forms-opportunities': formsOpportunities,
   'site-detection': siteDetection,
-  'guidance:high-organic-low-ctr': highOrganicLowCtrGuidance,
+  // KILL SWITCH: HOTLCTR disabled — see import above.
+  // 'guidance:high-organic-low-ctr': highOrganicLowCtrGuidance,
   'guidance:broken-links': brokenLinksGuidance,
   'guidance:metatags': metatagsGuidance,
   'alt-text': imageAltText,

--- a/test/audits/experimentation-opportunities.test.js
+++ b/test/audits/experimentation-opportunities.test.js
@@ -335,7 +335,9 @@ describe('Experimentation Opportunities Tests', () => {
   });
 
   describe('Message Generation', () => {
-    it('sends messages for each high-organic-low-ctr opportunity to mystique', async () => {
+    // SKIP: HOTLCTR kill switch is active in handler.js (HOTLCTR_DISABLED).
+    // Re-enable this test when reverting the kill switch.
+    it.skip('sends messages for each high-organic-low-ctr opportunity to mystique', async () => {
       context.audit.getAuditResult.returns({
         experimentationOpportunities: [
           {
@@ -1063,7 +1065,8 @@ describe('Experimentation Opportunities Tests', () => {
         expect(context.sqs.sendMessage).to.not.have.been.called;
       });
 
-      it('should filter and process only high-organic-low-ctr opportunities', async () => {
+      // SKIP: HOTLCTR kill switch is active in handler.js. Re-enable on revert.
+      it.skip('should filter and process only high-organic-low-ctr opportunities', async () => {
         context.audit.getAuditResult.returns({
           experimentationOpportunities: [
             {
@@ -1088,7 +1091,9 @@ describe('Experimentation Opportunities Tests', () => {
         expect(message1.type).to.equal('guidance:high-organic-low-ctr');
       });
 
-      it('should handle completely undefined audit result', async () => {
+      // SKIP: HOTLCTR kill switch in handler.js short-circuits before reaching
+      // the "audit result is undefined" log. Re-enable on revert.
+      it.skip('should handle completely undefined audit result', async () => {
         context.audit.getAuditResult.returns(undefined);
 
         await generateOpportunityAndSuggestions(context);


### PR DESCRIPTION
Kill switch for the v1 high-organic-low-ctr (HOTLCTR) audit pipeline. Stops new HOTLCTR opportunities from being created and drops in-flight Mystique guidance callbacks. Existing opportunities in the database are untouched. Reversible by removing the marked KILL SWITCH blocks.

- handler.js: early-return in generateOpportunityAndSuggestions guarded by HOTLCTR_DISABLED constant; SQS dispatch to Mystique skipped.
- index.js: guidance:high-organic-low-ctr handler unregistered.
- test: three v1-flow tests skipped with revert markers.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
