### PR TITLE
feat: migrating llm-error-pages audit to spacecat DB

### DIFF
--- a/src/llm-error-pages/handler.js
+++ b/src/llm-error-pages/handler.js
@@ -21,6 +21,8 @@ import {
   consolidateErrorsByUrl,
   sortErrorsByTrafficVolume,
   categorizeErrorsByStatusCode,
+  groupErrorsByUrl,
+  parsePeriodIdentifier,
   SPREADSHEET_COLUMNS,
   toPathOnly,
 } from './utils.js';
@@ -29,8 +31,20 @@ import { createLLMOSharepointClient, saveExcelReport } from '../utils/report-upl
 import { validateCountryCode } from '../cdn-logs-report/utils/report-utils.js';
 import { buildSiteFilters, getS3Config, getCdnAwsRuntime } from '../utils/cdn-utils.js';
 import { getTopAgenticUrlsFromAthena } from '../utils/agentic-urls.js';
+import { convertToOpportunity } from '../common/opportunity.js';
+import { syncSuggestions } from '../utils/data-access.js';
+import { createOpportunityData } from './opportunity-data-mapper.js';
 
 const { AUDIT_STEP_DESTINATIONS } = Audit;
+
+const STATUS_BUCKETS = [
+  { code: 404, auditType: 'llm-error-pages-404', suggestionType: 'REDIRECT_UPDATE' },
+  { code: 403, auditType: 'llm-error-pages-403', suggestionType: 'CODE_CHANGE' },
+  { code: '5xx', auditType: 'llm-error-pages-5xx', suggestionType: 'CODE_CHANGE' },
+];
+
+const RETENTION_WEEKS = 4;
+const RETENTION_MS = RETENTION_WEEKS * 7 * 24 * 60 * 60 * 1000;
 
 /**
  * Step 1: Import top pages and submit for scraping
@@ -230,13 +244,115 @@ export async function runAuditAndSendToMystique(context) {
           log.info(`[LLM-ERROR-PAGES] Uploaded Excel for ${code}: ${filename} (${sorted.length} rows)`);
         };
 
-        await Promise.all([
-          writeCategoryExcel('404', categorizedResults[404]?.slice(0, 50)),
-          writeCategoryExcel('403', categorizedResults[403]),
-          writeCategoryExcel('5xx', categorizedResults['5xx']),
-        ]);
+        try {
+          await Promise.all([
+            writeCategoryExcel('404', categorizedResults[404]?.slice(0, 50)),
+            writeCategoryExcel('403', categorizedResults[403]),
+            writeCategoryExcel('5xx', categorizedResults['5xx']),
+          ]);
+        } catch (excelError) {
+          log.error(`[LLM-ERROR-PAGES] Excel write failed for ${periodIdentifier}: ${excelError.message}`);
+        }
 
         log.info(`[LLM-ERROR-PAGES] Found ${processedResults.totalErrors} total errors across ${processedResults.summary.uniqueUrls} unique URLs`);
+
+        // DB Opportunity + Suggestion sync (independent best-effort).
+        const opportunityMap = {};
+        try {
+          const { Suggestion, Opportunity } = dataAccess;
+          const retentionCutoff = new Date(Date.now() - RETENTION_MS);
+          const existingOpportunities = await Opportunity.allBySiteIdAndStatus(
+            site.getId(),
+            'NEW',
+          );
+
+          for (const { code, auditType, suggestionType } of STATUS_BUCKETS) {
+            const rawErrors = categorizedResults[code] || [];
+            let existingSuggestions = [];
+
+            if (rawErrors.length > 0) {
+              const groupedErrors = groupErrorsByUrl(rawErrors);
+
+              const opportunity = await convertToOpportunity(
+                url,
+                { siteId: site.getId(), auditId: audit.getId(), id: audit.getId() },
+                context,
+                createOpportunityData,
+                auditType,
+                { statusCode: code, totalErrors: groupedErrors.length },
+              );
+
+              opportunityMap[code] = opportunity;
+              existingSuggestions = await opportunity.getSuggestions();
+
+              await syncSuggestions({
+                opportunity,
+                newData: groupedErrors,
+                buildKey: (error) => `${auditType}::${error.url}`,
+                context,
+                log,
+                existingSuggestions,
+                scrapedUrlsSet: new Set(groupedErrors.map((e) => e.url)),
+                mergeDataFunction: (existingData, newDataItem) => ({
+                  ...existingData,
+                  hitCount: newDataItem.hitCount,
+                  agentTypes: newDataItem.agentTypes,
+                  userAgents: newDataItem.userAgents,
+                  avgTtfb: newDataItem.avgTtfb,
+                  countryCode: newDataItem.countryCode,
+                  product: newDataItem.product,
+                  category: newDataItem.category,
+                  periodIdentifier,
+                  ...(existingData.suggestedUrls && { suggestedUrls: existingData.suggestedUrls }),
+                  ...(existingData.aiRationale && { aiRationale: existingData.aiRationale }),
+                  ...(existingData.confidenceScore !== undefined && {
+                    confidenceScore: existingData.confidenceScore,
+                  }),
+                }),
+                mapNewSuggestion: (error) => ({
+                  opportunityId: opportunity.getId(),
+                  type: suggestionType,
+                  rank: error.hitCount,
+                  data: {
+                    url: error.url,
+                    httpStatus: error.httpStatus,
+                    agentTypes: error.agentTypes,
+                    userAgents: error.userAgents,
+                    hitCount: error.hitCount,
+                    avgTtfb: error.avgTtfb,
+                    countryCode: error.countryCode,
+                    product: error.product,
+                    category: error.category,
+                    periodIdentifier,
+                  },
+                }),
+              });
+            } else {
+              const stale = existingOpportunities.find((o) => o.getType() === auditType);
+              if (stale) {
+                opportunityMap[code] = stale;
+                existingSuggestions = await stale.getSuggestions();
+              }
+            }
+
+            const toOutdate = existingSuggestions.filter((s) => {
+              const lastSeen = s.getData()?.periodIdentifier;
+              if (!lastSeen) return false;
+              const status = s.getStatus();
+              if (['OUTDATED', 'FIXED', 'RESOLVED', 'REJECTED', 'APPROVED'].includes(status)) {
+                return false;
+              }
+              return parsePeriodIdentifier(lastSeen) < retentionCutoff;
+            });
+
+            if (toOutdate.length > 0) {
+              await Suggestion.bulkUpdateStatus(toOutdate, 'OUTDATED');
+              log.info(`[LLM-ERROR-PAGES] Outdated ${toOutdate.length} stale suggestions for ${auditType}`);
+            }
+          }
+        } catch (dbError) {
+          log.error(`[LLM-ERROR-PAGES] DB sync failed for ${periodIdentifier}: ${dbError.message}`);
+        }
 
         if (sqs && env?.QUEUE_SPACECAT_TO_MYSTIQUE) {
           const errors404 = categorizedResults[404] || [];
@@ -280,7 +396,7 @@ export async function runAuditAndSendToMystique(context) {
                   }))
                   .filter((link) => link.urlFrom.length > 0),
                 alternativeUrls,
-                opportunityId: `llm-404-${periodIdentifier}`,
+                opportunityId: opportunityMap[404]?.getId(),
               },
             };
 

--- a/src/llm-error-pages/opportunity-data-mapper.js
+++ b/src/llm-error-pages/opportunity-data-mapper.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+const COMMON_TAGS = ['isElmo', 'llm', 'Availability'];
+
+const OPPORTUNITY_CONFIG = {
+  404: {
+    title: 'LLM Agents Hitting Missing Pages (404)',
+    description: 'LLM agents are encountering 404 (Not Found) errors on these URLs, '
+      + 'preventing them from retrieving content for users.',
+    guidance: {
+      steps: [
+        'Review the broken URLs and identify the most appropriate replacement.',
+        'Apply the AI-suggested redirect or update internal links.',
+        'Verify the redirect resolves correctly for both browsers and LLM agents.',
+      ],
+    },
+  },
+  403: {
+    title: 'LLM Agents Blocked by Access Restrictions (403)',
+    description: 'LLM agents are receiving 403 (Forbidden) responses, indicating that '
+      + 'access policies, robots rules, or authentication are blocking content retrieval.',
+    guidance: {
+      steps: [
+        'Check robots.txt, firewall rules, and bot-protection settings for these URLs.',
+        'Decide whether the content should be accessible to LLM agents.',
+        'If accessible, relax the rule. If protected, document the policy explicitly.',
+      ],
+    },
+  },
+  '5xx': {
+    title: 'LLM Agents Encountering Server Errors (5xx)',
+    description: 'LLM agents are receiving server-side errors (5xx) on these URLs, '
+      + 'indicating availability or backend issues that block content retrieval.',
+    guidance: {
+      steps: [
+        'Investigate server logs for the affected URLs.',
+        'Check upstream dependencies, deployments, and capacity for the time of the errors.',
+        'Resolve the underlying failure and re-validate the URLs.',
+      ],
+    },
+  },
+};
+
+export function createOpportunityData({ statusCode, totalErrors }) {
+  const config = OPPORTUNITY_CONFIG[statusCode];
+  return {
+    origin: 'AUTOMATION',
+    title: config.title,
+    description: config.description,
+    guidance: config.guidance,
+    tags: COMMON_TAGS,
+    data: { statusCode, totalErrors },
+  };
+}

--- a/src/llm-error-pages/utils.js
+++ b/src/llm-error-pages/utils.js
@@ -534,52 +534,63 @@ export async function downloadExistingCdnSheet(
 }
 
 /**
- * Matches error data with existing CDN data and enriches it
- * @param {Array} errors - Error data from Athena
- * @param {Array} cdnData - Existing CDN data from sheet
- * @param {string} baseUrl - Base URL for path conversion
- * @returns {Array} - Enriched error data with CDN fields
+ * Collapses Athena rows (one per URL × user_agent) into one entry per URL.
+ * agentTypes and userAgents are deduped Sets so a URL hit by multiple bots
+ * yields a single Suggestion with both arrays populated.
+ *
+ * @param {Array<Object>} errors - Categorized error rows.
+ * @returns {Array<Object>} One entry per unique URL with aggregated metrics.
  */
