### PR TITLE
Add broken-external-links audit type

### DIFF
--- a/docs/specs/add-broken-external-links-audit-type/spec.md
+++ b/docs/specs/add-broken-external-links-audit-type/spec.md
@@ -1,0 +1,145 @@
+## Spec: spacecat-audit-worker [TESTING-SDD-PR]
+
+### Problem
+There is no audit that checks a site's own pages for outbound links that are broken (4xx/5xx) on external hosts. Users cannot discover which of their pages link out to dead external resources, leading to poor user experience and SEO leakage. The `broken-external-links` audit closes this gap using the same Opportunity/Suggestion model as the existing link audits.
+
+### Implementation Tasks
+
+**Task 1 — Create audit directory**
+- Create `src/broken-external-links/` containing:
+  - `handler.js`
+  - `helpers.js`
+  - `opportunity-data-mapper.js`
+
+**Task 2 — `helpers.js`: link extraction and per-domain rate limiter**
+- `extractExternalLinks($, siteHostname)` — given a Cheerio-loaded document and the site's hostname, return all unique `href` values where `new URL(href).hostname !== siteHostname` and href starts with `http://` or `https://`.
+- `checkExternalLinks(links, log)` — checks each link's HTTP status using `tracingFetch` from `@adobe/spacecat-shared-utils`. Implements a per-domain rate limiter via a `Map<domain, lastRequestMs>`: before each request, compute `elapsed = Date.now() - lastRequestMs[domain]`; if `elapsed < DOMAIN_RATE_LIMIT_MS` (default 1000 ms), `await sleep(DOMAIN_RATE_LIMIT_MS - elapsed)`. Returns an array of `{ url, status }` for all links that returned `status >= 400`.
+- Constants: `DOMAIN_RATE_LIMIT_MS = 1000`, `FETCH_TIMEOUT_MS = 5000`, `MAX_PAGES = 100`, `MAX_EXTERNAL_LINKS_PER_PAGE = 50`.
+
+**Task 3 — `opportunity-data-mapper.js`**
+```js
+export function createOpportunityData() {
+  return {
+    runbook: 'https://...',  // TBD — create runbook doc
+    origin: 'AUTOMATION',
+    title: 'Fix broken external links to improve user experience',
+    description: 'External links returning 4xx or 5xx errors break user journeys and may signal stale or incorrect content.',
+    guidance: {
+      steps: [
+        'Review each broken external link listed below.',
+        'Update or remove links that no longer resolve.',
+        'Consider replacing with an archived version (e.g. Wayback Machine) where appropriate.',
+      ],
+    },
+    tags: ['Engagement', 'Traffic acquisition'],
+    data: {
+      dataSources: ['SITE'],
+    },
+  };
+}
+```
+
+**Task 4 — `handler.js`: RunnerAudit**
+
+Use `AuditBuilder.withRunner()` (single-step, no SQS fan-out needed for weekly cycle):
+
+```js
+import { tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
+import { load as cheerioLoad } from 'cheerio';
+import { Audit } from '@adobe/spacecat-shared-data-access';
+import { AuditBuilder } from '../common/audit-builder.js';
+import { convertToOpportunity } from '../common/opportunity.js';
+import { createOpportunityData } from './opportunity-data-mapper.js';
+import { extractExternalLinks, checkExternalLinks, MAX_PAGES } from './helpers.js';
+
+const AUDIT_TYPE = Audit.AUDIT_TYPES.BROKEN_EXTERNAL_LINKS;
+
+async function brokenExternalLinksRunner(auditUrl, context) {
+  const { site, dataAccess, log } = context;
+  const { SiteTopPage } = dataAccess;
+
+  const topPages = await SiteTopPage.allBySiteIdAndSourceAndGeo(
+    site.getId(), 'seo', 'global',
+  );
+  const pages = topPages.slice(0, MAX_PAGES);
+
+  const siteHostname = new URL(auditUrl).hostname;
+  const brokenLinksBySrcPage = [];
+
+  for (const page of pages) {
+    const pageUrl = page.getURL();
+    let html;
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const response = await fetch(pageUrl, { timeout: 8000 });
+      if (!response.ok) continue;
+      // eslint-disable-next-line no-await-in-loop
+      html = await response.text();
+    } catch (err) {
+      log.warn(`Failed to fetch page ${pageUrl}: ${err.message}`);
+      continue;
+    }
+
+    const $ = cheerioLoad(html);
+    const externalLinks = extractExternalLinks($, siteHostname);
+    if (externalLinks.length === 0) continue;
+
+    // eslint-disable-next-line no-await-in-loop
+    const broken = await checkExternalLinks(externalLinks, log);
+    if (broken.length > 0) {
+      brokenLinksBySrcPage.push({ pageUrl, brokenLinks: broken });
+    }
+  }
+
+  const auditResult = { brokenLinksBySrcPage, totalBrokenLinks: brokenLinksBySrcPage.reduce((acc, p) => acc + p.brokenLinks.length, 0) };
+
+  if (auditResult.totalBrokenLinks > 0) {
+    const suggestions = buildSuggestions(brokenLinksBySrcPage);
+    await convertToOpportunity(auditUrl, { siteId: site.getId(), ...auditResult }, context, createOpportunityData, AUDIT_TYPE);
+    await syncSuggestions(site.getId(), suggestions, context);
+  }
+
+  return { auditData: auditResult, fullAuditRef: auditUrl };
+}
+
+export default new AuditBuilder()
+  .withRunner(brokenExternalLinksRunner)
+  .build();
+```
+
+The handler builds one Suggestion per unique broken external URL (not per source page), attaching the list of `urlFrom` source pages as data. This mirrors the broken-backlinks suggestion model.
+
+**Task 5 — Register in `src/index.js`**
+- Import: `import brokenExternalLinks from './broken-external-links/handler.js';`
+- Add to `HANDLERS` map: `'broken-external-links': brokenExternalLinks,`
+
+**Task 6 — Tests in `test/broken-external-links/`**
+- `handler.test.js` — mock `SiteTopPage`, `tracingFetch`, `Opportunity`, `Suggestion`; verify happy path (broken links found → opportunity + suggestions created), no-broken-links path (no opportunity created), fetch-error path (page skipped, no throw), empty top-pages path.
+- `helpers.test.js` — test `extractExternalLinks` (filters internal, relative, mailto links), `checkExternalLinks` (rate-limit delay applied, 4xx/5xx recorded, 2xx/3xx ignored).
+- `opportunity-data-mapper.test.js` — snapshot test on returned object shape.
+
+### Affected Files
+- `src/broken-external-links/handler.js` (new)
+- `src/broken-external-links/helpers.js` (new)
+- `src/broken-external-links/opportunity-data-mapper.js` (new)
+- `src/index.js` (import + HANDLERS entry)
+- `test/broken-external-links/handler.test.js` (new)
+- `test/broken-external-links/helpers.test.js` (new)
+- `test/broken-external-links/opportunity-data-mapper.test.js` (new)
+
+### Testing Strategy
+- **100% line/branch/statement coverage** is enforced by CI (`c8` with thresholds in `.c8rc`).
+- Use `MockContextBuilder` from `test/support/` to construct the full Lambda context.
+- Mock `tracingFetch` via `nock` or `sinon.stub` — never make real HTTP calls in unit tests.
+- Fixture: a small HTML string with 3 external links (2 broken, 1 ok) is sufficient.
+- Rate-limit: use `sinon.useFakeTimers()` + stub `sleep` to verify the delay logic without real wall-clock waits.
+
+### Dependencies on Other Repos
+- **spacecat-shared must publish first.** After `Audit.AUDIT_TYPES.BROKEN_EXTERNAL_LINKS` is released, bump `@adobe/spacecat-shared-data-access` in this repo's `package.json` before implementing.
+
+### Notes
+- `MAX_PAGES = 100` is a pragmatic upper bound for Lambda timeout safety. Can be made configurable via `site.getConfig().getHandlerConfig('broken-external-links')?.maxPages`.
+- No retries on transient 5xx — per issue requirement. A transient 503 is reported as a broken link.
+- Skip `mailto:`, `tel:`, `#fragment-only`, and relative links in `extractExternalLinks`.
+- The audit intentionally does **not** use ScrapeCat / the SQS scraping pipeline to keep the implementation simple and avoid adding another multi-step async flow for a new audit type. Revisit if site scale demands it.
+- `spacecat-api-service` trigger registration is deferred to a future iteration; the audit is exercisable via the scheduled Jobs Dispatcher only until then.

