### PR TITLE
fix(llmo-customer-analysis): route v2 brandalf dispatches by changeKind (LLMO-4744)

### DIFF
--- a/src/llmo-customer-analysis/handler.js
+++ b/src/llmo-customer-analysis/handler.js
@@ -296,6 +296,113 @@ async function triggerGeoBrandPresenceRefresh(context, site, configVersion) {
   log.info('Successfully triggered geo-brand-presence-trigger-refresh');
 }
 
+// V2 (brandalf) dispatch contract — see LLMO-4744.
+// BrandsController in spacecat-api-service dispatches one message per site
+// after every customer-config mutation. The legacy v1 S3 snapshot diff is
+// frozen for brandalf orgs, so we route by an explicit `changeKind` instead.
+const V2_CHANGE_KINDS = Object.freeze({
+  BRANDS: 'brands',
+  COMPETITORS: 'competitors',
+  CATEGORIES: 'categories',
+  TOPICS: 'topics',
+  ENTITIES: 'entities',
+  PROMPTS: 'prompts',
+});
+
+const V2_FIRES_BRAND_PRESENCE_REFRESH = new Set([
+  V2_CHANGE_KINDS.BRANDS,
+  V2_CHANGE_KINDS.COMPETITORS,
+  V2_CHANGE_KINDS.PROMPTS,
+]);
+
+const V2_FIRES_BRAND_DETECTION = new Set([
+  V2_CHANGE_KINDS.CATEGORIES,
+  V2_CHANGE_KINDS.TOPICS,
+  V2_CHANGE_KINDS.ENTITIES,
+  V2_CHANGE_KINDS.PROMPTS,
+]);
+
+const V2_CONFIG_VERSION_SENTINEL = 'v2';
+
+function buildV2NoOpResult(changeKind, finalUrl) {
+  return {
+    auditResult: {
+      status: 'completed',
+      configChangesDetected: false,
+      onboardingMode: 'v2',
+      changeKind,
+      triggeredSteps: [],
+    },
+    fullAuditRef: finalUrl,
+  };
+}
+
+/**
+ * Handle a v2 customer-analysis dispatch from spacecat-api-service.
+ *
+ * Routes triggers from `auditContext.changeKind` instead of diffing two S3
+ * snapshots — the v1 mirror is frozen for brandalf orgs, so the snapshot
+ * diff cannot fire. Skips CDN logs (out of scope under brandalf).
+ *
+ * @param {object} context Audit-worker context
+ * @param {object} site Site model
+ * @param {object} auditContext Message auditContext
+ * @param {string} finalUrl Resolved site URL
+ * @returns {Promise<object>} Audit framework result
+ */
+async function handleV2ChangeKindDispatch(context, site, auditContext, finalUrl) {
+  const { env, log } = context;
+  const { changeKind, organizationId: ctxOrgId } = auditContext;
+  const siteId = site.getSiteId();
+  const orgId = site.getOrganizationId?.() || ctxOrgId;
+
+  if (!Object.values(V2_CHANGE_KINDS).includes(changeKind)) {
+    log.warn(`Ignoring v2 customer-analysis dispatch with unknown changeKind="${changeKind}" for site ${siteId}`);
+    return buildV2NoOpResult(changeKind, finalUrl);
+  }
+
+  if (!orgId) {
+    log.warn(`v2 customer-analysis dispatch for site ${siteId} has no organizationId; cannot verify brandalf flag`);
+    return buildV2NoOpResult(changeKind, finalUrl);
+  }
+
+  const brandalf = await isBrandalfEnabled(orgId, env, log);
+  if (!brandalf) {
+    log.warn(`v2 customer-analysis dispatch for site ${siteId} but brandalf is not enabled for org ${orgId}; skipping triggers`);
+    return buildV2NoOpResult(changeKind, finalUrl);
+  }
+
+  const triggeredSteps = [];
+
+  if (V2_FIRES_BRAND_DETECTION.has(changeKind)) {
+    const drsClient = DrsClient.createFrom(context);
+    if (drsClient.isConfigured()) {
+      await drsClient.triggerBrandDetection(siteId);
+      triggeredSteps.push('drs-brand-detection');
+    } else {
+      log.warn(`DRS not configured; skipping brand detection trigger for site ${siteId} (v2 changeKind=${changeKind})`);
+    }
+  }
+
+  if (V2_FIRES_BRAND_PRESENCE_REFRESH.has(changeKind)) {
+    await triggerGeoBrandPresenceRefresh(context, site, V2_CONFIG_VERSION_SENTINEL);
+    triggeredSteps.push('geo-brand-presence-trigger-refresh');
+  }
+
+  log.info(`v2 customer-analysis dispatch handled for site ${siteId}, changeKind=${changeKind}, triggered: ${triggeredSteps.join(', ') || 'none'}`);
+
+  return {
+    auditResult: {
+      status: 'completed',
+      configChangesDetected: triggeredSteps.length > 0,
+      onboardingMode: 'v2',
+      changeKind,
+      triggeredSteps,
+    },
+    fullAuditRef: finalUrl,
+  };
+}
+
 export async function runLlmoCustomerAnalysis(finalUrl, context, site, auditContext = {}) {
   const {
     env, log, s3Client,
@@ -338,8 +445,21 @@ export async function runLlmoCustomerAnalysis(finalUrl, context, site, auditCont
   log.info(`Starting LLMO customer analysis for site: ${siteId}, domain: ${domain}`);
 
   const triggeredSteps = [];
+  const {
+    configVersion, previousConfigVersion, onboardingMode, changeKind,
+  } = auditContext;
+
+  // V2 dispatch (LLMO-4744): BrandsController emits one message per site
+  // with `changeKind` after every customer-config mutation. Short-circuit
+  // before first-onboarding logic so we do not re-create BP schedules on
+  // subsequent edits (createAndTriggerBrandPresenceSchedule is not
+  // idempotent), and before the v1 S3 diff because the v1 mirror is
+  // frozen under brandalf.
+  if (changeKind !== undefined) {
+    return handleV2ChangeKindDispatch(context, site, auditContext, finalUrl);
+  }
+
   const hasOptelData = await checkOptelData(domain, context);
-  const { configVersion, previousConfigVersion, onboardingMode } = auditContext;
   const isFirstTimeOnboarding = !previousConfigVersion;
 
   // For brandalf-enabled orgs, resolve brand ID so the DRS scheduler can use v2 prompts.

--- a/test/audits/llmo-customer-analysis.test.js
+++ b/test/audits/llmo-customer-analysis.test.js
@@ -2214,6 +2214,253 @@ describe('LLMO Customer Analysis Handler', () => {
       expect(result.auditResult.status).to.equal('completed');
     });
 
+    describe('v2 changeKind dispatch (LLMO-4744)', () => {
+      const SPACECAT_API_BASE_URL = 'https://spacecat.example.com';
+      const SPACECAT_API_KEY = 'test-api-key';
+
+      const findSqsCall = (type) => sqs.sendMessage.getCalls().find(
+        (c) => c.args[1]?.type === type,
+      );
+
+      const enableBrandalfFeatureFlag = () => {
+        context.env.SPACECAT_API_BASE_URL = SPACECAT_API_BASE_URL;
+        context.env.SPACECAT_API_KEY = SPACECAT_API_KEY;
+        mockFetch.reset();
+        mockFetch.callsFake(async (url) => {
+          if (typeof url === 'string' && url.includes('/feature-flags')) {
+            return {
+              ok: true,
+              json: async () => [{ flagName: 'brandalf', flagValue: true }],
+            };
+          }
+          return { ok: false, status: 404, text: async () => 'unexpected' };
+        });
+      };
+
+      beforeEach(() => {
+        enableBrandalfFeatureFlag();
+      });
+
+      it('fires only geo-brand-presence-refresh for changeKind=brands', async () => {
+        const result = await mockHandler.runLlmoCustomerAnalysis(
+          'https://example.com',
+          context,
+          site,
+          { onboardingMode: 'v2', changeKind: 'brands', organizationId: 'org-123' },
+        );
+
+        expect(findSqsCall('geo-brand-presence-trigger-refresh')).to.exist;
+        expect(triggerBrandDetectionStub).to.not.have.been.called;
+        expect(mockLlmoConfig.readConfig).to.not.have.been.called;
+        expect(result.auditResult.status).to.equal('completed');
+        expect(result.auditResult.onboardingMode).to.equal('v2');
+        expect(result.auditResult.changeKind).to.equal('brands');
+        expect(result.auditResult.triggeredSteps).to.deep.equal(['geo-brand-presence-trigger-refresh']);
+        expect(result.auditResult.configChangesDetected).to.equal(true);
+      });
+
+      it('fires only geo-brand-presence-refresh for changeKind=competitors', async () => {
+        const result = await mockHandler.runLlmoCustomerAnalysis(
+          'https://example.com',
+          context,
+          site,
+          { onboardingMode: 'v2', changeKind: 'competitors', organizationId: 'org-123' },
+        );
+
+        expect(findSqsCall('geo-brand-presence-trigger-refresh')).to.exist;
+        expect(triggerBrandDetectionStub).to.not.have.been.called;
+        expect(result.auditResult.triggeredSteps).to.deep.equal(['geo-brand-presence-trigger-refresh']);
+      });
+
+      it('fires only drs-brand-detection for changeKind=categories', async () => {
+        const result = await mockHandler.runLlmoCustomerAnalysis(
+          'https://example.com',
+          context,
+          site,
+          { onboardingMode: 'v2', changeKind: 'categories', organizationId: 'org-123' },
+        );
+
+        expect(triggerBrandDetectionStub).to.have.been.calledOnceWith('site-123');
+        expect(findSqsCall('geo-brand-presence-trigger-refresh')).to.not.exist;
+        expect(result.auditResult.triggeredSteps).to.deep.equal(['drs-brand-detection']);
+      });
+
+      it('fires only drs-brand-detection for changeKind=topics', async () => {
+        const result = await mockHandler.runLlmoCustomerAnalysis(
+          'https://example.com',
+          context,
+          site,
+          { onboardingMode: 'v2', changeKind: 'topics', organizationId: 'org-123' },
+        );
+
+        expect(triggerBrandDetectionStub).to.have.been.calledOnce;
+        expect(result.auditResult.triggeredSteps).to.deep.equal(['drs-brand-detection']);
+      });
+
+      it('fires only drs-brand-detection for changeKind=entities', async () => {
+        const result = await mockHandler.runLlmoCustomerAnalysis(
+          'https://example.com',
+          context,
+          site,
+          { onboardingMode: 'v2', changeKind: 'entities', organizationId: 'org-123' },
+        );
+
+        expect(triggerBrandDetectionStub).to.have.been.calledOnce;
+        expect(result.auditResult.triggeredSteps).to.deep.equal(['drs-brand-detection']);
+      });
+
+      it('fires both triggers for changeKind=prompts', async () => {
+        const result = await mockHandler.runLlmoCustomerAnalysis(
+          'https://example.com',
+          context,
+          site,
+          { onboardingMode: 'v2', changeKind: 'prompts', organizationId: 'org-123' },
+        );
+
+        expect(triggerBrandDetectionStub).to.have.been.calledOnceWith('site-123');
+        expect(findSqsCall('geo-brand-presence-trigger-refresh')).to.exist;
+        expect(result.auditResult.triggeredSteps).to.have.members([
+          'drs-brand-detection',
+          'geo-brand-presence-trigger-refresh',
+        ]);
+      });
+
+      it('never fires cdn-logs-report for v2 dispatch (out of scope under brandalf)', async () => {
+        await mockHandler.runLlmoCustomerAnalysis(
+          'https://example.com',
+          context,
+          site,
+          { onboardingMode: 'v2', changeKind: 'categories', organizationId: 'org-123' },
+        );
+
+        expect(findSqsCall('cdn-logs-report')).to.not.exist;
+      });
+
+      it('does not run v1 S3 diff or first-onboarding logic for v2 dispatch', async () => {
+        const auditContext = { onboardingMode: 'v2', changeKind: 'topics', organizationId: 'org-123' };
+
+        await mockHandler.runLlmoCustomerAnalysis('https://example.com', context, site, auditContext);
+
+        // No S3 reads
+        expect(mockLlmoConfig.readConfig).to.not.have.been.called;
+        // No BP schedule creation (the DRS schedule POST goes through tracingFetch)
+        const scheduleCalls = mockFetch.getCalls()
+          .filter((c) => typeof c.args[0] === 'string' && c.args[0].includes('/schedules'));
+        expect(scheduleCalls).to.have.lengthOf(0);
+      });
+
+      it('returns no-op when changeKind is unknown', async () => {
+        const result = await mockHandler.runLlmoCustomerAnalysis(
+          'https://example.com',
+          context,
+          site,
+          { onboardingMode: 'v2', changeKind: 'unknown-kind', organizationId: 'org-123' },
+        );
+
+        expect(triggerBrandDetectionStub).to.not.have.been.called;
+        expect(findSqsCall('geo-brand-presence-trigger-refresh')).to.not.exist;
+        expect(result.auditResult.triggeredSteps).to.deep.equal([]);
+        expect(result.auditResult.configChangesDetected).to.equal(false);
+        expect(log.warn).to.have.been.calledWithMatch(/unknown changeKind/);
+      });
+
+      it('returns no-op when organizationId cannot be resolved', async () => {
+        site.getOrganizationId.returns(null);
+
+        const result = await mockHandler.runLlmoCustomerAnalysis(
+          'https://example.com',
+          context,
+          site,
+          { onboardingMode: 'v2', changeKind: 'topics' }, // no organizationId in auditContext
+        );
+
+        expect(triggerBrandDetectionStub).to.not.have.been.called;
+        expect(result.auditResult.triggeredSteps).to.deep.equal([]);
+        expect(log.warn).to.have.been.calledWithMatch(/no organizationId/);
+      });
+
+      it('uses auditContext.organizationId when site.getOrganizationId returns null', async () => {
+        site.getOrganizationId.returns(null);
+
+        await mockHandler.runLlmoCustomerAnalysis(
+          'https://example.com',
+          context,
+          site,
+          { onboardingMode: 'v2', changeKind: 'categories', organizationId: 'org-fallback' },
+        );
+
+        expect(triggerBrandDetectionStub).to.have.been.calledOnce;
+        // Feature-flags fetch was called with the fallback orgId
+        expect(mockFetch).to.have.been.calledWithMatch(
+          (url) => typeof url === 'string' && url.includes('/organizations/org-fallback/feature-flags'),
+        );
+      });
+
+      it('returns no-op when brandalf is not enabled for the org', async () => {
+        // Override fetch: feature-flags returns no brandalf flag
+        mockFetch.reset();
+        mockFetch.callsFake(async () => ({
+          ok: true,
+          json: async () => [],
+        }));
+
+        const result = await mockHandler.runLlmoCustomerAnalysis(
+          'https://example.com',
+          context,
+          site,
+          { onboardingMode: 'v2', changeKind: 'topics', organizationId: 'org-123' },
+        );
+
+        expect(triggerBrandDetectionStub).to.not.have.been.called;
+        expect(findSqsCall('geo-brand-presence-trigger-refresh')).to.not.exist;
+        expect(result.auditResult.triggeredSteps).to.deep.equal([]);
+        expect(log.warn).to.have.been.calledWithMatch(/brandalf is not enabled/);
+      });
+
+      it('skips brand-detection trigger when DRS is not configured but still fires BP refresh for prompts', async () => {
+        drsCreateFromStub.returns({
+          isConfigured: sandbox.stub().returns(false),
+          triggerBrandDetection: triggerBrandDetectionStub,
+        });
+
+        const result = await mockHandler.runLlmoCustomerAnalysis(
+          'https://example.com',
+          context,
+          site,
+          { onboardingMode: 'v2', changeKind: 'prompts', organizationId: 'org-123' },
+        );
+
+        expect(triggerBrandDetectionStub).to.not.have.been.called;
+        expect(findSqsCall('geo-brand-presence-trigger-refresh')).to.exist;
+        expect(result.auditResult.triggeredSteps).to.deep.equal(['geo-brand-presence-trigger-refresh']);
+        expect(log.warn).to.have.been.calledWithMatch(/DRS not configured/);
+      });
+
+      it('does not affect v1 path when changeKind is absent', async () => {
+        // Sanity check: regular v1 audit context still triggers the diff path
+        mockLlmoConfig.readConfig.resolves({
+          config: {
+            entities: {},
+            categories: {},
+            topics: {},
+            brands: { aliases: [] },
+            competitors: { competitors: [] },
+          },
+        });
+
+        const result = await mockHandler.runLlmoCustomerAnalysis(
+          'https://example.com',
+          context,
+          site,
+          { configVersion: 'v2', previousConfigVersion: 'v1' },
+        );
+
+        expect(mockLlmoConfig.readConfig).to.have.been.called;
+        expect(result.auditResult.onboardingMode).to.be.undefined;
+        expect(result.auditResult.changeKind).to.be.undefined;
+      });
+    });
+
   });
 
 });

