### PR TITLE
fix: persist daily db export batch ids

### DIFF
--- a/src/cdn-logs-report/handler.js
+++ b/src/cdn-logs-report/handler.js
@@ -34,46 +34,23 @@ import {
   runDailyReferralExport,
 } from './referral-daily-export.js';
 
-function getAgenticExportBatchId(agenticDbExportResult) {
-  return agenticDbExportResult.dailyAgenticExport?.batchId;
-}
-
-function addAgenticExportBatchIdToAuditResult(
-  results,
+function getAgenticDbExportAuditResult(
+  agenticDbExportResult,
   agenticReportConfig,
   s3Config,
-  batchId,
 ) {
+  const batchId = agenticDbExportResult.dailyAgenticExport?.batchId;
   if (!batchId) {
-    return results;
+    return null;
   }
 
-  let attached = false;
-  const enrichedResults = results.map((result) => {
-    if (result.name !== 'agentic') {
-      return result;
-    }
-    attached = true;
-    return {
-      ...result,
-      batchId,
-    };
-  });
-
-  if (attached) {
-    return enrichedResults;
-  }
-
-  return [
-    ...enrichedResults,
-    {
-      name: 'agentic',
-      table: agenticReportConfig.tableName,
-      database: s3Config.databaseName,
-      customer: s3Config.siteName,
-      batchId,
-    },
-  ];
+  return {
+    name: 'agentic-db-export',
+    table: agenticReportConfig.tableName,
+    database: s3Config.databaseName,
+    customer: s3Config.siteName,
+    batchId,
+  };
 }
 
 async function runCdnLogsReport(url, context, site, auditContext) {
@@ -252,12 +229,14 @@ async function runCdnLogsReport(url, context, site, auditContext) {
     }
   }
 
-  const auditResult = addAgenticExportBatchIdToAuditResult(
-    results,
+  const agenticDbExportAuditResult = getAgenticDbExportAuditResult(
+    agenticDbExportResult,
     agenticReportConfig,
     s3Config,
-    getAgenticExportBatchId(agenticDbExportResult),
   );
+  const auditResult = agenticDbExportAuditResult
+    ? [...results, agenticDbExportAuditResult]
+    : results;
 
   return {
     ...agenticDbExportResult,

--- a/src/cdn-logs-report/handler.js
+++ b/src/cdn-logs-report/handler.js
@@ -34,59 +34,17 @@ import {
   runDailyReferralExport,
 } from './referral-daily-export.js';
 
-const DAILY_AGENTIC_EXPORT_AUDIT_FIELDS = [
-  'enabled',
-  'success',
-  'skipped',
-  'queued',
-  'siteId',
-  'trafficDate',
-  'referenceDate',
-  'batchId',
-  'rowCount',
-  'classificationCount',
-  'bundleUri',
-  'delaySeconds',
-  'error',
-];
-
-function compactDailyAgenticExport(exportResult) {
-  return DAILY_AGENTIC_EXPORT_AUDIT_FIELDS.reduce((compact, field) => {
-    if (exportResult?.[field] !== undefined) {
-      return {
-        ...compact,
-        [field]: exportResult[field],
-      };
-    }
-    return compact;
-  }, {});
+function getAgenticExportBatchId(agenticDbExportResult) {
+  return agenticDbExportResult.dailyAgenticExport?.batchId;
 }
 
-function getAgenticExportAuditDetails(agenticDbExportResult) {
-  const details = {};
-  if (agenticDbExportResult.dailyAgenticExport) {
-    details.dailyAgenticExport = compactDailyAgenticExport(
-      agenticDbExportResult.dailyAgenticExport,
-    );
-  }
-
-  const dailyAgenticExports = (agenticDbExportResult.dailyAgenticExports || [])
-    .map(compactDailyAgenticExport)
-    .filter((exportResult) => Object.keys(exportResult).length > 0);
-  if (dailyAgenticExports.length > 0) {
-    details.dailyAgenticExports = dailyAgenticExports;
-  }
-
-  return details;
-}
-
-function addAgenticExportDetailsToAuditResult(
+function addAgenticExportBatchIdToAuditResult(
   results,
   agenticReportConfig,
   s3Config,
-  exportDetails,
+  batchId,
 ) {
-  if (Object.keys(exportDetails).length === 0) {
+  if (!batchId) {
     return results;
   }
 
@@ -98,7 +56,7 @@ function addAgenticExportDetailsToAuditResult(
     attached = true;
     return {
       ...result,
-      ...exportDetails,
+      batchId,
     };
   });
 
@@ -113,8 +71,7 @@ function addAgenticExportDetailsToAuditResult(
       table: agenticReportConfig.tableName,
       database: s3Config.databaseName,
       customer: s3Config.siteName,
-      success: exportDetails.dailyAgenticExport?.success !== false,
-      ...exportDetails,
+      batchId,
     },
   ];
 }
@@ -295,11 +252,11 @@ async function runCdnLogsReport(url, context, site, auditContext) {
     }
   }
 
-  const auditResult = addAgenticExportDetailsToAuditResult(
+  const auditResult = addAgenticExportBatchIdToAuditResult(
     results,
     agenticReportConfig,
     s3Config,
-    getAgenticExportAuditDetails(agenticDbExportResult),
+    getAgenticExportBatchId(agenticDbExportResult),
   );
 
   return {

--- a/src/cdn-logs-report/handler.js
+++ b/src/cdn-logs-report/handler.js
@@ -34,25 +34,6 @@ import {
   runDailyReferralExport,
 } from './referral-daily-export.js';
 
-function getAgenticDbExportAuditResult(
-  agenticDbExportResult,
-  agenticReportConfig,
-  s3Config,
-) {
-  const batchId = agenticDbExportResult.dailyAgenticExport?.batchId;
-  if (!batchId) {
-    return null;
-  }
-
-  return {
-    name: 'agentic-db-export',
-    table: agenticReportConfig.tableName,
-    database: s3Config.databaseName,
-    customer: s3Config.siteName,
-    batchId,
-  };
-}
-
 async function runCdnLogsReport(url, context, site, auditContext) {
   const { log } = context;
   const isDailyDateRun = Boolean(auditContext?.date);
@@ -229,14 +210,19 @@ async function runCdnLogsReport(url, context, site, auditContext) {
     }
   }
 
-  const agenticDbExportAuditResult = getAgenticDbExportAuditResult(
-    agenticDbExportResult,
-    agenticReportConfig,
-    s3Config,
-  );
-  const auditResult = agenticDbExportAuditResult
-    ? [...results, agenticDbExportAuditResult]
-    : results;
+  const auditResult = [...results];
+  if (agenticDbExportResult.dailyAgenticExport?.batchId) {
+    auditResult.push({
+      name: 'agentic-db-export',
+      batchId: agenticDbExportResult.dailyAgenticExport.batchId,
+    });
+  }
+  if (dailyReferralExport?.batchId) {
+    auditResult.push({
+      name: 'referral-db-export',
+      batchId: dailyReferralExport.batchId,
+    });
+  }
 
   return {
     ...agenticDbExportResult,

--- a/src/cdn-logs-report/handler.js
+++ b/src/cdn-logs-report/handler.js
@@ -34,6 +34,91 @@ import {
   runDailyReferralExport,
 } from './referral-daily-export.js';
 
+const DAILY_AGENTIC_EXPORT_AUDIT_FIELDS = [
+  'enabled',
+  'success',
+  'skipped',
+  'queued',
+  'siteId',
+  'trafficDate',
+  'referenceDate',
+  'batchId',
+  'rowCount',
+  'classificationCount',
+  'bundleUri',
+  'delaySeconds',
+  'error',
+];
+
+function compactDailyAgenticExport(exportResult) {
+  return DAILY_AGENTIC_EXPORT_AUDIT_FIELDS.reduce((compact, field) => {
+    if (exportResult?.[field] !== undefined) {
+      return {
+        ...compact,
+        [field]: exportResult[field],
+      };
+    }
+    return compact;
+  }, {});
+}
+
+function getAgenticExportAuditDetails(agenticDbExportResult) {
+  const details = {};
+  if (agenticDbExportResult.dailyAgenticExport) {
+    details.dailyAgenticExport = compactDailyAgenticExport(
+      agenticDbExportResult.dailyAgenticExport,
+    );
+  }
+
+  const dailyAgenticExports = (agenticDbExportResult.dailyAgenticExports || [])
+    .map(compactDailyAgenticExport)
+    .filter((exportResult) => Object.keys(exportResult).length > 0);
+  if (dailyAgenticExports.length > 0) {
+    details.dailyAgenticExports = dailyAgenticExports;
+  }
+
+  return details;
+}
+
+function addAgenticExportDetailsToAuditResult(
+  results,
+  agenticReportConfig,
+  s3Config,
+  exportDetails,
+) {
+  if (Object.keys(exportDetails).length === 0) {
+    return results;
+  }
+
+  let attached = false;
+  const enrichedResults = results.map((result) => {
+    if (result.name !== 'agentic') {
+      return result;
+    }
+    attached = true;
+    return {
+      ...result,
+      ...exportDetails,
+    };
+  });
+
+  if (attached) {
+    return enrichedResults;
+  }
+
+  return [
+    ...enrichedResults,
+    {
+      name: 'agentic',
+      table: agenticReportConfig.tableName,
+      database: s3Config.databaseName,
+      customer: s3Config.siteName,
+      success: exportDetails.dailyAgenticExport?.success !== false,
+      ...exportDetails,
+    },
+  ];
+}
+
 async function runCdnLogsReport(url, context, site, auditContext) {
   const { log } = context;
   const isDailyDateRun = Boolean(auditContext?.date);
@@ -210,9 +295,16 @@ async function runCdnLogsReport(url, context, site, auditContext) {
     }
   }
 
+  const auditResult = addAgenticExportDetailsToAuditResult(
+    results,
+    agenticReportConfig,
+    s3Config,
+    getAgenticExportAuditDetails(agenticDbExportResult),
+  );
+
   return {
     ...agenticDbExportResult,
-    auditResult: results,
+    auditResult,
     dailyReferralExport,
     fullAuditRef: `${site.getConfig()?.getLlmoDataFolder()}`,
   };

--- a/src/cdn-logs-report/referral-daily-export.js
+++ b/src/cdn-logs-report/referral-daily-export.js
@@ -243,6 +243,7 @@ export async function runDailyReferralExport({
     siteId,
     trafficDate,
     rowCount: rows.length,
+    batchId: dedupId,
     csvUri,
   };
 }

--- a/test/audits/cdn-logs-report/handler.test.js
+++ b/test/audits/cdn-logs-report/handler.test.js
@@ -728,7 +728,13 @@ describe('CDN Logs Report Handler', function test() {
         siteId: 'test-site',
         error: 'daily export boom',
       });
-      expect(result.auditResult).to.be.an('array').that.is.not.empty;
+      const agenticResult = result.auditResult.find((entry) => entry.name === 'agentic');
+      expect(agenticResult.dailyAgenticExport).to.deep.equal({
+        enabled: true,
+        success: false,
+        siteId: 'test-site',
+        error: 'daily export boom',
+      });
     });
 
     it('includes successful daily agentic export results for enabled sites', async () => {
@@ -736,7 +742,12 @@ describe('CDN Logs Report Handler', function test() {
         enabled: true,
         success: true,
         siteId: '9ae8877a-bbf3-407d-9adb-d6a72ce3c5e3',
+        trafficDate: '2026-03-31',
+        batchId: 'batch-123',
         rowCount: 12,
+        dispatch: {
+          queueUrl: 'https://sqs.us-east-1.amazonaws.com/123/analytics-queue',
+        },
       });
       const localHandler = await esmock('../../../src/cdn-logs-report/handler.js', {
         '../../../src/cdn-logs-report/agentic-daily-export.js': {
@@ -774,6 +785,20 @@ describe('CDN Logs Report Handler', function test() {
         enabled: true,
         success: true,
         siteId: '9ae8877a-bbf3-407d-9adb-d6a72ce3c5e3',
+        trafficDate: '2026-03-31',
+        batchId: 'batch-123',
+        rowCount: 12,
+        dispatch: {
+          queueUrl: 'https://sqs.us-east-1.amazonaws.com/123/analytics-queue',
+        },
+      });
+      const agenticResult = result.auditResult.find((entry) => entry.name === 'agentic');
+      expect(agenticResult.dailyAgenticExport).to.deep.equal({
+        enabled: true,
+        success: true,
+        siteId: '9ae8877a-bbf3-407d-9adb-d6a72ce3c5e3',
+        trafficDate: '2026-03-31',
+        batchId: 'batch-123',
         rowCount: 12,
       });
     });
@@ -784,6 +809,7 @@ describe('CDN Logs Report Handler', function test() {
         success: true,
         siteId: '9ae8877a-bbf3-407d-9adb-d6a72ce3c5e3',
         trafficDate: '2026-03-31',
+        batchId: 'date-batch-123',
       });
       const createSharepointStub = sandbox.stub().resolves(createMockSharepointClient(sandbox));
       const bulkPublishStub = sandbox.stub().resolves();
@@ -828,13 +854,27 @@ describe('CDN Logs Report Handler', function test() {
       expect(runDailyAgenticExportStub).to.have.been.calledOnce;
       expect(runDailyAgenticExportStub.firstCall.args[0].referenceDate.toISOString())
         .to.equal('2026-04-01T10:00:00.000Z');
-      expect(result.auditResult).to.deep.equal([]);
       expect(result.dailyAgenticExport).to.deep.equal({
         enabled: true,
         success: true,
         siteId: '9ae8877a-bbf3-407d-9adb-d6a72ce3c5e3',
         trafficDate: '2026-03-31',
+        batchId: 'date-batch-123',
       });
+      expect(result.auditResult).to.deep.equal([{
+        name: 'agentic',
+        table: 'aggregated_logs_example_com_consolidated',
+        database: 'cdn_logs_example_com',
+        customer: 'example',
+        success: true,
+        dailyAgenticExport: {
+          enabled: true,
+          success: true,
+          siteId: '9ae8877a-bbf3-407d-9adb-d6a72ce3c5e3',
+          trafficDate: '2026-03-31',
+          batchId: 'date-batch-123',
+        },
+      }]);
     });
 
     it('skips daily export when auditContext.weekOffset is provided', async () => {
@@ -1005,6 +1045,21 @@ describe('CDN Logs Report Handler', function test() {
         queued: true,
       });
       expect(result.dailyAgenticExports).to.have.length(7);
+      const agenticResult = result.auditResult.find((entry) => entry.name === 'agentic');
+      expect(agenticResult.dailyAgenticExport).to.deep.include({
+        enabled: true,
+        success: true,
+        queued: true,
+      });
+      expect(agenticResult.dailyAgenticExports).to.have.length(7);
+      expect(agenticResult.dailyAgenticExports[0]).to.deep.include({
+        enabled: true,
+        success: true,
+        queued: true,
+        siteId: 'test-site',
+        referenceDate: '2026-03-31T00:00:00.000Z',
+        delaySeconds: 0,
+      });
       expect(result.dailyReferralExport).to.equal(undefined);
     });
 

--- a/test/audits/cdn-logs-report/handler.test.js
+++ b/test/audits/cdn-logs-report/handler.test.js
@@ -731,6 +731,8 @@ describe('CDN Logs Report Handler', function test() {
       const agenticResult = result.auditResult.find((entry) => entry.name === 'agentic');
       expect(agenticResult).to.not.have.property('batchId');
       expect(agenticResult).to.not.have.property('dailyAgenticExport');
+      expect(result.auditResult.find((entry) => entry.name === 'agentic-db-export'))
+        .to.equal(undefined);
     });
 
     it('includes successful daily agentic export results for enabled sites', async () => {
@@ -789,8 +791,17 @@ describe('CDN Logs Report Handler', function test() {
         },
       });
       const agenticResult = result.auditResult.find((entry) => entry.name === 'agentic');
-      expect(agenticResult.batchId).to.equal('batch-123');
-      expect(agenticResult).to.not.have.property('dailyAgenticExport');
+      expect(agenticResult).to.not.have.property('batchId');
+      const agenticDbExportResult = result.auditResult.find(
+        (entry) => entry.name === 'agentic-db-export',
+      );
+      expect(agenticDbExportResult).to.deep.equal({
+        name: 'agentic-db-export',
+        table: 'aggregated_logs_example_com_consolidated',
+        database: 'cdn_logs_example_com',
+        customer: 'example',
+        batchId: 'batch-123',
+      });
     });
 
     it('skips sharepoint and weekly reports when auditContext.date is provided', async () => {
@@ -852,7 +863,7 @@ describe('CDN Logs Report Handler', function test() {
         batchId: 'date-batch-123',
       });
       expect(result.auditResult).to.deep.equal([{
-        name: 'agentic',
+        name: 'agentic-db-export',
         table: 'aggregated_logs_example_com_consolidated',
         database: 'cdn_logs_example_com',
         customer: 'example',
@@ -1032,6 +1043,8 @@ describe('CDN Logs Report Handler', function test() {
       expect(agenticResult).to.not.have.property('batchId');
       expect(agenticResult).to.not.have.property('dailyAgenticExport');
       expect(agenticResult).to.not.have.property('dailyAgenticExports');
+      expect(result.auditResult.find((entry) => entry.name === 'agentic-db-export'))
+        .to.equal(undefined);
       expect(result.dailyReferralExport).to.equal(undefined);
     });
 

--- a/test/audits/cdn-logs-report/handler.test.js
+++ b/test/audits/cdn-logs-report/handler.test.js
@@ -728,11 +728,7 @@ describe('CDN Logs Report Handler', function test() {
         siteId: 'test-site',
         error: 'daily export boom',
       });
-      const agenticResult = result.auditResult.find((entry) => entry.name === 'agentic');
-      expect(agenticResult).to.not.have.property('batchId');
-      expect(agenticResult).to.not.have.property('dailyAgenticExport');
-      expect(result.auditResult.find((entry) => entry.name === 'agentic-db-export'))
-        .to.equal(undefined);
+      expect(result.auditResult).to.be.an('array').that.is.not.empty;
     });
 
     it('includes successful daily agentic export results for enabled sites', async () => {
@@ -792,14 +788,8 @@ describe('CDN Logs Report Handler', function test() {
       });
       const agenticResult = result.auditResult.find((entry) => entry.name === 'agentic');
       expect(agenticResult).to.not.have.property('batchId');
-      const agenticDbExportResult = result.auditResult.find(
-        (entry) => entry.name === 'agentic-db-export',
-      );
-      expect(agenticDbExportResult).to.deep.equal({
+      expect(result.auditResult).to.deep.include({
         name: 'agentic-db-export',
-        table: 'aggregated_logs_example_com_consolidated',
-        database: 'cdn_logs_example_com',
-        customer: 'example',
         batchId: 'batch-123',
       });
     });
@@ -864,9 +854,6 @@ describe('CDN Logs Report Handler', function test() {
       });
       expect(result.auditResult).to.deep.equal([{
         name: 'agentic-db-export',
-        table: 'aggregated_logs_example_com_consolidated',
-        database: 'cdn_logs_example_com',
-        customer: 'example',
         batchId: 'date-batch-123',
       }]);
     });
@@ -1039,12 +1026,6 @@ describe('CDN Logs Report Handler', function test() {
         queued: true,
       });
       expect(result.dailyAgenticExports).to.have.length(7);
-      const agenticResult = result.auditResult.find((entry) => entry.name === 'agentic');
-      expect(agenticResult).to.not.have.property('batchId');
-      expect(agenticResult).to.not.have.property('dailyAgenticExport');
-      expect(agenticResult).to.not.have.property('dailyAgenticExports');
-      expect(result.auditResult.find((entry) => entry.name === 'agentic-db-export'))
-        .to.equal(undefined);
       expect(result.dailyReferralExport).to.equal(undefined);
     });
 
@@ -1126,6 +1107,7 @@ describe('CDN Logs Report Handler', function test() {
         siteId: 'test-site',
         trafficDate: '2026-03-31',
         rowCount: 7,
+        batchId: 'referral-batch-123',
       });
       const localHandler = await esmock('../../../src/cdn-logs-report/handler.js', {
         '../../../src/cdn-logs-report/agentic-daily-export.js': {
@@ -1156,6 +1138,11 @@ describe('CDN Logs Report Handler', function test() {
         siteId: 'test-site',
         trafficDate: '2026-03-31',
         rowCount: 7,
+        batchId: 'referral-batch-123',
+      });
+      expect(result.auditResult).to.deep.include({
+        name: 'referral-db-export',
+        batchId: 'referral-batch-123',
       });
     });
 

--- a/test/audits/cdn-logs-report/handler.test.js
+++ b/test/audits/cdn-logs-report/handler.test.js
@@ -729,12 +729,8 @@ describe('CDN Logs Report Handler', function test() {
         error: 'daily export boom',
       });
       const agenticResult = result.auditResult.find((entry) => entry.name === 'agentic');
-      expect(agenticResult.dailyAgenticExport).to.deep.equal({
-        enabled: true,
-        success: false,
-        siteId: 'test-site',
-        error: 'daily export boom',
-      });
+      expect(agenticResult).to.not.have.property('batchId');
+      expect(agenticResult).to.not.have.property('dailyAgenticExport');
     });
 
     it('includes successful daily agentic export results for enabled sites', async () => {
@@ -793,14 +789,8 @@ describe('CDN Logs Report Handler', function test() {
         },
       });
       const agenticResult = result.auditResult.find((entry) => entry.name === 'agentic');
-      expect(agenticResult.dailyAgenticExport).to.deep.equal({
-        enabled: true,
-        success: true,
-        siteId: '9ae8877a-bbf3-407d-9adb-d6a72ce3c5e3',
-        trafficDate: '2026-03-31',
-        batchId: 'batch-123',
-        rowCount: 12,
-      });
+      expect(agenticResult.batchId).to.equal('batch-123');
+      expect(agenticResult).to.not.have.property('dailyAgenticExport');
     });
 
     it('skips sharepoint and weekly reports when auditContext.date is provided', async () => {
@@ -866,14 +856,7 @@ describe('CDN Logs Report Handler', function test() {
         table: 'aggregated_logs_example_com_consolidated',
         database: 'cdn_logs_example_com',
         customer: 'example',
-        success: true,
-        dailyAgenticExport: {
-          enabled: true,
-          success: true,
-          siteId: '9ae8877a-bbf3-407d-9adb-d6a72ce3c5e3',
-          trafficDate: '2026-03-31',
-          batchId: 'date-batch-123',
-        },
+        batchId: 'date-batch-123',
       }]);
     });
 
@@ -1046,20 +1029,9 @@ describe('CDN Logs Report Handler', function test() {
       });
       expect(result.dailyAgenticExports).to.have.length(7);
       const agenticResult = result.auditResult.find((entry) => entry.name === 'agentic');
-      expect(agenticResult.dailyAgenticExport).to.deep.include({
-        enabled: true,
-        success: true,
-        queued: true,
-      });
-      expect(agenticResult.dailyAgenticExports).to.have.length(7);
-      expect(agenticResult.dailyAgenticExports[0]).to.deep.include({
-        enabled: true,
-        success: true,
-        queued: true,
-        siteId: 'test-site',
-        referenceDate: '2026-03-31T00:00:00.000Z',
-        delaySeconds: 0,
-      });
+      expect(agenticResult).to.not.have.property('batchId');
+      expect(agenticResult).to.not.have.property('dailyAgenticExport');
+      expect(agenticResult).to.not.have.property('dailyAgenticExports');
       expect(result.dailyReferralExport).to.equal(undefined);
     });
 


### PR DESCRIPTION
## Summary
- append minimal agentic-db-export/referral-db-export audit_result rows when a daily export has a batchId
- leave existing report rows unchanged
