### PR TITLE
fix(prerender): skip no-opportunity OUTDATED sync when scrape stats are unreliable

### DIFF
--- a/src/prerender/handler.js
+++ b/src/prerender/handler.js
@@ -29,6 +29,8 @@ import {
   PRERENDER_RECENT_PROCESSING_TIME_DAYS,
   MODE_AI_ONLY,
   MYSTIQUE_BATCH_SIZE,
+  PRERENDER_NO_OPP_OUTDATE_MIN_SUCCESSFUL_SCRAPES,
+  PRERENDER_NO_OPP_OUTDATE_SCRAPE_ERROR_RATE_PCT,
 } from './utils/constants.js';
 
 function rebaseUrl(url, preferredBase, log) {
@@ -50,6 +52,32 @@ const AUDIT_ERROR_MESSAGE = 'Audit failed';
 const getDomainWideSuggestionUrl = (baseUrl) => `${baseUrl}/* (All Domain URLs)`;
 
 const DOMAIN_WIDE_SUGGESTION_KEY = 'domain-wide-aggregate|prerender';
+
+/**
+ * Whether the no-opportunity `syncSuggestions` pass (marks prior suggestions OUTDATED) should run.
+ * When most submitted URLs failed to produce a successful comparison, the remaining successes
+ * are not treated as an authoritative "prerender resolved" signal — same thresholds ELMO uses
+ * for unreliable scrape stats (`hasEnoughScrapedPages` / `scrapingErrorRateHigh`).
+ *
+ * @param {object} params
+ * @param {number} params.urlsSubmittedForScraping
+ * @param {number} params.successfulComparisonsCount
+ * @param {number} params.scrapingErrorRate
+ * @returns {boolean}
+ */
+export function shouldSyncOutdatedForNoPrerenderFindings({
+  urlsSubmittedForScraping,
+  successfulComparisonsCount,
+  scrapingErrorRate,
+}) {
+  if (urlsSubmittedForScraping <= 0) {
+    return true;
+  }
+  const tooFewSuccessfulReviews = successfulComparisonsCount
+    < PRERENDER_NO_OPP_OUTDATE_MIN_SUCCESSFUL_SCRAPES;
+  const highScrapeFailureRate = scrapingErrorRate >= PRERENDER_NO_OPP_OUTDATE_SCRAPE_ERROR_RATE_PCT;
+  return !(tooFewSuccessfulReviews && highScrapeFailureRate);
+}
 
 /**
  * Checks if a suggestion's data represents a domain-wide suggestion.
@@ -1703,18 +1731,34 @@ export async function processContentAndGenerateOpportunities(context) {
       const existingOpportunity = opportunities.find((o) => o.getType() === AUDIT_TYPE);
 
       if (existingOpportunity) {
-        // Include domain-wide URL so aggregate suggestion can be marked outdated when appropriate
-        const scrapedUrlsForNoOppty = new Set(scrapedUrlsSet);
-        scrapedUrlsForNoOppty.add(getDomainWideSuggestionUrl(site.getBaseURL()));
-        await syncSuggestions({
-          opportunity: existingOpportunity,
-          newData: [],
-          context,
-          buildKey: (suggestionData) => suggestionData.url,
-          mapNewSuggestion: () => ({}),
-          scrapedUrlsSet: scrapedUrlsForNoOppty,
-        });
         opportunityWithSuggestions = existingOpportunity;
+        const runOutdatedSync = shouldSyncOutdatedForNoPrerenderFindings({
+          urlsSubmittedForScraping,
+          successfulComparisonsCount: successfulComparisons.length,
+          scrapingErrorRate,
+        });
+        if (!runOutdatedSync) {
+          log.warn(
+            `${LOG_PREFIX} Skipping no-opportunity OUTDATED sync: scrape outcomes too noisy to infer `
+            + `"prerender resolved" reliably. baseUrl=${site.getBaseURL()}, siteId=${siteId}, `
+            + `urlsSubmittedForScraping=${urlsSubmittedForScraping}, `
+            + `urlsScrapedSuccessfully=${successfulComparisons.length}, scrapingErrorRate=${scrapingErrorRate}%. `
+            + `Guard: successfulScrapes < ${PRERENDER_NO_OPP_OUTDATE_MIN_SUCCESSFUL_SCRAPES} AND `
+            + `scrapingErrorRate >= ${PRERENDER_NO_OPP_OUTDATE_SCRAPE_ERROR_RATE_PCT}%.`,
+          );
+        } else {
+          // Include domain-wide URL so aggregate suggestion can be marked outdated when appropriate
+          const scrapedUrlsForNoOppty = new Set(scrapedUrlsSet);
+          scrapedUrlsForNoOppty.add(getDomainWideSuggestionUrl(site.getBaseURL()));
+          await syncSuggestions({
+            opportunity: existingOpportunity,
+            newData: [],
+            context,
+            buildKey: (suggestionData) => suggestionData.url,
+            mapNewSuggestion: () => ({}),
+            scrapedUrlsSet: scrapedUrlsForNoOppty,
+          });
+        }
       }
     }
 

--- a/src/prerender/utils/constants.js
+++ b/src/prerender/utils/constants.js
@@ -20,3 +20,17 @@ export const TOP_ORGANIC_URLS_LIMIT = 200;
 export const PRERENDER_RECENT_PROCESSING_TIME_DAYS = 7;
 export const MODE_AI_ONLY = 'ai-only';
 export const MYSTIQUE_BATCH_SIZE = DAILY_BATCH_SIZE;
+
+/**
+ * Minimum successful HTML comparisons required before the no-opportunity OUTDATED sync runs
+ * when scrape failures are also high. Aligns with ELMO `hasEnoughScrapedPages` (50 URLs).
+ */
+export const PRERENDER_NO_OPP_OUTDATE_MIN_SUCCESSFUL_SCRAPES = 50;
+
+/**
+ * Scrape error rate (percent of submitted URLs without a successful comparison) above which
+ * the no-opportunity OUTDATED sync is skipped when successful scrapes are below
+ * PRERENDER_NO_OPP_OUTDATE_MIN_SUCCESSFUL_SCRAPES.
+ * Aligns with ELMO `scrapingErrorRateHigh` (30%).
+ */
+export const PRERENDER_NO_OPP_OUTDATE_SCRAPE_ERROR_RATE_PCT = 30;

--- a/test/audits/prerender/handler.test.js
+++ b/test/audits/prerender/handler.test.js
@@ -25,6 +25,7 @@ import prerenderHandler, {
   uploadStatusSummaryToS3,
   writeToCitabilityRecords,
   getScrapeJobStats,
+  shouldSyncOutdatedForNoPrerenderFindings,
 } from '../../../src/prerender/handler.js';
 import { analyzeHtmlForPrerender } from '../../../src/prerender/utils/html-comparator.js';
 import { createOpportunityData } from '../../../src/prerender/opportunity-data-mapper.js';
@@ -55,6 +56,40 @@ describe('Prerender Audit', () => {
       expect(importTopPages).to.be.a('function');
       expect(submitForScraping).to.be.a('function');
       expect(processContentAndGenerateOpportunities).to.be.a('function');
+    });
+  });
+
+  describe('shouldSyncOutdatedForNoPrerenderFindings', () => {
+    it('returns true when no URLs were submitted (nothing to gate)', () => {
+      expect(shouldSyncOutdatedForNoPrerenderFindings({
+        urlsSubmittedForScraping: 0,
+        successfulComparisonsCount: 0,
+        scrapingErrorRate: 100,
+      })).to.be.true;
+    });
+
+    it('returns true when successful scrapes reach the minimum despite a high error rate', () => {
+      expect(shouldSyncOutdatedForNoPrerenderFindings({
+        urlsSubmittedForScraping: 100,
+        successfulComparisonsCount: 50,
+        scrapingErrorRate: 50,
+      })).to.be.true;
+    });
+
+    it('returns true when the error rate is below the threshold', () => {
+      expect(shouldSyncOutdatedForNoPrerenderFindings({
+        urlsSubmittedForScraping: 40,
+        successfulComparisonsCount: 10,
+        scrapingErrorRate: 29,
+      })).to.be.true;
+    });
+
+    it('returns false when successes are below minimum and error rate is at threshold', () => {
+      expect(shouldSyncOutdatedForNoPrerenderFindings({
+        urlsSubmittedForScraping: 40,
+        successfulComparisonsCount: 10,
+        scrapingErrorRate: 75,
+      })).to.be.false;
     });
   });
 
