### PR TITLE
feat(llmo-referral-traffic-daily): use traffic-analysis with mode:daily instead of traffic-analysis-daily

### DIFF
--- a/src/llmo-referral-traffic-daily/handler.js
+++ b/src/llmo-referral-traffic-daily/handler.js
@@ -158,7 +158,7 @@ export async function triggerTrafficAnalysisDailyImport(context) {
   );
 
   return {
-    type: 'traffic-analysis-daily',
+    type: 'traffic-analysis',
     siteId,
     auditResult: {
       status: 'import-triggered',
@@ -170,9 +170,7 @@ export async function triggerTrafficAnalysisDailyImport(context) {
     },
     auditContext: {
       date,
-      year,
-      month,
-      day,
+      mode: 'daily',
     },
     fullAuditRef: finalUrl,
     allowCache: false,

--- a/test/audits/llmo-referral-traffic-daily/handler.test.js
+++ b/test/audits/llmo-referral-traffic-daily/handler.test.js
@@ -161,7 +161,7 @@ describe('LLMO Referral Traffic Daily Handler', function () {
       expect(result.auditResult.year).to.equal(2026);
       expect(result.auditResult.month).to.equal(4);
       expect(result.auditResult.day).to.equal(29);
-      expect(result.type).to.equal('traffic-analysis-daily');
+      expect(result.type).to.equal('traffic-analysis');
       expect(result.allowCache).to.equal(false);
       clock.restore();
     });
@@ -177,7 +177,7 @@ describe('LLMO Referral Traffic Daily Handler', function () {
       expect(result.auditResult.month).to.equal(3);
       expect(result.auditResult.day).to.equal(15);
       expect(result.auditContext).to.deep.equal({
-        date: '2026-03-15', year: 2026, month: 3, day: 15,
+        date: '2026-03-15', mode: 'daily',
       });
       expect(result.fullAuditRef).to.equal('https://example.com');
     });


### PR DESCRIPTION
## Context

Companion PR to adobe/spacecat-import-worker#733, which merged the `traffic-analysis-daily` import handler into `traffic-analysis` behind a `mode` parameter (`weekly` | `daily`, default: `weekly`).

## Changes

**`src/llmo-referral-traffic-daily/handler.js`** — `triggerTrafficAnalysisDailyImport`:
- `type: 'traffic-analysis-daily'` → `type: 'traffic-analysis'`
- `auditContext` now sends `{ date, mode: 'daily' }` instead of `{ date, year, month, day }`

**Why `auditContext.mode` and not top-level `mode`**

The `formatPayload` for `AUDIT_STEP_DESTINATIONS.IMPORT_WORKER` in `spacecat-shared-data-access` is an explicit whitelist. Any top-level field not in it (`type`, `siteId`, `pageUrl`, `startDate`, `endDate`, `urlConfigs`, `allowCache`, `auditContext`) is silently dropped. `mode` must therefore live inside `auditContext`.

**Why `year`/`month`/`day` are removed from `auditContext`**

The import-worker config provider only ever read `date` from `auditContext` and derived `year`/`month`/`day` itself via string splitting — the redundant fields were never consumed. Sending only `date` keeps the contract minimal.

**`referralTrafficDailyRunner` is unaffected**

Step 2 reads `year`/`month`/`day` from `auditResult` (stored in DynamoDB after step 1), not from `auditContext`. `auditResult` is unchanged.

## Test plan

- [x] Updated `expect(result.type).to.equal('traffic-analysis')`
- [x] Updated `auditContext` assertion to `{ date, mode: 'daily' }`
- [x] All 27 tests in `llmo-referral-traffic-daily/handler.test.js` pass

## Deploy order

Import-worker PR must be deployed first so the `traffic-analysis` handler already understands `mode: daily` before audit-worker starts sending it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)