### PR TITLE
feat: excludedelementclass for broken internal links

### DIFF
--- a/src/internal-links/config.js
+++ b/src/internal-links/config.js
@@ -11,7 +11,7 @@
  */
 
 import { hasText } from '@adobe/spacecat-shared-utils';
-import { PAGES_PER_BATCH } from './crawl-detection.js';
+import { PAGES_PER_BATCH } from './constants.js';
 import { MAX_BROKEN_LINKS_REPORTED } from './result-utils.js';
 
 const MAX_URLS_TO_PROCESS = 100;
@@ -108,6 +108,20 @@ function getStringListConfig(value, fallback) {
   }
 
   return fallback;
+}
+
+/**
+ * Normalizes `excludedElementClasses` from site handler config.
+ * Links (and other extracted references) are skipped when their DOM node or any
+ * ancestor has a `class` containing one of these tokens (see crawl `isUnderExcludedElement`).
+ * @param {string[]|string|undefined} raw - Array of class names, or comma-separated string
+ * @returns {string[]} Trimmed class tokens (leading "." stripped per entry)
+ */
+export function normalizeExcludedElementClasses(raw) {
+  const list = getStringListConfig(raw, []);
+  return list
+    .map((t) => String(t).trim().replace(/^\./, ''))
+    .filter((t) => t.length > 0);
 }
 
 export class InternalLinksConfigResolver {
@@ -233,6 +247,15 @@ export class InternalLinksConfigResolver {
       this.handlerConfig.mystiqueItemTypes,
       DEFAULT_MYSTIQUE_ITEM_TYPES,
     );
+  }
+
+  /**
+   * HTML `class` tokens: a link or asset reference is ignored if its own element or any
+   * ancestor has a `class` list containing one of these tokens (all descendants of such a
+   * subtree are therefore skipped).
+   */
+  getExcludedElementClasses() {
+    return normalizeExcludedElementClasses(this.handlerConfig.excludedElementClasses);
   }
 
   getBrightDataConfig() {

--- a/src/internal-links/constants.js
+++ b/src/internal-links/constants.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/** Default pages per batch for broken-internal-links crawl processing. */
+export const PAGES_PER_BATCH = 10;

--- a/src/internal-links/crawl-detection.js
+++ b/src/internal-links/crawl-detection.js
@@ -16,11 +16,15 @@ import { isWithinAuditScope } from './subpath-filter.js';
 import { isLinkInaccessible } from './helpers.js';
 import { limitConcurrency, sleep } from '../support/utils.js';
 import { buildBrokenLinkKey, getUrlCacheKey } from './link-key.js';
+import { normalizeExcludedElementClasses } from './config.js';
+import { PAGES_PER_BATCH } from './constants.js';
 import {
   createInternalLinksAuditLogger,
   isInternalLinksContextLogger,
 } from './logging.js';
 import { isSharedInternalResource } from './scope-utils.js';
+
+export { PAGES_PER_BATCH };
 
 const AUDIT_TYPE = 'broken-internal-links';
 
@@ -38,8 +42,6 @@ const DEFAULT_SCRAPE_FETCH_DELAY_MS = 50;
 const DEFAULT_LINK_CHECK_BATCH_SIZE = 10;
 const DEFAULT_MAX_CONCURRENT_LINK_CHECKS = 5;
 const DEFAULT_LINK_CHECK_DELAY_MS = 300;
-
-export const PAGES_PER_BATCH = 10;
 
 const parsePositiveInt = (value, fallback) => {
   const parsed = Number.parseInt(value, 10);
@@ -172,6 +174,34 @@ function resolveUrlCandidates(rawValue, pageUrl) {
     .map((entry) => normalizeDetectedUrlCandidate(entry))
     .filter((entry) => entry && !entry.startsWith('data:') && !entry.startsWith('#'))
     .map((entry) => stripAbsoluteUrlHash(new URL(entry, pageUrl).toString()));
+}
+
+/**
+ * Removes subtrees rooted at elements whose `class` contains an excluded token.
+ * Deepest nodes are removed first so nested excluded wrappers are safe.
+ * Mutates the document behind `$`; the callable `$` is unchanged.
+ */
+function filterExcludedElements($, excludedElementClasses) {
+  if (!excludedElementClasses?.length) {
+    return;
+  }
+  const excludedClassSet = new Set(excludedElementClasses);
+  const toRemove = [];
+
+  $('[class]').each((_, el) => {
+    const classAttr = $(el).attr('class');
+    if (!classAttr) {
+      return;
+    }
+    const hasExcluded = classAttr.split(/\s+/).filter(Boolean).some((c) => excludedClassSet.has(c));
+    if (hasExcluded) {
+      toRemove.push(el);
+    }
+  });
+  toRemove.sort((a, b) => $(b).parents().length - $(a).parents().length);
+  for (const el of toRemove) {
+    $(el).remove();
+  }
 }
 
 function pushResolvedReference({
@@ -861,6 +891,11 @@ export async function detectBrokenLinksFromCrawlBatch({
       }
 
       const $ = cheerioLoad(html);
+      const excludedElementClasses = normalizeExcludedElementClasses(
+        internalLinksConfig.excludedElementClasses,
+      );
+
+      filterExcludedElements($, excludedElementClasses);
       const internalLinks = extractInternalLinks($, pageUrl, baseHostname, log);
       const assetReferences = extractAssetReferences($, pageUrl, baseHostname, log);
 

--- a/test/audits/internal-links/config.test.js
+++ b/test/audits/internal-links/config.test.js
@@ -14,6 +14,7 @@ import { expect } from 'chai';
 import {
   InternalLinksConfigResolver,
   createInternalLinksConfigResolver,
+  normalizeExcludedElementClasses,
 } from '../../../src/internal-links/config.js';
 
 function createSite(config = {}, deliveryConfig = {}) {
@@ -160,6 +161,19 @@ describe('internal-links config resolver', () => {
       clickLoadMore: true,
       hideConsentBanners: true,
     });
+    expect(resolver.getExcludedElementClasses()).to.deep.equal([]);
+  });
+
+  it('returns excludedElementClasses from handler config', () => {
+    const resolver = new InternalLinksConfigResolver(createSite({
+      excludedElementClasses: ['.no-audit', 'editorial'],
+    }), {});
+
+    expect(resolver.getExcludedElementClasses()).to.deep.equal(['no-audit', 'editorial']);
+  });
+
+  it('normalizeExcludedElementClasses parses comma-separated string', () => {
+    expect(normalizeExcludedElementClasses('foo, .bar')).to.deep.equal(['foo', 'bar']);
   });
 
   it('prefers site config over env overrides', () => {

--- a/test/audits/internal-links/crawl-detection.test.js
+++ b/test/audits/internal-links/crawl-detection.test.js
@@ -1903,6 +1903,122 @@ describe('Crawl Detection Module', () => {
       expect(result.results[0].trafficDomain).to.equal(7);
     });
 
+    it('skips crawl extraction for links under ancestors with excludedElementClasses', async () => {
+      const scrapeResultPaths = new Map([
+        ['https://example.com/page1', 'scrapes/page1.json'],
+      ]);
+
+      const rawBody = `<html><body>
+        <div class="skip-bil">
+          <a href="/ignored">In skip</a>
+          <link rel="canonical" href="https://example.com/canon-ignored">
+          <link rel="alternate" hreflang="en" href="https://example.com/alt-ignored">
+          <form action="/form-ignored"><button type="submit">Go</button></form>
+          <img src="/img-ignored.png" alt="">
+          <img srcset="/srcset-ignored.png 1x" alt="">
+          <video><source srcset="/srcset-only-ignored.png 1x"></video>
+          <video><source src="/vid-ignored.mp4"></video>
+          <map name="m"><area shape="rect" coords="0,0,1,1" href="/area-ignored" alt=""></map>
+          <link rel="stylesheet" href="/ignored.css">
+          <script src="/ignored.js"></script>
+          <style>.x{background:url(/ignored-from-style.png)}</style>
+          <span style="background:url(/ignored-from-inline.png)">x</span>
+        </div>
+        <main><a href="/checked">Outside</a></main>
+      </body></html>`;
+
+      getObjectFromKeyStub.resolves({
+        scrapeResult: { rawBody },
+        finalUrl: 'https://example.com/page1',
+      });
+      isLinkInaccessibleStub.resolves(createValidationResponse(false));
+
+      const contextWithIgnore = {
+        ...mockContext,
+        site: {
+          ...mockSite,
+          getConfig: () => ({
+            getHandlers: () => ({
+              'broken-internal-links': {
+                config: {
+                  excludedElementClasses: ['skip-bil'],
+                },
+              },
+            }),
+          }),
+        },
+      };
+
+      await detectBrokenLinksFromCrawlBatch({
+        scrapeResultPaths,
+        batchStartIndex: 0,
+        batchSize: 1,
+        initialBrokenUrls: [],
+        initialWorkingUrls: [],
+      }, contextWithIgnore);
+
+      expect(isLinkInaccessibleStub.callCount).to.equal(1);
+      expect(isLinkInaccessibleStub.firstCall.args[0]).to.equal('https://example.com/checked');
+    });
+
+    it('retain crawl extraction for links without class', async () => {
+      const scrapeResultPaths = new Map([
+        ['https://example.com/page1', 'scrapes/page1.json'],
+      ]);
+
+      const rawBody = `<html><body>
+        <div class="">
+          <a href="/link1">Link 1</a>
+          <link rel="canonical" href="https://example.com/canon1">
+          <link rel="alternate" hreflang="en" href="https://example.com/alt1">
+          <form action="/form1"><button type="submit">Go</button></form>
+          <img src="/img1.png" alt="">
+          <img srcset="/srcset1.png 1x" alt="">
+          <video><source srcset="/srcset1.png 1x"></video>
+          <video><source src="/vid1.mp4"></video>
+          <map name="m"><area shape="rect" coords="0,0,1,1" href="/area1" alt=""></map>
+          <link rel="stylesheet" href="/style1.css">
+          <script src="/script1.js"></script>
+          <style>.x{background:url(/style1.png)}</style>
+          <span style="background:url(/inline1.png)">x</span>
+        </div>
+        <main><a href="/link2">Link 2</a></main>
+      </body></html>`;
+
+      getObjectFromKeyStub.resolves({
+        scrapeResult: { rawBody },
+        finalUrl: 'https://example.com/page1',
+      });
+      isLinkInaccessibleStub.resolves(createValidationResponse(false));
+
+      const contextWithIgnore = {
+        ...mockContext,
+        site: {
+          ...mockSite,
+          getConfig: () => ({
+            getHandlers: () => ({
+              'broken-internal-links': {
+                config: {
+                  excludedElementClasses: ['skip-bil'],
+                },
+              },
+            }),
+          }),
+        },
+      };
+
+      await detectBrokenLinksFromCrawlBatch({
+        scrapeResultPaths,
+        batchStartIndex: 0,
+        batchSize: 1,
+        initialBrokenUrls: [],
+        initialWorkingUrls: [],
+      }, contextWithIgnore);
+
+      expect(isLinkInaccessibleStub.callCount).to.equal(14);
+      expect(isLinkInaccessibleStub.firstCall.args[0]).to.equal('https://example.com/link1');
+    });
+
     it('should extract object data, meta refresh, and CSS url() references', async () => {
       const scrapeResultPaths = new Map([
         ['https://example.com/page1', 'scrapes/page1.json'],


### PR DESCRIPTION
added new functionality to broken internal links.
you can now add a list of element class to ignore in the site.config.handler. Any element (or its ancestor) with the excluded class will be ignored.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
