### PR TITLE
feat: Sitemap audit uses canonical URL as its suggested URL

### DIFF
--- a/src/sitemap/common.js
+++ b/src/sitemap/common.js
@@ -337,9 +337,77 @@ export function pathnameKey(urlString) {
 }
 
 /**
+ * Returns true if the canonical URL is a better match than the suggested URL.
+ * The canonical URL must match the suggested URL except for the canonical can lack a suffix.
+ *
+ * Examples of true:
+ * * https://www.example.com/my-stuff.page  and  https://www.example.com/my-stuff
+ * * https://www.example.com/my-stuff.html  and  https://www.example.com/my-stuff
+ *
+ * Examples of false:
+ * * https://www.example.com/my-stuff.page  and  https://www.example.com/my-stuffing
+ * * https://www.example.com/foo/bar        and  https://www.example.com/foo
+ *
+ * @param {string} suggestedUrl - What we think we want to suggest
+ * @param {string} canonicalUrl - Absolute canonical href from HTML page
+ * @returns {boolean}
+ */
+export function suggestedUrlMatchesCanonicalUrlWithoutSuffix(
+  suggestedUrl,
+  canonicalUrl,
+) {
+  let s;
+  let c;
+  try {
+    s = new URL(suggestedUrl);
+    c = new URL(canonicalUrl);
+  } catch {
+    return false;
+  }
+
+  if (s.protocol !== c.protocol) {
+    return false;
+  }
+  if (s.hostname.toLowerCase() !== c.hostname.toLowerCase()) {
+    return false;
+  }
+
+  const normalizePathname = (pathname) => {
+    let p = pathname;
+    if (p.length > 1 && p.endsWith('/')) {
+      p = p.slice(0, -1);
+    }
+    return p;
+  };
+
+  const sp = normalizePathname(s.pathname);
+  const cp = normalizePathname(c.pathname);
+
+  if (sp.length <= cp.length) {
+    return false;
+  }
+  if (!sp.startsWith(cp)) {
+    return false;
+  }
+
+  const rest = sp.slice(cp.length);
+  if (!rest.startsWith('.')) {
+    return false; // since we are looking for a suffix on the suggested URL
+  }
+  const afterDot = rest.slice(1);
+  if (afterDot.length === 0 || afterDot.includes('/')) {
+    return false;
+  }
+
+  return true; // the canonical URL can be used in place of the suggested URL
+}
+
+/**
  * Typically after a redirect {@code notOk} decision, GET the document and refine using
  * {@code rel="canonical"}. Promotes to {@code ok} when canonical matches the probed URL;
- * otherwise may replace {@code urlsSuggested} when canonical matches the suggested URL's path.
+ * otherwise may replace {@code urlsSuggested} when canonical matches the suggested URL's path
+ * (exact pathname) or extends it with a dot-suffix segment per
+ * {@link suggestedUrlMatchesCanonicalUrlWithoutSuffix}.
  *
  * @param {object} params
  * @param {string} params.documentUrl - URL to GET so we can extract its canonical href
@@ -396,10 +464,22 @@ async function refineSuggestedUrlWithItsCanonicalUrl({
   if (
     typeof suggestedUrl === 'string'
     && suggestedUrl.length > 0
-    && (pathnameKey(suggestedUrl) === pathnameKey(canonicalUrl))
+    && (pathnameKey(suggestedUrl) === pathnameKey(canonicalUrl)) // ignore query parms
   ) {
     log?.debug(
       `Sitemap: suggesting the canonical URL ${canonicalUrl} (replacing suggested ${suggestedUrl}) for probed ${probedUrl}.`,
+    );
+    return { ...notOkPayload, urlsSuggested: canonicalUrl };
+  }
+
+  // if the canonical URL is a reasonably shorter form of our suggested URL, use the canonical URL
+  if (
+    typeof suggestedUrl === 'string'
+    && suggestedUrl.length > 0
+    && suggestedUrlMatchesCanonicalUrlWithoutSuffix(suggestedUrl, canonicalUrl)
+  ) {
+    log?.debug(
+      `Sitemap: suggesting the canonical URL ${canonicalUrl} (terminal path extends canonical by dot suffix; replacing ${suggestedUrl}) for probed ${probedUrl}.`,
     );
     return { ...notOkPayload, urlsSuggested: canonicalUrl };
   }

--- a/test/audits/sitemap.test.js
+++ b/test/audits/sitemap.test.js
@@ -45,8 +45,9 @@ import {
   urlLooksLike404Page,
   formatUrlProbeErrorDetail,
   pathnameKey,
+  suggestedUrlMatchesCanonicalUrlWithoutSuffix,
+  extractCanonicalHrefFromHtml,
 } from '../../src/sitemap/common.js';
-import { extractCanonicalHrefFromHtml } from '../../src/sitemap/common.js';
 import { extractDomainAndProtocol } from '../../src/support/utils.js';
 import { MockContextBuilder } from '../shared.js';
 import { DATA_SOURCES } from '../../src/common/constants.js';
@@ -2514,6 +2515,32 @@ describe('filterValidUrls with redirect handling', () => {
     ]);
   });
 
+  it('uses canonical href when terminal pathname extends canonical by dot suffix (e.g. .page)', async () => {
+    const probed = 'https://example.com/r-dot';
+    const terminal = 'https://example.com/support/contact-us.page';
+    const canonicalClean = 'https://example.com/support/contact-us';
+    const html = `<!DOCTYPE html><html><head><link rel="canonical" href="${canonicalClean}" /></head><body></body></html>`;
+    const log = { debug: sandbox.spy() };
+
+    nock('https://example.com')
+      .head('/r-dot')
+      .reply(301, '', { Location: terminal });
+    nock('https://example.com').head('/support/contact-us.page').reply(200);
+    nock('https://example.com')
+      .get('/support/contact-us.page')
+      .reply(200, html, { 'Content-Type': 'text/html' });
+
+    const result = await filterValidUrls([probed], log);
+    expect(result.notOk).to.deep.equal([
+      {
+        url: probed,
+        statusCode: 301,
+        urlsSuggested: canonicalClean,
+      },
+    ]);
+    expect(log.debug).to.have.been.calledWith(sinon.match(/terminal path extends canonical by dot suffix/));
+  });
+
   it('GET for canonical uses non-HTML response without changing redirect notOk', async () => {
     const probed = 'https://example.com/r-json';
     const terminal = 'https://example.com/data.json';
@@ -2723,6 +2750,88 @@ describe('pathnameKey', () => {
 
   it('returns original string when URL parsing fails', () => {
     expect(pathnameKey('not-a-valid-url')).to.equal('not-a-valid-url');
+  });
+});
+
+describe('suggestedUrlMatchesCanonicalUrlWithoutSuffix', () => {
+  it('returns true when terminal path is canonical path plus dot suffix (e.g. .page)', () => {
+    expect(suggestedUrlMatchesCanonicalUrlWithoutSuffix(
+      'https://www.ups.com/us/en/support/contact-us.page',
+      'https://www.ups.com/us/en/support/contact-us',
+    )).to.equal(true);
+    expect(suggestedUrlMatchesCanonicalUrlWithoutSuffix(
+      'https://Example.COM/a/b.html',
+      'https://example.com/a/b',
+    )).to.equal(true);
+  });
+
+  it('returns true when trailing slashes normalize to the same dot-suffix relationship', () => {
+    expect(suggestedUrlMatchesCanonicalUrlWithoutSuffix(
+      'https://example.com/dir/name.page/',
+      'https://example.com/dir/name/',
+    )).to.equal(true);
+  });
+
+  it('returns false when extra segment would be another path level', () => {
+    expect(suggestedUrlMatchesCanonicalUrlWithoutSuffix(
+      'https://example.com/foo/bar',
+      'https://example.com/foo',
+    )).to.equal(false);
+  });
+
+  it('returns false when suggested pathname does not start with canonical pathname', () => {
+    expect(suggestedUrlMatchesCanonicalUrlWithoutSuffix(
+      'https://example.com/a/c.page',
+      'https://example.com/a/b',
+    )).to.equal(false);
+  });
+
+  it('returns false when dot-suffix segment contains a slash', () => {
+    expect(suggestedUrlMatchesCanonicalUrlWithoutSuffix(
+      'https://example.com/can./more',
+      'https://example.com/can',
+    )).to.equal(false);
+  });
+
+  it('returns false when rest is only a dot (no suffix segment)', () => {
+    expect(suggestedUrlMatchesCanonicalUrlWithoutSuffix(
+      'https://example.com/foo.',
+      'https://example.com/foo',
+    )).to.equal(false);
+  });
+
+  it('returns false when paths share a string prefix but not a dot boundary (e.g. /blog vs /blogging)', () => {
+    expect(suggestedUrlMatchesCanonicalUrlWithoutSuffix(
+      'https://example.com/blogging',
+      'https://example.com/blog',
+    )).to.equal(false);
+  });
+
+  it('returns false for invalid URLs, mismatched host, or mismatched protocol', () => {
+    expect(suggestedUrlMatchesCanonicalUrlWithoutSuffix('', 'https://example.com/a')).to.equal(false);
+    expect(suggestedUrlMatchesCanonicalUrlWithoutSuffix(
+      'not-a-url',
+      'https://example.com/a',
+    )).to.equal(false);
+    expect(suggestedUrlMatchesCanonicalUrlWithoutSuffix(
+      'https://example.com/a.page',
+      'not-a-url',
+    )).to.equal(false);
+    expect(suggestedUrlMatchesCanonicalUrlWithoutSuffix(
+      'https://other.com/a.page',
+      'https://example.com/a',
+    )).to.equal(false);
+    expect(suggestedUrlMatchesCanonicalUrlWithoutSuffix(
+      'http://example.com/a.page',
+      'https://example.com/a',
+    )).to.equal(false);
+  });
+
+  it('returns false when paths are identical', () => {
+    expect(suggestedUrlMatchesCanonicalUrlWithoutSuffix(
+      'https://example.com/p',
+      'https://example.com/p',
+    )).to.equal(false);
   });
 });
 


### PR DESCRIPTION
 * enhanced to ignore suffix, when applicable

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
