### PR TITLE
feat(prerender): skip permanently-failing URLs to save scraping bandwidth (LLMO-4040)

### DIFF
--- a/src/prerender/handler.js
+++ b/src/prerender/handler.js
@@ -29,6 +29,8 @@ import {
   PRERENDER_RECENT_PROCESSING_TIME_DAYS,
   MODE_AI_ONLY,
   MYSTIQUE_BATCH_SIZE,
+  SKIPPABLE_HTTP_STATUS_CODES,
+  SKIP_UNTIL_DAYS_BY_STATUS,
 } from './utils/constants.js';
 
 function rebaseUrl(url, preferredBase, log) {
@@ -309,6 +311,24 @@ function normalizePathname(url) {
   } catch {
     return url;
   }
+}
+
+/**
+ * Computes the timestamp (ms) until which a URL should be excluded from scraping,
+ * based on its HTTP error code and how many consecutive times it has failed.
+ *
+ * Probe windows must exceed the natural 7-day audit cadence
+ * (PRERENDER_RECENT_PROCESSING_TIME_DAYS) so that at least one cycle is saved.
+ *
+ * @param {number} statusCode - HTTP status code of the permanent failure.
+ * @param {number} consecutiveFailures - How many times in a row this URL has failed.
+ * @returns {number} Unix timestamp (ms) after which the URL should be retried.
+ */
+function computeSkipUntil(statusCode, consecutiveFailures) {
+  /* c8 ignore next -- defensive fallback; both constants are kept in sync */
+  const [firstDays, repeatDays] = SKIP_UNTIL_DAYS_BY_STATUS[statusCode] ?? [14, 28];
+  const days = consecutiveFailures <= 1 ? firstDays : repeatDays;
+  return Date.now() + days * 24 * 60 * 60 * 1000;
 }
 
 /**
@@ -820,6 +840,8 @@ export async function submitForScraping(context) {
     log,
     data,
     auditContext,
+    s3Client,
+    env,
   } = context;
 
   // Check for AI-only mode - skip scraping step (step 1 already triggered Mystique)
@@ -875,6 +897,7 @@ export async function submitForScraping(context) {
   let currentIncludedUrls;
   let isFirstRunOfCycle;
   let agenticNewThisCycle = 0;
+  let skippedBySkipUntil = 0;
 
   if (isSlackTriggered) {
     ({ urls: finalUrls, filteredCount } = mergeAndGetUniqueHtmlUrls([
@@ -907,7 +930,32 @@ export async function submitForScraping(context) {
       ...filteredIncludedURLs,
       ...filteredAgenticUrls,
     ];
-    const batchedUrls = orderedCandidateUrls.slice(0, DAILY_BATCH_SIZE);
+
+    // Filter URLs tombstoned by persistent scrape failures (skipUntil > now).
+    // Only applied in the normal daily-batch path — Slack-triggered and explicit-URL
+    // paths bypass this filter intentionally.
+    const skipUntilMap = new Map();
+    if (s3Client && env?.S3_SCRAPER_BUCKET_NAME) {
+      const statusKey = `${AUDIT_TYPE}/scrapes/${siteId}/status.json`;
+      // eslint-disable-next-line max-len
+      const existingStatus = await getObjectFromKey(s3Client, env.S3_SCRAPER_BUCKET_NAME, statusKey, log);
+      if (existingStatus?.pages) {
+        const now = Date.now();
+        for (const page of existingStatus.pages) {
+          if (page.skipUntil && page.skipUntil > now) {
+            skipUntilMap.set(normalizePathname(page.url), page.skipUntil);
+          }
+        }
+      }
+    }
+
+    skippedBySkipUntil = skipUntilMap.size > 0
+      ? orderedCandidateUrls.filter((url) => skipUntilMap.has(normalizePathname(url))).length
+      : 0;
+    const activeUrls = skippedBySkipUntil > 0
+      ? orderedCandidateUrls.filter((url) => !skipUntilMap.has(normalizePathname(url)))
+      : orderedCandidateUrls;
+    const batchedUrls = activeUrls.slice(0, DAILY_BATCH_SIZE);
 
     const organicUrlSet = new Set(filteredOrganicUrls);
     const includedUrlSet = new Set(filteredIncludedURLs);
@@ -931,6 +979,7 @@ export async function submitForScraping(context) {
     currentIncludedUrls=${currentIncludedUrls},
     isFirstRunOfCycle=${isFirstRunOfCycle},
     agenticNewThisCycle=${agenticNewThisCycle},
+    skippedBySkipUntil=${skippedBySkipUntil},
     baseUrl=${site.getBaseURL()},
     siteId=${siteId}`);
 
@@ -1334,6 +1383,14 @@ export async function uploadStatusSummaryToS3(auditUrl, auditData, context) {
       // Only stamp the current scrapeJobId for URLs actually submitted to this job.
       // For fallback URLs that weren't submitted, preserve the existing scrapeJobId.
       const wasSubmitted = !submittedUrlSet || submittedUrlSet.has(result.url);
+      const existing = existingPageMap.get(normalizePathname(result.url));
+      const statusCode = result.scrapeError?.statusCode;
+      // Set.has(undefined) safely returns false, so no explicit null-guard is needed here
+      const isSkippable = SKIPPABLE_HTTP_STATUS_CODES.has(statusCode);
+      const consecutiveFailures = isSkippable
+        ? (existing?.consecutiveFailures ?? 0) + 1 : undefined;
+      const skipUntil = isSkippable
+        ? computeSkipUntil(statusCode, consecutiveFailures) : undefined;
       return {
         url: result.url,
         scrapingStatus: result.error ? 'error' : 'success',
@@ -1346,19 +1403,35 @@ export async function uploadStatusSummaryToS3(auditUrl, auditData, context) {
         scrapedAt,
         scrapeJobId: wasSubmitted
           ? (scrapeJobId || null)
-          : (existingPageMap.get(normalizePathname(result.url))?.scrapeJobId ?? null),
+          : (existing?.scrapeJobId ?? null),
         ...(result.scrapeError && { scrapeError: result.scrapeError }),
+        ...(consecutiveFailures !== undefined && { consecutiveFailures }),
+        ...(skipUntil !== undefined && { skipUntil }),
       };
     });
 
     // missingPages should be precomputed by getScrapeJobStats and passed via auditResult.
     if (Array.isArray(auditResult.missingPages)) {
       currentPages.push(
-        ...auditResult.missingPages.map((page) => ({
-          ...page,
-          scrapedAt: page.scrapedAt || scrapedAt,
-          scrapeJobId: page.scrapeJobId || scrapeJobId || null,
-        })),
+        ...auditResult.missingPages.map((page) => {
+          const existing = existingPageMap.get(normalizePathname(page.url));
+          const statusCode = page.scrapeError?.statusCode;
+          // Set.has(undefined) safely returns false, so no explicit null-guard is needed here
+          const isSkippable = SKIPPABLE_HTTP_STATUS_CODES.has(statusCode);
+          const consecutiveFailures = isSkippable
+            ? (existing?.consecutiveFailures ?? 0) + 1
+            : undefined;
+          const skipUntil = isSkippable
+            ? computeSkipUntil(statusCode, consecutiveFailures)
+            : undefined;
+          return {
+            ...page,
+            scrapedAt: page.scrapedAt || scrapedAt,
+            scrapeJobId: page.scrapeJobId || scrapeJobId || null,
+            ...(consecutiveFailures !== undefined && { consecutiveFailures }),
+            ...(skipUntil !== undefined && { skipUntil }),
+          };
+        }),
       );
     }
 

--- a/src/prerender/utils/constants.js
+++ b/src/prerender/utils/constants.js
@@ -20,3 +20,30 @@ export const TOP_ORGANIC_URLS_LIMIT = 200;
 export const PRERENDER_RECENT_PROCESSING_TIME_DAYS = 7;
 export const MODE_AI_ONLY = 'ai-only';
 export const MYSTIQUE_BATCH_SIZE = DAILY_BATCH_SIZE;
+
+/**
+ * HTTP status codes that indicate permanent failures eligible for skip-list treatment.
+ * Once a URL hits one of these codes, it is assigned a skipUntil timestamp and excluded
+ * from future audit batches until the probe window opens.
+ *
+ * Must be codes where retrying on the next natural 7-day cycle is unlikely to succeed.
+ */
+export const SKIPPABLE_HTTP_STATUS_CODES = new Set([401, 403, 404, 406, 410, 444]);
+
+/**
+ * Skip window configuration per HTTP status code: [firstFailureDays, repeatFailureDays].
+ *
+ * The natural audit cadence is 7 days per URL (PRERENDER_RECENT_PROCESSING_TIME_DAYS).
+ * All skip windows must exceed 7 days to save at least one audit cycle.
+ *   - 14d = skip 1 extra cycle (probe on the 3rd natural window)
+ *   - 28d = skip 3 extra cycles
+ *   - 84d = skip 11 extra cycles (~3 months)
+ */
+export const SKIP_UNTIL_DAYS_BY_STATUS = {
+  404: [14, 28], // Page not found: likely gone but pages get restored — probe after 2/4 cycles
+  403: [14, 28], // Forbidden / bot-blocked: blocks can be lifted — probe after 2/4 cycles
+  401: [84, 84], // Unauthorized: won't recover until customer configures credentials
+  410: [84, 84], // Gone: server explicitly signals permanent removal
+  406: [14, 28], // Not acceptable: server rejects scraper headers
+  444: [14, 28], // Connection closed (nginx): active blocking
+};

