### PR TITLE
fix(toc): guard tocArrayToHast against empty-text headings (LLMO-4947)

### DIFF
--- a/src/headings/utils.js
+++ b/src/headings/utils.js
@@ -335,26 +335,28 @@ export function extractTocData($, getHeadingSelectorFn) {
  */
 export function tocArrayToHast(tocData) {
   // children for <ul>
-  const liNodes = tocData.map((item) => {
-    const isSub = Number(item.level) === 2;
+  const liNodes = tocData
+    .filter((item) => item.text && item.text.trim())
+    .map((item) => {
+      const isSub = Number(item.level) === 2;
 
-    return {
-      type: 'element',
-      tagName: 'li',
-      properties: isSub ? { className: ['toc-sub'] } : {},
-      children: [
-        {
-          type: 'element',
-          tagName: 'a',
-          properties: {
-            href: '#',
-            'data-selector': item.selector,
+      return {
+        type: 'element',
+        tagName: 'li',
+        properties: isSub ? { className: ['toc-sub'] } : {},
+        children: [
+          {
+            type: 'element',
+            tagName: 'a',
+            properties: {
+              href: '#',
+              'data-selector': item.selector,
+            },
+            children: [{ type: 'text', value: item.text }],
           },
-          children: [{ type: 'text', value: item.text }],
-        },
-      ],
-    };
-  });
+        ],
+      };
+    });
 
   const ul = {
     type: 'element',

--- a/test/audits/toc.test.js
+++ b/test/audits/toc.test.js
@@ -3050,6 +3050,20 @@ describe('TOC (Table of Contents) Audit', () => {
         expect(ul.children[0].children[0].properties['data-selector']).to.equal('h1#main');
         expect(ul.children[0].children[0].children[0].value).to.equal('Title');
       });
+
+      it('filters out items with empty or whitespace-only text', () => {
+        const tocData = [
+          { text: 'Valid Heading', level: 1, selector: 'h1#valid' },
+          { text: '', level: 1, selector: 'h1#empty' },
+          { text: '   ', level: 2, selector: 'h2#whitespace' },
+          { text: 'Another Valid', level: 2, selector: 'h2#also-valid' },
+        ];
+        const hast = tocArrayToHast(tocData);
+        const ul = hast.children[0].children[0];
+        expect(ul.children).to.have.lengthOf(2);
+        expect(ul.children[0].children[0].children[0].value).to.equal('Valid Heading');
+        expect(ul.children[1].children[0].children[0].value).to.equal('Another Valid');
+      });
     });
 
     describe('determineTocPlacement', () => {


### PR DESCRIPTION
## Summary

- **Problem:** The TOC audit suggestion for pages like `https://www.hdfc.bank.in/need-help/grievance-redressal` contained TOC entries with empty link text. AEM teaser `<h1>` elements whose visible label is CSS-rendered return `''` from Cheerio's `$(h).text()`, producing invisible unlabelled anchors in the rendered Table of Contents.
- **Root cause:** `extractTocData` already guards against empty text (Layer 1), but `tocArrayToHast` — which converts the stored heading array into a HAST tree — had no such guard (Layer 2). Legacy-persisted data that pre-dates the Layer 1 fix could still reach `tocArrayToHast` with empty text.
- **Fix:** Added `.filter((item) => item.text && item.text.trim())` at the top of `tocArrayToHast`, dropping empty/whitespace-only items before the HAST `<li><a>` nodes are built.

## Files Changed

- `src/headings/utils.js` — `tocArrayToHast`: added empty-text filter before `.map()`
- `test/audits/toc.test.js` — new test: _'filters out items with empty or whitespace-only text'_

## Test Plan

- [x] New unit test covers `text: ''` and `text: '   '` — both dropped from HAST output
- [x] Existing `tocArrayToHast` test still passes (166 total passing)
- [x] `eslint src/headings/utils.js` — no errors
- [ ] Full `npm test` in CI

## Jira

[LLMO-4947](https://jira.corp.adobe.com/browse/LLMO-4947)

🤖 Generated with [Claude Code](https://claude.com/claude-code)