### PR TITLE
fix(prerender): guard domain-wide suggestions from stale-page cleanup

### DIFF
--- a/src/utils/data-access.js
+++ b/src/utils/data-access.js
@@ -267,9 +267,16 @@ export const handleOutdatedSuggestions = async ({
       SuggestionDataAccess.STATUSES.IN_PROGRESS,
     ].includes(existing.getStatus()))
     .filter((existing) => {
-      // Preserve suggestions that have been deployed (tokowakaDeployed or edgeDeployed)
+      // Preserve prerender suggestions that are already deployed or covered by
+      // domain-wide deployment. Domain-wide rows are synthetic aggregate records,
+      // not real scraped URLs, so generic stale-page cleanup should not age them out.
       const data = existing.getData?.();
-      return !(data?.tokowakaDeployed || data?.edgeDeployed);
+      return !(
+        data?.tokowakaDeployed
+        || data?.edgeDeployed
+        || data?.coveredByDomainWide
+        || data?.isDomainWide
+      );
     })
     .filter((existing) => {
       // mark suggestions as outdated only if their URL was actually scraped

--- a/test/utils/data-access.test.js
+++ b/test/utils/data-access.test.js
@@ -1217,6 +1217,73 @@ describe('data-access', () => {
       expect(mockLogger.info).to.have.been.calledWith('[SuggestionSync] Final count of suggestions to mark as OUTDATED: 1');
     });
 
+    it('should not mark prerender domain-wide or covered suggestions as OUTDATED', async () => {
+      const buildKeyWithUrl = (data) => `${data.url}|${data.key ?? ''}`;
+
+      const domainWideSuggestion = {
+        id: 'domain-wide',
+        data: {
+          url: 'https://example.com/* (All Domain URLs)',
+          isDomainWide: true,
+        },
+        getId: sinon.stub().returns('domain-wide'),
+        getData: sinon.stub().returns({
+          url: 'https://example.com/* (All Domain URLs)',
+          isDomainWide: true,
+        }),
+        getStatus: sinon.stub().returns('NEW'),
+      };
+      const coveredSuggestion = {
+        id: 'covered',
+        data: {
+          url: 'https://example.com/page1',
+          key: 'page1',
+          coveredByDomainWide: 'domain-wide',
+        },
+        getId: sinon.stub().returns('covered'),
+        getData: sinon.stub().returns({
+          url: 'https://example.com/page1',
+          key: 'page1',
+          coveredByDomainWide: 'domain-wide',
+        }),
+        getStatus: sinon.stub().returns('NEW'),
+      };
+      const normalSuggestion = {
+        id: 'normal',
+        data: { url: 'https://example.com/page2', key: 'page2' },
+        getId: sinon.stub().returns('normal'),
+        getData: sinon.stub().returns({ url: 'https://example.com/page2', key: 'page2' }),
+        getStatus: sinon.stub().returns('NEW'),
+      };
+
+      const scrapedUrlsSet = new Set([
+        'https://example.com/* (All Domain URLs)',
+        'https://example.com/page1',
+        'https://example.com/page2',
+      ]);
+
+      mockOpportunity.getSuggestions.resolves([
+        domainWideSuggestion,
+        coveredSuggestion,
+        normalSuggestion,
+      ]);
+
+      await syncSuggestions({
+        opportunity: mockOpportunity,
+        newData: [],
+        context,
+        buildKey: buildKeyWithUrl,
+        mapNewSuggestion,
+        scrapedUrlsSet,
+      });
+
+      expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledOnceWith(
+        [normalSuggestion],
+        'OUTDATED',
+      );
+      expect(mockLogger.info).to.have.been.calledWith('[SuggestionSync] Final count of suggestions to mark as OUTDATED: 1');
+    });
+
     it('should update suggestions when they are detected again', async () => {
       const suggestionsData = [
         { key: '1', title: 'old title' },


### PR DESCRIPTION
## Summary

- `handleOutdatedSuggestions` was bulk-marking prerender domain-wide suggestions (`isDomainWide`, `coveredByDomainWide`) as `OUTDATED` on every no-op audit batch
- Domain-wide rows are synthetic aggregate records — not real scraped pages — so generic stale-page cleanup should never age them out
- Extended the deployed-record guard (which already preserved `tokowakaDeployed` / `edgeDeployed`) to also preserve `isDomainWide` and `coveredByDomainWide`

## Root Cause

Prerender passes a synthetic domain-level URL (e.g. `adobe.com/* (All Domain URLs)`) into `scrapedUrlsSet`. The outdating filter checked whether the suggestion's URL was scraped — it was — and then whether its key appeared in new findings — it didn't (it's a synthetic aggregate). Both conditions passed, so the domain-wide suggestion was marked `OUTDATED` repeatedly.

## Test Plan

- [x] New regression test: `should not mark prerender domain-wide or covered suggestions as OUTDATED`
- [x] `npm run test:spec -- test/utils/data-access.test.js` — 125 passing
- [x] `npm run lint` — clean

## Notes

This stops new bad transitions. Existing `OUTDATED` domain-wide rows already in the DB would need a one-time data fix to be repaired.