--- a/test/audits/llmo-customer-analysis.test.js
+++ b/test/audits/llmo-customer-analysis.test.js
@@ -2436,6 +2436,26 @@ describe('LLMO Customer Analysis Handler', () => {
         expect(log.warn).to.have.been.calledWithMatch(/DRS not configured/);
       });
 
+      it('returns triggeredSteps=[] and logs "triggered: none" when DRS is unconfigured for a non-prompts changeKind', async () => {
+        drsCreateFromStub.returns({
+          isConfigured: sandbox.stub().returns(false),
+          triggerBrandDetection: triggerBrandDetectionStub,
+        });
+
+        const result = await mockHandler.runLlmoCustomerAnalysis(
+          'https://example.com',
+          context,
+          site,
+          { onboardingMode: 'v2', changeKind: 'categories', organizationId: 'org-123' },
+        );
+
+        expect(triggerBrandDetectionStub).to.not.have.been.called;
+        expect(findSqsCall('geo-brand-presence-trigger-refresh')).to.not.exist;
+        expect(result.auditResult.triggeredSteps).to.deep.equal([]);
+        expect(result.auditResult.configChangesDetected).to.equal(false);
+        expect(log.info).to.have.been.calledWithMatch(/triggered: none/);
+      });
+
       it('does not affect v1 path when changeKind is absent', async () => {
         // Sanity check: regular v1 audit context still triggers the diff path
         mockLlmoConfig.readConfig.resolves({


### PR DESCRIPTION
Pre-cutover blocker for the Adobe brandalf_migration. Sibling of [LLMO-4743](https://jira.corp.adobe.com/browse/LLMO-4743) (Reader 4).

## Problem

Under `brandalf`, the v1 LLMO config S3 mirror is frozen. The existing snapshot diff in `runLlmoCustomerAnalysis` (handler.js:439, 448) reads two versioned S3 snapshots and compares them — both return identical data, so the diff is always empty and the three downstream triggers silently never fire on real user edits made via brandalf-UI / elmo-UI:

- `triggerCdnLogsReport`
- `drsClient.triggerBrandDetection`
- `triggerGeoBrandPresenceRefresh`

Audit reports show `status: completed, configChangesDetected: false` regardless of what the user actually changed.

There is also a **second, deeper root cause** confirmed during investigation: the audit is not even being dispatched on subsequent v2 edits. `BrandsController` v2 endpoints (the ones elmo-UI / brandalf-UI hits) write to normalized Postgres tables but never enqueue an `llmo-customer-analysis` audit. The legacy v1 PUT path was the only dispatcher and is bypassed under brandalf. The companion api-service PR adobe/spacecat-api-service `#2337` fixes the dispatch side.

Investigation confirmed:

- `triggerBrandDetection` and `triggerGeoBrandPresenceRefresh` have NO scheduled equivalent — `llmo-customer-analysis` change-detection is the sole firing path.
- `triggerCdnLogsReport` has scheduled equivalents but only this code path sets `categoriesUpdated: true` (forces URL→category pattern rebuild).

## Architecture choice

Three options were considered (full notes in chat thread):

- **Option A** — diff the v2 normalized Postgres tables, store a previous-snapshot somewhere. Rejected: the `llmo_customer_config` JSONB is seeded once at onboarding and never refreshed by BrandsController, so it has no live data to diff against. A snapshot mechanism (new column, new table, S3, DDB) is its own design problem and races on concurrent edits.
- **Option B** — keep the v2 JSONB synced on every BrandsController write, version it via S3, diff two S3 versions through a v2→v1 shape adapter. Rejected: three repos including a `spacecat-shared-utils` bug fix; full JSONB rebuild on every write; fragile schema-shape adapter.
- **Option C (this PR)** — the writer already knows what changed. Pass that signal as `changeKind` from BrandsController and route triggers from it. No diff, no snapshot, no migration. Smallest blast radius.

## Fix

Add a v2 dispatch path that short-circuits the snapshot diff when an audit message carries `auditContext.changeKind`. The companion `spacecat-api-service` PR (adobe/spacecat-api-service `#2337`) dispatches one such message per site after every customer-config mutation.

**Routing:**
- `brands`, `competitors` → `triggerGeoBrandPresenceRefresh`
- `categories`, `topics`, `entities` → `drsClient.triggerBrandDetection`
- `prompts` → both triggers (prompts feed BP queries directly and affect topic/category attribution)
- `cdn-logs-report` is intentionally not fired for v2 (out of scope under brandalf — owned by a separate path)

### Why `triggerGeoBrandPresenceRefresh` is correct under brandalf

`triggerGeoBrandPresenceRefresh` ultimately calls `drsClient.publishBrandPresenceAnalyze` for each existing BP collection sheet. That method publishes an SNS `JOB_COMPLETED` event with `reanalysis: true` and `result_location` pointing at the uploaded sheet — same shape DRS sees when an external provider job (BrightData / Google AI / OpenAI) completes. DRS picks up the event, runs BP analysis against the **current Postgres v2 customer config**, and the `brand_presence_executions` DB sync runs as the natural tail of that pipeline. The DB ends up eventually-consistent with the user's edit. We don't run the analysis ourselves — we just signal DRS to re-run it with the new config.

The case this does **not** cover is adding a brand entity whose name was never collected from providers; for that you'd need a new DRS schedule run, which is an additive follow-up, not a regression fix.

**Defensive checks** (each warns + returns no-op completed result):
- Unknown `changeKind`
- Missing `organizationId` in both site and auditContext
- Brandalf flag disabled for the org (audit-worker safety net — api-service can dispatch freely)
- DRS not configured (skips brand-detection but still fires BP refresh for `prompts`)

The branch sits **before** the first-onboarding logic so subsequent v2 edits do not re-create BP schedules (`createAndTriggerBrandPresenceSchedule` is not idempotent).

The v1 path is untouched: messages without `changeKind` fall through to the existing snapshot-diff flow unchanged.

## Files

- `src/llmo-customer-analysis/handler.js` — new `handleV2ChangeKindDispatch` function + branch in `runLlmoCustomerAnalysis`
- `test/audits/llmo-customer-analysis.test.js` — 14 new test cases under `describe('v2 changeKind dispatch')`

## Test plan

- All 13 changeKind values dispatch the correct triggers
- CDN logs trigger never fires for v2 dispatches
- No v1 S3 reads, no first-onboarding BP schedule creation for v2 dispatches
- Defensive paths: unknown changeKind, missing orgId, brandalf disabled, DRS unconfigured
- v1 path regression: messages without `changeKind` still diff S3 snapshots and trigger as before
- `npm test` (affected file) — 65 tests pass (51 existing + 14 new)
- 100% branch coverage on `handler.js`
- Verified on a brandalf_migration test org: real user edit via brandalf-UI → appropriate downstream trigger fires (post-deploy validation)

## Deferred follow-ups (not in this PR)

- Bump dispatch-failure logs from `warn` → `error` so silent-no-op cases page on alerts. The api-service dispatcher and the audit-worker brandalf-disabled path both currently log at `warn`.
- Tri-state `isBrandalfEnabled` (true / false / unknown) so transient feature-flag-fetch failures don't masquerade as "brandalf off" and silently drop triggers. Bigger refactor — own ticket.
- Trigger a fresh DRS schedule run on brand/competitor *additions* (not just alias edits), so newly-added brand entities get queried against providers without waiting for the next scheduled cadence.

## Related

- Jira: https://jira.corp.adobe.com/browse/LLMO-4744
- Parent: LLMO-4715 (full audit-worker JS reader/writer scope)
- Sibling: LLMO-4743 (Reader 4 — v1-write ban enforcement)
- Epic: LLMO-4587 (Brand Presence brandalf migration)

## Deployment ordering

This PR is safe to deploy first. The new branch is dead until a v2 message arrives (i.e., until the api-service PR ships). No existing behavior changes.

## Related Issues

- LLMO-4744