### PR TITLE
feat(commerce-enrichments): scrape as GPTBot user-agent

### DIFF
--- a/src/commerce-product-enrichments/handler.js
+++ b/src/commerce-product-enrichments/handler.js
@@ -147,6 +147,9 @@ async function buildScrapePayload({
       screenshotTypes: [],
       expandShadowDOM: false,
     },
+    customHeaders: {
+      'User-Agent': 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; GPTBot/1.2; +https://openai.com/gptbot',
+    },
     allowCache: false,
     maxScrapeAge: 0,
   };

--- a/test/audits/commerce-product-enrichments/handler.test.js
+++ b/test/audits/commerce-product-enrichments/handler.test.js
@@ -264,6 +264,9 @@ describe('Commerce Product Enrichments Handler', () => {
         screenshotTypes: [],
         expandShadowDOM: false,
       },
+      customHeaders: {
+        'User-Agent': 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; GPTBot/1.2; +https://openai.com/gptbot',
+      },
       allowCache: false,
       maxScrapeAge: 0,
     });
@@ -513,6 +516,9 @@ describe('Commerce Product Enrichments Handler', () => {
         waitTimeoutForMetaTags: 5000,
         screenshotTypes: [],
         expandShadowDOM: false,
+      },
+      customHeaders: {
+        'User-Agent': 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; GPTBot/1.2; +https://openai.com/gptbot',
       },
       allowCache: false,
       maxScrapeAge: 0,


### PR DESCRIPTION
Audit the site the way an LLM crawler sees it, so enrichment reflects what answer engines index. Sent via customHeaders on the scrape payload; content-scraper appends Spacecat/1.0 to the UA.

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [x] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
