### PR TITLE
fix: canonical / broken-backlinks / metatags - update opportunity when no issues detected

### DIFF
--- a/src/backlinks/handler.js
+++ b/src/backlinks/handler.js
@@ -14,6 +14,7 @@ import { tracingFetch as fetch, prependSchema, stripWWW } from '@adobe/spacecat-
 import SeoClient from '@adobe/mysticat-shared-seo-client';
 import {
   Audit,
+  Opportunity as OpportunityModel,
   Suggestion as SuggestionModel,
   FixEntity as FixEntityModel,
 } from '@adobe/spacecat-shared-data-access';
@@ -294,6 +295,27 @@ export const generateSuggestionData = async (context) => {
     || !Array.isArray(auditResult.brokenBacklinks)
     || auditResult.brokenBacklinks.length === 0) {
     log.info(`No broken backlinks found for ${site.getId()}, skipping opportunity creation`);
+
+    try {
+      const opportunities = await dataAccess.Opportunity
+        .allBySiteIdAndStatus(site.getId(), OpportunityModel.STATUSES.NEW);
+      const opportunity = opportunities
+        .find((oppty) => oppty.getType() === Audit.AUDIT_TYPES.BROKEN_BACKLINKS);
+      if (opportunity) {
+        log.info(`Resolving existing broken-backlinks opportunity ${opportunity.getId()} for ${site.getId()}`);
+        await opportunity.setStatus(OpportunityModel.STATUSES.RESOLVED);
+        const suggestions = await opportunity.getSuggestions();
+        if (suggestions?.length > 0) {
+          await dataAccess.Suggestion
+            .bulkUpdateStatus(suggestions, SuggestionModel.STATUSES.OUTDATED);
+        }
+        opportunity.setUpdatedBy('system');
+        await opportunity.save();
+      }
+    } catch (e) {
+      log.error(`Failed to resolve broken-backlinks opportunity for ${site.getId()}: ${e.message}`);
+    }
+
     return {
       status: 'complete',
     };

--- a/src/backlinks/handler.js
+++ b/src/backlinks/handler.js
@@ -14,7 +14,6 @@ import { tracingFetch as fetch, prependSchema, stripWWW } from '@adobe/spacecat-
 import SeoClient from '@adobe/mysticat-shared-seo-client';
 import {
   Audit,
-  Opportunity as OpportunityModel,
   Suggestion as SuggestionModel,
   FixEntity as FixEntityModel,
 } from '@adobe/spacecat-shared-data-access';
@@ -22,7 +21,7 @@ import { AuditBuilder } from '../common/audit-builder.js';
 import calculateKpiMetrics from './kpi-metrics.js';
 import { convertToOpportunity } from '../common/opportunity.js';
 import { createOpportunityData } from './opportunity-data-mapper.js';
-import { syncSuggestionsWithPublishDetection, warnOnInvalidSuggestionData } from '../utils/data-access.js';
+import { syncSuggestionsWithPublishDetection, warnOnInvalidSuggestionData, resolveOpportunityIfNoIssues } from '../utils/data-access.js';
 import { getMergedAuditInputUrls } from '../utils/audit-input-urls.js';
 import { filterByAuditScope, extractPathPrefix } from '../internal-links/subpath-filter.js';
 import {
@@ -296,29 +295,12 @@ export const generateSuggestionData = async (context) => {
     || auditResult.brokenBacklinks.length === 0) {
     log.info(`No broken backlinks found for ${site.getId()}, skipping opportunity creation`);
 
-    try {
-      const opportunities = await dataAccess.Opportunity
-        .allBySiteIdAndStatus(site.getId(), OpportunityModel.STATUSES.NEW);
-      const opportunity = opportunities
-        .find((oppty) => oppty.getType() === Audit.AUDIT_TYPES.BROKEN_BACKLINKS);
-      if (opportunity) {
-        log.info(`Resolving existing broken-backlinks opportunity ${opportunity.getId()} for ${site.getId()}`);
-        await opportunity.setStatus(OpportunityModel.STATUSES.RESOLVED);
-        const suggestions = await opportunity.getSuggestions();
-        const suggestionsToOutdate = (suggestions || []).filter((s) => [
-          SuggestionModel.STATUSES.NEW,
-          SuggestionModel.STATUSES.PENDING_VALIDATION,
-        ].includes(s.getStatus()));
-        if (suggestionsToOutdate.length > 0) {
-          await dataAccess.Suggestion
-            .bulkUpdateStatus(suggestionsToOutdate, SuggestionModel.STATUSES.OUTDATED);
-        }
-        opportunity.setUpdatedBy('system');
-        await opportunity.save();
-      }
-    } catch (e) {
-      log.error(`Failed to resolve broken-backlinks opportunity for ${site.getId()}: ${e.message}`);
-    }
+    await resolveOpportunityIfNoIssues(
+      site.getId(),
+      Audit.AUDIT_TYPES.BROKEN_BACKLINKS,
+      dataAccess,
+      log,
+    );
 
     return {
       status: 'complete',

--- a/src/backlinks/handler.js
+++ b/src/backlinks/handler.js
@@ -305,9 +305,13 @@ export const generateSuggestionData = async (context) => {
         log.info(`Resolving existing broken-backlinks opportunity ${opportunity.getId()} for ${site.getId()}`);
         await opportunity.setStatus(OpportunityModel.STATUSES.RESOLVED);
         const suggestions = await opportunity.getSuggestions();
-        if (suggestions?.length > 0) {
+        const suggestionsToOutdate = (suggestions || []).filter((s) => [
+          SuggestionModel.STATUSES.NEW,
+          SuggestionModel.STATUSES.PENDING_VALIDATION,
+        ].includes(s.getStatus()));
+        if (suggestionsToOutdate.length > 0) {
           await dataAccess.Suggestion
-            .bulkUpdateStatus(suggestions, SuggestionModel.STATUSES.OUTDATED);
+            .bulkUpdateStatus(suggestionsToOutdate, SuggestionModel.STATUSES.OUTDATED);
         }
         opportunity.setUpdatedBy('system');
         await opportunity.save();

--- a/src/canonical/handler.js
+++ b/src/canonical/handler.js
@@ -691,9 +691,13 @@ export async function processScrapedContent(context) {
         log.info(`[canonical] Resolving existing canonical opportunity ${opportunity.getId()} for ${baseURL}`);
         await opportunity.setStatus(OpportunityModel.STATUSES.RESOLVED);
         const suggestions = await opportunity.getSuggestions();
-        if (suggestions?.length > 0) {
+        const suggestionsToOutdate = (suggestions || []).filter((s) => [
+          SuggestionModel.STATUSES.NEW,
+          SuggestionModel.STATUSES.PENDING_VALIDATION,
+        ].includes(s.getStatus()));
+        if (suggestionsToOutdate.length > 0) {
           await dataAccess.Suggestion
-            .bulkUpdateStatus(suggestions, SuggestionModel.STATUSES.OUTDATED);
+            .bulkUpdateStatus(suggestionsToOutdate, SuggestionModel.STATUSES.OUTDATED);
         }
         opportunity.setUpdatedBy('system');
         await opportunity.save();

--- a/src/canonical/handler.js
+++ b/src/canonical/handler.js
@@ -13,7 +13,7 @@
 import {
   composeBaseURL, hasText, isString, tracingFetch as fetch,
 } from '@adobe/spacecat-shared-utils';
-import { Audit } from '@adobe/spacecat-shared-data-access';
+import { Audit, Opportunity as OpportunityModel, Suggestion as SuggestionModel } from '@adobe/spacecat-shared-data-access';
 import { retrievePageAuthentication } from '@adobe/spacecat-shared-ims-client';
 
 import { AuditBuilder } from '../common/audit-builder.js';
@@ -681,6 +681,27 @@ export async function processScrapedContent(context) {
   // all checks are successful, no issues were found
   if (Object.keys(filteredAggregatedResults).length === 0) {
     log.info(`[canonical] No canonical issues detected for ${baseURL}`);
+
+    const { dataAccess } = context;
+    try {
+      const opportunities = await dataAccess.Opportunity
+        .allBySiteIdAndStatus(site.getId(), OpportunityModel.STATUSES.NEW);
+      const opportunity = opportunities.find((oppty) => oppty.getType() === auditType);
+      if (opportunity) {
+        log.info(`[canonical] Resolving existing canonical opportunity ${opportunity.getId()} for ${baseURL}`);
+        await opportunity.setStatus(OpportunityModel.STATUSES.RESOLVED);
+        const suggestions = await opportunity.getSuggestions();
+        if (suggestions?.length > 0) {
+          await dataAccess.Suggestion
+            .bulkUpdateStatus(suggestions, SuggestionModel.STATUSES.OUTDATED);
+        }
+        opportunity.setUpdatedBy('system');
+        await opportunity.save();
+      }
+    } catch (e) {
+      log.error(`[canonical] Failed to resolve opportunity for ${baseURL}: ${e.message}`);
+    }
+
     return {
       fullAuditRef: baseURL,
       auditResult: {

--- a/src/canonical/handler.js
+++ b/src/canonical/handler.js
@@ -13,7 +13,7 @@
 import {
   composeBaseURL, hasText, isString, tracingFetch as fetch,
 } from '@adobe/spacecat-shared-utils';
-import { Audit, Opportunity as OpportunityModel, Suggestion as SuggestionModel } from '@adobe/spacecat-shared-data-access';
+import { Audit } from '@adobe/spacecat-shared-data-access';
 import { retrievePageAuthentication } from '@adobe/spacecat-shared-ims-client';
 
 import { AuditBuilder } from '../common/audit-builder.js';
@@ -22,6 +22,7 @@ import { isPreviewPage, isPdfUrl } from '../utils/url-utils.js';
 import {
   syncSuggestions,
   keepLatestMergeDataFunction,
+  resolveOpportunityIfNoIssues,
 } from '../utils/data-access.js';
 import { getMergedAuditInputUrls } from '../utils/audit-input-urls.js';
 import { convertToOpportunity } from '../common/opportunity.js';
@@ -683,28 +684,7 @@ export async function processScrapedContent(context) {
     log.info(`[canonical] No canonical issues detected for ${baseURL}`);
 
     const { dataAccess } = context;
-    try {
-      const opportunities = await dataAccess.Opportunity
-        .allBySiteIdAndStatus(site.getId(), OpportunityModel.STATUSES.NEW);
-      const opportunity = opportunities.find((oppty) => oppty.getType() === auditType);
-      if (opportunity) {
-        log.info(`[canonical] Resolving existing canonical opportunity ${opportunity.getId()} for ${baseURL}`);
-        await opportunity.setStatus(OpportunityModel.STATUSES.RESOLVED);
-        const suggestions = await opportunity.getSuggestions();
-        const suggestionsToOutdate = (suggestions || []).filter((s) => [
-          SuggestionModel.STATUSES.NEW,
-          SuggestionModel.STATUSES.PENDING_VALIDATION,
-        ].includes(s.getStatus()));
-        if (suggestionsToOutdate.length > 0) {
-          await dataAccess.Suggestion
-            .bulkUpdateStatus(suggestionsToOutdate, SuggestionModel.STATUSES.OUTDATED);
-        }
-        opportunity.setUpdatedBy('system');
-        await opportunity.save();
-      }
-    } catch (e) {
-      log.error(`[canonical] Failed to resolve opportunity for ${baseURL}: ${e.message}`);
-    }
+    await resolveOpportunityIfNoIssues(site.getId(), auditType, dataAccess, log);
 
     return {
       fullAuditRef: baseURL,

--- a/src/metatags/handler.js
+++ b/src/metatags/handler.js
@@ -27,7 +27,7 @@ import {
   PROJECTED_VALUE_THRESHOLD,
   TITLE,
 } from './constants.js';
-import { syncSuggestions } from '../utils/data-access.js';
+import { syncSuggestions, resolveOpportunityIfNoIssues } from '../utils/data-access.js';
 import { getMergedAuditInputUrls } from '../utils/audit-input-urls.js';
 import { createOpportunityData } from './opportunity-data-mapper.js';
 import { validateDetectedIssues } from './ssr-meta-validator.js';
@@ -307,6 +307,9 @@ export async function runAuditAndGenerateSuggestions(context) {
   // Check if there are any detected tags BEFORE proceeding
   if (!validatedDetectedTags || Object.keys(validatedDetectedTags).length === 0) {
     log.info(`[metatags] No valid metatag issues detected for ${site.getId()}, skipping opportunity creation`);
+
+    await resolveOpportunityIfNoIssues(site.getId(), auditType, context.dataAccess, log);
+
     return {
       status: 'complete',
     };

--- a/src/utils/data-access.js
+++ b/src/utils/data-access.js
@@ -11,6 +11,7 @@
  */
 import { isNonEmptyArray, isObject } from '@adobe/spacecat-shared-utils';
 import {
+  Opportunity as OpportunityDataAccess,
   Suggestion as SuggestionDataAccess,
   FixEntity as FixEntityDataAccess,
 } from '@adobe/spacecat-shared-data-access';
@@ -876,4 +877,40 @@ export async function syncSuggestionsWithPublishDetection({
     scrapedUrlsSet,
     existingSuggestions,
   });
+}
+
+/**
+ * Resolves the existing NEW opportunity for the given site and audit type when no issues are
+ * detected. Marks actionable suggestions (NEW, PENDING_VALIDATION) as OUTDATED while preserving
+ * suggestions already in terminal states (FIXED, SKIPPED, REJECTED, APPROVED, IN_PROGRESS).
+ *
+ * @param {string} siteId - The site ID.
+ * @param {string} auditType - The audit type (e.g. 'canonical', 'broken-backlinks').
+ * @param {object} dataAccess - The data access object.
+ * @param {object} log - Logger instance.
+ * @returns {Promise<void>}
+ */
+export async function resolveOpportunityIfNoIssues(siteId, auditType, dataAccess, log) {
+  try {
+    const opportunities = await dataAccess.Opportunity
+      .allBySiteIdAndStatus(siteId, OpportunityDataAccess.STATUSES.NEW);
+    const opportunity = opportunities.find((oppty) => oppty.getType() === auditType);
+    if (opportunity) {
+      log.info(`Resolving existing ${auditType} opportunity ${opportunity.getId()} for ${siteId}`);
+      await opportunity.setStatus(OpportunityDataAccess.STATUSES.RESOLVED);
+      const suggestions = await opportunity.getSuggestions();
+      const suggestionsToOutdate = (suggestions || []).filter((s) => [
+        SuggestionDataAccess.STATUSES.NEW,
+        SuggestionDataAccess.STATUSES.PENDING_VALIDATION,
+      ].includes(s.getStatus()));
+      if (suggestionsToOutdate.length > 0) {
+        await dataAccess.Suggestion
+          .bulkUpdateStatus(suggestionsToOutdate, SuggestionDataAccess.STATUSES.OUTDATED);
+      }
+      opportunity.setUpdatedBy('system');
+      await opportunity.save();
+    }
+  } catch (e) {
+    log.error(`Failed to resolve ${auditType} opportunity for ${siteId}: ${e.message}`);
+  }
 }

--- a/test/audits/backlinks.test.js
+++ b/test/audits/backlinks.test.js
@@ -455,6 +455,7 @@ describe('Backlinks Tests', function () {
         success: true,
         brokenBacklinks: [],
       });
+      context.dataAccess.Opportunity.allBySiteIdAndStatus.resolves([]);
 
       const result = await generateSuggestionData(context);
 
@@ -468,6 +469,7 @@ describe('Backlinks Tests', function () {
         success: true,
         brokenBacklinks: null,
       });
+      context.dataAccess.Opportunity.allBySiteIdAndStatus.resolves([]);
 
       const result = await generateSuggestionData(context);
 
@@ -479,10 +481,57 @@ describe('Backlinks Tests', function () {
       context.audit.getAuditResult.returns({
         success: true,
       });
+      context.dataAccess.Opportunity.allBySiteIdAndStatus.resolves([]);
 
       const result = await generateSuggestionData(context);
 
       expect(result).to.deep.equal({ status: 'complete' });
+    });
+
+    it('resolves existing NEW opportunity and marks suggestions OUTDATED when no broken backlinks found', async () => {
+      configuration.isHandlerEnabledForSite.returns(true);
+      context.audit.getAuditResult.returns({
+        success: true,
+        brokenBacklinks: [],
+      });
+
+      const mockSuggestions = [{ getId: () => 'suggestion-1' }];
+      const mockOpportunity = {
+        getId: sinon.stub().returns('oppty-id-1'),
+        getType: sinon.stub().returns('broken-backlinks'),
+        setStatus: sinon.stub(),
+        getSuggestions: sinon.stub().resolves(mockSuggestions),
+        setUpdatedBy: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+      const bulkUpdateStatusStub = sinon.stub().resolves();
+      context.dataAccess.Opportunity.allBySiteIdAndStatus.resolves([mockOpportunity]);
+      context.dataAccess.Suggestion.bulkUpdateStatus = bulkUpdateStatusStub;
+
+      const result = await generateSuggestionData(context);
+
+      expect(result).to.deep.equal({ status: 'complete' });
+      expect(mockOpportunity.setStatus).to.have.been.calledOnce;
+      expect(mockOpportunity.getSuggestions).to.have.been.calledOnce;
+      expect(bulkUpdateStatusStub).to.have.been.calledOnceWith(mockSuggestions, 'OUTDATED');
+      expect(mockOpportunity.setUpdatedBy).to.have.been.calledOnceWith('system');
+      expect(mockOpportunity.save).to.have.been.calledOnce;
+    });
+
+    it('logs error and still returns complete when opportunity lookup fails on no-backlinks path', async () => {
+      configuration.isHandlerEnabledForSite.returns(true);
+      context.audit.getAuditResult.returns({
+        success: true,
+        brokenBacklinks: [],
+      });
+      context.dataAccess.Opportunity.allBySiteIdAndStatus.rejects(new Error('DB error'));
+
+      const result = await generateSuggestionData(context);
+
+      expect(result).to.deep.equal({ status: 'complete' });
+      expect(context.log.error).to.have.been.calledWith(
+        sinon.match(/Failed to resolve broken-backlinks opportunity.*DB error/),
+      );
     });
 
     it('processes suggestions for broken backlinks and send message to mystique', async () => {

--- a/test/audits/backlinks.test.js
+++ b/test/audits/backlinks.test.js
@@ -495,7 +495,10 @@ describe('Backlinks Tests', function () {
         brokenBacklinks: [],
       });
 
-      const mockSuggestions = [{ getId: () => 'suggestion-1' }];
+      const mockSuggestions = [
+        { getId: () => 'suggestion-1', getStatus: () => 'NEW' },
+        { getId: () => 'suggestion-2', getStatus: () => 'PENDING_VALIDATION' },
+      ];
       const mockOpportunity = {
         getId: sinon.stub().returns('oppty-id-1'),
         getType: sinon.stub().returns('broken-backlinks'),
@@ -516,6 +519,61 @@ describe('Backlinks Tests', function () {
       expect(bulkUpdateStatusStub).to.have.been.calledOnceWith(mockSuggestions, 'OUTDATED');
       expect(mockOpportunity.setUpdatedBy).to.have.been.calledOnceWith('system');
       expect(mockOpportunity.save).to.have.been.calledOnce;
+    });
+
+    it('should not call bulkUpdateStatus when all suggestions are in preserved states', async () => {
+      configuration.isHandlerEnabledForSite.returns(true);
+      context.audit.getAuditResult.returns({ success: true, brokenBacklinks: [] });
+
+      const bulkUpdateStatusStub = sinon.stub().resolves();
+      const mockOpportunity = {
+        getId: sinon.stub().returns('oppty-id-1'),
+        getType: sinon.stub().returns('broken-backlinks'),
+        setStatus: sinon.stub(),
+        // null covers the (suggestions || []) fallback branch
+        getSuggestions: sinon.stub().resolves(null),
+        setUpdatedBy: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+      context.dataAccess.Opportunity.allBySiteIdAndStatus.resolves([mockOpportunity]);
+      context.dataAccess.Suggestion.bulkUpdateStatus = bulkUpdateStatusStub;
+
+      await generateSuggestionData(context);
+
+      expect(bulkUpdateStatusStub).to.not.have.been.called;
+      expect(mockOpportunity.save).to.have.been.calledOnce;
+    });
+
+    it('should only mark NEW and PENDING_VALIDATION suggestions OUTDATED, preserving FIXED/SKIPPED/REJECTED', async () => {
+      configuration.isHandlerEnabledForSite.returns(true);
+      context.audit.getAuditResult.returns({ success: true, brokenBacklinks: [] });
+
+      const newSuggestion = { getId: () => 's-new', getStatus: () => 'NEW' };
+      const pendingSuggestion = { getId: () => 's-pending', getStatus: () => 'PENDING_VALIDATION' };
+      const fixedSuggestion = { getId: () => 's-fixed', getStatus: () => 'FIXED' };
+      const skippedSuggestion = { getId: () => 's-skipped', getStatus: () => 'SKIPPED' };
+      const rejectedSuggestion = { getId: () => 's-rejected', getStatus: () => 'REJECTED' };
+
+      const bulkUpdateStatusStub = sinon.stub().resolves();
+      const mockOpportunity = {
+        getId: sinon.stub().returns('oppty-id-1'),
+        getType: sinon.stub().returns('broken-backlinks'),
+        setStatus: sinon.stub(),
+        getSuggestions: sinon.stub().resolves([
+          newSuggestion, pendingSuggestion, fixedSuggestion, skippedSuggestion, rejectedSuggestion,
+        ]),
+        setUpdatedBy: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+      context.dataAccess.Opportunity.allBySiteIdAndStatus.resolves([mockOpportunity]);
+      context.dataAccess.Suggestion.bulkUpdateStatus = bulkUpdateStatusStub;
+
+      await generateSuggestionData(context);
+
+      expect(bulkUpdateStatusStub).to.have.been.calledOnceWith(
+        [newSuggestion, pendingSuggestion],
+        'OUTDATED',
+      );
     });
 
     it('logs error and still returns complete when opportunity lookup fails on no-backlinks path', async () => {

--- a/test/audits/canonical.test.js
+++ b/test/audits/canonical.test.js
@@ -3037,7 +3037,7 @@ describe('Canonical URL Tests', () => {
           },
         });
         expect(context.log.error).to.have.been.calledWith(
-          '[canonical] Failed to resolve opportunity for https://example.com: DB connection error',
+          'Failed to resolve canonical opportunity for test-site-id: DB connection error',
         );
       });
 

--- a/test/audits/canonical.test.js
+++ b/test/audits/canonical.test.js
@@ -2797,7 +2797,10 @@ describe('Canonical URL Tests', () => {
 
         const mockGetObjectFromKey = sinon.stub().resolves(scrapedContent);
 
-        const mockSuggestions = [{ getId: () => 'suggestion-1' }];
+        const mockSuggestions = [
+          { getId: () => 'suggestion-1', getStatus: () => 'NEW' },
+          { getId: () => 'suggestion-2', getStatus: () => 'PENDING_VALIDATION' },
+        ];
         const mockOpportunity = {
           getId: sinon.stub().returns('oppty-id-1'),
           getType: sinon.stub().returns('canonical'),
@@ -2856,6 +2859,123 @@ describe('Canonical URL Tests', () => {
         expect(bulkUpdateStatusStub).to.have.been.calledOnceWith(mockSuggestions, 'OUTDATED');
         expect(mockOpportunity.setUpdatedBy).to.have.been.calledOnceWith('system');
         expect(mockOpportunity.save).to.have.been.calledOnce;
+      });
+
+      it('should not call bulkUpdateStatus when all suggestions are in preserved states', async () => {
+        const scrapedContent = {
+          url: 'https://example.com/page1',
+          finalUrl: 'https://example.com/page1',
+          isPreview: false,
+          scrapeResult: {
+            canonical: { exists: true, count: 1, href: 'https://example.com/page1', inHead: true },
+            rawBody: createValidRawBody('<html><head><link rel="canonical" href="https://example.com/page1"></head><body><p>Content for testing canonical URL validation.</p></body></html>'),
+          },
+        };
+
+        const bulkUpdateStatusStub = sinon.stub().resolves();
+        const mockOpportunity = {
+          getId: sinon.stub().returns('oppty-id-1'),
+          getType: sinon.stub().returns('canonical'),
+          setStatus: sinon.stub(),
+          // null covers the (suggestions || []) fallback branch
+          getSuggestions: sinon.stub().resolves(null),
+          setUpdatedBy: sinon.stub(),
+          save: sinon.stub().resolves(),
+        };
+
+        const testContext = {
+          ...context,
+          site,
+          s3Client: {},
+          scrapeResultPaths: new Map([
+            ['https://example.com/page1', 'scrapes/job-id/page1/scrape.json'],
+          ]),
+          audit: { getId: () => 'test-audit-id' },
+          dataAccess: {
+            ...context.dataAccess,
+            Opportunity: { allBySiteIdAndStatus: sinon.stub().resolves([mockOpportunity]) },
+            Suggestion: { bulkUpdateStatus: bulkUpdateStatusStub },
+          },
+        };
+
+        const { processScrapedContent: processScrapedContentMocked } = await esmock(
+          '../../src/canonical/handler.js',
+          {
+            '../../src/utils/s3-utils.js': { getObjectFromKey: sinon.stub().resolves(scrapedContent) },
+            '../../src/common/opportunity-utils.js': { checkGoogleConnection: sinon.stub().resolves(false) },
+          },
+        );
+
+        await processScrapedContentMocked(testContext);
+
+        expect(bulkUpdateStatusStub).to.not.have.been.called;
+        expect(mockOpportunity.save).to.have.been.calledOnce;
+      });
+
+      it('should only mark NEW and PENDING_VALIDATION suggestions as OUTDATED, preserving FIXED/SKIPPED/REJECTED', async () => {
+        const scrapedContent = {
+          url: 'https://example.com/page1',
+          finalUrl: 'https://example.com/page1',
+          isPreview: false,
+          scrapeResult: {
+            canonical: {
+              exists: true,
+              count: 1,
+              href: 'https://example.com/page1',
+              inHead: true,
+            },
+            rawBody: createValidRawBody('<html><head><link rel="canonical" href="https://example.com/page1"></head><body><p>Content for testing canonical URL validation.</p></body></html>'),
+          },
+        };
+
+        const newSuggestion = { getId: () => 's-new', getStatus: () => 'NEW' };
+        const pendingSuggestion = { getId: () => 's-pending', getStatus: () => 'PENDING_VALIDATION' };
+        const fixedSuggestion = { getId: () => 's-fixed', getStatus: () => 'FIXED' };
+        const skippedSuggestion = { getId: () => 's-skipped', getStatus: () => 'SKIPPED' };
+        const rejectedSuggestion = { getId: () => 's-rejected', getStatus: () => 'REJECTED' };
+        const allSuggestions = [
+          newSuggestion, pendingSuggestion, fixedSuggestion, skippedSuggestion, rejectedSuggestion,
+        ];
+
+        const bulkUpdateStatusStub = sinon.stub().resolves();
+        const mockOpportunity = {
+          getId: sinon.stub().returns('oppty-id-1'),
+          getType: sinon.stub().returns('canonical'),
+          setStatus: sinon.stub(),
+          getSuggestions: sinon.stub().resolves(allSuggestions),
+          setUpdatedBy: sinon.stub(),
+          save: sinon.stub().resolves(),
+        };
+
+        const testContext = {
+          ...context,
+          site,
+          s3Client: {},
+          scrapeResultPaths: new Map([
+            ['https://example.com/page1', 'scrapes/job-id/page1/scrape.json'],
+          ]),
+          audit: { getId: () => 'test-audit-id' },
+          dataAccess: {
+            ...context.dataAccess,
+            Opportunity: { allBySiteIdAndStatus: sinon.stub().resolves([mockOpportunity]) },
+            Suggestion: { bulkUpdateStatus: bulkUpdateStatusStub },
+          },
+        };
+
+        const { processScrapedContent: processScrapedContentMocked } = await esmock(
+          '../../src/canonical/handler.js',
+          {
+            '../../src/utils/s3-utils.js': { getObjectFromKey: sinon.stub().resolves(scrapedContent) },
+            '../../src/common/opportunity-utils.js': { checkGoogleConnection: sinon.stub().resolves(false) },
+          },
+        );
+
+        await processScrapedContentMocked(testContext);
+
+        expect(bulkUpdateStatusStub).to.have.been.calledOnceWith(
+          [newSuggestion, pendingSuggestion],
+          'OUTDATED',
+        );
       });
 
       it('should log error and still return success when opportunity lookup fails on no-issues path', async () => {

--- a/test/audits/canonical.test.js
+++ b/test/audits/canonical.test.js
@@ -2718,7 +2718,7 @@ describe('Canonical URL Tests', () => {
         expect(suggestionWithExplanation.data).to.have.property('suggestion');
       });
 
-      it('should return success when no canonical issues detected', async () => {
+      it('should return success when no canonical issues detected and no existing opportunity', async () => {
         const scrapedContent = {
           url: 'https://example.com/page1',
           finalUrl: 'https://example.com/page1',
@@ -2735,6 +2735,7 @@ describe('Canonical URL Tests', () => {
         };
 
         const mockGetObjectFromKey = sinon.stub().resolves(scrapedContent);
+        const allBySiteIdAndStatusStub = sinon.stub().resolves([]);
 
         const testContext = {
           ...context,
@@ -2745,6 +2746,12 @@ describe('Canonical URL Tests', () => {
           ]),
           audit: {
             getId: () => 'test-audit-id',
+          },
+          dataAccess: {
+            ...context.dataAccess,
+            Opportunity: {
+              allBySiteIdAndStatus: allBySiteIdAndStatusStub,
+            },
           },
         };
 
@@ -2769,6 +2776,149 @@ describe('Canonical URL Tests', () => {
             message: 'No canonical issues detected',
           },
         });
+        expect(allBySiteIdAndStatusStub).to.have.been.calledOnce;
+      });
+
+      it('should resolve existing NEW opportunity and mark suggestions OUTDATED when no issues detected', async () => {
+        const scrapedContent = {
+          url: 'https://example.com/page1',
+          finalUrl: 'https://example.com/page1',
+          isPreview: false,
+          scrapeResult: {
+            canonical: {
+              exists: true,
+              count: 1,
+              href: 'https://example.com/page1',
+              inHead: true,
+            },
+            rawBody: createValidRawBody('<html><head><link rel="canonical" href="https://example.com/page1"></head><body><p>Content for testing canonical URL validation.</p></body></html>'),
+          },
+        };
+
+        const mockGetObjectFromKey = sinon.stub().resolves(scrapedContent);
+
+        const mockSuggestions = [{ getId: () => 'suggestion-1' }];
+        const mockOpportunity = {
+          getId: sinon.stub().returns('oppty-id-1'),
+          getType: sinon.stub().returns('canonical'),
+          setStatus: sinon.stub(),
+          getSuggestions: sinon.stub().resolves(mockSuggestions),
+          setUpdatedBy: sinon.stub(),
+          save: sinon.stub().resolves(),
+        };
+        const bulkUpdateStatusStub = sinon.stub().resolves();
+        const allBySiteIdAndStatusStub = sinon.stub().resolves([mockOpportunity]);
+
+        const testContext = {
+          ...context,
+          site,
+          s3Client: {},
+          scrapeResultPaths: new Map([
+            ['https://example.com/page1', 'scrapes/job-id/page1/scrape.json'],
+          ]),
+          audit: {
+            getId: () => 'test-audit-id',
+          },
+          dataAccess: {
+            ...context.dataAccess,
+            Opportunity: {
+              allBySiteIdAndStatus: allBySiteIdAndStatusStub,
+            },
+            Suggestion: {
+              bulkUpdateStatus: bulkUpdateStatusStub,
+            },
+          },
+        };
+
+        const { processScrapedContent: processScrapedContentMocked } = await esmock(
+          '../../src/canonical/handler.js',
+          {
+            '../../src/utils/s3-utils.js': {
+              getObjectFromKey: mockGetObjectFromKey,
+            },
+            '../../src/common/opportunity-utils.js': {
+              checkGoogleConnection: sinon.stub().resolves(false),
+            },
+          },
+        );
+
+        const result = await processScrapedContentMocked(testContext);
+
+        expect(result).to.deep.equal({
+          fullAuditRef: 'https://example.com',
+          auditResult: {
+            status: 'success',
+            message: 'No canonical issues detected',
+          },
+        });
+        expect(mockOpportunity.setStatus).to.have.been.calledOnce;
+        expect(mockOpportunity.getSuggestions).to.have.been.calledOnce;
+        expect(bulkUpdateStatusStub).to.have.been.calledOnceWith(mockSuggestions, 'OUTDATED');
+        expect(mockOpportunity.setUpdatedBy).to.have.been.calledOnceWith('system');
+        expect(mockOpportunity.save).to.have.been.calledOnce;
+      });
+
+      it('should log error and still return success when opportunity lookup fails on no-issues path', async () => {
+        const scrapedContent = {
+          url: 'https://example.com/page1',
+          finalUrl: 'https://example.com/page1',
+          isPreview: false,
+          scrapeResult: {
+            canonical: {
+              exists: true,
+              count: 1,
+              href: 'https://example.com/page1',
+              inHead: true,
+            },
+            rawBody: createValidRawBody('<html><head><link rel="canonical" href="https://example.com/page1"></head><body><p>Content for testing canonical URL validation.</p></body></html>'),
+          },
+        };
+
+        const mockGetObjectFromKey = sinon.stub().resolves(scrapedContent);
+        const allBySiteIdAndStatusStub = sinon.stub().rejects(new Error('DB connection error'));
+
+        const testContext = {
+          ...context,
+          site,
+          s3Client: {},
+          scrapeResultPaths: new Map([
+            ['https://example.com/page1', 'scrapes/job-id/page1/scrape.json'],
+          ]),
+          audit: {
+            getId: () => 'test-audit-id',
+          },
+          dataAccess: {
+            ...context.dataAccess,
+            Opportunity: {
+              allBySiteIdAndStatus: allBySiteIdAndStatusStub,
+            },
+          },
+        };
+
+        const { processScrapedContent: processScrapedContentMocked } = await esmock(
+          '../../src/canonical/handler.js',
+          {
+            '../../src/utils/s3-utils.js': {
+              getObjectFromKey: mockGetObjectFromKey,
+            },
+            '../../src/common/opportunity-utils.js': {
+              checkGoogleConnection: sinon.stub().resolves(false),
+            },
+          },
+        );
+
+        const result = await processScrapedContentMocked(testContext);
+
+        expect(result).to.deep.equal({
+          fullAuditRef: 'https://example.com',
+          auditResult: {
+            status: 'success',
+            message: 'No canonical issues detected',
+          },
+        });
+        expect(context.log.error).to.have.been.calledWith(
+          '[canonical] Failed to resolve opportunity for https://example.com: DB connection error',
+        );
       });
 
       it('should skip page when statusCode is 4xx (avoids false canonical-tag-missing on error responses)', async function () {

--- a/test/metatags/metatags.test.js
+++ b/test/metatags/metatags.test.js
@@ -1584,6 +1584,7 @@ describe('Meta Tags', () => {
                 }),
               },
             ]),
+            bulkUpdateStatus: sinon.stub().resolves(),
             saveMany: sinon.stub().resolves(),
             STATUSES: {
               NEW: 'NEW',
@@ -1615,6 +1616,7 @@ describe('Meta Tags', () => {
           getType: () => 'meta-tags',
           setData: sinon.stub(),
           getData: sinon.stub(),
+          setStatus: sinon.stub(),
           setUpdatedBy: sinon.stub().returnsThis(),
         };
 
@@ -1982,45 +1984,128 @@ describe('Meta Tags', () => {
         expect(result).to.deep.equal({ status: 'complete' });
       });
 
-      it('should return { status: complete } if no valid metatag issues are detected', async () => {
-        const mockGetRUMDomainkey = sinon.stub().resolves('mockedDomainKey');
-        const mockCalculateCPCValue = sinon.stub().resolves(2);
-        const mockValidateDetectedIssues = sinon.stub()
-          .resolves({});
+      it('should return { status: complete } if no valid metatag issues are detected and no existing opportunity', async () => {
+        const mockValidateDetectedIssues = sinon.stub().resolves({});
         const auditStub = await esmock('../../src/metatags/handler.js', {
-          '../../src/support/utils.js': { getRUMDomainkey: mockGetRUMDomainkey, calculateCPCValue: mockCalculateCPCValue },
+          '../../src/support/utils.js': { calculateCPCValue: sinon.stub().resolves(2) },
           '@adobe/spacecat-shared-rum-api-client': RUMAPIClientStub,
           '../../src/common/index.js': { wwwUrlResolver: (siteObj) => siteObj.getBaseURL() },
-          '../../src/metatags/metatags-auto-suggest.js': sinon.stub().resolves({}),
-          '../../src/metatags/ssr-meta-validator.js': {
-            validateDetectedIssues: mockValidateDetectedIssues,
-          },
+          '../../src/metatags/ssr-meta-validator.js': { validateDetectedIssues: mockValidateDetectedIssues },
         });
 
+        dataAccessStub.Opportunity.allBySiteIdAndStatus.resolves([]);
         const result = await auditStub.runAuditAndGenerateSuggestions(context);
 
         expect(result).to.deep.equal({ status: 'complete' });
         expect(logStub.info).to.have.been.calledWith(sinon.match(/No valid metatag issues detected/));
+        expect(dataAccessStub.Opportunity.allBySiteIdAndStatus).to.have.been.calledOnce;
       });
 
-      it('should return { status: complete } if validatedDetectedTags is null', async () => {
-        const mockGetRUMDomainkey = sinon.stub().resolves('mockedDomainKey');
-        const mockCalculateCPCValue = sinon.stub().resolves(2);
-        const mockValidateDetectedIssues = sinon.stub()
-          .resolves(null);
+      it('should return { status: complete } if validatedDetectedTags is null and no existing opportunity', async () => {
+        const mockValidateDetectedIssues = sinon.stub().resolves(null);
         const auditStub = await esmock('../../src/metatags/handler.js', {
-          '../../src/support/utils.js': { getRUMDomainkey: mockGetRUMDomainkey, calculateCPCValue: mockCalculateCPCValue },
+          '../../src/support/utils.js': { calculateCPCValue: sinon.stub().resolves(2) },
           '@adobe/spacecat-shared-rum-api-client': RUMAPIClientStub,
           '../../src/common/index.js': { wwwUrlResolver: (siteObj) => siteObj.getBaseURL() },
-          '../../src/metatags/metatags-auto-suggest.js': sinon.stub().resolves({}),
-          '../../src/metatags/ssr-meta-validator.js': {
-            validateDetectedIssues: mockValidateDetectedIssues,
-          },
+          '../../src/metatags/ssr-meta-validator.js': { validateDetectedIssues: mockValidateDetectedIssues },
         });
+
+        dataAccessStub.Opportunity.allBySiteIdAndStatus.resolves([]);
+        const result = await auditStub.runAuditAndGenerateSuggestions(context);
+
+        expect(result).to.deep.equal({ status: 'complete' });
+      });
+
+      it('should resolve existing NEW opportunity and mark NEW/PENDING_VALIDATION suggestions OUTDATED when no metatag issues detected', async () => {
+        const mockValidateDetectedIssues = sinon.stub().resolves({});
+        const auditStub = await esmock('../../src/metatags/handler.js', {
+          '../../src/support/utils.js': { calculateCPCValue: sinon.stub().resolves(2) },
+          '@adobe/spacecat-shared-rum-api-client': RUMAPIClientStub,
+          '../../src/common/index.js': { wwwUrlResolver: (siteObj) => siteObj.getBaseURL() },
+          '../../src/metatags/ssr-meta-validator.js': { validateDetectedIssues: mockValidateDetectedIssues },
+        });
+
+        const mockSuggestions = [
+          { getId: () => 's-new', getStatus: () => 'NEW' },
+          { getId: () => 's-pending', getStatus: () => 'PENDING_VALIDATION' },
+        ];
+        metatagsOppty.getSuggestions = sinon.stub().resolves(mockSuggestions);
+        dataAccessStub.Opportunity.allBySiteIdAndStatus.resolves([metatagsOppty]);
 
         const result = await auditStub.runAuditAndGenerateSuggestions(context);
 
         expect(result).to.deep.equal({ status: 'complete' });
+        expect(metatagsOppty.setStatus).to.have.been.calledOnce;
+        expect(metatagsOppty.getSuggestions).to.have.been.calledOnce;
+        expect(dataAccessStub.Suggestion.bulkUpdateStatus)
+          .to.have.been.calledOnceWith(mockSuggestions, 'OUTDATED');
+        expect(metatagsOppty.setUpdatedBy).to.have.been.calledOnceWith('system');
+        expect(metatagsOppty.save).to.have.been.calledOnce;
+      });
+
+      it('should not call bulkUpdateStatus when all suggestions are in preserved states (metatags)', async () => {
+        const mockValidateDetectedIssues = sinon.stub().resolves({});
+        const auditStub = await esmock('../../src/metatags/handler.js', {
+          '../../src/support/utils.js': { calculateCPCValue: sinon.stub().resolves(2) },
+          '@adobe/spacecat-shared-rum-api-client': RUMAPIClientStub,
+          '../../src/common/index.js': { wwwUrlResolver: (siteObj) => siteObj.getBaseURL() },
+          '../../src/metatags/ssr-meta-validator.js': { validateDetectedIssues: mockValidateDetectedIssues },
+        });
+
+        // null covers the (suggestions || []) fallback branch
+        metatagsOppty.getSuggestions = sinon.stub().resolves(null);
+        dataAccessStub.Opportunity.allBySiteIdAndStatus.resolves([metatagsOppty]);
+
+        await auditStub.runAuditAndGenerateSuggestions(context);
+
+        expect(dataAccessStub.Suggestion.bulkUpdateStatus).to.not.have.been.called;
+        expect(metatagsOppty.save).to.have.been.calledOnce;
+      });
+
+      it('should only mark NEW and PENDING_VALIDATION suggestions OUTDATED, preserving FIXED/SKIPPED/REJECTED (metatags)', async () => {
+        const mockValidateDetectedIssues = sinon.stub().resolves({});
+        const auditStub = await esmock('../../src/metatags/handler.js', {
+          '../../src/support/utils.js': { calculateCPCValue: sinon.stub().resolves(2) },
+          '@adobe/spacecat-shared-rum-api-client': RUMAPIClientStub,
+          '../../src/common/index.js': { wwwUrlResolver: (siteObj) => siteObj.getBaseURL() },
+          '../../src/metatags/ssr-meta-validator.js': { validateDetectedIssues: mockValidateDetectedIssues },
+        });
+
+        const newSuggestion = { getId: () => 's-new', getStatus: () => 'NEW' };
+        const pendingSuggestion = { getId: () => 's-pending', getStatus: () => 'PENDING_VALIDATION' };
+        const fixedSuggestion = { getId: () => 's-fixed', getStatus: () => 'FIXED' };
+        const skippedSuggestion = { getId: () => 's-skipped', getStatus: () => 'SKIPPED' };
+        const rejectedSuggestion = { getId: () => 's-rejected', getStatus: () => 'REJECTED' };
+        metatagsOppty.getSuggestions = sinon.stub().resolves([
+          newSuggestion, pendingSuggestion, fixedSuggestion, skippedSuggestion, rejectedSuggestion,
+        ]);
+        dataAccessStub.Opportunity.allBySiteIdAndStatus.resolves([metatagsOppty]);
+
+        await auditStub.runAuditAndGenerateSuggestions(context);
+
+        expect(dataAccessStub.Suggestion.bulkUpdateStatus).to.have.been.calledOnceWith(
+          [newSuggestion, pendingSuggestion],
+          'OUTDATED',
+        );
+      });
+
+      it('should log error and still return complete when opportunity lookup fails on no-issues path (metatags)', async () => {
+        const mockValidateDetectedIssues = sinon.stub().resolves({});
+        const auditStub = await esmock('../../src/metatags/handler.js', {
+          '../../src/support/utils.js': { calculateCPCValue: sinon.stub().resolves(2) },
+          '@adobe/spacecat-shared-rum-api-client': RUMAPIClientStub,
+          '../../src/common/index.js': { wwwUrlResolver: (siteObj) => siteObj.getBaseURL() },
+          '../../src/metatags/ssr-meta-validator.js': { validateDetectedIssues: mockValidateDetectedIssues },
+        });
+
+        dataAccessStub.Opportunity.allBySiteIdAndStatus.rejects(new Error('DB error'));
+
+        const result = await auditStub.runAuditAndGenerateSuggestions(context);
+
+        expect(result).to.deep.equal({ status: 'complete' });
+        expect(logStub.error).to.have.been.calledWith(
+          sinon.match(/Failed to resolve meta-tags opportunity.*DB error/),
+        );
       });
 
       it('should handle error when Site.findById fails during useHostnameOnly check', async () => {

--- a/test/utils/data-access.test.js
+++ b/test/utils/data-access.test.js
@@ -32,6 +32,7 @@ import {
   warnOnInvalidSuggestionData,
   isTBYBSite,
   SUMMIT_PLG_HANDLER,
+  resolveOpportunityIfNoIssues,
 } from '../../src/utils/data-access.js';
 import { MockContextBuilder } from '../shared.js';
 
@@ -3344,6 +3345,110 @@ describe('data-access', () => {
 
     it('does not throw even when validation fails', () => {
       expect(() => warnOnInvalidSuggestionData(null, 'structured-data', mockLog)).to.not.throw();
+    });
+  });
+
+  describe('resolveOpportunityIfNoIssues', () => {
+    let log;
+    let dataAccess;
+    let bulkUpdateStatusStub;
+
+    beforeEach(() => {
+      log = { info: sinon.stub(), error: sinon.stub() };
+      bulkUpdateStatusStub = sinon.stub().resolves();
+      dataAccess = {
+        Opportunity: { allBySiteIdAndStatus: sinon.stub() },
+        Suggestion: { bulkUpdateStatus: bulkUpdateStatusStub },
+      };
+    });
+
+    it('does nothing when no existing NEW opportunity is found', async () => {
+      dataAccess.Opportunity.allBySiteIdAndStatus.resolves([]);
+
+      await resolveOpportunityIfNoIssues('site-1', 'canonical', dataAccess, log);
+
+      expect(bulkUpdateStatusStub).to.not.have.been.called;
+    });
+
+    it('does nothing when existing opportunity has a different audit type', async () => {
+      const otherOppty = { getType: () => 'broken-backlinks' };
+      dataAccess.Opportunity.allBySiteIdAndStatus.resolves([otherOppty]);
+
+      await resolveOpportunityIfNoIssues('site-1', 'canonical', dataAccess, log);
+
+      expect(bulkUpdateStatusStub).to.not.have.been.called;
+    });
+
+    it('resolves matching opportunity and marks NEW/PENDING_VALIDATION suggestions OUTDATED', async () => {
+      const newSuggestion = { getId: () => 's-new', getStatus: () => 'NEW' };
+      const pendingSuggestion = { getId: () => 's-pending', getStatus: () => 'PENDING_VALIDATION' };
+      const opportunity = {
+        getId: sinon.stub().returns('oppty-1'),
+        getType: () => 'canonical',
+        setStatus: sinon.stub(),
+        getSuggestions: sinon.stub().resolves([newSuggestion, pendingSuggestion]),
+        setUpdatedBy: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+      dataAccess.Opportunity.allBySiteIdAndStatus.resolves([opportunity]);
+
+      await resolveOpportunityIfNoIssues('site-1', 'canonical', dataAccess, log);
+
+      expect(opportunity.setStatus).to.have.been.calledOnce;
+      expect(bulkUpdateStatusStub).to.have.been.calledOnceWith(
+        [newSuggestion, pendingSuggestion],
+        'OUTDATED',
+      );
+      expect(opportunity.setUpdatedBy).to.have.been.calledOnceWith('system');
+      expect(opportunity.save).to.have.been.calledOnce;
+    });
+
+    it('preserves FIXED, SKIPPED, REJECTED suggestions and does not call bulkUpdateStatus', async () => {
+      const opportunity = {
+        getId: sinon.stub().returns('oppty-1'),
+        getType: () => 'canonical',
+        setStatus: sinon.stub(),
+        getSuggestions: sinon.stub().resolves([
+          { getId: () => 's-fixed', getStatus: () => 'FIXED' },
+          { getId: () => 's-skipped', getStatus: () => 'SKIPPED' },
+          { getId: () => 's-rejected', getStatus: () => 'REJECTED' },
+        ]),
+        setUpdatedBy: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+      dataAccess.Opportunity.allBySiteIdAndStatus.resolves([opportunity]);
+
+      await resolveOpportunityIfNoIssues('site-1', 'canonical', dataAccess, log);
+
+      expect(bulkUpdateStatusStub).to.not.have.been.called;
+      expect(opportunity.save).to.have.been.calledOnce;
+    });
+
+    it('handles null suggestions returned by getSuggestions without error', async () => {
+      const opportunity = {
+        getId: sinon.stub().returns('oppty-1'),
+        getType: () => 'canonical',
+        setStatus: sinon.stub(),
+        getSuggestions: sinon.stub().resolves(null),
+        setUpdatedBy: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+      dataAccess.Opportunity.allBySiteIdAndStatus.resolves([opportunity]);
+
+      await resolveOpportunityIfNoIssues('site-1', 'canonical', dataAccess, log);
+
+      expect(bulkUpdateStatusStub).to.not.have.been.called;
+      expect(opportunity.save).to.have.been.calledOnce;
+    });
+
+    it('logs error and does not throw when allBySiteIdAndStatus rejects', async () => {
+      dataAccess.Opportunity.allBySiteIdAndStatus.rejects(new Error('DB error'));
+
+      await resolveOpportunityIfNoIssues('site-1', 'canonical', dataAccess, log);
+
+      expect(log.error).to.have.been.calledWith(
+        sinon.match(/Failed to resolve canonical opportunity.*DB error/),
+      );
     });
   });
 });


### PR DESCRIPTION
For canonical, broken-backlinks and metatags audits: when a run finds no issues, any existing NEW opportunity is now set to RESOLVED and its NEW/PENDING_VALIDATION suggestions marked OUTDATED. Previously, these opportunities stayed open indefinitely after a clean audit run.

Suggestions in terminal states (FIXED, SKIPPED, REJECTED, APPROVED, IN_PROGRESS) are preserved, consistent with handleOutdatedSuggestions in the shared utils.

