### PR TITLE
fix(agentic): queue weekly DB export refreshes by date

### DIFF
--- a/src/cdn-analysis/handler.js
+++ b/src/cdn-analysis/handler.js
@@ -212,7 +212,11 @@ async function triggerSubAudits(context, site, detectedDays) {
     await sqs.sendMessage(auditQueue, {
       type: 'cdn-logs-report',
       siteId,
-      auditContext: { weekOffset },
+      auditContext: {
+        weekOffset,
+        refreshAgenticDailyExport: true,
+        triggeredBy: SERVICE_PROVIDER_TYPES.BYOCDN_OTHER,
+      },
     }, null, 900);
     log.info(`Triggered cdn-logs-report for siteId=${siteId} weekOffset=${weekOffset}`);
   }

--- a/src/cdn-logs-report/handler.js
+++ b/src/cdn-logs-report/handler.js
@@ -29,9 +29,7 @@ import { wwwUrlResolver } from '../common/base-audit.js';
 import { createLLMOSharepointClient, bulkPublishToAdminHlx } from '../utils/report-uploader.js';
 import { getConfigs } from './constants/report-configs.js';
 import { generatePatternsWorkbook } from './patterns/patterns-uploader.js';
-import {
-  runDailyAgenticExport,
-} from './agentic-daily-export.js';
+import { runAgenticDbExports } from './utils/agentic-db-export.js';
 import {
   runDailyReferralExport,
 } from './referral-daily-export.js';
