### PR TITLE
feat(semantic-value-visibility): use generic-autofix-edge as opportunity type

### DIFF
--- a/src/semantic-value-visibility/constants.js
+++ b/src/semantic-value-visibility/constants.js
@@ -12,4 +12,4 @@
 
 export const AUDIT_TYPE = 'semantic-value-visibility';
 export const GUIDANCE_TYPE = 'guidance:semantic-value-visibility';
-export const OPPORTUNITY_TYPE = 'semantic-value-visibility';
+export const OPPORTUNITY_TYPE = 'generic-autofix-edge';

--- a/src/semantic-value-visibility/guidance-handler.js
+++ b/src/semantic-value-visibility/guidance-handler.js
@@ -14,7 +14,15 @@ import { ok, notFound, badRequest } from '@adobe/spacecat-shared-http-utils';
 import { convertToOpportunity } from '../common/opportunity.js';
 import { syncSuggestions } from '../utils/data-access.js';
 import { createOpportunityData } from './opportunity-data-mapper.js';
-import { OPPORTUNITY_TYPE } from './constants.js';
+import { AUDIT_TYPE, OPPORTUNITY_TYPE } from './constants.js';
+
+// Matches SVV opportunities by subtype discriminator, regardless of which bucket type they carry.
+// Needed because OPPORTUNITY_TYPE ('generic-autofix-edge') is shared across multiple audits.
+const isSvvOpportunity = (oppty) => {
+  const metrics = oppty.getData?.()?.additionalMetrics;
+  const isSvvSubtype = (m) => m.key === 'subtype' && m.value === AUDIT_TYPE;
+  return Array.isArray(metrics) && metrics.some(isSvvSubtype);
+};
 
 /**
  * Guidance handler for semantic value visibility.
@@ -68,7 +76,9 @@ export default async function handler(message, context) {
     // Check if there's an existing opportunity to clean up
     const existing = await Opportunity.allBySiteIdAndStatus(siteId, 'NEW');
     const staleOpportunity = existing.find(
-      (oppty) => oppty.getType() === OPPORTUNITY_TYPE,
+      // Match new (generic-autofix-edge + subtype) and legacy (semantic-value-visibility) rows
+      (oppty) => oppty.getType() === AUDIT_TYPE
+        || (oppty.getType() === OPPORTUNITY_TYPE && isSvvOpportunity(oppty)),
     );
 
     if (staleOpportunity) {
@@ -91,6 +101,7 @@ export default async function handler(message, context) {
     createOpportunityData,
     OPPORTUNITY_TYPE,
     { guidance },
+    isSvvOpportunity,
   );
 
   if (!opportunity) {

--- a/src/semantic-value-visibility/opportunity-data-mapper.js
+++ b/src/semantic-value-visibility/opportunity-data-mapper.js
@@ -11,6 +11,7 @@
  */
 
 import { DATA_SOURCES } from '../common/constants.js';
+import { AUDIT_TYPE } from './constants.js';
 
 export function createOpportunityData(props = {}) {
   const { guidance = {} } = props;
@@ -28,6 +29,10 @@ export function createOpportunityData(props = {}) {
     tags: ['isElmo', 'content', 'edgeOptimize'],
     data: {
       dataSources: [DATA_SOURCES.SITE],
+      // Stable per-audit discriminator — required because OPPORTUNITY_TYPE is a shared bucket
+      // (generic-autofix-edge). Without this, stale-scan and upsert would match any
+      // generic-autofix-edge opportunity on the site, not just SVV ones.
+      additionalMetrics: [{ key: 'subtype', value: AUDIT_TYPE }],
     },
   };
 }

