### PR TITLE
fix: summarization - use updateByKeys to persist audit result in send-to-mystique step

### DIFF
--- a/src/summarization/handler.js
+++ b/src/summarization/handler.js
@@ -207,7 +207,7 @@ export async function submitForScraping(context) {
  */
 export async function sendToMystique(context) {
   const {
-    site, audit, auditContext, log, sqs, env, scrapeResultPaths, s3Client,
+    site, audit, auditContext, log, sqs, env, scrapeResultPaths, s3Client, dataAccess,
   } = context;
 
   const auditResult = audit.getAuditResult();
@@ -303,12 +303,11 @@ export async function sendToMystique(context) {
 
   // Persist the sent URLs and their content hashes on the audit so the guidance
   // handler can scope syncSuggestions correctly and store hashes with suggestions.
-  audit.setAuditResult({
-    ...auditResult,
-    scrapedUrlsSent: urlsToSend,
-    urlToContentHash,
-  });
-  await audit.save();
+  // Use updateByKeys to bypass the Audit schema's allowUpdates(false) restriction.
+  await dataAccess.Audit.updateByKeys(
+    { auditId: audit.getId() },
+    { auditResult: { ...auditResult, scrapedUrlsSent: urlsToSend, urlToContentHash } },
+  );
 
   const topPagesPayload = urlsToSend.map((url) => ({
     page_url: url,

--- a/test/audits/summarization/handler.test.js
+++ b/test/audits/summarization/handler.test.js
@@ -82,6 +82,9 @@ describe('Summarization Handler', () => {
       Opportunity: {
         allBySiteIdAndStatus: sandbox.stub().resolves([]),
       },
+      Audit: {
+        updateByKeys: sandbox.stub().resolves(),
+      },
     };
 
     context = {
@@ -630,7 +633,7 @@ describe('Summarization Handler', () => {
 
       expect(result).to.deep.equal({ status: 'complete' });
       expect(sqs.sendMessage).not.to.have.been.called;
-      expect(audit.save).not.to.have.been.called;
+      expect(dataAccess.Audit.updateByKeys).not.to.have.been.called;
       expect(log.info).to.have.been.calledWith(
         '[SUMMARIZATION] No pages to send to Mystique after filtering',
       );
@@ -656,19 +659,19 @@ describe('Summarization Handler', () => {
 
       await handler.sendToMystique(context);
 
-      expect(audit.setAuditResult).to.have.been.calledOnce;
-      const auditResultArg = audit.setAuditResult.getCall(0).args[0];
-      expect(auditResultArg.scrapedUrlsSent).to.deep.equal([
+      expect(dataAccess.Audit.updateByKeys).to.have.been.calledOnce;
+      const [keyArg, updateArg] = dataAccess.Audit.updateByKeys.getCall(0).args;
+      expect(keyArg).to.deep.equal({ auditId: 'audit-id-456' });
+      expect(updateArg.auditResult.scrapedUrlsSent).to.deep.equal([
         'https://adobe.com/page1',
         'https://adobe.com/page2',
         'https://adobe.com/page3',
       ]);
-      expect(auditResultArg.urlToContentHash).to.deep.equal({
+      expect(updateArg.auditResult.urlToContentHash).to.deep.equal({
         'https://adobe.com/page1': hash1,
         'https://adobe.com/page2': hash2,
         'https://adobe.com/page3': hash3,
       });
-      expect(audit.save).to.have.been.calledOnce;
     });
 
     it('should store empty urlToContentHash in audit result when s3Client is not configured (LLMO-4454)', async () => {
@@ -677,15 +680,15 @@ describe('Summarization Handler', () => {
 
       await sendToMystique(context);
 
-      expect(audit.setAuditResult).to.have.been.calledOnce;
-      const auditResultArg = audit.setAuditResult.getCall(0).args[0];
-      expect(auditResultArg.urlToContentHash).to.deep.equal({});
-      expect(auditResultArg.scrapedUrlsSent).to.deep.equal([
+      expect(dataAccess.Audit.updateByKeys).to.have.been.calledOnce;
+      const [keyArg, updateArg] = dataAccess.Audit.updateByKeys.getCall(0).args;
+      expect(keyArg).to.deep.equal({ auditId: 'audit-id-456' });
+      expect(updateArg.auditResult.urlToContentHash).to.deep.equal({});
+      expect(updateArg.auditResult.scrapedUrlsSent).to.deep.equal([
         'https://adobe.com/page1',
         'https://adobe.com/page2',
         'https://adobe.com/page3',
       ]);
-      expect(audit.save).to.have.been.calledOnce;
     });
 
     it('should send all pages when no matching summarization opportunity exists (LLMO-4454)', async () => {
@@ -1115,6 +1118,9 @@ describe('Summarization Handler - Athena/SEO fallback', () => {
         SiteTopPage: {
           allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([]),
         },
+        Audit: {
+          updateByKeys: sandbox.stub().resolves(),
+        },
       },
       scrapeResultPaths: new Map([
         ['https://adobe.com/athena-page1', 'path1'],
@@ -1168,6 +1174,9 @@ describe('Summarization Handler - Athena/SEO fallback', () => {
       dataAccess: {
         SiteTopPage: {
           allBySiteIdAndSourceAndGeo: sandbox.stub().resolves(topPages),
+        },
+        Audit: {
+          updateByKeys: sandbox.stub().resolves(),
         },
       },
       scrapeResultPaths: new Map([


### PR DESCRIPTION
## Summary
- Related to https://adobe.enterprise.slack.com/archives/C09UYE3U48P/p1778862991328429
- `audit.setAuditResult()` does not exist on Audit model instances because the Audit schema is configured with `.allowUpdates(false)`, which prevents the base model from auto-generating setter methods
- This caused `TypeError: audit.setAuditResult is not a function` at the `send-to-mystique` step of the summarization audit
- Replaced with `dataAccess.Audit.updateByKeys()`, which bypasses the schema restriction — the same pattern already used in `image-alt-text/handler.js`

## Test plan

- [ ] All existing summarization handler tests pass (`npm run test:spec -- test/audits/summarization/handler.test.js`)
- [ ] Test assertions updated to verify `dataAccess.Audit.updateByKeys` is called with the correct audit ID and result payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)