@@ -39,7 +37,9 @@ import {
 async function runCdnLogsReport(url, context, site, auditContext) {
   const { log } = context;
   const isDailyDateRun = Boolean(auditContext?.date);
-  const isWeeklyOnlyRun = auditContext?.weekOffset !== undefined;
+  const isWeeklyOnlyRun = auditContext?.weekOffset !== undefined
+    && auditContext?.weekOffset !== null;
+  const isCategoriesUpdateRun = auditContext?.categoriesUpdated === true;
 
   const awsRuntime = getCdnAwsRuntime(site, context);
   const { s3Client } = awsRuntime;
@@ -65,6 +65,7 @@ async function runCdnLogsReport(url, context, site, auditContext) {
 
   const results = [];
   const reportsToPublish = [];
+  let agenticReportHasData = false;
   if (!isDailyDateRun) {
     for (const reportConfig of reportConfigs) {
       // eslint-disable-next-line no-await-in-loop
@@ -72,6 +73,10 @@ async function runCdnLogsReport(url, context, site, auditContext) {
         log.info(`No data found for ${reportConfig.name} report - skipping`);
         // eslint-disable-next-line no-continue
         continue;
+      }
+
+      if (reportConfig.name === 'agentic') {
+        agenticReportHasData = true;
       }
 
       if (results.length === 0) {
@@ -85,7 +90,7 @@ async function runCdnLogsReport(url, context, site, auditContext) {
       // If weekOffset is not provided, run for both week 0 and -1 on Monday and
       // on non-Monday, run for current week. Otherwise, run for the provided weekOffset
       let weekOffsets;
-      if (auditContext?.weekOffset !== undefined) {
+      if (auditContext?.weekOffset !== undefined && auditContext?.weekOffset !== null) {
         weekOffsets = [auditContext.weekOffset];
       } else if (isMonday) {
         weekOffsets = [-1, 0];
@@ -158,33 +163,19 @@ async function runCdnLogsReport(url, context, site, auditContext) {
     }
   }
 
-  let dailyAgenticExport;
-  let dailyReferralExport;
-  if (!isWeeklyOnlyRun) {
-    if (!agenticReportConfig) {
-      log.debug(`Skipping daily agentic export for ${siteId}: agentic report config not found`);
-    } else {
-      try {
-        dailyAgenticExport = await runDailyAgenticExport({
-          athenaClient,
-          s3Client,
-          s3Config,
-          site,
-          context,
-          reportConfig: agenticReportConfig,
-          ...(auditContext?.date ? { referenceDate: new Date(auditContext.date) } : {}),
-        });
-      } catch (error) {
-        context.log.error(`Failed daily agentic export for site ${siteId}: ${error.message}`, error);
-        dailyAgenticExport = {
-          enabled: true,
-          success: false,
-          siteId,
-          error: error.message,
-        };
-      }
-    }
+  const agenticDbExportResult = await runAgenticDbExports({
+    athenaClient,
+    s3Client,
+    s3Config,
+    site,
+    context,
+    agenticReportConfig,
+    auditContext,
+    agenticReportHasData,
+  });
 
+  let dailyReferralExport;
+  if (!isWeeklyOnlyRun && !isCategoriesUpdateRun) {
     if (!referralReportConfig) {
       log.debug(`Skipping daily referral export for ${siteId}: referral report config not found`);
     } else {
@@ -220,8 +211,8 @@ async function runCdnLogsReport(url, context, site, auditContext) {
   }
 
   return {
+    ...agenticDbExportResult,
     auditResult: results,
-    dailyAgenticExport,
     dailyReferralExport,
     fullAuditRef: `${site.getConfig()?.getLlmoDataFolder()}`,
   };

--- a/src/cdn-logs-report/utils/agentic-db-export.js
+++ b/src/cdn-logs-report/utils/agentic-db-export.js
@@ -1,0 +1,302 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { runDailyAgenticExport } from '../agentic-daily-export.js';
+import { generateReportingPeriods } from './report-utils.js';
+import { SERVICE_PROVIDER_TYPES } from '../../utils/cdn-utils.js';
+
+const DAILY_EXPORT_MESSAGE_DELAY_SECONDS = 5;
+const ALLOWED_TRIGGERED_BY = new Set(Object.values(SERVICE_PROVIDER_TYPES));
+
+function hasWeekOffset(auditContext) {
+  return auditContext?.weekOffset !== undefined && auditContext?.weekOffset !== null;
+}
+
+function getSafeTriggeredBy(triggeredBy) {
+  return ALLOWED_TRIGGERED_BY.has(triggeredBy) ? triggeredBy : undefined;
+}
+
+function getAgenticDbExportReferenceDatesForWeek(weekOffset, referenceDate = new Date()) {
+  const { weeks } = generateReportingPeriods(referenceDate, weekOffset);
+  const weekStart = weeks[0]?.startDate;
+  if (!weekStart) {
+    return [];
+  }
+
+  // runDailyAgenticExport exports the previous UTC day, so each target
+  // traffic day uses the following midnight as its reference date.
+  const latestCompletedReferenceDate = new Date(Date.UTC(
+    referenceDate.getUTCFullYear(),
+    referenceDate.getUTCMonth(),
+    referenceDate.getUTCDate(),
+  ));
+  return Array.from({ length: 7 }, (_, index) => new Date(Date.UTC(
+    weekStart.getUTCFullYear(),
+    weekStart.getUTCMonth(),
+    weekStart.getUTCDate() + index + 1,
+  ))).filter((date) => date <= latestCompletedReferenceDate);
+}
+
+function shouldRefreshWeeklyAgenticDbExports(auditContext) {
+  // Keep Agentic DB refreshes behind one explicit signal. Other flags, such
+  // as categoriesUpdated, may affect report generation but should not be an
+  // independent DB export trigger.
+  return hasWeekOffset(auditContext)
+    && Boolean(auditContext?.refreshAgenticDailyExport);
+}
+
+function getFailureResult({
+  siteId,
+  error,
+  queued = false,
+}) {
+  return {
+    enabled: true,
+    success: false,
+    queued,
+    siteId,
+    error,
+  };
+}
+
+function getDateBasedReferenceDate(auditContext, siteId, context) {
+  if (!auditContext?.date) {
+    return undefined;
+  }
+
+  const referenceDate = new Date(auditContext.date);
+  if (Number.isNaN(referenceDate.getTime())) {
+    context.log.error(`Invalid date in auditContext for ${siteId}: ${auditContext.date}`);
+    return undefined;
+  }
+
+  return referenceDate;
+}
+
+async function runAgenticDbExportForReferenceDate({
+  athenaClient,
+  s3Client,
+  s3Config,
+  site,
+  context,
+  reportConfig,
+  referenceDate = new Date(),
+}) {
+  const siteId = site.getId();
+  try {
+    return await runDailyAgenticExport({
+      athenaClient,
+      s3Client,
+      s3Config,
+      site,
+      context,
+      reportConfig,
+      referenceDate,
+    });
+  } catch (error) {
+    context.log.error(`Failed daily agentic export for site ${siteId}: ${error.message}`, error);
+    return {
+      enabled: true,
+      success: false,
+      siteId,
+      error: error.message,
+    };
+  }
+}
+
+async function runDateBasedAgenticDbExport({
+  athenaClient,
+  s3Client,
+  s3Config,
+  site,
+  context,
+  agenticReportConfig,
+  auditContext,
+}) {
+  const siteId = site.getId();
+  const referenceDate = getDateBasedReferenceDate(auditContext, siteId, context);
+
+  return {
+    dailyAgenticExport: await runAgenticDbExportForReferenceDate({
+      athenaClient,
+      s3Client,
+      s3Config,
+      site,
+      context,
+      reportConfig: agenticReportConfig,
+      ...(referenceDate ? { referenceDate } : {}),
+    }),
+  };
+}
+
+async function queueDailyAgenticDbExport({
+  auditQueue,
+  siteId,
+  context,
+  auditContext,
+  referenceDate,
+  delaySeconds,
+}) {
+  try {
+    await context.sqs.sendMessage(auditQueue, {
+      type: 'cdn-logs-report',
+      siteId,
+      auditContext: {
+        date: referenceDate.toISOString(),
+        refreshAgenticDailyExport: true,
+        ...(auditContext.categoriesUpdated ? { categoriesUpdated: true } : {}),
+        ...(auditContext.triggeredBy ? { triggeredBy: auditContext.triggeredBy } : {}),
+        sourceWeekOffset: auditContext.weekOffset,
+      },
+    }, null, delaySeconds);
+
+    return {
+      enabled: true,
+      success: true,
+      queued: true,
+      siteId,
+      referenceDate: referenceDate.toISOString(),
+      delaySeconds,
+    };
+  } catch (error) {
+    context.log.error(`Failed to queue daily agentic DB export for site ${siteId}: ${error.message}`, error);
+    return {
+      enabled: true,
+      success: false,
+      queued: false,
+      siteId,
+      referenceDate: referenceDate.toISOString(),
+      delaySeconds,
+      error: error.message,
+    };
+  }
+}
+
+async function resolveAuditQueue(context, siteId) {
+  const { Configuration } = context.dataAccess;
+  try {
+    const configuration = await Configuration.findLatest();
+    const auditQueue = configuration?.getQueues?.()?.audits;
+    if (!auditQueue) {
+      const error = 'Audit queue not configured';
+      context.log.error(`${error} for site ${siteId}; skipping weekly DB export queueing`);
+      return {
+        failure: getFailureResult({ siteId, error }),
+      };
+    }
+
+    return { auditQueue };
+  } catch (error) {
+    context.log.error(`Failed to resolve audit queue for site ${siteId}: ${error.message}`, error);
+    return {
+      failure: getFailureResult({ siteId, error: error.message }),
+    };
+  }
+}
+
+async function queueWeeklyAgenticDbExports({
+  site,
+  context,
+  auditContext,
+}) {
+  const siteId = site.getId();
+  const dailyAgenticExports = [];
+  const referenceDates = getAgenticDbExportReferenceDatesForWeek(
+    auditContext.weekOffset,
+  );
+  if (referenceDates.length === 0) {
+    return {
+      dailyAgenticExport: null,
+      dailyAgenticExports,
+    };
+  }
+
+  const { auditQueue, failure } = await resolveAuditQueue(context, siteId);
+  if (failure) {
+    return {
+      dailyAgenticExport: failure,
+      dailyAgenticExports,
+    };
+  }
+
+  const triggeredBy = getSafeTriggeredBy(auditContext.triggeredBy);
+  const exportAuditContext = { ...auditContext, triggeredBy };
+
+  context.log.info(`Queueing weekly agentic DB exports for ${siteId}: weekOffset=${auditContext.weekOffset}, trigger=${triggeredBy || 'refreshAgenticDailyExport'}, days=${referenceDates.length}`);
+  for (const [index, referenceDate] of referenceDates.entries()) {
+    // Keep queueing sequential and lightly staggered so the weekly report Lambda
+    // only coordinates per-day work instead of owning all seven exports.
+    // eslint-disable-next-line no-await-in-loop
+    dailyAgenticExports.push(await queueDailyAgenticDbExport({
+      auditQueue,
+      siteId,
+      context,
+      auditContext: exportAuditContext,
+      referenceDate,
+      delaySeconds: index * DAILY_EXPORT_MESSAGE_DELAY_SECONDS,
+    }));
+  }
+
+  const failedExports = dailyAgenticExports.filter((result) => result && result.success === false);
+  if (failedExports.length > 0) {
+    context.log.warn(`Partial agentic DB export queueing failure for ${siteId}: ${failedExports.length}/${dailyAgenticExports.length} days failed`);
+  }
+
+  return {
+    dailyAgenticExport: dailyAgenticExports.at(-1),
+    dailyAgenticExports,
+  };
+}
+
+export async function runAgenticDbExports({
+  athenaClient,
+  s3Client,
+  s3Config,
+  site,
+  context,
+  agenticReportConfig,
+  auditContext,
+  agenticReportHasData,
+}) {
+  const siteId = site.getId();
+  if (!agenticReportConfig) {
+    context.log.debug(`Skipping agentic DB export for ${siteId}: agentic report config not found`);
+    return {};
+  }
+
+  if (!hasWeekOffset(auditContext)) {
+    return runDateBasedAgenticDbExport({
+      athenaClient,
+      s3Client,
+      s3Config,
+      site,
+      context,
+      agenticReportConfig,
+      auditContext,
+    });
+  }
+
+  if (!shouldRefreshWeeklyAgenticDbExports(auditContext)) {
+    return {};
+  }
+
+  if (!agenticReportHasData) {
+    context.log.info(`Skipping weekly agentic DB exports for ${siteId}: no agentic report data found`);
+    return {};
+  }
+
+  return queueWeeklyAgenticDbExports({
+    site,
+    context,
+    auditContext,
+  });
+}

--- a/src/llmo-customer-analysis/cdn-config-handler.js
+++ b/src/llmo-customer-analysis/cdn-config-handler.js
@@ -139,6 +139,7 @@ async function handleAdobeFastly(
     siteId,
     auditContext: {
       date: backfillDay.reportDate,
+      refreshAgenticDailyExport: true,
     },
   }, null, CDN_LOGS_REPORT_DELAY_SECONDS + (index * CDN_LOGS_ANALYSIS_DELAY_SECONDS)));
 

--- a/src/llmo-customer-analysis/handler.js
+++ b/src/llmo-customer-analysis/handler.js
@@ -275,6 +275,7 @@ export async function triggerCdnLogsReport(context, site) {
     auditContext: {
       weekOffset: -1,
       categoriesUpdated: true,
+      refreshAgenticDailyExport: true,
     },
   });
 

--- a/test/audits/cdn-analysis/handler.test.js
+++ b/test/audits/cdn-analysis/handler.test.js
@@ -584,6 +584,14 @@ describe('CDN Analysis Handler', () => {
         null,
         900,
       );
+
+      const reportCall = context.sqs.sendMessage.getCalls()
+        .find((call) => call.args[1].type === 'cdn-logs-report');
+      expect(reportCall.args[1].auditContext).to.deep.equal({
+        weekOffset: computeWeekOffset(2025, 6, 14),
+        refreshAgenticDailyExport: true,
+        triggeredBy: 'byocdn-other',
+      });
     });
 
     it('byocdn-other sub-audit processes logs normally without scanning', async () => {

--- a/test/audits/cdn-logs-report/handler.test.js
+++ b/test/audits/cdn-logs-report/handler.test.js
@@ -700,6 +700,9 @@ describe('CDN Logs Report Handler', function test() {
           runDailyReferralExport: sandbox.stub().resolves({ enabled: true, success: true }),
         },
       }, {
+        '../../../src/cdn-logs-report/agentic-daily-export.js': {
+          runDailyAgenticExport: runDailyAgenticExportStub,
+        },
         '../../../src/utils/report-uploader.js': {
           createLLMOSharepointClient: sandbox.stub().resolves(createMockSharepointClient(sandbox)),
           saveExcelReport: saveExcelReportStub,
@@ -743,6 +746,9 @@ describe('CDN Logs Report Handler', function test() {
           runDailyReferralExport: sandbox.stub().resolves({ enabled: true, success: true }),
         },
       }, {
+        '../../../src/cdn-logs-report/agentic-daily-export.js': {
+          runDailyAgenticExport: runDailyAgenticExportStub,
+        },
         '../../../src/utils/report-uploader.js': {
           createLLMOSharepointClient: sandbox.stub().resolves(createMockSharepointClient(sandbox)),
           saveExcelReport: saveExcelReportStub,
@@ -793,6 +799,9 @@ describe('CDN Logs Report Handler', function test() {
           runWeeklyReport: runWeeklyReportStub,
         },
       }, {
+        '../../../src/cdn-logs-report/agentic-daily-export.js': {
+          runDailyAgenticExport: runDailyAgenticExportStub,
+        },
         '../../../src/utils/report-uploader.js': {
           createLLMOSharepointClient: createSharepointStub,
           saveExcelReport: saveExcelReportStub,
@@ -841,6 +850,22 @@ describe('CDN Logs Report Handler', function test() {
           runDailyReferralExport: sandbox.stub().resolves({ enabled: true, success: true }),
         },
       }, {
+        '../../../src/cdn-logs-report/agentic-daily-export.js': {
+          runDailyAgenticExport: runDailyAgenticExportStub,
+        },
+        '../../../src/cdn-logs-report/utils/report-utils.js': {
+          loadSql: sandbox.stub().resolves('SELECT 1'),
+          generateReportingPeriods: sandbox.stub().returns({
+            weeks: [{
+              startDate: new Date('2026-03-30T00:00:00.000Z'),
+              endDate: new Date('2026-04-05T23:59:59.999Z'),
+            }],
+            periodIdentifier: 'w14-2026',
+          }),
+          fetchRemotePatterns: sandbox.stub().resolves({ pagetype: { data: [] } }),
+          queryIndexHasPatternsFile: sandbox.stub().resolves(false),
+          getConfigCategories: sandbox.stub().resolves(['Category A']),
+        },
         '../../../src/utils/report-uploader.js': {
           createLLMOSharepointClient: sandbox.stub().resolves(createMockSharepointClient(sandbox)),
           saveExcelReport: saveExcelReportStub,
@@ -858,6 +883,129 @@ describe('CDN Logs Report Handler', function test() {
       expect(runDailyAgenticExportStub).to.not.have.been.called;
       expect(result.dailyAgenticExport).to.equal(undefined);
       expect(result.auditResult).to.not.be.empty;
+    });
+
+    it('queues date-based agentic DB exports for weekly refreshes without running daily exports inline', async () => {
+      const runDailyAgenticExportStub = sandbox.stub().resolves({
+        enabled: true,
+        success: true,
+      });
+      const runDailyReferralExportStub = sandbox.stub().resolves({ enabled: true, success: true });
+      const generatePatternsWorkbookStub = sandbox.stub().resolves(true);
+      const runWeeklyReportStub = sandbox.stub().resolves({ success: true, uploadResult: null });
+      context.dataAccess.Configuration = {
+        findLatest: sandbox.stub().resolves({
+          getQueues: () => ({ audits: 'https://sqs.us-east-1.amazonaws.com/123/audits-queue' }),
+        }),
+      };
+
+      const localHandler = await esmock('../../../src/cdn-logs-report/handler.js', {
+        '../../../src/cdn-logs-report/agentic-daily-export.js': {
+          runDailyAgenticExport: runDailyAgenticExportStub,
+        },
+        '../../../src/cdn-logs-report/referral-daily-export.js': {
+          runDailyReferralExport: runDailyReferralExportStub,
+        },
+        '../../../src/cdn-logs-report/utils/report-utils.js': {
+          loadSql: sandbox.stub().resolves('SELECT 1'),
+          generateReportingPeriods: sandbox.stub().returns({
+            weeks: [{
+              startDate: new Date('2026-03-30T00:00:00.000Z'),
+              endDate: new Date('2026-04-05T23:59:59.999Z'),
+            }],
+            periodIdentifier: 'w14-2026',
+          }),
+          fetchRemotePatterns: sandbox.stub().resolves({ pagetype: { data: [] } }),
+          queryIndexHasPatternsFile: sandbox.stub().resolves(false),
+          getConfigCategories: sandbox.stub().resolves(['Category A']),
+        },
+        '../../../src/utils/cdn-utils.js': {
+          pathHasData: sandbox.stub().resolves(true),
+          getS3Config: sandbox.stub().returns({
+            bucket: 'test-bucket',
+            siteKey: 'example_com',
+            siteName: 'example',
+            databaseName: 'cdn_logs_example_com',
+            getAthenaTempLocation: () => 's3://temp',
+          }),
+          getCdnAwsRuntime: sandbox.stub().returns({
+            s3Client: {},
+            createAthenaClient: sandbox.stub().returns({
+              execute: sandbox.stub().resolves(),
+            }),
+          }),
+        },
+        '../../../src/cdn-logs-report/utils/report-runner.js': {
+          runWeeklyReport: runWeeklyReportStub,
+        },
+        '../../../src/utils/report-uploader.js': {
+          createLLMOSharepointClient: sandbox.stub().resolves(createMockSharepointClient(sandbox)),
+          saveExcelReport: saveExcelReportStub,
+          bulkPublishToAdminHlx: sandbox.stub().resolves(),
+        },
+        '../../../src/cdn-logs-report/constants/report-configs.js': {
+          getConfigs: sandbox.stub().returns([{
+            name: 'agentic',
+            aggregatedLocation: 's3://bucket/aggregated/test-site/',
+            tableName: 'aggregated_logs_example_com_consolidated',
+            filePrefix: 'agentictraffic',
+            folderSuffix: 'agentic-traffic',
+            workbookCreator: 'Spacecat Agentic Flat Report',
+            queryFunction: sandbox.stub(),
+            sheetName: 'shared-all',
+          }]),
+        },
+        '../../../src/cdn-logs-report/patterns/patterns-uploader.js': {
+          generatePatternsWorkbook: generatePatternsWorkbookStub,
+        },
+      }, {
+        '../../../src/cdn-logs-report/agentic-daily-export.js': {
+          runDailyAgenticExport: runDailyAgenticExportStub,
+        },
+        '../../../src/cdn-logs-report/utils/report-utils.js': {
+          loadSql: sandbox.stub().resolves('SELECT 1'),
+          generateReportingPeriods: sandbox.stub().returns({
+            weeks: [{
+              startDate: new Date('2026-03-30T00:00:00.000Z'),
+              endDate: new Date('2026-04-05T23:59:59.999Z'),
+            }],
+            periodIdentifier: 'w14-2026',
+          }),
+          fetchRemotePatterns: sandbox.stub().resolves({ pagetype: { data: [] } }),
+          queryIndexHasPatternsFile: sandbox.stub().resolves(false),
+          getConfigCategories: sandbox.stub().resolves(['Category A']),
+        },
+        '../../../src/utils/report-uploader.js': {
+          createLLMOSharepointClient: sandbox.stub().resolves(createMockSharepointClient(sandbox)),
+          saveExcelReport: saveExcelReportStub,
+          bulkPublishToAdminHlx: sandbox.stub().resolves(),
+        },
+      });
+
+      const result = await localHandler.runner(
+        'https://example.com',
+        context,
+        site,
+        createAuditContext(sandbox, { weekOffset: -1, refreshAgenticDailyExport: true }),
+      );
+
+      expect(runWeeklyReportStub).to.have.been.calledOnce;
+      expect(generatePatternsWorkbookStub).to.not.have.been.called;
+      expect(runDailyAgenticExportStub).to.not.have.been.called;
+      expect(runDailyReferralExportStub).to.not.have.been.called;
+      expect(context.sqs.sendMessage).to.have.callCount(7);
+      expect(context.sqs.sendMessage.firstCall.args[1].auditContext).to.deep.equal({
+        date: '2026-03-31T00:00:00.000Z',
+        refreshAgenticDailyExport: true,
+        sourceWeekOffset: -1,
+      });
+      expect(result.dailyAgenticExport).to.deep.include({
+        enabled: true,
+        success: true,
+        queued: true,
+      });
+      expect(result.dailyAgenticExports).to.have.length(7);
+      expect(result.dailyReferralExport).to.equal(undefined);
     });
 
     it('skips daily referral export when auditContext.weekOffset is provided', async () => {
@@ -1040,6 +1188,84 @@ describe('CDN Logs Report Handler', function test() {
 
       expect(runDailyReferralExportStub.firstCall.args[0].referenceDate.toISOString())
         .to.equal('2026-04-01T10:00:00.000Z');
+    });
+
+    it('skips daily referral export for category-refresh agentic DB fanout messages', async () => {
+      const runDailyAgenticExportStub = sandbox.stub().resolves({ enabled: true, success: true });
+      const runDailyReferralExportStub = sandbox.stub().resolves({ enabled: true, success: true });
+      const localHandler = await esmock('../../../src/cdn-logs-report/handler.js', {
+        '../../../src/cdn-logs-report/agentic-daily-export.js': {
+          runDailyAgenticExport: runDailyAgenticExportStub,
+        },
+        '../../../src/cdn-logs-report/referral-daily-export.js': {
+          runDailyReferralExport: runDailyReferralExportStub,
+        },
+      }, {
+        '../../../src/utils/report-uploader.js': {
+          createLLMOSharepointClient: sandbox.stub().resolves(createMockSharepointClient(sandbox)),
+          saveExcelReport: saveExcelReportStub,
+          bulkPublishToAdminHlx: sandbox.stub().resolves(),
+        },
+      });
+
+      const result = await localHandler.runner(
+        'https://example.com',
+        context,
+        site,
+        createAuditContext(sandbox, {
+          date: '2026-04-01T00:00:00.000Z',
+          refreshAgenticDailyExport: true,
+          categoriesUpdated: true,
+          sourceWeekOffset: -1,
+        }),
+      );
+
+      expect(runDailyReferralExportStub).to.not.have.been.called;
+      expect(result.dailyReferralExport).to.equal(undefined);
+    });
+
+    it('runs daily referral export for BYOCDN other agentic DB fanout messages', async () => {
+      const runDailyAgenticExportStub = sandbox.stub().resolves({ enabled: true, success: true });
+      const runDailyReferralExportStub = sandbox.stub().resolves({
+        enabled: true,
+        success: true,
+        trafficDate: '2026-03-31',
+      });
+      const localHandler = await esmock('../../../src/cdn-logs-report/handler.js', {
+        '../../../src/cdn-logs-report/agentic-daily-export.js': {
+          runDailyAgenticExport: runDailyAgenticExportStub,
+        },
+        '../../../src/cdn-logs-report/referral-daily-export.js': {
+          runDailyReferralExport: runDailyReferralExportStub,
+        },
+      }, {
+        '../../../src/utils/report-uploader.js': {
+          createLLMOSharepointClient: sandbox.stub().resolves(createMockSharepointClient(sandbox)),
+          saveExcelReport: saveExcelReportStub,
+          bulkPublishToAdminHlx: sandbox.stub().resolves(),
+        },
+      });
+
+      const result = await localHandler.runner(
+        'https://example.com',
+        context,
+        site,
+        createAuditContext(sandbox, {
+          date: '2026-04-01T00:00:00.000Z',
+          refreshAgenticDailyExport: true,
+          sourceWeekOffset: 0,
+          triggeredBy: 'byocdn-other',
+        }),
+      );
+
+      expect(runDailyReferralExportStub).to.have.been.calledOnce;
+      expect(runDailyReferralExportStub.firstCall.args[0].referenceDate.toISOString())
+        .to.equal('2026-04-01T00:00:00.000Z');
+      expect(result.dailyReferralExport).to.deep.equal({
+        enabled: true,
+        success: true,
+        trafficDate: '2026-03-31',
+      });
     });
 
     describe('LLMO pattern fetch scenarios', () => {

--- a/test/audits/cdn-logs-report/utils/agentic-db-export.test.js
+++ b/test/audits/cdn-logs-report/utils/agentic-db-export.test.js
@@ -1,0 +1,400 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import esmock from 'esmock';
+
+use(sinonChai);
+
+describe('agentic DB export orchestration', () => {
+  let sandbox;
+  let clock;
+  let runDailyAgenticExportStub;
+  let generateReportingPeriodsStub;
+  let module;
+
+  function createArgs(overrides = {}) {
+    return {
+      athenaClient: {},
+      s3Client: {},
+      s3Config: { databaseName: 'cdn_logs_example' },
+      site: {
+        getId: () => 'site-1',
+      },
+      context: {
+        log: {
+          debug: sandbox.spy(),
+          info: sandbox.spy(),
+          warn: sandbox.spy(),
+          error: sandbox.spy(),
+        },
+        dataAccess: {
+          Configuration: {
+            findLatest: sandbox.stub().resolves({
+              getQueues: () => ({ audits: 'https://sqs.us-east-1.amazonaws.com/123/audits-queue' }),
+            }),
+          },
+        },
+        sqs: {
+          sendMessage: sandbox.stub().resolves(),
+        },
+      },
+      agenticReportConfig: {
+        name: 'agentic',
+        tableName: 'aggregated_logs_example_consolidated',
+      },
+      auditContext: {},
+      agenticReportHasData: true,
+      ...overrides,
+    };
+  }
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    clock = sinon.useFakeTimers({
+      now: new Date('2026-04-30T12:00:00.000Z'),
+      toFake: ['Date'],
+    });
+    runDailyAgenticExportStub = sandbox.stub().resolves({
+      enabled: true,
+      success: true,
+      trafficDate: '2026-04-29',
+    });
+    generateReportingPeriodsStub = sandbox.stub().returns({
+      weeks: [{
+        startDate: new Date('2026-03-30T00:00:00.000Z'),
+        endDate: new Date('2026-04-05T23:59:59.999Z'),
+      }],
+      periodIdentifier: 'w14-2026',
+    });
+    module = await esmock('../../../../src/cdn-logs-report/utils/agentic-db-export.js', {
+      '../../../../src/cdn-logs-report/agentic-daily-export.js': {
+        runDailyAgenticExport: runDailyAgenticExportStub,
+      },
+      '../../../../src/cdn-logs-report/utils/report-utils.js': {
+        generateReportingPeriods: generateReportingPeriodsStub,
+      },
+    });
+  });
+
+  afterEach(() => {
+    clock.restore();
+    sandbox.restore();
+  });
+
+  it('skips when agentic report config is unavailable', async () => {
+    const args = createArgs({ agenticReportConfig: null });
+
+    const result = await module.runAgenticDbExports(args);
+
+    expect(result).to.deep.equal({});
+    expect(runDailyAgenticExportStub).to.not.have.been.called;
+    expect(args.context.log.debug).to.have.been.calledWith(
+      'Skipping agentic DB export for site-1: agentic report config not found',
+    );
+  });
+
+  it('runs a single daily export for normal non-weekly report runs', async () => {
+    const result = await module.runAgenticDbExports(createArgs());
+
+    expect(runDailyAgenticExportStub).to.have.been.calledOnce;
+    expect(runDailyAgenticExportStub.firstCall.args[0].referenceDate.toISOString())
+      .to.equal('2026-04-30T12:00:00.000Z');
+    expect(result.dailyAgenticExport).to.deep.equal({
+      enabled: true,
+      success: true,
+      trafficDate: '2026-04-29',
+    });
+  });
+
+  it('captures single daily export failures without failing the caller', async () => {
+    runDailyAgenticExportStub.rejects(new Error('daily export failed'));
+    const args = createArgs({
+      auditContext: { refreshAgenticDailyExport: true },
+    });
+
+    const result = await module.runAgenticDbExports(args);
+
+    expect(args.context.log.error).to.have.been.calledWith(
+      'Failed daily agentic export for site site-1: daily export failed',
+      sinon.match.instanceOf(Error),
+    );
+    expect(result.dailyAgenticExport).to.deep.equal({
+      enabled: true,
+      success: false,
+      siteId: 'site-1',
+      error: 'daily export failed',
+    });
+  });
+
+  it('passes a valid date-based run reference date through to the daily export', async () => {
+    await module.runAgenticDbExports(createArgs({
+      auditContext: {
+        date: '2026-04-01T10:00:00.000Z',
+      },
+    }));
+
+    expect(runDailyAgenticExportStub).to.have.been.calledOnce;
+    expect(runDailyAgenticExportStub.firstCall.args[0].referenceDate.toISOString())
+      .to.equal('2026-04-01T10:00:00.000Z');
+  });
+
+  it('logs invalid date-based run input and falls back to the default daily export date', async () => {
+    const args = createArgs({
+      auditContext: {
+        date: 'not-a-real-date',
+      },
+    });
+
+    await module.runAgenticDbExports(args);
+
+    expect(args.context.log.error).to.have.been.calledWith(
+      'Invalid date in auditContext for site-1: not-a-real-date',
+    );
+    expect(runDailyAgenticExportStub).to.have.been.calledOnce;
+    expect(runDailyAgenticExportStub.firstCall.args[0].referenceDate.toISOString())
+      .to.equal('2026-04-30T12:00:00.000Z');
+  });
+
+  it('skips normal weekly report runs without a refresh flag', async () => {
+    const result = await module.runAgenticDbExports(createArgs({
+      auditContext: { weekOffset: -1 },
+    }));
+
+    expect(result).to.deep.equal({});
+    expect(runDailyAgenticExportStub).to.not.have.been.called;
+  });
+
+  it('treats null weekOffset as a non-weekly daily export run', async () => {
+    const args = createArgs({
+      auditContext: { weekOffset: null, refreshAgenticDailyExport: true },
+    });
+
+    const result = await module.runAgenticDbExports(args);
+
+    expect(runDailyAgenticExportStub).to.have.been.calledOnce;
+    expect(args.context.dataAccess.Configuration.findLatest).to.not.have.been.called;
+    expect(args.context.sqs.sendMessage).to.not.have.been.called;
+    expect(result.dailyAgenticExport).to.deep.equal({
+      enabled: true,
+      success: true,
+      trafficDate: '2026-04-29',
+    });
+  });
+
+  it('skips weekly refreshes when the agentic report has no data', async () => {
+    const args = createArgs({
+      auditContext: { weekOffset: -1, refreshAgenticDailyExport: true },
+      agenticReportHasData: false,
+    });
+
+    const result = await module.runAgenticDbExports(args);
+
+    expect(result).to.deep.equal({});
+    expect(runDailyAgenticExportStub).to.not.have.been.called;
+    expect(args.context.log.info).to.have.been.calledWith(
+      'Skipping weekly agentic DB exports for site-1: no agentic report data found',
+    );
+  });
+
+  it('does not treat categoriesUpdated alone as a DB export trigger', async () => {
+    const result = await module.runAgenticDbExports(createArgs({
+      auditContext: { weekOffset: -1, categoriesUpdated: true },
+    }));
+
+    expect(result).to.deep.equal({});
+    expect(runDailyAgenticExportStub).to.not.have.been.called;
+  });
+
+  it('queues seven date-based exports for completed weekly DB refreshes and keeps the singular result contract', async () => {
+    const args = createArgs({
+      auditContext: {
+        weekOffset: -1,
+        categoriesUpdated: true,
+        refreshAgenticDailyExport: true,
+      },
+    });
+
+    const result = await module.runAgenticDbExports(args);
+
+    expect(runDailyAgenticExportStub).to.not.have.been.called;
+    expect(args.context.sqs.sendMessage).to.have.callCount(7);
+    expect(args.context.sqs.sendMessage.firstCall).to.have.been.calledWith(
+      'https://sqs.us-east-1.amazonaws.com/123/audits-queue',
+      {
+        type: 'cdn-logs-report',
+        siteId: 'site-1',
+        auditContext: {
+          date: '2026-03-31T00:00:00.000Z',
+          refreshAgenticDailyExport: true,
+          categoriesUpdated: true,
+          sourceWeekOffset: -1,
+        },
+      },
+      null,
+      0,
+    );
+    expect(args.context.sqs.sendMessage.lastCall.args[1].auditContext.date)
+      .to.equal('2026-04-06T00:00:00.000Z');
+    expect(args.context.sqs.sendMessage.lastCall.args[3]).to.equal(30);
+    expect(result.dailyAgenticExports).to.have.length(7);
+    expect(result.dailyAgenticExport).to.deep.equal(result.dailyAgenticExports.at(-1));
+    expect(args.context.log.info).to.have.been.calledWith(
+      'Queueing weekly agentic DB exports for site-1: weekOffset=-1, trigger=refreshAgenticDailyExport, days=7',
+    );
+  });
+
+  it('runs only completed current-week exports for BYOCDN refreshes', async () => {
+    generateReportingPeriodsStub.returns({
+      weeks: [{
+        startDate: new Date('2026-04-27T00:00:00.000Z'),
+        endDate: new Date('2026-05-03T23:59:59.999Z'),
+      }],
+      periodIdentifier: 'w18-2026',
+    });
+    const args = createArgs({
+      auditContext: {
+        weekOffset: 0,
+        refreshAgenticDailyExport: true,
+        triggeredBy: 'byocdn-other',
+      },
+    });
+
+    const result = await module.runAgenticDbExports(args);
+
+    expect(runDailyAgenticExportStub).to.not.have.been.called;
+    expect(args.context.sqs.sendMessage).to.have.callCount(3);
+    expect(args.context.sqs.sendMessage.firstCall.args[1].auditContext).to.deep.equal({
+      date: '2026-04-28T00:00:00.000Z',
+      refreshAgenticDailyExport: true,
+      triggeredBy: 'byocdn-other',
+      sourceWeekOffset: 0,
+    });
+    expect(args.context.sqs.sendMessage.lastCall.args[1].auditContext.date)
+      .to.equal('2026-04-30T00:00:00.000Z');
+    expect(result.dailyAgenticExports).to.have.length(3);
+    expect(args.context.log.info).to.have.been.calledWith(
+      'Queueing weekly agentic DB exports for site-1: weekOffset=0, trigger=byocdn-other, days=3',
+    );
+  });
+
+  it('continues queueing when one date-based export message fails', async () => {
+    const args = createArgs({
+      auditContext: { weekOffset: -1, refreshAgenticDailyExport: true },
+    });
+    args.context.sqs.sendMessage.onCall(3).rejects(new Error('queue failed'));
+
+    const result = await module.runAgenticDbExports(args);
+
+    expect(args.context.sqs.sendMessage).to.have.callCount(7);
+    expect(result.dailyAgenticExports).to.have.length(7);
+    expect(result.dailyAgenticExports[3]).to.include({
+      success: false,
+      queued: false,
+      error: 'queue failed',
+    });
+    expect(args.context.log.warn).to.have.been.calledWith(
+      'Partial agentic DB export queueing failure for site-1: 1/7 days failed',
+    );
+  });
+
+  it('does not forward invalid triggeredBy values to queued date-based exports', async () => {
+    const args = createArgs({
+      auditContext: {
+        weekOffset: -1,
+        refreshAgenticDailyExport: true,
+        triggeredBy: 'bad\ntrigger',
+      },
+    });
+
+    await module.runAgenticDbExports(args);
+
+    expect(args.context.sqs.sendMessage.firstCall.args[1].auditContext).to.deep.equal({
+      date: '2026-03-31T00:00:00.000Z',
+      refreshAgenticDailyExport: true,
+      sourceWeekOffset: -1,
+    });
+    expect(args.context.log.info).to.have.been.calledWith(
+      'Queueing weekly agentic DB exports for site-1: weekOffset=-1, trigger=refreshAgenticDailyExport, days=7',
+    );
+  });
+
+  it('captures Configuration lookup failures without failing weekly report results', async () => {
+    const args = createArgs({
+      auditContext: { weekOffset: -1, refreshAgenticDailyExport: true },
+    });
+    args.context.dataAccess.Configuration.findLatest.rejects(new Error('configuration unavailable'));
+
+    const result = await module.runAgenticDbExports(args);
+
+    expect(args.context.sqs.sendMessage).to.not.have.been.called;
+    expect(args.context.log.error).to.have.been.calledWith(
+      'Failed to resolve audit queue for site site-1: configuration unavailable',
+      sinon.match.instanceOf(Error),
+    );
+    expect(result).to.deep.equal({
+      dailyAgenticExport: {
+        enabled: true,
+        success: false,
+        queued: false,
+        siteId: 'site-1',
+        error: 'configuration unavailable',
+      },
+      dailyAgenticExports: [],
+    });
+  });
+
+  it('captures missing audit queue configuration without throwing', async () => {
+    const args = createArgs({
+      auditContext: { weekOffset: -1, refreshAgenticDailyExport: true },
+    });
+    args.context.dataAccess.Configuration.findLatest.resolves({
+      getQueues: () => ({}),
+    });
+
+    const result = await module.runAgenticDbExports(args);
+
+    expect(args.context.sqs.sendMessage).to.not.have.been.called;
+    expect(args.context.log.error).to.have.been.calledWith(
+      'Audit queue not configured for site site-1; skipping weekly DB export queueing',
+    );
+    expect(result).to.deep.equal({
+      dailyAgenticExport: {
+        enabled: true,
+        success: false,
+        queued: false,
+        siteId: 'site-1',
+        error: 'Audit queue not configured',
+      },
+      dailyAgenticExports: [],
+    });
+  });
+
+  it('returns an empty weekly result when the reporting period has no week start', async () => {
+    generateReportingPeriodsStub.returns({
+      weeks: [],
+      periodIdentifier: 'w14-2026',
+    });
+    const args = createArgs({
+      auditContext: { weekOffset: -1, refreshAgenticDailyExport: true },
+    });
+
+    const result = await module.runAgenticDbExports(args);
+
+    expect(runDailyAgenticExportStub).to.not.have.been.called;
+    expect(args.context.dataAccess.Configuration.findLatest).to.not.have.been.called;
+    expect(result.dailyAgenticExport).to.equal(null);
+    expect(result.dailyAgenticExports).to.deep.equal([]);
+  });
+});

--- a/test/audits/llmo-customer-analysis-cdn-config.test.js
+++ b/test/audits/llmo-customer-analysis-cdn-config.test.js
@@ -419,6 +419,7 @@ describe('CDN Config Handler', () => {
       dailyReportCalls.forEach((call, index) => {
         expect(call.args[1].auditContext).to.deep.equal({
           date: getExpectedReportDate(cdnLogsAnalysisCalls[index]),
+          refreshAgenticDailyExport: true,
         });
         expect(call.args[3]).to.equal(900 + (index * 5));
       });
@@ -559,6 +560,7 @@ describe('CDN Config Handler', () => {
       dailyReportCalls.forEach((call, index) => {
         expect(call.args[1].auditContext).to.deep.equal({
           date: getExpectedReportDate(cdnLogsAnalysisCalls[index]),
+          refreshAgenticDailyExport: true,
         });
         expect(call.args[3]).to.equal(900 + (index * 5));
       });

--- a/test/audits/llmo-customer-analysis.test.js
+++ b/test/audits/llmo-customer-analysis.test.js
@@ -260,7 +260,14 @@ describe('LLMO Customer Analysis Handler', () => {
       expect(sqs.sendMessage).to.have.callCount(1);
       expect(sqs.sendMessage).to.have.been.calledWith(
         'https://sqs.us-east-1.amazonaws.com/123456789/audits-queue',
-        sinon.match({ type: 'cdn-logs-report' }),
+        sinon.match({
+          type: 'cdn-logs-report',
+          auditContext: {
+            weekOffset: -1,
+            categoriesUpdated: true,
+            refreshAgenticDailyExport: true,
+          },
+        }),
       );
       expect(result.auditResult.status).to.equal('completed');
       expect(result.auditResult.configChangesDetected).to.equal(true);
@@ -629,7 +636,14 @@ describe('LLMO Customer Analysis Handler', () => {
       expect(sqs.sendMessage).to.have.callCount(2);
       expect(sqs.sendMessage).to.have.been.calledWith(
         'https://sqs.us-east-1.amazonaws.com/123456789/audits-queue',
-        sinon.match({ type: 'cdn-logs-report' }),
+        sinon.match({
+          type: 'cdn-logs-report',
+          auditContext: {
+            weekOffset: -1,
+            categoriesUpdated: true,
+            refreshAgenticDailyExport: true,
+          },
+        }),
       );
       expect(sqs.sendMessage).to.have.been.calledWith(
         'https://sqs.us-east-1.amazonaws.com/123456789/audits-queue',


### PR DESCRIPTION
## Summary
- Preserve the default `cdn-logs-report` behavior: normal/date-based runs still execute one daily Agentic DB export.
- For weekly DB refresh triggers, queue one date-based `cdn-logs-report` message per completed UTC day instead of running 7 exports inline.
- Use `refreshAgenticDailyExport` as the explicit weekly DB refresh signal for LLMO category changes and BYOCDN/CDN config refresh paths.
- Keep `categoriesUpdated` scoped to category/pattern/report refresh behavior, not as its own DB export trigger.

## Use Cases Covered
- Normal scheduled report run: SharePoint/report flow + yesterday's DB export.
- Date-based report run: single-day DB export for the provided date.
- Category-change refresh: weekly report refresh, then queued daily DB exports for that week.
- BYOCDN/CDN config refresh: weekly refresh expands into completed daily DB export jobs.
- Current-week refresh: only completed UTC days are queued; future days are skipped.

## Jira
- LLMO-4654
- LLMO-4655
