### PR TITLE
docs(cwv): document this repo's role in cross-repo CWV autofix flow

### DIFF
--- a/docs/cwv-autofix-flow.md
+++ b/docs/cwv-autofix-flow.md
@@ -1,0 +1,83 @@
+# CWV Autofix — `spacecat-audit-worker` Role
+
+This repo owns **Stage 1** of the cross-repo CWV autofix chain. The full E2E flow lives in mystique:
+
+> **[CWV Autofix — End-to-End Flow](https://git.corp.adobe.com/experience-platform/mystique/blob/main/docs/opportunities/cwv/e2e-flow.md)** (the hub doc — read this first if you're new to the flow)
+
+The chain spans four repos:
+
+1. **`spacecat-audit-worker`** (this repo) — runs the CWV audit, persists the opportunity, triggers the chain
+2. [`spacecat-import-worker`](https://github.com/adobe/spacecat-import-worker) — mirrors the customer's source code into S3 (parallel branch, fanned out by Step 1 of this audit)
+3. [Mystique](https://git.corp.adobe.com/experience-platform/mystique) — generates guidance text + a code patch via two separate tasks
+4. [`spacecat-autofix-worker`](https://github.com/adobe/spacecat-autofix-worker) — opens a GitHub Issue + PR carrying the patch
+
+## What this repo does
+
+The CWV audit is a 2-step `StepAudit` registered as audit type `cwv` ([`src/cwv/handler.js`](../src/cwv/handler.js), registered in [`src/index.js`](../src/index.js)):
+
+**Step 1 — `collectCWVDataAndImportCode`** ([`src/cwv/handler.js`](../src/cwv/handler.js)):
+- Builds the prioritized CWV audit result from RUM (failing pages first, padded with passing entries) — see [`src/cwv/cwv-audit-result.js`](../src/cwv/cwv-audit-result.js)
+- Returns `{ type: 'code', siteId, allowCache: false }` to the `IMPORT_WORKER` step destination, which **fans out to [`spacecat-import-worker`](https://github.com/adobe/spacecat-import-worker)** to mirror the customer repo into S3 in parallel
+
+**Step 2 — `syncOpportunityAndSuggestionsStep`** ([`src/cwv/handler.js`](../src/cwv/handler.js)):
+- Creates Opportunity (type `cwv`) + Suggestions (type `CODE_CHANGE`) — see [`src/cwv/opportunity-sync.js`](../src/cwv/opportunity-sync.js)
+- [`processAutoSuggest`](../src/cwv/auto-suggest.js) sends one `guidance:cwv` SQS message **per eligible suggestion** to Mystique on `QUEUE_SPACECAT_TO_MYSTIQUE`
+
+## Outbound message (this repo → mystique)
+
+```json
+{
+  "type": "guidance:cwv",
+  "siteId": "...",
+  "auditId": "...",
+  "deliveryType": "aem_cs",
+  "time": "2026-05-07T...",
+  "data": {
+    "type": "cwv",
+    "url": "https://example.com/page",
+    "opportunityId": "...",
+    "suggestionId": "...",
+    "device_type": "mobile",
+    "codeBucket": "...",
+    "codePath": "code/{siteId}/{source}/{owner}/{repo}/{encodedRef}/repository.zip"
+  }
+}
+```
+
+`codeBucket` and `codePath` are only set when the per-site `cwv-auto-fix` flag is enabled — they tell Mystique where the import-worker mirrored the customer repo.
+
+## Eligibility gate
+
+A suggestion is sent to Mystique only when ALL of:
+- Status is `NEW`
+- No guidance has been written yet
+- `type: 'url'` (group-type suggestions are skipped)
+- The site has `cwv-auto-suggest` enabled in `Configuration`
+
+## Feature flags (per site, in `Configuration`)
+
+| Flag | Effect |
+|---|---|
+| `cwv-auto-suggest` | gates whether the `guidance:cwv` SQS message is sent at all |
+| `cwv-auto-fix` | gates whether `codeBucket` / `codePath` are included (so Mystique can do a code fix, not just guidance) |
+
+Both flags are checked in this repo. The autofix-worker also checks `cwv-auto-fix` independently — both must be enabled for the chain to complete.
+
+## Key files
+
+- [`src/cwv/handler.js`](../src/cwv/handler.js) — `StepAudit` definition (2 steps)
+- [`src/cwv/auto-suggest.js`](../src/cwv/auto-suggest.js) — `processAutoSuggest`, sends `guidance:cwv` to Mystique
+- [`src/cwv/opportunity-sync.js`](../src/cwv/opportunity-sync.js) — creates Opportunity + Suggestion records
+- [`src/cwv/cwv-audit-result.js`](../src/cwv/cwv-audit-result.js) — builds the prioritized CWV result from RUM
+- [`src/index.js`](../src/index.js) — `HANDLERS` map registration
+
+## What happens next
+
+After the message lands on `QUEUE_SPACECAT_TO_MYSTIQUE`, control passes to **[Mystique](https://git.corp.adobe.com/experience-platform/mystique)**, which runs:
+
+- `GenerateCWVGuidanceTask` — produces markdown per metric (LCP / CLS / INP) and writes it back to `data.issues[].value` via the SpaceCat REST API
+- `GenerateCWVCodeFixTask` — downloads the ZIP that the import-worker wrote, runs `CodeApplicationAndRegressionCrew` (CrewAI + `aider`), and writes the resulting unified diff back to `data.patchContent` (also via REST)
+
+The patch is later applied by **[`spacecat-autofix-worker`](https://github.com/adobe/spacecat-autofix-worker)** when the user accepts the suggestion in the UI.
+
+For the full picture (message schemas, S3 key shape, Mystique internals, verification recipe), see the [hub doc](https://git.corp.adobe.com/experience-platform/mystique/blob/main/docs/opportunities/cwv/e2e-flow.md).

--- a/docs/cwv-autofix-flow.md
+++ b/docs/cwv-autofix-flow.md
@@ -4,12 +4,14 @@ This repo owns **Stage 1** of the cross-repo CWV autofix chain. The full E2E flo
 
 > **[CWV Autofix — End-to-End Flow](https://git.corp.adobe.com/experience-platform/mystique/blob/main/docs/opportunities/cwv/e2e-flow.md)** (the hub doc — read this first if you're new to the flow)
 
-The chain spans four repos:
+The CWV chain currently spans four repos:
 
 1. **`spacecat-audit-worker`** (this repo) — runs the CWV audit, persists the opportunity, triggers the chain
 2. [`spacecat-import-worker`](https://github.com/adobe/spacecat-import-worker) — mirrors the customer's source code into S3 (parallel branch, fanned out by Step 1 of this audit)
 3. [Mystique](https://git.corp.adobe.com/experience-platform/mystique) — generates guidance text + a code patch via two separate tasks
 4. [`spacecat-autofix-worker`](https://github.com/adobe/spacecat-autofix-worker) — opens a GitHub Issue + PR carrying the patch
+
+**Adjacent (not currently in the CWV path):** [`spacecat-content-scraper`](https://github.com/adobe/spacecat-content-scraper) — see ["Adjacent: `spacecat-content-scraper`"](#adjacent-spacecat-content-scraper) below.
 
 ## What this repo does
 
@@ -81,3 +83,9 @@ After the message lands on `QUEUE_SPACECAT_TO_MYSTIQUE`, control passes to **[My
 The patch is later applied by **[`spacecat-autofix-worker`](https://github.com/adobe/spacecat-autofix-worker)** when the user accepts the suggestion in the UI.
 
 For the full picture (message schemas, S3 key shape, Mystique internals, verification recipe), see the [hub doc](https://git.corp.adobe.com/experience-platform/mystique/blob/main/docs/opportunities/cwv/e2e-flow.md).
+
+## Adjacent: `spacecat-content-scraper`
+
+This repo also fans out to [`spacecat-content-scraper`](https://github.com/adobe/spacecat-content-scraper) for **other** audits (accessibility, forms-opportunities, experimentation-opportunities, structured-data, preflight-accessibility, readability) via `AUDIT_STEP_DESTINATIONS.CONTENT_SCRAPER` — but **not from the CWV `StepAudit`**. The CWV audit's `StepAudit` only sends to `IMPORT_WORKER` (Step 1).
+
+`content-scraper` registers a `cwv-labs` handler that could capture lab-measured CWV metrics (HAR, perf entries, LCP, CLS, long tasks under PSI throttling profiles), but no production code path here currently invokes it. Mystique's CWV guidance flow runs its own in-process Playwright collector instead. See the [hub's "Adjacent component" section](https://git.corp.adobe.com/experience-platform/mystique/blob/main/docs/opportunities/cwv/e2e-flow.md#adjacent-component-spacecat-content-scraper) and the [content-scraper spoke](https://github.com/adobe/spacecat-content-scraper/blob/main/docs/cwv-autofix-flow.md) for the gap analysis.


### PR DESCRIPTION
## Summary

Adds [`docs/cwv-autofix-flow.md`](https://github.com/adobe/spacecat-audit-worker/blob/docs/cwv-autofix-e2e/docs/cwv-autofix-flow.md) describing this repo's piece of the cross-repo CWV autofix chain:

- This repo runs the CWV audit as a 2-step `StepAudit` (Step 1 fans out to `spacecat-import-worker`; Step 2 sends `guidance:cwv` to Mystique on `QUEUE_SPACECAT_TO_MYSTIQUE`)
- Documents the outbound message shape (the `guidance:cwv` payload Mystique consumes)
- Lists the eligibility gate and the two feature flags (`cwv-auto-suggest`, `cwv-auto-fix`)
- Notes `spacecat-content-scraper` as an adjacent platform component used by other audits but NOT from the CWV `StepAudit`
- Points at the canonical hub doc in mystique for the full E2E picture

## Context — coordinated 5-PR series

This is one of five documentation PRs (one per repo) opened together so the team can review the cross-repo CWV autofix flow as a whole. The hub doc lives in mystique; the four SpaceCat workers each get a stub that links back. `spacecat-content-scraper` is documented as an adjacent component (not currently in the CWV path).

**Companion PRs:**
- 📌 hub: [experience-platform/mystique#1869](https://git.corp.adobe.com/experience-platform/mystique/pull/1869)
- spoke: [adobe/spacecat-import-worker#741](https://github.com/adobe/spacecat-import-worker/pull/741)
- spoke: [adobe/spacecat-autofix-worker#589](https://github.com/adobe/spacecat-autofix-worker/pull/589)
- spoke: [adobe/spacecat-content-scraper#871](https://github.com/adobe/spacecat-content-scraper/pull/871) (adjacent component)

Please coordinate merges so the cross-links resolve.

## Test plan

- [ ] Verify renders correctly on GitHub (file links, code blocks, table)
- [ ] Spot-check that the documented file paths actually exist on `main`
- [ ] Confirm the message-shape table matches `processAutoSuggest` in `src/cwv/auto-suggest.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)