### PR TITLE
fix(vulnerabilities): skip components whose CVEs are all ignored

### DIFF
--- a/src/vulnerabilities/handler.js
+++ b/src/vulnerabilities/handler.js
@@ -250,7 +250,14 @@ export const opportunityAndSuggestionsStep = async (context) => {
 
   const { vulnerabilityReport } = auditResult;
 
-  if (!isNonEmptyArray(vulnerabilityReport.vulnerableComponents)) {
+  // Drop components whose active vulnerabilities list is null/empty — every CVE on them
+  // has been ignored and there is nothing the customer can act on. Routing the all-ignored
+  // case through the "no vulnerabilities" branch below also resolves any stale opportunity.
+  const actionableComponents = isNonEmptyArray(vulnerabilityReport.vulnerableComponents)
+    ? vulnerabilityReport.vulnerableComponents.filter((c) => isNonEmptyArray(c.vulnerabilities))
+    : [];
+
+  if (!isNonEmptyArray(actionableComponents)) {
     // No vulnerabilities found
     // Fetch opportunity
     let opportunity;
@@ -295,7 +302,7 @@ export const opportunityAndSuggestionsStep = async (context) => {
   // Populate suggestions
   await syncSuggestions({
     opportunity,
-    newData: vulnerabilityReport.vulnerableComponents,
+    newData: actionableComponents,
     context,
     buildKey,
     mapNewSuggestion:

--- a/test/audits/vulnerabilities.test.js
+++ b/test/audits/vulnerabilities.test.js
@@ -22,6 +22,7 @@ import {
   VULNERABILITY_REPORT_WITH_VULNERABILITIES,
   VULNERABILITY_REPORT_NO_VULNERABILITIES,
   VULNERABILITY_REPORT_MULTIPLE_COMPONENTS,
+  VULNERABILITY_REPORT_ALL_IGNORED,
 } from '../fixtures/vulnerabilities/vulnerability-reports.js';
 import {
   vulnerabilityAuditRunner, opportunityAndSuggestionsStep, extractCodeInfo, buildKey,
@@ -415,6 +416,50 @@ describe('Vulnerabilities Handler Integration Tests', () => {
 
       expect(result).to.deep.equal({ status: 'complete' });
       expect(context.dataAccess.Opportunity.create).to.not.have.been.called;
+    });
+
+    it('should not create suggestions for components whose vulnerabilities are all ignored (null/empty)', async () => {
+      context.audit = {
+        getAuditResult: () => ({
+          vulnerabilityReport: VULNERABILITY_REPORT_ALL_IGNORED,
+          success: true,
+        }),
+        getId: () => 'test-audit-id',
+      };
+
+      const result = await opportunityAndSuggestionsStep(context);
+
+      expect(result).to.deep.equal({ status: 'complete' });
+      // Components with vulnerabilities=null are non-actionable — no opportunity gets created.
+      expect(context.dataAccess.Opportunity.create).to.not.have.been.called;
+    });
+
+    it('should resolve a stale opportunity when every reported component has all vulnerabilities ignored', async () => {
+      const suggestions = [
+        { getId: () => 'suggestion1', getStatus: () => 'NEW' },
+      ];
+      const staleOpportunity = {
+        getType: () => 'security-vulnerabilities',
+        setStatus: sandbox.stub().resolves(),
+        getSuggestions: sandbox.stub().resolves(suggestions),
+        setUpdatedBy: sandbox.stub().resolves(),
+        save: sandbox.stub().resolves(),
+      };
+      context.site.getOpportunitiesByStatus.resolves([staleOpportunity]);
+
+      context.audit = {
+        getAuditResult: () => ({
+          vulnerabilityReport: VULNERABILITY_REPORT_ALL_IGNORED,
+          success: true,
+        }),
+        getId: () => 'test-audit-id',
+      };
+
+      const result = await opportunityAndSuggestionsStep(context);
+
+      expect(result).to.deep.equal({ status: 'complete' });
+      expect(staleOpportunity.setStatus).to.have.been.calledWith('RESOLVED');
+      expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledWith(suggestions, 'FIXED');
     });
 
     it('should process vulnerabilities and create opportunities with suggestions', async () => {

--- a/test/fixtures/vulnerabilities/vulnerability-reports.js
+++ b/test/fixtures/vulnerabilities/vulnerability-reports.js
@@ -133,6 +133,82 @@ export const VULNERABILITY_REPORT_MIXED_SEVERITIES = {
   ],
 };
 
+export const VULNERABILITY_REPORT_ALL_IGNORED = {
+  summary: {
+    totalComponents: 2,
+    totalVulnerabilities: 0,
+    criticalVulnerabilities: 0,
+    highVulnerabilities: 0,
+    mediumVulnerabilities: 0,
+    lowVulnerabilities: 0,
+    ignoredVulnerabilities: 4,
+  },
+  vulnerableComponents: [
+    {
+      name: 'org.apache.tomcat:tomcat-el-api',
+      version: '10.1.54',
+      recommendedVersion: '',
+      path: 'jcr_root/apps/netcentric/actool/install/accesscontroltool-bundle-4.1.1-SNAPSHOT.jar:tomcat-el-api-10.1.54.jar',
+      vulnerabilities: null,
+      ignoredVulnerabilities: [
+        {
+          id: 'CVE-2016-5425',
+          score: 7.8,
+          severity: 'High',
+          description: 'Tomcat RPM weak permissions on RHEL/Fedora.',
+          url: 'https://nvd.nist.gov/vuln/detail/CVE-2016-5425',
+          ignoreCause: 'Vulnerability not present in this component',
+          ignoreDetails: 'CVE describes a vulnerability in the RHEL/Fedora Tomcat RPM, not in the JAR.',
+        },
+        {
+          id: 'CVE-2016-6325',
+          score: 7.8,
+          severity: 'High',
+          description: 'Tomcat RPM weak permissions on RHEL/JBoss EWS 2.',
+          url: 'https://nvd.nist.gov/vuln/detail/CVE-2016-6325',
+          ignoreCause: 'Vulnerability not present in this component',
+          ignoreDetails: 'CVE describes a vulnerability in the RHEL/Fedora Tomcat RPM, not in the JAR.',
+        },
+      ],
+      dependencyTree: [
+        '[root]',
+        'biz.netcentric.cq.tools.accesscontroltool/accesscontroltool-bundle@4.1.1-SNAPSHOT',
+      ],
+    },
+    {
+      name: 'org.apache.tomcat:tomcat-jasper-el',
+      version: '10.1.54',
+      recommendedVersion: '',
+      path: 'jcr_root/apps/netcentric/actool/install/accesscontroltool-bundle-4.1.1-SNAPSHOT.jar:tomcat-jasper-el-10.1.54.jar',
+      vulnerabilities: null,
+      ignoredVulnerabilities: [
+        {
+          id: 'CVE-2016-5425',
+          score: 7.8,
+          severity: 'High',
+          description: 'Tomcat RPM weak permissions on RHEL/Fedora.',
+          url: 'https://nvd.nist.gov/vuln/detail/CVE-2016-5425',
+          ignoreCause: 'Vulnerability not present in this component',
+          ignoreDetails: 'CVE describes a vulnerability in the RHEL/Fedora Tomcat RPM, not in the JAR.',
+        },
+        {
+          id: 'CVE-2016-6325',
+          score: 7.8,
+          severity: 'High',
+          description: 'Tomcat RPM weak permissions on RHEL/JBoss EWS 2.',
+          url: 'https://nvd.nist.gov/vuln/detail/CVE-2016-6325',
+          ignoreCause: 'Vulnerability not present in this component',
+          ignoreDetails: 'CVE describes a vulnerability in the RHEL/Fedora Tomcat RPM, not in the JAR.',
+        },
+      ],
+      dependencyTree: [
+        '[root]',
+        'biz.netcentric.cq.tools.accesscontroltool/accesscontroltool-bundle@4.1.1-SNAPSHOT',
+      ],
+    },
+  ],
+};
+
 export const VULNERABILITY_REPORT_MULTIPLE_COMPONENTS = {
   summary: {
     totalComponents: 2,


### PR DESCRIPTION
## Summary
- Components where every CVE has been moved to `ignoredVulnerabilities` (so `vulnerabilities` is `null` or `[]`) are no longer surfaced as suggestions — there is nothing actionable for the customer.
- The all-ignored case now routes through the existing "no vulnerabilities" branch in `opportunityAndSuggestionsStep`, which skips opportunity creation when none exists and resolves any stale opportunity (status → `RESOLVED`, suggestions → `FIXED`).

## Why
Real customer report observed in production: `summary.totalVulnerabilities = 0`, `summary.ignoredVulnerabilities = 4`, two `vulnerableComponents` entries each with `vulnerabilities: null`. Previously the handler still created a "security risk" opportunity with empty/zero-rank suggestions, which is noisy and not actionable.

## Test plan
- [x] `npm run test:spec -- test/audits/vulnerabilities.test.js` — 46 passing
- [x] Full vulnerabilities suite — 58 passing, 100% lines/branches/functions/statements coverage on `src/vulnerabilities/`
- [x] New fixture `VULNERABILITY_REPORT_ALL_IGNORED` mirrors the real customer payload
- [x] New tests assert: (a) no opportunity created when all components are non-actionable, (b) any stale existing opportunity gets resolved and its suggestions marked fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)