### PR TITLE
fix: imperva path does not require underscore path to work

### DIFF
--- a/src/cdn-analysis/sql/imperva/create-raw-table.sql
+++ b/src/cdn-analysis/sql/imperva/create-raw-table.sql
@@ -57,7 +57,7 @@ WITH SERDEPROPERTIES (
 LOCATION '{{rawLocation}}'
 TBLPROPERTIES (
   'schema_version'            = '1',
-  'skip.header.line.count'    = '4',
+  'skip.header.line.count'    = '11',
   'projection.enabled'        = 'false',
   'has_encrypted_data'        = 'false'
 );

--- a/src/llmo-customer-analysis/cdn-config-handler.js
+++ b/src/llmo-customer-analysis/cdn-config-handler.js
@@ -218,11 +218,6 @@ export async function handleCdnBucketConfigChanges(context, data) {
   if (allowedPaths && allowedPaths.length > 0) {
     const [firstPath] = allowedPaths;
     [pathId] = firstPath.split('/');
-    // For byocdn-imperva the raw prefix uses underscores ({pathId}_raw_{provider}/),
-    // so the first path segment includes the suffix — strip it to recover the bare pathId.
-    if (cdnProvider === SERVICE_PROVIDER_TYPES.BYOCDN_IMPERVA && pathId.includes('_raw_byocdn-imperva')) {
-      pathId = pathId.replace('_raw_byocdn-imperva', '');
-    }
   }
 
   if (cdnProvider === SERVICE_PROVIDER_TYPES.COMMERCE_FASTLY) {

--- a/src/utils/cdn-utils.js
+++ b/src/utils/cdn-utils.js
@@ -242,13 +242,9 @@ export function buildCdnPaths(bucketName, serviceProvider, timeParts, pathId = n
   } = timeParts;
 
   // New standardized bucket structure: cdn-logs-adobe-{env}/{pathId}/raw/{serviceProvider}/
-  // For byocdn-imperva, pathId, 'raw', and serviceProvider are joined with underscores
   if (isStandardAdobeCdnBucket(bucketName) && pathId) {
-    const rawLocation = serviceProvider.includes('byocdn-imperva')
-      ? `s3://${bucketName}/${pathId}_raw_${serviceProvider}/`
-      : `s3://${bucketName}/${pathId}/raw/${serviceProvider}/`;
     return {
-      rawLocation,
+      rawLocation: `s3://${bucketName}/${pathId}/raw/${serviceProvider}/`,
       aggregatedLocation: `s3://${bucketName}/${pathId}/aggregated/`,
       aggregatedOutput: `s3://${bucketName}/${pathId}/aggregated/${year}/${month}/${day}/${hour}/`,
       aggregatedReferralLocation: `s3://${bucketName}/${pathId}/aggregated-referral/`,
@@ -338,24 +334,6 @@ export async function getBucketInfo(s3Client, bucketName, pathId = null) {
       providers = (response.CommonPrefixes || [])
         .map((prefix) => prefix.Prefix.replace(`${pathId}/raw/`, '').replace('/', ''))
         .filter((provider) => provider && provider.length > 0);
-
-      // Also discover providers using the underscore layout: {pathId}_raw_{provider}/
-      // Imperva logs are delivered with pathId, "raw", and provider joined by underscores
-      // instead of slashes, so a separate listing is needed to find them.
-      const underscoreResponse = await s3Client.send(new ListObjectsV2Command({
-        Bucket: bucketName,
-        Prefix: `${pathId}_raw_`,
-        Delimiter: '/',
-        MaxKeys: 10,
-      }));
-
-      const underscorePrefix = `${pathId}_raw_`;
-      const underscoreProviders = (underscoreResponse.CommonPrefixes || [])
-        .filter((prefix) => prefix.Prefix.startsWith(underscorePrefix))
-        .map((prefix) => prefix.Prefix.slice(underscorePrefix.length).replace(/\/$/, ''))
-        .filter((provider) => provider && provider.length > 0);
-
-      providers = [...providers, ...underscoreProviders];
 
       return { isLegacy: isLegacyBucketStructure(providers), providers };
     }

--- a/test/audits/cdn-analysis/handler.test.js
+++ b/test/audits/cdn-analysis/handler.test.js
@@ -58,10 +58,8 @@ function createS3MockForCdnType(cdnType, options = {}) {
     },
     imperva: {
       logSample: null,
-      keyPath: `${orgId}_raw_byocdn-imperva/somefile.log`,
-      // underscore-layout prefix used for both provider discovery and raw data check
-      prefix: `${orgId}_raw_byocdn-imperva/`,
-      underscoreLayout: true,
+      keyPath: `${orgId}/raw/byocdn-imperva/somefile.log`,
+      prefix: `${orgId}/raw/byocdn-imperva/`,
     },
   };
 
@@ -78,17 +76,6 @@ function createS3MockForCdnType(cdnType, options = {}) {
       const { Prefix = '' } = command.input || {};
       if (Prefix.includes('aggregated')) {
         return Promise.resolve({ Contents: [] });
-      }
-      if (config.underscoreLayout) {
-        // Slash-layout listing (getBucketInfo first call) returns no providers;
-        // underscore-layout listing and raw data check both use the underscore prefix.
-        if (Prefix.endsWith('/raw/')) {
-          return Promise.resolve({ Contents: [], CommonPrefixes: [] });
-        }
-        return Promise.resolve({
-          Contents: [{ Key: config.keyPath }],
-          CommonPrefixes: [{ Prefix: config.prefix }],
-        });
       }
       return Promise.resolve({
         Contents: [{ Key: config.keyPath }],

--- a/test/audits/llmo-customer-analysis-cdn-config.test.js
+++ b/test/audits/llmo-customer-analysis-cdn-config.test.js
@@ -476,18 +476,6 @@ describe('CDN Config Handler', () => {
       expect(mockSite.save).to.have.been.called;
     });
 
-    it('should extract bare orgId from byocdn-imperva underscore-layout allowedPaths', async () => {
-      const data = {
-        allowedPaths: ['TestOrg123AdobeOrg_raw_byocdn-imperva/somefile.log'],
-        cdnProvider: 'byocdn-imperva',
-      };
-
-      await cdnConfigHandler.handleCdnBucketConfigChanges(context, data);
-
-      expect(mockSiteConfig.updateLlmoCdnBucketConfig).to.have.been.calledWith({ orgId: 'TestOrg123AdobeOrg' });
-      expect(mockSite.save).to.have.been.called;
-    });
-
     it('should handle bucket configuration when both bucketName and allowedPaths provided', async () => {
       nock('https://main--project-elmo-ui-data--adobe.aem.live')
         .get('/adobe-managed-domains/commerce-fastly-domains.json?limit=10000')

--- a/test/utils/cdn-utils.test.js
+++ b/test/utils/cdn-utils.test.js
@@ -235,10 +235,9 @@ describe('CDN Utils', () => {
     });
 
     it('returns modern bucket info when byocdn-other prefix exists', async () => {
-      s3Client.send.onFirstCall().resolves({
+      s3Client.send.resolves({
         CommonPrefixes: [{ Prefix: `${pathId}/raw/byocdn-other/` }],
       });
-      s3Client.send.onSecondCall().resolves({ CommonPrefixes: [] });
 
       const result = await getBucketInfo(s3Client, bucketName, pathId);
 
@@ -247,9 +246,8 @@ describe('CDN Utils', () => {
     });
 
     it('returns modern bucket info when byocdn-imperva prefix exists', async () => {
-      s3Client.send.onFirstCall().resolves({ CommonPrefixes: [] });
-      s3Client.send.onSecondCall().resolves({
-        CommonPrefixes: [{ Prefix: `${pathId}_raw_byocdn-imperva/` }],
+      s3Client.send.resolves({
+        CommonPrefixes: [{ Prefix: `${pathId}/raw/byocdn-imperva/` }],
       });
 
       const result = await getBucketInfo(s3Client, bucketName, pathId);


### PR DESCRIPTION
- Fix skip.header.line.count in the Imperva raw table DDL from 4 to 11 — the Imperva log format has 11 header lines before the first data row (6 metadata lines + |==| separator + 4 W3C comment lines), not 4.
- Remove the underscore in the S3 path -- there's no need, as long as the last character is not a trailing slash