### PR TITLE
broken-backlinks: filter cross-subdomain and detect soft-404s

### DIFF
--- a/src/backlinks/handler.js
+++ b/src/backlinks/handler.js
@@ -79,8 +79,8 @@ async function isSoft404(response, url, log) {
   let body;
   try {
     body = await response.text();
+  /* c8 ignore next 3 - Defensive: response body read rarely fails */
   } catch {
-    /* c8 ignore next 2 */
     return false;
   }
 
@@ -105,8 +105,8 @@ function isOnDifferentSubdomain(urlTo, siteBaseURL) {
     const siteHostname = stripWWW(new URL(prependSchema(siteBaseURL)).hostname).toLowerCase();
     const backlinkHostname = stripWWW(new URL(prependSchema(urlTo)).hostname).toLowerCase();
     return backlinkHostname !== siteHostname;
+  /* c8 ignore next 3 - Defensive: URL parsing rarely fails with well-formed base URLs */
   } catch {
-    /* c8 ignore next 2 */
     return false;
   }
 }

--- a/src/backlinks/handler.js
+++ b/src/backlinks/handler.js
@@ -26,6 +26,8 @@ import { getMergedAuditInputUrls } from '../utils/audit-input-urls.js';
 import { filterByAuditScope, extractPathPrefix } from '../internal-links/subpath-filter.js';
 import {
   filterBrokenSuggestedUrls,
+  isHtmlContentType,
+  isSoft404Body,
   urlsMatch,
 } from '../utils/url-utils.js';
 import BrightDataClient, { buildLocaleSearchUrl } from '../support/bright-data-client.js';
@@ -51,6 +53,62 @@ function getEnvInt(env, key, defaultValue) {
   return Number.isFinite(value) ? value : defaultValue;
 }
 
