### PR TITLE
fix: exclude static-asset URLs from audit query

### DIFF
--- a/src/llm-error-pages/sql/llm-error-pages.sql
+++ b/src/llm-error-pages/sql/llm-error-pages.sql
@@ -11,6 +11,7 @@ WITH classified_data AS (
     {{pageCategoryClassification}} as category
   FROM {{databaseName}}.{{tableName}}
   {{whereClause}}
+  {{excludedUrlSuffixesFilter}}
 ),
 aggregated_data AS (
   SELECT 

--- a/src/llm-error-pages/utils.js
+++ b/src/llm-error-pages/utils.js
@@ -14,6 +14,7 @@ import { getStaticContent, isoCalendarWeek } from '@adobe/spacecat-shared-utils'
 import { buildUserAgentDisplaySQL, buildAgentTypeClassificationSQL, PROVIDER_USER_AGENT_PATTERNS } from '../common/user-agent-classification.js';
 import { DEFAULT_COUNTRY_PATTERNS } from '../common/country-patterns.js';
 import { fetchAgenticUrlClassificationRules } from '../common/agentic-url-classification-rules.js';
+import { buildExcludedUrlSuffixesFilter } from '../cdn-logs-report/utils/query-builder.js';
 
 // ============================================================================
 // CONSTANTS
@@ -29,6 +30,15 @@ export const LLM_USER_AGENT_PATTERNS = Object.fromEntries(
 // Maximum rows returned per status code (404, 403, 5xx) in a single Athena query.
 // Each status is capped independently so no single status can dominate results.
 export const ROWS_PER_STATUS = 300;
+
+// URL suffixes excluded from the audit — static assets that LLM bots
+// sometimes emit but that don't represent actionable error pages.
+export const EXCLUDED_URL_SUFFIXES = [
+  // Images
+  '.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg', '.ico', '.bmp',
+  // Documents
+  '.pdf', '.doc', '.docx', '.xls', '.xlsx', '.ppt', '.pptx', '.rtf',
+];
 
 const TIME_CONSTANTS = {
   ISO_MONDAY: 1,
@@ -207,6 +217,7 @@ export async function buildLlmErrorPagesQuery(options) {
     databaseName,
     tableName,
     whereClause,
+    excludedUrlSuffixesFilter: buildExcludedUrlSuffixesFilter(EXCLUDED_URL_SUFFIXES),
     // user-agent labeling and classification
     userAgentDisplay: buildUserAgentDisplaySQL(),
     agentTypeClassification: buildAgentTypeClassificationSQL(),

--- a/test/audits/llm-error-pages/utils.test.js
+++ b/test/audits/llm-error-pages/utils.test.js
@@ -30,6 +30,7 @@ import {
   toPathOnly,
   downloadExistingCdnSheet,
   matchErrorsWithCdnData,
+  EXCLUDED_URL_SUFFIXES,
 } from '../../../src/llm-error-pages/utils.js';
 import { extractSiteKeyFromBaseURL, getS3Config } from '../../../src/utils/cdn-utils.js';
 
@@ -96,6 +97,16 @@ describe('LLM Error Pages Utils', () => {
     it('should be case insensitive', () => {
       const result = getLlmProviderPattern('CHATGPT');
       expect(result).to.equal('(?i)(ChatGPT|GPTBot|OAI-SearchBot|OAI-AdsBot)(?!.*(Tokowaka|Spacecat))');
+    });
+  });
+
+  describe('EXCLUDED_URL_SUFFIXES', () => {
+    it('should include common image and document extensions', () => {
+      expect(EXCLUDED_URL_SUFFIXES).to.include('.jpg');
+      expect(EXCLUDED_URL_SUFFIXES).to.include('.jpeg');
+      expect(EXCLUDED_URL_SUFFIXES).to.include('.png');
+      expect(EXCLUDED_URL_SUFFIXES).to.include('.pdf');
+      expect(EXCLUDED_URL_SUFFIXES).to.include('.docx');
     });
   });
 
@@ -273,6 +284,18 @@ describe('LLM Error Pages Utils', () => {
         }),
         './src/llm-error-pages/sql/llm-error-pages.sql',
       );
+    });
+
+    it('should pass excludedUrlSuffixesFilter excluding static asset extensions', async () => {
+      await utils.buildLlmErrorPagesQuery(mockOptions);
+
+      const callArg = mockGetStaticContent.firstCall.args[0];
+      expect(callArg).to.have.property('excludedUrlSuffixesFilter');
+      expect(callArg.excludedUrlSuffixesFilter).to.include('NOT regexp_like(url');
+      expect(callArg.excludedUrlSuffixesFilter).to.include('\\.pdf');
+      expect(callArg.excludedUrlSuffixesFilter).to.include('\\.jpg');
+      expect(callArg.excludedUrlSuffixesFilter).to.include('\\.png');
+      expect(callArg.excludedUrlSuffixesFilter).to.include('\\.docx');
     });
 
     it('should handle template with only static content', async () => {


### PR DESCRIPTION
## Summary
Static-asset URLs (.jpg, .pdf, etc.) were appearing in the weekly LLM error-page reports despite not being actionable error pages. This PR filters them out at the Athena query layer so they never surface in either the Excel report or the DB-backed Suggestions.

## Related Issues
https://jira.corp.adobe.com/browse/LLMO-4751

Thanks for contributing!