--- a/test/audits/semantic-value-visibility/guidance-handler.test.js
+++ b/test/audits/semantic-value-visibility/guidance-handler.test.js
@@ -316,7 +316,7 @@ describe('Semantic Value Visibility Guidance Handler', () => {
     it('should mark stale opportunity as RESOLVED when no new suggestions', async () => {
       const staleOpportunity = {
         getId: sinon.stub().returns('stale-oppty-123'),
-        getType: sinon.stub().returns('semantic-value-visibility'),
+        getType: sinon.stub().returns('generic-autofix-edge'),
         setStatus: sinon.stub(),
         setUpdatedBy: sinon.stub(),
         save: sinon.stub().resolves(),

--- a/test/audits/semantic-value-visibility/guidance-handler.test.js
+++ b/test/audits/semantic-value-visibility/guidance-handler.test.js
@@ -313,10 +313,11 @@ describe('Semantic Value Visibility Guidance Handler', () => {
   });
 
   describe('stale opportunity cleanup', () => {
-    it('should mark stale opportunity as RESOLVED when no new suggestions', async () => {
+    it('should mark stale SVV opportunity as RESOLVED when no new suggestions', async () => {
       const staleOpportunity = {
         getId: sinon.stub().returns('stale-oppty-123'),
         getType: sinon.stub().returns('generic-autofix-edge'),
+        getData: sinon.stub().returns({ additionalMetrics: [{ key: 'subtype', value: 'semantic-value-visibility' }] }),
         setStatus: sinon.stub(),
         setUpdatedBy: sinon.stub(),
         save: sinon.stub().resolves(),
@@ -328,15 +329,123 @@ describe('Semantic Value Visibility Guidance Handler', () => {
         siteId: 'site-123',
         auditId: 'audit-456',
         url: 'https://example.com',
-        data: {
-          suggestions: [],
-        },
+        data: { suggestions: [] },
       };
 
       await handler(message, context);
 
       expect(staleOpportunity.setStatus).to.have.been.calledWith('RESOLVED');
       expect(staleOpportunity.save).to.have.been.calledOnce;
+    });
+
+    it('should not resolve a foreign generic-autofix-edge opportunity on the same site', async () => {
+      const foreignOpportunity = {
+        getId: sinon.stub().returns('foreign-oppty-456'),
+        getType: sinon.stub().returns('generic-autofix-edge'),
+        // different subtype — belongs to another audit, not SVV
+        getData: sinon.stub().returns({ additionalMetrics: [{ key: 'subtype', value: 'canonical' }] }),
+        setStatus: sinon.stub(),
+        setUpdatedBy: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      Opportunity.allBySiteIdAndStatus.resolves([foreignOpportunity]);
+
+      const message = {
+        siteId: 'site-123',
+        auditId: 'audit-456',
+        url: 'https://example.com',
+        data: { suggestions: [] },
+      };
+
+      await handler(message, context);
+
+      expect(foreignOpportunity.setStatus).not.to.have.been.called;
+      expect(foreignOpportunity.save).not.to.have.been.called;
+    });
+
+    it('should resolve legacy semantic-value-visibility opportunity during transition', async () => {
+      const legacyOpportunity = {
+        getId: sinon.stub().returns('legacy-oppty-789'),
+        getType: sinon.stub().returns('semantic-value-visibility'),
+        getData: sinon.stub().returns({}),
+        setStatus: sinon.stub(),
+        setUpdatedBy: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      Opportunity.allBySiteIdAndStatus.resolves([legacyOpportunity]);
+
+      const message = {
+        siteId: 'site-123',
+        auditId: 'audit-456',
+        url: 'https://example.com',
+        data: { suggestions: [] },
+      };
+
+      await handler(message, context);
+
+      expect(legacyOpportunity.setStatus).to.have.been.calledWith('RESOLVED');
+      expect(legacyOpportunity.save).to.have.been.calledOnce;
+    });
+  });
+
+  describe('convertToOpportunity comparisonFn', () => {
+    it('should pass comparisonFn as seventh argument to convertToOpportunity', async () => {
+      const message = {
+        siteId: 'site-123',
+        auditId: 'audit-456',
+        url: 'https://example.com',
+        data: {
+          url: 'https://example.com',
+          guidance: {},
+          suggestions: [{ data: { imageUrl: 'https://example.com/img.jpg', semanticHtml: '<section>Test</section>' } }],
+        },
+      };
+
+      await handler(message, context);
+
+      expect(convertToOpportunityStub).to.have.been.calledOnce;
+      const [, , , , , , comparisonFn] = convertToOpportunityStub.getCall(0).args;
+      expect(comparisonFn).to.be.a('function');
+    });
+
+    it('comparisonFn should return true for SVV opportunity with correct subtype', async () => {
+      const message = {
+        siteId: 'site-123',
+        auditId: 'audit-456',
+        url: 'https://example.com',
+        data: {
+          url: 'https://example.com',
+          guidance: {},
+          suggestions: [{ data: { imageUrl: 'https://example.com/img.jpg', semanticHtml: '<section>Test</section>' } }],
+        },
+      };
+
+      await handler(message, context);
+
+      const [, , , , , , comparisonFn] = convertToOpportunityStub.getCall(0).args;
+      const svvOppty = { getData: () => ({ additionalMetrics: [{ key: 'subtype', value: 'semantic-value-visibility' }] }) };
+      expect(comparisonFn(svvOppty)).to.equal(true);
+    });
+
+    it('comparisonFn should return false for foreign opportunity with different subtype', async () => {
+      const message = {
+        siteId: 'site-123',
+        auditId: 'audit-456',
+        url: 'https://example.com',
+        data: {
+          url: 'https://example.com',
+          guidance: {},
+          suggestions: [{ data: { imageUrl: 'https://example.com/img.jpg', semanticHtml: '<section>Test</section>' } }],
+        },
+      };
+
+      await handler(message, context);
+
+      const [, , , , , , comparisonFn] = convertToOpportunityStub.getCall(0).args;
+      const foreignOppty = { getData: () => ({ additionalMetrics: [{ key: 'subtype', value: 'canonical' }] }) };
+      expect(comparisonFn(foreignOppty)).to.equal(false);
     });
   });
 });

--- a/test/audits/semantic-value-visibility/opportunity-data-mapper.test.js
+++ b/test/audits/semantic-value-visibility/opportunity-data-mapper.test.js
@@ -40,6 +40,13 @@ describe('Semantic Value Visibility Opportunity Data Mapper', () => {
       expect(result.data.dataSources).to.include(DATA_SOURCES.SITE);
     });
 
+    it('should include additionalMetrics subtype discriminator', () => {
+      const result = createOpportunityData({ guidance: krisshopFixture.guidance });
+
+      expect(result.data.additionalMetrics).to.be.an('array').with.lengthOf(1);
+      expect(result.data.additionalMetrics[0]).to.deep.equal({ key: 'subtype', value: 'semantic-value-visibility' });
+    });
+
     it('should include guidance with insight, rationale, recommendation', () => {
       const result = createOpportunityData({ guidance: krisshopFixture.guidance });
 


### PR DESCRIPTION
## Summary

- Changes `OPPORTUNITY_TYPE` from `'semantic-value-visibility'` to `'generic-autofix-edge'` so created opportunities are editable in the back-office and routable in elmo-ui via `GenericTokawakaPatchOpportunitySection`
- Audit trigger (`semantic-value-visibility` Slack command) and Mystique routing (`guidance:semantic-value-visibility`) are unaffected — only the stored opportunity type in SpaceCat changes

## Fixes (addressing review feedback)

- **Type collision**: added `additionalMetrics: [{ key: 'subtype', value: 'semantic-value-visibility' }]` to opportunity data as a stable per-audit discriminator. Both the stale-scan and `convertToOpportunity` now use an `isSvvOpportunity` predicate keyed on this field — prevents SVV from silently resolving or overwriting foreign `generic-autofix-edge` opportunities on the same site
- **Legacy orphans**: stale-scan treats both the old `semantic-value-visibility` type and the new `generic-autofix-edge` + subtype as SVV during a transition window — existing prod rows get resolved naturally on the next SVV run with no suggestions, no zombie rows

## Test plan

- [x] 30 SVV unit tests pass locally
- [x] Regression test: foreign `generic-autofix-edge` opp on same site is not touched
- [x] Regression test: legacy `semantic-value-visibility` opp is resolved during transition
- [x] `comparisonFn` passed to `convertToOpportunity` and validated for correct/incorrect subtype
- [x] `additionalMetrics` subtype discriminator asserted in mapper test
- [ ] Trigger audit via Slack `run audit semantic-value-visibility` — confirms audit still runs
- [ ] Verify created opportunity has `type: generic-autofix-edge` in SpaceCat API response
- [ ] Verify opportunity is editable in back-office
- [ ] Verify opportunity renders correctly in elmo-ui via `GenericTokawakaPatchOpportunitySection`

🤖 Generated with [Claude Code](https://claude.com/claude-code)