@@ -1583,7 +1618,8 @@ describe('Prerender Audit', () => {
       // Note: Suggestion syncing is now handled by the well-tested syncSuggestions() utility function.
       // These tests verify the behavior when no new prerender needs are found.
 
-      it('should call syncSuggestions with empty array when existing opportunity is found', async () => {
+      it('should call syncSuggestions with empty array when existing opportunity is found', async function () {
+        this.timeout(10000);
         const mockOpportunity = {
           getId: () => 'existing-opportunity-id',
           getType: () => 'prerender',
@@ -1605,6 +1641,28 @@ describe('Prerender Audit', () => {
           },
         });
 
+        const htmlFixture = '<html><body><p>hello world prerender stable content for both sides</p></body></html>';
+        const s3SendStub = sandbox.stub().callsFake((command) => {
+          if (command.constructor?.name !== 'GetObjectCommand') {
+            return Promise.resolve({});
+          }
+          const { Key } = command.input;
+          if (Key.endsWith('scrape.json')) {
+            return Promise.resolve({
+              ContentType: 'application/json',
+              Body: {
+                transformToString: () => Promise.resolve(JSON.stringify({
+                  status: 'COMPLETE',
+                  isDeployedAtEdge: false,
+                })),
+              },
+            });
+          }
+          return Promise.resolve({
+            Body: { transformToString: () => Promise.resolve(htmlFixture) },
+          });
+        });
+
         const context = {
           site: {
             getId: () => 'test-site-id',
@@ -1624,8 +1682,6 @@ describe('Prerender Audit', () => {
             ScrapeUrl: {
               allByScrapeJobId: sandbox.stub().resolves([
                 { getUrl: () => 'https://example.com/test' },
-                { getUrl: () => 'https://example.com/other1' },
-                { getUrl: () => 'https://example.com/other2' },
               ]),
             },
           },
@@ -1636,9 +1692,7 @@ describe('Prerender Audit', () => {
             error: sandbox.stub(),
           },
           s3Client: {
-            send: sandbox.stub().resolves({
-              Body: { transformToString: () => Promise.resolve('') },
-            }),
+            send: s3SendStub,
           },
           env: { S3_SCRAPER_BUCKET_NAME: 'test-bucket' },
           auditContext: { scrapeJobId: 'test-job-id' },
@@ -1649,7 +1703,7 @@ describe('Prerender Audit', () => {
 
         expect(result.status).to.equal('complete');
         expect(result.auditResult.urlsNeedingPrerender).to.equal(0);
-        expect(result.auditResult.urlsSubmittedForScraping).to.equal(3);
+        expect(result.auditResult.urlsSubmittedForScraping).to.equal(1);
         expect(result.auditResult.urlsScrapedSuccessfully).to.be.a('number');
         expect(result.auditResult.scrapingErrorRate).to.be.a('number');
 
@@ -1675,6 +1729,104 @@ describe('Prerender Audit', () => {
         // Verify log message indicates no opportunity was found
         const infoLogs = context.log.info.args.map(call => call[0]);
         expect(infoLogs.some(msg => msg.includes('No opportunity found'))).to.be.true;
+      });
+
+      it('should skip no-opportunity OUTDATED sync when scrape stats are too unreliable', async function () {
+        this.timeout(15000);
+        const mockOpportunity = {
+          getId: () => 'existing-opportunity-id',
+          getType: () => 'prerender',
+          getSuggestions: sandbox.stub().resolves([]),
+        };
+
+        const allBySiteIdAndStatusStub = sandbox.stub().resolves([mockOpportunity]);
+        const syncSuggestionsStub = sandbox.stub().resolves();
+
+        const mockHandler = await esmock('../../../src/prerender/handler.js', {
+          '../../../src/utils/data-access.js': {
+            syncSuggestions: syncSuggestionsStub,
+          },
+        });
+
+        const htmlFixture = '<html><body><p>hello world prerender stable content for both sides</p></body></html>';
+        const s3SendStub = sandbox.stub().callsFake((command) => {
+          if (command.constructor?.name !== 'GetObjectCommand') {
+            return Promise.resolve({});
+          }
+          const { Key } = command.input;
+          if (Key.endsWith('scrape.json')) {
+            if (Key.includes('/missing-')) {
+              return Promise.reject(Object.assign(new Error('NoSuchKey'), { name: 'NoSuchKey' }));
+            }
+            return Promise.resolve({
+              ContentType: 'application/json',
+              Body: {
+                transformToString: () => Promise.resolve(JSON.stringify({
+                  status: 'COMPLETE',
+                  isDeployedAtEdge: false,
+                })),
+              },
+            });
+          }
+          return Promise.resolve({
+            Body: { transformToString: () => Promise.resolve(htmlFixture) },
+          });
+        });
+
+        const comparedUrls = Array.from({ length: 10 }, (_, i) => `https://example.com/p${i}`);
+        const scrapeResultPaths = new Map(comparedUrls.map((u) => [u, '/tmp/x']));
+        const extraMissing = Array.from({ length: 30 }, (_, i) => ({
+          getUrl: () => `https://example.com/missing-${i}`,
+        }));
+        const scrapeUrlRows = [
+          ...comparedUrls.map((u) => ({ getUrl: () => u })),
+          ...extraMissing,
+        ];
+
+        const context = {
+          site: {
+            getId: () => 'test-site-id',
+            getBaseURL: () => 'https://example.com',
+          },
+          audit: {
+            getId: () => 'audit-id',
+            getFullAuditRef: () => 'https://example.com',
+            getAuditedAt: () => '2024-01-01T00:00:00Z',
+            getInvocationId: () => 'invocation-123',
+          },
+          dataAccess: {
+            Opportunity: {
+              allBySiteIdAndStatus: allBySiteIdAndStatusStub,
+            },
+            LatestAudit: { updateByKeys: sandbox.stub().resolves() },
+            ScrapeUrl: {
+              allByScrapeJobId: sandbox.stub().resolves(scrapeUrlRows),
+            },
+          },
+          log: {
+            info: sandbox.stub(),
+            debug: sandbox.stub(),
+            warn: sandbox.stub(),
+            error: sandbox.stub(),
+          },
+          s3Client: { send: s3SendStub },
+          env: { S3_SCRAPER_BUCKET_NAME: 'test-bucket' },
+          auditContext: { scrapeJobId: 'test-job-id' },
+          scrapeResultPaths,
+        };
+
+        const result = await mockHandler.processContentAndGenerateOpportunities(context);
+
+        expect(result.status).to.equal('complete');
+        expect(result.auditResult.urlsNeedingPrerender).to.equal(0);
+        expect(result.auditResult.urlsSubmittedForScraping).to.equal(40);
+        expect(result.auditResult.urlsScrapedSuccessfully).to.equal(10);
+        expect(result.auditResult.scrapingErrorRate).to.equal(75);
+
+        expect(syncSuggestionsStub).to.not.have.been.called;
+        expect(context.log.warn).to.have.been.calledWith(
+          sinon.match(/Skipping no-opportunity OUTDATED sync/),
+        );
       });
 
       it('should fallback to urlsToCheck.length when ScrapeUrl.allByScrapeJobId throws', async () => {
@@ -1823,13 +1975,33 @@ describe('Prerender Audit', () => {
         expect(result.auditResult.scrapingErrorRate).to.equal(0);
       });
 
-      it('should upload status.json when catch throws (branch coverage)', async () => {
+      it('should upload status.json when catch throws (branch coverage)', async function () {
+        this.timeout(10000);
         const syncSuggestionsStub = sandbox.stub().rejects(new Error('Sync failed'));
-        const s3SendStub = sandbox.stub().callsFake((cmd) => (
-          cmd.input?.Key?.includes('status.json')
-            ? Promise.resolve({})
-            : Promise.resolve({ Body: { transformToString: () => Promise.resolve('') } })
-        ));
+        const htmlFixture = '<html><body><p>hello world prerender stable content for both sides</p></body></html>';
+        const s3SendStub = sandbox.stub().callsFake((cmd) => {
+          if (cmd.constructor?.name === 'PutObjectCommand' && cmd.input?.Key?.includes('status.json')) {
+            return Promise.resolve({});
+          }
+          if (cmd.constructor?.name !== 'GetObjectCommand') {
+            return Promise.resolve({});
+          }
+          const { Key } = cmd.input;
+          if (Key.endsWith('scrape.json')) {
+            return Promise.resolve({
+              ContentType: 'application/json',
+              Body: {
+                transformToString: () => Promise.resolve(JSON.stringify({
+                  status: 'COMPLETE',
+                  isDeployedAtEdge: false,
+                })),
+              },
+            });
+          }
+          return Promise.resolve({
+            Body: { transformToString: () => Promise.resolve(htmlFixture) },
+          });
+        });
 
         const mockHandler = await esmock('../../../src/prerender/handler.js', {
           '../../../src/utils/data-access.js': {
@@ -1851,6 +2023,7 @@ describe('Prerender Audit', () => {
           },
           dataAccess: {
             Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([{ getId: () => 'x', getType: () => 'prerender' }]) },
+            LatestAudit: { updateByKeys: sandbox.stub().resolves() },
             ScrapeUrl: { allByScrapeJobId: sandbox.stub().resolves([{ getUrl: () => 'https://example.com/test' }]) },
           },
           log: { info: sandbox.stub(), debug: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub() },
@@ -1870,18 +2043,38 @@ describe('Prerender Audit', () => {
         expect(statusBody.scrapeForbidden).to.be.false;
       });
 
-      it('should return error result and upload status.json when syncSuggestions throws', async () => {
+      it('should return error result and upload status.json when syncSuggestions throws', async function () {
+        this.timeout(10000);
         const mockOpportunity = {
           getId: () => 'existing-opportunity-id',
           getType: () => 'prerender',
         };
         const allBySiteIdAndStatusStub = sandbox.stub().resolves([mockOpportunity]);
         const syncSuggestionsStub = sandbox.stub().rejects(new Error('Sync failed'));
-        const s3SendStub = sandbox.stub().callsFake((cmd) => (
-          cmd.input?.Key?.includes('status.json')
-            ? Promise.resolve({})
-            : Promise.resolve({ Body: { transformToString: () => Promise.resolve('') } })
-        ));
+        const htmlFixture = '<html><body><p>hello world prerender stable content for both sides</p></body></html>';
+        const s3SendStub = sandbox.stub().callsFake((cmd) => {
+          if (cmd.constructor?.name === 'PutObjectCommand' && cmd.input?.Key?.includes('status.json')) {
+            return Promise.resolve({});
+          }
+          if (cmd.constructor?.name !== 'GetObjectCommand') {
+            return Promise.resolve({});
+          }
+          const { Key } = cmd.input;
+          if (Key.endsWith('scrape.json')) {
+            return Promise.resolve({
+              ContentType: 'application/json',
+              Body: {
+                transformToString: () => Promise.resolve(JSON.stringify({
+                  status: 'COMPLETE',
+                  isDeployedAtEdge: false,
+                })),
+              },
+            });
+          }
+          return Promise.resolve({
+            Body: { transformToString: () => Promise.resolve(htmlFixture) },
+          });
+        });
 
         const mockHandler = await esmock('../../../src/prerender/handler.js', {
           '../../../src/utils/data-access.js': {
@@ -1903,6 +2096,7 @@ describe('Prerender Audit', () => {
           },
           dataAccess: {
             Opportunity: { allBySiteIdAndStatus: allBySiteIdAndStatusStub },
+            LatestAudit: { updateByKeys: sandbox.stub().resolves() },
             ScrapeUrl: { allByScrapeJobId: sandbox.stub().resolves([{ getUrl: () => 'https://example.com/test' }]) },
           },
           log: { info: sandbox.stub(), debug: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub() },
@@ -8615,11 +8809,12 @@ describe('Prerender Audit', () => {
       expect(syncCall).to.not.have.property('stalenessDays');
     });
 
-    it('should not augment scrapedUrlsSet with PageCitability records from other writes', async () => {
+    it('should not augment scrapedUrlsSet with PageCitability records from other writes', async function () {
+      this.timeout(10000);
       const syncSuggestionsStub = sinon.stub().resolves();
       const mockOpportunity = {
         getId: () => 'opp-id',
-        getType: sinon.stub().returns('prerender'),
+        getType: () => 'prerender',
         getSuggestions: sinon.stub().resolves([]),
       };
 
@@ -8639,12 +8834,38 @@ describe('Prerender Audit', () => {
         getUpdatedAt: () => new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString(),
       };
 
+      const htmlFixture = '<html><body><p>hello world prerender stable content for both sides</p></body></html>';
+      const s3SendStub = sinon.stub().callsFake((command) => {
+        if (command.constructor?.name !== 'GetObjectCommand') {
+          return Promise.resolve({});
+        }
+        const { Key } = command.input;
+        if (Key.endsWith('scrape.json')) {
+          return Promise.resolve({
+            ContentType: 'application/json',
+            Body: {
+              transformToString: () => Promise.resolve(JSON.stringify({
+                status: 'COMPLETE',
+                isDeployedAtEdge: false,
+              })),
+            },
+          });
+        }
+        return Promise.resolve({
+          Body: { transformToString: () => Promise.resolve(htmlFixture) },
+        });
+      });
+
       const context = {
         site: { getId: () => 'site-1', getBaseURL: () => 'https://example.com' },
         audit: { getId: () => 'audit-id' },
         dataAccess: {
           Opportunity: {
             allBySiteIdAndStatus: sinon.stub().resolves([mockOpportunity]),
+          },
+          LatestAudit: { updateByKeys: sinon.stub().resolves() },
+          ScrapeUrl: {
+            allByScrapeJobId: sinon.stub().resolves([{ getUrl: () => 'https://example.com/page1' }]),
           },
           PageCitability: {
             allBySiteId: sinon.stub().resolves([recentCitabilityRecord, staleCitabilityRecord]),
@@ -8654,9 +8875,7 @@ describe('Prerender Audit', () => {
         log: {
           info: sinon.stub(), debug: sinon.stub(), warn: sinon.stub(), error: sinon.stub(),
         },
-        s3Client: {
-          send: sinon.stub().resolves({ Body: { transformToString: () => Promise.resolve('') } }),
-        },
+        s3Client: { send: s3SendStub },
         env: { S3_SCRAPER_BUCKET_NAME: 'test-bucket' },
         auditContext: { scrapeJobId: 'job-1' },
         scrapeResultPaths: new Map([['https://example.com/page1', '/tmp/page1']]),


### PR DESCRIPTION
## Summary
When a prerender audit finds **no URLs needing prerender** but an existing opportunity is still NEW, the worker calls `syncSuggestions` with `newData: []` so `handleOutdatedSuggestions` can mark rescraped suggestions as OUTDATED. That is correct when scrape outcomes are trustworthy.

If most submitted URLs **failed** to produce a successful HTML comparison while fewer than **50** succeeded, treating the remainder as an authoritative "prerender resolved" signal matches neither ELMO (`scrapingErrorRateHigh` / `hasEnoughScrapedPages`) nor operator expectations: mass OUTDATED with `updatedBy: system` was observed in that regime.

## Changes
- Add `shouldSyncOutdatedForNoPrerenderFindings` (exported for tests) using the same thresholds as ELMO: **50** minimum successful scrapes and **30%** scraping error rate.
- In the **no opportunity found** branch: always assign `opportunityWithSuggestions` before gating; **skip** the OUTDATED `syncSuggestions` call when the guard fails; log a **warn** with counts.
- Constants: `PRERENDER_NO_OPP_OUTDATE_MIN_SUCCESSFUL_SCRAPES`, `PRERENDER_NO_OPP_OUTDATE_SCRAPE_ERROR_RATE_PCT`.

## Tests
- Unit tests for the pure guard function.
- Integration: reliable S3 fixtures so existing no-opportunity tests still exercise `syncSuggestions`; new case for 40 submitted / 10 successful / 75% error rate asserts sync is skipped.
- Adjust `syncSuggestions` throw tests and `scrapedUrlsSet` test to use reliable HTML + `ScrapeUrl` rows so the guard allows the code paths they assert.

Branch: `fix/prerender-no-opp-outdated-sync-noisy-scrapes`.

Made with [Cursor](https://cursor.com)