### PR TITLE
fix(toc): update opportunity description to mention heading-based suggestion generation (LLMO-5006)

### DIFF
--- a/src/toc/opportunity-data-mapper.js
+++ b/src/toc/opportunity-data-mapper.js
@@ -16,7 +16,7 @@ const OpptyDataForTOC = {
   runbook: '',
   origin: 'AUTOMATION',
   title: '[Beta] Add Table of Content',
-  description: 'Ensure table of contents (TOC) is properly implemented in the <head> section of each page. Proper TOC implementation improves accessibility and helps search engines and generative engines understand page content',
+  description: 'Ensure table of contents (TOC) is properly implemented in the <head> section of each page. Proper TOC implementation improves accessibility and helps search engines and generative engines understand page content. Suggestions are generated based on page heading (H1, H2) structure, so pages with correct heading structure will produce accurate TOC suggestions.',
   guidance: {
     steps: [
       'Review pages flagged for TOC issues in the audit results.',

--- a/test/audits/toc.test.js
+++ b/test/audits/toc.test.js
@@ -1511,6 +1511,24 @@ describe('TOC (Table of Contents) Audit', () => {
       expect(opportunityData.description).to.include('table of contents');
     });
 
+    it('description mentions heading-based suggestion generation', async () => {
+      const { createOpportunityDataForTOC } = await import('../../src/toc/opportunity-data-mapper.js');
+      const opportunityData = createOpportunityDataForTOC();
+
+      expect(opportunityData.description).to.include('H1, H2');
+      expect(opportunityData.description).to.include('heading structure');
+      expect(opportunityData.description).to.include('accurate TOC suggestions');
+    });
+
+    it('description contains both accessibility context and heading guidance', async () => {
+      const { createOpportunityDataForTOC } = await import('../../src/toc/opportunity-data-mapper.js');
+      const opportunityData = createOpportunityDataForTOC();
+
+      expect(opportunityData.description).to.include('accessibility');
+      expect(opportunityData.description).to.include('generative engines');
+      expect(opportunityData.description).to.include('Suggestions are generated based on page heading');
+    });
+
     it('includes proper guidance steps for TOC', async () => {
       const { createOpportunityDataForTOC } = await import('../../src/toc/opportunity-data-mapper.js');
       const opportunityData = createOpportunityDataForTOC();


### PR DESCRIPTION
## Summary
- Updates the `description` field in `OpptyDataForTOC` (`src/toc/opportunity-data-mapper.js`) to explain that suggestions are generated from the page's H1/H2 heading structure
- Helps users understand why only pages with proper heading structure receive TOC suggestions in Site Optimizer
- Adds 2 test cases covering the new description text

## Jira
[LLMO-5006](https://jira.corp.adobe.com/browse/LLMO-5006) — child of [LLMO-28](https://jira.corp.adobe.com/browse/LLMO-28)

## Test plan
- [x] New tests added in `test/audits/toc.test.js` — both passing
- [ ] Lint passes (`npm run lint`)
- [ ] Existing tests continue to pass (`npm test`)
- [ ] Verify updated description appears in Site Optimizer TOC opportunity card

🤖 Generated with [Claude Code](https://claude.com/claude-code)