### PR TITLE
fix(no-cta-above-the-fold): filter on absolute thresholds instead of bounce share

### DIFF
--- a/src/no-cta-above-the-fold/queries.js
+++ b/src/no-cta-above-the-fold/queries.js
@@ -53,42 +53,33 @@ source_stats AS (
     FROM mobile_paid
     GROUP BY trf_channel
 ),
-highest_pageviews AS (
+candidates AS (
     SELECT
-        path,
-        trf_channel,
-        pageviews,
-        row_count,
-        bounces,
-        CAST(bounces AS DOUBLE) / NULLIF(row_count, 0) AS bounce_rate
-    FROM mobile_paid
-    WHERE pageviews >= ${pageViewThreshold}
-),
-top_bounces AS (
-    SELECT
-        h.path,
-        h.trf_channel,
-        h.pageviews,
-        h.row_count,
-        h.bounce_rate,
+        p.path,
+        p.trf_channel,
+        p.pageviews,
+        p.row_count,
+        p.bounces,
+        CAST(p.bounces AS DOUBLE) / NULLIF(p.row_count, 0) AS bounce_rate,
         ss.channel_bounce_rate,
-        h.bounces,
         ss.channel_bounces,
-        CAST(h.bounces AS DOUBLE) / NULLIF(ss.channel_bounces, 0) AS bounce_share,
-        CAST(h.bounces AS DOUBLE) / NULLIF(ss.channel_bounces, 0) * 100 AS bounce_share_pct
-    FROM highest_pageviews h
-    JOIN source_stats ss ON h.trf_channel = ss.trf_channel
-    WHERE h.bounce_rate >= ss.channel_bounce_rate
-      AND CAST(h.bounces AS DOUBLE) / NULLIF(ss.channel_bounces, 0) >= 0.10
+        CAST(p.pageviews AS DOUBLE) * CAST(p.bounces AS DOUBLE) / NULLIF(p.row_count, 0) AS projected_traffic_lost,
+        CAST(p.pageviews AS DOUBLE) * CAST(p.bounces AS DOUBLE) / NULLIF(p.row_count, 0) * ${ESTIMATED_CPC} AS projected_traffic_value
+    FROM mobile_paid p
+    JOIN source_stats ss
+      ON p.trf_channel = ss.trf_channel
+    WHERE p.pageviews >= ${pageViewThreshold}
+      AND p.bounces >= 25
+      AND CAST(p.bounces AS DOUBLE) / NULLIF(p.row_count, 0) >= GREATEST(ss.channel_bounce_rate, 0.50)
 ),
 deduped AS (
     SELECT
         *,
         ROW_NUMBER() OVER (
             PARTITION BY path
-            ORDER BY bounce_share DESC, pageviews DESC
+            ORDER BY projected_traffic_lost DESC, pageviews DESC, bounces DESC
         ) AS path_rank
-    FROM top_bounces
+    FROM candidates
 )
 SELECT
     path,
@@ -99,11 +90,10 @@ SELECT
     channel_bounce_rate,
     bounces,
     channel_bounces,
-    bounce_share_pct,
-    CAST(pageviews AS DOUBLE) * bounce_rate AS projected_traffic_lost,
-    CAST(pageviews AS DOUBLE) * bounce_rate * ${ESTIMATED_CPC} AS projected_traffic_value
+    projected_traffic_lost,
+    projected_traffic_value
 FROM deduped
 WHERE path_rank = 1
-ORDER BY bounce_share_pct DESC
+ORDER BY projected_traffic_lost DESC
 `.trim();
 }

--- a/src/no-cta-above-the-fold/queries.js
+++ b/src/no-cta-above-the-fold/queries.js
@@ -12,6 +12,14 @@
 
 import { ESTIMATED_CPC } from './guidance-opportunity-mapper.js';
 
+// Minimum sampled bounce events required for the bounce-rate signal to be
+// statistically credible.
+const MIN_BOUNCES = 25;
+
+// Absolute bounce-rate floor below which a path is not surfaced regardless of
+// how high the channel baseline is.
+const ABSOLUTE_BOUNCE_RATE_FLOOR = 0.50;
+
 /**
  * @param {Object} params - Template parameters
  * @param {string} params.siteId - Site ID
@@ -69,10 +77,13 @@ candidates AS (
     JOIN source_stats ss
       ON p.trf_channel = ss.trf_channel
     WHERE p.pageviews >= ${pageViewThreshold}
-      AND p.bounces >= 25
-      AND CAST(p.bounces AS DOUBLE) / NULLIF(p.row_count, 0) >= GREATEST(ss.channel_bounce_rate, 0.50)
+      AND p.bounces >= ${MIN_BOUNCES}
+      AND CAST(p.bounces AS DOUBLE) / NULLIF(p.row_count, 0) >= GREATEST(ss.channel_bounce_rate, ${ABSOLUTE_BOUNCE_RATE_FLOOR})
 ),
 deduped AS (
+    -- A path can qualify on multiple channels; keep the slice with the highest
+    -- projected traffic lost so the report attributes each path to where it
+    -- has the most impact.
     SELECT
         *,
         ROW_NUMBER() OVER (

--- a/test/audits/no-cta-above-the-fold/queries.test.js
+++ b/test/audits/no-cta-above-the-fold/queries.test.js
@@ -44,5 +44,23 @@ describe("No Engageable Content query template", () => {
     expect(query).to.include("5000");
     expect(query).to.include("(year = 2024 AND month = 8)");
   });
+
+  it("applies the minimum bounces threshold", () => {
+    const query = getNoCTAAboveTheFoldAnalysisQuery(defaultParams);
+
+    expect(query).to.include("p.bounces >= 25");
+  });
+
+  it("applies the absolute bounce-rate floor against the channel baseline", () => {
+    const query = getNoCTAAboveTheFoldAnalysisQuery(defaultParams);
+
+    expect(query).to.include("GREATEST(ss.channel_bounce_rate, 0.5)");
+  });
+
+  it("ranks candidates by projected traffic lost", () => {
+    const query = getNoCTAAboveTheFoldAnalysisQuery(defaultParams);
+
+    expect(query).to.include("ORDER BY projected_traffic_lost DESC");
+  });
 });
 


### PR DESCRIPTION
## Summary

The no-cta-above-the-fold audit was missing a lot of pages it should have flagged. The query required each candidate path to absorb at least 10% of its channel's total bounces — a bar that scales with channel size. On sites that run paid traffic across many pages, no single page could clear it, so the audit returned almost nothing actionable. On sites with very low paid traffic the same filter let through paths backed by only a few sampled bounces — not enough signal to trust.

This PR replaces the share-based filter with two absolute thresholds that don't scale with site size, so the audit detects bounce-prone paid pages consistently regardless of how big or small the site is.

 ## Changes
 
  - **Drop the 10% bounce-share filter** — the main reason high-traffic paid pages on busy sites were being hidden.
  - **Add a 50% absolute bounce-rate floor** — surfaced paths must bounce above their channel baseline AND above 50% in absolute terms.
  - **Add a `bounces >= 25` filter** — the bounce-rate signal must be built on enough sampled events to be statistically reliable.
  - **Rank candidates by projected traffic lost** (pageviews × bounce_rate) instead of bounce-share percentage, so the report prioritizes pages by absolute traffic impact.
  - Drop the `bounce_share_pct` column from the output (no downstream consumers).