### PR TITLE
feat(rum-config): add periodic rum-config-refresh handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@adobe/mysticat-shared-seo-client": "1.3.0",
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
         "@adobe/spacecat-shared-athena-client": "1.9.11",
-        "@adobe/spacecat-shared-data-access": "https://gist.githubusercontent.com/Sugandhgyl/383af13fb32c5d0307dba87ce88f699c/raw/adobe-spacecat-shared-data-access-3.62.0.tgz",
+        "@adobe/spacecat-shared-data-access": "3.63.0",
         "@adobe/spacecat-shared-data-access-v2": "npm:@adobe/spacecat-shared-data-access@2.109.0",
         "@adobe/spacecat-shared-drs-client": "1.7.1",
         "@adobe/spacecat-shared-google-client": "1.5.11",
@@ -2334,18 +2334,18 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "3.62.0",
-      "resolved": "https://gist.githubusercontent.com/Sugandhgyl/383af13fb32c5d0307dba87ce88f699c/raw/adobe-spacecat-shared-data-access-3.62.0.tgz",
-      "integrity": "sha512-zm/K1aL/vwpUCExUrqeW95UQb0gMmPmz72EuiGZvHWrp0fgMqFZY996f5wn9g4bGFfusOVpGvhLTY6uSTXanZg==",
+      "version": "3.63.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-3.63.0.tgz",
+      "integrity": "sha512-3ZjwhQig41OuhEhRpAO+LyBmViz31E4nb18rFDVIZ2md1Fn0eyGmCaTAvlO49f2dziMBdJUcHeO7TOkF4+RlGw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",
         "@adobe/spacecat-shared-utils": "1.105.0",
         "@aws-sdk/client-s3": "^3.940.0",
-        "@supabase/postgrest-js": "2.101.1",
+        "@supabase/postgrest-js": "2.105.4",
         "@types/joi": "17.2.3",
         "aws-xray-sdk": "3.12.0",