--- a/src/broken-external-links/handler.js
+++ b/src/broken-external-links/handler.js
@@ -52,11 +52,12 @@ export function buildSuggestions(brokenLinksBySrcPage) {
  * and creates an Opportunity with per-broken-URL Suggestions.
  *
  * @param {string} auditUrl - The resolved base URL for the audit.
- * @param {Object} context - Lambda context (site, dataAccess, log).
+ * @param {Object} context - Lambda context (dataAccess, log, etc.).
+ * @param {Object} site - The site object.
  * @returns {Promise<{auditData: Object, fullAuditRef: string}>}
  */
-export async function brokenExternalLinksRunner(auditUrl, context) {
-  const { site, dataAccess, log } = context;
+export async function brokenExternalLinksRunner(auditUrl, context, site) {
+  const { dataAccess, log } = context;
   const { SiteTopPage } = dataAccess;
 
   const topPages = await SiteTopPage.allBySiteIdAndSourceAndGeo(

--- a/src/broken-external-links/handler.js
+++ b/src/broken-external-links/handler.js
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { load as cheerioLoad } from 'cheerio';
+import { tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
+import { AuditBuilder } from '../common/audit-builder.js';
+import { convertToOpportunity } from '../common/opportunity.js';
+import { syncSuggestions } from '../utils/data-access.js';
+import { createOpportunityData } from './opportunity-data-mapper.js';
+import {
+  extractExternalLinks,
+  checkExternalLinks,
+  MAX_PAGES,
+} from './helpers.js';
+
+// Use string literal until spacecat-shared-data-access publishes BROKEN_EXTERNAL_LINKS constant.
+// Switch to Audit.AUDIT_TYPES.BROKEN_EXTERNAL_LINKS once the package is bumped.
+const AUDIT_TYPE = 'broken-external-links';
+
+/**
+ * Aggregates broken links by unique broken URL, collecting source pages.
+ * One suggestion per broken external URL, with all referring page URLs in data.urlFrom.
+ *
+ * @param {Array<{pageUrl: string, brokenLinks: Array<{url: string, status: number}>}>} brokenLinksBySrcPage
+ * @returns {Array<{url: string, status: number, urlFrom: string[]}>}
+ */
+export function buildSuggestions(brokenLinksBySrcPage) {
+  const byUrl = new Map();
+  for (const { pageUrl, brokenLinks } of brokenLinksBySrcPage) {
+    for (const { url, status } of brokenLinks) {
+      if (!byUrl.has(url)) {
+        byUrl.set(url, { url, status, urlFrom: [] });
+      }
+      byUrl.get(url).urlFrom.push(pageUrl);
+    }
+  }
+  return Array.from(byUrl.values());
+}
+
+/**
+ * Runner function for the broken-external-links audit.
+ * Fetches top pages, extracts external links, checks their HTTP status,
+ * and creates an Opportunity with per-broken-URL Suggestions.
+ *
+ * @param {string} auditUrl - The resolved base URL for the audit.
+ * @param {Object} context - Lambda context (site, dataAccess, log).
+ * @returns {Promise<{auditData: Object, fullAuditRef: string}>}
+ */
+export async function brokenExternalLinksRunner(auditUrl, context) {
+  const { site, dataAccess, log } = context;
+  const { SiteTopPage } = dataAccess;
+
+  const topPages = await SiteTopPage.allBySiteIdAndSourceAndGeo(
+    site.getId(),
+    'seo',
+    'global',
+  );
+  const pages = topPages.slice(0, MAX_PAGES);
+
+  const siteHostname = new URL(auditUrl).hostname;
+  const brokenLinksBySrcPage = [];
+
+  for (const page of pages) {
+    const pageUrl = page.getURL();
+    let html;
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const response = await fetch(pageUrl, { timeout: 8000 });
+      if (!response.ok) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      // eslint-disable-next-line no-await-in-loop
+      html = await response.text();
+    } catch (err) {
+      log.warn(`Failed to fetch page ${pageUrl}: ${err.message}`);
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
+    const $ = cheerioLoad(html);
+    const externalLinks = extractExternalLinks($, siteHostname);
+    if (externalLinks.length === 0) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    const broken = await checkExternalLinks(externalLinks, log);
+    if (broken.length > 0) {
+      brokenLinksBySrcPage.push({ pageUrl, brokenLinks: broken });
+    }
+  }
+
+  const totalBrokenLinks = brokenLinksBySrcPage
+    .reduce((acc, p) => acc + p.brokenLinks.length, 0);
+  const auditResult = { brokenLinksBySrcPage, totalBrokenLinks };
+
+  if (totalBrokenLinks > 0) {
+    const suggestions = buildSuggestions(brokenLinksBySrcPage);
+
+    const opportunity = await convertToOpportunity(
+      auditUrl,
+      { siteId: site.getId() },
+      context,
+      createOpportunityData,
+      AUDIT_TYPE,
+    );
+
+    await syncSuggestions({
+      opportunity,
+      newData: suggestions,
+      buildKey: (data) => data.url,
+      context,
+      mapNewSuggestion: (data) => ({
+        opportunityId: opportunity.getId(),
+        type: 'REDIRECT_UPDATE',
+        rank: data.status,
+        data: {
+          url: data.url,
+          status: data.status,
+          urlFrom: data.urlFrom,
+        },
+      }),
+    });
+  }
+
+  return { auditData: auditResult, fullAuditRef: auditUrl };
+}
+
+export default new AuditBuilder()
+  .withRunner(brokenExternalLinksRunner)
+  .build();

--- a/src/broken-external-links/helpers.js
+++ b/src/broken-external-links/helpers.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
+import { sleep } from '../support/utils.js';
+
+export const DOMAIN_RATE_LIMIT_MS = 1000;
+export const FETCH_TIMEOUT_MS = 5000;
+export const MAX_PAGES = 100;
+export const MAX_EXTERNAL_LINKS_PER_PAGE = 50;
+
+/**
+ * Extracts unique external href values from a Cheerio-loaded document.
+ * Skips internal links, relative links, mailto:, tel:, and fragment-only links.
+ *
+ * @param {import('cheerio').CheerioAPI} $ - Cheerio instance loaded with page HTML.
+ * @param {string} siteHostname - The site's hostname to exclude (e.g. "example.com").
+ * @returns {string[]} Array of unique external absolute URLs.
+ */
+export function extractExternalLinks($, siteHostname) {
+  const seen = new Set();
+  const result = [];
+
+  $('a[href]').each((_, el) => {
+    const href = $(el).attr('href');
+    if (!href) return;
+    if (!href.startsWith('http://') && !href.startsWith('https://')) return;
+    let parsed;
+    try {
+      parsed = new URL(href);
+    } catch {
+      return;
+    }
+    if (parsed.hostname === siteHostname) return;
+    const normalized = parsed.href;
+    if (!seen.has(normalized)) {
+      seen.add(normalized);
+      result.push(normalized);
+    }
+  });
+
+  return result.slice(0, MAX_EXTERNAL_LINKS_PER_PAGE);
+}
+
+/**
+ * Checks each external link's HTTP status, applying a per-domain rate limit.
+ * Returns only links that returned status >= 400.
+ *
+ * @param {string[]} links - Array of absolute URLs to check.
+ * @param {Object} log - Logger instance.
+ * @returns {Promise<Array<{url: string, status: number}>>} Broken links (status >= 400).
+ */
+export async function checkExternalLinks(links, log) {
+  const lastRequestMs = new Map();
+  const broken = [];
+
+  for (const url of links) {
+    let domain;
+    try {
+      domain = new URL(url).hostname;
+    } catch {
+      // skip unparseable URLs
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
+    const last = lastRequestMs.get(domain);
+    if (last !== undefined) {
+      const elapsed = Date.now() - last;
+      if (elapsed < DOMAIN_RATE_LIMIT_MS) {
+        // eslint-disable-next-line no-await-in-loop
+        await sleep(DOMAIN_RATE_LIMIT_MS - elapsed);
+      }
+    }
+
+    lastRequestMs.set(domain, Date.now());
+
+    let status;
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const response = await fetch(url, { timeout: FETCH_TIMEOUT_MS });
+      status = response.status;
+    } catch (err) {
+      log.warn(`Failed to check external link ${url}: ${err.message}`);
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
+    if (status >= 400) {
+      broken.push({ url, status });
+    }
+  }
+
+  return broken;
+}

--- a/src/broken-external-links/opportunity-data-mapper.js
+++ b/src/broken-external-links/opportunity-data-mapper.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+export function createOpportunityData() {
+  return {
+    runbook: 'https://adobe.sharepoint.com/:w:/r/sites/aemsites-engineering/_layouts/15/doc2.aspx?sourcedoc=%7BAC174971-BA97-44A9-9560-90BE6C7CF789%7D&file=Experience_Success_Studio_Broken_External_Links_Runbook.docx&action=default&mobileredirect=true',
+    origin: 'AUTOMATION',
+    title: 'Fix broken external links to improve user experience',
+    description: 'External links returning 4xx or 5xx errors break user journeys and may signal stale or incorrect content.',
+    guidance: {
+      steps: [
+        'Review each broken external link listed below.',
+        'Update or remove links that no longer resolve.',
+        'Consider replacing with an archived version (e.g. Wayback Machine) where appropriate.',
+      ],
+    },
+    tags: ['Engagement', 'Traffic acquisition'],
+    data: {
+      dataSources: ['SITE'],
+    },
+  };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -125,6 +125,7 @@ import drsPromptGeneration from './drs-prompt-generation/handler.js';
 import offsiteBrandPresence from './offsite-brand-presence/handler.js';
 import { refreshGeoBrandPresenceSheetsHandler } from './geo-brand-presence/geo-brand-presence-refresh-handler.js';
 import { refreshGeoBrandPresenceDailyHandler } from './geo-brand-presence-daily/geo-brand-presence-refresh-handler.js';
+import brokenExternalLinks from './broken-external-links/handler.js';
 
 const HANDLERS = {
   accessibility,
@@ -145,6 +146,7 @@ const HANDLERS = {
   'page-type-detection': pageTypeDetection,
   canonical,
   'broken-backlinks': backlinks,
+  'broken-external-links': brokenExternalLinks,
   'broken-internal-links': internalLinks,
   'experimentation-ess-daily': essExperimentationDaily,
   'experimentation-ess-all': essExperimentationAll,

--- a/test/broken-external-links/handler.test.js
+++ b/test/broken-external-links/handler.test.js
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import nock from 'nock';
+import esmock from 'esmock';
+import { MockContextBuilder } from '../shared.js';
+
+use(sinonChai);
+
+const AUDIT_URL = 'https://example.com';
+
+const HTML_WITH_BROKEN_LINKS = `
+  <html><body>
+    <a href="https://broken.com/404">broken 404</a>
+    <a href="https://also-broken.com/500">broken 500</a>
+    <a href="https://working.com/ok">working</a>
+  </body></html>
+`;
+
+const HTML_WITH_ALL_OK_EXTERNAL_LINKS = `
+  <html><body>
+    <a href="https://working.com/ok">working</a>
+    <a href="https://working2.com/ok2">working2</a>
+  </body></html>
+`;
+
+const HTML_WITH_NO_EXTERNAL_LINKS = `
+  <html><body>
+    <a href="/internal">internal</a>
+    <a href="https://example.com/page">same domain</a>
+  </body></html>
+`;
+
+describe('broken-external-links handler', () => {
+  let sandbox;
+  let context;
+  let site;
+  let convertToOpportunityStub;
+  let syncSuggestionsStub;
+  let handlerModule;
+  let mockOpportunity;
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+
+    mockOpportunity = {
+      getId: sandbox.stub().returns('opp-123'),
+      getType: sandbox.stub().returns('broken-external-links'),
+    };
+
+    convertToOpportunityStub = sandbox.stub().resolves(mockOpportunity);
+    syncSuggestionsStub = sandbox.stub().resolves();
+
+    handlerModule = await esmock('../../src/broken-external-links/handler.js', {
+      '../../src/common/opportunity.js': {
+        convertToOpportunity: convertToOpportunityStub,
+      },
+      '../../src/utils/data-access.js': {
+        syncSuggestions: syncSuggestionsStub,
+      },
+    });
+
+    context = new MockContextBuilder()
+      .withSandbox(sandbox)
+      .withOverrides({
+        dataAccess: {
+          SiteTopPage: {
+            allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([
+              { getURL: () => 'https://example.com/page1' },
+            ]),
+          },
+          Opportunity: {
+            allBySiteIdAndStatus: sandbox.stub().resolves([]),
+            create: sandbox.stub().resolves(mockOpportunity),
+          },
+          Suggestion: {
+            saveMany: sandbox.stub().resolves(),
+            bulkUpdateStatus: sandbox.stub().resolves(),
+            allByOpportunityIdAndStatus: sandbox.stub().resolves([]),
+          },
+        },
+      })
+      .build();
+
+    site = context.site;
+  });
+
+  afterEach(() => {
+    nock.cleanAll();
+    sandbox.restore();
+  });
+
+  describe('brokenExternalLinksRunner', () => {
+    it('happy path: finds broken links, creates opportunity and suggestions', async () => {
+      nock('https://example.com').get('/page1').reply(200, HTML_WITH_BROKEN_LINKS);
+      nock('https://broken.com').get('/404').reply(404);
+      nock('https://also-broken.com').get('/500').reply(500);
+      nock('https://working.com').get('/ok').reply(200);
+
+      const result = await handlerModule.brokenExternalLinksRunner(AUDIT_URL, context, site);
+
+      expect(result.fullAuditRef).to.equal(AUDIT_URL);
+      expect(result.auditData.totalBrokenLinks).to.equal(2);
+      expect(result.auditData.brokenLinksBySrcPage).to.have.length(1);
+      expect(result.auditData.brokenLinksBySrcPage[0].pageUrl).to.equal('https://example.com/page1');
+      expect(result.auditData.brokenLinksBySrcPage[0].brokenLinks).to.have.length(2);
+      expect(convertToOpportunityStub).to.have.been.calledOnce;
+      expect(syncSuggestionsStub).to.have.been.calledOnce;
+
+      // Verify inline functions passed to syncSuggestions are correct
+      const callArgs = syncSuggestionsStub.firstCall.args[0];
+      expect(callArgs.opportunity).to.equal(mockOpportunity);
+      expect(callArgs.newData).to.be.an('array').with.length(2);
+
+      // Test buildKey inline function
+      const buildKey = callArgs.buildKey;
+      expect(buildKey({ url: 'https://broken.com/404' })).to.equal('https://broken.com/404');
+
+      // Test mapNewSuggestion inline function
+      const mapNewSuggestion = callArgs.mapNewSuggestion;
+      const mapped = mapNewSuggestion({
+        url: 'https://broken.com/404',
+        status: 404,
+        urlFrom: ['https://example.com/page1'],
+      });
+      expect(mapped.opportunityId).to.equal('opp-123');
+      expect(mapped.type).to.equal('REDIRECT_UPDATE');
+      expect(mapped.rank).to.equal(404);
+      expect(mapped.data.url).to.equal('https://broken.com/404');
+      expect(mapped.data.status).to.equal(404);
+      expect(mapped.data.urlFrom).to.deep.equal(['https://example.com/page1']);
+    });
+
+    it('external links present but all ok: does not create opportunity', async () => {
+      nock('https://example.com').get('/page1').reply(200, HTML_WITH_ALL_OK_EXTERNAL_LINKS);
+      nock('https://working.com').get('/ok').reply(200);
+      nock('https://working2.com').get('/ok2').reply(200);
+
+      const result = await handlerModule.brokenExternalLinksRunner(AUDIT_URL, context, site);
+
+      expect(result.auditData.totalBrokenLinks).to.equal(0);
+      expect(convertToOpportunityStub).to.not.have.been.called;
+      expect(syncSuggestionsStub).to.not.have.been.called;
+    });
+
+    it('page with only internal links: skips external check, no opportunity', async () => {
+      nock('https://example.com').get('/page1').reply(200, HTML_WITH_NO_EXTERNAL_LINKS);
+
+      const result = await handlerModule.brokenExternalLinksRunner(AUDIT_URL, context, site);
+
+      expect(result.auditData.totalBrokenLinks).to.equal(0);
+      expect(convertToOpportunityStub).to.not.have.been.called;
+    });
+
+    it('empty top-pages: returns zero broken links and does not create opportunity', async () => {
+      context.dataAccess.SiteTopPage.allBySiteIdAndSourceAndGeo.resolves([]);
+
+      const result = await handlerModule.brokenExternalLinksRunner(AUDIT_URL, context, site);
+
+      expect(result.auditData.totalBrokenLinks).to.equal(0);
+      expect(result.auditData.brokenLinksBySrcPage).to.deep.equal([]);
+      expect(convertToOpportunityStub).to.not.have.been.called;
+    });
+
+    it('fetch error on page: warns and skips to next page without throwing', async () => {
+      context.dataAccess.SiteTopPage.allBySiteIdAndSourceAndGeo.resolves([
+        { getURL: () => 'https://example.com/bad-page' },
+        { getURL: () => 'https://example.com/good-page' },
+      ]);
+      nock('https://example.com').get('/bad-page').replyWithError('connection refused');
+      nock('https://example.com').get('/good-page').reply(200, HTML_WITH_NO_EXTERNAL_LINKS);
+
+      const result = await handlerModule.brokenExternalLinksRunner(AUDIT_URL, context, site);
+
+      expect(result.auditData.totalBrokenLinks).to.equal(0);
+      expect(context.log.warn).to.have.been.calledOnce;
+      expect(convertToOpportunityStub).to.not.have.been.called;
+    });
+
+    it('non-200 page response: skips page and does not create opportunity', async () => {
+      nock('https://example.com').get('/page1').reply(404, 'Not Found');
+
+      const result = await handlerModule.brokenExternalLinksRunner(AUDIT_URL, context, site);
+
+      expect(result.auditData.totalBrokenLinks).to.equal(0);
+      expect(convertToOpportunityStub).to.not.have.been.called;
+    });
+  });
+
+  describe('buildSuggestions', () => {
+    it('aggregates broken links by unique broken URL, collecting all source pages', () => {
+      const brokenLinksBySrcPage = [
+        {
+          pageUrl: 'https://example.com/p1',
+          brokenLinks: [
+            { url: 'https://broken.com/a', status: 404 },
+            { url: 'https://broken.com/b', status: 500 },
+          ],
+        },
+        {
+          pageUrl: 'https://example.com/p2',
+          brokenLinks: [
+            { url: 'https://broken.com/a', status: 404 },
+          ],
+        },
+      ];
+
+      const result = handlerModule.buildSuggestions(brokenLinksBySrcPage);
+
+      expect(result).to.have.length(2);
+
+      const urlA = result.find((r) => r.url === 'https://broken.com/a');
+      expect(urlA).to.exist;
+      expect(urlA.status).to.equal(404);
+      expect(urlA.urlFrom).to.deep.equal([
+        'https://example.com/p1',
+        'https://example.com/p2',
+      ]);
+
+      const urlB = result.find((r) => r.url === 'https://broken.com/b');
+      expect(urlB).to.exist;
+      expect(urlB.status).to.equal(500);
+      expect(urlB.urlFrom).to.deep.equal(['https://example.com/p1']);
+    });
+
+    it('returns empty array when input is empty', () => {
+      expect(handlerModule.buildSuggestions([])).to.deep.equal([]);
+    });
+
+    it('handles single page with single broken link', () => {
+      const input = [{
+        pageUrl: 'https://example.com/page',
+        brokenLinks: [{ url: 'https://broken.com/x', status: 404 }],
+      }];
+      const result = handlerModule.buildSuggestions(input);
+      expect(result).to.have.length(1);
+      expect(result[0].url).to.equal('https://broken.com/x');
+      expect(result[0].urlFrom).to.deep.equal(['https://example.com/page']);
+    });
+  });
+});

--- a/test/broken-external-links/helpers.test.js
+++ b/test/broken-external-links/helpers.test.js
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import nock from 'nock';
+import esmock from 'esmock';
+import { load as cheerioLoad } from 'cheerio';
+import {
+  extractExternalLinks,
+  DOMAIN_RATE_LIMIT_MS,
+  FETCH_TIMEOUT_MS,
+  MAX_PAGES,
+  MAX_EXTERNAL_LINKS_PER_PAGE,
+} from '../../src/broken-external-links/helpers.js';
+
+use(sinonChai);
+
+describe('broken-external-links helpers', () => {
+  const siteHostname = 'example.com';
+
+  afterEach(() => {
+    nock.cleanAll();
+    sinon.restore();
+  });
+
+  describe('constants', () => {
+    it('exports DOMAIN_RATE_LIMIT_MS = 1000', () => {
+      expect(DOMAIN_RATE_LIMIT_MS).to.equal(1000);
+    });
+
+    it('exports FETCH_TIMEOUT_MS = 5000', () => {
+      expect(FETCH_TIMEOUT_MS).to.equal(5000);
+    });
+
+    it('exports MAX_PAGES = 100', () => {
+      expect(MAX_PAGES).to.equal(100);
+    });
+
+    it('exports MAX_EXTERNAL_LINKS_PER_PAGE = 50', () => {
+      expect(MAX_EXTERNAL_LINKS_PER_PAGE).to.equal(50);
+    });
+  });
+
+  describe('extractExternalLinks', () => {
+    it('returns external http/https links', () => {
+      const html = `
+        <html><body>
+          <a href="https://external.com/page1">link1</a>
+          <a href="https://other.org/page2">link2</a>
+        </body></html>
+      `;
+      const $ = cheerioLoad(html);
+      const result = extractExternalLinks($, siteHostname);
+      expect(result).to.include('https://external.com/page1');
+      expect(result).to.include('https://other.org/page2');
+    });
+
+    it('excludes links to the same hostname', () => {
+      const html = `
+        <html><body>
+          <a href="https://example.com/internal">internal</a>
+          <a href="https://external.com/page">external</a>
+        </body></html>
+      `;
+      const $ = cheerioLoad(html);
+      const result = extractExternalLinks($, siteHostname);
+      expect(result).to.not.include('https://example.com/internal');
+      expect(result).to.include('https://external.com/page');
+    });
+
+    it('excludes relative links', () => {
+      const html = `
+        <html><body>
+          <a href="/relative/path">relative</a>
+          <a href="https://external.com/abs">absolute</a>
+        </body></html>
+      `;
+      const $ = cheerioLoad(html);
+      const result = extractExternalLinks($, siteHostname);
+      expect(result).to.not.include('/relative/path');
+      expect(result).to.include('https://external.com/abs');
+    });
+
+    it('excludes mailto: and tel: links', () => {
+      const html = `
+        <html><body>
+          <a href="mailto:test@example.com">email</a>
+          <a href="tel:+1234567890">phone</a>
+          <a href="https://external.com/ok">ok</a>
+        </body></html>
+      `;
+      const $ = cheerioLoad(html);
+      const result = extractExternalLinks($, siteHostname);
+      expect(result).to.not.include('mailto:test@example.com');
+      expect(result).to.not.include('tel:+1234567890');
+      expect(result).to.include('https://external.com/ok');
+    });
+
+    it('excludes fragment-only links', () => {
+      const html = `
+        <html><body>
+          <a href="#section">fragment</a>
+          <a href="https://external.com/page">external</a>
+        </body></html>
+      `;
+      const $ = cheerioLoad(html);
+      const result = extractExternalLinks($, siteHostname);
+      expect(result).to.not.include('#section');
+      expect(result).to.include('https://external.com/page');
+    });
+
+    it('skips href with empty string value', () => {
+      const html = `
+        <html><body>
+          <a href="">empty href</a>
+          <a href="https://external.com/ok">valid</a>
+        </body></html>
+      `;
+      const $ = cheerioLoad(html);
+      const result = extractExternalLinks($, siteHostname);
+      expect(result).to.include('https://external.com/ok');
+      expect(result).to.not.include('');
+    });
+
+    it('skips href values that start with https:// but are not parseable as URLs', () => {
+      const html = `
+        <html><body>
+          <a href="https://">incomplete url</a>
+          <a href="https://valid.com/page">valid url</a>
+        </body></html>
+      `;
+      const $ = cheerioLoad(html);
+      const result = extractExternalLinks($, siteHostname);
+      expect(result).to.include('https://valid.com/page');
+      expect(result).to.not.include('https://');
+    });
+
+    it('deduplicates the same URL', () => {
+      const html = `
+        <html><body>
+          <a href="https://external.com/dup">first</a>
+          <a href="https://external.com/dup">second</a>
+        </body></html>
+      `;
+      const $ = cheerioLoad(html);
+      const result = extractExternalLinks($, siteHostname);
+      const dupCount = result.filter((u) => u === 'https://external.com/dup').length;
+      expect(dupCount).to.equal(1);
+    });
+
+    it('limits results to MAX_EXTERNAL_LINKS_PER_PAGE', () => {
+      const links = Array.from(
+        { length: MAX_EXTERNAL_LINKS_PER_PAGE + 10 },
+        (_, i) => `<a href="https://ext${i}.com/page">link</a>`,
+      ).join('');
+      const html = `<html><body>${links}</body></html>`;
+      const $ = cheerioLoad(html);
+      const result = extractExternalLinks($, siteHostname);
+      expect(result).to.have.length(MAX_EXTERNAL_LINKS_PER_PAGE);
+    });
+
+    it('returns empty array when no links present', () => {
+      const $ = cheerioLoad('<html><body><p>no links</p></body></html>');
+      expect(extractExternalLinks($, siteHostname)).to.deep.equal([]);
+    });
+
+    it('returns empty array when only internal links present', () => {
+      const html = '<html><body><a href="https://example.com/page">internal</a></body></html>';
+      const $ = cheerioLoad(html);
+      expect(extractExternalLinks($, siteHostname)).to.deep.equal([]);
+    });
+  });
+
+  describe('checkExternalLinks', () => {
+    let checkExternalLinksWithSleep;
+    let sleepStub;
+
+    beforeEach(async () => {
+      sleepStub = sinon.stub().resolves();
+      const module = await esmock('../../src/broken-external-links/helpers.js', {
+        '../../src/support/utils.js': { sleep: sleepStub },
+      });
+      checkExternalLinksWithSleep = module.checkExternalLinks;
+    });
+
+    it('returns broken links (status >= 400)', async () => {
+      nock('https://broken.com').get('/404').reply(404);
+      nock('https://broken.com').get('/500').reply(500);
+      nock('https://ok.com').get('/200').reply(200);
+
+      const log = { warn: sinon.stub() };
+      const result = await checkExternalLinksWithSleep(
+        ['https://broken.com/404', 'https://broken.com/500', 'https://ok.com/200'],
+        log,
+      );
+
+      expect(result).to.have.length(2);
+      expect(result.find((r) => r.url === 'https://broken.com/404').status).to.equal(404);
+      expect(result.find((r) => r.url === 'https://broken.com/500').status).to.equal(500);
+    });
+
+    it('excludes successful responses (2xx)', async () => {
+      nock('https://ok.com').get('/ok').reply(200);
+
+      const log = { warn: sinon.stub() };
+      const result = await checkExternalLinksWithSleep(['https://ok.com/ok'], log);
+      expect(result).to.deep.equal([]);
+    });
+
+    it('applies rate limit sleep for same-domain sequential requests within rate limit', async () => {
+      nock('https://samedom.com').get('/first').reply(404);
+      nock('https://samedom.com').get('/second').reply(404);
+
+      const log = { warn: sinon.stub() };
+      await checkExternalLinksWithSleep(
+        ['https://samedom.com/first', 'https://samedom.com/second'],
+        log,
+      );
+
+      expect(sleepStub).to.have.been.calledOnce;
+    });
+
+    it('skips sleep when elapsed time already exceeds rate limit', async () => {
+      // Stub Date.now to simulate enough time having passed between same-domain requests
+      let nowCallCount = 0;
+      sinon.stub(Date, 'now').callsFake(() => {
+        nowCallCount += 1;
+        if (nowCallCount === 1) return 0;        // first URL: stored as lastRequestMs
+        if (nowCallCount === 2) return 2000;     // second URL: elapsed = 2000 - 0 = 2000 >= 1000
+        return 2000;
+      });
+
+      nock('https://samedom2.com').get('/first').reply(404);
+      nock('https://samedom2.com').get('/second').reply(404);
+
+      const log = { warn: sinon.stub() };
+      await checkExternalLinksWithSleep(
+        ['https://samedom2.com/first', 'https://samedom2.com/second'],
+        log,
+      );
+
+      expect(sleepStub).to.not.have.been.called;
+    });
+
+    it('does not apply rate limit delay for different-domain requests', async () => {
+      nock('https://domain1.com').get('/page').reply(404);
+      nock('https://domain2.com').get('/page').reply(404);
+
+      const log = { warn: sinon.stub() };
+      await checkExternalLinksWithSleep(
+        ['https://domain1.com/page', 'https://domain2.com/page'],
+        log,
+      );
+
+      expect(sleepStub).to.not.have.been.called;
+    });
+
+    it('skips and warns on fetch error', async () => {
+      nock('https://errored.com').get('/page').replyWithError('connection refused');
+      nock('https://ok.com').get('/ok').reply(200);
+
+      const log = { warn: sinon.stub() };
+      const result = await checkExternalLinksWithSleep(
+        ['https://errored.com/page', 'https://ok.com/ok'],
+        log,
+      );
+
+      expect(result).to.deep.equal([]);
+      expect(log.warn).to.have.been.calledOnce;
+    });
+
+    it('skips URLs that cannot be parsed', async () => {
+      const log = { warn: sinon.stub() };
+      const result = await checkExternalLinksWithSleep(['not-a-url'], log);
+      expect(result).to.deep.equal([]);
+    });
+
+    it('returns empty array for empty input', async () => {
+      const log = { warn: sinon.stub() };
+      const result = await checkExternalLinksWithSleep([], log);
+      expect(result).to.deep.equal([]);
+    });
+  });
+});

--- a/test/broken-external-links/opportunity-data-mapper.test.js
+++ b/test/broken-external-links/opportunity-data-mapper.test.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+import { expect } from 'chai';
+import { createOpportunityData } from '../../src/broken-external-links/opportunity-data-mapper.js';
+
+describe('broken-external-links opportunity-data-mapper', () => {
+  it('returns an object with the expected shape', () => {
+    const result = createOpportunityData();
+
+    expect(result).to.be.an('object');
+    expect(result.origin).to.equal('AUTOMATION');
+    expect(result.title).to.be.a('string').and.not.be.empty;
+    expect(result.description).to.be.a('string').and.not.be.empty;
+    expect(result.runbook).to.be.a('string').and.not.be.empty;
+    expect(result.guidance).to.be.an('object');
+    expect(result.guidance.steps).to.be.an('array').with.length.greaterThan(0);
+    expect(result.tags).to.be.an('array').that.includes('Engagement');
+    expect(result.data).to.be.an('object');
+    expect(result.data.dataSources).to.be.an('array').that.includes('SITE');
+  });
+
+  it('returns a new object on each call', () => {
+    const first = createOpportunityData();
+    const second = createOpportunityData();
+    expect(first).to.not.equal(second);
+  });
+});


### PR DESCRIPTION
Part of [Adobe-AEM-Sites/aso-ai-toolkit#31](https://github.com/Adobe-AEM-Sites/aso-ai-toolkit/issues/31)

## Generated by the SDD cross-repo pipeline

Implementation from the spec on the central issue. The per-repo spec is
committed at `docs/specs/add-broken-external-links-audit-type/spec.md` as the first commit.

## Commits



## Cross-Repo Coordination

- Other PRs in this feature will be linked from the central issue's
  dashboard comment as they open. Check the central issue before
  merging.
- If this PR depends on a newer version of a shared package, the
  dependency note above (or in the central issue) lists the manual
  version-bump steps.

---

Review will run automatically once M3 ships. Until then, you can
trigger review manually via `/pr-review` (if the target repo has
`ai-review-kit.yml`) or run a local review.