### PR TITLE
fix(cdn-logs-report): bound bulkPublishToAdminHlx wait, fire-and-forget publish

### DIFF
--- a/src/cdn-logs-report/handler.js
+++ b/src/cdn-logs-report/handler.js
@@ -198,15 +198,11 @@ async function runCdnLogsReport(url, context, site, auditContext) {
     }
   }
 
-  // Publish is fire-and-forget; record jobUrls for out-of-band verification.
-  let bulkPublish;
   if (reportsToPublish.length > 0) {
     try {
-      const jobUrls = await bulkPublishToAdminHlx(reportsToPublish, log);
-      bulkPublish = { success: true, ...jobUrls };
+      await bulkPublishToAdminHlx(reportsToPublish, log);
     } catch (error) {
       log.error('Failed to bulk publish reports:', error);
-      bulkPublish = { success: false, error: error.message };
     }
   }
 
@@ -228,7 +224,6 @@ async function runCdnLogsReport(url, context, site, auditContext) {
     ...agenticDbExportResult,
     auditResult,
     dailyReferralExport,
-    bulkPublish,
     fullAuditRef: `${site.getConfig()?.getLlmoDataFolder()}`,
   };
 }

--- a/src/cdn-logs-report/handler.js
+++ b/src/cdn-logs-report/handler.js
@@ -198,12 +198,17 @@ async function runCdnLogsReport(url, context, site, auditContext) {
     }
   }
 
-  // Batch publish all uploaded reports using bulk API
+  // Batch publish all uploaded reports using bulk API. The publish leg is
+  // fire-and-forget, so we record the jobUrls in the return value for
+  // out-of-band verification when the admin.hlx.page job completes.
+  let bulkPublish;
   if (reportsToPublish.length > 0) {
     try {
-      await bulkPublishToAdminHlx(reportsToPublish, log);
+      const jobUrls = await bulkPublishToAdminHlx(reportsToPublish, log);
+      bulkPublish = { success: true, ...jobUrls };
     } catch (error) {
       log.error('Failed to bulk publish reports:', error);
+      bulkPublish = { success: false, error: error.message };
     }
   }
 
@@ -225,6 +230,7 @@ async function runCdnLogsReport(url, context, site, auditContext) {
     ...agenticDbExportResult,
     auditResult,
     dailyReferralExport,
+    bulkPublish,
     fullAuditRef: `${site.getConfig()?.getLlmoDataFolder()}`,
   };
 }

--- a/src/cdn-logs-report/handler.js
+++ b/src/cdn-logs-report/handler.js
@@ -198,9 +198,7 @@ async function runCdnLogsReport(url, context, site, auditContext) {
     }
   }
 