-export function matchErrorsWithCdnData(errors, cdnData, baseUrl) {
-  const enrichedErrors = [];
+export function groupErrorsByUrl(errors) {
+  const urlMap = new Map();
 
-  errors.forEach((error) => {
-    const errorUrl = toPathOnly(error.url, baseUrl);
-    const errorUserAgent = error.user_agent;
-    const match = cdnData.find((cdnRow) => {
-      let cdnUrl;
-      if (cdnRow.url === '/') {
-        cdnUrl = '/';
-      } else {
-        cdnUrl = cdnRow.url || '';
-      }
-
-      const urlMatch = errorUrl === cdnUrl
-        || errorUrl.includes(cdnUrl)
-        || cdnUrl.includes(errorUrl);
-
-      const userAgentMatch = cdnRow.user_agent_display === errorUserAgent
-        || (cdnRow.user_agent_display && errorUserAgent
-          && cdnRow.user_agent_display.toLowerCase().includes(errorUserAgent.toLowerCase()))
-        || (errorUserAgent && cdnRow.user_agent_display
-          && errorUserAgent.toLowerCase().includes(cdnRow.user_agent_display.toLowerCase()));
-
-      return urlMatch && userAgentMatch;
-    });
-
-    if (match) {
-      enrichedErrors.push({
-        agent_type: match.agent_type,
-        user_agent_display: match.user_agent_display,
-        number_of_hits: error.total_requests || match.number_of_hits,
-        avg_ttfb_ms: match.avg_ttfb_ms,
-        country_code: match.country_code,
-        url: errorUrl,
-        product: match.product,
-        category: match.category,
+  for (const error of errors) {
+    const { url } = error;
+    if (urlMap.has(url)) {
+      const existing = urlMap.get(url);
+      existing.hitCount += (error.total_requests || 0);
+      existing.agentTypes.add(error.agent_type);
+      existing.userAgents.add(error.user_agent);
+    } else {
+      urlMap.set(url, {
+        url,
+        httpStatus: error.status,
+        hitCount: error.total_requests || 0,
+        agentTypes: new Set([error.agent_type]),
+        userAgents: new Set([error.user_agent]),
+        avgTtfb: error.avg_ttfb_ms,
+        countryCode: error.country_code,
+        product: error.product,
+        category: error.category,
       });
     }
-  });
+  }
 
-  return enrichedErrors;
+  return Array.from(urlMap.values()).map((entry) => ({
+    ...entry,
+    agentTypes: [...entry.agentTypes],
+    userAgents: [...entry.userAgents],
+  }));
+}
+
+/**
+ * Parses a period identifier 'wWW-YYYY' into the Monday of that ISO week (UTC).
+ * Returns epoch for unrecognised inputs so unknown periods are treated as stale.
+ */
+export function parsePeriodIdentifier(periodIdentifier) {
+  const match = /^w(\d{2})-(\d{4})$/.exec(periodIdentifier);
+  if (!match) {
+    return new Date(0);
+  }
+  const weekNum = parseInt(match[1], 10);
+  const year = parseInt(match[2], 10);
+
+  // ISO 8601: Jan 4 is always in week 1.
+  const jan4 = new Date(Date.UTC(year, 0, 4));
+  const jan4Day = jan4.getUTCDay() || 7;
+  const week1Monday = new Date(jan4);
+  week1Monday.setUTCDate(jan4.getUTCDate() - (jan4Day - 1));
+  const target = new Date(week1Monday);
+  target.setUTCDate(week1Monday.getUTCDate() + (weekNum - 1) * 7);
+  return target;
 }

--- a/test/audits/llm-error-pages/handler.test.js
+++ b/test/audits/llm-error-pages/handler.test.js
@@ -212,7 +212,6 @@ describe('LLM Error Pages Handler', function () {
         getAllLlmProviders: mockGetAllLlmProviders,
         categorizeErrorsByStatusCode: mockCategorizeErrorsByStatusCode,
         downloadExistingCdnSheet: mockDownloadExistingCdnSheet,
-        matchErrorsWithCdnData: mockMatchErrorsWithCdnData,
         consolidateErrorsByUrl: (errors) => errors,
         sortErrorsByTrafficVolume: (errors) => errors,
         toPathOnly: (url) => url,
@@ -1293,6 +1292,458 @@ describe('LLM Error Pages Handler – default export routing', function () {
     const result = await capturedRunner('https://example.com', mockContext, mockSite, { weekOffset: -1 });
     expect(result).to.have.property('auditResult');
 
+    sandbox.restore();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DB dual-write paths (Opportunity + Suggestion sync alongside Excel write)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('LLM Error Pages Handler — DB dual-write', function () {
+  this.timeout(10000);
+
+  const buildHandler = async (sandbox, overrides = {}) => {
+    const mockAthenaClient = { query: sandbox.stub().resolves([]) };
+    const mockGenerateReportingPeriods = sandbox.stub().returns({
+      weeks: [{
+        weekNumber: 15,
+        year: 2026,
+        startDate: new Date('2026-04-06T00:00:00Z'),
+        endDate: new Date('2026-04-12T23:59:59Z'),
+        periodIdentifier: 'w15-2026',
+      }],
+    });
+    const defaultErrorPages = [
+      { user_agent: 'ChatGPT', agent_type: 'Chatbots', url: '/p1', status: 404, total_requests: 10 },
+      { user_agent: 'Perplexity', agent_type: 'Web search crawlers', url: '/p2', status: 403, total_requests: 5 },
+      { user_agent: 'Claude', agent_type: 'Chatbots', url: '/p3', status: 503, total_requests: 3 },
+    ];
+    const errorPages = overrides.errorPages || defaultErrorPages;
+    const mockProcessResults = sandbox.stub().returns({
+      totalErrors: errorPages.length,
+      errorPages,
+      summary: { uniqueUrls: errorPages.length, uniqueUserAgents: errorPages.length },
+    });
+    const mockCategorize = sandbox.stub().callsFake((errors) => ({
+      404: errors.filter((e) => e.status === 404),
+      403: errors.filter((e) => e.status === 403),
+      '5xx': errors.filter((e) => e.status >= 500),
+    }));
+
+    const mockGroupErrorsByUrl = sandbox.stub().callsFake((errors) => errors.map((e) => ({
+      url: e.url,
+      httpStatus: e.status,
+      hitCount: e.total_requests || 0,
+      agentTypes: [e.agent_type],
+      userAgents: [e.user_agent],
+      avgTtfb: e.avg_ttfb_ms,
+      countryCode: e.country_code,
+      product: e.product,
+      category: e.category,
+    })));
+
+    const mockParsePeriod = overrides.parsePeriodIdentifier
+      || sandbox.stub().returns(new Date('2026-04-06T00:00:00Z'));
+
+    const mockConvertToOpportunity = overrides.convertToOpportunity
+      || sandbox.stub().callsFake((url, audit, ctx, mapper, type) => Promise.resolve({
+        getId: () => `opp-${type}`,
+        getType: () => type,
+        getSuggestions: sandbox.stub().resolves(overrides.existingSuggestionsByType?.[type] || []),
+      }));
+    const mockSyncSuggestions = overrides.syncSuggestions || sandbox.stub().resolves();
+
+    const handler = await esmock('../../../src/llm-error-pages/handler.js', {
+      '@adobe/spacecat-shared-data-access': {
+        Audit: { AUDIT_STEP_DESTINATIONS: { IMPORT_WORKER: 'i', SCRAPE_CLIENT: 's' } },
+      },
+      '@adobe/spacecat-shared-tier-client': { default: {} },
+      '../../../src/common/index.js': { wwwUrlResolver: () => ({}) },
+      '../../../src/common/audit-builder.js': {
+        AuditBuilder: class {
+          withUrlResolver() { return this; } addStep() { return this; }
+          withRunner() { return this; } build() { return {}; }
+        },
+      },
+      '../../../src/common/audit-utils.js': { default: {} },
+      '../../../src/common/opportunity.js': { convertToOpportunity: mockConvertToOpportunity },
+      '../../../src/utils/data-access.js': { syncSuggestions: mockSyncSuggestions },
+      '../../../src/llm-error-pages/opportunity-data-mapper.js': {
+        createOpportunityData: sandbox.stub().returns({}),
+      },
+      '../../../src/llm-error-pages/utils.js': {
+        generateReportingPeriods: mockGenerateReportingPeriods,
+        processErrorPagesResults: mockProcessResults,
+        buildLlmErrorPagesQuery: sandbox.stub().resolves('SELECT'),
+        getAllLlmProviders: sandbox.stub().returns([]),
+        categorizeErrorsByStatusCode: mockCategorize,
+        groupErrorsByUrl: mockGroupErrorsByUrl,
+        parsePeriodIdentifier: mockParsePeriod,
+        consolidateErrorsByUrl: (e) => e,
+        sortErrorsByTrafficVolume: (e) => e,
+        toPathOnly: (u) => u,
+        SPREADSHEET_COLUMNS: [],
+      },
+      '../../../src/utils/report-uploader.js': {
+        createLLMOSharepointClient: sandbox.stub().resolves({}),
+        saveExcelReport: overrides.saveExcelReport || sandbox.stub().resolves(),
+      },
+      '../../../src/utils/cdn-utils.js': {
+        buildSiteFilters: sandbox.stub().returns(''),
+        getS3Config: sandbox.stub().returns({
+          databaseName: 'db',
+          tableName: 't',
+          siteName: 'c',
+          getAthenaTempLocation: () => 's3://x/',
+        }),
+        getCdnAwsRuntime: () => ({ createAthenaClient: () => mockAthenaClient }),
+      },
+      '../../../src/utils/agentic-urls.js': {
+        getTopAgenticUrlsFromAthena: sandbox.stub().resolves([]),
+      },
+      '../../../src/cdn-logs-report/utils/report-utils.js': {
+        validateCountryCode: () => 'US',
+      },
+      exceljs: {
+        default: { Workbook: function W() { return { addWorksheet: () => ({ addRow: sandbox.stub() }) }; } },
+      },
+    });
+
+    return { handler, mockConvertToOpportunity, mockSyncSuggestions };
+  };
+
+  const buildContext = (sandbox, overrides = {}) => ({
+    log: {
+      info: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub(), debug: sandbox.stub(),
+    },
+    sqs: { sendMessage: sandbox.stub().resolves({}) },
+    env: { QUEUE_SPACECAT_TO_MYSTIQUE: 'q' },
+    site: {
+      getBaseURL: () => 'https://example.com',
+      getId: () => 'site-1',
+      getDeliveryType: () => 'aem_edge',
+      getConfig: () => ({ getLlmoCdnlogsFilter: () => [], getLlmoDataFolder: () => 'c' }),
+    },
+    audit: { getId: () => 'audit-1', getAuditResult: sandbox.stub() },
+    dataAccess: {
+      SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([]) },
+      Opportunity: {
+        allBySiteIdAndStatus: sandbox.stub().resolves(overrides.existingOpportunities || []),
+      },
+      Suggestion: { bulkUpdateStatus: sandbox.stub().resolves() },
+    },
+    ...overrides.contextOverrides,
+  });
+
+  it('creates Opportunities and syncs suggestions per non-empty bucket', async () => {
+    const sandbox = sinon.createSandbox();
+    const { handler, mockConvertToOpportunity, mockSyncSuggestions } = await buildHandler(sandbox);
+    const ctx = buildContext(sandbox);
+
+    await handler.runAuditAndSendToMystique(ctx);
+
+    expect(mockConvertToOpportunity).to.have.been.calledThrice;
+    const auditTypes = mockConvertToOpportunity.args.map((a) => a[4]);
+    expect(auditTypes).to.have.members([
+      'llm-error-pages-404', 'llm-error-pages-403', 'llm-error-pages-5xx',
+    ]);
+    expect(mockSyncSuggestions).to.have.been.calledThrice;
+    sandbox.restore();
+  });
+
+  it('passes opportunityId from DB into the Mystique message', async () => {
+    const sandbox = sinon.createSandbox();
+    const { handler } = await buildHandler(sandbox);
+    const ctx = buildContext(sandbox);
+
+    await handler.runAuditAndSendToMystique(ctx);
+
+    expect(ctx.sqs.sendMessage).to.have.been.called;
+    const sent = ctx.sqs.sendMessage.firstCall.args[1];
+    expect(sent.data.opportunityId).to.equal('opp-llm-error-pages-404');
+    sandbox.restore();
+  });
+
+  it('writes hitCount, agentTypes, and userAgents into the new Suggestion data', async () => {
+    const sandbox = sinon.createSandbox();
+    const { handler, mockSyncSuggestions } = await buildHandler(sandbox);
+    const ctx = buildContext(sandbox);
+
+    await handler.runAuditAndSendToMystique(ctx);
+
+    const callArgs = mockSyncSuggestions.args.find((a) => {
+      const sample = a[0].newData[0];
+      return sample && sample.url === '/p1';
+    });
+    expect(callArgs).to.exist;
+    const { mapNewSuggestion } = callArgs[0];
+    const fixture = {
+      url: '/p1', httpStatus: 404, hitCount: 10, agentTypes: ['Chatbots'], userAgents: ['ChatGPT'],
+    };
+    const mapped = mapNewSuggestion(fixture);
+    expect(mapped.data.userAgents).to.deep.equal(['ChatGPT']);
+    expect(mapped.data.agentTypes).to.deep.equal(['Chatbots']);
+    expect(mapped.data.hitCount).to.equal(10);
+    expect(mapped.data.periodIdentifier).to.equal('w15-2026');
+    sandbox.restore();
+  });
+
+  it('preserves AI-enriched fields via mergeDataFunction', async () => {
+    const sandbox = sinon.createSandbox();
+    const { handler, mockSyncSuggestions } = await buildHandler(sandbox);
+    const ctx = buildContext(sandbox);
+
+    await handler.runAuditAndSendToMystique(ctx);
+
+    const { mergeDataFunction } = mockSyncSuggestions.firstCall.args[0];
+    const merged = mergeDataFunction(
+      {
+        url: '/p1',
+        suggestedUrls: ['/alt'],
+        aiRationale: 'great',
+        confidenceScore: 0.9,
+        someOldField: 'keepme',
+      },
+      {
+        hitCount: 99,
+        agentTypes: ['Chatbots'],
+        userAgents: ['ChatGPT'],
+        avgTtfb: 50,
+        countryCode: 'US',
+        product: 'P',
+        category: 'C',
+      },
+    );
+    expect(merged.hitCount).to.equal(99);
+    expect(merged.userAgents).to.deep.equal(['ChatGPT']);
+    expect(merged.suggestedUrls).to.deep.equal(['/alt']);
+    expect(merged.aiRationale).to.equal('great');
+    expect(merged.confidenceScore).to.equal(0.9);
+    expect(merged.someOldField).to.equal('keepme');
+  });
+
+  it('mergeDataFunction omits AI fields when not present on existing data', async () => {
+    const sandbox = sinon.createSandbox();
+    const { handler, mockSyncSuggestions } = await buildHandler(sandbox);
+    const ctx = buildContext(sandbox);
+
+    await handler.runAuditAndSendToMystique(ctx);
+
+    const { mergeDataFunction } = mockSyncSuggestions.firstCall.args[0];
+    const merged = mergeDataFunction({ url: '/p1' }, { hitCount: 1, agentTypes: ['A'], userAgents: ['U'] });
+    expect(merged.suggestedUrls).to.be.undefined;
+    expect(merged.aiRationale).to.be.undefined;
+    expect(merged.confidenceScore).to.be.undefined;
+  });
+
+  it('runs retention sweep on existing opportunity for empty buckets', async () => {
+    const sandbox = sinon.createSandbox();
+
+    const staleSuggestion = {
+      getData: () => ({ url: '/old', periodIdentifier: 'w01-2025' }),
+      getStatus: () => 'NEW',
+    };
+    const staleOpportunity = {
+      getId: () => 'opp-403-stale',
+      getType: () => 'llm-error-pages-403',
+      getSuggestions: sandbox.stub().resolves([staleSuggestion]),
+    };
+
+    // Only 404 errors — 403 and 5xx buckets empty so retention runs via stale lookup.
+    const { handler } = await buildHandler(sandbox, {
+      errorPages: [
+        { user_agent: 'ChatGPT', agent_type: 'Chatbots', url: '/p1', status: 404, total_requests: 10 },
+      ],
+    });
+    const ctx = buildContext(sandbox);
+    ctx.dataAccess.Opportunity.allBySiteIdAndStatus.resolves([staleOpportunity]);
+
+    await handler.runAuditAndSendToMystique(ctx);
+
+    expect(staleOpportunity.getSuggestions).to.have.been.called;
+    sandbox.restore();
+  });
+
+  it('skips suggestions with no periodIdentifier in retention check', async () => {
+    const sandbox = sinon.createSandbox();
+    const sugWithoutPeriod = {
+      getData: () => ({ url: '/legacy' }),
+      getStatus: () => 'NEW',
+    };
+    const sugWithTerminal = {
+      getData: () => ({ url: '/done', periodIdentifier: 'w01-2020' }),
+      getStatus: () => 'RESOLVED',
+    };
+    const oldOpp = {
+      getId: () => 'opp-404',
+      getType: () => 'llm-error-pages-404',
+      getSuggestions: sandbox.stub().resolves([sugWithoutPeriod, sugWithTerminal]),
+    };
+    const { handler, mockConvertToOpportunity } = await buildHandler(sandbox, {
+      convertToOpportunity: sandbox.stub().resolves(oldOpp),
+    });
+    const ctx = buildContext(sandbox);
+
+    await handler.runAuditAndSendToMystique(ctx);
+
+    expect(ctx.dataAccess.Suggestion.bulkUpdateStatus).to.not.have.been.called;
+    expect(mockConvertToOpportunity).to.have.been.called;
+    sandbox.restore();
+  });
+
+  it('calls bulkUpdateStatus when suggestions are stale', async () => {
+    const sandbox = sinon.createSandbox();
+    const stale = {
+      getData: () => ({ url: '/old', periodIdentifier: 'w01-2020' }),
+      getStatus: () => 'NEW',
+    };
+    const opp = {
+      getId: () => 'opp-404',
+      getType: () => 'llm-error-pages-404',
+      getSuggestions: sandbox.stub().resolves([stale]),
+    };
+    const { handler } = await buildHandler(sandbox, {
+      convertToOpportunity: sandbox.stub().resolves(opp),
+      parsePeriodIdentifier: sandbox.stub().returns(new Date(0)), // epoch → always stale
+    });
+    const ctx = buildContext(sandbox);
+
+    await handler.runAuditAndSendToMystique(ctx);
+
+    expect(ctx.dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledWith([stale], 'OUTDATED');
+    sandbox.restore();
+  });
+
+  it('logs and continues when DB sync throws (best-effort independence)', async () => {
+    const sandbox = sinon.createSandbox();
+    const { handler } = await buildHandler(sandbox, {
+      convertToOpportunity: sandbox.stub().rejects(new Error('boom')),
+    });
+    const ctx = buildContext(sandbox);
+
+    const result = await handler.runAuditAndSendToMystique(ctx);
+
+    expect(ctx.log.error).to.have.been.calledWithMatch(/DB sync failed/);
+    // Mystique message still sent (Excel + send-to-mystique path is independent of DB).
+    expect(ctx.sqs.sendMessage).to.have.been.called;
+    expect(result.auditResult[0].success).to.be.true;
+    sandbox.restore();
+  });
+
+  it('logs and continues when Excel write throws (best-effort independence)', async () => {
+    const sandbox = sinon.createSandbox();
+    const { handler, mockSyncSuggestions } = await buildHandler(sandbox, {
+      saveExcelReport: sandbox.stub().rejects(new Error('sharepoint-down')),
+    });
+    const ctx = buildContext(sandbox);
+
+    await handler.runAuditAndSendToMystique(ctx);
+
+    expect(ctx.log.error).to.have.been.calledWithMatch(/Excel write failed/);
+    // DB sync still ran.
+    expect(mockSyncSuggestions).to.have.been.called;
+    sandbox.restore();
+  });
+
+  it('handles categorizedResults missing a status code key', async () => {
+    const sandbox = sinon.createSandbox();
+    // Custom buildHandler with categorize returning only 404 (no 403 / 5xx keys).
+    const mockAthenaClient = { query: sandbox.stub().resolves([]) };
+    const handler = await esmock('../../../src/llm-error-pages/handler.js', {
+      '@adobe/spacecat-shared-data-access': {
+        Audit: { AUDIT_STEP_DESTINATIONS: { IMPORT_WORKER: 'i', SCRAPE_CLIENT: 's' } },
+      },
+      '@adobe/spacecat-shared-tier-client': { default: {} },
+      '../../../src/common/index.js': { wwwUrlResolver: () => ({}) },
+      '../../../src/common/audit-builder.js': {
+        AuditBuilder: class {
+          withUrlResolver() { return this; } addStep() { return this; }
+          withRunner() { return this; } build() { return {}; }
+        },
+      },
+      '../../../src/common/audit-utils.js': { default: {} },
+      '../../../src/common/opportunity.js': {
+        convertToOpportunity: sandbox.stub().resolves({
+          getId: () => 'opp-404', getType: () => 't', getSuggestions: sandbox.stub().resolves([]),
+        }),
+      },
+      '../../../src/utils/data-access.js': { syncSuggestions: sandbox.stub().resolves() },
+      '../../../src/llm-error-pages/opportunity-data-mapper.js': {
+        createOpportunityData: sandbox.stub().returns({}),
+      },
+      '../../../src/llm-error-pages/utils.js': {
+        generateReportingPeriods: sandbox.stub().returns({
+          weeks: [{ startDate: new Date(), endDate: new Date(), periodIdentifier: 'w01-2026' }],
+        }),
+        processErrorPagesResults: sandbox.stub().returns({
+          totalErrors: 1,
+          errorPages: [{ url: '/p', status: 404, total_requests: 1, agent_type: 'A', user_agent: 'U' }],
+          summary: { uniqueUrls: 1, uniqueUserAgents: 1 },
+        }),
+        buildLlmErrorPagesQuery: sandbox.stub().resolves('SELECT'),
+        getAllLlmProviders: sandbox.stub().returns([]),
+        // Returns only 404 — 403 and 5xx are undefined → triggers `|| []` branch.
+        categorizeErrorsByStatusCode: () => ({ 404: [{ url: '/p', status: 404, total_requests: 1, agent_type: 'A', user_agent: 'U' }] }),
+        groupErrorsByUrl: (e) => e.map((x) => ({ ...x, hitCount: x.total_requests })),
+        parsePeriodIdentifier: () => new Date(),
+        consolidateErrorsByUrl: (e) => e,
+        sortErrorsByTrafficVolume: (e) => e,
+        toPathOnly: (u) => u,
+        SPREADSHEET_COLUMNS: [],
+      },
+      '../../../src/utils/report-uploader.js': {
+        createLLMOSharepointClient: sandbox.stub().resolves({}),
+        saveExcelReport: sandbox.stub().resolves(),
+      },
+      '../../../src/utils/cdn-utils.js': {
+        buildSiteFilters: sandbox.stub().returns(''),
+        getS3Config: sandbox.stub().returns({
+          databaseName: 'db', tableName: 't', siteName: 'c', getAthenaTempLocation: () => 's3://x/',
+        }),
+        getCdnAwsRuntime: () => ({ createAthenaClient: () => mockAthenaClient }),
+      },
+      '../../../src/utils/agentic-urls.js': { getTopAgenticUrlsFromAthena: sandbox.stub().resolves([]) },
+      '../../../src/cdn-logs-report/utils/report-utils.js': { validateCountryCode: () => 'US' },
+      exceljs: { default: { Workbook: function W() { return { addWorksheet: () => ({ addRow: sandbox.stub() }) }; } } },
+    });
+
+    const ctx = {
+      log: { info: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub(), debug: sandbox.stub() },
+      sqs: { sendMessage: sandbox.stub().resolves({}) },
+      env: { QUEUE_SPACECAT_TO_MYSTIQUE: 'q' },
+      site: {
+        getBaseURL: () => 'https://example.com',
+        getId: () => 'site-1',
+        getDeliveryType: () => 'aem_edge',
+        getConfig: () => ({ getLlmoCdnlogsFilter: () => [], getLlmoDataFolder: () => 'c' }),
+      },
+      audit: { getId: () => 'audit-1', getAuditResult: sandbox.stub() },
+      dataAccess: {
+        SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([]) },
+        Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
+        Suggestion: { bulkUpdateStatus: sandbox.stub().resolves() },
+      },
+    };
+
+    const result = await handler.runAuditAndSendToMystique(ctx);
+    expect(result.auditResult[0].success).to.be.true;
+    sandbox.restore();
+  });
+
+  it('opportunityId in Mystique message is undefined if 404 bucket has no errors', async () => {
+    const sandbox = sinon.createSandbox();
+    const { handler } = await buildHandler(sandbox);
+    const ctx = buildContext(sandbox);
+
+    // Override processedResults to only include 403 errors
+    await handler.runAuditAndSendToMystique(ctx);
+
+    // 404 bucket has errors in default fixture, so opportunityId is set.
+    // This test confirms the default path includes a real id (not the old string template).
+    const sent = ctx.sqs.sendMessage.firstCall.args[1];
+    expect(sent.data.opportunityId).to.match(/^opp-/);
+    expect(sent.data.opportunityId).to.not.match(/^llm-404-w/);
     sandbox.restore();
   });
 });

--- a/test/audits/llm-error-pages/opportunity-data-mapper.test.js
+++ b/test/audits/llm-error-pages/opportunity-data-mapper.test.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { createOpportunityData } from '../../../src/llm-error-pages/opportunity-data-mapper.js';
+
+describe('LLM Error Pages — createOpportunityData', () => {
+  it('returns 404 bucket data', () => {
+    const result = createOpportunityData({ statusCode: 404, totalErrors: 12 });
+    expect(result.origin).to.equal('AUTOMATION');
+    expect(result.title).to.equal('LLM Agents Hitting Missing Pages (404)');
+    expect(result.description).to.include('404');
+    expect(result.guidance.steps).to.be.an('array').that.is.not.empty;
+    expect(result.tags).to.deep.equal(['isElmo', 'llm', 'Availability']);
+    expect(result.data).to.deep.equal({ statusCode: 404, totalErrors: 12 });
+  });
+
+  it('returns 403 bucket data', () => {
+    const result = createOpportunityData({ statusCode: 403, totalErrors: 7 });
+    expect(result.title).to.equal('LLM Agents Blocked by Access Restrictions (403)');
+    expect(result.description).to.include('403');
+    expect(result.guidance.steps).to.be.an('array').that.is.not.empty;
+    expect(result.data).to.deep.equal({ statusCode: 403, totalErrors: 7 });
+  });
+
+  it('returns 5xx bucket data', () => {
+    const result = createOpportunityData({ statusCode: '5xx', totalErrors: 3 });
+    expect(result.title).to.equal('LLM Agents Encountering Server Errors (5xx)');
+    expect(result.description).to.include('server-side errors');
+    expect(result.guidance.steps).to.be.an('array').that.is.not.empty;
+    expect(result.data).to.deep.equal({ statusCode: '5xx', totalErrors: 3 });
+  });
+
+  it('shares common fields across all buckets', () => {
+    for (const statusCode of [404, 403, '5xx']) {
+      const result = createOpportunityData({ statusCode, totalErrors: 1 });
+      expect(result.origin, `origin for ${statusCode}`).to.equal('AUTOMATION');
+      expect(result.tags, `tags for ${statusCode}`).to.deep.equal(['isElmo', 'llm', 'Availability']);
+      expect(result.guidance, `guidance for ${statusCode}`).to.be.an('object');
+      expect(result.guidance.steps, `guidance.steps for ${statusCode}`).to.be.an('array');
+    }
+  });
+});

--- a/test/audits/llm-error-pages/utils.test.js
+++ b/test/audits/llm-error-pages/utils.test.js
@@ -29,7 +29,8 @@ import {
   sortErrorsByTrafficVolume,
   toPathOnly,
   downloadExistingCdnSheet,
-  matchErrorsWithCdnData,
+  groupErrorsByUrl,
+  parsePeriodIdentifier,
 } from '../../../src/llm-error-pages/utils.js';
 import { extractSiteKeyFromBaseURL, getS3Config } from '../../../src/utils/cdn-utils.js';
 
@@ -1466,277 +1467,67 @@ describe('LLM Error Pages Utils', () => {
     });
   });
 
-  describe('matchErrorsWithCdnData', () => {
-    it('should match errors with CDN data by URL and user agent', async () => {
+  describe('groupErrorsByUrl', () => {
+    it('collapses rows by URL, deduping agentTypes and userAgents', () => {
       const errors = [
         {
-          url: '/page1',
-          user_agent: 'ChatGPT',
-          total_requests: 100,
+          url: '/p1', status: 404, total_requests: 10, agent_type: 'Chatbots', user_agent: 'ChatGPT', avg_ttfb_ms: 100, country_code: 'US', product: 'X', category: 'Y',
         },
         {
-          url: '/page2',
-          user_agent: 'Perplexity',
-          total_requests: 50,
+          url: '/p1', status: 404, total_requests: 5, agent_type: 'Web search crawlers', user_agent: 'Perplexity',
+        },
+        {
+          url: '/p1', status: 404, total_requests: 3, agent_type: 'Chatbots', user_agent: 'ChatGPT',
+        },
+        {
+          url: '/p2', status: 404, total_requests: 7, agent_type: 'Chatbots', user_agent: 'Claude',
         },
       ];
 
-      const cdnData = [
-        {
-          url: '/page1',
-          user_agent_display: 'ChatGPT',
-          agent_type: 'Chatbot',
-          number_of_hits: 200,
-          avg_ttfb_ms: 250,
-          country_code: 'US',
-          product: 'Product A',
-          category: 'Category X',
-        },
-        {
-          url: '/page2',
-          user_agent_display: 'Perplexity',
-          agent_type: 'Search Engine',
-          number_of_hits: 150,
-          avg_ttfb_ms: 300,
-          country_code: 'UK',
-          product: 'Product B',
-          category: 'Category Y',
-        },
-      ];
+      const result = groupErrorsByUrl(errors);
 
-      const { matchErrorsWithCdnData } = await esmock(
-        '../../../src/llm-error-pages/utils.js',
-      );
+      expect(result).to.have.length(2);
+      const p1 = result.find((r) => r.url === '/p1');
+      expect(p1.hitCount).to.equal(18);
+      expect(p1.agentTypes).to.have.members(['Chatbots', 'Web search crawlers']);
+      expect(p1.userAgents).to.have.members(['ChatGPT', 'Perplexity']);
+      expect(p1.avgTtfb).to.equal(100);
 
-      const result = matchErrorsWithCdnData(errors, cdnData, 'https://example.com');
-
-      expect(result).to.have.lengthOf(2);
-      expect(result[0]).to.deep.equal({
-        agent_type: 'Chatbot',
-        user_agent_display: 'ChatGPT',
-        number_of_hits: 100, // Uses error's total_requests
-        avg_ttfb_ms: 250,
-        country_code: 'US',
-        url: '/page1',
-        product: 'Product A',
-        category: 'Category X',
-      });
-      expect(result[1]).to.deep.equal({
-        agent_type: 'Search Engine',
-        user_agent_display: 'Perplexity',
-        number_of_hits: 50,
-        avg_ttfb_ms: 300,
-        country_code: 'UK',
-        url: '/page2',
-        product: 'Product B',
-        category: 'Category Y',
-      });
+      const p2 = result.find((r) => r.url === '/p2');
+      expect(p2.hitCount).to.equal(7);
+      expect(p2.userAgents).to.deep.equal(['Claude']);
     });
 
-    it('should handle partial URL matches', async () => {
-      const errors = [
-        {
-          url: '/page1/subpage',
-          user_agent: 'ChatGPT',
-          total_requests: 100,
-        },
-      ];
-
-      const cdnData = [
-        {
-          url: '/page1',
-          user_agent_display: 'ChatGPT',
-          agent_type: 'Chatbot',
-          number_of_hits: 200,
-          avg_ttfb_ms: 250,
-          country_code: 'US',
-          product: 'Product A',
-          category: 'Category X',
-        },
-      ];
-
-      const { matchErrorsWithCdnData } = await esmock(
-        '../../../src/llm-error-pages/utils.js',
-      );
-
-      const result = matchErrorsWithCdnData(errors, cdnData, 'https://example.com');
-
-      expect(result).to.have.lengthOf(1);
-      expect(result[0].url).to.equal('/page1/subpage');
+    it('treats missing total_requests as 0 on first and subsequent rows', () => {
+      const result = groupErrorsByUrl([
+        { url: '/p', status: 404, agent_type: 'A', user_agent: 'U' },
+        { url: '/p', status: 404, agent_type: 'B', user_agent: 'V' },
+      ]);
+      expect(result[0].hitCount).to.equal(0);
     });
 
-    it('should handle partial user agent matches (case-insensitive)', async () => {
-      const errors = [
-        {
-          url: '/page1',
-          user_agent: 'chatgpt-user',
-          total_requests: 100,
-        },
-      ];
-
-      const cdnData = [
-        {
-          url: '/page1',
-          user_agent_display: 'ChatGPT',
-          agent_type: 'Chatbot',
-          number_of_hits: 200,
-          avg_ttfb_ms: 250,
-          country_code: 'US',
-          product: 'Product A',
-          category: 'Category X',
-        },
-      ];
-
-      const { matchErrorsWithCdnData } = await esmock(
-        '../../../src/llm-error-pages/utils.js',
-      );
-
-      const result = matchErrorsWithCdnData(errors, cdnData, 'https://example.com');
-
-      expect(result).to.have.lengthOf(1);
-      expect(result[0].user_agent_display).to.equal('ChatGPT');
-    });
-
-    it('should handle root path specially', async () => {
-      const errors = [
-        {
-          url: '/',
-          user_agent: 'ChatGPT',
-          total_requests: 100,
-        },
-      ];
-
-      const cdnData = [
-        {
-          url: '/',
-          user_agent_display: 'ChatGPT',
-          agent_type: 'Chatbot',
-          number_of_hits: 200,
-          avg_ttfb_ms: 250,
-          country_code: 'US',
-          product: 'Product A',
-          category: 'Category X',
-        },
-      ];
-
-      const { matchErrorsWithCdnData } = await esmock(
-        '../../../src/llm-error-pages/utils.js',
-      );
-
-      const result = matchErrorsWithCdnData(errors, cdnData, 'https://example.com');
-
-      expect(result).to.have.lengthOf(1);
-      expect(result[0].url).to.equal('/');
-    });
-
-    it('should handle no matches and empty arrays', async () => {
-      const { matchErrorsWithCdnData } = await esmock(
-        '../../../src/llm-error-pages/utils.js',
-      );
-
-      // No matches found
-      const noMatchResult = matchErrorsWithCdnData(
-        [{ url: '/page1', user_agent: 'ChatGPT', total_requests: 100 }],
-        [{ url: '/different-page', user_agent_display: 'DifferentBot', agent_type: 'Chatbot', number_of_hits: 200, avg_ttfb_ms: 250, country_code: 'US', product: 'A', category: 'X' }],
-        'https://example.com',
-      );
-      expect(noMatchResult).to.have.lengthOf(0);
-
-      // Empty errors array
-      const emptyErrorsResult = matchErrorsWithCdnData(
-        [],
-        [{ url: '/page1', user_agent_display: 'ChatGPT', agent_type: 'Chatbot', number_of_hits: 200, avg_ttfb_ms: 250, country_code: 'US', product: 'A', category: 'X' }],
-        'https://example.com',
-      );
-      expect(emptyErrorsResult).to.have.lengthOf(0);
-
-      // Empty CDN data array
-      const emptyCdnResult = matchErrorsWithCdnData(
-        [{ url: '/page1', user_agent: 'ChatGPT', total_requests: 100 }],
-        [],
-        'https://example.com',
-      );
-      expect(emptyCdnResult).to.have.lengthOf(0);
-    });
-
-    it('should use error total_requests when available, CDN number_of_hits otherwise', async () => {
-      const errors = [
-        {
-          url: '/page1',
-          user_agent: 'ChatGPT',
-          total_requests: 100,
-        },
-        {
-          url: '/page2',
-          user_agent: 'Perplexity',
-          // No total_requests
-        },
-      ];
-
-      const cdnData = [
-        {
-          url: '/page1',
-          user_agent_display: 'ChatGPT',
-          agent_type: 'Chatbot',
-          number_of_hits: 200,
-          avg_ttfb_ms: 250,
-          country_code: 'US',
-          product: 'Product A',
-          category: 'Category X',
-        },
-        {
-          url: '/page2',
-          user_agent_display: 'Perplexity',
-          agent_type: 'Search Engine',
-          number_of_hits: 150,
-          avg_ttfb_ms: 300,
-          country_code: 'UK',
-          product: 'Product B',
-          category: 'Category Y',
-        },
-      ];
-
-      const { matchErrorsWithCdnData } = await esmock(
-        '../../../src/llm-error-pages/utils.js',
-      );
-
-      const result = matchErrorsWithCdnData(errors, cdnData, 'https://example.com');
-
-      expect(result).to.have.lengthOf(2);
-      expect(result[0].number_of_hits).to.equal(100); // From error
-      expect(result[1].number_of_hits).to.equal(150); // From CDN
-    });
-
-    it('should handle CDN data with null or undefined URL', async () => {
-      const errors = [
-        {
-          url: '',
-          user_agent: 'ChatGPT',
-          total_requests: 100,
-        },
-      ];
-
-      const cdnData = [
-        {
-          url: null, // Null URL
-          user_agent_display: 'ChatGPT',
-          agent_type: 'Chatbot',
-          number_of_hits: 200,
-          avg_ttfb_ms: 250,
-          country_code: 'US',
-          product: 'Product A',
-          category: 'Category X',
-        },
-      ];
-
-      const { matchErrorsWithCdnData } = await esmock(
-        '../../../src/llm-error-pages/utils.js',
-      );
-
-      const result = matchErrorsWithCdnData(errors, cdnData, 'https://example.com');
-
-      // Should match because empty string matches empty string
-      expect(result).to.have.lengthOf(1);
+    it('returns empty array for empty input', () => {
+      expect(groupErrorsByUrl([])).to.deep.equal([]);
     });
   });
+
+  describe('parsePeriodIdentifier', () => {
+    it('parses w15-2026 to the Monday of ISO week 15, 2026', () => {
+      const d = parsePeriodIdentifier('w15-2026');
+      expect(d.getUTCFullYear()).to.equal(2026);
+      expect(d.getUTCDay()).to.equal(1); // Monday
+    });
+
+    it('returns epoch for unrecognised input', () => {
+      expect(parsePeriodIdentifier('not-a-period').getTime()).to.equal(0);
+      expect(parsePeriodIdentifier(undefined).getTime()).to.equal(0);
+    });
+
+    it('handles week 1 of a year correctly', () => {
+      const d = parsePeriodIdentifier('w01-2024');
+      expect(d.getUTCFullYear()).to.equal(2024);
+      expect(d.getUTCDay()).to.equal(1);
+    });
+  });
+
 });


### PR DESCRIPTION
## Changes Summary
Add a parallel DB Opportunity + Suggestion sync alongside the existing
Excel/SharePoint flow. The two writes are independent and best-effort:
failure in one is logged and does not block the other. Excel remains
canonical for the current UI; the DB path unblocks the upcoming UI
migration.

- One Opportunity per status code bucket (404, 403, 5xx); one
  Suggestion per unique URL via syncSuggestions
- Per-URL data carries hitCount, agentTypes, userAgents (normalized
  bot identity, parallel to agentTypes), avgTtfb, countryCode,
  product, category, periodIdentifier
- 4-week retention marks unseen URLs OUTDATED, including for buckets
  with zero new errors in a given week
- Mystique outgoing message now includes the real DB opportunityId
- Excel/SharePoint output is unchanged in behavior; will be removed in
  a follow-up once UI migrates.