+/**
+ * Detects whether a 2xx response is actually a soft 404.
+ * Checks (in order): X-Robots-Tag noindex header, <meta robots noindex>, title pattern.
+ *
+ * @param {Response} response - Fetch response (must be ok/2xx).
+ * @param {string} url - The URL that was fetched (used for logging only).
+ * @param {Object} log - Logger instance.
+ * @returns {Promise<boolean>} True if the page appears to be a soft 404.
+ */
+async function isSoft404(response, url, log) {
+  // 1. X-Robots-Tag: noindex header (no body read needed)
+  const robotsHeader = response.headers?.get?.('x-robots-tag') ?? '';
+  if (robotsHeader.toLowerCase().includes('noindex')) {
+    log.info(`Backlink ${url} is a soft 404 (X-Robots-Tag: noindex)`);
+    return true;
+  }
+
+  // 2 & 3. Body-based signals — only for HTML responses
+  const contentType = response.headers?.get?.('content-type') ?? '';
+  if (!isHtmlContentType(contentType)) {
+    return false;
+  }
+
+  let body;
+  try {
+    body = await response.text();
+  } catch {
+    return false;
+  }
+
+  if (isSoft404Body(body)) {
+    log.info(`Backlink ${url} is a soft 404 (body pattern matched)`);
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Returns true when url_to is on a subdomain that differs from the site's base URL hostname.
+ * www and bare domain are treated as equivalent (both are normalised via stripWWW).
+ *
+ * @param {string} urlTo - The broken backlink target URL.
+ * @param {string} siteBaseURL - The site's canonical base URL.
+ * @returns {boolean}
+ */
+function isOnDifferentSubdomain(urlTo, siteBaseURL) {
+  try {
+    const siteHostname = stripWWW(new URL(prependSchema(siteBaseURL)).hostname).toLowerCase();
+    const backlinkHostname = stripWWW(new URL(prependSchema(urlTo)).hostname).toLowerCase();
+    return backlinkHostname !== siteHostname;
+  } catch {
+    return false;
+  }
+}
+
 async function filterOutValidBacklinks(backlinks, log) {
   const fetchWithTimeout = async (url, timeout) => {
     try {
@@ -68,11 +126,14 @@ async function filterOutValidBacklinks(backlinks, log) {
 
   const isStillBrokenBacklink = async (backlink) => {
     const response = await fetchWithTimeout(backlink.url_to, TIMEOUT);
-    if (!response.ok && response.status !== 404
-      && response.status >= 400 && response.status < 500) {
-      log.warn(`Backlink ${backlink.url_to} returned status ${response.status}`);
+    if (!response.ok) {
+      if (response.status !== 404 && response.status >= 400 && response.status < 500) {
+        log.warn(`Backlink ${backlink.url_to} returned status ${response.status}`);
+      }
+      return true;
     }
-    return !response.ok;
+    // 2xx — verify the page is not a soft 404
+    return isSoft404(response, backlink.url_to, log);
   };
 
   const backlinkStatuses = [];
@@ -190,7 +251,7 @@ export async function brokenBacklinksAuditRunner(auditUrl, context, site) {
       }
     };
 
-    const filteredBacklinks = result?.backlinks?.filter((backlink) => {
+    const excludedFilteredBacklinks = result?.backlinks?.filter((backlink) => {
       if (!excludedURLs || excludedURLs.length === 0) {
         return true;
       }
@@ -200,6 +261,17 @@ export async function brokenBacklinksAuditRunner(auditUrl, context, site) {
         const normalizedExcluded = normalizeUrl(excludedUrl);
         return normalizedBacklink === normalizedExcluded;
       });
+    });
+
+    // Drop backlinks whose target belongs to a different subdomain than the audited site.
+    // www and the bare domain are treated as the same host and are never filtered.
+    const siteBaseURL = site.getBaseURL();
+    const filteredBacklinks = excludedFilteredBacklinks?.filter((backlink) => {
+      if (isOnDifferentSubdomain(backlink.url_to, siteBaseURL)) {
+        log.debug(`Excluding backlink ${backlink.url_to}: different subdomain from ${siteBaseURL}`);
+        return false;
+      }
+      return true;
     });
 
     return {

--- a/src/backlinks/handler.js
+++ b/src/backlinks/handler.js
@@ -79,7 +79,8 @@ async function isSoft404(response, url, log) {
   let body;
   try {
     body = await response.text();
-  } catch /* c8 ignore next */ {
+  } catch {
+    /* c8 ignore next */
     return false;
   }
 
@@ -104,7 +105,8 @@ function isOnDifferentSubdomain(urlTo, siteBaseURL) {
     const siteHostname = stripWWW(new URL(prependSchema(siteBaseURL)).hostname).toLowerCase();
     const backlinkHostname = stripWWW(new URL(prependSchema(urlTo)).hostname).toLowerCase();
     return backlinkHostname !== siteHostname;
-  } catch /* c8 ignore next */ {
+  } catch {
+    /* c8 ignore next */
     return false;
   }
 }

--- a/src/backlinks/handler.js
+++ b/src/backlinks/handler.js
@@ -41,6 +41,12 @@ const BRIGHT_DATA_VALIDATE_URLS = 'BRIGHT_DATA_VALIDATE_URLS';
 const BRIGHT_DATA_MAX_RESULTS = 'BRIGHT_DATA_MAX_RESULTS';
 const BRIGHT_DATA_REQUEST_DELAY_MS = 'BRIGHT_DATA_REQUEST_DELAY_MS';
 
+// Matches <meta name="robots" content="...noindex..."> in both attribute orderings.
+const NOINDEX_META_RE = [
+  /<meta[^>]+name=["']robots["'][^>]*content=["'][^"']*noindex/i,
+  /<meta[^>]+content=["'][^"']*noindex[^"']*["'][^>]*name=["']robots["']/i,
+];
+
 function getEnvBool(env, key, defaultValue) {
   if (env?.[key] === undefined) {
     return defaultValue;
@@ -55,7 +61,7 @@ function getEnvInt(env, key, defaultValue) {
 
 /**
  * Detects whether a 2xx response is actually a soft 404.
- * Checks (in order): X-Robots-Tag noindex header, <meta robots noindex>, title pattern.
+ * Checks (in order): X-Robots-Tag noindex header, <meta robots noindex>, body text patterns.
  *
  * @param {Response} response - Fetch response (must be ok/2xx).
  * @param {string} url - The URL that was fetched (used for logging only).
@@ -84,6 +90,13 @@ async function isSoft404(response, url, log) {
     return false;
   }
 
+  // 2. <meta name="robots" content="noindex">
+  if (NOINDEX_META_RE.some((re) => re.test(body))) {
+    log.info(`Backlink ${url} is a soft 404 (noindex meta tag)`);
+    return true;
+  }
+
+  // 3. Body text patterns (strips tags, multilingual)
   if (isSoft404Body(body)) {
     log.info(`Backlink ${url} is a soft 404 (body pattern matched)`);
     return true;

--- a/src/backlinks/handler.js
+++ b/src/backlinks/handler.js
@@ -80,7 +80,7 @@ async function isSoft404(response, url, log) {
   try {
     body = await response.text();
   } catch {
-    /* c8 ignore next */
+    /* c8 ignore next 2 */
     return false;
   }
 
@@ -106,7 +106,7 @@ function isOnDifferentSubdomain(urlTo, siteBaseURL) {
     const backlinkHostname = stripWWW(new URL(prependSchema(urlTo)).hostname).toLowerCase();
     return backlinkHostname !== siteHostname;
   } catch {
-    /* c8 ignore next */
+    /* c8 ignore next 2 */
     return false;
   }
 }

--- a/src/backlinks/handler.js
+++ b/src/backlinks/handler.js
@@ -79,7 +79,7 @@ async function isSoft404(response, url, log) {
   let body;
   try {
     body = await response.text();
-  } catch {
+  } catch /* c8 ignore next */ {
     return false;
   }
 
@@ -104,7 +104,7 @@ function isOnDifferentSubdomain(urlTo, siteBaseURL) {
     const siteHostname = stripWWW(new URL(prependSchema(siteBaseURL)).hostname).toLowerCase();
     const backlinkHostname = stripWWW(new URL(prependSchema(urlTo)).hostname).toLowerCase();
     return backlinkHostname !== siteHostname;
-  } catch {
+  } catch /* c8 ignore next */ {
     return false;
   }
 }

--- a/src/internal-links/helpers.js
+++ b/src/internal-links/helpers.js
@@ -14,6 +14,7 @@ import {
   createInternalLinksAuditLogger,
   isInternalLinksContextLogger,
 } from './logging.js';
+import { isHtmlContentType, isSoft404Body } from '../utils/url-utils.js';
 
 const AUDIT_TYPE = 'broken-internal-links';
 
@@ -145,49 +146,6 @@ function isMalformedPageUrl(url) {
   return /\/\.[a-z0-9]+(\?.*)?(?:#.*)?$/i.test(url);
 }
 
-function shouldInspectForSoft404(contentType) {
-  /* c8 ignore next - Defensive fallback for null/undefined contentType */
-  return /^text\/html\b|^application\/xhtml\+xml\b/i.test(contentType || '');
-}
-
-function isSoft404Text(bodyText) {
-  /* c8 ignore next - Defensive fallback for null/undefined bodyText */
-  const text = String(bodyText || '')
-    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
-    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
-    .replace(/<[^>]+>/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim()
-    .toLowerCase();
-
-  if (!text) {
-    return false;
-  }
-
-  const normalizedText = text.slice(0, 12000);
-
-  return [
-    /404 not found/,
-    /page not found/,
-    /not found/,
-    /the page you (requested|are looking for).{0,40}(could not be found|does not exist|is unavailable)/,
-    /sorry[, ]+we (couldn'?t|can'?t) find/,
-    /sorry[, ]+the page.{0,40}(could not be found|does not exist|is unavailable)/,
-    /we can'?t seem to find the page/,
-    /this page no longer exists/,
-    /the requested url was not found/,
-    /error 404/,
-    /seite nicht gefunden/,
-    /page introuvable/,
-    /page non trouv[ée]e/,
-    /p[áa]gina no encontrada/,
-    /pagina non trovata/,
-    /p[áa]gina n[ãa]o encontrada/,
-    /pagina niet gevonden/,
-    /ページが見つかりません/,
-  ].some((pattern) => pattern.test(normalizedText));
-}
-
 async function releaseResponseBody(response, log, requestLabel) {
   if (!response) {
     return;
@@ -276,9 +234,9 @@ async function checkLinkWithGet(url, log) {
     const contentType = getResponse.headers.get('content-type') || null;
     const statusBucket = classifyStatusBucket(status);
 
-    if (statusBucket === null && status === 200 && shouldInspectForSoft404(contentType)) {
+    if (statusBucket === null && status === 200 && isHtmlContentType(contentType)) {
       const responseText = await getResponse.text();
-      if (isSoft404Text(responseText)) {
+      if (isSoft404Body(responseText)) {
         log.info(`✗ BROKEN LINK FOUND: ${url} (GET ${status}, bucket=${STATUS_BUCKETS.SOFT_404})`);
         return {
           isBroken: true, httpStatus: status, statusBucket: STATUS_BUCKETS.SOFT_404, contentType,

--- a/src/utils/url-utils.js
+++ b/src/utils/url-utils.js
@@ -222,6 +222,65 @@ export function joinBaseAndPath(baseURL, path) {
 }
 
 /**
+ * Returns true when a Content-Type value indicates an HTML document.
+ * Matches text/html and application/xhtml+xml (with optional charset suffix).
+ *
+ * @param {string} contentType - The Content-Type header value.
+ * @returns {boolean}
+ */
+export function isHtmlContentType(contentType) {
+  /* c8 ignore next - Defensive fallback for null/undefined contentType */
+  return /^text\/html\b|^application\/xhtml\+xml\b/i.test(contentType || '');
+}
+
+/**
+ * Returns true when the stripped body text of a 200 response matches known soft-404 patterns.
+ * Strips <script>, <style> and all other HTML tags before matching so inline JS/CSS text
+ * cannot produce false positives. Checks the first 12 000 characters of the cleaned text.
+ * Patterns cover English and several other languages (DE, FR, ES, IT, PT, NL, JA).
+ *
+ * @param {string} bodyText - Raw HTML body (or plain text) of the response.
+ * @returns {boolean}
+ */
+export function isSoft404Body(bodyText) {
+  /* c8 ignore next - Defensive fallback for null/undefined bodyText */
+  const text = String(bodyText || '')
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
+
+  if (!text) {
+    return false;
+  }
+
+  const normalizedText = text.slice(0, 12000);
+
+  return [
+    /404 not found/,
+    /page not found/,
+    /not found/,
+    /the page you (requested|are looking for).{0,40}(could not be found|does not exist|is unavailable)/,
+    /sorry[, ]+we (couldn'?t|can'?t) find/,
+    /sorry[, ]+the page.{0,40}(could not be found|does not exist|is unavailable)/,
+    /we can'?t seem to find the page/,
+    /this page no longer exists/,
+    /the requested url was not found/,
+    /error 404/,
+    /seite nicht gefunden/,
+    /page introuvable/,
+    /page non trouv[ée]e/,
+    /p[áa]gina no encontrada/,
+    /pagina non trovata/,
+    /p[áa]gina n[ãa]o encontrada/,
+    /pagina niet gevonden/,
+    /ページが見つかりません/,
+  ].some((pattern) => pattern.test(normalizedText));
+}
+
+/**
  * Strips query string from a URL, keeping only the origin and path.
  * @param {string} url - The URL to strip.
  * @returns {string} - URL without query string.

--- a/test/audits/backlinks.test.js
+++ b/test/audits/backlinks.test.js
@@ -377,6 +377,216 @@ describe('Backlinks Tests', function () {
       .equal(auditDataMock.auditResult.brokenBacklinks.concat(brokenBacklinkWithTimeout));
   });
 
+  describe('subdomain filtering', () => {
+    it('should exclude backlinks whose url_to is on a different subdomain', async () => {
+      const backlinks = [
+        {
+          title: 'same domain',
+          url_from: 'https://ref.com/page',
+          url_to: 'https://foo.com/some-page',
+          traffic_domain: 50,
+        },
+        {
+          title: 'www variant – should not be filtered',
+          url_from: 'https://ref.com/page',
+          url_to: 'https://www.foo.com/some-page',
+          traffic_domain: 40,
+        },
+        {
+          title: 'different subdomain – should be excluded',
+          url_from: 'https://ref.com/page',
+          url_to: 'https://careers.foo.com/jobs',
+          traffic_domain: 30,
+        },
+        {
+          title: 'another subdomain – should be excluded',
+          url_from: 'https://ref.com/page',
+          url_to: 'https://blog.foo.com/post',
+          traffic_domain: 20,
+        },
+      ];
+
+      nock('https://foo.com')
+        .get('/some-page')
+        .reply(404);
+
+      nock('https://www.foo.com')
+        .get('/some-page')
+        .reply(404);
+
+      mockSeoClient.getBrokenBacklinks.resolves({
+        result: { backlinks },
+        fullAuditRef: auditUrl,
+      });
+
+      const result = await brokenBacklinksAuditRunner(auditUrl, context, site2);
+      const resultUrls = result.auditResult.brokenBacklinks.map((b) => b.url_to);
+
+      expect(resultUrls).to.include('https://foo.com/some-page');
+      expect(resultUrls).to.include('https://www.foo.com/some-page');
+      expect(resultUrls).to.not.include('https://careers.foo.com/jobs');
+      expect(resultUrls).to.not.include('https://blog.foo.com/post');
+    });
+
+    it('should keep all backlinks when site uses www and url_to uses bare domain', async () => {
+      const backlinks = [
+        {
+          title: 'bare domain – must not be filtered',
+          url_from: 'https://ref.com/page',
+          url_to: 'https://example.com/page',
+          traffic_domain: 50,
+        },
+      ];
+
+      nock('https://example.com')
+        .get('/page')
+        .reply(404);
+
+      const wwwSite = {
+        getId: () => 'www-site',
+        getBaseURL: () => 'https://www.example.com',
+        getConfig: () => ({ getExcludedURLs: () => [] }),
+      };
+
+      mockSeoClient.getBrokenBacklinks.resolves({
+        result: { backlinks },
+        fullAuditRef: auditUrl,
+      });
+
+      const result = await brokenBacklinksAuditRunner(auditUrl, context, wwwSite);
+      expect(result.auditResult.brokenBacklinks).to.have.length(1);
+      expect(result.auditResult.brokenBacklinks[0].url_to).to.equal('https://example.com/page');
+    });
+  });
+
+  describe('soft-404 detection', () => {
+    it('should keep backlink when 200 response has X-Robots-Tag: noindex', async () => {
+      nock('https://foo.com')
+        .get('/soft-404-robots-header')
+        .reply(200, '<html><body>Custom 404</body></html>', {
+          'content-type': 'text/html',
+          'x-robots-tag': 'noindex',
+        });
+
+      const backlinks = [
+        {
+          title: 'soft 404 via X-Robots-Tag',
+          url_from: 'https://ref.com/page',
+          url_to: 'https://foo.com/soft-404-robots-header',
+          traffic_domain: 50,
+        },
+      ];
+
+      mockSeoClient.getBrokenBacklinks.resolves({
+        result: { backlinks },
+        fullAuditRef: auditUrl,
+      });
+
+      const result = await brokenBacklinksAuditRunner(auditUrl, context, site2);
+      expect(result.auditResult.brokenBacklinks).to.have.length(1);
+      expect(result.auditResult.brokenBacklinks[0].url_to)
+        .to.equal('https://foo.com/soft-404-robots-header');
+    });
+
+    it('should keep backlink when 200 response has <meta robots noindex>', async () => {
+      const html = '<html><head><meta name="robots" content="noindex, nofollow"></head><body>Oops</body></html>';
+      nock('https://foo.com')
+        .get('/soft-404-meta')
+        .reply(200, html, { 'content-type': 'text/html' });
+
+      const backlinks = [
+        {
+          title: 'soft 404 via meta noindex',
+          url_from: 'https://ref.com/page',
+          url_to: 'https://foo.com/soft-404-meta',
+          traffic_domain: 50,
+        },
+      ];
+
+      mockSeoClient.getBrokenBacklinks.resolves({
+        result: { backlinks },
+        fullAuditRef: auditUrl,
+      });
+
+      const result = await brokenBacklinksAuditRunner(auditUrl, context, site2);
+      expect(result.auditResult.brokenBacklinks).to.have.length(1);
+    });
+
+    it('should keep backlink when 200 response title contains "404 Not Found"', async () => {
+      const html = '<html><head><title>404 Not Found</title></head><body>The page you requested was not found.</body></html>';
+      nock('https://foo.com')
+        .get('/soft-404-title')
+        .reply(200, html, { 'content-type': 'text/html' });
+
+      const backlinks = [
+        {
+          title: 'soft 404 via title',
+          url_from: 'https://ref.com/page',
+          url_to: 'https://foo.com/soft-404-title',
+          traffic_domain: 50,
+        },
+      ];
+
+      mockSeoClient.getBrokenBacklinks.resolves({
+        result: { backlinks },
+        fullAuditRef: auditUrl,
+      });
+
+      const result = await brokenBacklinksAuditRunner(auditUrl, context, site2);
+      expect(result.auditResult.brokenBacklinks).to.have.length(1);
+    });
+
+    it('should drop backlink when 200 response is a real page (no soft-404 signals)', async () => {
+      const html = '<html><head><title>Welcome to Foo</title></head><body>Content here.</body></html>';
+      nock('https://foo.com')
+        .get('/real-page')
+        .reply(200, html, { 'content-type': 'text/html' });
+
+      const backlinks = [
+        {
+          title: 'real page returning 200',
+          url_from: 'https://ref.com/page',
+          url_to: 'https://foo.com/real-page',
+          traffic_domain: 50,
+        },
+      ];
+
+      mockSeoClient.getBrokenBacklinks.resolves({
+        result: { backlinks },
+        fullAuditRef: auditUrl,
+      });
+
+      const result = await brokenBacklinksAuditRunner(auditUrl, context, site2);
+      expect(result.auditResult.brokenBacklinks).to.have.length(0);
+    });
+
+    it('should keep backlink when 200 non-HTML response has noindex in x-robots-tag', async () => {
+      nock('https://foo.com')
+        .get('/soft-404-non-html')
+        .reply(200, 'some plain text', {
+          'content-type': 'text/plain',
+          'x-robots-tag': 'noindex',
+        });
+
+      const backlinks = [
+        {
+          title: 'soft 404 non-HTML noindex header',
+          url_from: 'https://ref.com/page',
+          url_to: 'https://foo.com/soft-404-non-html',
+          traffic_domain: 50,
+        },
+      ];
+
+      mockSeoClient.getBrokenBacklinks.resolves({
+        result: { backlinks },
+        fullAuditRef: auditUrl,
+      });
+
+      const result = await brokenBacklinksAuditRunner(auditUrl, context, site2);
+      expect(result.auditResult.brokenBacklinks).to.have.length(1);
+    });
+  });
+
   it('should handle audit api errors gracefully', async () => {
     mockSeoClient.getBrokenBacklinks.rejects(new Error('SEO API request failed with status: 500'));
 

--- a/test/fixtures/broken-backlinks/sites.js
+++ b/test/fixtures/broken-backlinks/sites.js
@@ -15,10 +15,10 @@ import { Config } from '@adobe/spacecat-shared-data-access/src/models/site/confi
 const siteData = {
   getConfig: () => Config({}),
   getId: () => 'site1',
-  getBaseURL: () => 'https://bar.foo.com',
+  getBaseURL: () => 'https://foo.com',
   getIsLive: () => true,
   getOrganizationId: () => 'org1',
-  resolveFinalURL: () => 'https://bar.foo.com',
+  resolveFinalURL: () => 'https://foo.com',
 };
 
 export const site = siteData;


### PR DESCRIPTION
Adds subdomain filtering to exclude broken backlinks pointing to sibling subdomains outside the audited site's scope, and introduces soft-404 detection so URLs returning HTTP 200 are not automatically dismissed when the response carries a noindex signal or a body matching known "page not found" patterns across multiple languages.


Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
