### PR TITLE
fix(semantic-value-visibility): set tags on opportunity update in convertToOpportunity

### DIFF
--- a/src/common/opportunity.js
+++ b/src/common/opportunity.js
@@ -103,6 +103,9 @@ export async function convertToOpportunity(auditUrl, auditData, context, createO
           dataSources: opportunityInstance.data?.dataSources,
         });
       }
+      if (opportunityInstance.tags?.length) {
+        opportunity.setTags(opportunityInstance.tags);
+      }
       opportunity.setUpdatedBy('system');
       await opportunity.save();
       return opportunity;

--- a/test/audits/backlinks.test.js
+++ b/test/audits/backlinks.test.js
@@ -137,6 +137,7 @@ describe('Backlinks Tests', function () {
       getType: () => 'broken-backlinks',
       setData: () => { },
       getData: () => { },
+      setTags: sinon.stub(),
       setUpdatedBy: sinon.stub().returnsThis(),
       setLastAuditedAt: sinon.stub(),
     };
@@ -995,6 +996,7 @@ describe('Backlinks Tests', function () {
         getType: () => 'broken-backlinks',
         setData: () => {},
         getData: () => {},
+        setTags: sinon.stub(),
         setUpdatedBy: sinon.stub().returnsThis(),
         setLastAuditedAt: sinon.stub(),
       };
@@ -1071,6 +1073,7 @@ describe('Backlinks Tests', function () {
         getType: () => 'broken-backlinks',
         setData: () => {},
         getData: () => {},
+        setTags: sinon.stub(),
         setUpdatedBy: sinon.stub().returnsThis(),
         setLastAuditedAt: sinon.stub(),
       };
@@ -1159,6 +1162,7 @@ describe('Backlinks Tests', function () {
         getType: () => 'broken-backlinks',
         setData: () => {},
         getData: () => {},
+        setTags: sinon.stub(),
         setUpdatedBy: sinon.stub().returnsThis(),
         setLastAuditedAt: sinon.stub(),
       };

--- a/test/audits/canonical.test.js
+++ b/test/audits/canonical.test.js
@@ -1883,6 +1883,7 @@ describe('Canonical URL Tests', () => {
         }),
         setData: sinon.stub(),
         setStatus: sinon.stub(),
+        setTags: sinon.stub(),
         setUpdatedBy: sinon.stub(),
         setAuditId: sinon.stub(),
       };
@@ -1947,6 +1948,7 @@ describe('Canonical URL Tests', () => {
         getStatus: sinon.stub().returns('NEW'),
         setData: sinon.stub(),
         setAuditId: sinon.stub(),
+        setTags: sinon.stub(),
         setUpdatedBy: sinon.stub(),
         save: sinon.stub().resolves(),
         getSuggestions: sinon.stub().resolves([]),
@@ -3063,6 +3065,7 @@ describe('Canonical URL Tests', () => {
           getStatus: sinon.stub().returns('NEW'),
           setData: sinon.stub(),
           setAuditId: sinon.stub(),
+          setTags: sinon.stub(),
           setUpdatedBy: sinon.stub(),
           save: sinon.stub().resolves(),
           getSuggestions: sinon.stub().resolves([]),

--- a/test/audits/cwv.test.js
+++ b/test/audits/cwv.test.js
@@ -379,6 +379,7 @@ describe('collectCWVDataAndImportCode Tests', () => {
         getData: sandbox.stub().returns(opptyData),
         setData: sandbox.stub(),
         save: sandbox.stub().resolves(),
+        setTags: sinon.stub(),
         setUpdatedBy: sandbox.stub().returnsThis(),
         setLastAuditedAt: sandbox.stub(),
         siteId: 'site-id',
@@ -505,6 +506,7 @@ describe('collectCWVDataAndImportCode Tests', () => {
         getData: () => (suggestion.data),
         setData: sinon.stub(),
         getStatus: sinon.stub().returns('NEW'),
+        setTags: sinon.stub(),
         setUpdatedBy: sinon.stub().returnsThis(),
       }));
       oppty.getSuggestions.resolves(existingSuggestions);

--- a/test/audits/headings.test.js
+++ b/test/audits/headings.test.js
@@ -3273,6 +3273,7 @@ describe('Headings Audit', () => {
                 }),
                 setAuditId: sinon.stub(),
                 setData: sinon.stub(),
+                setTags: sinon.stub(),
                 setUpdatedBy: sinon.stub(),
                 save: sinon.stub().resolves(),
                 getId: () => 'test-existing-opportunity-id'

--- a/test/audits/hreflang.test.js
+++ b/test/audits/hreflang.test.js
@@ -773,6 +773,7 @@ describe('Hreflang Audit', () => {
         getData: sinon.stub().returns({}),
         setData: sinon.stub(),
         setStatus: sinon.stub(),
+        setTags: sinon.stub(),
         setUpdatedBy: sinon.stub(),
       };
 
@@ -875,6 +876,7 @@ describe('Hreflang Audit', () => {
         }),
         setData: sinon.stub(),
         setStatus: sinon.stub(),
+        setTags: sinon.stub(),
         setUpdatedBy: sinon.stub(),
         setAuditId: sinon.stub(),
       };
@@ -939,6 +941,7 @@ describe('Hreflang Audit', () => {
         getStatus: sinon.stub().returns('NEW'),
         setData: sinon.stub(),
         setAuditId: sinon.stub(),
+        setTags: sinon.stub(),
         setUpdatedBy: sinon.stub(),
         save: sinon.stub().resolves(),
         getSuggestions: sinon.stub().resolves([]),

--- a/test/audits/internal-links/handler.test.js
+++ b/test/audits/internal-links/handler.test.js
@@ -1138,6 +1138,7 @@ describe('broken-internal-links audit opportunity and suggestions', () => {
       save: sandbox.stub().resolves(),
       setData: () => { },
       getData: () => { },
+      setTags: sinon.stub(),
       setUpdatedBy: sandbox.stub().returnsThis(),
     };
 
@@ -1518,6 +1519,7 @@ describe('broken-internal-links audit opportunity and suggestions', () => {
       save: sandbox.spy(sandbox.stub().resolves()),
       getType: () => 'broken-internal-links',
       getSuggestions: sandbox.stub().resolves(mockSuggestions),
+      setTags: sinon.stub(),
       setUpdatedBy: sandbox.stub().returnsThis(),
     };
 
@@ -1633,6 +1635,7 @@ describe('broken-internal-links audit opportunity and suggestions', () => {
       getData: () => suggestion.data,
       setData: sinon.stub(),
       getStatus: sinon.stub().returns('NEW'),
+      setTags: sinon.stub(),
       setUpdatedBy: sinon.stub().returnsThis(),
     }));
     opportunity.getSuggestions.resolves(existingSuggestions);

--- a/test/audits/product-metatags.test.js
+++ b/test/audits/product-metatags.test.js
@@ -568,6 +568,7 @@ describe('Product MetaTags', () => {
         finalUrl: 'http://example.com',
         audit,
         opportunity: {
+          setTags: sinon.stub(),
           setUpdatedBy: sinon.stub(),
         },
       };
@@ -1402,6 +1403,7 @@ describe('Product MetaTags', () => {
           getType: () => 'product-metatags',
           setData: () => {},
           getData: () => {},
+          setTags: sinon.stub(),
           setUpdatedBy: sinon.stub().returnsThis(),
         };
         logStub = {
@@ -1552,6 +1554,7 @@ describe('Product MetaTags', () => {
           remove: sinon.stub(),
           setData: sinon.stub(),
           save: sinon.stub(),
+          setTags: sinon.stub(),
           setUpdatedBy: sinon.stub().returnsThis(),
         };
 
@@ -4859,6 +4862,7 @@ describe('Product MetaTags', () => {
         getType: () => 'product-metatags',
         setData: () => {},
         getData: () => {},
+        setTags: sinon.stub(),
         setUpdatedBy: sinon.stub().returnsThis(),
       };
       dataAccessStub = {
@@ -5100,6 +5104,7 @@ describe('Product MetaTags', () => {
             getType: () => 'product-metatags',
             setData: () => {},
             getData: () => {},
+            setTags: sinon.stub(),
             setUpdatedBy: sinon.stub().returnsThis(),
           }),
         },

--- a/test/audits/structured-data/structured-data.test.js
+++ b/test/audits/structured-data/structured-data.test.js
@@ -340,6 +340,7 @@ describe('Structured Data Audit', () => {
         getType: () => 'structured-data',
         getData: () => ({ dataSources: ['SEO', 'Site'] }),
         setData: () => {},
+        setTags: sinon.stub(),
         setUpdatedBy: () => {},
         save: () => {},
         getId: () => 'opportunity-id-12345',

--- a/test/common/opportunity.test.js
+++ b/test/common/opportunity.test.js
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import esmock from 'esmock';
+
+use(sinonChai);
+
+describe('convertToOpportunity', () => {
+  let convertToOpportunity;
+  let Opportunity;
+  let checkGoogleConnectionStub;
+  let context;
+  let auditData;
+  let createOpportunityData;
+
+  const auditUrl = 'https://example.com/page';
+  const auditType = 'semantic-value-visibility';
+  const opportunityInstance = {
+    runbook: '',
+    origin: 'AUTOMATION',
+    title: 'Test title',
+    description: 'Test description',
+    guidance: {},
+    tags: ['isElmo', 'semantic-value-visibility'],
+    data: { dataSources: ['site'] },
+  };
+
+  beforeEach(async () => {
+    checkGoogleConnectionStub = sinon.stub().resolves(true);
+
+    Opportunity = {
+      allBySiteIdAndStatus: sinon.stub(),
+      create: sinon.stub(),
+    };
+
+    context = {
+      log: { error: sinon.stub(), info: sinon.stub() },
+      dataAccess: { Opportunity },
+    };
+
+    auditData = { siteId: 'site-123', id: 'audit-456' };
+    createOpportunityData = sinon.stub().returns(opportunityInstance);
+
+    ({ convertToOpportunity } = await esmock(
+      '../../src/common/opportunity.js',
+      {
+        '../../src/common/opportunity-utils.js': {
+          checkGoogleConnection: checkGoogleConnectionStub,
+        },
+      },
+    ));
+  });
+
+  afterEach(() => sinon.restore());
+
+  describe('CREATE path — no existing opportunity', () => {
+    beforeEach(() => {
+      Opportunity.allBySiteIdAndStatus.resolves([]);
+      Opportunity.create.resolves({ getId: () => 'new-oppty-1' });
+    });
+
+    it('creates opportunity with tags', async () => {
+      await convertToOpportunity(auditUrl, auditData, context, createOpportunityData, auditType);
+
+      expect(Opportunity.create).to.have.been.calledOnce;
+      const created = Opportunity.create.firstCall.args[0];
+      expect(created.tags).to.deep.equal(['isElmo', 'semantic-value-visibility']);
+    });
+  });
+
+  describe('UPDATE path — existing opportunity found', () => {
+    let existingOpportunity;
+
+    beforeEach(() => {
+      existingOpportunity = {
+        getType: sinon.stub().returns(auditType),
+        getData: sinon.stub().returns({ dataSources: ['site'] }),
+        setAuditId: sinon.stub(),
+        setData: sinon.stub(),
+        setTags: sinon.stub(),
+        setUpdatedBy: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+      Opportunity.allBySiteIdAndStatus.resolves([existingOpportunity]);
+    });
+
+    it('calls setTags with tags from the opportunity mapper', async () => {
+      await convertToOpportunity(auditUrl, auditData, context, createOpportunityData, auditType);
+
+      expect(existingOpportunity.setTags).to.have.been.calledOnceWith(['isElmo', 'semantic-value-visibility']);
+    });
+
+    it('saves after setting tags', async () => {
+      await convertToOpportunity(auditUrl, auditData, context, createOpportunityData, auditType);
+
+      expect(existingOpportunity.setTags).to.have.been.calledBefore(existingOpportunity.save);
+    });
+
+    it('does not call setTags when mapper returns no tags', async () => {
+      createOpportunityData.returns({ ...opportunityInstance, tags: [] });
+
+      await convertToOpportunity(auditUrl, auditData, context, createOpportunityData, auditType);
+
+      expect(existingOpportunity.setTags).not.to.have.been.called;
+    });
+
+    it('does not call setTags when mapper returns undefined tags', async () => {
+      createOpportunityData.returns({ ...opportunityInstance, tags: undefined });
+
+      await convertToOpportunity(auditUrl, auditData, context, createOpportunityData, auditType);
+
+      expect(existingOpportunity.setTags).not.to.have.been.called;
+    });
+  });
+});

--- a/test/shared.js
+++ b/test/shared.js
@@ -68,6 +68,7 @@ export class MockContextBuilder {
         save: this.sandbox.stub(),
         setData: this.sandbox.stub(),
         getData: this.sandbox.stub(),
+        setTags: this.sandbox.stub(),
         setUpdatedBy: this.sandbox.stub(),
       },
       Suggestion: {


### PR DESCRIPTION
## Summary
- In `convertToOpportunity`, tags from the opportunity data mapper were only applied on **CREATE**, not on **UPDATE**
- When an opportunity already existed (re-triggered audit), the update path skipped `setTags()` — so `isElmo` was never set on existing opportunities
- This caused semantic-value-visibility opportunities to be invisible in the LLMO UI (which filters by `isElmo` tag via `isValidElmoOpportunity()`)

## Fix
Add `opportunity.setTags(opportunityInstance.tags)` in the update branch before `save()`, guarded by a length check to avoid clearing tags unnecessarily.

The `isElmo` tag is already correctly defined in `src/semantic-value-visibility/opportunity-data-mapper.js` — this fix ensures it's applied on every run, not just the first one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)