--- a/test/audits/prerender/handler.test.js
+++ b/test/audits/prerender/handler.test.js
@@ -1128,6 +1128,225 @@ describe('Prerender Audit', () => {
         expect(athenaStub).to.have.been.called;
       });
 
+      describe('skipUntil URL filtering in normal batch mode', () => {
+        it('should exclude URLs with an active skipUntil from the scraping batch', async () => {
+          const now = Date.now();
+          const skippedUrl = 'https://example.com/blocked-page';
+          const allowedUrl = 'https://example.com/allowed-page';
+
+          const getObjectFromKeyStub = sandbox.stub().resolves({
+            pages: [
+              { url: skippedUrl, skipUntil: now + 14 * 24 * 60 * 60 * 1000 },
+              { url: allowedUrl, skipUntil: now - 1000 }, // expired — should NOT be skipped
+            ],
+          });
+
+          const mockHandler = await esmock('../../../src/prerender/handler.js', {
+            '../../../src/utils/s3-utils.js': {
+              getObjectFromKey: getObjectFromKeyStub,
+              getObjectKeysUsingPrefix: sandbox.stub().resolves([]),
+            },
+            '../../../src/utils/agentic-urls.js': {
+              getTopAgenticUrlsFromAthena: async () => [],
+              getPreferredBaseUrl: () => 'https://example.com',
+            },
+          });
+
+          const context = {
+            site: {
+              getId: () => 'site-1',
+              getBaseURL: () => 'https://example.com',
+              getConfig: () => ({ getIncludedURLs: () => [] }),
+            },
+            dataAccess: {
+              SiteTopPage: {
+                allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([
+                  { getUrl: () => skippedUrl },
+                  { getUrl: () => allowedUrl },
+                ]),
+              },
+              PageCitability: { allByIndexKeys: sandbox.stub().resolves([]) },
+            },
+            s3Client: { send: sandbox.stub() },
+            env: { S3_SCRAPER_BUCKET_NAME: 'test-bucket' },
+            log: { info: sandbox.stub(), debug: sandbox.stub(), warn: sandbox.stub() },
+          };
+
+          const result = await mockHandler.submitForScraping(context);
+          const submittedUrls = result.urls.map((u) => u.url);
+          expect(submittedUrls).to.not.include(skippedUrl);
+          expect(submittedUrls).to.include(allowedUrl);
+          expect(context.log.info).to.have.been.calledWithMatch('skippedBySkipUntil=1');
+        });
+
+        it('should not filter anything when no URLs have an active skipUntil', async () => {
+          const getObjectFromKeyStub = sandbox.stub().resolves({
+            pages: [
+              { url: 'https://example.com/old-blocked', skipUntil: Date.now() - 1 }, // expired
+            ],
+          });
+
+          const mockHandler = await esmock('../../../src/prerender/handler.js', {
+            '../../../src/utils/s3-utils.js': {
+              getObjectFromKey: getObjectFromKeyStub,
+              getObjectKeysUsingPrefix: sandbox.stub().resolves([]),
+            },
+            '../../../src/utils/agentic-urls.js': {
+              getTopAgenticUrlsFromAthena: async () => [],
+              getPreferredBaseUrl: () => 'https://example.com',
+            },
+          });
+
+          const context = {
+            site: {
+              getId: () => 'site-1',
+              getBaseURL: () => 'https://example.com',
+              getConfig: () => ({ getIncludedURLs: () => [] }),
+            },
+            dataAccess: {
+              SiteTopPage: {
+                allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([
+                  { getUrl: () => 'https://example.com/old-blocked' },
+                ]),
+              },
+              PageCitability: { allByIndexKeys: sandbox.stub().resolves([]) },
+            },
+            s3Client: { send: sandbox.stub() },
+            env: { S3_SCRAPER_BUCKET_NAME: 'test-bucket' },
+            log: { info: sandbox.stub(), debug: sandbox.stub(), warn: sandbox.stub() },
+          };
+
+          const result = await mockHandler.submitForScraping(context);
+          expect(result.urls).to.have.lengthOf(1);
+          expect(context.log.info).to.have.been.calledWithMatch('skippedBySkipUntil=0');
+        });
+
+        it('should skip status.json load and not filter when s3Client is absent', async () => {
+          const getObjectFromKeyStub = sandbox.stub().resolves({
+            pages: [{ url: 'https://example.com/blocked', skipUntil: Date.now() + 99999 }],
+          });
+
+          const mockHandler = await esmock('../../../src/prerender/handler.js', {
+            '../../../src/utils/s3-utils.js': {
+              getObjectFromKey: getObjectFromKeyStub,
+              getObjectKeysUsingPrefix: sandbox.stub().resolves([]),
+            },
+            '../../../src/utils/agentic-urls.js': {
+              getTopAgenticUrlsFromAthena: async () => [],
+              getPreferredBaseUrl: () => 'https://example.com',
+            },
+          });
+
+          // No s3Client in context — guard should prevent the status.json load
+          const context = {
+            site: {
+              getId: () => 'site-1',
+              getBaseURL: () => 'https://example.com',
+              getConfig: () => ({ getIncludedURLs: () => [] }),
+            },
+            dataAccess: {
+              SiteTopPage: {
+                allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([
+                  { getUrl: () => 'https://example.com/blocked' },
+                ]),
+              },
+              PageCitability: { allByIndexKeys: sandbox.stub().resolves([]) },
+            },
+            // s3Client intentionally omitted
+            env: { S3_SCRAPER_BUCKET_NAME: 'test-bucket' },
+            log: { info: sandbox.stub(), debug: sandbox.stub(), warn: sandbox.stub() },
+          };
+
+          const result = await mockHandler.submitForScraping(context);
+          // URL must NOT be filtered (no s3Client means no status.json loaded)
+          expect(result.urls.map((u) => u.url)).to.include('https://example.com/blocked');
+          expect(getObjectFromKeyStub).to.not.have.been.called;
+        });
+
+        it('should not apply skipUntil filter in Slack-triggered mode', async () => {
+          const now = Date.now();
+          const getObjectFromKeyStub = sandbox.stub().resolves({
+            pages: [{ url: 'https://example.com/blocked', skipUntil: now + 99999 }],
+          });
+
+          const mockHandler = await esmock('../../../src/prerender/handler.js', {
+            '../../../src/utils/s3-utils.js': {
+              getObjectFromKey: getObjectFromKeyStub,
+              getObjectKeysUsingPrefix: sandbox.stub().resolves([]),
+            },
+            '../../../src/utils/agentic-urls.js': {
+              getTopAgenticUrlsFromAthena: async () => [],
+              getPreferredBaseUrl: () => 'https://example.com',
+            },
+          });
+
+          const context = {
+            site: {
+              getId: () => 'site-1',
+              getBaseURL: () => 'https://example.com',
+              getConfig: () => ({ getIncludedURLs: () => [] }),
+            },
+            auditContext: { slackContext: { channelId: 'C12345' } }, // Slack trigger
+            dataAccess: {
+              SiteTopPage: {
+                allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([
+                  { getUrl: () => 'https://example.com/blocked' },
+                ]),
+              },
+              PageCitability: { allByIndexKeys: sandbox.stub().resolves([]) },
+            },
+            s3Client: { send: sandbox.stub() },
+            env: { S3_SCRAPER_BUCKET_NAME: 'test-bucket' },
+            log: { info: sandbox.stub(), debug: sandbox.stub(), warn: sandbox.stub() },
+          };
+
+          const result = await mockHandler.submitForScraping(context);
+          // Slack path bypasses the skip-until filter entirely
+          expect(result.urls.map((u) => u.url)).to.include('https://example.com/blocked');
+          expect(getObjectFromKeyStub).to.not.have.been.called;
+        });
+
+        it('should handle status.json with no pages array (null return from getObjectFromKey)', async () => {
+          // getObjectFromKey returns null when file missing/unreadable
+          const getObjectFromKeyStub = sandbox.stub().resolves(null);
+
+          const mockHandler = await esmock('../../../src/prerender/handler.js', {
+            '../../../src/utils/s3-utils.js': {
+              getObjectFromKey: getObjectFromKeyStub,
+              getObjectKeysUsingPrefix: sandbox.stub().resolves([]),
+            },
+            '../../../src/utils/agentic-urls.js': {
+              getTopAgenticUrlsFromAthena: async () => [],
+              getPreferredBaseUrl: () => 'https://example.com',
+            },
+          });
+
+          const context = {
+            site: {
+              getId: () => 'site-1',
+              getBaseURL: () => 'https://example.com',
+              getConfig: () => ({ getIncludedURLs: () => [] }),
+            },
+            dataAccess: {
+              SiteTopPage: {
+                allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([
+                  { getUrl: () => 'https://example.com/page1' },
+                ]),
+              },
+              PageCitability: { allByIndexKeys: sandbox.stub().resolves([]) },
+            },
+            s3Client: { send: sandbox.stub() },
+            env: { S3_SCRAPER_BUCKET_NAME: 'test-bucket' },
+            log: { info: sandbox.stub(), debug: sandbox.stub(), warn: sandbox.stub() },
+          };
+
+          // Should proceed normally without filtering
+          const result = await mockHandler.submitForScraping(context);
+          expect(result.urls).to.have.lengthOf(1);
+          expect(result.urls[0].url).to.equal('https://example.com/page1');
+        });
+      });
+
     });
 
     describe('processContentAndGenerateOpportunities', () => {
@@ -6891,6 +7110,211 @@ describe('Prerender Audit', () => {
 
       expect(earlyPage.usedEarlyClientSideHtml).to.equal(true);
       expect(normalPage.usedEarlyClientSideHtml).to.equal(false);
+    });
+
+    describe('skipUntil tombstoning via consecutiveFailures', () => {
+      it('should set consecutiveFailures=1 and skipUntil on first 404 in missingPages', async () => {
+        const before = Date.now();
+        const auditData = {
+          siteId: 'test-site-id',
+          auditedAt: '2025-01-01T00:00:00.000Z',
+          auditResult: {
+            results: [],
+            missingPages: [{
+              url: 'https://example.com/gone-page',
+              scrapingStatus: 'failed',
+              needsPrerender: false,
+              scrapeError: { statusCode: 404, message: 'Not Found' },
+            }],
+          },
+        };
+
+        await uploadStatusSummaryToS3('https://example.com', auditData, context);
+
+        const uploadedData = JSON.parse(getPutCall(mockS3Client.send).args[0].input.Body);
+        const page = uploadedData.pages.find((p) => p.url === 'https://example.com/gone-page');
+        expect(page).to.exist;
+        expect(page.consecutiveFailures).to.equal(1);
+        // First failure for 404: 14 days window
+        const expectedMinSkipUntil = before + 14 * 24 * 60 * 60 * 1000;
+        expect(page.skipUntil).to.be.at.least(expectedMinSkipUntil);
+        expect(page.skipUntil).to.be.below(expectedMinSkipUntil + 5000);
+      });
+
+      it('should set consecutiveFailures=2 and longer skipUntil on repeated 404 failure', async () => {
+        const existingStatus = {
+          pages: [{
+            url: 'https://example.com/gone-page',
+            scrapingStatus: 'failed',
+            consecutiveFailures: 1,
+            skipUntil: Date.now() - 1, // expired
+          }],
+        };
+        mockS3Client.send.callsFake((command) => {
+          if (command.constructor.name === 'GetObjectCommand') {
+            return Promise.resolve({
+              Body: { transformToString: () => Promise.resolve(JSON.stringify(existingStatus)) },
+            });
+          }
+          return Promise.resolve({});
+        });
+
+        const before = Date.now();
+        const auditData = {
+          siteId: 'test-site-id',
+          auditedAt: '2025-01-15T00:00:00.000Z',
+          auditResult: {
+            results: [],
+            missingPages: [{
+              url: 'https://example.com/gone-page',
+              scrapingStatus: 'failed',
+              scrapeError: { statusCode: 404, message: 'Not Found' },
+            }],
+          },
+        };
+
+        await uploadStatusSummaryToS3('https://example.com', auditData, context);
+
+        const uploadedData = JSON.parse(getPutCall(mockS3Client.send).args[0].input.Body);
+        const page = uploadedData.pages.find((p) => p.url === 'https://example.com/gone-page');
+        expect(page.consecutiveFailures).to.equal(2);
+        // Repeat failure for 404: 28 days window
+        const expectedMinSkipUntil = before + 28 * 24 * 60 * 60 * 1000;
+        expect(page.skipUntil).to.be.at.least(expectedMinSkipUntil);
+        expect(page.skipUntil).to.be.below(expectedMinSkipUntil + 5000);
+      });
+
+      it('should use 84-day window for 401 (unauthorized) failures', async () => {
+        const before = Date.now();
+        const auditData = {
+          siteId: 'test-site-id',
+          auditedAt: '2025-01-01T00:00:00.000Z',
+          auditResult: {
+            results: [],
+            missingPages: [{
+              url: 'https://example.com/protected',
+              scrapingStatus: 'failed',
+              scrapeError: { statusCode: 401, message: 'Unauthorized' },
+            }],
+          },
+        };
+
+        await uploadStatusSummaryToS3('https://example.com', auditData, context);
+
+        const uploadedData = JSON.parse(getPutCall(mockS3Client.send).args[0].input.Body);
+        const page = uploadedData.pages.find((p) => p.url === 'https://example.com/protected');
+        expect(page.consecutiveFailures).to.equal(1);
+        // 401 always uses 84-day window
+        const expectedMinSkipUntil = before + 84 * 24 * 60 * 60 * 1000;
+        expect(page.skipUntil).to.be.at.least(expectedMinSkipUntil);
+        expect(page.skipUntil).to.be.below(expectedMinSkipUntil + 5000);
+      });
+
+      it('should NOT set consecutiveFailures for non-skippable errors (e.g., 500)', async () => {
+        const auditData = {
+          siteId: 'test-site-id',
+          auditedAt: '2025-01-01T00:00:00.000Z',
+          auditResult: {
+            results: [],
+            missingPages: [{
+              url: 'https://example.com/server-error',
+              scrapingStatus: 'failed',
+              scrapeError: { statusCode: 500, message: 'Internal Server Error' },
+            }],
+          },
+        };
+
+        await uploadStatusSummaryToS3('https://example.com', auditData, context);
+
+        const uploadedData = JSON.parse(getPutCall(mockS3Client.send).args[0].input.Body);
+        const page = uploadedData.pages.find((p) => p.url === 'https://example.com/server-error');
+        expect(page).to.not.have.property('consecutiveFailures');
+        expect(page).to.not.have.property('skipUntil');
+      });
+
+      it('should set consecutiveFailures and skipUntil for 403 in currentPages results', async () => {
+        const before = Date.now();
+        const auditData = {
+          siteId: 'test-site-id',
+          auditedAt: '2025-01-01T00:00:00.000Z',
+          auditResult: {
+            results: [{
+              url: 'https://example.com/forbidden',
+              error: true,
+              needsPrerender: false,
+              scrapeError: { statusCode: 403, message: 'Forbidden' },
+            }],
+          },
+        };
+
+        await uploadStatusSummaryToS3('https://example.com', auditData, context);
+
+        const uploadedData = JSON.parse(getPutCall(mockS3Client.send).args[0].input.Body);
+        const page = uploadedData.pages.find((p) => p.url === 'https://example.com/forbidden');
+        expect(page.consecutiveFailures).to.equal(1);
+        // First failure for 403: 14-day window
+        const expectedMinSkipUntil = before + 14 * 24 * 60 * 60 * 1000;
+        expect(page.skipUntil).to.be.at.least(expectedMinSkipUntil);
+        expect(page.skipUntil).to.be.below(expectedMinSkipUntil + 5000);
+      });
+
+      it('should NOT set consecutiveFailures for non-skippable status code in currentPages results', async () => {
+        const auditData = {
+          siteId: 'test-site-id',
+          auditedAt: '2025-01-01T00:00:00.000Z',
+          auditResult: {
+            results: [{
+              url: 'https://example.com/server-error',
+              error: true,
+              needsPrerender: false,
+              scrapeError: { statusCode: 500, message: 'Internal Server Error' },
+            }],
+          },
+        };
+
+        await uploadStatusSummaryToS3('https://example.com', auditData, context);
+
+        const uploadedData = JSON.parse(getPutCall(mockS3Client.send).args[0].input.Body);
+        const page = uploadedData.pages.find((p) => p.url === 'https://example.com/server-error');
+        expect(page).to.not.have.property('consecutiveFailures');
+        expect(page).to.not.have.property('skipUntil');
+      });
+
+      it('should NOT carry over consecutiveFailures when a previously-tombstoned URL now succeeds', async () => {
+        const existingStatus = {
+          pages: [{
+            url: 'https://example.com/recovered-page',
+            scrapingStatus: 'failed',
+            consecutiveFailures: 2,
+            skipUntil: Date.now() - 1, // expired probe window
+          }],
+        };
+        mockS3Client.send.callsFake((command) => {
+          if (command.constructor.name === 'GetObjectCommand') {
+            return Promise.resolve({
+              Body: { transformToString: () => Promise.resolve(JSON.stringify(existingStatus)) },
+            });
+          }
+          return Promise.resolve({});
+        });
+
+        const auditData = {
+          siteId: 'test-site-id',
+          auditedAt: '2025-02-01T00:00:00.000Z',
+          auditResult: {
+            // URL now succeeds — no scrapeError
+            results: [{ url: 'https://example.com/recovered-page', error: false, needsPrerender: false }],
+          },
+        };
+
+        await uploadStatusSummaryToS3('https://example.com', auditData, context);
+
+        const uploadedData = JSON.parse(getPutCall(mockS3Client.send).args[0].input.Body);
+        const page = uploadedData.pages.find((p) => p.url === 'https://example.com/recovered-page');
+        expect(page.scrapingStatus).to.equal('success');
+        expect(page).to.not.have.property('consecutiveFailures');
+        expect(page).to.not.have.property('skipUntil');
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

Saves scraping bandwidth on URLs that persistently fail with permanent HTTP errors by tombstoning them with a `skipUntil` timestamp so they are excluded from future daily batches until a probe window opens.

**Problem (LLMO-4040):** A significant portion of scraping bandwidth is spent retrying URLs that will never succeed within the current cycle — 404 (page gone), 401 (auth required), 403 (bot-blocked), 406 (headers rejected), 410 (permanently removed), 444 (nginx-closed). Since each URL is audited on a natural 7-day cadence, any `skipUntil` must exceed 7 days to save at least one cycle.

**Solution:** Three co-ordinated changes:

### `constants.js`
- `SKIPPABLE_HTTP_STATUS_CODES` — set of HTTP codes that indicate permanent failures
- `SKIP_UNTIL_DAYS_BY_STATUS` — per-code probe windows (first failure / repeat):
  - 404 / 403 / 406 / 444 → 14d / 28d (recoverable; blocks can be lifted, pages restored)
  - 401 / 410 → 84d / 84d (permanent until customer action or server config change)

### `handler.js` — `uploadStatusSummaryToS3` (status.json writer)
When persisting `status.json`, computes `consecutiveFailures` (incremented per run from the prior `status.json` entry) and `skipUntil` (timestamp) for pages whose `scrapeError.statusCode` is in `SKIPPABLE_HTTP_STATUS_CODES`. Covers both `auditResult.results` (COMPLETE-status URLs with scrapeError) and `auditResult.missingPages` (FAILED-status URLs). When a URL recovers and scrapes successfully, these fields are simply absent — no explicit state reset needed.

### `handler.js` — `submitForScraping` (daily batch selector)
Loads `status.json` before slicing to `DAILY_BATCH_SIZE` (320), builds a `skipUntilMap` from entries where `skipUntil > now`, and removes those URLs from the candidate set. Intentionally **bypassed** for:
- Slack-triggered runs (`auditContext.slackContext.channelId`) — operators can manually probe tombstoned URLs
- Explicit URL runs (`auditContext.urls`) — targeted reruns bypass tombstoning

### Auto-restore mechanism
Completely implicit: when a tombstoned URL's `skipUntil` expires it re-enters the candidate pool. If the next scrape succeeds, `uploadStatusSummaryToS3` writes the result without `consecutiveFailures`/`skipUntil` — auto-restoring the URL to normal rotation.

## Related PRs
- **spacecat-content-scraper**: `feat/LLMO-4040-scrape-failure-skip-logic` — adds `error.category` field to failure `scrape.json` (prerequisite for richer error classification)

## Test plan
- [ ] `uploadStatusSummaryToS3`: first 404 failure → `consecutiveFailures=1`, `skipUntil ≈ now + 14d`
- [ ] `uploadStatusSummaryToS3`: repeat 404 failure (prior `consecutiveFailures=1`) → `consecutiveFailures=2`, `skipUntil ≈ now + 28d`
- [ ] `uploadStatusSummaryToS3`: 401 failure → `skipUntil ≈ now + 84d`
- [ ] `uploadStatusSummaryToS3`: non-skippable 500 error → no `consecutiveFailures` / `skipUntil`
- [ ] `uploadStatusSummaryToS3`: 403 in `results` (COMPLETE-status) → gets `consecutiveFailures` and `skipUntil`
- [ ] `uploadStatusSummaryToS3`: previously-tombstoned URL succeeds → fields absent (auto-restore)
- [ ] `submitForScraping`: URL with active `skipUntil` is excluded from batch; expired `skipUntil` is not
- [ ] `submitForScraping`: no `s3Client` → no status.json load, no filtering (guard path)
- [ ] `submitForScraping`: Slack-triggered → skipUntil filter bypassed, tombstoned URL included
- [ ] `submitForScraping`: null return from `getObjectFromKey` → proceeds without filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)