-  // Batch publish all uploaded reports using bulk API. The publish leg is
-  // fire-and-forget, so we record the jobUrls in the return value for
-  // out-of-band verification when the admin.hlx.page job completes.
+  // Publish is fire-and-forget; record jobUrls for out-of-band verification.
   let bulkPublish;
   if (reportsToPublish.length > 0) {
     try {

--- a/src/cdn-logs-report/handler.js
+++ b/src/cdn-logs-report/handler.js
@@ -198,6 +198,7 @@ async function runCdnLogsReport(url, context, site, auditContext) {
     }
   }
 
+  // Batch publish all uploaded reports using bulk API
   if (reportsToPublish.length > 0) {
     try {
       await bulkPublishToAdminHlx(reportsToPublish, log);

--- a/src/utils/report-uploader.js
+++ b/src/utils/report-uploader.js
@@ -21,10 +21,6 @@ const XLSX_MAGIC = Buffer.from([0x50, 0x4B, 0x03, 0x04]);
 const XLSX_RETRY_MAX = 3;
 const XLSX_RETRY_DELAY_MS = 60_000;
 
-// admin.hlx.page bulk-job polling. Cap was 10 min (120 x 5s) before SKYSI-79147
-// showed stuck publishes holding ~30/50 SQS-Lambda slots for 13-15 min and
-// starving the audit queue. Coralogix data put the 99th percentile preview
-// completion at ~2.6 min, so 3 min covers observed cases with margin.
 const BULK_POLL_INTERVAL_MS = 5_000;
 const BULK_POLL_TIMEOUT_MS = 3 * 60_000;
 const BULK_POLL_MAX_ATTEMPTS = Math.ceil(BULK_POLL_TIMEOUT_MS / BULK_POLL_INTERVAL_MS);
@@ -341,18 +337,10 @@ async function runBulkJob(route, operation, paths, log, { wait = true } = {}) {
 }
 
 /**
- * Bulk preview and publish files to admin.hlx.page.
- *
- * Preview is awaited (preview must be ready for publish to do anything useful).
- * Publish is submitted fire-and-forget so the audit Lambda does not hold its
- * SQS concurrency slot waiting on admin.hlx.page job completion. The job
- * continues server-side; the returned jobUrl is the correlation handle for
- * out-of-band verification.
- *
+ * Bulk preview (awaited) and publish (fire-and-forget) files to admin.hlx.page.
  * @param {Array<{filename: string, outputLocation: string}>} reports - Reports to publish
  * @param {object} log - Logger
  * @returns {Promise<{ previewJobUrl: string, publishJobUrl: string } | undefined>}
- *   The admin.hlx.page job URLs for each leg, or undefined if no reports.
  */
 export async function bulkPublishToAdminHlx(reports, log) {
   if (!reports?.length) {

--- a/src/utils/report-uploader.js
+++ b/src/utils/report-uploader.js
@@ -312,7 +312,7 @@ async function runBulkJob(route, operation, paths, log, { wait = true } = {}) {
 
   if (!wait) {
     log.info(`%s: ${operation} job fire-and-forget, not polling for completion: ${jobUrl}`, AUDIT_NAME);
-    return jobUrl;
+    return;
   }
 
   for (let i = 0; i < BULK_POLL_MAX_ATTEMPTS; i += 1) {
@@ -330,31 +330,29 @@ async function runBulkJob(route, operation, paths, log, { wait = true } = {}) {
     const { state, progress } = status;
     log.info(`%s: ${operation} status: ${state} - ${progress?.success ?? 0} success, ${progress?.failed ?? 0} failed for job URL: ${jobUrl}`, AUDIT_NAME);
     if (state === 'stopped') {
-      return jobUrl;
+      return;
     }
   }
   throw new Error(`${operation} timeout for job URL: ${jobUrl}`);
 }
 
 /**
- * Bulk preview (awaited) and publish (fire-and-forget) files to admin.hlx.page.
+ * Bulk preview and publish files to admin.hlx.page
  * @param {Array<{filename: string, outputLocation: string}>} reports - Reports to publish
  * @param {object} log - Logger
- * @returns {Promise<{ previewJobUrl: string, publishJobUrl: string } | undefined>}
  */
 export async function bulkPublishToAdminHlx(reports, log) {
   if (!reports?.length) {
-    return undefined;
+    return;
   }
 
   const paths = reports.map((r) => `/${r.outputLocation}/${r.filename.replace(/\.[^/.]+$/, '')}.json`);
   log.info(`%s: Starting bulk publish for ${paths.length} files`, AUDIT_NAME);
 
   try {
-    const previewJobUrl = await runBulkJob('preview', 'preview', paths, log);
-    const publishJobUrl = await runBulkJob('live', 'publish', paths, log, { wait: false });
+    await runBulkJob('preview', 'preview', paths, log);
+    await runBulkJob('live', 'publish', paths, log, { wait: false });
     log.info(`%s: Bulk publish submitted for ${paths.length} files (preview complete, publish fire-and-forget)`, AUDIT_NAME);
-    return { previewJobUrl, publishJobUrl };
   } catch (error) {
     log.error(`%s: Bulk publish failed for paths [${paths.join(', ')}]: ${error.message}`, AUDIT_NAME);
     throw error;

--- a/src/utils/report-uploader.js
+++ b/src/utils/report-uploader.js
@@ -290,7 +290,7 @@ export async function uploadAndPublishFile(
   }
 }
 
-async function runBulkJob(route, operation, paths, log) {
+async function runBulkJob(route, operation, paths, log, { wait = true } = {}) {
   const headers = { Cookie: `auth_token=${process.env.ADMIN_HLX_API_KEY}`, 'Content-Type': 'application/json' };
   const url = `https://admin.hlx.page/${route}/adobe/project-elmo-ui-data/main/*`;
   const res = await fetchWithRetry(
@@ -305,6 +305,11 @@ async function runBulkJob(route, operation, paths, log) {
     throw new Error(`No job URL from ${operation}`);
   }
   log.info(`%s: ${operation} job started for ${paths.length} paths: ${paths.join(', ')}, job URL: ${jobUrl}`, AUDIT_NAME);
+
+  if (!wait) {
+    log.info(`%s: ${operation} job fire-and-forget, not polling for completion: ${jobUrl}`, AUDIT_NAME);
+    return;
+  }
 
   // Poll until complete for 10 minutes
   for (let i = 0; i < 120; i += 1) {
@@ -343,8 +348,8 @@ export async function bulkPublishToAdminHlx(reports, log) {
 
   try {
     await runBulkJob('preview', 'preview', paths, log);
-    await runBulkJob('live', 'publish', paths, log);
-    log.info(`%s: Bulk publish completed for ${paths.length} files`, AUDIT_NAME);
+    await runBulkJob('live', 'publish', paths, log, { wait: false });
+    log.info(`%s: Bulk publish submitted for ${paths.length} files (preview complete, publish fire-and-forget)`, AUDIT_NAME);
   } catch (error) {
     log.error(`%s: Bulk publish failed for paths [${paths.join(', ')}]: ${error.message}`, AUDIT_NAME);
     throw error;

--- a/src/utils/report-uploader.js
+++ b/src/utils/report-uploader.js
@@ -311,8 +311,8 @@ async function runBulkJob(route, operation, paths, log, { wait = true } = {}) {
     return;
   }
 
-  // Poll until complete for 2 minutes
-  for (let i = 0; i < 24; i += 1) {
+  // Poll until complete for 3 minutes
+  for (let i = 0; i < 36; i += 1) {
     // eslint-disable-next-line no-await-in-loop
     await sleep(5000);
     // eslint-disable-next-line no-await-in-loop

--- a/src/utils/report-uploader.js
+++ b/src/utils/report-uploader.js
@@ -311,8 +311,8 @@ async function runBulkJob(route, operation, paths, log, { wait = true } = {}) {
     return;
   }
 
-  // Poll until complete for 10 minutes
-  for (let i = 0; i < 120; i += 1) {
+  // Poll until complete for 2 minutes
+  for (let i = 0; i < 24; i += 1) {
     // eslint-disable-next-line no-await-in-loop
     await sleep(5000);
     // eslint-disable-next-line no-await-in-loop

--- a/src/utils/report-uploader.js
+++ b/src/utils/report-uploader.js
@@ -21,6 +21,14 @@ const XLSX_MAGIC = Buffer.from([0x50, 0x4B, 0x03, 0x04]);
 const XLSX_RETRY_MAX = 3;
 const XLSX_RETRY_DELAY_MS = 60_000;
 
+// admin.hlx.page bulk-job polling. Cap was 10 min (120 x 5s) before SKYSI-79147
+// showed stuck publishes holding ~30/50 SQS-Lambda slots for 13-15 min and
+// starving the audit queue. Coralogix data put the 99th percentile preview
+// completion at ~2.6 min, so 3 min covers observed cases with margin.
+const BULK_POLL_INTERVAL_MS = 5_000;
+const BULK_POLL_TIMEOUT_MS = 3 * 60_000;
+const BULK_POLL_MAX_ATTEMPTS = Math.ceil(BULK_POLL_TIMEOUT_MS / BULK_POLL_INTERVAL_MS);
+
 /**
  * @import { SharepointClient } from '@adobe/spacecat-helix-content-sdk/src/sharepoint/client.js'
  */
@@ -308,13 +316,12 @@ async function runBulkJob(route, operation, paths, log, { wait = true } = {}) {
 
   if (!wait) {
     log.info(`%s: ${operation} job fire-and-forget, not polling for completion: ${jobUrl}`, AUDIT_NAME);
-    return;
+    return jobUrl;
   }
 
-  // Poll until complete for 3 minutes
-  for (let i = 0; i < 36; i += 1) {
+  for (let i = 0; i < BULK_POLL_MAX_ATTEMPTS; i += 1) {
     // eslint-disable-next-line no-await-in-loop
-    await sleep(5000);
+    await sleep(BULK_POLL_INTERVAL_MS);
     // eslint-disable-next-line no-await-in-loop
     const statusRes = await fetchWithRetry(
       jobUrl,
@@ -327,29 +334,39 @@ async function runBulkJob(route, operation, paths, log, { wait = true } = {}) {
     const { state, progress } = status;
     log.info(`%s: ${operation} status: ${state} - ${progress?.success ?? 0} success, ${progress?.failed ?? 0} failed for job URL: ${jobUrl}`, AUDIT_NAME);
     if (state === 'stopped') {
-      return;
+      return jobUrl;
     }
   }
   throw new Error(`${operation} timeout for job URL: ${jobUrl}`);
 }
 
 /**
- * Bulk preview and publish files to admin.hlx.page
+ * Bulk preview and publish files to admin.hlx.page.
+ *
+ * Preview is awaited (preview must be ready for publish to do anything useful).
+ * Publish is submitted fire-and-forget so the audit Lambda does not hold its
+ * SQS concurrency slot waiting on admin.hlx.page job completion. The job
+ * continues server-side; the returned jobUrl is the correlation handle for
+ * out-of-band verification.
+ *
  * @param {Array<{filename: string, outputLocation: string}>} reports - Reports to publish
  * @param {object} log - Logger
+ * @returns {Promise<{ previewJobUrl: string, publishJobUrl: string } | undefined>}
+ *   The admin.hlx.page job URLs for each leg, or undefined if no reports.
  */
 export async function bulkPublishToAdminHlx(reports, log) {
   if (!reports?.length) {
-    return;
+    return undefined;
   }
 
   const paths = reports.map((r) => `/${r.outputLocation}/${r.filename.replace(/\.[^/.]+$/, '')}.json`);
   log.info(`%s: Starting bulk publish for ${paths.length} files`, AUDIT_NAME);
 
   try {
-    await runBulkJob('preview', 'preview', paths, log);
-    await runBulkJob('live', 'publish', paths, log, { wait: false });
+    const previewJobUrl = await runBulkJob('preview', 'preview', paths, log);
+    const publishJobUrl = await runBulkJob('live', 'publish', paths, log, { wait: false });
     log.info(`%s: Bulk publish submitted for ${paths.length} files (preview complete, publish fire-and-forget)`, AUDIT_NAME);
+    return { previewJobUrl, publishJobUrl };
   } catch (error) {
     log.error(`%s: Bulk publish failed for paths [${paths.join(', ')}]: ${error.message}`, AUDIT_NAME);
     throw error;

--- a/test/utils/report-uploader.test.js
+++ b/test/utils/report-uploader.test.js
@@ -654,39 +654,5 @@ describe('Utils Report Uploader', () => {
         sinon.match(/Bulk publish failed/),
       );
     });
-
-    it('should return job URLs on success', async () => {
-      const previewJobUrl = 'https://admin.hlx.page/job/preview-job';
-      const publishJobUrl = 'https://admin.hlx.page/job/publish-job';
-
-      fetchStub.onCall(0).resolves({
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        json: sandbox.stub().resolves({ links: { self: previewJobUrl } }),
-      });
-      fetchStub.onCall(1).resolves({
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        json: sandbox.stub().resolves({
-          state: 'stopped',
-          progress: { total: 1, processed: 1, failed: 0 },
-        }),
-      });
-      fetchStub.onCall(2).resolves({
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        json: sandbox.stub().resolves({ links: { self: publishJobUrl } }),
-      });
-
-      const result = await bulkPublishToAdminHlx(
-        [{ filename: 'r.xlsx', outputLocation: 'site/x' }],
-        mockContext.log,
-      );
-
-      expect(result).to.deep.equal({ previewJobUrl, publishJobUrl });
-    });
   });
 });

--- a/test/utils/report-uploader.test.js
+++ b/test/utils/report-uploader.test.js
@@ -515,7 +515,7 @@ describe('Utils Report Uploader', () => {
   });
 
   describe('bulkPublishToAdminHlx', () => {
-    it('should retry bulk status checks when Helix returns 429', async function bulkPollRetryTest() {
+    it('should retry preview status checks when Helix returns 429 and fire-and-forget publish', async function bulkPollRetryTest() {
       this.timeout(2000);
 
       const previewJobUrl = 'https://admin.hlx.page/job/preview-job';
@@ -554,33 +554,69 @@ describe('Utils Report Uploader', () => {
         statusText: 'OK',
         json: sandbox.stub().resolves({ links: { self: liveJobUrl } }),
       });
-      fetchStub.onCall(4).resolves({
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        json: sandbox.stub().resolves({
-          state: 'stopped',
-          progress: {
-            total: 2,
-            processed: 2,
-            failed: 0,
-          },
-        }),
-      });
 
       await bulkPublishToAdminHlx([
         { filename: 'agentictraffic-w10-2026.xlsx', outputLocation: 'allianz-at/agentic-traffic' },
         { filename: 'referral-traffic-w10-2026.xlsx', outputLocation: 'allianz-at/referral-traffic-cdn' },
       ], mockContext.log);
 
-      expect(fetchStub.callCount).to.equal(5);
+      // 4 calls: POST preview, GET preview status (429), GET preview status (stopped), POST publish
+      // No 5th call — publish is fire-and-forget
+      expect(fetchStub.callCount).to.equal(4);
+      const publishStatusChecks = fetchStub.getCalls().filter((c) => c.args[0] === liveJobUrl);
+      expect(publishStatusChecks).to.have.lengthOf(0);
       expect(mockContext.log.warn).to.have.been.calledWith(
         sinon.match(/preview status check Helix API failed with error 429 Too Many Requests.*retrying in \d+ms.*attempt 1\/3/),
       );
       expect(sleepStub).to.have.been.calledWith(10000);
+      expect(mockContext.log.info).to.have.been.calledWith(
+        sinon.match(/publish job fire-and-forget, not polling for completion/),
+      );
+      expect(mockContext.log.info).to.have.been.calledWith(
+        sinon.match(/Bulk publish submitted for 2 files \(preview complete, publish fire-and-forget\)/),
+      );
       expect(mockContext.log.error).to.not.have.been.calledWith(
         sinon.match(/Bulk publish failed/),
       );
+    });
+
+    it('should throw when publish POST returns no job URL', async () => {
+      const previewJobUrl = 'https://admin.hlx.page/job/preview-job';
+
+      fetchStub.onCall(0).resolves({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: sandbox.stub().resolves({ links: { self: previewJobUrl } }),
+      });
+      fetchStub.onCall(1).resolves({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: sandbox.stub().resolves({
+          state: 'stopped',
+          progress: { total: 1, processed: 1, failed: 0 },
+        }),
+      });
+      fetchStub.onCall(2).resolves({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: sandbox.stub().resolves({ links: {} }),
+      });
+
+      await expect(bulkPublishToAdminHlx(
+        [{ filename: 'r.xlsx', outputLocation: 'site/x' }],
+        mockContext.log,
+      )).to.be.rejectedWith('No job URL from publish');
+      expect(mockContext.log.error).to.have.been.calledWith(
+        sinon.match(/Bulk publish failed/),
+      );
+    });
+
+    it('should be a no-op when given no reports', async () => {
+      await bulkPublishToAdminHlx([], mockContext.log);
+      expect(fetchStub.callCount).to.equal(0);
     });
   });
 });

--- a/test/utils/report-uploader.test.js
+++ b/test/utils/report-uploader.test.js
@@ -618,5 +618,75 @@ describe('Utils Report Uploader', () => {
       await bulkPublishToAdminHlx([], mockContext.log);
       expect(fetchStub.callCount).to.equal(0);
     });
+
+    it('should throw preview timeout when state never reaches stopped within the cap', async function previewCapTest() {
+      this.timeout(5000);
+
+      const previewJobUrl = 'https://admin.hlx.page/job/preview-job';
+
+      fetchStub.onCall(0).resolves({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: sandbox.stub().resolves({ links: { self: previewJobUrl } }),
+      });
+      // All subsequent status checks return 'running' so the loop runs to the cap
+      fetchStub.resolves({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: sandbox.stub().resolves({
+          state: 'running',
+          progress: { total: 1, processed: 0, failed: 0 },
+        }),
+      });
+
+      await expect(bulkPublishToAdminHlx(
+        [{ filename: 'r.xlsx', outputLocation: 'site/x' }],
+        mockContext.log,
+      )).to.be.rejectedWith(/^preview timeout for job URL:/);
+
+      // 36 iterations of sleep(5000) -> sleep stubbed, no real wait
+      expect(sleepStub.withArgs(5000).callCount).to.equal(36);
+      // 1 POST + 36 status GETs = 37 fetches
+      expect(fetchStub.callCount).to.equal(37);
+      expect(mockContext.log.error).to.have.been.calledWith(
+        sinon.match(/Bulk publish failed/),
+      );
+    });
+
+    it('should return job URLs on success', async () => {
+      const previewJobUrl = 'https://admin.hlx.page/job/preview-job';
+      const publishJobUrl = 'https://admin.hlx.page/job/publish-job';
+
+      fetchStub.onCall(0).resolves({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: sandbox.stub().resolves({ links: { self: previewJobUrl } }),
+      });
+      fetchStub.onCall(1).resolves({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: sandbox.stub().resolves({
+          state: 'stopped',
+          progress: { total: 1, processed: 1, failed: 0 },
+        }),
+      });
+      fetchStub.onCall(2).resolves({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: sandbox.stub().resolves({ links: { self: publishJobUrl } }),
+      });
+
+      const result = await bulkPublishToAdminHlx(
+        [{ filename: 'r.xlsx', outputLocation: 'site/x' }],
+        mockContext.log,
+      );
+
+      expect(result).to.deep.equal({ previewJobUrl, publishJobUrl });
+    });
   });
 });


### PR DESCRIPTION
## Summary

Bounds the time `bulkPublishToAdminHlx` keeps an SQS-triggered Lambda slot tied up when `admin.hlx.page` is slow or stuck:

- **Preview leg:** poll cap reduced from 10 min (120 × 5s) → 3 min (36 × 5s).
- **Publish leg:** fire-and-forget. POST the bulk-publish job and return as soon as `admin.hlx.page` accepts it. The job continues server-side; the audit Lambda releases its concurrency slot. `jobUrl` is captured in existing `info` logs for out-of-band verification.

Worst-case time inside `bulkPublishToAdminHlx`: ~20 min → ~3 min plus one POST.

## Context

Root-cause analysis from the [SKYSI-79147 thread](https://cq-dev.slack.com/archives/C05A45JBP9N/p1779153480728129?thread_ts=1776076022.090159&cid=C05A45JBP9N):

> The `cdn-logs-report` audit calls `admin.hlx.page` bulk-publish, which reproducibly times out daily in the 11:30–13:30 IST window. Each stuck audit holds an SQS-triggered Lambda slot for ~13–15 min. With `MaximumConcurrency = 50, BatchSize = 1` on `spacecat-audit-jobs`, ~30 of 50 slots get stuck on `cdn-logs-report`, the queue can't drain, oldest-message-age crosses the 90-min threshold, and `Oldest Message Age High` fires Sev-1 to Skyline on-call.

This PR implements recommended fix #1 from that analysis: bound the publish wait so a stuck publish fails-fast and returns its slot.

Related: [SKYSI-79147](https://jira.corp.adobe.com/browse/SKYSI-79147), [SITES-34588](https://jira.corp.adobe.com/browse/SITES-34588).

## Why 3 minutes

Coralogix data, prod audit-worker, last 6h, lines matching `preview status` (288 traces):

| Polls | Approx duration | Traces | % |
|-------|-----------------|--------|---|
| 1 | ~5s | 160 | 56% |
| 2 | ~10s | 63 | 22% |
| 3 | ~15s | 9 | 3% |
| 4–10 | 20–50s | 17 | 6% |
| 11–23 | 55–115s | 21 | 7% |
| 24–31 | 120–155s | 18 | 6% |

Worst observed: 31 polls / ~155s. A 3-min cap (36 × 5s) covers every observed case with margin; the prior 10-min cap was never hit but was the headroom that allowed publish to hog slots for 13–15 min.

## Changes

`src/utils/report-uploader.js`
- Add `BULK_POLL_INTERVAL_MS`, `BULK_POLL_TIMEOUT_MS`, `BULK_POLL_MAX_ATTEMPTS` constants alongside existing `XLSX_RETRY_*`.
- `runBulkJob(route, operation, paths, log, { wait = true } = {})` — when `wait: false`, returns immediately after the POST succeeds and admin API returns a `jobUrl`.
- Preview polling uses `BULK_POLL_MAX_ATTEMPTS` / `BULK_POLL_INTERVAL_MS`.
- `bulkPublishToAdminHlx` calls publish with `{ wait: false }`.

`test/utils/report-uploader.test.js`
- Update existing 429-retry test: asserts 4 fetches (no 5th for publish status), asserts no fetches against publish job URL, asserts new fire-and-forget log line.
- New test: throws when publish POST returns no job URL.
- New test: no-op when given no reports.
- New test: throws preview timeout when status never reaches `stopped` within the cap (asserts 36 sleeps and 37 fetches).

## Trade-offs

- Preview now fails fast at 3 min instead of 10. Failure semantics in the handler are unchanged (already log-and-continue), so this surfaces more "preview timeout" log lines but doesn't change audit success/failure.
- Publish job completion is no longer observed by the audit. `jobUrl` is in `info` logs (`preview job started ...`, `publish job started ...`) so on-call can grep Coralogix; the `admin.hlx.page` job itself is the system of record for whether the file actually went live.

## Test plan
- [x] `npx mocha test/utils/report-uploader.test.js` — 23 passing
- [x] `npx mocha test/audits/cdn-logs-report/handler.test.js` — 33 passing
- [x] `npx eslint src/utils/report-uploader.js test/utils/report-uploader.test.js` — clean
- [ ] Deploy to dev; trigger `cdn-logs-report` audit; confirm in Coralogix the new `publish job fire-and-forget` and `Bulk publish submitted ... (preview complete, publish fire-and-forget)` log lines appear.
- [ ] Monitor `spacecat-audit-jobs` SQS oldest-message-age in the next daily peak window; expect slot hold to drop from 13–15 min → ≤3 min.

🤖 Generated with [Claude Code](https://claude.com/claude-code)