### PR TITLE
fix(cdn-logs-report): set FIFO attributes on agentic analytics publish

### DIFF
--- a/src/cdn-logs-report/agentic-daily-export.js
+++ b/src/cdn-logs-report/agentic-daily-export.js
@@ -154,12 +154,14 @@ async function dispatchAnalyticsEvent({
     throw new Error('analytics queue is not configured');
   }
 
+  const pipelineId = 'agentic_traffic';
+  const siteId = site.getId();
   const message = {
     type: 'batch.completed',
     correlationId: batchId,
-    pipeline_id: 'agentic_traffic',
+    pipeline_id: pipelineId,
     s3_uri: bundleUri,
-    site_id: site.getId(),
+    site_id: siteId,
     start_date: trafficDate,
     end_date: trafficDate,
     row_count: rowCount,
@@ -169,12 +171,23 @@ async function dispatchAnalyticsEvent({
     message.org_id = site.getOrganizationId();
   }
 
-  await context.sqs.sendMessage(queueUrl, message);
+  // Analytics ingestion queue is FIFO with content-based deduplication
+  // disabled. Group key follows the (pipeline_id, site_id) convention from
+  // spacecat-infrastructure#480 so concurrent imports for the same scope
+  // serialize, while different sites/pipelines run in parallel. Dedup key
+  // is batchId — unique per attempt, replays inside the SQS 5-minute dedup
+  // window collapse.
+  const messageGroupId = `${pipelineId}:${siteId}`;
+  const messageDeduplicationId = batchId;
+
+  await context.sqs.sendMessage(queueUrl, message, messageGroupId, 0, messageDeduplicationId);
 
   return {
     queueUrl,
     messageType: message.type,
     pipelineId: message.pipeline_id,
+    messageGroupId,
+    messageDeduplicationId,
   };
 }
 

--- a/src/support/sqs.js
+++ b/src/support/sqs.js
@@ -24,7 +24,7 @@ class SQS {
     this.context = context;
   }
 
-  async sendMessage(queueUrl, message, msgGroupId, delaySeconds = 0) {
+  async sendMessage(queueUrl, message, msgGroupId, delaySeconds = 0, msgDedupId = undefined) {
     const body = {
       ...message,
       timestamp: new Date().toISOString(),
@@ -40,19 +40,28 @@ class SQS {
     // Uses type (opptyType) as the group identifier to ensure per-audit-type fairness.
     const resolvedGroupId = msgGroupId || body.type || undefined;
 
-    const asJSON = JSON.stringify(body);
-    const msgCommand = new SendMessageCommand({
-      MessageBody: asJSON,
+    const params = {
+      MessageBody: JSON.stringify(body),
       QueueUrl: queueUrl,
       MessageGroupId: resolvedGroupId,
       DelaySeconds: delaySeconds,
-    });
+    };
+
+    // FIFO queues with content-based deduplication disabled require an explicit
+    // MessageDeduplicationId on every publish. Only set when the caller provides
+    // one — standard queues reject the attribute, and FIFO queues with
+    // content-based dedup don't need it.
+    if (msgDedupId) {
+      params.MessageDeduplicationId = msgDedupId;
+    }
+
+    const msgCommand = new SendMessageCommand(params);
 
     try {
       const data = await this.sqsClient.send(msgCommand);
       const queueName = queueUrl?.split('/').pop() || 'unknown';
       const messageType = body.type || 'unknown';
-      this.log.info(`Success, message sent. Queue: ${queueName}, Type: ${messageType}, MessageID: ${data.MessageId}${body.traceId ? `, TraceID: ${body.traceId}` : ''}${resolvedGroupId ? `, GroupID: ${resolvedGroupId}` : ''}`);
+      this.log.info(`Success, message sent. Queue: ${queueName}, Type: ${messageType}, MessageID: ${data.MessageId}${body.traceId ? `, TraceID: ${body.traceId}` : ''}${resolvedGroupId ? `, GroupID: ${resolvedGroupId}` : ''}${msgDedupId ? `, DedupID: ${msgDedupId}` : ''}`);
     } catch (e) {
       const { type, code, message: msg } = e;
       this.log.error(`Message send failed. Type: ${type}, Code: ${code}, Message: ${msg}`, e);

--- a/src/support/sqs.js
+++ b/src/support/sqs.js
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 import { SendMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
+import { hasText } from '@adobe/spacecat-shared-utils';
 
 /**
  * @class SQS utility to send messages to SQS
@@ -22,6 +23,10 @@ class SQS {
     this.sqsClient = new SQSClient({ region });
     this.log = log;
     this.context = context;
+  }
+
+  static #isFifoQueue(queueUrl) {
+    return hasText(queueUrl) && queueUrl.toLowerCase().endsWith('.fifo');
   }
 
   async sendMessage(queueUrl, message, msgGroupId, delaySeconds = 0, msgDedupId = undefined) {
@@ -48,10 +53,10 @@ class SQS {
     };
 
     // FIFO queues with content-based deduplication disabled require an explicit
-    // MessageDeduplicationId on every publish. Only set when the caller provides
-    // one — standard queues reject the attribute, and FIFO queues with
-    // content-based dedup don't need it.
-    if (msgDedupId) {
+    // MessageDeduplicationId on every publish. Gate on the FIFO suffix so the
+    // same code is safe both before and after a queue is converted to FIFO —
+    // standard queues reject MessageDeduplicationId with InvalidParameterValue.
+    if (msgDedupId && SQS.#isFifoQueue(queueUrl)) {
       params.MessageDeduplicationId = msgDedupId;
     }
 

--- a/test/audits/cdn-logs-report/agentic-daily-export.test.js
+++ b/test/audits/cdn-logs-report/agentic-daily-export.test.js
@@ -159,6 +159,9 @@ describe('agentic daily export', () => {
         end_date: '2026-03-31',
         row_count: 1,
       }),
+      'agentic_traffic:9ae8877a-bbf3-407d-9adb-d6a72ce3c5e3',
+      0,
+      'batch-123',
     );
     expect(result).to.include({
       enabled: true,
@@ -219,6 +222,36 @@ describe('agentic daily export', () => {
       trafficDate: '2026-03-31',
       rowCount: 1,
     })).to.be.rejectedWith('analytics queue is not configured');
+  });
+
+  it('dispatches with FIFO MessageGroupId and MessageDeduplicationId', async () => {
+    const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js');
+    const sendMessage = sandbox.stub().resolves();
+
+    const result = await module.testHelpers.dispatchAnalyticsEvent({
+      context: { sqs: { sendMessage } },
+      queueUrl: 'https://sqs.us-east-1.amazonaws.com/123/analytics-queue.fifo',
+      site: {
+        getId: () => 'site-1',
+        getOrganizationId: () => 'org-1',
+      },
+      batchId: 'batch-uuid-abc',
+      bundleUri: 's3://bucket/agentic-traffic-daily-export/site-1/agentic-traffic/2026/03/31/20260401T100000000Z/',
+      trafficDate: '2026-03-31',
+      rowCount: 7,
+    });
+
+    expect(sendMessage).to.have.been.calledOnceWith(
+      'https://sqs.us-east-1.amazonaws.com/123/analytics-queue.fifo',
+      sinon.match({ pipeline_id: 'agentic_traffic', site_id: 'site-1', row_count: 7 }),
+      'agentic_traffic:site-1',
+      0,
+      'batch-uuid-abc',
+    );
+    expect(result).to.include({
+      messageGroupId: 'agentic_traffic:site-1',
+      messageDeduplicationId: 'batch-uuid-abc',
+    });
   });
 
   it('requires an importer bucket before running the daily export', async () => {

--- a/test/support/sqs.test.js
+++ b/test/support/sqs.test.js
@@ -234,6 +234,71 @@ describe('sqs', () => {
     }).with(sqsWrapper)({}, context);
   });
 
+  it('includes MessageDeduplicationId when an explicit msgDedupId is provided', async () => {
+    const message = { type: 'agentic_traffic', key: 'value' };
+    const queueUrl = 'https://sqs.us-east-1.amazonaws.com/123456789/analytics-queue.fifo';
+
+    nock('https://sqs.us-east-1.amazonaws.com')
+      .post('/')
+      .reply(200, (_, body) => {
+        const parsed = JSON.parse(body);
+        expect(parsed.MessageDeduplicationId).to.equal('batch-uuid-abc');
+        expect(parsed.MessageGroupId).to.equal('agentic_traffic:site-1');
+        return {
+          MessageId: 'message-id',
+          MD5OfMessageBody: crypto.createHash('md5').update(parsed.MessageBody, 'utf-8').digest('hex'),
+        };
+      });
+
+    await wrap(async (req, ctx) => {
+      await ctx.sqs.sendMessage(queueUrl, message, 'agentic_traffic:site-1', 0, 'batch-uuid-abc');
+    }).with(sqsWrapper)({}, context);
+  });
+
+  it('omits MessageDeduplicationId when no msgDedupId is provided', async () => {
+    const message = { type: 'agentic_traffic', key: 'value' };
+    const queueUrl = 'https://sqs.us-east-1.amazonaws.com/123456789/analytics-queue.fifo';
+
+    nock('https://sqs.us-east-1.amazonaws.com')
+      .post('/')
+      .reply(200, (_, body) => {
+        const parsed = JSON.parse(body);
+        expect(parsed.MessageDeduplicationId).to.be.undefined;
+        return {
+          MessageId: 'message-id',
+          MD5OfMessageBody: crypto.createHash('md5').update(parsed.MessageBody, 'utf-8').digest('hex'),
+        };
+      });
+
+    await wrap(async (req, ctx) => {
+      await ctx.sqs.sendMessage(queueUrl, message);
+    }).with(sqsWrapper)({}, context);
+  });
+
+  it('includes DedupID in log when msgDedupId is set', async () => {
+    const message = { type: 'agentic_traffic', key: 'value' };
+    const queueUrl = 'https://sqs.us-east-1.amazonaws.com/123456789/analytics-queue.fifo';
+    const logSpy = sandbox.spy(context.log, 'info');
+
+    nock('https://sqs.us-east-1.amazonaws.com')
+      .post('/')
+      .reply(200, (_, body) => {
+        const { MessageBody } = JSON.parse(body);
+        return {
+          MessageId: 'message-id',
+          MD5OfMessageBody: crypto.createHash('md5').update(MessageBody, 'utf-8').digest('hex'),
+        };
+      });
+
+    await wrap(async (req, ctx) => {
+      await ctx.sqs.sendMessage(queueUrl, message, 'agentic_traffic:site-1', 0, 'batch-uuid-abc');
+    }).with(sqsWrapper)({}, context);
+
+    expect(logSpy).to.have.been.calledWith(
+      'Success, message sent. Queue: analytics-queue.fifo, Type: agentic_traffic, MessageID: message-id, GroupID: agentic_traffic:site-1, DedupID: batch-uuid-abc',
+    );
+  });
+
   it('includes GroupID in log when MessageGroupId is set', async () => {
     const message = { type: 'accessibility', key: 'value' };
     const queueUrl = 'https://sqs.us-east-1.amazonaws.com/123456789/test-queue';

--- a/test/support/sqs.test.js
+++ b/test/support/sqs.test.js
@@ -275,6 +275,31 @@ describe('sqs', () => {
     }).with(sqsWrapper)({}, context);
   });
 
+  it('omits MessageDeduplicationId on a standard (non-.fifo) queue even if msgDedupId is provided', async () => {
+    // Standard queues reject MessageDeduplicationId with InvalidParameterValue.
+    // The same code path runs both before and after a queue is converted to
+    // FIFO; the FIFO-suffix gate keeps it safe in either state.
+    const message = { type: 'agentic_traffic', key: 'value' };
+    const queueUrl = 'https://sqs.us-east-1.amazonaws.com/123456789/analytics-queue';
+
+    nock('https://sqs.us-east-1.amazonaws.com')
+      .post('/')
+      .reply(200, (_, body) => {
+        const parsed = JSON.parse(body);
+        expect(parsed.MessageDeduplicationId).to.be.undefined;
+        // MessageGroupId is still set — standard queues now accept it for fair queuing.
+        expect(parsed.MessageGroupId).to.equal('agentic_traffic:site-1');
+        return {
+          MessageId: 'message-id',
+          MD5OfMessageBody: crypto.createHash('md5').update(parsed.MessageBody, 'utf-8').digest('hex'),
+        };
+      });
+
+    await wrap(async (req, ctx) => {
+      await ctx.sqs.sendMessage(queueUrl, message, 'agentic_traffic:site-1', 0, 'batch-uuid-abc');
+    }).with(sqsWrapper)({}, context);
+  });
+
   it('includes DedupID in log when msgDedupId is set', async () => {
     const message = { type: 'agentic_traffic', key: 'value' };
     const queueUrl = 'https://sqs.us-east-1.amazonaws.com/123456789/analytics-queue.fifo';


### PR DESCRIPTION
## Summary

Pairs with [spacecat-infrastructure#480](https://github.com/adobe/spacecat-infrastructure/pull/480), which converts the analytics ingestion path (SNS topic + SQS queue + DLQ) to FIFO. Once that infra PR applies, the audit-worker's `dispatchAnalyticsEvent` will hard-fail on every attempt because the FIFO queue rejects publishes that lack `MessageGroupId` and `MessageDeduplicationId` (the new queue has `content_based_deduplication = false`).

This PR adds the missing attributes.

## Changes

**`src/support/sqs.js`** — extend the local `SQS.sendMessage` signature with an optional `msgDedupId` parameter and forward it as `MessageDeduplicationId`. Backward compatible: only set when the caller supplies a non-empty value, so all existing 2/3-arg call sites are untouched.

**`src/cdn-logs-report/agentic-daily-export.js`** — `dispatchAnalyticsEvent`:
- `MessageGroupId = ` `` `${pipeline_id}:${site_id}` `` per the infra PR's convention. Concurrent imports for the same scope serialize through the FIFO group; different sites/pipelines run in parallel.
- `MessageDeduplicationId = batchId` (uuid generated per export run). Retries inside SQS's 5-minute dedup window collapse to a single delivery.
- Return shape now exposes `messageGroupId` and `messageDeduplicationId` for observability.

## Why this group key

`(pipeline_id, site_id)` matches the infra PR convention so the audit-worker's `agentic_traffic` import group is independent of the projector's post-success `agentic_traffic_daily_refresh` and `agentic_traffic_weekly_refresh` groups (different DB tables, no contention). Putting them in the same group would needlessly serialize unrelated work.

## Test plan

- [x] `npx mocha --spec test/support/sqs.test.js --spec test/audits/cdn-logs-report/agentic-daily-export.test.js --exit` — 28 passing.
- [x] New tests cover: dedup-id applied on FIFO publish, dedup-id omitted when not provided, log line includes DedupID, end-to-end `dispatchAnalyticsEvent` returns the new fields and calls `sendMessage` with all five args.
- [x] Lint clean.
- [ ] Coordinate apply-time with infra PR #480.

## Related

- Pairs with [spacecat-infrastructure#480](https://github.com/adobe/spacecat-infrastructure/pull/480) — must land + deploy in lockstep.
- Pairs with the projector PR (separate) which adds FIFO attributes on the post-success refresh enqueues + DLQ writes.
- Optional follow-up: [spacecat-shared#1566](https://github.com/adobe/spacecat-shared/pull/1566) adds the same `messageDeduplicationId` parameter to the shared utils helper, useful for any future FIFO consumer using the shared sender.

🤖 Generated with [Claude Code](https://claude.com/claude-code)