### PR TITLE
fix(cdn-logs-report): use S3_IMPORTER_BUCKET_NAME and new key prefix for referral daily export

### DIFF
--- a/src/cdn-logs-report/referral-daily-export.js
+++ b/src/cdn-logs-report/referral-daily-export.js
@@ -52,7 +52,7 @@ export function getPreviousUtcDate(referenceDate = new Date()) {
 
 function getCsvKey(siteId, trafficDate) {
   const [year, month, day] = trafficDate.split('-');
-  return `aggregated-referral-llmo-daily-csvs/${siteId}/${year}/${month}/${day}/data.csv`;
+  return `referral-traffic-cdn-daily-export/csvs/${siteId}/${year}/${month}/${day}/data.csv`;
 }
 
 async function ensureAthenaDatabase(athenaClient, databaseName) {
@@ -153,7 +153,10 @@ export async function runDailyReferralExport({
   const { log } = context;
   const trafficDateObj = getPreviousUtcDate(referenceDate);
   const trafficDate = trafficDateObj.toISOString().split('T')[0];
-  const { bucket } = s3Config;
+  const bucket = context.env?.S3_IMPORTER_BUCKET_NAME;
+  if (!bucket) {
+    throw new Error('S3_IMPORTER_BUCKET_NAME must be provided for referral daily export');
+  }
   const siteId = site.getId();
 
   const queueUrl = await getAnalyticsQueueUrl(context);

--- a/test/audits/cdn-logs-report/referral-daily-export.test.js
+++ b/test/audits/cdn-logs-report/referral-daily-export.test.js
@@ -51,7 +51,7 @@ describe('referral daily export', function referralDailyExportTests() {
 
   function makeContext(overrides = {}) {
     return {
-      env: {},
+      env: { S3_IMPORTER_BUCKET_NAME: 'spacecat-importer-bucket' },
       dataAccess: {
         Configuration: {
           findLatest: sandbox.stub().resolves(createConfiguration()),
@@ -129,9 +129,9 @@ describe('referral daily export', function referralDailyExportTests() {
       '[Athena Query] referral_daily_flat_data',
     );
     expect(s3Client.send).to.have.been.calledOnce;
-    expect(s3Client.send.firstCall.args[0].input.Bucket).to.equal('spacecat-dev-cdn-logs-aggregates-us-east-1');
+    expect(s3Client.send.firstCall.args[0].input.Bucket).to.equal('spacecat-importer-bucket');
     expect(s3Client.send.firstCall.args[0].input.Key).to.equal(
-      'aggregated-referral-llmo-daily-csvs/site-abc/2026/03/31/data.csv',
+      'referral-traffic-cdn-daily-export/csvs/site-abc/2026/03/31/data.csv',
     );
     expect(s3Client.send.firstCall.args[0].input.Body).to.include('traffic_date,host,url_path');
     expect(s3Client.send.firstCall.args[0].input.Body).to.include('2026-03-31,www.example.com,/products/ai');
@@ -141,7 +141,7 @@ describe('referral daily export', function referralDailyExportTests() {
         type: 'batch.completed',
         correlationId: expectedDedupId,
         pipeline_id: 'referral_traffic_cdn',
-        s3_uri: 's3://spacecat-dev-cdn-logs-aggregates-us-east-1/aggregated-referral-llmo-daily-csvs/site-abc/2026/03/31/data.csv',
+        s3_uri: 's3://spacecat-importer-bucket/referral-traffic-cdn-daily-export/csvs/site-abc/2026/03/31/data.csv',
         site_id: 'site-abc',
         org_id: 'org-1',
         start_date: '2026-03-31',
@@ -159,7 +159,7 @@ describe('referral daily export', function referralDailyExportTests() {
       siteId: 'site-abc',
       trafficDate: '2026-03-31',
       rowCount: 1,
-      csvUri: 's3://spacecat-dev-cdn-logs-aggregates-us-east-1/aggregated-referral-llmo-daily-csvs/site-abc/2026/03/31/data.csv',
+      csvUri: 's3://spacecat-importer-bucket/referral-traffic-cdn-daily-export/csvs/site-abc/2026/03/31/data.csv',
     });
     expect(context.log.info).to.have.been.calledWith(
       '[cdn-logs-report] Daily referral export dispatched for site-abc (https://www.example.com) on 2026-03-31. Rows: 1',
@@ -389,6 +389,20 @@ describe('referral daily export', function referralDailyExportTests() {
     expect(csvBody).to.include('2026-03-31');
   });
 
+  it('throws when S3_IMPORTER_BUCKET_NAME is not set', async () => {
+    const module = await loadModule(sandbox.stub());
+
+    await expect(module.runDailyReferralExport({
+      athenaClient: { execute: sandbox.stub().resolves(), query: sandbox.stub().resolves([]) },
+      s3Client: { send: sandbox.stub().resolves({}) },
+      s3Config: { databaseName: 'cdn_db' },
+      site: makeSite(),
+      context: makeContext({ env: {} }),
+      reportConfig: { tableName: 'referral_table' },
+      referenceDate: new Date('2026-04-01T00:00:00Z'),
+    })).to.be.rejectedWith('S3_IMPORTER_BUCKET_NAME must be provided for referral daily export');
+  });
+
   it('throws when analytics queue is not configured', async () => {
     const module = await loadModule(sandbox.stub());
 
@@ -504,7 +518,7 @@ describe('referral daily export', function referralDailyExportTests() {
     await module.testHelpers.cleanupCsvFromS3({
       s3Client,
       bucket: 'cdn-bucket',
-      csvKey: 'aggregated-referral-llmo-daily-csvs/site-abc/2026/03/31/data.csv',
+      csvKey: 'referral-traffic-cdn-daily-export/csvs/site-abc/2026/03/31/data.csv',
       log,
     });
 


### PR DESCRIPTION
## Summary

- Switches the referral daily export S3 bucket source from `s3Config.bucket` to `context.env.S3_IMPORTER_BUCKET_NAME`, aligning it with how the agentic daily export works
- Changes the S3 key prefix from `aggregated-referral-llmo-daily-csvs/` to `referral-traffic-cdn-daily-export/csvs/`
- Adds a startup guard that throws early if `S3_IMPORTER_BUCKET_NAME` is not set

## Test plan

- [ ] All 21 existing referral daily export tests pass
- [ ] New test covers the missing `S3_IMPORTER_BUCKET_NAME` error path

🤖 Generated with [Claude Code](https://claude.com/claude-code)