### PR TITLE
fix: cap cdn-config-handler SQS delays at 900s

### DIFF
--- a/src/llmo-customer-analysis/cdn-config-handler.js
+++ b/src/llmo-customer-analysis/cdn-config-handler.js
@@ -16,8 +16,12 @@ import {
 import { getImsOrgId } from '../utils/data-access.js';
 import { SERVICE_PROVIDER_TYPES } from '../utils/cdn-utils.js';
 
+const SQS_MAX_DELAY_SECONDS = 900;
 const CDN_LOGS_ANALYSIS_DELAY_SECONDS = 5;
-const CDN_LOGS_REPORT_DELAY_SECONDS = 900;
+// Base wait so cdn-logs-report fires after cdn-logs-analysis has had time to
+// complete. Kept under SQS_MAX_DELAY_SECONDS so per-day staggering can still
+// add headroom without exceeding the SQS DelaySeconds hard limit.
+const CDN_LOGS_REPORT_DELAY_SECONDS = 800;
 
 function getAdobeFastlyBackfillDays(referenceDate = new Date()) {
   const lastMonday = startOfWeek(subWeeks(referenceDate, 1), { weekStartsOn: 1 });
@@ -121,7 +125,10 @@ async function handleAdobeFastly(
           hour: 8,
           processFullDay: true,
         },
-      }, null, index * CDN_LOGS_ANALYSIS_DELAY_SECONDS));
+      }, null, Math.min(
+        index * CDN_LOGS_ANALYSIS_DELAY_SECONDS,
+        SQS_MAX_DELAY_SECONDS,
+      )));
     }
 
     await Promise.all(analysisPromises);
@@ -141,7 +148,10 @@ async function handleAdobeFastly(
       date: backfillDay.reportDate,
       refreshAgenticDailyExport: true,
     },
-  }, null, CDN_LOGS_REPORT_DELAY_SECONDS + (index * CDN_LOGS_ANALYSIS_DELAY_SECONDS)));
+  }, null, Math.min(
+    CDN_LOGS_REPORT_DELAY_SECONDS + (index * CDN_LOGS_ANALYSIS_DELAY_SECONDS),
+    SQS_MAX_DELAY_SECONDS,
+  )));
 
   await Promise.all(reportPromises);
 }

--- a/test/audits/llmo-customer-analysis-cdn-config.test.js
+++ b/test/audits/llmo-customer-analysis-cdn-config.test.js
@@ -413,7 +413,7 @@ describe('CDN Config Handler', () => {
       expect(cdnLogsAnalysisCalls.length).to.be.greaterThan(0);
       expect(weeklyReportCalls).to.have.length(1);
       expect(weeklyReportCalls[0].args[1].auditContext).to.deep.equal({ weekOffset: -1 });
-      expect(weeklyReportCalls[0].args[3]).to.equal(900);
+      expect(weeklyReportCalls[0].args[3]).to.equal(800);
       expect(dailyReportCalls).to.have.length(cdnLogsAnalysisCalls.length);
 
       dailyReportCalls.forEach((call, index) => {
@@ -421,7 +421,9 @@ describe('CDN Config Handler', () => {
           date: getExpectedReportDate(cdnLogsAnalysisCalls[index]),
           refreshAgenticDailyExport: true,
         });
-        expect(call.args[3]).to.equal(900 + (index * 5));
+        // Daily report delay is base (800s) + per-day staggering, capped at
+        // the SQS 900s hard limit so total stays valid even for long backfills.
+        expect(call.args[3]).to.equal(Math.min(800 + (index * 5), 900));
       });
     });
 
@@ -550,7 +552,30 @@ describe('CDN Config Handler', () => {
           date: getExpectedReportDate(cdnLogsAnalysisCalls[index]),
           refreshAgenticDailyExport: true,
         });
-        expect(call.args[3]).to.equal(900 + (index * 5));
+        // Daily report delay is base (800s) + per-day staggering, capped at
+        // the SQS 900s hard limit so total stays valid even for long backfills.
+        expect(call.args[3]).to.equal(Math.min(800 + (index * 5), 900));
+      });
+
+      clock.restore();
+    });
+
+    it('caps every queued message delay at the SQS 900s hard limit', async () => {
+      const clock = sandbox.useFakeTimers(new Date('2025-01-10T12:00:00Z'));
+      context.dataAccess.LatestAudit.findBySiteIdAndAuditType.resolves({
+        getAuditResult: () => ({}),
+        getFullAuditRef: () => '',
+      });
+
+      await cdnConfigHandler.handleCdnBucketConfigChanges(
+        context,
+        { cdnProvider: 'aem-cs-fastly' },
+      );
+
+      const allDelays = context.sqs.sendMessage.getCalls().map((c) => c.args[3]);
+      expect(allDelays.length).to.be.greaterThan(0);
+      allDelays.forEach((delay) => {
+        expect(delay).to.be.at.most(900);
       });
 
       clock.restore();
@@ -577,7 +602,9 @@ describe('CDN Config Handler', () => {
       expect(dailyReportCalls.length).to.be.greaterThan(0);
       dailyReportCalls.forEach((call, index) => {
         expect(call.args[1].auditContext.date).to.match(/T00:00:00\.000Z$/);
-        expect(call.args[3]).to.equal(900 + (index * 5));
+        // Daily report delay is base (800s) + per-day staggering, capped at
+        // the SQS 900s hard limit so total stays valid even for long backfills.
+        expect(call.args[3]).to.equal(Math.min(800 + (index * 5), 900));
       });
       // Verify it checked for cdn-logs-analysis
       expect(context.dataAccess.LatestAudit.findBySiteIdAndAuditType).to.have.been.calledWith(
@@ -617,7 +644,9 @@ describe('CDN Config Handler', () => {
       expect(dailyReportCalls.length).to.be.greaterThan(0);
       dailyReportCalls.forEach((call, index) => {
         expect(call.args[1].auditContext.date).to.match(/T00:00:00\.000Z$/);
-        expect(call.args[3]).to.equal(900 + (index * 5));
+        // Daily report delay is base (800s) + per-day staggering, capped at
+        // the SQS 900s hard limit so total stays valid even for long backfills.
+        expect(call.args[3]).to.equal(Math.min(800 + (index * 5), 900));
       });
       expect(context.dataAccess.LatestAudit.findBySiteIdAndAuditType).to.have.been.calledWith(
         'site-123',


### PR DESCRIPTION
## Summary

- \`CDN_LOGS_REPORT_DELAY_SECONDS\` was set to 900 (the SQS \`DelaySeconds\` hard limit) and then per-day staggering was added on top — for ~14-day backfills the total delay could reach ~965s, which AWS rejects with \`InvalidParameterValue\`.
- Lower \`CDN_LOGS_REPORT_DELAY_SECONDS\` to 800 to leave headroom for staggering.
- Wrap both staggered \`sqs.sendMessage\` delays in \`Math.min(..., SQS_MAX_DELAY_SECONDS)\` as a defensive guard.

## Test plan

- [x] \`npm run test:spec -- test/audits/llmo-customer-analysis-cdn-config.test.js\` (30 passing)
- [x] 100% coverage on \`src/llmo-customer-analysis/cdn-config-handler.js\`
- [x] New test asserts every queued message delay is \`≤ 900s\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)