### PR TITLE
fix: broken-backlinks - support two-level locale URL structures in Bright Data

### DIFF
--- a/src/support/bright-data-client.js
+++ b/src/support/bright-data-client.js
@@ -100,7 +100,14 @@ export function extractLocaleFromUrl(url) {
       return null;
     }
     const firstSegment = segments[0].toLowerCase();
-    return isValidLocale(firstSegment) ? firstSegment : null;
+    if (!isValidLocale(firstSegment)) {
+      return null;
+    }
+    // Detect two-level locale structures like /hk/zh_HK/ or /us/en/ (region + language)
+    if (segments.length > 1 && isValidLocale(segments[1])) {
+      return `${firstSegment}/${segments[1].toLowerCase()}`;
+    }
+    return firstSegment;
   } catch {
     return null;
   }
@@ -287,6 +294,10 @@ class BrightDataClient {
       // Match any first path segment that is a valid locale (dk, uk, apac, emea, etc.)
       const segments = path.split('/').filter((seg) => seg.length > 0);
       if (segments.length > 0 && isValidLocale(segments[0])) {
+        // Detect two-level locale structures like /hk/zh_HK/ or /us/en/ (region + language)
+        if (segments.length > 1 && isValidLocale(segments[1])) {
+          return `${segments[0].toLowerCase()}/${segments[1].toLowerCase()}`;
+        }
         return segments[0].toLowerCase();
       }
 
@@ -324,6 +335,10 @@ class BrightDataClient {
       // Match any first path segment that is a valid locale (dk, uk, apac, emea, etc.)
       const segments = path.split('/').filter((seg) => seg.length > 0);
       if (segments.length > 0 && isValidLocale(segments[0])) {
+        // Detect two-level locale structures like /hk/zh_HK/ or /us/en/ (region + language)
+        if (segments.length > 1 && isValidLocale(segments[1])) {
+          return `${segments[0].toLowerCase()}/${segments[1].toLowerCase()}`;
+        }
         return segments[0].toLowerCase();
       }
 
@@ -564,6 +579,20 @@ class BrightDataClient {
       return { hl: null, gl: null };
     }
     const normalized = locale.toLowerCase();
+
+    // Two-level locale: us/en or hk/zh_hk -> use the last (most specific) part for hl/gl
+    if (normalized.includes('/')) {
+      const lastPart = normalized.split('/').pop();
+      const lastFullMatch = lastPart.match(/^([a-z]{2})[_-]([a-z]{2})$/);
+      if (lastFullMatch && KNOWN_LOCALES.has(lastFullMatch[1])) {
+        return { hl: lastFullMatch[1], gl: lastFullMatch[2].toUpperCase() };
+      }
+      if (KNOWN_LOCALES.has(lastPart)) {
+        const country = LOCALE_TO_COUNTRY[lastPart];
+        return { hl: lastPart, gl: country };
+      }
+      return { hl: null, gl: null };
+    }
 
     // Full locale: xx_yy or xx-yy -> hl=xx, gl=YY (only if language is in whitelist)
     const fullMatch = normalized.match(/^([a-z]{2})[_-]([a-z]{2})$/);

--- a/test/support/bright-data-client.test.js
+++ b/test/support/bright-data-client.test.js
@@ -126,6 +126,19 @@ describe('BrightDataClient', () => {
       expect(client.extractLocale('https://example.com/emea/page')).to.equal('emea');
     });
 
+    it('extracts two-level locale from path (region/language)', () => {
+      expect(client.extractLocale('https://example.com/us/en/products')).to.equal('us/en');
+      expect(client.extractLocale('https://example.com/de/de/about')).to.equal('de/de');
+      expect(client.extractLocale('https://example.com/jp/ja/docs')).to.equal('jp/ja');
+      expect(client.extractLocale('https://example.com/hk/zh/page')).to.equal('hk/zh');
+    });
+
+    it('extracts two-level locale with composite second segment (region/lang-region)', () => {
+      expect(client.extractLocale('https://example.com/hk/zh_hk/page')).to.equal('hk/zh_hk');
+      expect(client.extractLocale('https://example.com/hk/zh_HK/manage/flight')).to.equal('hk/zh_hk');
+      expect(client.extractLocale('https://example.com/jp/ja-jp/shoe-guide')).to.equal('jp/ja-jp');
+    });
+
     it('returns null for codes not in any locale list', () => {
       expect(client.extractLocale('https://example.com/xy/products')).to.be.null;
       expect(client.extractLocale('https://example.com/zz/about')).to.be.null;
@@ -163,6 +176,12 @@ describe('BrightDataClient', () => {
       expect(client.extractLocaleFromBaseUrl('https://www.bulk.com/uk')).to.equal('uk');
       expect(client.extractLocaleFromBaseUrl('https://www.bulk.com/eu/')).to.equal('eu');
       expect(client.extractLocaleFromBaseUrl('https://www.bulk.com/apac')).to.equal('apac');
+    });
+
+    it('extracts two-level locale from base URL (region/language)', () => {
+      expect(client.extractLocaleFromBaseUrl('https://example.com/us/en')).to.equal('us/en');
+      expect(client.extractLocaleFromBaseUrl('https://example.com/hk/zh_hk')).to.equal('hk/zh_hk');
+      expect(client.extractLocaleFromBaseUrl('https://example.com/jp/ja-jp')).to.equal('jp/ja-jp');
     });
 
     it('returns null for base URL without locale', () => {
@@ -473,6 +492,13 @@ describe('BrightDataClient', () => {
       expect(extractLocaleFromUrl('https://example.com/pt-br/page')).to.equal('pt-br');
     });
 
+    it('extracts two-level locale from URL path (region/language)', () => {
+      expect(extractLocaleFromUrl('https://example.com/us/en/page')).to.equal('us/en');
+      expect(extractLocaleFromUrl('https://example.com/de/de/sustainability')).to.equal('de/de');
+      expect(extractLocaleFromUrl('https://example.com/hk/zh_HK/manage/flight')).to.equal('hk/zh_hk');
+      expect(extractLocaleFromUrl('https://example.com/jp/ja-jp/shoe-guide')).to.equal('jp/ja-jp');
+    });
+
     it('returns null when first segment is not a locale', () => {
       expect(extractLocaleFromUrl('https://example.com/blog/page')).to.be.null;
       expect(extractLocaleFromUrl('https://example.com/products/item')).to.be.null;
@@ -513,6 +539,15 @@ describe('BrightDataClient', () => {
         .to.equal('https://example.com/fr');
       expect(buildLocaleSearchUrl('https://example.com', 'https://example.com/ko-kr/page'))
         .to.equal('https://example.com/ko-kr');
+    });
+
+    it('appends two-level locale from broken link (region/language)', () => {
+      expect(buildLocaleSearchUrl('https://example.com', 'https://example.com/us/en/page'))
+        .to.equal('https://example.com/us/en');
+      expect(buildLocaleSearchUrl('https://example.com', 'https://example.com/de/de/sustainability'))
+        .to.equal('https://example.com/de/de');
+      expect(buildLocaleSearchUrl('https://example.com', 'https://example.com/hk/zh_HK/manage/flight'))
+        .to.equal('https://example.com/hk/zh_hk');
     });
 
     it('returns base URL unchanged when base already has a subpath', () => {
@@ -597,10 +632,27 @@ describe('BrightDataClient', () => {
       expect(client.resolveGoogleLocaleParams('ja')).to.deep.equal({ hl: 'ja', gl: 'JP' });
     });
 
+    it('maps two-level locale (region/language) to hl/gl using last segment', () => {
+      expect(client.resolveGoogleLocaleParams('us/en')).to.deep.equal({ hl: 'en', gl: 'US' });
+      expect(client.resolveGoogleLocaleParams('de/de')).to.deep.equal({ hl: 'de', gl: 'DE' });
+      expect(client.resolveGoogleLocaleParams('jp/ja')).to.deep.equal({ hl: 'ja', gl: 'JP' });
+    });
+
+    it('maps two-level locale with composite second segment (region/lang-region) to hl/gl', () => {
+      expect(client.resolveGoogleLocaleParams('hk/zh_hk')).to.deep.equal({ hl: 'zh', gl: 'HK' });
+      expect(client.resolveGoogleLocaleParams('jp/ja-jp')).to.deep.equal({ hl: 'ja', gl: 'JP' });
+      expect(client.resolveGoogleLocaleParams('us/en-us')).to.deep.equal({ hl: 'en', gl: 'US' });
+    });
+
     it('returns null for invalid locale formats', () => {
       expect(client.resolveGoogleLocaleParams('xyz')).to.deep.equal({ hl: null, gl: null });
       expect(client.resolveGoogleLocaleParams('xy_zz')).to.deep.equal({ hl: null, gl: null });
       expect(client.resolveGoogleLocaleParams('toolong')).to.deep.equal({ hl: null, gl: null });
+    });
+
+    it('returns null for two-level locale where last segment is unrecognized', () => {
+      expect(client.resolveGoogleLocaleParams('us/xy')).to.deep.equal({ hl: null, gl: null });
+      expect(client.resolveGoogleLocaleParams('hk/zz_zz')).to.deep.equal({ hl: null, gl: null });
     });
   });
 


### PR DESCRIPTION
Broken backlinks audit was only detecting the first path segment as locale for sites using region/language URL structures (e.g. /us/en/, /hk/zh_HK/), resulting in an overly broad Bright Data search scope and locale tokens polluting keyword queries. This fix extends locale detection across two consecutive path segments and updates hl/gl resolution accordingly, correctly scoping searches for ~14-18% of audited sites.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
