### PR TITLE
feat(geo-brand-presence): forward v2 brand_id to DRS (LLMO-4716)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@adobe/spacecat-shared-athena-client": "1.9.11",
         "@adobe/spacecat-shared-data-access": "3.56.1",
         "@adobe/spacecat-shared-data-access-v2": "npm:@adobe/spacecat-shared-data-access@2.109.0",
-        "@adobe/spacecat-shared-drs-client": "1.6.0",
+        "@adobe/spacecat-shared-drs-client": "1.7.0",
         "@adobe/spacecat-shared-google-client": "1.5.11",
         "@adobe/spacecat-shared-gpt-client": "1.6.22",
         "@adobe/spacecat-shared-html-analyzer": "1.2.10",
@@ -3039,9 +3039,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-drs-client": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-drs-client/-/spacecat-shared-drs-client-1.6.0.tgz",
-      "integrity": "sha512-MMuyoSlQTR8D2pqymauvTvWgYEXh5chtCzDO9VJmlyZgjcORLMug1wvtIjAKJD/dR8SXu4FGaVGukgIBCj3xSQ==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-drs-client/-/spacecat-shared-drs-client-1.7.0.tgz",
+      "integrity": "sha512-+lQLN1/OnKzaCrvg4ppsWXitzjuNF1Ady4+hB4vfCEUfhikNuKndRLND4HtkGpckHIAUOJMOGdjGw8G6O11nlA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/spacecat-shared-utils": "1.98.1",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@adobe/spacecat-shared-athena-client": "1.9.11",
     "@adobe/spacecat-shared-data-access": "3.56.1",
     "@adobe/spacecat-shared-data-access-v2": "npm:@adobe/spacecat-shared-data-access@2.109.0",
-    "@adobe/spacecat-shared-drs-client": "1.6.0",
+    "@adobe/spacecat-shared-drs-client": "1.7.0",
     "@adobe/spacecat-shared-google-client": "1.5.11",
     "@adobe/spacecat-shared-gpt-client": "1.6.22",
     "@adobe/spacecat-shared-html-analyzer": "1.2.10",

--- a/src/geo-brand-presence-daily/geo-brand-presence-refresh-handler.js
+++ b/src/geo-brand-presence-daily/geo-brand-presence-refresh-handler.js
@@ -20,6 +20,7 @@ import { getLastNumberOfWeeks } from '@adobe/spacecat-shared-utils';
 import DrsClient from '@adobe/spacecat-shared-drs-client';
 import { createLLMOSharepointClient, readFromSharePoint } from '../utils/report-uploader.js';
 import { getImsOrgId } from '../utils/data-access.js';
