### PR TITLE
feat(llmo-customer-analysis): enable llmo-referral-traffic-daily audit on onboarding

### DIFF
--- a/src/llmo-customer-analysis/handler.js
+++ b/src/llmo-customer-analysis/handler.js
@@ -26,6 +26,7 @@ import { handleCdnBucketConfigChanges } from './cdn-config-handler.js';
 import { sendOnboardingNotification } from './onboarding-notifications.js';
 
 const REFERRAL_TRAFFIC_AUDIT = 'llmo-referral-traffic';
+const REFERRAL_TRAFFIC_DAILY_AUDIT = 'llmo-referral-traffic-daily';
 const REFERRAL_TRAFFIC_IMPORT = 'traffic-analysis';
 
 /**
@@ -314,6 +315,7 @@ export async function runLlmoCustomerAnalysis(finalUrl, context, site, auditCont
       'llm-error-pages',
       'summarization',
       REFERRAL_TRAFFIC_AUDIT,
+      REFERRAL_TRAFFIC_DAILY_AUDIT,
       'readability',
       'wikipedia-analysis',
     ];

--- a/test/audits/llmo-customer-analysis.test.js
+++ b/test/audits/llmo-customer-analysis.test.js
@@ -1268,6 +1268,7 @@ describe('LLMO Customer Analysis Handler', () => {
         'llm-error-pages',
         'summarization',
         'llmo-referral-traffic',
+        'llmo-referral-traffic-daily',
         'readability',
         'wikipedia-analysis',
       ];


### PR DESCRIPTION
## Summary
- Adds `llmo-referral-traffic-daily` to the list of audits enabled during LLMO customer onboarding, alongside the existing `llmo-referral-traffic`
- Introduces a `REFERRAL_TRAFFIC_DAILY_AUDIT` constant to keep it consistent with the `REFERRAL_TRAFFIC_AUDIT` pattern
- Updates the test assertion to expect the new audit in the enabled list

## Test plan
- [ ] Existing test `should enable audits and save configuration when enableAudits is called` updated to assert `llmo-referral-traffic-daily` is enabled
- [ ] All 50 tests in `llmo-customer-analysis.test.js` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)