### PR TITLE
feat: Broken internal link cross locale

### DIFF
--- a/src/internal-links/config.js
+++ b/src/internal-links/config.js
@@ -258,6 +258,15 @@ export class InternalLinksConfigResolver {
     return normalizeExcludedElementClasses(this.handlerConfig.excludedElementClasses);
   }
 
+  /**
+   * When true, RUM rows where referrer and 404 target use different locale-like
+   * first path segments (e.g. /fr → /de) are dropped before validation.
+   * Default to false.
+   */
+  getExcludeCrossLocalePDP() {
+    return getBooleanConfig(this.handlerConfig.excludeCrossLocalePDP, false);
+  }
+
   getBrightDataConfig() {
     return {
       validateUrls: this.handlerConfig.validateBrightDataUrls

--- a/src/internal-links/config.js
+++ b/src/internal-links/config.js
@@ -11,7 +11,7 @@
  */
 
 import { hasText } from '@adobe/spacecat-shared-utils';
-import { PAGES_PER_BATCH } from './crawl-detection.js';
+import { PAGES_PER_BATCH } from './constants.js';
 import { MAX_BROKEN_LINKS_REPORTED } from './result-utils.js';
 
 const MAX_URLS_TO_PROCESS = 100;
@@ -108,6 +108,20 @@ function getStringListConfig(value, fallback) {
   }
 
   return fallback;
+}
+
+/**
+ * Normalizes `excludedElementClasses` from site handler config.
+ * Links (and other extracted references) are skipped when their DOM node or any
+ * ancestor has a `class` containing one of these tokens (see crawl `isUnderExcludedElement`).
+ * @param {string[]|string|undefined} raw - Array of class names, or comma-separated string
+ * @returns {string[]} Trimmed class tokens (leading "." stripped per entry)
+ */
+export function normalizeExcludedElementClasses(raw) {
+  const list = getStringListConfig(raw, []);
+  return list
+    .map((t) => String(t).trim().replace(/^\./, ''))
+    .filter((t) => t.length > 0);
 }
 
 export class InternalLinksConfigResolver {
@@ -233,6 +247,15 @@ export class InternalLinksConfigResolver {
       this.handlerConfig.mystiqueItemTypes,
       DEFAULT_MYSTIQUE_ITEM_TYPES,
     );
+  }
+
+  /**
+   * HTML `class` tokens: a link or asset reference is ignored if its own element or any
+   * ancestor has a `class` list containing one of these tokens (all descendants of such a
+   * subtree are therefore skipped).
+   */
+  getExcludedElementClasses() {
+    return normalizeExcludedElementClasses(this.handlerConfig.excludedElementClasses);
   }
 
   getBrightDataConfig() {

--- a/src/internal-links/constants.js
+++ b/src/internal-links/constants.js
@@ -1,0 +1,14 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/** Default pages per batch for broken-internal-links crawl processing. */
+export const PAGES_PER_BATCH = 10;

--- a/src/internal-links/crawl-detection.js
+++ b/src/internal-links/crawl-detection.js
@@ -16,11 +16,15 @@ import { isWithinAuditScope } from './subpath-filter.js';
 import { isLinkInaccessible } from './helpers.js';
 import { limitConcurrency, sleep } from '../support/utils.js';
 import { buildBrokenLinkKey, getUrlCacheKey } from './link-key.js';
+import { normalizeExcludedElementClasses } from './config.js';
+import { PAGES_PER_BATCH } from './constants.js';
 import {
   createInternalLinksAuditLogger,
   isInternalLinksContextLogger,
 } from './logging.js';
 import { isSharedInternalResource } from './scope-utils.js';
+
+export { PAGES_PER_BATCH };
 
 const AUDIT_TYPE = 'broken-internal-links';
 
@@ -38,8 +42,6 @@ const DEFAULT_SCRAPE_FETCH_DELAY_MS = 50;
 const DEFAULT_LINK_CHECK_BATCH_SIZE = 10;
 const DEFAULT_MAX_CONCURRENT_LINK_CHECKS = 5;
 const DEFAULT_LINK_CHECK_DELAY_MS = 300;
-
-export const PAGES_PER_BATCH = 10;
 
 const parsePositiveInt = (value, fallback) => {
   const parsed = Number.parseInt(value, 10);
@@ -172,6 +174,34 @@ function resolveUrlCandidates(rawValue, pageUrl) {
     .map((entry) => normalizeDetectedUrlCandidate(entry))
     .filter((entry) => entry && !entry.startsWith('data:') && !entry.startsWith('#'))
     .map((entry) => stripAbsoluteUrlHash(new URL(entry, pageUrl).toString()));
+}
+
+/**
+ * Removes subtrees rooted at elements whose `class` contains an excluded token.
+ * Deepest nodes are removed first so nested excluded wrappers are safe.
+ * Mutates the document behind `$`; the callable `$` is unchanged.
+ */
+function filterExcludedElements($, excludedElementClasses) {
+  if (!excludedElementClasses?.length) {
+    return;
+  }
+  const excludedClassSet = new Set(excludedElementClasses);
+  const toRemove = [];
+
+  $('[class]').each((_, el) => {
+    const classAttr = $(el).attr('class');
+    if (!classAttr) {
+      return;
+    }
+    const hasExcluded = classAttr.split(/\s+/).filter(Boolean).some((c) => excludedClassSet.has(c));
+    if (hasExcluded) {
+      toRemove.push(el);
+    }
+  });
+  toRemove.sort((a, b) => $(b).parents().length - $(a).parents().length);
+  for (const el of toRemove) {
+    $(el).remove();
+  }
 }
 
 function pushResolvedReference({
@@ -861,6 +891,11 @@ export async function detectBrokenLinksFromCrawlBatch({
       }
 
       const $ = cheerioLoad(html);
+      const excludedElementClasses = normalizeExcludedElementClasses(
+        internalLinksConfig.excludedElementClasses,
+      );
+
+      filterExcludedElements($, excludedElementClasses);
       const internalLinks = extractInternalLinks($, pageUrl, baseHostname, log);
       const assetReferences = extractAssetReferences($, pageUrl, baseHostname, log);
 

--- a/src/internal-links/rum-detection.js
+++ b/src/internal-links/rum-detection.js
@@ -10,7 +10,9 @@
  * governing permissions and limitations under the License.
  */
 
+import { createInternalLinksConfigResolver } from './config.js';
 import { createInternalLinksStepLogger } from './logging.js';
+import { isCrossLocalePDP404RumPair } from './scope-utils.js';
 
 const RUM_VALIDATION_CONCURRENCY = 10;
 
@@ -101,10 +103,24 @@ export function createInternalLinksRumSteps({
         log.info(`Filtered out ${internal404Links.length - scopedInternal404Links.length} RUM links outside the audit scope before validation`);
       }
 
-      log.info(`Validating ${scopedInternal404Links.length} scoped links (target + referring page)...`);
+      const configResolver = createInternalLinksConfigResolver(site, context.env ?? {});
+      const excludeCrossLocalePDP = configResolver.getExcludeCrossLocalePDP();
+
+      const rumLinksForValidation = scopedInternal404Links.filter(
+        (link) => !excludeCrossLocalePDP
+          || !isCrossLocalePDP404RumPair(link.url_from, link.url_to),
+      );
+
+      if (excludeCrossLocalePDP && rumLinksForValidation.length < scopedInternal404Links.length) {
+        log.info(
+          `Filtered out ${scopedInternal404Links.length - rumLinksForValidation.length} cross-locale 404 RUM PDP links before validation`,
+        );
+      }
+
+      log.info(`Validating ${rumLinksForValidation.length} scoped links (target + referring page)...`);
 
       const accessibilitySettled = await mapSettledInBatches(
-        scopedInternal404Links,
+        rumLinksForValidation,
         RUM_VALIDATION_CONCURRENCY,
         async (link) => {
           const [targetSettled, referringSettled] = await Promise.allSettled([

--- a/src/internal-links/scope-utils.js
+++ b/src/internal-links/scope-utils.js
@@ -92,3 +92,53 @@ export function extractLocalePathPrefix(url) {
     return '';
   }
 }
+
+/**
+ * True when RUM pairs a referring page and 404 target whose first path segments are
+ * both locale-like but different (e.g. /fr/... → /de/...). Those rows are often noise
+ * for same-locale broken-link remediation when the site is audited at domain root.
+ * Same number of segments
+ * all segments are identical except for the first one (locale)
+ *
+ * @param {string} urlFrom - Referrer URL from RUM
+ * @param {string} urlTo - 404 target URL from RUM
+ * @returns {boolean}
+ */
+export function isCrossLocalePDP404RumPair(urlFrom, urlTo) {
+  // base case: one/both of the urls are not valid
+  if (!urlFrom || !urlTo) {
+    return false;
+  }
+
+  try {
+    const urlFromParsed = new URL(prependSchema(urlFrom));
+    const urlToParsed = new URL(prependSchema(urlTo));
+    const { pathname: urlFromPathname } = urlFromParsed;
+    const { pathname: urlToPathname } = urlToParsed;
+
+    if ((!urlFromPathname || urlFromPathname === '/') || (!urlToPathname || urlToPathname === '/')) {
+      return false;
+    }
+
+    const fromSegments = urlFromPathname.split('/').filter((seg) => seg.length > 0);
+    const toSegments = urlToPathname.split('/').filter((seg) => seg.length > 0);
+
+    if (fromSegments.length !== toSegments.length || fromSegments.length < 2) {
+      return false;
+    }
+
+    if (fromSegments[0].toLowerCase() === toSegments[0].toLowerCase()) {
+      return false;
+    }
+
+    for (let i = 1; i < fromSegments.length; i += 1) {
+      if (fromSegments[i] !== toSegments[i]) {
+        return false;
+      }
+    }
+
+    return true;
+  } catch (error) {
+    return false;
+  }
+}

--- a/test/audits/internal-links/config.test.js
+++ b/test/audits/internal-links/config.test.js
@@ -146,6 +146,7 @@ describe('internal-links config resolver', () => {
       'audio',
       'media',
     ]);
+    expect(resolver.getExcludeCrossLocalePDP()).to.equal(false);
     expect(resolver.getMystiqueItemTypes()).to.deep.equal([
       'link',
       'form',
@@ -170,6 +171,20 @@ describe('internal-links config resolver', () => {
     }), {});
 
     expect(resolver.getExcludedElementClasses()).to.deep.equal(['no-audit', 'editorial']);
+  });
+
+  it('returns excludeCrossLocalePDP from handler config when the value is set to true', () => {
+    const resolver = new InternalLinksConfigResolver(createSite({
+      excludeCrossLocalePDP: true,
+    }), {});
+    expect(resolver.getExcludeCrossLocalePDP()).to.equal(true);
+  });
+  
+  it('returns excludeCrossLocalePDP from handler config when the value is set to false', () => {
+    const resolver = new InternalLinksConfigResolver(createSite({
+      excludeCrossLocalePDP: false,
+    }), {});
+    expect(resolver.getExcludeCrossLocalePDP()).to.equal(false);
   });
 
   it('normalizeExcludedElementClasses parses comma-separated string', () => {

--- a/test/audits/internal-links/config.test.js
+++ b/test/audits/internal-links/config.test.js
@@ -14,6 +14,7 @@ import { expect } from 'chai';
 import {
   InternalLinksConfigResolver,
   createInternalLinksConfigResolver,
+  normalizeExcludedElementClasses,
 } from '../../../src/internal-links/config.js';
 
 function createSite(config = {}, deliveryConfig = {}) {
@@ -160,6 +161,19 @@ describe('internal-links config resolver', () => {
       clickLoadMore: true,
       hideConsentBanners: true,
     });
+    expect(resolver.getExcludedElementClasses()).to.deep.equal([]);
+  });
+
+  it('returns excludedElementClasses from handler config', () => {
+    const resolver = new InternalLinksConfigResolver(createSite({
+      excludedElementClasses: ['.no-audit', 'editorial'],
+    }), {});
+
+    expect(resolver.getExcludedElementClasses()).to.deep.equal(['no-audit', 'editorial']);
+  });
+
+  it('normalizeExcludedElementClasses parses comma-separated string', () => {
+    expect(normalizeExcludedElementClasses('foo, .bar')).to.deep.equal(['foo', 'bar']);
   });
 
   it('prefers site config over env overrides', () => {

--- a/test/audits/internal-links/crawl-detection.test.js
+++ b/test/audits/internal-links/crawl-detection.test.js
@@ -1903,6 +1903,122 @@ describe('Crawl Detection Module', () => {
       expect(result.results[0].trafficDomain).to.equal(7);
     });
 
+    it('skips crawl extraction for links under ancestors with excludedElementClasses', async () => {
+      const scrapeResultPaths = new Map([
+        ['https://example.com/page1', 'scrapes/page1.json'],
+      ]);
+
+      const rawBody = `<html><body>
+        <div class="skip-bil">
+          <a href="/ignored">In skip</a>
+          <link rel="canonical" href="https://example.com/canon-ignored">
+          <link rel="alternate" hreflang="en" href="https://example.com/alt-ignored">
+          <form action="/form-ignored"><button type="submit">Go</button></form>
+          <img src="/img-ignored.png" alt="">
+          <img srcset="/srcset-ignored.png 1x" alt="">
+          <video><source srcset="/srcset-only-ignored.png 1x"></video>
+          <video><source src="/vid-ignored.mp4"></video>
+          <map name="m"><area shape="rect" coords="0,0,1,1" href="/area-ignored" alt=""></map>
+          <link rel="stylesheet" href="/ignored.css">
+          <script src="/ignored.js"></script>
+          <style>.x{background:url(/ignored-from-style.png)}</style>
+          <span style="background:url(/ignored-from-inline.png)">x</span>
+        </div>
+        <main><a href="/checked">Outside</a></main>
+      </body></html>`;
+
+      getObjectFromKeyStub.resolves({
+        scrapeResult: { rawBody },
+        finalUrl: 'https://example.com/page1',
+      });
+      isLinkInaccessibleStub.resolves(createValidationResponse(false));
+
+      const contextWithIgnore = {
+        ...mockContext,
+        site: {
+          ...mockSite,
+          getConfig: () => ({
+            getHandlers: () => ({
+              'broken-internal-links': {
+                config: {
+                  excludedElementClasses: ['skip-bil'],
+                },
+              },
+            }),
+          }),
+        },
+      };
+
+      await detectBrokenLinksFromCrawlBatch({
+        scrapeResultPaths,
+        batchStartIndex: 0,
+        batchSize: 1,
+        initialBrokenUrls: [],
+        initialWorkingUrls: [],
+      }, contextWithIgnore);
+
+      expect(isLinkInaccessibleStub.callCount).to.equal(1);
+      expect(isLinkInaccessibleStub.firstCall.args[0]).to.equal('https://example.com/checked');
+    });
+
+    it('retain crawl extraction for links without class', async () => {
+      const scrapeResultPaths = new Map([
+        ['https://example.com/page1', 'scrapes/page1.json'],
+      ]);
+
+      const rawBody = `<html><body>
+        <div class="">
+          <a href="/link1">Link 1</a>
+          <link rel="canonical" href="https://example.com/canon1">
+          <link rel="alternate" hreflang="en" href="https://example.com/alt1">
+          <form action="/form1"><button type="submit">Go</button></form>
+          <img src="/img1.png" alt="">
+          <img srcset="/srcset1.png 1x" alt="">
+          <video><source srcset="/srcset1.png 1x"></video>
+          <video><source src="/vid1.mp4"></video>
+          <map name="m"><area shape="rect" coords="0,0,1,1" href="/area1" alt=""></map>
+          <link rel="stylesheet" href="/style1.css">
+          <script src="/script1.js"></script>
+          <style>.x{background:url(/style1.png)}</style>
+          <span style="background:url(/inline1.png)">x</span>
+        </div>
+        <main><a href="/link2">Link 2</a></main>
+      </body></html>`;
+
+      getObjectFromKeyStub.resolves({
+        scrapeResult: { rawBody },
+        finalUrl: 'https://example.com/page1',
+      });
+      isLinkInaccessibleStub.resolves(createValidationResponse(false));
+
+      const contextWithIgnore = {
+        ...mockContext,
+        site: {
+          ...mockSite,
+          getConfig: () => ({
+            getHandlers: () => ({
+              'broken-internal-links': {
+                config: {
+                  excludedElementClasses: ['skip-bil'],
+                },
+              },
+            }),
+          }),
+        },
+      };
+
+      await detectBrokenLinksFromCrawlBatch({
+        scrapeResultPaths,
+        batchStartIndex: 0,
+        batchSize: 1,
+        initialBrokenUrls: [],
+        initialWorkingUrls: [],
+      }, contextWithIgnore);
+
+      expect(isLinkInaccessibleStub.callCount).to.equal(14);
+      expect(isLinkInaccessibleStub.firstCall.args[0]).to.equal('https://example.com/link1');
+    });
+
     it('should extract object data, meta refresh, and CSS url() references', async () => {
       const scrapeResultPaths = new Map([
         ['https://example.com/page1', 'scrapes/page1.json'],

--- a/test/audits/internal-links/rum-detection.test.js
+++ b/test/audits/internal-links/rum-detection.test.js
@@ -63,11 +63,19 @@ describe('internal-links rum-detection', () => {
     };
   }
 
-  function createSite() {
-    return {
+  function createSite(handlerConfig) {
+    const site = {
       getId: () => 'site-1',
       getBaseURL: () => 'https://example.com',
     };
+    if (handlerConfig !== undefined) {
+      site.getConfig = () => ({
+        getHandlers: () => ({
+          'broken-internal-links': { config: handlerConfig },
+        }),
+      });
+    }
+    return site;
   }
 
   function createSteps(overrides = {}) {
@@ -380,6 +388,75 @@ describe('internal-links rum-detection', () => {
 
     expect(result.auditResult.brokenInternalLinks).to.have.lengthOf(1);
     expect(log.info).to.have.been.calledWith('Filtered out 1 RUM links outside the audit scope before validation');
+  });
+
+  it('filters cross-locale PDP RUM pairs before validation when excludeCrossLocalePDP is true', async () => {
+    const rumApiClient = {
+      query: sinon.stub().resolves([
+        {
+          url_from: 'https://example.com/fr/widget/missing',
+          url_to: 'https://example.com/de/widget/missing',
+          traffic_domain: 99,
+        },
+        {
+          url_from: 'https://example.com/en/page',
+          url_to: 'https://example.com/en/missing',
+          traffic_domain: 5,
+        },
+      ]),
+    };
+    const isLinkInaccessible = createRumValidationStub();
+    const log = createLog();
+    const { internalLinksAuditRunner } = createSteps({ isLinkInaccessible });
+
+    const result = await internalLinksAuditRunner('https://example.com', {
+      log,
+      site: createSite({ excludeCrossLocalePDP: true }),
+      rumApiClient,
+      finalUrl: 'https://example.com',
+    });
+
+    expect(result.auditResult.brokenInternalLinks).to.deep.equal([{
+      urlFrom: 'https://example.com/en/page',
+      urlTo: 'https://example.com/en/missing',
+      trafficDomain: 5,
+      detectionSource: 'rum',
+      httpStatus: 404,
+      statusBucket: 'not_found_404',
+      contentType: 'text/html',
+      priority: 'high',
+    }]);
+    expect(log.info).to.have.been.calledWith(
+      'Filtered out 1 cross-locale 404 RUM PDP links before validation',
+    );
+  });
+
+  it('keeps cross-locale RUM rows when excludeCrossLocalePDP is false', async () => {
+    const rumApiClient = {
+      query: sinon.stub().resolves([
+        {
+          url_from: 'https://example.com/fr/page',
+          url_to: 'https://example.com/de/missing',
+          traffic_domain: 99,
+        },
+      ]),
+    };
+    const isLinkInaccessible = createRumValidationStub();
+    const log = createLog();
+    const { internalLinksAuditRunner } = createSteps({ isLinkInaccessible });
+
+    const result = await internalLinksAuditRunner('https://example.com', {
+      log,
+      site: createSite({ excludeCrossLocalePDP: false }),
+      rumApiClient,
+      finalUrl: 'https://example.com',
+    });
+
+    expect(result.auditResult.brokenInternalLinks).to.have.lengthOf(1);
+    expect(result.auditResult.brokenInternalLinks[0].urlTo).to.equal('https://example.com/de/missing');
+    expect(log.info).not.to.have.been.calledWith(
+      sinon.match(/cross-locale 404 RUM PDP/),
+    );
   });
 
   it('throws from the top-pages step when rum detection fails', async () => {

--- a/test/audits/internal-links/scope-utils.test.js
+++ b/test/audits/internal-links/scope-utils.test.js
@@ -13,6 +13,7 @@
 import { expect } from 'chai';
 import {
   extractLocalePathPrefix,
+  isCrossLocalePDP404RumPair,
   isSharedInternalResource,
 } from '../../../src/internal-links/scope-utils.js';
 
@@ -64,6 +65,81 @@ describe('internal-links scope-utils', () => {
     it('handles double-slash and malformed urls defensively', () => {
       expect(extractLocalePathPrefix('https://bulk.com//')).to.equal('');
       expect(extractLocalePathPrefix('://invalid')).to.equal('');
+    });
+  });
+
+  describe('isCrossLocalePDP404RumPair', () => {
+    it('returns false when either argument is missing', () => {
+      expect(isCrossLocalePDP404RumPair('', 'https://example.com/de/a/b')).to.equal(false);
+      expect(isCrossLocalePDP404RumPair('https://example.com/fr/a/b', '')).to.equal(false);
+      expect(isCrossLocalePDP404RumPair(null, 'https://example.com/de/a/b')).to.equal(false);
+    });
+
+    it('returns false when either pathname is empty or root-only', () => {
+      expect(isCrossLocalePDP404RumPair(
+        'https://example.com',
+        'https://example.com/de/item/x',
+      )).to.equal(false);
+      expect(isCrossLocalePDP404RumPair(
+        'https://example.com/fr/item/x',
+        'https://example.com',
+      )).to.equal(false);
+    });
+
+    it('returns false when segment counts differ or path is too shallow', () => {
+      expect(isCrossLocalePDP404RumPair(
+        'https://example.com/fr/a/b',
+        'https://example.com/de/a',
+      )).to.equal(false);
+      expect(isCrossLocalePDP404RumPair(
+        'https://example.com/fr',
+        'https://example.com/de',
+      )).to.equal(false);
+    });
+
+    it('returns false when either side has no locale-like prefix', () => {
+      expect(isCrossLocalePDP404RumPair(
+        'https://example.com/blog/post',
+        'https://example.com/fr/missing',
+      )).to.equal(false);
+      expect(isCrossLocalePDP404RumPair(
+        'https://example.com/fr/page',
+        'https://example.com/products/missing',
+      )).to.equal(false);
+    });
+
+    it('returns false when both sides share the same locale prefix', () => {
+      expect(isCrossLocalePDP404RumPair(
+        'https://example.com/fr/page',
+        'https://example.com/fr/missing',
+      )).to.equal(false);
+      expect(isCrossLocalePDP404RumPair(
+        'https://example.com/FR/page',
+        'https://example.com/fr/missing',
+      )).to.equal(false);
+    });
+
+    it('returns false when non-locale segments after the first differ', () => {
+      expect(isCrossLocalePDP404RumPair(
+        'https://example.com/fr/a/b',
+        'https://example.com/de/a/c',
+      )).to.equal(false);
+    });
+
+    it('returns true when locales differ and all following path segments match', () => {
+      expect(isCrossLocalePDP404RumPair(
+        'https://example.com/fr/product/slug',
+        'https://example.com/de/product/slug',
+      )).to.equal(true);
+      expect(isCrossLocalePDP404RumPair(
+        'https://example.com/en-us/a/b',
+        'https://example.com/de-de/a/b',
+      )).to.equal(true);
+    });
+
+    it('returns false when URL parsing throws', () => {
+      expect(isCrossLocalePDP404RumPair('https://%zz', 'https://example.com/de/a/b')).to.equal(false);
+      expect(isCrossLocalePDP404RumPair('https://example.com/fr/a/b', 'https://%zz')).to.equal(false);
     });
   });
 });


### PR DESCRIPTION
added new functionality to broken internal links.
you can now add a list of element class to ignore in the site.config.handler. Any element (or its ancestor) with the excluded class will be ignored.
you can now ignore pdp links that go across locale.

- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