+import { resolveBrandIdForSite } from '../utils/brand-resolver.js';
 import {
   refreshDirectoryS3Key,
   refreshMetadataFileS3Key,
@@ -283,8 +284,20 @@ export async function refreshGeoBrandPresenceDailyHandler(message, context) {
     const { configVersion } = auditContext;
     const imsOrgId = await getImsOrgId(site, dataAccess, log);
     const brand = site.getConfig()?.getLlmoBrand?.() ?? null;
+    // LLMO-4716: resolve v2 brand_id once per audit (per site), thread onto every
+    // SNS publish below so the DRS Fargate runner branches v1/v2 correctly. 404
+    // returns null (v1 / brandalf-migration / no active brand). 5xx throws so
+    // SQS retries — silently continuing without brand_id for a brandalf=true org
+    // would degrade to stale-config v1 reads with no surfaced error.
+    const orgId = site.getOrganizationId?.() ?? null;
+    let brandId = null;
+    if (orgId) {
+      brandId = await resolveBrandIdForSite(orgId, siteId, env, log);
+    } else {
+      log.warn(`%s: site ${siteId} has no organizationId — skipping brand_id resolution`, AUDIT_NAME);
+    }
 
-    log.info(`%s: Site details for auditId: ${auditId}, siteId: ${siteId}, configVersion: ${configVersion || 'none'}`, AUDIT_NAME);
+    log.info(`%s: Site details for auditId: ${auditId}, siteId: ${siteId}, configVersion: ${configVersion || 'none'}, brandId: ${brandId || 'none'}`, AUDIT_NAME);
 
     log.info(`%s: Processing ${sheets.length} sheets for auditId: ${auditId}, siteId: ${siteId}`, AUDIT_NAME);
     const processingStartTime = Date.now();
@@ -329,6 +342,7 @@ export async function refreshGeoBrandPresenceDailyHandler(message, context) {
           runFrequency,
           brand,
           imsOrgId,
+          brandId,
         });
         log.info(
           `%s: DRS analyze triggered for sheet ${sheetName}, siteId: ${siteId}, jobId: ${publishedJobId}`,

--- a/src/geo-brand-presence-daily/geo-brand-presence-refresh-handler.js
+++ b/src/geo-brand-presence-daily/geo-brand-presence-refresh-handler.js
@@ -253,6 +253,25 @@ export async function refreshGeoBrandPresenceDailyHandler(message, context) {
 
   log.info(`%s: DRS S3 is configured, routing refresh via DRS for siteId: ${siteId}`, AUDIT_NAME);
 
+  // LLMO-4716: resolve v2 brand_id once per audit (per site), thread onto every
+  // SNS publish below so the DRS Fargate runner branches v1/v2 correctly. 404
+  // returns null (v1 / brandalf-migration / no active brand). 5xx throws so
+  // SQS retries — silently continuing without brand_id for a brandalf=true org
+  // would degrade to stale-config v1 reads with no surfaced error.
+  //
+  // Resolved BEFORE the S3 metadata write so a fail-closed throw doesn't leave
+  // an orphaned `metadata.json` for an audit that never ran. The throw bypasses
+  // the outer catch block too, so DLQ messages preserve the original
+  // `[BrandResolver]` error context instead of being rewrapped as
+  // "Failed to create S3 folder".
+  const orgId = site.getOrganizationId?.() ?? null;
+  let brandId = null;
+  if (orgId) {
+    brandId = await resolveBrandIdForSite(orgId, siteId, env, log);
+  } else {
+    log.warn(`%s: site ${siteId} has no organizationId — skipping brand_id resolution`, AUDIT_NAME);
+  }
+
   try {
     log.debug(`%s: Creating metadata for ${sheets.length} sheets, auditId: ${auditId}, siteId: ${siteId}`, AUDIT_NAME);
 
@@ -284,18 +303,6 @@ export async function refreshGeoBrandPresenceDailyHandler(message, context) {
     const { configVersion } = auditContext;
     const imsOrgId = await getImsOrgId(site, dataAccess, log);
     const brand = site.getConfig()?.getLlmoBrand?.() ?? null;
-    // LLMO-4716: resolve v2 brand_id once per audit (per site), thread onto every
-    // SNS publish below so the DRS Fargate runner branches v1/v2 correctly. 404
-    // returns null (v1 / brandalf-migration / no active brand). 5xx throws so
-    // SQS retries — silently continuing without brand_id for a brandalf=true org
-    // would degrade to stale-config v1 reads with no surfaced error.
-    const orgId = site.getOrganizationId?.() ?? null;
-    let brandId = null;
-    if (orgId) {
-      brandId = await resolveBrandIdForSite(orgId, siteId, env, log);
-    } else {
-      log.warn(`%s: site ${siteId} has no organizationId — skipping brand_id resolution`, AUDIT_NAME);
-    }
 
     log.info(`%s: Site details for auditId: ${auditId}, siteId: ${siteId}, configVersion: ${configVersion || 'none'}, brandId: ${brandId || 'none'}`, AUDIT_NAME);
 
@@ -418,8 +425,8 @@ export async function refreshGeoBrandPresenceDailyHandler(message, context) {
     log[logLevel](logMsg, ...logArgs);
   } catch (error) {
     log.error('%s:Failed to create S3 folder for audit %s: %s', AUDIT_NAME, auditId, errorMsg(error));
-    errMsg = `${AUDIT_NAME}:Failed to create S3 folder for audit ${auditId}`;
-    throw new Error(errMsg);
+    errMsg = `${AUDIT_NAME}:Failed to create S3 folder for audit ${auditId}: ${errorMsg(error)}`;
+    throw new Error(errMsg, { cause: error });
   }
 
   log.info('Site: %s, Audit: %s, Context:', site, {}, auditContext);

--- a/src/geo-brand-presence/geo-brand-presence-refresh-handler.js
+++ b/src/geo-brand-presence/geo-brand-presence-refresh-handler.js
@@ -20,6 +20,7 @@ import { getLastNumberOfWeeks } from '@adobe/spacecat-shared-utils';
 import DrsClient from '@adobe/spacecat-shared-drs-client';
 import { createLLMOSharepointClient, readFromSharePoint } from '../utils/report-uploader.js';
 import { getImsOrgId } from '../utils/data-access.js';
+import { resolveBrandIdForSite } from '../utils/brand-resolver.js';
 import {
   refreshDirectoryS3Key,
   refreshMetadataFileS3Key,
@@ -281,8 +282,20 @@ export async function refreshGeoBrandPresenceSheetsHandler(message, context) {
     const { configVersion } = auditContext;
     const imsOrgId = await getImsOrgId(site, dataAccess, log);
     const brand = site.getConfig()?.getLlmoBrand?.() ?? null;
+    // LLMO-4716: resolve v2 brand_id once per audit (per site), thread onto every
+    // SNS publish below so the DRS Fargate runner branches v1/v2 correctly. 404
+    // returns null (v1 / brandalf-migration / no active brand). 5xx throws so
+    // SQS retries — silently continuing without brand_id for a brandalf=true org
+    // would degrade to stale-config v1 reads with no surfaced error.
+    const orgId = site.getOrganizationId?.() ?? null;
+    let brandId = null;
+    if (orgId) {
+      brandId = await resolveBrandIdForSite(orgId, siteId, env, log);
+    } else {
+      log.warn(`%s: site ${siteId} has no organizationId — skipping brand_id resolution`, AUDIT_NAME);
+    }
 
-    log.info(`%s: Site details for auditId: ${auditId}, siteId: ${siteId}, configVersion: ${configVersion || 'none'}`, AUDIT_NAME);
+    log.info(`%s: Site details for auditId: ${auditId}, siteId: ${siteId}, configVersion: ${configVersion || 'none'}, brandId: ${brandId || 'none'}`, AUDIT_NAME);
 
     log.info(`%s: Processing ${sheets.length} sheets for auditId: ${auditId}, siteId: ${siteId}`, AUDIT_NAME);
     const processingStartTime = Date.now();
@@ -327,6 +340,7 @@ export async function refreshGeoBrandPresenceSheetsHandler(message, context) {
           runFrequency,
           brand,
           imsOrgId,
+          brandId,
         });
         log.info(
           `%s: DRS analyze triggered for sheet ${sheetName}, siteId: ${siteId}, jobId: ${publishedJobId}`,

--- a/src/geo-brand-presence/geo-brand-presence-refresh-handler.js
+++ b/src/geo-brand-presence/geo-brand-presence-refresh-handler.js
@@ -250,6 +250,25 @@ export async function refreshGeoBrandPresenceSheetsHandler(message, context) {
 
   log.info(`%s: DRS S3 is configured, routing refresh via DRS for siteId: ${siteId}`, AUDIT_NAME);
 
+  // LLMO-4716: resolve v2 brand_id once per audit (per site), thread onto every
+  // SNS publish below so the DRS Fargate runner branches v1/v2 correctly. 404
+  // returns null (v1 / brandalf-migration / no active brand). 5xx throws so
+  // SQS retries — silently continuing without brand_id for a brandalf=true org
+  // would degrade to stale-config v1 reads with no surfaced error.
+  //
+  // Resolved BEFORE the S3 metadata write so a fail-closed throw doesn't leave
+  // an orphaned `metadata.json` for an audit that never ran. The throw bypasses
+  // the outer catch block too, so DLQ messages preserve the original
+  // `[BrandResolver]` error context instead of being rewrapped as
+  // "Failed to create S3 folder".
+  const orgId = site.getOrganizationId?.() ?? null;
+  let brandId = null;
+  if (orgId) {
+    brandId = await resolveBrandIdForSite(orgId, siteId, env, log);
+  } else {
+    log.warn(`%s: site ${siteId} has no organizationId — skipping brand_id resolution`, AUDIT_NAME);
+  }
+
   try {
     // Create a metadata file to establish the folder structure
     log.debug(`%s: Creating metadata for ${sheets.length} sheets, auditId: ${auditId}, siteId: ${siteId}`, AUDIT_NAME);
@@ -282,18 +301,6 @@ export async function refreshGeoBrandPresenceSheetsHandler(message, context) {
     const { configVersion } = auditContext;
     const imsOrgId = await getImsOrgId(site, dataAccess, log);
     const brand = site.getConfig()?.getLlmoBrand?.() ?? null;
-    // LLMO-4716: resolve v2 brand_id once per audit (per site), thread onto every
-    // SNS publish below so the DRS Fargate runner branches v1/v2 correctly. 404
-    // returns null (v1 / brandalf-migration / no active brand). 5xx throws so
-    // SQS retries — silently continuing without brand_id for a brandalf=true org
-    // would degrade to stale-config v1 reads with no surfaced error.
-    const orgId = site.getOrganizationId?.() ?? null;
-    let brandId = null;
-    if (orgId) {
-      brandId = await resolveBrandIdForSite(orgId, siteId, env, log);
-    } else {
-      log.warn(`%s: site ${siteId} has no organizationId — skipping brand_id resolution`, AUDIT_NAME);
-    }
 
     log.info(`%s: Site details for auditId: ${auditId}, siteId: ${siteId}, configVersion: ${configVersion || 'none'}, brandId: ${brandId || 'none'}`, AUDIT_NAME);
 
@@ -416,8 +423,8 @@ export async function refreshGeoBrandPresenceSheetsHandler(message, context) {
     log[logLevel](logMsg, ...logArgs);
   } catch (error) {
     log.error('%s:Failed to create S3 folder for audit %s: %s', AUDIT_NAME, auditId, errorMsg(error));
-    errMsg = `${AUDIT_NAME}:Failed to create S3 folder for audit ${auditId}`;
-    throw new Error(errMsg);
+    errMsg = `${AUDIT_NAME}:Failed to create S3 folder for audit ${auditId}: ${errorMsg(error)}`;
+    throw new Error(errMsg, { cause: error });
   }
 
   log.info('Site: %s, Audit: %s, Context:', site, {}, auditContext);

--- a/src/utils/brand-resolver.js
+++ b/src/utils/brand-resolver.js
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * LLMO-4716: Resolve the v2 `brand_id` for a given (organization, site) pair via
+ * spacecat-api-service. Used by the brand-presence refresh handlers
+ * (geo-brand-presence and geo-brand-presence-daily) to thread `brandId` onto
+ * the SNS payload that triggers DRS Fargate brand-presence analysis.
+ *
+ * The endpoint encapsulates the full v1/v2 decision (brandalf flag,
+ * brandalf-migration semantics, kill-switch, multi-brand-per-site rule). Callers
+ * stay dumb — they ask "what's the brand?" and get a UUID or null.
+ *
+ * Failure-mode contract:
+ *  - 200  → return brand id
+ *  - 404  → return null (deliberate "no v2 brand" — v1 orgs, brandalf-migration-only,
+ *           kill-switch-degraded, or no active brand for this site). Callers leave
+ *           brand_id unset so the runner takes the v1 path.
+ *  - 5xx / network / timeout / parse error → THROW. For brandalf=true orgs,
+ *    proceeding without brand_id silently degrades to v1 reads from a
+ *    no-longer-published spreadsheet mirror — the BP pipeline keeps running but
+ *    produces meaningless output. Failing fast lets SQS retry the audit and
+ *    surfaces the issue via DLQ instead of producing silent bad data.
+ */
+
+import { tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
+
+const LOG_PREFIX = '[BrandResolver]';
+const FETCH_TIMEOUT_MS = 30000;
+const USER_AGENT = 'spacecat-audit-worker/brand-resolver';
+
+/**
+ * @param {string} orgId - SpaceCat organization UUID
+ * @param {string} siteId - Site UUID
+ * @param {object} env - Lambda environment (must include SPACECAT_API_BASE_URL,
+ *   SPACECAT_API_KEY)
+ * @param {object} log - Logger
+ * @returns {Promise<string|null>} The brand UUID, or null if the org has no v2
+ *   brand for this site.
+ */
+export async function resolveBrandIdForSite(orgId, siteId, env, log) {
+  const apiBase = env?.SPACECAT_API_BASE_URL;
+  const apiKey = env?.SPACECAT_API_KEY;
+  if (!apiBase || !apiKey) {
+    throw new Error(
+      `${LOG_PREFIX} SPACECAT_API_BASE_URL or SPACECAT_API_KEY not configured`,
+    );
+  }
+  if (!orgId || !siteId) {
+    throw new Error(`${LOG_PREFIX} orgId and siteId are required`);
+  }
+
+  const url = `${apiBase}/v2/orgs/${encodeURIComponent(orgId)}/sites/${encodeURIComponent(siteId)}/brand`;
+  const headers = {
+    'x-api-key': apiKey,
+    'User-Agent': USER_AGENT,
+  };
+
+  log.info(`${LOG_PREFIX} Resolving brand for org=${orgId} site=${siteId}`);
+
+  let response;
+  try {
+    response = await fetch(url, { headers, timeout: FETCH_TIMEOUT_MS });
+  } catch (error) {
+    // Network/timeout/abort — treat as transient. SQS retry will re-attempt.
+    throw new Error(
+      `${LOG_PREFIX} Brand resolution failed (network/timeout) for org=${orgId} site=${siteId}: ${error.message}`,
+      { cause: error },
+    );
+  }
+
+  if (response.status === 404) {
+    log.info(
+      `${LOG_PREFIX} No v2 brand for org=${orgId} site=${siteId} — runner will take v1 path`,
+    );
+    return null;
+  }
+
+  if (!response.ok) {
+    // 5xx and any non-404 4xx are surfaced — better to retry than to silently
+    // continue without brand_id for what may well be a v2 org.
+    let body = '';
+    try {
+      body = await response.text();
+    } catch {
+      // ignore body-read failure
+    }
+    throw new Error(
+      `${LOG_PREFIX} Brand resolution failed for org=${orgId} site=${siteId}: `
+      + `${response.status} ${response.statusText} — ${body.slice(0, 200)}`,
+    );
+  }
+
+  let brand;
+  try {
+    brand = await response.json();
+  } catch (error) {
+    throw new Error(
+      `${LOG_PREFIX} Brand resolution returned non-JSON for org=${orgId} site=${siteId}: ${error.message}`,
+      { cause: error },
+    );
+  }
+
+  if (!brand || typeof brand.id !== 'string' || brand.id.length === 0) {
+    log.warn(
+      `${LOG_PREFIX} Brand resolution returned no id for org=${orgId} site=${siteId} — treating as no v2 brand`,
+    );
+    return null;
+  }
+
+  log.info(
+    `${LOG_PREFIX} Resolved brand=${brand.id} for org=${orgId} site=${siteId}`,
+  );
+  return brand.id;
+}

--- a/test/audits/geo-brand-presence-daily/geo-brand-presence-refresh-handler.test.js
+++ b/test/audits/geo-brand-presence-daily/geo-brand-presence-refresh-handler.test.js
@@ -220,8 +220,13 @@ describe('Geo Brand Presence Daily Refresh Handler', () => {
       withSheets([SHEET_W45]);
       resolveBrandIdForSiteStub.rejects(new Error('SpaceCat 503'));
 
-      await expect(refreshGeoBrandPresenceDailyHandler(MESSAGE, context)).to.be.rejected;
+      // Brand resolution runs BEFORE the S3 metadata write and outside the
+      // outer try/catch, so the original `[BrandResolver]` message is preserved
+      // for DLQ triage and no orphaned metadata.json file is left behind.
+      await expect(refreshGeoBrandPresenceDailyHandler(MESSAGE, context))
+        .to.be.rejectedWith(/SpaceCat 503/);
       expect(publishBrandPresenceAnalyzeStub).to.not.have.been.called;
+      expect(s3Client.send).to.not.have.been.called;
     });
 
     it('skips brand resolution and logs warning when site has no organizationId', async () => {

--- a/test/audits/geo-brand-presence-daily/geo-brand-presence-refresh-handler.test.js
+++ b/test/audits/geo-brand-presence-daily/geo-brand-presence-refresh-handler.test.js
@@ -39,6 +39,7 @@ describe('Geo Brand Presence Daily Refresh Handler', () => {
   let publishBrandPresenceAnalyzeStub;
   let drsClientStub;
   let drsCreateFromStub;
+  let resolveBrandIdForSiteStub;
 
   // 3 past full weeks; the handler computes current week (47) as lastFull+1
   const LAST_4_WEEKS = [
@@ -64,6 +65,8 @@ describe('Geo Brand Presence Daily Refresh Handler', () => {
     };
 
     drsCreateFromStub = sandbox.stub().returns(drsClientStub);
+
+    resolveBrandIdForSiteStub = sandbox.stub().resolves(null);
 
     log = {
       info: sandbox.stub(),
@@ -122,6 +125,9 @@ describe('Geo Brand Presence Daily Refresh Handler', () => {
         createLLMOSharepointClient: createLLMOSharepointClientStub,
         readFromSharePoint: readFromSharePointStub,
       },
+      '../../../src/utils/brand-resolver.js': {
+        resolveBrandIdForSite: resolveBrandIdForSiteStub,
+      },
     });
 
     refreshGeoBrandPresenceDailyHandler = handlerModule.refreshGeoBrandPresenceDailyHandler;
@@ -173,7 +179,7 @@ describe('Geo Brand Presence Daily Refresh Handler', () => {
       );
     });
 
-    it('calls publishBrandPresenceAnalyze with runFrequency daily, jobId, brand, imsOrgId', async () => {
+    it('calls publishBrandPresenceAnalyze with runFrequency daily, jobId, brand, imsOrgId, brandId', async () => {
       withSheets([SHEET_W45]);
 
       await refreshGeoBrandPresenceDailyHandler(MESSAGE, context);
@@ -189,7 +195,47 @@ describe('Geo Brand Presence Daily Refresh Handler', () => {
         runFrequency: 'daily',
         brand: 'test-brand',
         imsOrgId: 'test-ims-org-id',
+        brandId: null,
       }));
+    });
+
+    it('forwards brandId resolved from spacecat-api-service to publishBrandPresenceAnalyze (v2 org)', async () => {
+      withSheets([SHEET_W45]);
+      resolveBrandIdForSiteStub.resolves('brand-uuid-daily');
+
+      await refreshGeoBrandPresenceDailyHandler(MESSAGE, context);
+
+      expect(resolveBrandIdForSiteStub).to.have.been.calledOnceWith(
+        'test-org-id',
+        'test-site-123',
+        context.env,
+        log,
+      );
+      expect(publishBrandPresenceAnalyzeStub.firstCall.args[1]).to.include({
+        brandId: 'brand-uuid-daily',
+      });
+    });
+
+    it('propagates resolver errors so SQS retries (fail-closed on 5xx)', async () => {
+      withSheets([SHEET_W45]);
+      resolveBrandIdForSiteStub.rejects(new Error('SpaceCat 503'));
+
+      await expect(refreshGeoBrandPresenceDailyHandler(MESSAGE, context)).to.be.rejected;
+      expect(publishBrandPresenceAnalyzeStub).to.not.have.been.called;
+    });
+
+    it('skips brand resolution and logs warning when site has no organizationId', async () => {
+      withSheets([SHEET_W45]);
+      site.getOrganizationId = () => null;
+
+      await refreshGeoBrandPresenceDailyHandler(MESSAGE, context);
+
+      expect(resolveBrandIdForSiteStub).to.not.have.been.called;
+      expect(log.warn).to.have.been.calledWith(
+        sinon.match(/has no organizationId/),
+        sinon.match.any,
+      );
+      expect(publishBrandPresenceAnalyzeStub.firstCall.args[1]).to.include({ brandId: null });
     });
 
     it('normalizes hyphenated providers to underscores before publishing to DRS', async () => {

--- a/test/audits/geo-brand-presence-refresh.test.js
+++ b/test/audits/geo-brand-presence-refresh.test.js
@@ -230,16 +230,21 @@ describe('Geo Brand Presence Refresh Handler', () => {
       expect(publishBrandPresenceAnalyzeStub.firstCall.args[1]).to.include({ brandId: null });
     });
 
-    it('propagates resolver errors so SQS retries (fail-closed on 5xx)', async () => {
+    it('propagates resolver errors with original message so DLQ shows the real cause', async () => {
       withSheets([SHEET_W45]);
-      resolveBrandIdForSiteStub.rejects(new Error('SpaceCat 503'));
+      const cause = new Error('SpaceCat 503');
+      resolveBrandIdForSiteStub.rejects(cause);
 
-      // The handler's outer catch wraps the failure with its audit prefix —
-      // the important thing is that the run rejects (so SQS retries) and DRS
-      // is never invoked.
+      // Brand resolution runs BEFORE the S3 metadata write and outside the
+      // outer try/catch, so the original `[BrandResolver]` message is preserved
+      // for DLQ triage rather than being rewrapped as "Failed to create S3
+      // folder".
       await expect(refreshGeoBrandPresenceSheetsHandler(MESSAGE, context))
-        .to.be.rejected;
+        .to.be.rejectedWith(/SpaceCat 503/);
       expect(publishBrandPresenceAnalyzeStub).to.not.have.been.called;
+      // Metadata write must NOT fire when the resolver fails — otherwise we'd
+      // litter S3 with orphaned metadata.json files (one per SQS retry).
+      expect(s3Client.send).to.not.have.been.called;
     });
 
     it('skips brand resolution and logs warning when site has no organizationId', async () => {

--- a/test/audits/geo-brand-presence-refresh.test.js
+++ b/test/audits/geo-brand-presence-refresh.test.js
@@ -39,6 +39,7 @@ describe('Geo Brand Presence Refresh Handler', () => {
   let publishBrandPresenceAnalyzeStub;
   let drsClientStub;
   let drsCreateFromStub;
+  let resolveBrandIdForSiteStub;
 
   // last 4 weeks used across most tests
   const LAST_4_WEEKS = [
@@ -65,6 +66,10 @@ describe('Geo Brand Presence Refresh Handler', () => {
     };
 
     drsCreateFromStub = sandbox.stub().returns(drsClientStub);
+
+    // Default: brand resolver returns null (v1 / brandalf-migration / no active brand).
+    // Tests that need a non-null brandId override per-test.
+    resolveBrandIdForSiteStub = sandbox.stub().resolves(null);
 
     log = {
       info: sandbox.stub(),
@@ -123,6 +128,9 @@ describe('Geo Brand Presence Refresh Handler', () => {
         createLLMOSharepointClient: createLLMOSharepointClientStub,
         readFromSharePoint: readFromSharePointStub,
       },
+      '../../src/utils/brand-resolver.js': {
+        resolveBrandIdForSite: resolveBrandIdForSiteStub,
+      },
     });
 
     refreshGeoBrandPresenceSheetsHandler = handlerModule.refreshGeoBrandPresenceSheetsHandler;
@@ -174,7 +182,7 @@ describe('Geo Brand Presence Refresh Handler', () => {
       );
     });
 
-    it('calls publishBrandPresenceAnalyze with correct args including jobId, brand, imsOrgId', async () => {
+    it('calls publishBrandPresenceAnalyze with correct args including jobId, brand, imsOrgId, brandId', async () => {
       withSheets([SHEET_W45]);
 
       await refreshGeoBrandPresenceSheetsHandler(MESSAGE, context);
@@ -191,7 +199,61 @@ describe('Geo Brand Presence Refresh Handler', () => {
         runFrequency: 'weekly',
         brand: 'test-brand',
         imsOrgId: 'test-ims-org-id',
+        brandId: null,
       });
+    });
+
+    it('forwards brandId resolved from spacecat-api-service to publishBrandPresenceAnalyze (v2 org)', async () => {
+      withSheets([SHEET_W45]);
+      resolveBrandIdForSiteStub.resolves('brand-uuid-42');
+
+      await refreshGeoBrandPresenceSheetsHandler(MESSAGE, context);
+
+      expect(resolveBrandIdForSiteStub).to.have.been.calledOnceWith(
+        'test-org-id',
+        'test-site-123',
+        context.env,
+        log,
+      );
+      expect(publishBrandPresenceAnalyzeStub).to.have.been.calledOnce;
+      expect(publishBrandPresenceAnalyzeStub.firstCall.args[1]).to.include({
+        brandId: 'brand-uuid-42',
+      });
+    });
+
+    it('passes brandId=null when resolver returns null (v1 org / no active brand)', async () => {
+      withSheets([SHEET_W45]);
+      resolveBrandIdForSiteStub.resolves(null);
+
+      await refreshGeoBrandPresenceSheetsHandler(MESSAGE, context);
+
+      expect(publishBrandPresenceAnalyzeStub.firstCall.args[1]).to.include({ brandId: null });
+    });
+
+    it('propagates resolver errors so SQS retries (fail-closed on 5xx)', async () => {
+      withSheets([SHEET_W45]);
+      resolveBrandIdForSiteStub.rejects(new Error('SpaceCat 503'));
+
+      // The handler's outer catch wraps the failure with its audit prefix —
+      // the important thing is that the run rejects (so SQS retries) and DRS
+      // is never invoked.
+      await expect(refreshGeoBrandPresenceSheetsHandler(MESSAGE, context))
+        .to.be.rejected;
+      expect(publishBrandPresenceAnalyzeStub).to.not.have.been.called;
+    });
+
+    it('skips brand resolution and logs warning when site has no organizationId', async () => {
+      withSheets([SHEET_W45]);
+      site.getOrganizationId = () => null;
+
+      await refreshGeoBrandPresenceSheetsHandler(MESSAGE, context);
+
+      expect(resolveBrandIdForSiteStub).to.not.have.been.called;
+      expect(log.warn).to.have.been.calledWith(
+        sinon.match(/has no organizationId/),
+        sinon.match.any,
+      );
+      expect(publishBrandPresenceAnalyzeStub.firstCall.args[1]).to.include({ brandId: null });
     });
 
     it('normalizes hyphenated providers to underscores before publishing to DRS', async () => {

--- a/test/utils/brand-resolver.test.js
+++ b/test/utils/brand-resolver.test.js
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
+import esmock from 'esmock';
+
+use(sinonChai);
+use(chaiAsPromised);
+
+describe('brand-resolver (LLMO-4716)', () => {
+  let sandbox;
+  let mockFetch;
+  let resolveBrandIdForSite;
+  let log;
+
+  const ORG_ID = 'org-uuid-1';
+  const SITE_ID = 'site-uuid-1';
+  const ENV = {
+    SPACECAT_API_BASE_URL: 'https://spacecat.example.com/api/v1',
+    SPACECAT_API_KEY: 'test-key',
+  };
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    mockFetch = sandbox.stub();
+    log = {
+      info: sandbox.stub(),
+      warn: sandbox.stub(),
+      error: sandbox.stub(),
+      debug: sandbox.stub(),
+    };
+
+    const mod = await esmock('../../src/utils/brand-resolver.js', {
+      '@adobe/spacecat-shared-utils': {
+        tracingFetch: mockFetch,
+      },
+    });
+    resolveBrandIdForSite = mod.resolveBrandIdForSite;
+  });
+
+  afterEach(() => sandbox.restore());
+
+  function makeResponse({
+    status, ok, body, throwOnText, throwOnJson,
+  }) {
+    return {
+      status,
+      statusText: status === 200 ? 'OK' : 'Error',
+      ok: ok !== undefined ? ok : status >= 200 && status < 300,
+      json: throwOnJson
+        ? sandbox.stub().rejects(new Error('bad json'))
+        : sandbox.stub().resolves(body),
+      text: throwOnText
+        ? sandbox.stub().rejects(new Error('cannot read body'))
+        : sandbox.stub().resolves(typeof body === 'string' ? body : JSON.stringify(body)),
+    };
+  }
+
+  it('throws when SPACECAT_API_BASE_URL is missing', async () => {
+    await expect(resolveBrandIdForSite(ORG_ID, SITE_ID, { SPACECAT_API_KEY: 'k' }, log))
+      .to.be.rejectedWith(/SPACECAT_API_BASE_URL or SPACECAT_API_KEY not configured/);
+  });
+
+  it('throws when SPACECAT_API_KEY is missing', async () => {
+    await expect(resolveBrandIdForSite(ORG_ID, SITE_ID, { SPACECAT_API_BASE_URL: 'http://x' }, log))
+      .to.be.rejectedWith(/SPACECAT_API_BASE_URL or SPACECAT_API_KEY not configured/);
+  });
+
+  it('throws when env is undefined', async () => {
+    await expect(resolveBrandIdForSite(ORG_ID, SITE_ID, undefined, log))
+      .to.be.rejectedWith(/SPACECAT_API_BASE_URL or SPACECAT_API_KEY not configured/);
+  });
+
+  it('throws when orgId is missing', async () => {
+    await expect(resolveBrandIdForSite('', SITE_ID, ENV, log))
+      .to.be.rejectedWith(/orgId and siteId are required/);
+  });
+
+  it('throws when siteId is missing', async () => {
+    await expect(resolveBrandIdForSite(ORG_ID, '', ENV, log))
+      .to.be.rejectedWith(/orgId and siteId are required/);
+  });
+
+  it('returns the brand id on 200', async () => {
+    mockFetch.resolves(makeResponse({
+      status: 200,
+      body: { id: 'brand-uuid-42', name: 'Acme', status: 'active' },
+    }));
+
+    const result = await resolveBrandIdForSite(ORG_ID, SITE_ID, ENV, log);
+
+    expect(result).to.equal('brand-uuid-42');
+    expect(mockFetch).to.have.been.calledOnce;
+    const [url, opts] = mockFetch.firstCall.args;
+    expect(url).to.equal(
+      `${ENV.SPACECAT_API_BASE_URL}/v2/orgs/${ORG_ID}/sites/${SITE_ID}/brand`,
+    );
+    expect(opts.headers).to.include({
+      'x-api-key': ENV.SPACECAT_API_KEY,
+      'User-Agent': 'spacecat-audit-worker/brand-resolver',
+    });
+    expect(opts.timeout).to.equal(30000);
+  });
+
+  it('returns null on 404', async () => {
+    mockFetch.resolves(makeResponse({ status: 404, ok: false, body: 'Not Found' }));
+
+    const result = await resolveBrandIdForSite(ORG_ID, SITE_ID, ENV, log);
+
+    expect(result).to.be.null;
+    expect(log.info).to.have.been.calledWith(
+      sinon.match(/No v2 brand for org=/),
+    );
+  });
+
+  it('throws on 5xx (fail-closed)', async () => {
+    mockFetch.resolves(makeResponse({
+      status: 503, ok: false, body: 'Service Unavailable',
+    }));
+
+    await expect(resolveBrandIdForSite(ORG_ID, SITE_ID, ENV, log))
+      .to.be.rejectedWith(/503/);
+  });
+
+  it('handles 5xx body-read failure gracefully', async () => {
+    mockFetch.resolves(makeResponse({
+      status: 502, ok: false, throwOnText: true, body: 'unused',
+    }));
+
+    await expect(resolveBrandIdForSite(ORG_ID, SITE_ID, ENV, log))
+      .to.be.rejectedWith(/502/);
+  });
+
+  it('throws on network error', async () => {
+    mockFetch.rejects(new Error('connect ECONNREFUSED'));
+
+    await expect(resolveBrandIdForSite(ORG_ID, SITE_ID, ENV, log))
+      .to.be.rejectedWith(/network\/timeout/);
+  });
+
+  it('throws on non-JSON 200 body', async () => {
+    mockFetch.resolves(makeResponse({
+      status: 200, throwOnJson: true, body: '<html>',
+    }));
+
+    await expect(resolveBrandIdForSite(ORG_ID, SITE_ID, ENV, log))
+      .to.be.rejectedWith(/non-JSON/);
+  });
+
+  it('returns null on 200 body with no id (treated as no brand)', async () => {
+    mockFetch.resolves(makeResponse({ status: 200, body: { name: 'No-id' } }));
+
+    const result = await resolveBrandIdForSite(ORG_ID, SITE_ID, ENV, log);
+    expect(result).to.be.null;
+    expect(log.warn).to.have.been.calledWith(
+      sinon.match(/returned no id/),
+    );
+  });
+
+  it('returns null on 200 body that is null', async () => {
+    mockFetch.resolves(makeResponse({ status: 200, body: null }));
+
+    const result = await resolveBrandIdForSite(ORG_ID, SITE_ID, ENV, log);
+    expect(result).to.be.null;
+  });
+
+  it('returns null on 200 body where id is empty string', async () => {
+    mockFetch.resolves(makeResponse({ status: 200, body: { id: '' } }));
+
+    const result = await resolveBrandIdForSite(ORG_ID, SITE_ID, ENV, log);
+    expect(result).to.be.null;
+  });
+
+  it('url-encodes orgId and siteId path segments', async () => {
+    mockFetch.resolves(makeResponse({ status: 200, body: { id: 'b1' } }));
+
+    await resolveBrandIdForSite('org with space', 'site/with/slashes', ENV, log);
+
+    const [url] = mockFetch.firstCall.args;
+    expect(url).to.equal(
+      `${ENV.SPACECAT_API_BASE_URL}/v2/orgs/org%20with%20space/sites/site%2Fwith%2Fslashes/brand`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Both `geo-brand-presence` and `geo-brand-presence-daily` refresh handlers now resolve the v2 brand once per audit (per site) via the new LLMO-4716 spacecat-api-service endpoint, then thread `brandId` through `drsClient.publishBrandPresenceAnalyze` so the DRS Fargate runner enters the v2 config path for brandalf-true orgs.

## Failure contract

A new `src/utils/brand-resolver.js` encapsulates the HTTP call:

| Result | Caller behavior |
| --- | --- |
| `200` | Use the brand id |
| `404` | Return `null` — deliberate "no v2 brand" (v1 orgs / brandalf-migration / kill-switch / no active brand for site). Caller forwards `null` and the runner takes v1 |
| `5xx / network / timeout / parse error` | **Throw**. For brandalf-true orgs, silently continuing without `brand_id` falls back to v1 reads from a no-longer-published spreadsheet mirror — the BP pipeline keeps running but produces meaningless output. Failing fast lets SQS retry and surface the issue via DLQ instead of silent bad data. |

## Files

- `src/utils/brand-resolver.js` (new) — HTTP client to the LLMO-4716 endpoint
- `src/geo-brand-presence/geo-brand-presence-refresh-handler.js` — resolve + forward
- `src/geo-brand-presence-daily/geo-brand-presence-refresh-handler.js` — resolve + forward
- `test/utils/brand-resolver.test.js` (new, 15 cases) + expansions to both refresh-handler test files

## Context

LLMO-4716 — required for Adobe brandalf flip on 2026-05-06. Adobe's existing audit-worker SNS publishes don't carry `brand_id`; without this change the runner reads stale v1 LLMO config from the no-longer-published spreadsheet mirror.

## Self-review applied

A multi-agent local review surfaced two issues; addressed in a follow-up commit:

- **Resolver errors were silently re-wrapped as misleading "Failed to create S3 folder for audit"** — the brand resolution call ran inside the outer try/catch, so when the resolver fail-closed-threw on a 5xx, DLQ messages pointed at S3 instead of the real cause (the brand endpoint). Hoisted the resolver call above the metadata write and outside the try/catch so the original `[BrandResolver]` error propagates unwrapped to DLQ. Also: when other errors fall into the outer catch (S3 / SharePoint / DRS upload), `throw new Error(msg, { cause: error })` now preserves the original error chain.
- **Brand resolution after S3 metadata write left orphan `metadata.json` files** — when the resolver threw, the metadata file had already been written; SQS retry created a fresh auditId, so orphans accumulated until manual cleanup. Same hoist fixes this — no S3 write fires when the resolver fails. Tests assert `s3Client.send` is never invoked on resolver failure.

## Deferred follow-ups

These items were considered and deliberately deferred:

- **30s fetch timeout** is generous for a single-row DB lookup behind Fastly. Other handlers in this repo use 10s. Worth tightening once we measure dev latency, but not load-bearing for correctness.
- **No in-process retry on 5xx** — relies on SQS retry. A single 250ms-backoff retry would absorb the common transient case without paying the SQS-replay tax (which re-runs SharePoint reads + DRS uploads). Filed as a follow-up.
- **Resolver throws on any non-404 4xx**. 401/403 fail-closed is correct (auth misconfig should be loud); 400 is unlikely in practice. Documented in the file header; classification refinement deferred.
- **`requireSpacecatApi(env)` helper extraction** — this is the fourth direct caller of spacecat-api in the worker. A thin shared client would centralize timeout/auth/retry policy. Architectural follow-up.
- **Cross-org blast radius on 5xx** — when SpaceCat API is briefly unavailable, every BP audit fails (not just brandalf orgs). For v1 orgs the resolver returns 404 (no error) so they're unaffected in steady state; the cross-org risk is only real during a true API outage, when fail-closed is the safer default. Trade-off documented; revisit if false-positive failures become noisy in dev.
- **No structured signal for "v2-path entry"** — adding a CloudWatch metric on `brand_id` set rate would make the 2026-05-06 go/no-go verification minutes-fast instead of log-grep slow. Filed as ops-readiness follow-up.

## Rollout — depends on two PRs

⚠️ **This PR must NOT merge until both of the following ship:**

1. [spacecat-shared#1586](https://github.com/adobe/spacecat-shared/pull/1586) — adds the `brandId` parameter to `publishBrandPresenceAnalyze`. **Release must publish before this PR merges.** Bump `@adobe/spacecat-shared-drs-client` in `package.json` once the release is live.
2. [spacecat-api-service#2334](https://github.com/adobe/spacecat-api-service/pull/2334) — adds the resolver endpoint this PR calls. **Endpoint must be deployed before this PR is enabled in prod.**

## Test plan

- [x] 7751 unit tests passing (audit-worker full suite)
- [x] 100% coverage on `brand-resolver.js` and both refresh handlers
- [x] Lint clean
- [x] Resolver-error preservation test asserts original `[BrandResolver]` message survives the throw
- [x] Orphan-metadata test asserts `s3Client.send` never fires when resolver fails
- [x] Bump `@adobe/spacecat-shared-drs-client` once shared release publishes
- [ ] Manual smoke after deploy on a brandalf-test org:
  - [ ] Trigger `geo-brand-presence-refresh` → confirm `brandId` resolved in audit-worker logs, SNS published with `metadata.brand_id`
  - [ ] DRS-side: confirm Job record has `brand_id`, runner enters v2 path
  - [ ] Trigger same on a non-brandalf org → endpoint returns 404 → SNS published without `brand_id` → runner stays on v1 path
  - [ ] Verify fail-closed: when SpaceCat API is artificially flapping (5xx), audit fails with the resolver error message intact in DLQ

🤖 Generated with [Claude Code](https://claude.com/claude-code)