-        "joi": "18.1.2",
+        "joi": "18.2.1",
         "pluralize": "8.0.0"
       },
       "engines": {
@@ -3034,9 +3034,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access/node_modules/joi": {
-      "version": "18.1.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.1.2.tgz",
-      "integrity": "sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
+      "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/address": "^5.1.1",
@@ -14209,9 +14209,9 @@
       "license": "MIT"
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "2.101.1",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.101.1.tgz",
-      "integrity": "sha512-UW1RajH5jbZoK+ldAJ1I6VZ+HWwZ2oaKjEQ6Gn+AQ67CHQVxGl8wNQoLYyumbyaExm41I+wn7arulcY1eHeZJw==",
+      "version": "2.105.4",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.105.4.tgz",
+      "integrity": "sha512-SppIyLo/kTwIlz1qpv2HN1EQqBg0GVktrDDFsXygYROha3MgVn4rT7p5EjFHFqXQm2rdRGb/BI7bc+jr10m91w==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@adobe/mysticat-shared-seo-client": "1.3.0",
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
         "@adobe/spacecat-shared-athena-client": "1.9.11",
-        "@adobe/spacecat-shared-data-access": "3.62.0",
+        "@adobe/spacecat-shared-data-access": "https://gist.githubusercontent.com/Sugandhgyl/383af13fb32c5d0307dba87ce88f699c/raw/adobe-spacecat-shared-data-access-3.62.0.tgz",
         "@adobe/spacecat-shared-data-access-v2": "npm:@adobe/spacecat-shared-data-access@2.109.0",
         "@adobe/spacecat-shared-drs-client": "1.7.1",
         "@adobe/spacecat-shared-google-client": "1.5.11",
@@ -2335,8 +2335,8 @@
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
       "version": "3.62.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-3.62.0.tgz",
-      "integrity": "sha512-ek3WengZxG3xvV3CsQlc7UluRHbwVnwqiyTHtRDDWl5x93/c03cjb7TsQ4QLSuZn/LZ4GoH0AzjD7/p1hbjdUA==",
+      "resolved": "https://gist.githubusercontent.com/Sugandhgyl/383af13fb32c5d0307dba87ce88f699c/raw/adobe-spacecat-shared-data-access-3.62.0.tgz",
+      "integrity": "sha512-zm/K1aL/vwpUCExUrqeW95UQb0gMmPmz72EuiGZvHWrp0fgMqFZY996f5wn9g4bGFfusOVpGvhLTY6uSTXanZg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@adobe/mysticat-shared-seo-client": "1.3.0",
     "@adobe/spacecat-helix-content-sdk": "1.4.33",
     "@adobe/spacecat-shared-athena-client": "1.9.11",
-    "@adobe/spacecat-shared-data-access": "https://gist.githubusercontent.com/Sugandhgyl/383af13fb32c5d0307dba87ce88f699c/raw/adobe-spacecat-shared-data-access-3.62.0.tgz",
+    "@adobe/spacecat-shared-data-access": "3.63.0",
     "@adobe/spacecat-shared-data-access-v2": "npm:@adobe/spacecat-shared-data-access@2.109.0",
     "@adobe/spacecat-shared-drs-client": "1.7.1",
     "@adobe/spacecat-shared-google-client": "1.5.11",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@adobe/mysticat-shared-seo-client": "1.3.0",
     "@adobe/spacecat-helix-content-sdk": "1.4.33",
     "@adobe/spacecat-shared-athena-client": "1.9.11",
-    "@adobe/spacecat-shared-data-access": "3.62.0",
+    "@adobe/spacecat-shared-data-access": "https://gist.githubusercontent.com/Sugandhgyl/383af13fb32c5d0307dba87ce88f699c/raw/adobe-spacecat-shared-data-access-3.62.0.tgz",
     "@adobe/spacecat-shared-data-access-v2": "npm:@adobe/spacecat-shared-data-access@2.109.0",
     "@adobe/spacecat-shared-drs-client": "1.7.1",
     "@adobe/spacecat-shared-google-client": "1.5.11",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "hedy -v --test-bundle",
     "deploy": "hedy -v --deploy --aws-deploy-bucket=spacecat-prod-deploy --pkgVersion=latest --aws-reserved-concurrency=100",
     "deploy-stage": "hedy -v --deploy --aws-deploy-bucket=spacecat-stage-deploy --pkgVersion=latest --aws-reserved-concurrency=10",
-    "deploy-dev": "hedy -v --deploy --pkgVersion=ci$CI_BUILD_NUM -l sugandhg --aws-deploy-bucket=spacecat-dev-deploy --cleanup-ci=24h --aws-reserved-concurrency=10",
+    "deploy-dev": "hedy -v --deploy --pkgVersion=ci$CI_BUILD_NUM -l latest --aws-deploy-bucket=spacecat-dev-deploy --cleanup-ci=24h --aws-reserved-concurrency=10",
     "deploy-secrets": "hedy --aws-update-secrets --params-file=secrets/secrets.env",
     "prepare": "husky",
     "local-build": "sam build",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "hedy -v --test-bundle",
     "deploy": "hedy -v --deploy --aws-deploy-bucket=spacecat-prod-deploy --pkgVersion=latest --aws-reserved-concurrency=100",
     "deploy-stage": "hedy -v --deploy --aws-deploy-bucket=spacecat-stage-deploy --pkgVersion=latest --aws-reserved-concurrency=10",
-    "deploy-dev": "hedy -v --deploy --pkgVersion=ci$CI_BUILD_NUM -l latest --aws-deploy-bucket=spacecat-dev-deploy --cleanup-ci=24h --aws-reserved-concurrency=10",
+    "deploy-dev": "hedy -v --deploy --pkgVersion=ci$CI_BUILD_NUM -l sugandhg --aws-deploy-bucket=spacecat-dev-deploy --cleanup-ci=24h --aws-reserved-concurrency=10",
     "deploy-secrets": "hedy --aws-update-secrets --params-file=secrets/secrets.env",
     "prepare": "husky",
     "local-build": "sam build",

--- a/src/index.js
+++ b/src/index.js
@@ -87,6 +87,7 @@ import pageTypeGuidance from './page-type/guidance-handler.js';
 import hreflang from './hreflang/handler.js';
 import optimizationReportCallback from './optimization-report/handler.js';
 import llmoConfigDbSync from './llmo-config-db-sync/handler.js';
+import rumConfigRefresh from './rum-config-refresh/handler.js';
 import llmoCustomerAnalysis from './llmo-customer-analysis/handler.js';
 import llmoOnboardingPublish from './llmo-onboarding-publish/handler.js';
 import headings from './headings/handler.js';
@@ -231,6 +232,7 @@ const HANDLERS = {
   'offsite-brand-presence': offsiteBrandPresence,
   'geo-brand-presence-trigger-refresh': refreshGeoBrandPresenceSheetsHandler,
   'refresh:geo-brand-presence-daily': refreshGeoBrandPresenceDailyHandler,
+  'rum-config-refresh': rumConfigRefresh,
   dummy: (message) => ok(message),
 };
 

--- a/src/rum-config-refresh/handler.js
+++ b/src/rum-config-refresh/handler.js
@@ -12,7 +12,6 @@
 
 import RUMAPIClient from '@adobe/spacecat-shared-rum-api-client';
 import { ok, internalServerError } from '@adobe/spacecat-shared-http-utils';
-import { Config } from '@adobe/spacecat-shared-data-access/src/models/site/config.js';
 
 const STALENESS_DAYS = 7;
 const STALENESS_MS = STALENESS_DAYS * 24 * 60 * 60 * 1000;
@@ -65,7 +64,7 @@ export default async function rumConfigRefresh(message, context) {
   try {
     const siteConfig = site.getConfig();
     siteConfig.updateRumConfig(hasDomainKey);
-    site.setConfig(Config.toDynamoItem(siteConfig));
+    site.setConfig(siteConfig.state);
     await site.save();
     log.info(`[rum-config-refresh] Updated rumConfig for site ${siteId}: hasDomainKey=${hasDomainKey}`);
     return ok({ hasDomainKey, updated: true });

--- a/src/rum-config-refresh/handler.js
+++ b/src/rum-config-refresh/handler.js
@@ -12,6 +12,7 @@
 
 import RUMAPIClient from '@adobe/spacecat-shared-rum-api-client';
 import { ok, internalServerError } from '@adobe/spacecat-shared-http-utils';
+import { Config } from '@adobe/spacecat-shared-data-access/src/models/site/config.js';
 
 const STALENESS_DAYS = 7;
 const STALENESS_MS = STALENESS_DAYS * 24 * 60 * 60 * 1000;
@@ -29,6 +30,11 @@ export default async function rumConfigRefresh(message, context) {
   const { log } = context;
   const { siteId } = message;
 
+  if (!siteId) {
+    log.error('[rum-config-refresh] Missing siteId in message payload');
+    return ok({ skipped: true, reason: 'missing siteId' });
+  }
+
   const { Site } = context.dataAccess;
   const site = await Site.findById(siteId);
   if (!site) {
@@ -45,26 +51,37 @@ export default async function rumConfigRefresh(message, context) {
     }
   }
 
-  const domain = site.getBaseURL().replace(/^https?:\/\//, '');
+  const domain = new URL(site.getBaseURL()).hostname;
   let hasDomainKey = false;
+  let timeoutId;
+  let timedOut = false;
 
   try {
     const rumApiClient = RUMAPIClient.createFrom(context);
     await Promise.race([
       rumApiClient.retrieveDomainkey(domain),
       new Promise((_, reject) => {
-        setTimeout(() => reject(new Error('RUM check timed out')), RUM_CHECK_TIMEOUT_MS);
+        timeoutId = setTimeout(() => {
+          timedOut = true;
+          reject(new Error('RUM check timed out'));
+        }, RUM_CHECK_TIMEOUT_MS);
       }),
     ]);
     hasDomainKey = true;
   } catch (e) {
+    if (timedOut) {
+      log.error(`[rum-config-refresh] RUM check timed out for ${domain}, skipping config update`);
+      return ok({ skipped: true, reason: 'timeout' });
+    }
     log.warn(`[rum-config-refresh] RUM check failed for ${domain}: ${e.message}`);
+  } finally {
+    clearTimeout(timeoutId);
   }
 
   try {
     const siteConfig = site.getConfig();
     siteConfig.updateRumConfig(hasDomainKey);
-    site.setConfig(siteConfig.state);
+    site.setConfig(Config.toDynamoItem(siteConfig));
     await site.save();
     log.info(`[rum-config-refresh] Updated rumConfig for site ${siteId}: hasDomainKey=${hasDomainKey}`);
     return ok({ hasDomainKey, updated: true });

--- a/src/rum-config-refresh/handler.js
+++ b/src/rum-config-refresh/handler.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import RUMAPIClient from '@adobe/spacecat-shared-rum-api-client';
+import { ok, internalServerError } from '@adobe/spacecat-shared-http-utils';
+
+const STALENESS_DAYS = 7;
+const STALENESS_MS = STALENESS_DAYS * 24 * 60 * 60 * 1000;
+const RUM_CHECK_TIMEOUT_MS = 3000;
+
+/**
+ * Periodic refresh handler for site RUM domain key availability.
+ * Skips sites whose rumConfig was checked within the last 7 days.
+ * Re-runs the domain key check for stale sites and persists the result.
+ *
+ * Triggered by an external orchestration service sending an SQS message:
+ *   { type: 'rum-config-refresh', siteId: '<uuid>' }
+ */
+export default async function rumConfigRefresh(message, context) {
+  const { log } = context;
+  const { siteId } = message;
+
+  const { Site } = context.dataAccess;
+  const site = await Site.findById(siteId);
+  if (!site) {
+    log.error(`[rum-config-refresh] Site not found: ${siteId}`);
+    return ok({ skipped: true, reason: 'site not found' });
+  }
+
+  const rumConfig = site.getConfig().getRumConfig();
+  if (rumConfig?.lastCheckedAt) {
+    const age = Date.now() - new Date(rumConfig.lastCheckedAt).getTime();
+    if (age < STALENESS_MS) {
+      log.info(`[rum-config-refresh] Skipping site ${siteId}: checked ${Math.floor(age / 86400000)}d ago`);
+      return ok({ skipped: true, reason: 'recently checked' });
+    }
+  }
+
+  const domain = site.getBaseURL().replace(/^https?:\/\//, '');
+  let hasDomainKey = false;
+
+  try {
+    const rumApiClient = RUMAPIClient.createFrom(context);
+    await Promise.race([
+      rumApiClient.retrieveDomainkey(domain),
+      new Promise((_, reject) => {
+        setTimeout(() => reject(new Error('RUM check timed out')), RUM_CHECK_TIMEOUT_MS);
+      }),
+    ]);
+    hasDomainKey = true;
+  } catch (e) {
+    log.warn(`[rum-config-refresh] RUM check failed for ${domain}: ${e.message}`);
+  }
+
+  try {
+    site.getConfig().updateRumConfig(hasDomainKey);
+    await site.save();
+    log.info(`[rum-config-refresh] Updated rumConfig for site ${siteId}: hasDomainKey=${hasDomainKey}`);
+    return ok({ hasDomainKey, updated: true });
+  } catch (e) {
+    log.error(`[rum-config-refresh] Failed to save rumConfig for site ${siteId}: ${e.message}`);
+    return internalServerError(`Failed to save rumConfig: ${e.message}`);
+  }
+}

--- a/src/rum-config-refresh/handler.js
+++ b/src/rum-config-refresh/handler.js
@@ -12,6 +12,7 @@
 
 import RUMAPIClient from '@adobe/spacecat-shared-rum-api-client';
 import { ok, internalServerError } from '@adobe/spacecat-shared-http-utils';
+import { Config } from '@adobe/spacecat-shared-data-access/src/models/site/config.js';
 
 const STALENESS_DAYS = 7;
 const STALENESS_MS = STALENESS_DAYS * 24 * 60 * 60 * 1000;
@@ -62,7 +63,9 @@ export default async function rumConfigRefresh(message, context) {
   }
 
   try {
-    site.getConfig().updateRumConfig(hasDomainKey);
+    const siteConfig = site.getConfig();
+    siteConfig.updateRumConfig(hasDomainKey);
+    site.setConfig(Config.toDynamoItem(siteConfig));
     await site.save();
     log.info(`[rum-config-refresh] Updated rumConfig for site ${siteId}: hasDomainKey=${hasDomainKey}`);
     return ok({ hasDomainKey, updated: true });

--- a/test/audits/rum-config-refresh.test.js
+++ b/test/audits/rum-config-refresh.test.js
@@ -31,10 +31,12 @@ describe('rum-config-refresh handler', () => {
   let mockSite;
   let mockConfig;
   let retrieveDomainkeyStub;
+  let toDynamoItemStub;
   let handler;
 
   beforeEach(async () => {
     retrieveDomainkeyStub = sandbox.stub();
+    toDynamoItemStub = sandbox.stub().returns({});
 
     handler = await esmock(
       '../../src/rum-config-refresh/handler.js',
@@ -44,11 +46,13 @@ describe('rum-config-refresh handler', () => {
             createFrom: () => ({ retrieveDomainkey: retrieveDomainkeyStub }),
           },
         },
+        '@adobe/spacecat-shared-data-access/src/models/site/config.js': {
+          Config: { toDynamoItem: toDynamoItemStub },
+        },
       },
     );
 
     mockConfig = {
-      state: {},
       getRumConfig: sandbox.stub().returns(undefined),
       updateRumConfig: sandbox.stub(),
     };
@@ -69,6 +73,18 @@ describe('rum-config-refresh handler', () => {
 
   afterEach(() => {
     sandbox.restore();
+  });
+
+  describe('missing siteId', () => {
+    it('returns ok with skipped=true when siteId is absent from message', async () => {
+      const result = await handler.default({}, context);
+
+      expect(result.status).to.equal(200);
+      const body = await result.json();
+      expect(body).to.deep.equal({ skipped: true, reason: 'missing siteId' });
+      expect(context.log.error).to.have.been.calledWithMatch('Missing siteId');
+      expect(context.dataAccess.Site.findById).not.to.have.been.called;
+    });
   });
 
   describe('site not found', () => {
@@ -132,6 +148,7 @@ describe('rum-config-refresh handler', () => {
       const body = await result.json();
       expect(body).to.deep.equal({ hasDomainKey: true, updated: true });
       expect(mockConfig.updateRumConfig).to.have.been.calledWith(true);
+      expect(toDynamoItemStub).to.have.been.calledWith(mockConfig);
       expect(mockSite.save).to.have.been.calledOnce;
     });
 
@@ -144,11 +161,12 @@ describe('rum-config-refresh handler', () => {
       const body = await result.json();
       expect(body).to.deep.equal({ hasDomainKey: false, updated: true });
       expect(mockConfig.updateRumConfig).to.have.been.calledWith(false);
+      expect(toDynamoItemStub).to.have.been.calledWith(mockConfig);
       expect(mockSite.save).to.have.been.calledOnce;
       expect(context.log.warn).to.have.been.calledWithMatch('RUM check failed');
     });
 
-    it('sets hasDomainKey=false when RUM check times out', async () => {
+    it('skips config update and does not write lastCheckedAt when RUM check times out', async () => {
       const clock = sinon.useFakeTimers();
       retrieveDomainkeyStub.returns(new Promise(() => {})); // never resolves
 
@@ -159,12 +177,13 @@ describe('rum-config-refresh handler', () => {
 
       expect(result.status).to.equal(200);
       const body = await result.json();
-      expect(body).to.deep.equal({ hasDomainKey: false, updated: true });
-      expect(mockConfig.updateRumConfig).to.have.been.calledWith(false);
-      expect(context.log.warn).to.have.been.calledWithMatch('timed out');
+      expect(body).to.deep.equal({ skipped: true, reason: 'timeout' });
+      expect(mockConfig.updateRumConfig).not.to.have.been.called;
+      expect(mockSite.save).not.to.have.been.called;
+      expect(context.log.error).to.have.been.calledWithMatch('timed out');
     });
 
-    it('strips protocol from baseURL before calling retrieveDomainkey', async () => {
+    it('extracts hostname from baseURL before calling retrieveDomainkey', async () => {
       retrieveDomainkeyStub.resolves('domainkey-abc');
 
       await handler.default({ siteId: SITE_ID }, context);

--- a/test/audits/rum-config-refresh.test.js
+++ b/test/audits/rum-config-refresh.test.js
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
+import esmock from 'esmock';
+import { MockContextBuilder } from '../shared.js';
+
+use(sinonChai);
+use(chaiAsPromised);
+
+const sandbox = sinon.createSandbox();
+
+const SITE_ID = 'test-site-id';
+const BASE_URL = 'https://www.example.com';
+
+describe('rum-config-refresh handler', () => {
+  let context;
+  let mockSite;
+  let mockConfig;
+  let retrieveDomainkeyStub;
+  let handler;
+
+  beforeEach(async () => {
+    retrieveDomainkeyStub = sandbox.stub();
+
+    handler = await esmock(
+      '../../src/rum-config-refresh/handler.js',
+      {
+        '@adobe/spacecat-shared-rum-api-client': {
+          default: {
+            createFrom: () => ({ retrieveDomainkey: retrieveDomainkeyStub }),
+          },
+        },
+      },
+    );
+
+    mockConfig = {
+      getRumConfig: sandbox.stub().returns(undefined),
+      updateRumConfig: sandbox.stub(),
+    };
+
+    mockSite = {
+      getBaseURL: sandbox.stub().returns(BASE_URL),
+      getConfig: sandbox.stub().returns(mockConfig),
+      save: sandbox.stub().resolves(),
+    };
+
+    context = new MockContextBuilder()
+      .withSandbox(sandbox)
+      .build();
+
+    context.dataAccess.Site.findById.resolves(mockSite);
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('site not found', () => {
+    it('returns ok with skipped=true when site does not exist', async () => {
+      context.dataAccess.Site.findById.resolves(null);
+
+      const result = await handler.default({ siteId: SITE_ID }, context);
+
+      expect(result.status).to.equal(200);
+      const body = await result.json();
+      expect(body).to.deep.equal({ skipped: true, reason: 'site not found' });
+      expect(context.log.error).to.have.been.calledWithMatch('Site not found');
+    });
+  });
+
+  describe('staleness check', () => {
+    it('skips when rumConfig was checked within the last 7 days', async () => {
+      const recentDate = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+      mockConfig.getRumConfig.returns({ hasDomainKey: true, lastCheckedAt: recentDate });
+
+      const result = await handler.default({ siteId: SITE_ID }, context);
+
+      expect(result.status).to.equal(200);
+      const body = await result.json();
+      expect(body).to.deep.equal({ skipped: true, reason: 'recently checked' });
+      expect(retrieveDomainkeyStub).not.to.have.been.called;
+      expect(mockSite.save).not.to.have.been.called;
+    });
+
+    it('proceeds when rumConfig has no lastCheckedAt', async () => {
+      mockConfig.getRumConfig.returns(undefined);
+      retrieveDomainkeyStub.resolves('domainkey-value');
+
+      const result = await handler.default({ siteId: SITE_ID }, context);
+
+      expect(result.status).to.equal(200);
+      const body = await result.json();
+      expect(body).to.deep.equal({ hasDomainKey: true, updated: true });
+    });
+
+    it('proceeds when lastCheckedAt is older than 7 days', async () => {
+      const staleDate = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
+      mockConfig.getRumConfig.returns({ hasDomainKey: false, lastCheckedAt: staleDate });
+      retrieveDomainkeyStub.resolves('domainkey-value');
+
+      const result = await handler.default({ siteId: SITE_ID }, context);
+
+      expect(result.status).to.equal(200);
+      const body = await result.json();
+      expect(body).to.deep.equal({ hasDomainKey: true, updated: true });
+    });
+  });
+
+  describe('RUM domain key check', () => {
+    it('sets hasDomainKey=true when retrieveDomainkey resolves', async () => {
+      retrieveDomainkeyStub.resolves('domainkey-abc');
+
+      const result = await handler.default({ siteId: SITE_ID }, context);
+
+      expect(result.status).to.equal(200);
+      const body = await result.json();
+      expect(body).to.deep.equal({ hasDomainKey: true, updated: true });
+      expect(mockConfig.updateRumConfig).to.have.been.calledWith(true);
+      expect(mockSite.save).to.have.been.calledOnce;
+    });
+
+    it('sets hasDomainKey=false when retrieveDomainkey rejects', async () => {
+      retrieveDomainkeyStub.rejects(new Error('no domain key found'));
+
+      const result = await handler.default({ siteId: SITE_ID }, context);
+
+      expect(result.status).to.equal(200);
+      const body = await result.json();
+      expect(body).to.deep.equal({ hasDomainKey: false, updated: true });
+      expect(mockConfig.updateRumConfig).to.have.been.calledWith(false);
+      expect(mockSite.save).to.have.been.calledOnce;
+      expect(context.log.warn).to.have.been.calledWithMatch('RUM check failed');
+    });
+
+    it('sets hasDomainKey=false when RUM check times out', async () => {
+      const clock = sinon.useFakeTimers();
+      retrieveDomainkeyStub.returns(new Promise(() => {})); // never resolves
+
+      const resultPromise = handler.default({ siteId: SITE_ID }, context);
+      await clock.tickAsync(4000); // advance past the 3 s timeout
+      const result = await resultPromise;
+      clock.restore();
+
+      expect(result.status).to.equal(200);
+      const body = await result.json();
+      expect(body).to.deep.equal({ hasDomainKey: false, updated: true });
+      expect(mockConfig.updateRumConfig).to.have.been.calledWith(false);
+      expect(context.log.warn).to.have.been.calledWithMatch('timed out');
+    });
+
+    it('strips protocol from baseURL before calling retrieveDomainkey', async () => {
+      retrieveDomainkeyStub.resolves('domainkey-abc');
+
+      await handler.default({ siteId: SITE_ID }, context);
+
+      expect(retrieveDomainkeyStub).to.have.been.calledWith('www.example.com');
+    });
+  });
+
+  describe('save failure', () => {
+    it('returns 500 when site.save() throws', async () => {
+      retrieveDomainkeyStub.resolves('domainkey-abc');
+      mockSite.save.rejects(new Error('DynamoDB write failed'));
+
+      const result = await handler.default({ siteId: SITE_ID }, context);
+
+      expect(result.status).to.equal(500);
+      expect(context.log.error).to.have.been.calledWithMatch('Failed to save');
+    });
+  });
+});

--- a/test/audits/rum-config-refresh.test.js
+++ b/test/audits/rum-config-refresh.test.js
@@ -48,6 +48,7 @@ describe('rum-config-refresh handler', () => {
     );
 
     mockConfig = {
+      state: {},
       getRumConfig: sandbox.stub().returns(undefined),
       updateRumConfig: sandbox.stub(),
     };
@@ -55,6 +56,7 @@ describe('rum-config-refresh handler', () => {
     mockSite = {
       getBaseURL: sandbox.stub().returns(BASE_URL),
       getConfig: sandbox.stub().returns(mockConfig),
+      setConfig: sandbox.stub(),
       save: sandbox.stub().resolves(),
     };
 


### PR DESCRIPTION
Adds a **new audit-worker handler (type: rum-config-refresh)** that re-checks **RUM** domain key availability for a site and persists the result in `site.config.rumConfig`. Sites checked within the last 7 days are skipped to avoid hammering the RUM API.

## **CHANGES**
- Skips sites whose `rumConfig.lastCheckedAt `is within the last 7 days
- Calls `RUMAPIClient.retrieveDomainkey(domain)` with a 3s timeout for stale/unchecked sites
- Persists { hasDomainKey, lastCheckedAt } back via site.getConfig().updateRumConfig() + site.save()
- Returns internalServerError only if the DB write fails — RUM failures are non-fatal and set hasDomainKey=false

The orchestration service sends { type: 'rum-config-refresh', siteId: '<uuid>' } on a daily cadence.

## Changes
- src/rum-config-refresh/handler.js — new handler
- src/index.js — registers 'rum-config-refresh' in HANDLERS
- test/audits/rum-config-refresh.test.js — 9 tests

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
