### PR TITLE
fix: use default processingType for TOC scrape submission

### DIFF
--- a/src/toc/handler.js
+++ b/src/toc/handler.js
@@ -342,8 +342,6 @@ export async function submitForScraping(context) {
   return {
     urls: topPages.map((url) => ({ url })),
     siteId: site.getId(),
-    processingType: auditType,
-    options: { storagePrefix: auditType },
     maxScrapeAge: 24,
   };
 }

--- a/test/audits/toc.test.js
+++ b/test/audits/toc.test.js
@@ -3403,8 +3403,8 @@ describe('TOC (Table of Contents) Audit', () => {
       const result = await submitForScraping(context);
 
       expect(result.urls).to.deep.equal([{ url }]);
-      expect(result.processingType).to.equal('toc');
-      expect(result.options).to.deep.equal({ storagePrefix: 'toc' });
+      expect(result.processingType).to.be.undefined;
+      expect(result.options).to.be.undefined;
       expect(result.maxScrapeAge).to.equal(24);
       expect(logSpy.info).to.have.been.calledWith('[TOC] Submitting 1 URLs for scraping');
     });


### PR DESCRIPTION
## Summary
- Removed `processingType: auditType` from `submitForScraping` — the scrape worker has no handler registered for `'toc'`, causing _"No handler found for processingType: toc"_ on every audit run. Omitting it lets the framework fall back to `'default'` (the scrape client default).
- Removed `options: { storagePrefix: auditType }` — this field is not recognized by the scrape client or scrape worker and was silently ignored.

## Test plan
- [ ] Existing `submitForScraping` test updated to assert `processingType` and `options` are `undefined`
- [ ] All 151 TOC tests pass (`npm run test:spec -- test/audits/toc.test.js`)
- [ ] Verify TOC audit scrape jobs complete successfully in a non-prod environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)