### PR TITLE
feat(llmo-referral-traffic-daily): add daily LLM referral traffic audit

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -78,6 +78,7 @@ import missingAltTextGuidance from './image-alt-text/guidance-missing-alt-text-h
 import readabilityOpportunities from './readability/opportunities/handler.js';
 import unifiedReadabilityGuidance from './readability/shared/unified-guidance-handler.js';
 import llmoReferralTraffic from './llmo-referral-traffic/handler.js';
+import llmoReferralTrafficDaily from './llmo-referral-traffic-daily/handler.js';
 import llmErrorPages from './llm-error-pages/handler.js';
 import llmErrorPagesGuidance from './llm-error-pages/guidance-handler.js';
 import paidTrafficAnalysis from './paid-traffic-analysis/handler.js';
@@ -184,6 +185,7 @@ const HANDLERS = {
   'detect:form-details': detectFormDetails,
   'page-intent': pageIntent,
   'llmo-referral-traffic': llmoReferralTraffic,
+  'llmo-referral-traffic-daily': llmoReferralTrafficDaily,
   'llm-error-pages': llmErrorPages,
   'guidance:llm-error-pages': llmErrorPagesGuidance,
   'optimization-report-callback': optimizationReportCallback,

--- a/src/llmo-referral-traffic-daily/handler.js
+++ b/src/llmo-referral-traffic-daily/handler.js
@@ -10,8 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import { GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
-import { v4 as uuidv4 } from 'uuid';
+import { createHash } from 'crypto';
+import { DeleteObjectCommand, GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
 import { parquetReadObjects } from 'hyparquet';
 import { Audit } from '@adobe/spacecat-shared-data-access';
 import { AuditBuilder } from '../common/audit-builder.js';
@@ -47,6 +47,12 @@ function consentToBool(raw) {
   return ['hidden', 'suppressed', 'accept'].includes(String(raw).toLowerCase());
 }
 
+function validateDate(date) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    throw new Error(`Invalid date format: ${date}`);
+  }
+}
+
 const CSV_COLUMNS = [
   'traffic_date', 'host', 'url_path', 'trf_platform', 'device', 'region',
   'pageviews', 'consent', 'trf_type', 'trf_channel', 'bounced', 'updated_by',
@@ -54,7 +60,7 @@ const CSV_COLUMNS = [
 
 function escapeCsvValue(value) {
   const normalized = String(value ?? '');
-  if (/["\n,]/.test(normalized)) {
+  if (/["\r\n,]/.test(normalized)) {
     return `"${normalized.replace(/"/g, '""')}"`;
   }
   return normalized;
@@ -77,10 +83,12 @@ function buildCsvRows(records, host) {
       const device = row.device || '';
       const region = extractCountryCode(urlPath);
       const consentBool = consentToBool(row.consent);
-      const bounced = 1 - Number(row.engaged || 0);
+      const bounced = row.engaged > 0 ? 0 : 1;
       const pageviews = Number(row.pageviews || 0);
 
-      const key = `${trafficDate}|${host}|${urlPath}|${trfPlatform}|${device}|${region}|${consentBool}|${bounced}`;
+      const key = JSON.stringify([
+        trafficDate, host, urlPath, trfPlatform, device, region, consentBool, bounced,
+      ]);
 
       if (grouped.has(key)) {
         grouped.get(key).pageviews += pageviews;
@@ -106,15 +114,15 @@ function buildCsvRows(records, host) {
   return [...grouped.values()];
 }
 
-function getCsvS3Key(siteId, year, month, day) {
+function getCsvS3Dir(siteId, year, month, day) {
   const paddedMonth = String(month).padStart(2, '0');
   const paddedDay = String(day).padStart(2, '0');
-  return `rum-metrics-compact/llmo-daily-csvs/siteid=${siteId}/year=${year}/month=${paddedMonth}/day=${paddedDay}/data.csv`;
+  return `rum-metrics-compact/llmo-daily-csvs/siteid=${siteId}/year=${year}/month=${paddedMonth}/day=${paddedDay}`;
 }
 
 async function getAnalyticsQueueUrl(context) {
   const configuration = await context?.dataAccess?.Configuration?.findLatest?.();
-  return configuration?.getQueues?.().analytics || '';
+  return configuration?.getQueues?.()?.analytics || '';
 }
 
 export async function triggerTrafficAnalysisDailyImport(context) {
@@ -133,10 +141,17 @@ export async function triggerTrafficAnalysisDailyImport(context) {
     [date] = yesterday.toISOString().split('T');
   }
 
+  validateDate(date);
+
   const [yearStr, monthStr, dayStr] = date.split('-');
   const year = Number(yearStr);
   const month = Number(monthStr);
   const day = Number(dayStr);
+
+  // Path mirrors createS3DailyKey in spacecat-import-worker/src/ingestor/traffic-analysis-daily.js
+  const paddedMonth = String(month).padStart(2, '0');
+  const paddedDay = String(day).padStart(2, '0');
+  const parquetKey = `rum-metrics-compact/data-daily/siteid=${siteId}/year=${year}/month=${paddedMonth}/day=${paddedDay}/data.parquet`;
 
   log.info(
     `[llmo-referral-traffic-daily] Triggering traffic-analysis-daily import for site: ${siteId}, date: ${date}`,
@@ -151,6 +166,7 @@ export async function triggerTrafficAnalysisDailyImport(context) {
       year,
       month,
       day,
+      parquetKey,
     },
     auditContext: {
       date,
@@ -180,12 +196,16 @@ export async function referralTrafficDailyRunner(context) {
 
   const auditResult = audit.getAuditResult();
   const {
-    date, year, month, day,
+    date, year, month, day, parquetKey,
   } = auditResult;
   const siteId = site.getId();
   const host = new URL(site.getBaseURL()).hostname;
 
-  const parquetKey = `rum-metrics-compact/data-daily/siteid=${siteId}/year=${year}/month=${String(month).padStart(2, '0')}/day=${String(day).padStart(2, '0')}/data.parquet`;
+  validateDate(date);
+
+  const csvDir = getCsvS3Dir(siteId, year, month, day);
+  const csvKey = `${csvDir}/referral_traffic.csv`;
+  const s3Uri = `s3://${bucket}/${csvDir}/`;
 
   log.info(
     `[llmo-referral-traffic-daily] Starting daily referral traffic export for site: ${siteId}, date: ${date}`,
@@ -195,13 +215,15 @@ export async function referralTrafficDailyRunner(context) {
   try {
     const response = await s3Client.send(new GetObjectCommand({ Bucket: bucket, Key: parquetKey }));
     const bytes = await response.Body.transformToByteArray();
-    records = await parquetReadObjects({ file: bytes.buffer });
+    records = await parquetReadObjects({
+      file: bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+    });
   } catch (err) {
     if (err.name === 'NoSuchKey') {
       log.info(`[llmo-referral-traffic-daily] No parquet found at ${parquetKey} for site ${siteId}`);
       return {
         auditResult: { date, rowCount: 0 },
-        fullAuditRef: `s3://${bucket}/${getCsvS3Key(siteId, year, month, day)}`,
+        fullAuditRef: s3Uri,
       };
     }
     throw err;
@@ -213,11 +235,10 @@ export async function referralTrafficDailyRunner(context) {
     log.info(`[llmo-referral-traffic-daily] No LLM referral rows after filter for site ${siteId} on ${date}`);
     return {
       auditResult: { date, rowCount: 0 },
-      fullAuditRef: `s3://${bucket}/${getCsvS3Key(siteId, year, month, day)}`,
+      fullAuditRef: s3Uri,
     };
   }
 
-  const csvKey = getCsvS3Key(siteId, year, month, day);
   const csvBody = serializeCsv(rows);
 
   await s3Client.send(new PutObjectCommand({
@@ -227,15 +248,16 @@ export async function referralTrafficDailyRunner(context) {
     ContentType: 'text/csv',
   }));
 
-  log.info(`[llmo-referral-traffic-daily] Uploaded CSV to s3://${bucket}/${csvKey} (${rows.length} rows)`);
+  log.info(`[llmo-referral-traffic-daily] Uploaded CSV to ${csvKey} (${rows.length} rows)`);
 
-  const batchId = uuidv4();
-  const s3Uri = `s3://${bucket}/${csvKey}`;
+  const dedupId = createHash('sha256')
+    .update(`${siteId}:${date}:referral_traffic_optel`)
+    .digest('hex');
   const messageGroupId = `referral_traffic_optel:${siteId}`;
 
   const message = {
     type: 'batch.completed',
-    correlationId: batchId,
+    correlationId: dedupId,
     pipeline_id: 'referral_traffic_optel',
     s3_uri: s3Uri,
     site_id: siteId,
@@ -248,9 +270,17 @@ export async function referralTrafficDailyRunner(context) {
     message.org_id = site.getOrganizationId();
   }
 
-  await context.sqs.sendMessage(queueUrl, message, messageGroupId, 0, batchId);
+  try {
+    await context.sqs.sendMessage(queueUrl, message, messageGroupId, 0, dedupId);
+  } catch (err) {
+    log.error(`[llmo-referral-traffic-daily] SQS dispatch failed for site ${siteId}; cleaning up uploaded CSV`);
+    await s3Client.send(new DeleteObjectCommand({ Bucket: bucket, Key: csvKey }));
+    throw err;
+  }
 
-  log.info(`[llmo-referral-traffic-daily] Dispatched analytics event for site ${siteId}, date ${date}, batchId: ${batchId}`);
+  log.info(
+    `[llmo-referral-traffic-daily] Dispatched analytics event for site ${siteId}, date ${date}, dedupId: ${dedupId}`,
+  );
 
   return {
     auditResult: { date, csvKey, rowCount: rows.length },

--- a/src/llmo-referral-traffic-daily/handler.js
+++ b/src/llmo-referral-traffic-daily/handler.js
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import { v4 as uuidv4 } from 'uuid';
+import { parquetReadObjects } from 'hyparquet';
+import { Audit } from '@adobe/spacecat-shared-data-access';
+import { AuditBuilder } from '../common/audit-builder.js';
+import { wwwUrlResolver } from '../common/index.js';
+import { DEFAULT_COUNTRY_PATTERNS } from '../common/country-patterns.js';
+
+const { AUDIT_STEP_DESTINATIONS } = Audit;
+
+const COMPILED_COUNTRY_PATTERNS = DEFAULT_COUNTRY_PATTERNS.map(({ name, regex }) => {
+  let flags = '';
+  let pat = regex;
+  if (pat.startsWith('(?i)')) {
+    flags += 'i';
+    pat = pat.slice(4);
+  }
+  return { name, re: new RegExp(pat, flags) };
+});
+
+function extractCountryCode(url) {
+  for (const { re } of COMPILED_COUNTRY_PATTERNS) {
+    const match = url.match(re);
+    if (match && match[1]) {
+      return match[1].toUpperCase();
+    }
+  }
+  return 'GLOBAL';
+}
+
+function consentToBool(raw) {
+  if (raw == null || raw === '') {
+    return true;
+  }
+  return ['hidden', 'suppressed', 'accept'].includes(String(raw).toLowerCase());
+}
+
+const CSV_COLUMNS = [
+  'traffic_date', 'host', 'url_path', 'trf_platform', 'device', 'region',
+  'pageviews', 'consent', 'trf_type', 'trf_channel', 'bounced', 'updated_by',
+];
+
+function escapeCsvValue(value) {
+  const normalized = String(value ?? '');
+  if (/["\n,]/.test(normalized)) {
+    return `"${normalized.replace(/"/g, '""')}"`;
+  }
+  return normalized;
+}
+
+export function serializeCsv(rows) {
+  const header = CSV_COLUMNS.join(',');
+  const body = rows.map((row) => CSV_COLUMNS.map((col) => escapeCsvValue(row[col])).join(','));
+  return [header, ...body].join('\r\n');
+}
+
+function buildCsvRows(records, host) {
+  const grouped = new Map();
+
+  for (const row of records) {
+    if (row.trf_type === 'earned' && row.trf_channel === 'llm') {
+      const trafficDate = row.date || '';
+      const urlPath = row.path || '';
+      const trfPlatform = row.trf_platform || '';
+      const device = row.device || '';
+      const region = extractCountryCode(urlPath);
+      const consentBool = consentToBool(row.consent);
+      const bounced = 1 - Number(row.engaged || 0);
+      const pageviews = Number(row.pageviews || 0);
+
+      const key = `${trafficDate}|${host}|${urlPath}|${trfPlatform}|${device}|${region}|${consentBool}|${bounced}`;
+
+      if (grouped.has(key)) {
+        grouped.get(key).pageviews += pageviews;
+      } else {
+        grouped.set(key, {
+          traffic_date: trafficDate,
+          host,
+          url_path: urlPath,
+          trf_platform: trfPlatform,
+          device,
+          region,
+          pageviews,
+          consent: consentBool ? 'true' : 'false',
+          trf_type: 'earned',
+          trf_channel: 'llm',
+          bounced,
+          updated_by: 'spacecat:optel',
+        });
+      }
+    }
+  }
+
+  return [...grouped.values()];
+}
+
+function getCsvS3Key(siteId, year, month, day) {
+  const paddedMonth = String(month).padStart(2, '0');
+  const paddedDay = String(day).padStart(2, '0');
+  return `rum-metrics-compact/llmo-daily-csvs/siteid=${siteId}/year=${year}/month=${paddedMonth}/day=${paddedDay}/data.csv`;
+}
+
+async function getAnalyticsQueueUrl(context) {
+  const configuration = await context?.dataAccess?.Configuration?.findLatest?.();
+  return configuration?.getQueues?.().analytics || '';
+}
+
+export async function triggerTrafficAnalysisDailyImport(context) {
+  const {
+    site, finalUrl, log, auditContext = {},
+  } = context;
+
+  const siteId = site.getId();
+  let date;
+
+  if (auditContext.date) {
+    date = auditContext.date;
+  } else {
+    const yesterday = new Date();
+    yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+    [date] = yesterday.toISOString().split('T');
+  }
+
+  const [yearStr, monthStr, dayStr] = date.split('-');
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  const day = Number(dayStr);
+
+  log.info(
+    `[llmo-referral-traffic-daily] Triggering traffic-analysis-daily import for site: ${siteId}, date: ${date}`,
+  );
+
+  return {
+    type: 'traffic-analysis-daily',
+    siteId,
+    auditResult: {
+      status: 'import-triggered',
+      date,
+      year,
+      month,
+      day,
+    },
+    auditContext: {
+      date,
+      year,
+      month,
+      day,
+    },
+    fullAuditRef: finalUrl,
+    allowCache: false,
+  };
+}
+
+export async function referralTrafficDailyRunner(context) {
+  const {
+    env, log, audit, site, s3Client,
+  } = context;
+
+  const { S3_IMPORTER_BUCKET_NAME: bucket } = env;
+  if (!bucket) {
+    throw new Error('S3_IMPORTER_BUCKET_NAME must be provided for llmo-referral-traffic-daily audit');
+  }
+
+  const queueUrl = await getAnalyticsQueueUrl(context);
+  if (!queueUrl) {
+    throw new Error('analytics queue is not configured');
+  }
+
+  const auditResult = audit.getAuditResult();
+  const {
+    date, year, month, day,
+  } = auditResult;
+  const siteId = site.getId();
+  const host = new URL(site.getBaseURL()).hostname;
+
+  const parquetKey = `rum-metrics-compact/data-daily/siteid=${siteId}/year=${year}/month=${String(month).padStart(2, '0')}/day=${String(day).padStart(2, '0')}/data.parquet`;
+
+  log.info(
+    `[llmo-referral-traffic-daily] Starting daily referral traffic export for site: ${siteId}, date: ${date}`,
+  );
+
+  let records;
+  try {
+    const response = await s3Client.send(new GetObjectCommand({ Bucket: bucket, Key: parquetKey }));
+    const bytes = await response.Body.transformToByteArray();
+    records = await parquetReadObjects({ file: bytes.buffer });
+  } catch (err) {
+    if (err.name === 'NoSuchKey') {
+      log.info(`[llmo-referral-traffic-daily] No parquet found at ${parquetKey} for site ${siteId}`);
+      return {
+        auditResult: { date, rowCount: 0 },
+        fullAuditRef: `s3://${bucket}/${getCsvS3Key(siteId, year, month, day)}`,
+      };
+    }
+    throw err;
+  }
+
+  const rows = buildCsvRows(records, host);
+
+  if (rows.length === 0) {
+    log.info(`[llmo-referral-traffic-daily] No LLM referral rows after filter for site ${siteId} on ${date}`);
+    return {
+      auditResult: { date, rowCount: 0 },
+      fullAuditRef: `s3://${bucket}/${getCsvS3Key(siteId, year, month, day)}`,
+    };
+  }
+
+  const csvKey = getCsvS3Key(siteId, year, month, day);
+  const csvBody = serializeCsv(rows);
+
+  await s3Client.send(new PutObjectCommand({
+    Bucket: bucket,
+    Key: csvKey,
+    Body: csvBody,
+    ContentType: 'text/csv',
+  }));
+
+  log.info(`[llmo-referral-traffic-daily] Uploaded CSV to s3://${bucket}/${csvKey} (${rows.length} rows)`);
+
+  const batchId = uuidv4();
+  const s3Uri = `s3://${bucket}/${csvKey}`;
+  const messageGroupId = `referral_traffic_optel:${siteId}`;
+
+  const message = {
+    type: 'batch.completed',
+    correlationId: batchId,
+    pipeline_id: 'referral_traffic_optel',
+    s3_uri: s3Uri,
+    site_id: siteId,
+    start_date: date,
+    end_date: date,
+    row_count: rows.length,
+  };
+
+  if (site.getOrganizationId?.()) {
+    message.org_id = site.getOrganizationId();
+  }
+
+  await context.sqs.sendMessage(queueUrl, message, messageGroupId, 0, batchId);
+
+  log.info(`[llmo-referral-traffic-daily] Dispatched analytics event for site ${siteId}, date ${date}, batchId: ${batchId}`);
+
+  return {
+    auditResult: { date, csvKey, rowCount: rows.length },
+    fullAuditRef: s3Uri,
+  };
+}
+
+export default new AuditBuilder()
+  .withUrlResolver(wwwUrlResolver)
+  .addStep(
+    'trigger-traffic-analysis-daily-import',
+    triggerTrafficAnalysisDailyImport,
+    AUDIT_STEP_DESTINATIONS.IMPORT_WORKER,
+  )
+  .addStep(
+    'run-referral-traffic-daily',
+    referralTrafficDailyRunner,
+  )
+  .build();

--- a/src/llmo-referral-traffic-daily/handler.js
+++ b/src/llmo-referral-traffic-daily/handler.js
@@ -114,10 +114,10 @@ function buildCsvRows(records, host) {
   return [...grouped.values()];
 }
 
-function getCsvS3Dir(siteId, year, month, day) {
+function getCsvS3Key(siteId, year, month, day) {
   const paddedMonth = String(month).padStart(2, '0');
   const paddedDay = String(day).padStart(2, '0');
-  return `rum-metrics-compact/llmo-daily-csvs/siteid=${siteId}/year=${year}/month=${paddedMonth}/day=${paddedDay}`;
+  return `rum-metrics-compact/llmo-daily-csvs/siteid=${siteId}/year=${year}/month=${paddedMonth}/day=${paddedDay}/data.csv`;
 }
 
 async function getAnalyticsQueueUrl(context) {
@@ -203,9 +203,8 @@ export async function referralTrafficDailyRunner(context) {
 
   validateDate(date);
 
-  const csvDir = getCsvS3Dir(siteId, year, month, day);
-  const csvKey = `${csvDir}/referral_traffic.csv`;
-  const s3Uri = `s3://${bucket}/${csvDir}/`;
+  const csvKey = getCsvS3Key(siteId, year, month, day);
+  const s3Uri = `s3://${bucket}/${csvKey}`;
 
   log.info(
     `[llmo-referral-traffic-daily] Starting daily referral traffic export for site: ${siteId}, date: ${date}`,

--- a/test/audits/llmo-referral-traffic-daily/handler.test.js
+++ b/test/audits/llmo-referral-traffic-daily/handler.test.js
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import { createHash } from 'crypto';
 import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
@@ -20,6 +21,8 @@ import { MockContextBuilder } from '../../shared.js';
 
 use(sinonChai);
 use(chaiAsPromised);
+
+const EXPECTED_PARQUET_KEY = 'rum-metrics-compact/data-daily/siteid=site-123/year=2026/month=04/day=29/data.parquet';
 
 // Minimal parquet row fixture representing one LLM referral row
 const PARQUET_ROW = {
@@ -37,14 +40,40 @@ const PARQUET_ROW = {
 describe('serializeCsv', () => {
   it('should render null field values as empty string', () => {
     const rows = [{
-      traffic_date: '2026-04-29', host: 'example.com', url_path: '/page',
-      trf_platform: null, device: 'desktop', region: 'GLOBAL',
-      pageviews: 1, consent: 'true', trf_type: 'earned', trf_channel: 'llm',
-      bounced: 0, updated_by: 'spacecat:optel',
+      traffic_date: '2026-04-29',
+      host: 'example.com',
+      url_path: '/page',
+      trf_platform: null,
+      device: 'desktop',
+      region: 'GLOBAL',
+      pageviews: 1,
+      consent: 'true',
+      trf_type: 'earned',
+      trf_channel: 'llm',
+      bounced: 0,
+      updated_by: 'spacecat:optel',
     }];
     const csv = serializeCsv(rows);
-    // null trf_platform should produce an empty field (two consecutive commas)
     expect(csv).to.include('2026-04-29,example.com,/page,,desktop');
+  });
+
+  it('should quote CSV values that contain carriage return', () => {
+    const rows = [{
+      traffic_date: '2026-04-29',
+      host: 'example.com',
+      url_path: '/page',
+      trf_platform: 'platform\rwith\rcr',
+      device: 'desktop',
+      region: 'GLOBAL',
+      pageviews: 1,
+      consent: 'true',
+      trf_type: 'earned',
+      trf_channel: 'llm',
+      bounced: 0,
+      updated_by: 'spacecat:optel',
+    }];
+    const csv = serializeCsv(rows);
+    expect(csv).to.include('"platform\rwith\rcr"');
   });
 });
 
@@ -57,7 +86,6 @@ describe('LLMO Referral Traffic Daily Handler', function () {
   let audit;
   let s3ClientStub;
   let sqsSendMessageStub;
-  let uuidStub;
   let parquetReadObjectsStub;
   let handlerModule;
 
@@ -68,7 +96,6 @@ describe('LLMO Referral Traffic Daily Handler', function () {
   beforeEach(async () => {
     s3ClientStub = { send: sandbox.stub() };
     sqsSendMessageStub = sandbox.stub().resolves();
-    uuidStub = sandbox.stub().returns('test-uuid-1234');
     parquetReadObjectsStub = sandbox.stub().resolves([PARQUET_ROW]);
 
     site = {
@@ -84,6 +111,7 @@ describe('LLMO Referral Traffic Daily Handler', function () {
         year: 2026,
         month: 4,
         day: 29,
+        parquetKey: EXPECTED_PARQUET_KEY,
       }),
     };
 
@@ -107,10 +135,10 @@ describe('LLMO Referral Traffic Daily Handler', function () {
 
     handlerModule = await esmock('../../../src/llmo-referral-traffic-daily/handler.js', {
       'hyparquet': { parquetReadObjects: parquetReadObjectsStub },
-      'uuid': { v4: uuidStub },
       '@aws-sdk/client-s3': {
         GetObjectCommand: sinon.stub().callsFake((args) => ({ ...args, _type: 'GetObjectCommand' })),
         PutObjectCommand: sinon.stub().callsFake((args) => ({ ...args, _type: 'PutObjectCommand' })),
+        DeleteObjectCommand: sinon.stub().callsFake((args) => ({ ...args, _type: 'DeleteObjectCommand' })),
       },
     });
   });
@@ -154,12 +182,13 @@ describe('LLMO Referral Traffic Daily Handler', function () {
       expect(result.fullAuditRef).to.equal('https://example.com');
     });
 
-    it('should include siteId in the returned message', async () => {
+    it('should include siteId and parquetKey in the returned message', async () => {
       context.auditContext = { date: '2026-04-29' };
       context.finalUrl = 'https://example.com';
 
       const result = await handlerModule.triggerTrafficAnalysisDailyImport(context);
       expect(result.siteId).to.equal('site-123');
+      expect(result.auditResult.parquetKey).to.equal(EXPECTED_PARQUET_KEY);
     });
 
     it('should default auditContext to empty object when absent from context', async () => {
@@ -170,6 +199,13 @@ describe('LLMO Referral Traffic Daily Handler', function () {
       const result = await handlerModule.triggerTrafficAnalysisDailyImport(context);
       expect(result.auditResult.date).to.equal('2026-04-29');
       clock.restore();
+    });
+
+    it('should throw on invalid date format', async () => {
+      context.auditContext = { date: '2026/04/29' };
+      context.finalUrl = 'https://example.com';
+      await expect(handlerModule.triggerTrafficAnalysisDailyImport(context))
+        .to.be.rejectedWith('Invalid date format: 2026/04/29');
     });
   });
 
@@ -190,6 +226,23 @@ describe('LLMO Referral Traffic Daily Handler', function () {
         .to.be.rejectedWith('analytics queue is not configured');
     });
 
+    it('should throw if getQueues returns null', async () => {
+      context.dataAccess.Configuration.findLatest.resolves({
+        getQueues: () => null,
+      });
+      await expect(handlerModule.referralTrafficDailyRunner(context))
+        .to.be.rejectedWith('analytics queue is not configured');
+    });
+
+    it('should throw on invalid date format', async () => {
+      audit.getAuditResult.returns({
+        date: 'not-a-date', year: 2026, month: 4, day: 29,
+        parquetKey: EXPECTED_PARQUET_KEY,
+      });
+      await expect(handlerModule.referralTrafficDailyRunner(context))
+        .to.be.rejectedWith('Invalid date format: not-a-date');
+    });
+
     it('should return early with rowCount 0 when parquet does not exist (NoSuchKey)', async () => {
       const noSuchKeyError = new Error('NoSuchKey');
       noSuchKeyError.name = 'NoSuchKey';
@@ -200,6 +253,7 @@ describe('LLMO Referral Traffic Daily Handler', function () {
       expect(result.auditResult.rowCount).to.equal(0);
       expect(result.auditResult.date).to.equal('2026-04-29');
       expect(result.fullAuditRef).to.include('s3://test-bucket');
+      expect(result.fullAuditRef).to.match(/\/$/);
     });
 
     it('should rethrow non-NoSuchKey S3 errors', async () => {
@@ -221,7 +275,6 @@ describe('LLMO Referral Traffic Daily Handler', function () {
         engaged: 1,
       }]);
 
-      // First send() is GetObjectCommand (read parquet), simulate success
       s3ClientStub.send.resolves({
         Body: {
           transformToByteArray: sandbox.stub().resolves(new Uint8Array([0])),
@@ -248,7 +301,9 @@ describe('LLMO Referral Traffic Daily Handler', function () {
       expect(result.auditResult.rowCount).to.equal(1);
       expect(result.auditResult.date).to.equal('2026-04-29');
       expect(result.auditResult.csvKey).to.include('rum-metrics-compact/llmo-daily-csvs/siteid=site-123');
+      expect(result.auditResult.csvKey).to.include('referral_traffic.csv');
       expect(result.fullAuditRef).to.include('s3://test-bucket');
+      expect(result.fullAuditRef).to.match(/\/$/);
 
       // Verify PutObjectCommand was sent with CSV
       const putCall = s3ClientStub.send.secondCall.args[0];
@@ -256,9 +311,12 @@ describe('LLMO Referral Traffic Daily Handler', function () {
       expect(putCall.Body).to.include('traffic_date,host,url_path');
       expect(putCall.Body).to.include('2026-04-29');
 
-      // Verify analytics SQS message
+      // Verify analytics SQS message shape and deterministic dedup ID
       expect(sqsSendMessageStub).to.have.been.calledOnce;
       const [queueUrl, msg, groupId,, dedupId] = sqsSendMessageStub.firstCall.args;
+      const expectedDedupId = createHash('sha256')
+        .update('site-123:2026-04-29:referral_traffic_optel')
+        .digest('hex');
       expect(queueUrl).to.include('analytics');
       expect(msg.pipeline_id).to.equal('referral_traffic_optel');
       expect(msg.type).to.equal('batch.completed');
@@ -267,8 +325,11 @@ describe('LLMO Referral Traffic Daily Handler', function () {
       expect(msg.row_count).to.equal(1);
       expect(msg.start_date).to.equal('2026-04-29');
       expect(msg.end_date).to.equal('2026-04-29');
+      expect(msg.correlationId).to.equal(expectedDedupId);
+      expect(msg.s3_uri).to.include('rum-metrics-compact/llmo-daily-csvs/siteid=site-123');
+      expect(msg.s3_uri).to.match(/\/$/);
       expect(groupId).to.equal('referral_traffic_optel:site-123');
-      expect(dedupId).to.equal('test-uuid-1234');
+      expect(dedupId).to.equal(expectedDedupId);
     });
 
     it('should omit org_id when getOrganizationId returns falsy', async () => {
@@ -283,8 +344,27 @@ describe('LLMO Referral Traffic Daily Handler', function () {
       const result = await handlerModule.referralTrafficDailyRunner(context);
 
       expect(result.auditResult.rowCount).to.equal(1);
-      const [,msg] = sqsSendMessageStub.firstCall.args;
+      const [, msg] = sqsSendMessageStub.firstCall.args;
       expect(msg).not.to.have.property('org_id');
+    });
+
+    it('should delete uploaded CSV when SQS dispatch fails', async () => {
+      parquetReadObjectsStub.resolves([PARQUET_ROW]);
+      s3ClientStub.send
+        .onFirstCall().resolves({
+          Body: { transformToByteArray: sandbox.stub().resolves(new Uint8Array([0])) },
+        })
+        .onSecondCall().resolves({})  // PUT succeeds
+        .onThirdCall().resolves({});  // DELETE cleanup
+
+      sqsSendMessageStub.rejects(new Error('SQS unavailable'));
+
+      await expect(handlerModule.referralTrafficDailyRunner(context))
+        .to.be.rejectedWith('SQS unavailable');
+
+      expect(s3ClientStub.send).to.have.been.calledThrice;
+      const deleteCall = s3ClientStub.send.thirdCall.args[0];
+      expect(deleteCall.Key).to.include('referral_traffic.csv');
     });
 
     it('should aggregate pageviews for same group key', async () => {
@@ -380,7 +460,11 @@ describe('LLMO Referral Traffic Daily Handler', function () {
 
     it('should use correct S3 path for CSV with padded month and day', async () => {
       audit.getAuditResult.returns({
-        date: '2026-01-05', year: 2026, month: 1, day: 5,
+        date: '2026-01-05',
+        year: 2026,
+        month: 1,
+        day: 5,
+        parquetKey: 'rum-metrics-compact/data-daily/siteid=site-123/year=2026/month=01/day=05/data.parquet',
       });
       parquetReadObjectsStub.resolves([{ ...PARQUET_ROW, date: '2026-01-05' }]);
       s3ClientStub.send
@@ -392,7 +476,7 @@ describe('LLMO Referral Traffic Daily Handler', function () {
       const result = await handlerModule.referralTrafficDailyRunner(context);
 
       expect(result.auditResult.csvKey).to.equal(
-        'rum-metrics-compact/llmo-daily-csvs/siteid=site-123/year=2026/month=01/day=05/data.csv',
+        'rum-metrics-compact/llmo-daily-csvs/siteid=site-123/year=2026/month=01/day=05/referral_traffic.csv',
       );
     });
 
@@ -411,8 +495,6 @@ describe('LLMO Referral Traffic Daily Handler', function () {
     });
 
     it('should fall back to empty string for missing row fields', async () => {
-      // Row with undefined date, path, trf_platform, device, pageviews, consent
-      // covers all || '' fallbacks and escapeCsvValue(undefined) branch
       parquetReadObjectsStub.resolves([{
         trf_type: 'earned',
         trf_channel: 'llm',

--- a/test/audits/llmo-referral-traffic-daily/handler.test.js
+++ b/test/audits/llmo-referral-traffic-daily/handler.test.js
@@ -253,7 +253,6 @@ describe('LLMO Referral Traffic Daily Handler', function () {
       expect(result.auditResult.rowCount).to.equal(0);
       expect(result.auditResult.date).to.equal('2026-04-29');
       expect(result.fullAuditRef).to.include('s3://test-bucket');
-      expect(result.fullAuditRef).to.match(/\/$/);
     });
 
     it('should rethrow non-NoSuchKey S3 errors', async () => {
@@ -301,9 +300,8 @@ describe('LLMO Referral Traffic Daily Handler', function () {
       expect(result.auditResult.rowCount).to.equal(1);
       expect(result.auditResult.date).to.equal('2026-04-29');
       expect(result.auditResult.csvKey).to.include('rum-metrics-compact/llmo-daily-csvs/siteid=site-123');
-      expect(result.auditResult.csvKey).to.include('referral_traffic.csv');
+      expect(result.auditResult.csvKey).to.include('data.csv');
       expect(result.fullAuditRef).to.include('s3://test-bucket');
-      expect(result.fullAuditRef).to.match(/\/$/);
 
       // Verify PutObjectCommand was sent with CSV
       const putCall = s3ClientStub.send.secondCall.args[0];
@@ -327,7 +325,7 @@ describe('LLMO Referral Traffic Daily Handler', function () {
       expect(msg.end_date).to.equal('2026-04-29');
       expect(msg.correlationId).to.equal(expectedDedupId);
       expect(msg.s3_uri).to.include('rum-metrics-compact/llmo-daily-csvs/siteid=site-123');
-      expect(msg.s3_uri).to.match(/\/$/);
+      expect(msg.s3_uri).to.include('data.csv');
       expect(groupId).to.equal('referral_traffic_optel:site-123');
       expect(dedupId).to.equal(expectedDedupId);
     });
@@ -364,7 +362,7 @@ describe('LLMO Referral Traffic Daily Handler', function () {
 
       expect(s3ClientStub.send).to.have.been.calledThrice;
       const deleteCall = s3ClientStub.send.thirdCall.args[0];
-      expect(deleteCall.Key).to.include('referral_traffic.csv');
+      expect(deleteCall.Key).to.include('data.csv');
     });
 
     it('should aggregate pageviews for same group key', async () => {
@@ -476,7 +474,10 @@ describe('LLMO Referral Traffic Daily Handler', function () {
       const result = await handlerModule.referralTrafficDailyRunner(context);
 
       expect(result.auditResult.csvKey).to.equal(
-        'rum-metrics-compact/llmo-daily-csvs/siteid=site-123/year=2026/month=01/day=05/referral_traffic.csv',
+        'rum-metrics-compact/llmo-daily-csvs/siteid=site-123/year=2026/month=01/day=05/data.csv',
+      );
+      expect(result.fullAuditRef).to.equal(
+        's3://test-bucket/rum-metrics-compact/llmo-daily-csvs/siteid=site-123/year=2026/month=01/day=05/data.csv',
       );
     });
 

--- a/test/audits/llmo-referral-traffic-daily/handler.test.js
+++ b/test/audits/llmo-referral-traffic-daily/handler.test.js
@@ -1,0 +1,451 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
+import esmock from 'esmock';
+import { serializeCsv } from '../../../src/llmo-referral-traffic-daily/handler.js';
+import { MockContextBuilder } from '../../shared.js';
+
+use(sinonChai);
+use(chaiAsPromised);
+
+// Minimal parquet row fixture representing one LLM referral row
+const PARQUET_ROW = {
+  path: '/us/page1',
+  date: '2026-04-29',
+  trf_type: 'earned',
+  trf_channel: 'llm',
+  trf_platform: 'chatgpt',
+  device: 'desktop',
+  consent: 'accept',
+  pageviews: 100,
+  engaged: 1,
+};
+
+describe('serializeCsv', () => {
+  it('should render null field values as empty string', () => {
+    const rows = [{
+      traffic_date: '2026-04-29', host: 'example.com', url_path: '/page',
+      trf_platform: null, device: 'desktop', region: 'GLOBAL',
+      pageviews: 1, consent: 'true', trf_type: 'earned', trf_channel: 'llm',
+      bounced: 0, updated_by: 'spacecat:optel',
+    }];
+    const csv = serializeCsv(rows);
+    // null trf_platform should produce an empty field (two consecutive commas)
+    expect(csv).to.include('2026-04-29,example.com,/page,,desktop');
+  });
+});
+
+describe('LLMO Referral Traffic Daily Handler', function () {
+  this.timeout(10000);
+
+  let sandbox;
+  let context;
+  let site;
+  let audit;
+  let s3ClientStub;
+  let sqsSendMessageStub;
+  let uuidStub;
+  let parquetReadObjectsStub;
+  let handlerModule;
+
+  before(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  beforeEach(async () => {
+    s3ClientStub = { send: sandbox.stub() };
+    sqsSendMessageStub = sandbox.stub().resolves();
+    uuidStub = sandbox.stub().returns('test-uuid-1234');
+    parquetReadObjectsStub = sandbox.stub().resolves([PARQUET_ROW]);
+
+    site = {
+      getId: sandbox.stub().returns('site-123'),
+      getBaseURL: sandbox.stub().returns('https://example.com'),
+      getOrganizationId: sandbox.stub().returns('org-456'),
+    };
+
+    audit = {
+      getAuditResult: sandbox.stub().returns({
+        status: 'import-triggered',
+        date: '2026-04-29',
+        year: 2026,
+        month: 4,
+        day: 29,
+      }),
+    };
+
+    context = new MockContextBuilder()
+      .withSandbox(sandbox)
+      .withOverrides({
+        site,
+        audit,
+        s3Client: s3ClientStub,
+        sqs: { sendMessage: sqsSendMessageStub },
+        env: { S3_IMPORTER_BUCKET_NAME: 'test-bucket' },
+        dataAccess: {
+          Configuration: {
+            findLatest: sandbox.stub().resolves({
+              getQueues: () => ({ analytics: 'https://sqs.us-east-1.amazonaws.com/test/analytics.fifo' }),
+            }),
+          },
+        },
+      })
+      .build();
+
+    handlerModule = await esmock('../../../src/llmo-referral-traffic-daily/handler.js', {
+      'hyparquet': { parquetReadObjects: parquetReadObjectsStub },
+      'uuid': { v4: uuidStub },
+      '@aws-sdk/client-s3': {
+        GetObjectCommand: sinon.stub().callsFake((args) => ({ ...args, _type: 'GetObjectCommand' })),
+        PutObjectCommand: sinon.stub().callsFake((args) => ({ ...args, _type: 'PutObjectCommand' })),
+      },
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  // ───────────────────────────── Step 1 ─────────────────────────────
+
+  describe('triggerTrafficAnalysisDailyImport', () => {
+    it('should use yesterday when auditContext.date is not set', async () => {
+      const clock = sandbox.useFakeTimers(new Date('2026-04-30T10:00:00Z'));
+      context.auditContext = {};
+      context.finalUrl = 'https://example.com';
+
+      const result = await handlerModule.triggerTrafficAnalysisDailyImport(context);
+
+      expect(result.auditResult.date).to.equal('2026-04-29');
+      expect(result.auditResult.year).to.equal(2026);
+      expect(result.auditResult.month).to.equal(4);
+      expect(result.auditResult.day).to.equal(29);
+      expect(result.type).to.equal('traffic-analysis-daily');
+      expect(result.allowCache).to.equal(false);
+      clock.restore();
+    });
+
+    it('should use auditContext.date when provided', async () => {
+      context.auditContext = { date: '2026-03-15' };
+      context.finalUrl = 'https://example.com';
+
+      const result = await handlerModule.triggerTrafficAnalysisDailyImport(context);
+
+      expect(result.auditResult.date).to.equal('2026-03-15');
+      expect(result.auditResult.year).to.equal(2026);
+      expect(result.auditResult.month).to.equal(3);
+      expect(result.auditResult.day).to.equal(15);
+      expect(result.auditContext).to.deep.equal({
+        date: '2026-03-15', year: 2026, month: 3, day: 15,
+      });
+      expect(result.fullAuditRef).to.equal('https://example.com');
+    });
+
+    it('should include siteId in the returned message', async () => {
+      context.auditContext = { date: '2026-04-29' };
+      context.finalUrl = 'https://example.com';
+
+      const result = await handlerModule.triggerTrafficAnalysisDailyImport(context);
+      expect(result.siteId).to.equal('site-123');
+    });
+
+    it('should default auditContext to empty object when absent from context', async () => {
+      const clock = sandbox.useFakeTimers(new Date('2026-04-30T00:30:00Z'));
+      delete context.auditContext;
+      context.finalUrl = 'https://example.com';
+
+      const result = await handlerModule.triggerTrafficAnalysisDailyImport(context);
+      expect(result.auditResult.date).to.equal('2026-04-29');
+      clock.restore();
+    });
+  });
+
+  // ───────────────────────────── Step 2 ─────────────────────────────
+
+  describe('referralTrafficDailyRunner', () => {
+    it('should throw if S3_IMPORTER_BUCKET_NAME is not set', async () => {
+      context.env = {};
+      await expect(handlerModule.referralTrafficDailyRunner(context))
+        .to.be.rejectedWith('S3_IMPORTER_BUCKET_NAME must be provided');
+    });
+
+    it('should throw if analytics queue is not configured', async () => {
+      context.dataAccess.Configuration.findLatest.resolves({
+        getQueues: () => ({ analytics: '' }),
+      });
+      await expect(handlerModule.referralTrafficDailyRunner(context))
+        .to.be.rejectedWith('analytics queue is not configured');
+    });
+
+    it('should return early with rowCount 0 when parquet does not exist (NoSuchKey)', async () => {
+      const noSuchKeyError = new Error('NoSuchKey');
+      noSuchKeyError.name = 'NoSuchKey';
+      s3ClientStub.send.rejects(noSuchKeyError);
+
+      const result = await handlerModule.referralTrafficDailyRunner(context);
+
+      expect(result.auditResult.rowCount).to.equal(0);
+      expect(result.auditResult.date).to.equal('2026-04-29');
+      expect(result.fullAuditRef).to.include('s3://test-bucket');
+    });
+
+    it('should rethrow non-NoSuchKey S3 errors', async () => {
+      const genericError = new Error('Access Denied');
+      genericError.name = 'AccessDenied';
+      s3ClientStub.send.rejects(genericError);
+
+      await expect(handlerModule.referralTrafficDailyRunner(context))
+        .to.be.rejectedWith('Access Denied');
+    });
+
+    it('should return early with rowCount 0 when no rows pass the LLM filter', async () => {
+      parquetReadObjectsStub.resolves([{
+        path: '/page1',
+        date: '2026-04-29',
+        trf_type: 'paid',
+        trf_channel: 'social',
+        pageviews: 100,
+        engaged: 1,
+      }]);
+
+      // First send() is GetObjectCommand (read parquet), simulate success
+      s3ClientStub.send.resolves({
+        Body: {
+          transformToByteArray: sandbox.stub().resolves(new Uint8Array([0])),
+        },
+      });
+
+      const result = await handlerModule.referralTrafficDailyRunner(context);
+
+      expect(result.auditResult.rowCount).to.equal(0);
+      expect(sqsSendMessageStub).not.to.have.been.called;
+    });
+
+    it('should upload CSV and dispatch analytics event for valid data', async () => {
+      parquetReadObjectsStub.resolves([PARQUET_ROW]);
+
+      s3ClientStub.send
+        .onFirstCall().resolves({
+          Body: { transformToByteArray: sandbox.stub().resolves(new Uint8Array([0])) },
+        })
+        .onSecondCall().resolves({});
+
+      const result = await handlerModule.referralTrafficDailyRunner(context);
+
+      expect(result.auditResult.rowCount).to.equal(1);
+      expect(result.auditResult.date).to.equal('2026-04-29');
+      expect(result.auditResult.csvKey).to.include('rum-metrics-compact/llmo-daily-csvs/siteid=site-123');
+      expect(result.fullAuditRef).to.include('s3://test-bucket');
+
+      // Verify PutObjectCommand was sent with CSV
+      const putCall = s3ClientStub.send.secondCall.args[0];
+      expect(putCall.ContentType).to.equal('text/csv');
+      expect(putCall.Body).to.include('traffic_date,host,url_path');
+      expect(putCall.Body).to.include('2026-04-29');
+
+      // Verify analytics SQS message
+      expect(sqsSendMessageStub).to.have.been.calledOnce;
+      const [queueUrl, msg, groupId,, dedupId] = sqsSendMessageStub.firstCall.args;
+      expect(queueUrl).to.include('analytics');
+      expect(msg.pipeline_id).to.equal('referral_traffic_optel');
+      expect(msg.type).to.equal('batch.completed');
+      expect(msg.site_id).to.equal('site-123');
+      expect(msg.org_id).to.equal('org-456');
+      expect(msg.row_count).to.equal(1);
+      expect(msg.start_date).to.equal('2026-04-29');
+      expect(msg.end_date).to.equal('2026-04-29');
+      expect(groupId).to.equal('referral_traffic_optel:site-123');
+      expect(dedupId).to.equal('test-uuid-1234');
+    });
+
+    it('should omit org_id when getOrganizationId returns falsy', async () => {
+      site.getOrganizationId.returns(null);
+      parquetReadObjectsStub.resolves([PARQUET_ROW]);
+      s3ClientStub.send
+        .onFirstCall().resolves({
+          Body: { transformToByteArray: sandbox.stub().resolves(new Uint8Array([0])) },
+        })
+        .onSecondCall().resolves({});
+
+      const result = await handlerModule.referralTrafficDailyRunner(context);
+
+      expect(result.auditResult.rowCount).to.equal(1);
+      const [,msg] = sqsSendMessageStub.firstCall.args;
+      expect(msg).not.to.have.property('org_id');
+    });
+
+    it('should aggregate pageviews for same group key', async () => {
+      parquetReadObjectsStub.resolves([
+        { ...PARQUET_ROW, pageviews: 40 },
+        { ...PARQUET_ROW, pageviews: 60 },
+      ]);
+
+      s3ClientStub.send
+        .onFirstCall().resolves({
+          Body: { transformToByteArray: sandbox.stub().resolves(new Uint8Array([0])) },
+        })
+        .onSecondCall().resolves({});
+
+      const result = await handlerModule.referralTrafficDailyRunner(context);
+
+      expect(result.auditResult.rowCount).to.equal(1);
+      const putCall = s3ClientStub.send.secondCall.args[0];
+      expect(putCall.Body).to.include('100');
+    });
+
+    it('should produce two rows for same path with different bounced values', async () => {
+      parquetReadObjectsStub.resolves([
+        { ...PARQUET_ROW, engaged: 1, pageviews: 70 },  // bounced=0
+        { ...PARQUET_ROW, engaged: 0, pageviews: 30 },  // bounced=1
+      ]);
+
+      s3ClientStub.send
+        .onFirstCall().resolves({
+          Body: { transformToByteArray: sandbox.stub().resolves(new Uint8Array([0])) },
+        })
+        .onSecondCall().resolves({});
+
+      const result = await handlerModule.referralTrafficDailyRunner(context);
+      expect(result.auditResult.rowCount).to.equal(2);
+    });
+
+    it('should correctly derive region from path', async () => {
+      parquetReadObjectsStub.resolves([{ ...PARQUET_ROW, path: '/de/page1' }]);
+      s3ClientStub.send
+        .onFirstCall().resolves({
+          Body: { transformToByteArray: sandbox.stub().resolves(new Uint8Array([0])) },
+        })
+        .onSecondCall().resolves({});
+
+      await handlerModule.referralTrafficDailyRunner(context);
+
+      const putCall = s3ClientStub.send.secondCall.args[0];
+      expect(putCall.Body).to.include('DE');
+    });
+
+    it('should default region to GLOBAL for unrecognized path', async () => {
+      parquetReadObjectsStub.resolves([{ ...PARQUET_ROW, path: '/some/generic/path' }]);
+      s3ClientStub.send
+        .onFirstCall().resolves({
+          Body: { transformToByteArray: sandbox.stub().resolves(new Uint8Array([0])) },
+        })
+        .onSecondCall().resolves({});
+
+      await handlerModule.referralTrafficDailyRunner(context);
+
+      const putCall = s3ClientStub.send.secondCall.args[0];
+      expect(putCall.Body).to.include('GLOBAL');
+    });
+
+    it('should map consent=null to true (consent=true in CSV)', async () => {
+      parquetReadObjectsStub.resolves([{ ...PARQUET_ROW, consent: null }]);
+      s3ClientStub.send
+        .onFirstCall().resolves({
+          Body: { transformToByteArray: sandbox.stub().resolves(new Uint8Array([0])) },
+        })
+        .onSecondCall().resolves({});
+
+      await handlerModule.referralTrafficDailyRunner(context);
+
+      const putCall = s3ClientStub.send.secondCall.args[0];
+      expect(putCall.Body).to.include(',true,');
+    });
+
+    it('should map consent=reject to false (consent=false in CSV)', async () => {
+      parquetReadObjectsStub.resolves([{ ...PARQUET_ROW, consent: 'reject' }]);
+      s3ClientStub.send
+        .onFirstCall().resolves({
+          Body: { transformToByteArray: sandbox.stub().resolves(new Uint8Array([0])) },
+        })
+        .onSecondCall().resolves({});
+
+      await handlerModule.referralTrafficDailyRunner(context);
+
+      const putCall = s3ClientStub.send.secondCall.args[0];
+      expect(putCall.Body).to.include(',false,');
+    });
+
+    it('should use correct S3 path for CSV with padded month and day', async () => {
+      audit.getAuditResult.returns({
+        date: '2026-01-05', year: 2026, month: 1, day: 5,
+      });
+      parquetReadObjectsStub.resolves([{ ...PARQUET_ROW, date: '2026-01-05' }]);
+      s3ClientStub.send
+        .onFirstCall().resolves({
+          Body: { transformToByteArray: sandbox.stub().resolves(new Uint8Array([0])) },
+        })
+        .onSecondCall().resolves({});
+
+      const result = await handlerModule.referralTrafficDailyRunner(context);
+
+      expect(result.auditResult.csvKey).to.equal(
+        'rum-metrics-compact/llmo-daily-csvs/siteid=site-123/year=2026/month=01/day=05/data.csv',
+      );
+    });
+
+    it('should set updated_by to spacecat:optel in every CSV row', async () => {
+      parquetReadObjectsStub.resolves([PARQUET_ROW]);
+      s3ClientStub.send
+        .onFirstCall().resolves({
+          Body: { transformToByteArray: sandbox.stub().resolves(new Uint8Array([0])) },
+        })
+        .onSecondCall().resolves({});
+
+      await handlerModule.referralTrafficDailyRunner(context);
+
+      const putCall = s3ClientStub.send.secondCall.args[0];
+      expect(putCall.Body).to.include('spacecat:optel');
+    });
+
+    it('should fall back to empty string for missing row fields', async () => {
+      // Row with undefined date, path, trf_platform, device, pageviews, consent
+      // covers all || '' fallbacks and escapeCsvValue(undefined) branch
+      parquetReadObjectsStub.resolves([{
+        trf_type: 'earned',
+        trf_channel: 'llm',
+        engaged: 1,
+        // date, path, trf_platform, device, pageviews, consent intentionally absent
+      }]);
+      s3ClientStub.send
+        .onFirstCall().resolves({
+          Body: { transformToByteArray: sandbox.stub().resolves(new Uint8Array([0])) },
+        })
+        .onSecondCall().resolves({});
+
+      const result = await handlerModule.referralTrafficDailyRunner(context);
+      expect(result.auditResult.rowCount).to.equal(1);
+    });
+
+    it('should quote CSV values that contain commas or double quotes', async () => {
+      parquetReadObjectsStub.resolves([{
+        ...PARQUET_ROW,
+        trf_platform: 'platform,with,commas',
+        device: 'device"with"quotes',
+      }]);
+      s3ClientStub.send
+        .onFirstCall().resolves({
+          Body: { transformToByteArray: sandbox.stub().resolves(new Uint8Array([0])) },
+        })
+        .onSecondCall().resolves({});
+
+      await handlerModule.referralTrafficDailyRunner(context);
+
+      const putCall = s3ClientStub.send.secondCall.args[0];
+      expect(putCall.Body).to.include('"platform,with,commas"');
+      expect(putCall.Body).to.include('"device""with""quotes"');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a new `llmo-referral-traffic-daily` two-step `StepAudit`
- Step 1 (`trigger-traffic-analysis-daily-import`) sends a message to import-worker to fetch one day of RUM data; defaults to yesterday UTC, overridable via `auditContext.date` (YYYY-MM-DD)
- Step 2 (`run-referral-traffic-daily`) reads the stored parquet from S3 via `hyparquet`, transforms it into a 12-column CSV matching the optel column contract, uploads to `rum-metrics-compact/llmo-daily-csvs/`, and dispatches a `batch.completed` analytics SQS event for projector ingestion
- 100% line/branch/statement coverage

## Test plan

- [ ] `npm run test:spec -- test/audits/llmo-referral-traffic-daily/handler.test.js` — 22 tests, all green, 100% coverage
- [ ] Verify step 1 dispatches to `AUDIT_STEP_DESTINATIONS.IMPORT_WORKER`
- [ ] Verify step 2 reads parquet from `rum-metrics-compact/data-daily/`, writes CSV to `rum-metrics-compact/llmo-daily-csvs/`, and sends correct SQS analytics message with `pipeline_id: referral_traffic_optel`
- [ ] Companion import-worker PR: adobe/spacecat-import-worker feat/traffic-analysis-daily-import

🤖 Generated with [Claude Code](https://claude.com/claude-code)