### PR TITLE
fix(semantic-value-visibility): use CODE_CHANGE as suggestion type

### DIFF
--- a/src/semantic-value-visibility/guidance-handler.js
+++ b/src/semantic-value-visibility/guidance-handler.js
@@ -107,7 +107,7 @@ export default async function handler(message, context) {
     buildKey: (suggestionData) => suggestionData.imageUrl,
     mapNewSuggestion: (suggestionData) => ({
       opportunityId: opportunity.getId(),
-      type: 'SUGGESTION_CODE',
+      type: 'CODE_CHANGE',
       rank: 0,
       data: suggestionData,
     }),

--- a/test/audits/semantic-value-visibility/guidance-handler.test.js
+++ b/test/audits/semantic-value-visibility/guidance-handler.test.js
@@ -184,7 +184,7 @@ describe('Semantic Value Visibility Guidance Handler', () => {
       const mappedSuggestion = syncArgs.mapNewSuggestion(testData);
 
       expect(mappedSuggestion.opportunityId).to.equal('oppty-123');
-      expect(mappedSuggestion.type).to.equal('SUGGESTION_CODE');
+      expect(mappedSuggestion.type).to.equal('CODE_CHANGE');
       expect(mappedSuggestion.rank).to.equal(0);
       expect(mappedSuggestion.data).to.deep.equal(testData);
     });


### PR DESCRIPTION
## Summary

Fixes `ValidationError2: type is invalid` on PROD: the guidance handler set `type: 'SUGGESTION_CODE'`, which is not in the suggestion type enum. As a result, opportunities are created but all Mystique-returned suggestions fail to persist.

Discovered during a prod debugging session with Daniel.

## Fix

Replace `'SUGGESTION_CODE'` with `'CODE_CHANGE'` — matches the pattern used by other Tokowaka HTML-injection handlers:
- `src/summarization/guidance-handler.js:52`
- `src/toc/handler.js:454`
- `src/headings/handler.js:545`
- `src/hreflang/handler.js:293`
- `src/canonical/handler.js:675`
- `src/csp/csp.js:196`
- `src/structured-data/handler.js:133`

Image-enrichment generates `<section data-llm-shadow>...` HTML, same shape as those handlers. `CONTENT_UPDATE` (used by `faqs`, `wikipedia-analysis`) is for text/copy rewrites and does not fit HTML injection.

## Files changed
- `src/semantic-value-visibility/guidance-handler.js:110`
- `test/audits/semantic-value-visibility/guidance-handler.test.js:187`

## Test plan
- [x] `npx mocha test/audits/semantic-value-visibility/guidance-handler.test.js` passes (11 tests)
- [ ] Verified on PROD after merge: suggestions persist with `type: 'CODE_CHANGE'`

## Related
- Rename PR #2447 (image-enrichment) — will absorb this fix via "Update branch" once this lands; git's rename detection moves the change into `src/image-enrichment/guidance-handler.js`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)