### PR TITLE
feat(vulnerabilities): include imsOrg in codefix message (CQ-4363440)

### DIFF
--- a/src/vulnerabilities/handler.js
+++ b/src/vulnerabilities/handler.js
@@ -344,6 +344,7 @@ export const opportunityAndSuggestionsStep = async (context) => {
     SuggestionDataAccess.STATUSES.PENDING_VALIDATION,
   ].includes(s.getStatus()));
   const suggestionIds = newSuggestions.map((s) => s.getId());
+  const imsOrg = await getImsOrgId(site, dataAccess, log);
   const message = {
     type: 'codefix:security-vulnerabilities',
     siteId: site.getId(),
@@ -355,6 +356,7 @@ export const opportunityAndSuggestionsStep = async (context) => {
       suggestionIds,
       codeBucket: codeInfo.codeBucket,
       codePath: codeInfo.codePath,
+      imsOrg,
     },
   };
 

--- a/test/audits/vulnerabilities.test.js
+++ b/test/audits/vulnerabilities.test.js
@@ -667,6 +667,7 @@ describe('Vulnerabilities Handler Integration Tests', () => {
         'codePath',
         'code/ad3d5bb7-9e85-4195-94e8-833cc5a73253/github/adobe/mystique-project/main/repository.zip',
       );
+      expect(message.data).to.have.property('imsOrg', 'test-ims-org');
     });
 
     it('should skip starfish-auto-code when queue env var is not configured', async () => {


### PR DESCRIPTION
## Summary
- Adds the site's IMS org id to the `codefix:security-vulnerabilities` SQS message payload sent from `opportunityAndSuggestionsStep`.
- Enables the downstream vulnerabilities code-fix handler to mint an S2S access token scoped to the correct org when calling the SpaceCat API, replacing the deprecated API key flow.
- Related Jira: [CQ-4363440](https://jira.corp.adobe.com/browse/CQ-4363440)

## Test plan
- [x] Updated `test/audits/vulnerabilities.test.js` asserts `imsOrg` is present on the emitted message data
- [x] `npm run test:spec -- test/audits/vulnerabilities.test.js` — vulnerabilities handler at 100% coverage
- [x] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)