### PR TITLE
fix(prerender): remove phantom-error fallback when all scrape jobs fail

### DIFF
--- a/src/prerender/.claude/api-service-deploy-rollback.md
+++ b/src/prerender/.claude/api-service-deploy-rollback.md
@@ -1,0 +1,157 @@
+# API Service — Tokowaka Deploy & Rollback
+
+Covers the two HTTP endpoints in `spacecat-api-service` that write `edgeDeployed` and `coveredByDomainWide` to Suggestion.data. The audit worker never calls these directly but reads their downstream effects.
+
+Source file: `spacecat-api-service/src/controllers/suggestions.js`  
+Routes file: `spacecat-api-service/src/routes/index.js:272-273`
+
+---
+
+## Endpoints
+
+| Method | URL | Controller function |
+|--------|-----|---------------------|
+| `POST` | `/sites/:siteId/opportunities/:opportunityId/suggestions/edge-deploy` | `deploySuggestionToEdge` |
+| `POST` | `/sites/:siteId/opportunities/:opportunityId/suggestions/edge-rollback` | `rollbackSuggestionFromEdge` |
+
+Both return **HTTP 207 Multi-Status** — per-suggestion success/failure, even for partial results.
+
+---
+
+## Access Control (Both Endpoints — All Three Required)
+
+```
+1. accessControlUtil.hasAccess(site)         → 403 if user not in org
+2. accessControlUtil.isLLMOAdministrator()   → 403 if not LLMO admin
+3. accessControlUtil.isOwnerOfSite(site)     → 403 if not site owner
+```
+
+All three checks must pass. Any failure returns 403 with specific message.
+
+---
+
+## Deploy: `deploySuggestionToEdge` (lines 1608–2034)
+
+### Input
+- `suggestionIds[]` from request body (deduplicated)
+- Optional header `Prefer: respond-async` → triggers geo-experiment mode (see below)
+
+### Validation Guards
+| Condition | Error |
+|-----------|-------|
+| Suggestion not found | 404 |
+| Domain-wide suggestion missing `allowedRegexPatterns` | 400 |
+| Status not `NEW` or `PENDING_VALIDATION` | 400 |
+
+### Call to TokowakaClient
+```js
+const deployResult = await tokowakaClient.deployToEdge({
+  site,
+  opportunity,
+  targetSuggestions: allTargetSuggestions,  // regular + domain-wide
+  allSuggestions,
+  updatedBy: profile?.email || 'tokowaka-deployment',
+});
+```
+
+Returns: `{ succeededSuggestions[], failedSuggestions[], coveredSuggestions[] }`
+
+### Fields Written to Suggestion.data on Success
+| Field | Value | Who writes it |
+|-------|-------|---------------|
+| `edgeDeployed` | `Date.now()` (ms epoch) | `TokowakaClient.deployToEdge()` |
+| `coveredByDomainWide` | UUID of domain-wide suggestion | `TokowakaClient.deployToEdge()` for covered suggestions |
+| `coveredByDomainWide` | `'same-batch-deployment'` string literal | `TokowakaClient.deployToEdge()` for same-batch URL suggestions |
+
+### Status Is NOT Changed
+Deploy **does not change** `Suggestion.status`. It stays `NEW` or `PENDING_VALIDATION` after deploy. Only `data.edgeDeployed` is what makes the UI classify a suggestion as "Fixed".
+
+### Geo-Experiment Mode (Prefer: respond-async)
+When the header `Prefer: respond-async` is present:
+- Creates `GeoExperiment` record with status `GENERATING_BASELINE`, phase `PRE_ANALYSIS_STARTED`
+- Uploads prompts to S3
+- Submits pre-analysis schedule to DRS
+- Sets `edgeOptimizeStatus: 'EXPERIMENT_IN_PROGRESS'` on suggestions
+- Returns 207 immediately with experiment metadata (does NOT call `deployToEdge`)
+
+This is a separate code path — the suggestion is NOT deployed in this mode.
+
+### Error on TokowakaClient failure
+All targeted suggestions move to `failedSuggestions[]` with status 500. No partial deploy.
+
+---
+
+## Rollback: `rollbackSuggestionFromEdge` (lines 2207–2467)
+
+### Input
+- `suggestionIds[]` from request body (must be non-empty)
+
+### Validation Guards
+| Condition | Error |
+|-----------|-------|
+| Suggestion not found | 404 |
+| `data.edgeDeployed` is falsy (not deployed) | 400 "Suggestion has not been deployed, cannot rollback" |
+
+### Two Code Paths: Domain-Wide vs Regular
+
+#### Domain-Wide Rollback (handled directly in controller)
+```
+tokowakaClient.fetchMetaconfig(baseURL)
+→ remove prerender from metaconfig
+→ tokowakaClient.uploadMetaconfig(baseURL, updatedMetaconfig)
+→ clear edgeDeployed + tokowakaDeployed from domain-wide suggestion
+→ find all suggestions where coveredByDomainWide === domainSuggestionId
+→ clear edgeDeployed + tokowakaDeployed + coveredByDomainWide from each covered suggestion
+→ set updatedBy = 'domain-wide-rollback'
+```
+
+#### Regular URL Rollback (via TokowakaClient)
+```js
+const result = await tokowakaClient.rollbackSuggestions(site, opportunity, regularSuggestions);
+```
+On success: clear `edgeDeployed` + `tokowakaDeployed` from each suggestion.
+
+### Fields Cleared from Suggestion.data on Rollback
+| Field | Cleared for |
+|-------|------------|
+| `edgeDeployed` | All rolled-back suggestions (regular + domain-wide) |
+| `tokowakaDeployed` | All rolled-back suggestions (**legacy field**, kept for backward compat) |
+| `coveredByDomainWide` | Only for suggestions that were covered by the rolled-back domain-wide |
+
+### Status Is NOT Changed
+Rollback **does not change** `Suggestion.status`. Status remains whatever it was before.
+
+### `updatedBy` field
+Always written: `profile?.email || 'tokowaka-rollback'` (or `'domain-wide-rollback'` for covered suggestions).
+
+---
+
+## What the Audit Worker Sees After These Operations
+
+| After deploy | Audit worker reads |
+|-------------|-------------------|
+| `edgeDeployed` set on URL suggestion | Suggestion preserved (not marked OUTDATED); excluded from active count |
+| `coveredByDomainWide` set | Suggestion hidden from UI Current tab; not marked OUTDATED |
+| `edgeOptimizeStatus: 'EXPERIMENT_IN_PROGRESS'` | Suggestion in geo-experiment — do not touch |
+
+| After rollback | Audit worker reads |
+|---------------|-------------------|
+| `edgeDeployed` cleared | Suggestion eligible for re-scraping and OUTDATED marking again |
+| `coveredByDomainWide` cleared | Suggestion re-appears in UI Current tab |
+
+### Legacy `tokowakaDeployed` Field
+Rollback always clears `tokowakaDeployed` (legacy). If the audit worker ever encounters a suggestion with `tokowakaDeployed` but no `edgeDeployed`, it's a suggestion from before the field rename — treat it the same as `edgeDeployed` for preservation purposes.
+
+---
+
+## `edgeOptimizeStatus` Field Lifecycle
+
+This field is set/cleared by the API service, not the audit worker:
+
+| Value | Meaning | Set when |
+|-------|---------|----------|
+| `'STALE'` | Content changed after deploy | Checked by Tokowaka CDN on subsequent requests |
+| `'EXPERIMENT_IN_PROGRESS'` | Geo-experiment running | Deploy called with `Prefer: respond-async` |
+| cleared | Normal deployed state | After re-deploy (removes STALE) |
+
+The audit worker should **not write** `edgeOptimizeStatus`. It reads it for the UI (fixed tab "Content Changed" indicator comes from this field).

--- a/src/prerender/.claude/batch-mechanics.md
+++ b/src/prerender/.claude/batch-mechanics.md
@@ -1,0 +1,172 @@
+# Batch Mechanics — Prerender Audit (Step 2 & Step 3 Processing)
+
+Read this file when working on: URL selection logic, PageCitability dedup, DAILY_BATCH_SIZE tuning, the three submitForScraping paths, or step 3 metrics/citability writes.
+
+---
+
+## URL Sources & Limits
+
+| Constant | Value | Source |
+|----------|-------|--------|
+| `TOP_ORGANIC_URLS_LIMIT` | 200 | GSC via SiteTopPage (highest priority) — was accidentally left at 5 in a debug state; if this looks wrong again, check the constant |
+| `TOP_AGENTIC_URLS_LIMIT` | 2,000 | Athena CDN logs, HTTP 200 only |
+| `DAILY_BATCH_SIZE` | 320 | Hard cap for scraper submission per audit run |
+
+---
+
+## Three Paths in submitForScraping
+
+The function has three distinct code paths. They share **no** URL-filtering logic.
+
+### CSV path (`auditContext.urls` present)
+
+```
+1. Rebase auditContext.urls to preferredBase
+2. mergeAndGetUniqueHtmlUrls()  → dedup + HTML-only filter
+3. Return immediately           → does NOT read status.json
+```
+
+### Slack path (`auditContext.slackContext.channelId` set)
+
+```
+1. Read siteStatus (status.json from S3)       ← bot-block sticky check is SKIPPED for Slack
+2. getTopOrganicUrlsFromSeo()  → organic URLs
+3. site.getConfig().getIncludedURLs()           → included URLs
+4. Rebase both to preferredBase
+5. mergeAndGetUniqueHtmlUrls([organic, included])
+   → NO PageCitability dedup
+   → NO edgeDeployed filter
+   → NO DAILY_BATCH_SIZE cap
+6. Return
+```
+
+Slack bypasses batching so operators get a full on-demand result (D-16).
+
+### Normal scheduled path
+
+```
+1. Read siteStatus (status.json from S3)
+2. Sticky bot-block check (isStickyBotBlocked)
+   → If blocked within 3-day window: return { urls: [], domainBlocked: true }
+3. getTopOrganicUrlsFromSeo()  → organic (up to 200)
+4. getTopAgenticUrls()         → agentic (up to 2,000)
+5. site.getConfig().getIncludedURLs()  → included
+6. Rebase all three to preferredBase
+7. getRecentlyProcessedPathnames() → Set<pathname> from PageCitability (7-day window)
+8. getEdgeDeployedPathnames(siteStatus) → Set<pathname> from status.json pages[].isDeployedAtEdge
+9. Filter each source independently:
+   filteredOrganic   = organic.filter(notRecent).filter(notEdgeDeployed)
+   filteredIncluded  = included.filter(notRecent).filter(notEdgeDeployed)
+   filteredAgentic   = agentic.filter(notRecent).filter(notEdgeDeployed)
+10. Concatenate in priority order (NOT sorted — concat order IS the priority):
+    candidates = [...filteredOrganic, ...filteredIncluded, ...filteredAgentic]
+11. Slice to DAILY_BATCH_SIZE=320
+12. mergeAndGetUniqueHtmlUrls(batchedUrls)  → final dedup + HTML-only filter
+13. Return
+```
+
+### edgeDeployedPathnames Source
+
+`edgeDeployedPathnames` in step 2 is populated from `getEdgeDeployedPathnames(siteStatus)`, which reads `status.json pages[].isDeployedAtEdge` — the **previous scrape run's** results.
+
+This is **not** the same as querying `Suggestion.data.edgeDeployed` from the DB. The scraper writes `isDeployedAtEdge` per URL based on Tokowaka/CDN response headers it detects. The step 2 filter reads that previous scraper verdict from S3 status.json rather than hitting the DB.
+
+---
+
+## isFirstRunOfCycle
+
+```js
+const hasRecentOrganic = filteredOrganicUrls.length !== topPagesUrls.length;
+isFirstRunOfCycle = !hasRecentOrganic;
+```
+
+`isFirstRunOfCycle = true` means none of the organic URLs were excluded by the 7-day PageCitability dedup — i.e., the site's organic URLs haven't been processed recently and this is the start of a fresh rotation cycle. Logged in `prerender_submit_scraping_metrics`.
+
+---
+
+## PageCitability Dedup Window
+
+- **Time-based**: 7 days from `PageCitability.updatedAt` (not `createdAt` — if a URL is reprocessed, `updatedAt` resets, extending its exclusion window by another 7 days)
+- **Purpose**: Avoid re-scraping same URL within a week; spreads the full URL inventory across ~7 daily runs
+- **isFirstRunOfCycle flag**: When all organic URLs pass the dedup (none excluded), it signals the previous cycle completed and a new one is starting
+
+---
+
+## prerender_submit_scraping_metrics Log
+
+Emitted once per step 2 run (for all three paths). Monitored by ops.
+
+```
+submittedUrls       — final URL count after all filtering
+agenticUrls         — raw agentic count before filtering (0 for CSV)
+topPagesUrls        — raw organic count before filtering (0 for CSV)
+includedURLs        — raw includedURLs count before filtering (0 for CSV)
+filteredOutUrls     — URLs removed by mergeAndGetUniqueHtmlUrls
+currentOrganic      — organic URLs in the final batch
+currentIncludedUrls — included URLs in the final batch
+currentAgentic      — agentic URLs in the final batch
+isFirstRunOfCycle   — true if no organic URLs were deduped (fresh cycle)
+agenticNewThisCycle — agentic URLs that passed the 7-day dedup filter
+edgeDeployedUrls    — count of URLs excluded by edge-deployed filter
+baseUrl, siteId
+```
+
+---
+
+## prerender_ai_summary_metrics Log
+
+Emitted once per `guidance-handler.js` invocation after `Suggestion.saveMany()` succeeds. Monitored for Mystique quality tracking per paid customer.
+
+```
+siteId
+baseUrl             — site.getBaseURL()
+opportunityId
+isPaidLLMOCustomer  — boolean, from site config (affects dashboard visibility)
+totalSuggestions    — count of suggestions updated in this batch (suggestionsToSave.length)
+valuableSuggestions — count where valid aiSummary AND valuable=true
+validAiSummaryCount — count where aiSummary is non-null and !== 'not available'
+```
+
+---
+
+## AI-Only Mode Override (`handleAiOnlyMode`)
+
+**Trigger**: `getModeFromData(data).mode === 'ai-only'` — detected in step 1, which immediately calls `handleAiOnlyMode` and returns its result. Steps 2 and 3 both detect the flag and return `{ status: 'skipped' }`.
+
+**`handleAiOnlyMode` flow** (`handler.js:727`):
+```
+1. Parse optional params from data: { opportunityId, scrapeJobId }
+2. scrapeJobId resolution:
+   - If provided in data → use it
+   - If absent → readSiteStatusJson() → use status.json scrapeJobId
+   - If still absent → return error
+3. Opportunity resolution:
+   - If opportunityId provided → Opportunity.findById(opportunityId)
+   - If absent → Opportunity.allBySiteIdAndStatus(siteId, 'NEW').find(type==='prerender')
+   - Validate opportunity.getSiteId() === siteId (security check)
+4. sendPrerenderGuidanceRequestToMystique(baseUrl, auditData, opportunity, context, null)
+   → null preBuiltCandidates → derives candidates from all DB suggestions (ai-only path)
+   → builds suggestionId from actual DB UUID (not URL)
+5. Return { status: 'complete', mode: 'ai-only', opportunityId, suggestionCount }
+```
+
+**Batch size**: Respects `MYSTIQUE_BATCH_SIZE` only — no DAILY_BATCH_SIZE involved.
+
+**Use case**: Re-process AI summaries without new scraping (quota exhaustion, prompt updates, model changes).
+
+---
+
+## writeToCitabilityRecords — Fields Written to PageCitability
+
+Writes the following fields (all from `compareHtmlContent` result), in batches of 10:
+
+```
+citabilityScore   ← from stats.citationReadability
+contentRatio      ← from contentGainRatio
+wordDifference    ← from stats.wordDiff
+botWords          ← from wordCountBefore
+normalWords       ← from wordCountAfter
+isDeployedAtEdge  ← from scrape.json
+```
+
+Only URLs where `result.error !== true` are written. Uses per-record `save()` (not `saveMany`) but batched 10 at a time to limit concurrent S3/DB pressure.

--- a/src/prerender/.claude/coding-guidelines.md
+++ b/src/prerender/.claude/coding-guidelines.md
@@ -1,0 +1,121 @@
+# Coding Guidelines & PR Checklist — Prerender Audit
+
+Read this before writing or reviewing any change to `src/prerender/`.
+
+---
+
+## 1 · Respect Invariants First
+
+Before changing any logic, check [decision-log.md](decision-log.md) for a decision entry covering that area.
+
+**Hard rules**:
+- The audit worker only writes status `NEW` (on creation) and `OUTDATED` (on update) — never any other status
+- `data.coveredByDomainWide` is the only `Suggestion.data` field the main handler mutates on existing suggestions
+- `data.aiSummary` + `data.valuable` are only mutated by `guidance-handler.js` (always as a pair — never independently)
+- `data.edgeDeployed` is never written by the audit worker — it is owned exclusively by user deploy action via `spacecat-api-service`
+- All other `Suggestion.data` fields (`scrapeJobId`, `wordCountBefore`, etc.) are write-once at creation time
+
+If a proposed change would violate any of these, that's a signal to re-examine the approach, not to patch around it.
+
+---
+
+## 2 · Extension Over Modification
+
+Prefer adding new behavior alongside existing logic over replacing it.
+
+- If you're modifying a guard condition (e.g., OUTDATED marking, ACTIVE_STATUSES, bot-block thresholds) — document why the invariant is changing in `decision-log.md` before merging
+- If you're changing what data fields get written to `status.json` or `Suggestion.data` — treat it as a locked-contract change (see §6)
+- When in doubt: does this change break any of the 10 behavioral contract tests listed in CLAUDE.md? Run them first
+
+---
+
+## 3 · KISS · DRY · YAGNI · SOLID
+
+| Principle | What it means here |
+|-----------|-------------------|
+| **KISS** | If a function needs a paragraph comment to explain what it does, simplify it. The prerender handler grew to 1,875 lines because of incremental complexity — resist adding more |
+| **DRY** | `normalizePathname` is in `src/utils/utils.js` (shared by 10+ audits). `mergeAndGetUniqueHtmlUrls` is in `src/prerender/utils/utils.js`. Check before writing a new URL utility |
+| **YAGNI** | Don't add configuration flags, fallback modes, or "future-proof" abstractions unless there's an active requirement. `MODE_AI_ONLY` and `DAILY_BATCH_SIZE` exist because they were needed — not as contingencies |
+| **SOLID** | Single responsibility: scraping submission, content comparison, suggestion sync, and Mystique queuing are separate concerns — keep them that way when extracting modules |
+
+---
+
+## 4 · Test-First for Any Refactoring
+
+1. Write (or verify) behavioral contract tests covering the function's observable output before touching the implementation
+2. Confirm tests pass on the existing code
+3. Extract / refactor
+4. Confirm the same tests still pass — no new test logic needed if behavior is unchanged
+5. Update all `esmock` stub paths in the **same PR** as the function move — never leave stubs pointing at the old path
+
+The 10 contract tests in CLAUDE.md are the minimum bar. Each covers a non-obvious invariant that has caused production incidents.
+
+---
+
+## 5 · Bulk DB Operations — No N+1
+
+The PostgREST connection pool is **200 connections shared across 10 ECS tasks** (20 per task). A loop of individual saves will exhaust it under load.
+
+| Instead of | Use |
+|------------|-----|
+| `Promise.all(items.map(i => i.save()))` | `Suggestion.saveMany(items)` |
+| `for (id of ids) Suggestion.findById(id)` | `Suggestion.batchGetByKeys(keys)` |
+| `Promise.all(items.map(i => i.remove()))` | `Suggestion.removeByIds(ids)` |
+
+This applies to: `syncSuggestions`, `markDeployedUrlSuggestionsAsCovered`, `guidance-handler.js` batch saves, and any new loop over suggestions.
+
+---
+
+## 6 · Locked-Contract Checklist
+
+Stop and coordinate with UI and api-service teams before merging if your change touches any of:
+
+- [ ] `status.json` field names or semantics → impacts `project-elmo-ui` directly
+- [ ] `Suggestion.data` field names → impacts `spacecat-api-service` DTOs and `project-elmo-ui` display
+- [ ] S3 path format (`sanitizeImportPath` regex) → breaks historical artifact lookups
+- [ ] `shouldPreserveDomainWideSuggestion` logic → changes which domain-wide suggestions survive audit runs
+- [ ] `processingType: 'prerender'` in `createScrapeJob` call → must match `PrerenderHandler.accepts()` in scraper
+- [ ] Mystique SQS payload shape → must include `suggestionId`; Pydantic validates it on the other end
+
+For any of these: open a coordination issue, get sign-off, then merge.
+
+---
+
+## 7 · Log Level Discipline
+
+| Level | Use for |
+|-------|---------|
+| `log.info` | Key audit milestones (batch submitted, sync complete, bot-block detected), metrics that ops monitors |
+| `log.debug` | Verbose per-URL tracing, intermediate values, fallback path taken |
+| `log.warn` | Unexpected-but-recoverable (missing scrapeJobId, suggestion skipped, fallback activated) |
+| `log.error` | Actual failures that abort processing or require investigation |
+
+Several PRs existed purely to downgrade noise (#2314, #2305). Don't log at `error` for expected edge cases (missing optional field, empty result set).
+
+---
+
+## 8 · 100% c8 Coverage
+
+Coverage is enforced at 100% lines/branches/statements. Every new code path must be tested.
+
+- `/* c8 ignore next N */` is allowed **only** with an explanation comment stating why the branch is untestable (environment-dependent, defensive guard for impossible state, etc.)
+- Never use `c8 ignore` to hide testable logic
+- **`c8 ignore` means "not tested" — it does NOT mean "unreachable in production"**. Code with `c8 ignore` can and does run in production (e.g. the step 3 fallback path fires when `scrapeResultPaths` is empty — all scrapes failed). Don't infer from `c8 ignore` that code is dead or safe to delete without understanding when it actually executes.
+- When extracting a function to a new file, review any existing `c8 ignore` comments — branches that were untestable in the old context may now be testable in isolation
+
+---
+
+## 9 · Update the Brain Map on Every PR
+
+When a PR changes behavior, update the relevant doc:
+
+| Change type | Update |
+|-------------|--------|
+| New invariant or changed logic | `CLAUDE.md` — relevant section + Key Invariants if applicable |
+| Why a non-obvious decision was made | `decision-log.md` — new D-XX entry |
+| Scraper output format / S3 schema | `.claude/scraper-internals.md` |
+| Shared package API change | `.claude/shared-packages.md` |
+| status.json or Suggestion.data field change | `.claude/ui-data-map.md` + `.claude/api-service-deploy-rollback.md` |
+| New write to Suggestion.data or status | `CLAUDE.md` — "What the audit worker writes" table |
+
+The brain map is only useful if it stays current. A stale doc is worse than no doc — future Claude (and future engineers) will trust it and get burned.

--- a/src/prerender/.claude/decision-log.md
+++ b/src/prerender/.claude/decision-log.md
@@ -1,0 +1,233 @@
+# Decision Log — Prerender Audit
+
+Historical decisions with their reasons, what was tried before, and commit references.
+Read this when you need to understand WHY the code looks a specific way, or before changing a non-obvious invariant.
+
+---
+
+## D-01 · coveredByDomainWide instead of SKIPPED for domain-wide coverage
+
+**Decision**: When a domain-wide suggestion is deployed, individual URL suggestions get `coveredByDomainWide` set (status stays `NEW`), not moved to `SKIPPED`.
+
+**Why**: Rollback via `spacecat-api-service` only clears `coveredByDomainWide` — it does not touch suggestion status. With `SKIPPED`, the UI had to explicitly call `bulkUpdateSuggestionsStatus(NEW)` after every rollback. With `coveredByDomainWide`, clearing the field on rollback auto-returns suggestions to the Current tab with no UI changes needed.
+
+**Evolution**:
+1. `d429a739` — First attempt: move to SKIPPED on domain-wide deploy
+2. `8d9aec57` — Reverted (implementation issues)
+3. `ae12fbf3` — Re-applied SKIPPED approach with refinements
+4. `831dda76` (#2223) — Refined: only move to SKIPPED if URL is confirmed deployed at edge in current run (not all NEW suggestions)
+5. `93a12733` (#2326) — **Current approach**: replaced SKIPPED with `coveredByDomainWide` field entirely
+
+**Superseded**: All SKIPPED-based approaches (D-01 steps 1–4) are superseded by step 5.
+
+---
+
+## D-02 · scrapeJobId stored per-suggestion, not per-audit-run
+
+**Decision**: `Suggestion.data.scrapeJobId` stores the ID from when the suggestion was first created. It is never overwritten by subsequent audit runs.
+
+**Why**: Mystique constructs S3 paths for markdown files using `{scrapeJobId}/{path}/markdown-diff.md`. The actual artifacts on S3 were written under the scrapeJobId active when the suggestion was created. Using the current run's scrapeJobId caused `NoSuchKey` errors in Mystique for every site where the suggestion predated the current run.
+
+**Additional failure mode** (#2320): In fallback mode (all scrape results returned 404), the code was stamping the current run's scrapeJobId on ALL suggestions including ones from previous batches, overwriting their correct IDs and breaking their S3 lookups with `scrapingStatus: error`.
+
+**Commits**: `93435341` (#2300) — persist scrapeJobId per suggestion; `872baa49` (#2320) — fix fallback mode overwriting previous IDs
+
+---
+
+## D-03 · Two-path bot-block detection (COMPLETE + FAILED status)
+
+**Decision**: `getScrapeJobStats()` has two separate paths for 403 counting: one for COMPLETE-status URLs (via in-memory comparisonResults) and one for FAILED-status URLs (via DB + S3 scrape.json).
+
+**Why**: `getScrapeResultPaths` only returns URLs with `ScrapeUrl.status = COMPLETE`. When the scraper marks a 403 URL as `FAILED` directly, that URL never enters `scrapeResultPaths` and was invisible to the original bot-block detection. Sites where the scraper returned FAILED for every 403 URL showed `scrapeForbiddenCount: 0` and `scrapeForbidden: false` even when completely blocked.
+
+**Note**: COMPLETE-status 403 URLs (where `scrape.json` has `error.statusCode: 403`) were already counted correctly via `compareHtmlContent`'s `Promise.allSettled` path. The FAILED path was additive coverage.
+
+**Commit**: `a9fc3478` (#2245)
+
+---
+
+## D-04 · isAllDomainDeployedAtEdge must filter out OUTDATED suggestions
+
+**Decision**: When checking if a domain-wide suggestion is actively deployed at edge, the lookup must filter out OUTDATED-status suggestions.
+
+**Why**: Production data for wkkellogg.com had 14 OUTDATED domain-wide suggestions (from prior audit runs) before the 1 active NEW suggestion with `edgeDeployed` set. `Array.find()` returned the first match — an OUTDATED suggestion — whose `edgeDeployed` was undefined, causing `isAllDomainDeployedAtEdge` to return false. NEW suggestions were never moved to covered state despite the domain being deployed.
+
+**Rule**: Only active (non-OUTDATED) domain-wide suggestions are authoritative for edge deployment state.
+
+**Commit**: `12fdd13f` (#2196)
+
+---
+
+## D-05 · Bot-block thresholds: 403 ratio ≥ 0.5 AND confidence ≥ 0.99
+
+**Decision**: Both conditions must be true; neither threshold is negotiable.
+
+**Why**: Root cause analysis of 311,086 scrape failures showed 10.4% (32,333) were HTTP 403 bot-blocks with no per-domain detection before submitting. Thresholds were calibrated to minimize false positives (suppressing legitimate sites) while catching genuine bot-blocking.
+
+**Breakdown from analysis**:
+- HTTP 404: 37.8% (117,462) — agentic URL source includes CDN-served 404s
+- HTTP 403: 10.4% (32,333) — domains actively blocking the scraper
+- HTTP 429: ~1.1% — rate limiting
+- HTTP 410: <1% — permanently removed pages
+
+**Commit**: `721a9c99` (#2510)
+
+---
+
+## D-06 · isDeployedAtEdge URLs excluded from scrapedUrlsSet
+
+**Decision**: URLs where `isDeployedAtEdge=true` are filtered out before submission to the scraper and excluded from OUTDATED marking.
+
+**Why**: Same 311K failure analysis (#2510) — scraping already-deployed URLs was wasteful. If a URL is serving optimized content via Tokowaka CDN, it doesn't need to be analyzed for prerender gaps.
+
+**Commit**: `721a9c99` (#2510), first introduced in `08c53058` (#2183)
+
+---
+
+## D-07 · Don't send FIXED or edgeDeployed suggestions to Mystique
+
+**Decision**: `sendPrerenderGuidanceRequestToMystique` skips suggestions where `status === 'FIXED'` or `data.edgeDeployed` is set.
+
+**Why**: The UI never displays AI summaries for deployed or fixed suggestions. Previously only OUTDATED suggestions were filtered — FIXED and deployed suggestions were still sent, generating summaries that were never surfaced and wasting Mystique quota.
+
+**Commit**: `0d4f7046` (#2201)
+
+---
+
+## D-08 · suggestionId is required in Mystique SQS payload
+
+**Decision**: Every `guidance:prerender` SQS message must include `suggestionId`.
+
+**Why**: Mystique parses the payload via Pydantic union types. `PrerenderSuggestionMessageData` requires `suggestion_id: str`. If absent, Pydantic validation fails and the message is dropped. Production data for micron.com showed 8 of 13 suggestions missing `suggestionId` due to URL mismatch (www.micron.com vs micron.com) in the `urlToSuggestionId` map lookup — exact string match silently returned `undefined`.
+
+**Rule**: Always normalize URLs to the site's `preferredBase` domain before building the suggestion ID map.
+
+**Commit**: `001b563a` (#2373)
+
+---
+
+## D-09 · Daily batching replaced weekly full-site scan
+
+**Decision**: Audit runs daily with `DAILY_BATCH_SIZE=320`, deduplicated against PageCitability records (7-day window), rather than weekly full-site scans.
+
+**Why**: Weekly scan was scraping up to 2,200 URLs at once (overlapping with page-citability audit). Daily batching: (1) spreads load, (2) avoids re-scraping the same URL within 7 days, (3) eliminated duplicate scraping between prerender and page-citability audits by sharing the PageCitability dedup table.
+
+**Commit**: `ce68df2b` (#2146)
+
+---
+
+## D-10 · TOP_ORGANIC_URLS_LIMIT is 200, not 5
+
+**Decision**: `TOP_ORGANIC_URLS_LIMIT = 200`
+
+**Why**: Was accidentally left at `5` (a debug value) and shipped to production. If this constant ever looks suspiciously small again, check `src/prerender/utils/constants.js` before investigating deeper.
+
+**Commit**: `b10ec480` (#2532)
+
+---
+
+## D-11 · S3 path uses `scrapeJobId` UUID, not `siteId`
+
+**Decision**: S3 paths for scrape artifacts are `prerender/scrapes/{scrapeJobId}/{sanitizedPath}/...` where `scrapeJobId` is a random UUID generated by `ScrapeClient`.
+
+**Why**: Before PR #1772, the audit used `CONTENT_SCRAPER` which assigned `siteId` as the job ID, so paths were `prerender/scrapes/{siteId}/...`. PR #1772 migrated to `SCRAPE_CLIENT` (which generates random UUIDs), but the audit worker still tried to download files using `siteId`. Result: no files found, no analysis performed, no suggestions created for every site.
+
+**Additional**: The migration also required switching from `type` → `processingType` in the `createScrapeJob()` call, and `allowCache: false` → `maxScrapeAge: 0`. These are the correct field names for `ScrapeClient`.
+
+**Commits**: `db44bc2b` (#1772) — SCRAPE_CLIENT migration; `5d377936` (#1786) — fix S3 path to use `scrapeJobId`
+
+---
+
+## D-12 · status.json is primary UI data source (LatestAudit removed)
+
+**Decision**: The UI reads `prerender/scrapes/{siteId}/status.json` from S3 as the sole source of audit results. `LatestAudit` is not used for prerender.
+
+**Why**: `LatestAudit.updateByKeys()` was failing in production (lilly.com) because `LatestAudit.create()` was disabled in data-access v3. Rather than fixing the LatestAudit pathway, the decision was to make `status.json` the authoritative source. This also allows uploading error state when the audit fails mid-run — so the UI always shows accurate status even for partial failures.
+
+**Key implication**: `status.json` must be uploaded even when `syncSuggestions` throws, so the UI doesn't show stale successful state. There's an explicit error-path upload in step 3.
+
+**Commit**: `11d59f11` (#2065)
+
+---
+
+## D-13 · Dummy opportunity for scrape-forbidden sites
+
+**Decision**: When all scraped URLs return 403 (`scrapeForbidden=true`), a dummy opportunity is created with no suggestions rather than returning nothing.
+
+**Why**: The UI expects an opportunity record to display the "bot-blocked" state. Without it, the UI shows no opportunity and the user sees nothing. The dummy opportunity communicates that the site was visited but blocked.
+
+**Commit**: `e0d31dc9` (#1462)
+
+---
+
+## D-14 · SQS 256 KB limit → MYSTIQUE_BATCH_SIZE = 100
+
+**Decision**: Mystique guidance messages are sent in chunks of `MYSTIQUE_BATCH_SIZE = 100` suggestions per SQS message (not all suggestions in one message).
+
+**Why**: Production incident at lenscrafters.com: the site had 1,700+ historical suggestions; sending all active suggestions in one SQS message exceeded AWS's hard 262,144-byte limit. The entire Mystique batch was silently dropped. At ~600 bytes per suggestion entry, batches of 100 ≈ 60 KB comfortably stay under the limit.
+
+**Secondary fix in same PR**: `effectiveScrapeJobId` must now be resolved per suggestion (see D-02). If neither `data.scrapeJobId` nor `data.originalHtmlKey` can yield a job ID, the suggestion is **skipped** with a warn log (previously fell back to the audit-level job ID, producing wrong S3 keys silently).
+
+**Commit**: `7751f0bd` (#2338)
+
+---
+
+## D-15 · `valuable` flag must stay in sync with `aiSummary`
+
+**Decision**: The `valuable` boolean is only updated when the Mystique response includes a valid (non-null, non-"Not available") `aiSummary`. When `aiSummary` is invalid, both `aiSummary` and `valuable` are preserved from the previous value.
+
+**Why**: Before this fix, `aiSummary` was conditionally updated but `valuable` was always overwritten. If a suggestion had `valuable: false` and a valid `aiSummary` from a prior run, a subsequent Mystique response with no valid summary would reset `valuable` to `true` (the default) while preserving the old `aiSummary`. The two fields fell out of sync, showing incorrect business value assessments.
+
+**Rule**: `valuable` and `aiSummary` are a pair — update both or neither.
+
+**Commit**: `45b640db` (#2369)
+
+---
+
+## D-16 · Slack-triggered audit bypasses daily batching and agentic URLs
+
+**Decision**: When a prerender audit is triggered via Slack command (`run {site} prerender`), the audit uses organic + included URLs only, with no agentic URL sources and no PageCitability recency filter.
+
+**Why**: Slack-triggered runs are explicit manual requests — the operator wants to see results now, not a batch-limited subset. Daily batching and agentic URL sourcing are load-management features for scheduled runs; they create unexpected sparseness for on-demand debugging. Detection via `auditContext.slackContext.channelId`.
+
+**Commit**: `dcd3b8aa` (#2307)
+
+---
+
+## D-17 · `overrideBaseURL` from site config has highest URL normalization priority
+
+**Decision**: If `site.config.overrideBaseURL` is set and includes a valid protocol, all URL sources (organic, includedURLs, csvUrls, agentic) are rebased to that domain — it takes priority over `getPreferredBaseUrl`'s site-level detection.
+
+**Why**: Some sites have a canonical production domain that differs from the `baseURL` stored in SpaceCat. Without `overrideBaseURL`, rebased URLs used the SpaceCat `baseURL`, causing suggestions to be created under the wrong domain and preventing correct S3 key construction.
+
+**Commit**: `889559fd` (#2328)
+
+---
+
+## D-18 · `mergeAndGetUniqueHtmlUrls` deduplicates www/non-www and HTML-only
+
+**Decision**: Before submitting URLs to the scraper, all URL lists are merged through `mergeAndGetUniqueHtmlUrls`, which (1) removes duplicate paths regardless of www prefix, and (2) filters out non-HTML URLs (images, PDFs, etc.).
+
+**Why**: Paid LLMO customers with large sites had both www and non-www variants of the same path in GSC data — scraping both was redundant. Additionally, agentic URL sources sometimes included CDN-served assets (images, PDFs) which produced 404s and inflated the error rate. Both problems were identified through logging improvements for paid customers.
+
+**Commit**: `d3b84e52` (#1879)
+
+---
+
+## D-19 · `usedEarlyClientSideHtml` flag propagated to status.json
+
+**Decision**: The `usedEarlyClientSideHtml` boolean from `scrape.json` is passed through to the corresponding `pages[]` entry in `status.json` (sparse write — omitted when not set).
+
+**Why**: When the scraper falls back to early client-side HTML (before full JS execution completes), the content comparison is less reliable. The UI needs to know which pages used this fallback to potentially caveat the content gain ratio displayed. Without this flag, the UI had no way to distinguish reliable from fallback-quality analysis.
+
+**Commit**: `5305142f` (#2330)
+
+---
+
+## D-20 · `html-comparator-util.js` wrapper kept despite shared html-analyzer package
+
+**Decision**: After extracting HTML analysis to `@adobe/spacecat-shared-html-analyzer`, a thin wrapper `html-comparator-util.js` was kept in the prerender module rather than calling the shared package directly.
+
+**Why**: The wrapper maintains separation of concerns between (1) the shared package's generic analysis API and (2) the prerender-specific transformation of results (field name mapping, threshold application). It also keeps the shared package mockable in isolation during testing without coupling test setup to the shared package's internals.
+
+**Commit**: `66d0cf41` (#1501)

--- a/src/prerender/.claude/handler-reference.md
+++ b/src/prerender/.claude/handler-reference.md
@@ -1,0 +1,196 @@
+# Prerender Behavioural Contracts — Reference Index
+
+> This file is the **single source of truth** for the prerender audit's observable behaviour.
+> Read this instead of `handler.js` when writing or debugging tests.
+> Update it when handler behaviour changes.
+
+---
+
+## S3 Key Format
+
+```
+prerender/scrapes/{siteId}/status.json           ← site-level state
+prerender/scrapes/{scrapeJobId}/{segment}/server-side.html
+prerender/scrapes/{scrapeJobId}/{segment}/client-side.html
+prerender/scrapes/{scrapeJobId}/{segment}/scrape.json
+```
+
+**`segment`** = `sanitizeImportPath(pathname)`:
+1. Strip leading/trailing slashes
+2. Replace `/`, `.`, `_` with `-`
+3. Collapse consecutive `-` to one `-`
+4. Strip leading/trailing `-`
+5. Root path (`/`) → empty segment → no slash before file name
+
+**Examples:**
+| URL | segment | server key |
+|-----|---------|------------|
+| `https://example.com/` | _(empty)_ | `prerender/scrapes/{job}/server-side.html` |
+| `https://example.com/page-1` | `page-1` | `prerender/scrapes/{job}/page-1/server-side.html` |
+| `https://example.com/a/b.html` | `a-b-html` | `prerender/scrapes/{job}/a-b-html/server-side.html` |
+
+**`helpers.js` exports `scrapeKeys(scrapeJobId, url)`** — mirrors this logic exactly.
+
+---
+
+## S3 Object Types
+
+| Object | Value stored | `ContentType` header | How handler reads it |
+|--------|-------------|---------------------|----------------------|
+| `*.html` | raw HTML string | absent / `text/html` | `getObjectFromKey` returns raw string |
+| `scrape.json` | JSON object | `application/json` | `getObjectFromKey` returns parsed object |
+| `status.json` | JSON object | `application/json` | `getObjectFromKey` returns parsed object |
+
+**`buildS3Client` rule:** pass a `string` value for HTML files; pass a plain `object` for JSON files.
+
+---
+
+## Handler Constants
+
+| Constant | Value | Meaning |
+|----------|-------|---------|
+| `CONTENT_GAIN_THRESHOLD` | `1.1` | client/server word ratio ≥ 1.1 → `needsPrerender=true` |
+| `TOP_ORGANIC_URLS_LIMIT` | `200` | `getTopOrganicUrlsFromSeo` slices organics to this |
+| `DAILY_BATCH_SIZE` | `320` | normal-mode cap (organic + included + agentic) |
+| `BOT_BLOCK_WINDOW_DAYS` | `3` | sticky scrapeForbidden expires after this many days |
+| `BOT_BLOCK_CONFIDENCE_THRESHOLD` | `0.99` | reactive block requires confidence ≥ this |
+| `BOT_BLOCK_403_RATIO` | `0.5` | reactive block fires only when 403 ratio ≥ this |
+| `PAGE_CITABILITY_DEDUP_WINDOW_DAYS` | `7` | URLs processed within this window are excluded |
+
+---
+
+## Audit Steps
+
+```
+Step 1: importTopPages          → returns { trigger, urls?, auditContext }
+Step 2: submitForScraping       → returns { urls, auditContext }
+Step 3: processContentAndGenerateOpportunities  → returns { status, auditResult }
+```
+
+`auditContext.next` determines which step runs.
+
+---
+
+## Step 2 — Modes
+
+| Mode | Trigger | Dedup | Status.json read | Batch cap |
+|------|---------|-------|-----------------|-----------|
+| normal | no `urls` in auditContext | PageCitability 7-day | yes | DAILY_BATCH_SIZE=320 |
+| CSV | `auditContext.urls` present | none | no | no cap |
+| Slack | `auditContext.slack=true` | none | skips sticky bot-block | no cap |
+
+**`domainBlocked` flag** is set in `auditContext` when sticky bot-block fires; forwarded to step 3.
+
+---
+
+## Step 2 — URL Selection (normal mode)
+
+1. `getTopOrganicUrlsFromSeo` → slices to `TOP_ORGANIC_URLS_LIMIT=200`
+2. `getTopAgenticUrls` → catches all errors (Athena unavailable) → returns `[]`
+3. Append `includedURLs` from site config
+4. Subtract edge-deployed URLs from `status.json.pages[].isDeployedAtEdge=true`
+5. Subtract URLs in `PageCitability` within 7-day window
+6. Slice to `DAILY_BATCH_SIZE=320`
+
+---
+
+## Step 3 — Execution Order
+
+1. **`detectWrongEdgeDeployedStatus`** — unconditional, runs even when `isDomainBlocked=true`
+2. **`isDomainBlocked` check** — if true → set `scrapeForbidden=true`, skip HTML comparison, jump to status write
+3. **HTML comparison loop** — for each URL in `scrapeResultPaths`:
+   - Read `server-side.html` + `client-side.html` from S3
+   - Missing HTML → error result for that URL (not a crash)
+   - Ratio ≥ 1.1 → `needsPrerender=true`; `scrape.json.isDeployedAtEdge=true` → excluded from `scrapedUrlsSet`
+4. **`getScrapeJobStats`** — counts 403s from COMPLETE + FAILED-status URLs via `ScrapeUrl` DB + S3 scrape.json
+   - `ScrapeUrl` missing from `dataAccess` → fallback: `urlsSubmittedForScraping = urlsToCheck.length`
+   - `allByScrapeJobId` rejects → same fallback (error caught internally)
+5. **`detectBotBlocker`** — only if 403 ratio ≥ 0.5; requires confidence ≥ 0.99 + known CDN for `scrapeForbidden=true`
+   - Throws → warning logged, `scrapeForbidden=false`, audit continues
+6. **Branch routing:**
+   - **Branch A** (prerender URLs found + no domain block) → `convertToOpportunity` + `syncSuggestions`
+   - **Branch B** (prerender URLs found + `scrapeForbidden=true`) → `convertToOpportunity` with domain-wide suggestion + `syncSuggestions`
+   - **Branch C** (no prerender URLs) → mark existing NEW suggestions OUTDATED via `Suggestion.bulkUpdateStatus`
+7. **Write `status.json`** — merges current pages with prior pages not in current run
+
+---
+
+## Step 3 — Error Handling
+
+| Exception source | Caught? | Observable effect |
+|-----------------|---------|-------------------|
+| `Opportunity.allBySiteIdAndStatus` rejects | **No** — propagates | Lambda invocation fails; SQS retries |
+| `Opportunity.create` rejects | **Yes** | `log.error` called; function returns `undefined` |
+| `detectBotBlocker` throws | **Yes** | `log.warn` with "detectBotBlocker failed"; `scrapeForbidden=false` |
+| `ScrapeUrl.allByScrapeJobId` throws | **Yes** | fallback count used; audit completes |
+| S3 `GetObjectCommand` NoSuchKey (HTML) | **Yes** | per-URL error result; `urlsScrapedSuccessfully` not incremented |
+
+---
+
+## status.json Shape
+
+```json
+{
+  "scrapeForbidden": false,
+  "scrapeForbiddenSince": "2025-01-01T00:00:00.000Z",
+  "scrapeJobId": "job-abc",
+  "urlsSubmittedForScraping": 42,
+  "pages": [
+    {
+      "url": "https://example.com/page-1",
+      "needsPrerender": true,
+      "isDeployedAtEdge": false,
+      "scrapeError": { "statusCode": 403, "message": "Forbidden" }
+    }
+  ]
+}
+```
+
+**Merge rule:** pages from prior `status.json` not in the current scrape run are preserved.
+
+---
+
+## Stubs Needed Per Step
+
+### Step 2 (`submitForScraping`)
+
+| Stub | Purpose |
+|------|---------|
+| `s3Client.send` (GetObjectCommand for statusKey) | reads `status.json` for bot-block check + edge-deployed URLs |
+| `SiteTopPage.allBySiteIdAndSourceAndGeo` | organic URL source |
+| `PageCitability.allByIndexKeys` | dedup window |
+| `site.getConfig().getIncludedURLs()` | `includedURLs` |
+
+### Step 3 (`processContentAndGenerateOpportunities`)
+
+| Stub | Purpose |
+|------|---------|
+| `s3Client.send` (GetObjectCommand) | reads status.json + HTML + scrape.json |
+| `s3Client.send` (PutObjectCommand) | writes status.json (inspect with `captureStatusWrite`) |
+| `ScrapeUrl.allByScrapeJobId` | getScrapeJobStats stats counting |
+| `Opportunity.allBySiteIdAndStatus` | find existing opportunity |
+| `Opportunity.create` | create new opportunity (Branch A/B) |
+| `Suggestion.bulkUpdateStatus` | mark outdated suggestions (Branch C) |
+| `Suggestion.saveMany` | save new suggestions (Branch A/B) |
+
+---
+
+## Helpers Quick Reference (`helpers.js`)
+
+| Export | Use |
+|--------|-----|
+| `scrapeKeys(scrapeJobId, url)` | compute canonical S3 key triplet |
+| `buildUrlS3Content(scrapeJobId, url, opts)` | build partial S3 keyMap for one URL |
+| `statusKey(siteId)` | `prerender/scrapes/{siteId}/status.json` |
+| `buildStatus(opts)` | valid `status.json` object |
+| `daysAgo(n)` | ISO timestamp N days in the past |
+| `captureStatusWrite(s3Client)` | parse body of first PutObjectCommand |
+| `buildContext(sandbox, overrides)` | full handler context with safe defaults |
+| `buildS3Client(sandbox, keyMap)` | dispatch-by-key S3 stub |
+| `buildDataAccess(sandbox, opts)` | all entity stubs the handler touches |
+| `buildSite(opts)` | site object stub |
+| `buildOpportunity(sandbox, opts)` | opportunity object stub |
+| `buildSuggestion(sandbox, opts)` | suggestion object stub |
+| `HTML_SAME` | identical server+client HTML (ratio=1.0, no prerender) |
+| `HTML_SERVER_SPARSE` | sparse server HTML |
+| `HTML_CLIENT_NEEDS_PRERENDER` | rich client HTML (pair with sparse server → ratio>1.1) |

--- a/src/prerender/.claude/refactoring-proposal.md
+++ b/src/prerender/.claude/refactoring-proposal.md
@@ -1,0 +1,267 @@
+# Refactoring Proposal — Prerender Audit Handler
+
+**Current state**: `handler.js` is 1,875 lines, 34 functions, three entangled code paths.
+**Target state**: `handler.js` is ~60 lines. Every step reads like a specification. The logic is in named modules.
+
+**Goal**: reading handler.js tells you WHAT the audit does. The modules tell you HOW.
+**Constraint**: all 10 behavioral contract tests in `CLAUDE.md` must stay green throughout.
+
+---
+
+## North Star — Target handler.js
+
+This is the complete target for the handler file. Every function it calls will live in a named module.
+
+```js
+// ─── Step 1 ──────────────────────────────────────────────────────────────────
+export async function importTopPages(context) {
+  const mode = resolveMode(context);
+  if (mode.isAiOnly) return handleAiOnlyMode(context);
+  return buildImportTrigger(context);
+}
+
+// ─── Step 2 ──────────────────────────────────────────────────────────────────
+export async function submitForScraping(context) {
+  const mode = resolveMode(context);
+  if (mode.isAiOnly) return { status: 'skipped' };
+
+  const status = await readSiteStatus(context);
+  if (isStickyBotBlocked(context, status)) return buildBotBlockedResult(context, status);
+
+  const rawUrls = await fetchUrls(context, mode);
+  const batchUrls = await filterUrls(context, mode, rawUrls, status);
+
+  logSubmitMetrics(context, mode, rawUrls, batchUrls);
+
+  return submitScrapeJob(context, batchUrls);
+}
+
+// ─── Step 3 ──────────────────────────────────────────────────────────────────
+export async function processContentAndGenerateOpportunities(context) {
+  const mode = resolveMode(context);
+  if (mode.isAiOnly) return { status: 'skipped' };
+
+  await detectInvariantViolations(context);
+
+  const guard = await earlyExitGuard(context);
+  if (guard.exit) return guard.result;
+
+  const comparisons = await compareAllUrls(context);
+  const stats = await collectScrapeStats(context, comparisons);
+
+  if (stats.zeroResults) return uploadStatus(context, zeroResultsPayload(context, stats));
+
+  const botBlock = detectBotBlock(stats);
+  const opportunity = await syncOpportunity(context, comparisons);
+  const { suggestions, covered } = await syncSuggestions(context, comparisons, botBlock);
+  await markCovered(context, covered);
+  await writeCitability(context, comparisons);
+  await queueMystique(context, suggestions);
+  return uploadStatus(context, buildStatusPayload(context, stats, botBlock, comparisons));
+}
+```
+
+**Why this works**: every `if` is a guard clause that exits early. There is no nesting. The happy path is the bottom of each step. The functions read left-to-right: what is computed, what is written, what is sent.
+
+**Convention**: `context` is always the first argument. Return objects carry boolean flags (`mode.isAiOnly`, `guard.exit`, `stats.zeroResults`) instead of inline conditions.
+
+---
+
+## Module Map
+
+Each module owns one concern. `handler.js` imports from all of them and owns nothing else.
+
+| Module | Exports | Responsibility |
+|--------|---------|----------------|
+| `mode-resolver.js` | `resolveMode(context)` | Returns `{ isAiOnly, isCsv, isSlack, isNormal }`. Called at entry of all 3 steps — currently checked in 4 scattered places. |
+| `ai-only.js` | `handleAiOnlyMode(context)` | Full ai-only flow: scrapeJobId resolution, opportunity lookup, security check, Mystique dispatch. Currently 50+ lines embedded in step 1. |
+| `import-trigger.js` | `buildImportTrigger(context)` | Builds the `{ type: 'top-pages', siteId, ... }` trigger object. |
+| `url-fetcher.js` | `fetchUrls(context, mode)` | Dispatches to mode-specific sources: CSV from `auditContext.urls`, Slack from organic+includedURLs, Normal from organic+agentic+includedURLs. |
+| `url-filter.js` | `filterUrls(context, mode, rawUrls, status)` | Per-mode filtering: CSV/Slack → dedup+HTML-only; Normal → PageCitability dedup + edge-deployed filter + DAILY_BATCH_SIZE cap. |
+| `bot-block.js` | `isStickyBotBlocked(context, status)` `buildBotBlockedResult(context, status)` `detectBotBlock(stats)` | Stage 1 (sticky pre-scrape check) and Stage 2 (reactive post-scrape ratio + confidence check). Returns clean result objects — no throws. |
+| `status-reader.js` | `readSiteStatus(context)` | Reads status.json from S3. Returns the full status object. |
+| `exit-guard.js` | `earlyExitGuard(context)` | Reads isDomainBlocked from auditContext; if blocked, creates domain-blocked opportunity and uploads status. Returns `{ exit: true, result }` or `{ exit: false }`. Combines two checks that currently live inline in step 3. |
+| `html-comparator.js` | `compareAllUrls(context)` | Parallel S3 download of server-side.html + client-side.html + scrape.json per URL, runs `analyzeHtmlForPrerender`, returns `comparisons[]`. |
+| `scrape-stats.js` | `collectScrapeStats(context, comparisons)` | Wraps `getScrapeJobStats`: queries ScrapeUrl DB + S3 scrape.json for FAILED-status URLs, returns `{ zeroResults, urlsSubmitted, missingPages, scrapeForbiddenCount, submittedUrlSet }`. |
+| `opportunity-syncer.js` | `syncOpportunity(context, comparisons)` `syncSuggestions(context, comparisons, botBlock)` → `{ suggestions, covered }` `markCovered(context, covered)` `detectInvariantViolations(context)` | All suggestion/opportunity DB mutations. `syncSuggestions` returns `{ suggestions, covered }` — the handler never builds these sets itself. `detectInvariantViolations` is diagnostic-only (logs, never throws). |
+| `status-writer.js` | `uploadStatus(context, payload)` `zeroResultsPayload(context, stats)` `buildStatusPayload(context, stats, botBlock, comparisons)` `buildBotBlockedResult(context, status)` | All status.json writes. Builder functions are pure (no S3 calls). `uploadStatus` is the only S3 writer. |
+| `citability-writer.js` | `writeCitability(context, comparisons)` | Writes PageCitability records in batches of 10. |
+| `mystique.js` | `queueMystique(context, suggestions)` | Sends guidance request to Mystique via SQS. Handles batch chunking, skip conditions (OUTDATED, FIXED, edgeDeployed). |
+| `metrics.js` | `logSubmitMetrics(context, mode, rawUrls, batchUrls)` | Emits `prerender_submit_scraping_metrics`. Single call site, always after filtering. |
+
+---
+
+## Data Shapes Between Stages
+
+These are the values that flow from one stage to the next. Keeping them explicit prevents hidden coupling.
+
+### `mode` — output of `resolveMode`
+
+```js
+{
+  isAiOnly: boolean,
+  isCsv: boolean,
+  isSlack: boolean,
+  isNormal: boolean,
+}
+```
+
+Replaces the current 4 scattered `MODE_AI_ONLY` / `auditContext.slackContext` / `auditContext.urls` checks.
+
+### `guard` — output of `earlyExitGuard`
+
+```js
+// Blocked:
+{ exit: true, result: { status: 'domain-blocked', ... } }
+
+// Not blocked:
+{ exit: false }
+```
+
+Internally, `earlyExitGuard` reads `isDomainBlocked` from auditContext, creates the domain-blocked opportunity if needed, and uploads status. The handler only checks the `exit` flag.
+
+### `comparisons[]` — output of `compareAllUrls`
+
+```js
+{
+  url,
+  needsPrerender,        // contentGainRatio >= 1.1
+  contentGainRatio,
+  wordCountBefore,
+  wordCountAfter,
+  citabilityScore,
+  isDeployedAtEdge,      // from scrape.json
+  usedEarlyClientSideHtml,
+  scrapeForbidden,       // error.statusCode === 403
+  scrapeError,           // error object from scrape.json
+  error,                 // boolean — HTML comparison itself failed
+}
+```
+
+### `stats` — output of `collectScrapeStats`
+
+```js
+{
+  zeroResults,           // boolean — comparisons.length === 0 or no successful scrapes
+  urlsSubmitted,         // total URLs in the scrape job
+  scrapeForbiddenCount,  // 403 count (COMPLETE + FAILED paths)
+  missingPages,          // per-URL error details for status.json
+  submittedUrlSet,       // Set<url> from ScrapeUrl DB (for scrapeJobId assignment)
+}
+```
+
+`zeroResults` is computed inside `collectScrapeStats` so the handler never inspects `comparisons.length` directly.
+
+### `{ suggestions, covered }` — output of `syncSuggestions`
+
+```js
+{
+  suggestions: Suggestion[],   // the NEW suggestions to send to Mystique
+  covered: Suggestion[],       // suggestions whose URLs are edge-deployed and covered by domain-wide
+}
+```
+
+`markCovered(context, covered)` writes `coveredByDomainWide` on these. `queueMystique(context, suggestions)` sends the Mystique batch. The handler never builds either array.
+
+---
+
+## What Changes in Each Step
+
+### Step 1 (2 meaningful changes)
+
+1. `resolveMode` replaces the scattered `MODE_AI_ONLY` checks and returns a clean boolean-flag object
+2. `handleAiOnlyMode` extracted from step 1 body into `ai-only.js`
+
+### Step 2 (biggest change)
+
+The three code paths (CSV / Slack / Normal) are collapsed into two pure functions:
+- `fetchUrls(context, mode)` — dispatches to mode-specific sourcing, returns raw URL list
+- `filterUrls(context, mode, rawUrls, status)` — applies mode-specific filters, returns final URL array
+
+The bot-block check moves from an inline `if` to `isStickyBotBlocked(context, status)` — same logic, named and testable independently.
+
+### Step 3 (removes fallback, adds zero-results guard)
+
+The untested `/* c8 ignore */` fallback that silently processes stale HTML is **replaced** with `stats.zeroResults`:
+- Before: zero scrapes → re-fetch all URLs → compare against old S3 HTML → upload status that looks like success
+- After: zero scrapes → `stats.zeroResults = true` → upload honest status with `scrapingErrorRate = 100%` → exit cleanly without touching suggestions
+
+The `isDomainBlocked` check moves out of inline `if` into `earlyExitGuard`, which also handles the domain-blocked opportunity creation and status upload internally — step 3 just reads `guard.exit`.
+
+The three-way opportunity branch (`urlsNeedingPrerender > 0` / `scrapeForbidden` / neither) is absorbed into `syncSuggestions`, which returns `{ suggestions, covered }`. `botBlock` flows in as a parameter — `syncSuggestions` uses it to decide whether to create the scrapeForbidden opportunity instead of the normal prerender opportunity.
+
+---
+
+## Observability — Preserved Log Keys
+
+Both monitored log keys must survive the refactoring unchanged.
+
+| Log key | Emitted by | Trigger |
+|---------|-----------|---------|
+| `prerender_submit_scraping_metrics` | `metrics.js: logSubmitMetrics` | Once per step 2 run, after `filterUrls` |
+| `prerender_ai_summary_metrics` | `guidance-handler.js` | After `Suggestion.saveMany` in guidance flow |
+
+Field names are not changed. If the emit point moves, update dashboard queries.
+
+---
+
+## TDD Implementation Order
+
+Work in this order. Each step is independently deliverable — the 10 contract tests stay green after each.
+
+1. **`mode-resolver.js`** — pure function, zero dependencies, write tests first
+2. **`bot-block.js`** — `isStickyBotBlocked` + `detectBotBlock` + `buildBotBlockedResult` — pure functions, test against known status.json shapes
+3. **`url-filter.js`** — stub `PageCitability` + `getEdgeDeployedPathnames` — verify same URLs pass/fail as current handler
+4. **`url-fetcher.js`** — stub `getTopOrganicUrlsFromSeo` + `getTopAgenticUrls` — verify per-mode URL sets
+5. **Step 2 collapse** — wire `fetchUrls` + `filterUrls` + `isStickyBotBlocked` into handler; all three path contract tests pass
+6. **`scrape-stats.js`** — stub `ScrapeUrl` DB + S3 `scrape.json` reads; verify `scrapeForbiddenCount` dual-path counting; `zeroResults` flag tested here
+7. **`exit-guard.js`** — test: `isDomainBlocked=true` → `guard.exit=true`, `uploadStatus` called with blocked payload, `syncSuggestions` never called
+8. **`status-writer.js`** — pure builder functions first (no S3); then `uploadStatus` with stubbed S3
+9. **`opportunity-syncer.js`** — extract `syncSuggestions` + `markCovered`; verify `{ suggestions, covered }` shape; preserve all OUTDATED / coveredByDomainWide invariants; `botBlock` parameter drives scrapeForbidden opportunity path
+10. **Step 3 full collapse** — wire all modules into the ~20-line target; all 10 contract tests pass
+
+---
+
+## Implementation Risks
+
+### esmock Path Sensitivity (Critical Risk)
+
+- **Current**: 115 esmock instantiations in `handler.test.js` mock specific function exports
+- **Risk**: Moving functions to new files breaks all paths (e.g., `esmock('../src/prerender/handler.js', ...)` expects specific export names)
+- **Mitigation**: When extracting functions:
+  1. Identify all esmock stubs that reference the function
+  2. Update stub paths to new module location
+  3. Re-run tests; if any path fails, verify import/export is correct
+  4. Consider creating adapter exports in handler.js during transition (minimize esmock churn)
+
+### c8 Coverage Ignore Branches
+
+- **Current**: 6 branches marked with `/* c8 ignore next N */`
+- **Risk**: When extracted to new modules, these branches become mandatory test coverage
+- **Action**: When extracting, review each ignore comment:
+  - If condition is testable, add tests to cover the branch
+  - If condition is environment-dependent, preserve ignore with explanation comment
+  - Update c8 ignore block count if branches are refactored
+
+### Test Architecture Impact
+
+- **Handler exports**: 8 main entry points (steps 1-3, helper exports)
+- **Esmock dependency**: All mocking depends on exact export names and file paths
+- **Migration strategy**: Extract functions, then immediately update esmock stubs before running tests (batch the refactor + test updates together, don't separate them)
+
+### Shared Function Hazards
+
+- **normalizePathname**: Used by 10+ audits (GSC, lighthouse, etc.); if moved, must coordinate updates across repo
+- **mergeAndGetUniqueHtmlUrls**: Duplication confirmed in prerender (`src/prerender/utils/utils.js`) vs canonical (`src/utils/audit-input-urls.js`); safe to remove prerender copy if consensus reached
+- **Audit-specific utils**: URL sanitization, bot-block regex — stay in `src/prerender/` to avoid coupling with other audits
+
+---
+
+## Module Extraction Checklist (per extraction)
+
+1. **Identify esmock impact**: Grep for function name in `handler.test.js`; list all mocking paths
+2. **Check shared usage**: Does this function exist elsewhere? (`normalizePathname`, `mergeAndGetUniqueHtmlUrls`)
+3. **Verify locked contracts**: Are any locked field names referenced? (status.json, Suggestion.data, S3 paths)
+4. **Write behavioral tests**: Before extraction, write test that verifies observable output (not internal logic)
+5. **Extract + update stubs**: Move function, update all esmock instantiations, run tests
+6. **Review c8 ignores**: Any ignored branches now tested? Update ignore count

--- a/src/prerender/.claude/scraper-internals.md
+++ b/src/prerender/.claude/scraper-internals.md
@@ -1,0 +1,84 @@
+# Scraper Internals — spacecat-content-scraper
+
+Source: `spacecat-content-scraper/src/handlers/prerender-handler.js`
+
+---
+
+## What the Scraper Does Per URL
+
+```
+1. Validates URL — skips .pdf/.jpg/.zip/etc. (non-HTML extensions)
+2. Sanitizes URL path → sanitizedImportPath (see regex in CLAUDE.md URL Normalization section)
+3. Launches Chromium via Puppeteer with prerender-specific args:
+   - Denies all permissions (geolocation, notifications)
+   - Blocks images/media/fonts (blockHeavyResources=true in profile)
+   - Handles CORS preflight with permissive headers
+4. Captures server-side HTML from response.text() (raw HTTP response — what bots see)
+5. detectEdgeDeployment() — separate GET request with Tokowaka UA
+6. Settle loop: waits for DOM stability + network idle (up to 2 rounds)
+7. expandShadowDOM() — inlines shadow DOM content into main DOM
+8. Captures client-side HTML via page.content() (after JS execution)
+9. Fallback: if page.content() fails, uses earlyClientSideHtml (captured right after DOMContentLoaded)
+10. detectBotProtection() — checks for bot-blocking signals in response
+11. Stores to S3: server-side.html, client-side.html, server-side-html.md, markdown-diff.md, scrape.json
+```
+
+---
+
+## Bot Protection → No scrape.json (Critical for Audit Worker)
+
+When `botProtection.blocked = true`:
+- Scraper returns immediately without calling `#store()`
+- **No `scrape.json` is written to S3**
+- `ScrapeUrl.status` is set to `FAILED` with reason indicating bot-block
+- Audit worker's `getScrapeJobStats()` detects this via missing S3 key + `ScrapeUrl` status
+
+---
+
+## Markdown Files — Why They Exist
+
+The scraper uses `@adobe/spacecat-shared-html-analyzer` to produce:
+- **`server-side-html.md`**: markdown of the server-side HTML (nav/footer stripped) — clean input for Mystique
+- **`markdown-diff.md`**: only the *added* markdown blocks (content in client-side but absent from server-side) — what Mystique actually summarizes
+
+This means Mystique receives pre-processed markdown, not raw HTML. The audit worker references these files via `originalHtmlKey` / `prerenderedHtmlKey` in Suggestion.data, but those point to the `.html` files — the `.md` files are consumed directly by the DRS/Mystique pipeline.
+
+---
+
+## `usedEarlyClientSideHtml` Flag
+
+When the settle loop fails (browser crash, TargetCloseError) and early HTML was available, the scraper:
+- Uses the HTML captured right after `domcontentloaded`
+- Sets `usedEarlyClientSideHtml: true` in `scrape.json`
+- The audit worker reads this flag and stores it in `Suggestion.data` and `status.json pages[]`
+
+This is relevant because early HTML may be less complete than fully-settled HTML — the flag lets the UI show a warning.
+
+---
+
+## Edge Deployment Detection
+
+The scraper makes a separate HTTP GET request using:
+```
+User-Agent: Mozilla/5.0 ... Tokowaka-AI Tokowaka/1.0 AdobeEdgeOptimize-AI AdobeEdgeOptimize/1.0
+```
+If any of these response headers are present → `isDeployedAtEdge = true`:
+- `x-edgeoptimize-cache`
+- `x-edgeoptimize-proxy`
+- `x-tokowaka-cache`
+- `x-tokowaka-proxy`
+
+`isDeployedAtEdge` in `scrape.json` is a **boolean**. It is forwarded as-is to `status.json pages[].isDeployedAtEdge` by the audit worker. It is **NOT** the same as `Suggestion.data.edgeDeployed`, which is an ms epoch timestamp set exclusively by user deploy action from the UI.
+
+---
+
+## Key Decision Points for Audit Worker Code
+
+| Scraper condition | What audit worker sees | Audit worker action |
+|-------------------|------------------------|---------------------|
+| Bot-blocked URL | No `scrape.json` at S3 path | Count toward 403 ratio |
+| `isDeployedAtEdge: true` in scrape.json | boolean | Forward as-is to `status.json pages[].isDeployedAtEdge`; also triggers `coveredByDomainWide` logic |
+| `usedEarlyClientSideHtml: true` | boolean | Forward to Suggestion.data + status.json pages[] |
+| `error.statusCode: 403` in scrape.json | object | Count toward 403 ratio for bot-block detection |
+| `hasMarkdownDiffFile: false` | boolean | Mystique gets no clean input for this URL |
+| `status: 'FAILED'` in scrape.json | string | URL failed scraping; do not mark existing suggestion OUTDATED |

--- a/src/prerender/.claude/shared-packages.md
+++ b/src/prerender/.claude/shared-packages.md
@@ -1,0 +1,294 @@
+# Shared Packages — Prerender Audit
+
+Detailed API reference for the packages the prerender audit directly depends on.
+
+---
+
+## `@adobe/spacecat-shared-html-analyzer`
+
+Used in step 3 to compare server-rendered vs. client-rendered HTML.
+
+**Key functions used by prerender:**
+
+| Function | Returns | Notes |
+|----------|---------|-------|
+| `calculateStats(originalHTML, currentHTML)` | `{ wordCountBefore, wordCountAfter, wordDiff, contentIncreaseRatio, citationReadability }` | Primary function for per-URL comparison |
+| `analyzeTextComparison(initHtml, finHtml)` | Full diff object + hashes | Used for detailed comparison reports |
+| `filterHtmlContent` / `stripTagsToText` | Plain text | Strips nav/footer/cookie banners before counting |
+
+**Critical name mapping** — the same concept has different names in different layers:
+
+| Layer | Field name |
+|-------|------------|
+| `html-analyzer` output | `contentIncreaseRatio` |
+| `PageCitability` DB field | `contentRatio` |
+| `Suggestion.data` field | `contentGainRatio` |
+| `status.json` pages[] | `contentGainRatio` |
+| `CONTENT_GAIN_THRESHOLD` constant | 1.1 (ratio threshold = "10% more content client-side") |
+
+**Behavior notes:**
+- Server-side HTML **always** includes `<noscript>` content (what bots see)
+- Client-side HTML **excludes** `<noscript>` by default (what users see after JS runs)
+- `ignoreNavFooter=true` by default — strips `nav`, `header`, `footer`, ARIA banners before word counting
+- `citationReadability` = what % of original words survive into the rendered page (100% = no loss)
+
+---
+
+## `@adobe/spacecat-shared-scrape-client`
+
+Used in step 2 to submit URLs to `spacecat-content-scraper`.
+
+**Factory:** `ScrapeClient.createFrom(context)` — requires `context.dataAccess`, `context.sqs`, `context.log`, `context.env`
+
+**Config env var:** `SCRAPE_JOB_CONFIGURATION` (JSON string) must have:
+- `scrapeWorkerQueue` — SQS URL for the scraper
+- `s3Bucket` — S3 bucket for scrape results
+- `maxUrlsPerJob` — hard cap on URLs per job (default 1; prerender passes batches up to DAILY_BATCH_SIZE)
+- `maxUrlsPerMessage` — SQS message splitting threshold (default 1000)
+- `options` — `{ enableJavascript, hideConsentBanners }`
+
+**Key methods:**
+
+```js
+// Submit a batch of URLs for scraping
+const job = await scrapeClient.createScrapeJob({
+  urls,                         // string[] — the batch
+  processingType: 'prerender',  // MUST be 'prerender' — routes to PrerenderHandler
+  maxScrapeAge: 24,             // hours before forcing re-scrape
+  metaData: {},                 // passed to scraper, not used by prerender
+});
+// Returns: ScrapeJobDto { id, baseURL, processingType, options, startedAt, status, urlCount, ... }
+
+// Get result paths (step 3 uses this to find S3 HTML files)
+const pathMap = await scrapeClient.getScrapeResultPaths(jobId);
+// Returns: Map<url, s3Path> — only COMPLETE status URLs
+
+// Get all URL results with status
+const results = await scrapeClient.getScrapeJobUrlResults(jobId);
+// Returns: [{ url, status, reason, path }]
+```
+
+**ScrapeJob statuses:** `RUNNING | COMPLETE | FAILED | STOPPED` — expires after **120 days**
+
+**ScrapeUrl statuses:** `PENDING | REDIRECT | RUNNING | COMPLETE | FAILED | STOPPED`
+
+**abortInfo on ScrapeJob** — set when bot-blocking detected during scraping:
+```js
+abortInfo: {
+  reason: string,
+  details: {
+    blockedUrlsCount: number,
+    totalUrlsCount: number,
+    blockedUrls: [{ url, blockerType, httpStatus, confidence }],
+    blockedUrlsSampled: boolean,  // true if > 400KB truncated
+    byBlockerType: object,        // dynamic keys
+    byHttpStatus: object,         // dynamic keys
+    auditType: string,
+    siteId: string,
+    siteUrl: string,
+  }
+}
+```
+This is what prerender's `getScrapeJobStats()` reads to count 403s for bot-block detection.
+
+---
+
+## `@adobe/spacecat-shared-data-access` — Entities Used by Prerender
+
+### `PageCitability` — 7-day dedup window
+
+```
+DB table: page_citabilities
+Expires: not TTL-based (no withRecordExpiry), manual cleanup
+```
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `siteId` | FK | belongs_to Site |
+| `url` | string (required) | page URL, must be valid URL |
+| `citabilityScore` | number | priority rank — lower = higher priority |
+| `contentRatio` | number | = html-analyzer's `contentIncreaseRatio` = Suggestion.data `contentGainRatio` |
+| `wordDifference` | number | absolute word count delta |
+| `botWords` | number | word count before JS (server-side) |
+| `normalWords` | number | word count after JS (client-side) |
+| `isDeployedAtEdge` | boolean | edge delivery detected |
+| `updatedBy` | string | who last updated |
+
+**Indexed by:** `url` + `updatedAt` — prerender queries recent records via `updatedAt` to find URLs processed within 7-day window.
+
+**How prerender uses it:**
+- Step 2: queries PageCitability for this site, filters URLs with `updatedAt` within last 7 days (PRERENDER_RECENT_PROCESSING_TIME_DAYS=7) → skips those from daily batch
+- Step 3: writes citabilityScore + contentRatio + other fields after HTML comparison
+
+### `ScrapeJob` — scrape job tracking
+
+```
+DB table: scrape_jobs
+Expires: 120 days (withRecordExpiry)
+```
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `baseURL` | string | site being scraped |
+| `processingType` | string | `'prerender'` for prerender scrape jobs |
+| `status` | enum | RUNNING / COMPLETE / FAILED / STOPPED |
+| `urlCount` | number | total URLs in job |
+| `successCount` | number | COMPLETE URLs |
+| `failedCount` | number | FAILED URLs |
+| `options` | object | scrape options (enableJavascript, etc.) |
+| `abortInfo` | map | bot-block details — read by `getScrapeJobStats()` |
+| `startedAt` | ISO date | job start |
+| `endedAt` | ISO date | job end |
+
+### `ScrapeUrl` — per-URL scrape result
+
+```
+DB table: scrape_urls
+Expires: set on ScrapeUrl model (separate from ScrapeJob TTL)
+```
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `scrapeJobId` | FK | belongs_to ScrapeJob |
+| `url` | string | the URL scraped |
+| `status` | enum | PENDING/REDIRECT/RUNNING/COMPLETE/FAILED/STOPPED |
+| `path` | string | S3 path to scrape result |
+| `reason` | string | failure reason if FAILED |
+| `processingType` | string | matches parent ScrapeJob |
+| `isOriginal` | boolean | true if original URL (not redirect target) |
+
+**How prerender uses it:** `getScrapeJobStats()` calls `ScrapeUrl.allByScrapeJobId(jobId)` to count FAILED 403 URLs for bot-block ratio calculation.
+
+### `Suggestion` — prerender suggestions
+
+**Type:** `CONFIG_UPDATE` (from `Suggestion.TYPES.CONFIG_UPDATE`)
+
+**All statuses:**
+```
+NEW → APPROVED → IN_PROGRESS → FIXED
+              ↘ SKIPPED
+              ↘ REJECTED
+              ↘ OUTDATED
+              ↘ ERROR
+              ↘ PENDING_VALIDATION
+```
+
+**Prerender-active statuses** (ACTIVE_STATUSES, preserved across audits):
+`['NEW', 'APPROVED', 'APPROVED_AS_DRAFT']` — note `APPROVED_AS_DRAFT` is NOT in `Suggestion.STATUSES` enum, it's a prerender-specific extension.
+
+---
+
+## `@adobe/spacecat-shared-tokowaka-client`
+
+Tokowaka is the **edge optimization service** that enables server-side prerendering at the CDN layer. The client manages two types of S3 configs and is invoked by `spacecat-api-service` (never the audit worker) when a user deploys suggestions from the UI.
+
+### S3 Config Structure
+
+**Per-URL config** — written for each deployed URL:
+```
+S3 key: opportunities/{hostname-no-www}/{base64url(pathname)}
+e.g.:  opportunities/mazdausa.com/L3Zlb2ljbGVz  (= /vehicles)
+
+Contents:
+{
+  url: "https://www.mazdausa.com/vehicles",
+  version: "1.0",
+  forceFail: false,
+  prerender: true,   // ← set to true by PrerenderMapper.requiresPrerender()
+  patches: []        // ← always empty for prerender (no DOM modifications)
+}
+```
+
+**Domain metaconfig** — one per domain, controls site-level settings and domain-wide prerender:
+```
+S3 key: opportunities/{hostname-no-www}/config
+e.g.:  opportunities/mazdausa.com/config
+
+Contents:
+{
+  siteId: "...",
+  apiKeys: ["sha256-base64url..."],
+  tokowakaEnabled: true,
+  enhancements: true,
+  patches: { "/vehicles": true, ... },  // tracks which paths have been deployed
+  prerender: { allowList: ["/*"] }       // only present for domain-wide or stage domains
+}
+```
+
+**S3 path helpers** (from `s3-utils.js`):
+- `getHostName()`: strips `www.` prefix from hostname
+- `normalizePath()`: removes trailing slash (except root `/`)
+- `base64UrlEncode()`: RFC 4648 URL-safe base64, no padding
+
+**Preview configs** use `preview/` prefix: `preview/opportunities/{hostname}/...`
+
+### PrerenderMapper — What It Does
+
+The `PrerenderMapper` is the glue between prerender suggestions and Tokowaka configs:
+
+| Method | Returns | Why |
+|--------|---------|-----|
+| `requiresPrerender()` | `true` | Sets `prerender: true` in the URL config |
+| `allowConfigsWithoutPatch()` | `true` | Allows uploading a config with `patches: []` |
+| `suggestionsToPatches()` | `[]` | Prerender has no DOM patches — just enables prerendering |
+| `canDeploy(suggestion)` | `{ eligible: true }` if `data.url` is set | Any suggestion with a URL is deployable |
+
+### `deployToEdge()` — The Full Deploy Flow
+
+This is the method called by `spacecat-api-service` when the user deploys from the UI. **This is where `edgeDeployed` and `coveredByDomainWide` are written.**
+
+```
+Input: { site, opportunity, targetSuggestions, allSuggestions }
+
+Split targetSuggestions into:
+  ├── domainWideSuggestions  (data.isDomainWide === true)
+  └── validSuggestions       (status === NEW or PENDING_VALIDATION)
+
+If both present: filter validSuggestions that match domain-wide patterns → skippedInBatch
+
+For validSuggestions (regular URL deploy):
+  deploySuggestions() → per-URL S3 config upload → CDN invalidate
+  → suggestion.data.edgeDeployed = Date.now()   ← SET HERE (not in audit worker)
+  → s.save()
+
+For domainWideSuggestions (domain-wide deploy):
+  metaconfig.prerender = { allowList: allowedRegexPatterns }
+  uploadMetaconfig() → CDN invalidate metaconfig
+  → domainWideSuggestion.data.edgeDeployed = Date.now()  ← only on THIS suggestion
+  → allSuggestions matching patterns → coveredByDomainWide = suggestion.getId()  ← other suggestions get UUID
+
+For skippedInBatch (URL suggestions covered by domain-wide in same deploy batch):
+  → suggestion.data.coveredByDomainWide = 'same-batch-deployment'  ← string literal, not UUID
+  → suggestion.data.skippedInDeployment = true
+```
+
+**Critical: `edgeDeployed` and `coveredByDomainWide` are NEVER written by the audit worker.** They are written exclusively by `deployToEdge()` in the api-service call path.
+
+### Eligible Suggestion Statuses for Edge Deploy
+
+Only `NEW` and `PENDING_VALIDATION` suggestions can be edge-deployed. `APPROVED`, `IN_PROGRESS`, `FIXED`, `SKIPPED` are ineligible — they get returned in `failedSuggestions` with statusCode 400.
+
+### Rollback for Prerender
+
+`rollbackSuggestions()` for opportunity type `'prerender'` sets `prerender: false` in the URL config (rather than removing patches, since prerender configs have no patches).
+
+### Env Vars Required
+
+| Variable | Purpose |
+|----------|---------|
+| `TOKOWAKA_SITE_CONFIG_BUCKET` | S3 bucket for deployed per-URL configs and metaconfigs |
+| `TOKOWAKA_PREVIEW_BUCKET` | S3 bucket for preview configs |
+| `TOKOWAKA_CDN_PROVIDER` | Comma-separated CDN providers: `cloudfront`, `fastly` |
+| `TOKOWAKA_EDGE_URL` | Edge proxy URL — required only for `previewSuggestions()` |
+
+### What the Audit Worker Sees from Tokowaka
+
+The audit worker does NOT call TokowakaClient directly. But it reads the downstream effects:
+
+| What audit worker reads | Where it comes from |
+|------------------------|---------------------|
+| `Suggestion.data.edgeDeployed` | Written by `deployToEdge()` — timestamps a user deploy |
+| `Suggestion.data.coveredByDomainWide` | Written by `deployToEdge()` or audit worker itself (for isDeployedAtEdge=true URLs) |
+| `isDeployedAtEdge: true` in scrape.json | Written by content-scraper detecting `x-tokowaka-request-id` / `x-edgeoptimize-request-id` response headers |
+
+The scraper's `detectEdgeDeployment()` uses exactly those two headers to detect active Tokowaka prerendering — the same headers that `checkEdgeOptimizeStatus()` in TokowakaClient checks.

--- a/src/prerender/.claude/suggestion-lifecycle.md
+++ b/src/prerender/.claude/suggestion-lifecycle.md
@@ -1,0 +1,202 @@
+# Suggestion Lifecycle — Prerender Audit
+
+Read this file when working on: suggestion creation/update logic, OUTDATED marking, domain-wide suggestion preservation, `syncSuggestions`, `coveredByDomainWide`, or `edgeDeployed` handling.
+
+---
+
+## Suggestion Data Fields (Locked Contracts)
+
+Suggestions have **type `CONFIG_UPDATE`** (not `prerender`). Changing field names or semantics requires coordinated PRs across spacecat-api-service and project-elmo-ui.
+
+### Per-URL Suggestion data fields
+
+```json
+{
+  "url": "string (page URL)",
+  "scrapeJobId": "string (optional — may be absent for older suggestions)",
+  "wordCountBefore": 70,
+  "wordCountAfter": 5881,
+  "contentGainRatio": 84.01,
+  "citabilityScore": 1,
+  "originalHtmlKey": "prerender/scrapes/{scrapeJobId}/{sanitizedPath}/server-side.html",
+  "prerenderedHtmlKey": "prerender/scrapes/{scrapeJobId}/{sanitizedPath}/client-side.html",
+  "valuable": true,
+  "aiSummary": "string (optional — absent until Mystique processes it)",
+  "edgeDeployed": 1777489106583,
+  "coveredByDomainWide": "uuid-of-domain-wide-suggestion | null"
+}
+```
+
+- **`edgeDeployed`**: **Timestamp (number, ms since epoch)** — when edge deployment was detected, NOT a boolean. Check truthiness (`if (data.edgeDeployed)`) to test presence.
+- **`coveredByDomainWide`**: **UUID string** (the suggestion ID of the covering domain-wide suggestion), NOT a boolean. Null when not covered.
+- **`citabilityScore`**: Integer ranking for URL prioritization; lower is higher priority.
+- **`valuable`**: Optional boolean; set by Mystique AI after analysis.
+- **`aiSummary`**: Optional string; set by Mystique AI; absent until processed.
+
+### Domain-Wide Suggestion data fields
+
+```json
+{
+  "url": "https://example.com/* (All Domain URLs)",
+  "pathPattern": "/*",
+  "isDomainWide": true,
+  "wordCountBefore": 43493,
+  "wordCountAfter": 331864,
+  "contentGainRatio": 4053.34,
+  "aiReadablePercent": 1079,
+  "allowedRegexPatterns": ["/*"]
+}
+```
+
+Does NOT have `originalHtmlKey`, `prerenderedHtmlKey`, `scrapeJobId`, `citabilityScore`, `valuable`, `aiSummary`.
+
+---
+
+## Golden Rules (Never Violate)
+
+These six invariants define correctness for the prerender opportunity system. Any code path — audit worker, api-service, guidance-handler — that would violate one of these is a bug.
+
+| Rule ID | Invariant | Exception / Detail |
+|---------|-----------|-------------------|
+| `multi-dw-NEW` | Exactly **one** domain-wide suggestion with `status=NEW` must exist per site at any time | A domain-wide can transition to OUTDATED — that is the only other allowed status (see `dw-wrong-status`) |
+| `dw-wrong-status` | Domain-wide suggestion status must be **NEW or OUTDATED only** — never FIXED, SKIPPED, APPROVED, etc. | System creates it as NEW; only audit worker may set it OUTDATED |
+| `edgeDep-wrong-status` | If `data.edgeDeployed` is set on a suggestion, its status must be **NEW** | OUTDATED is allowed **only** when another non-OUTDATED suggestion exists at the same normalized path (covers www/non-www and trailing-slash variants — duplicate cleanup scenario) |
+| `edgeDep-covByDW-mutex` | `data.edgeDeployed` and `data.coveredByDomainWide` are **mutually exclusive** — a suggestion must never have both set | A suggestion is either directly deployed (`edgeDeployed`) OR covered by the domain-wide deploy (`coveredByDomainWide`), never both |
+| `dw-deployed-no-covByDomWide` | If the domain-wide suggestion has `edgeDeployed` set AND a URL's `isDeployedAtEdge=true` in status.json AND the URL suggestion does **not** have `edgeDeployed`, then `data.coveredByDomainWide` **must** be set to the domain-wide suggestion's UUID | This is the only data mutation the audit worker performs on an existing suggestion that is not newly created |
+| `sys-SKIPPED-FIXED` | The **system must never set** `status=SKIPPED` or `status=FIXED` on a suggestion | SKIPPED and FIXED are user-action statuses only: SKIPPED set by UI, FIXED set by spacecat-api-service after deploy validation. Audit worker writes only NEW and OUTDATED. |
+
+**Scraping corollary (not a DB invariant but enforced in step 2):**
+If `isDeployedAtEdge=true` for a URL in `status.json`, that URL is excluded from the scrape job submission. It will not appear in the next batch's comparison results.
+
+---
+
+## All Suggestion Statuses
+
+Complete status set from `Suggestion.STATUSES` (`spacecat-shared-data-access`):
+
+| Status | Set by | Prerender context |
+|--------|--------|-------------------|
+| `NEW` | Audit worker (`syncSuggestions`) | Default for newly created suggestions |
+| `APPROVED` | UI user action | User approved suggestion for deployment |
+| `IN_PROGRESS` | spacecat-api-service | Deployment in progress |
+| `SKIPPED` | UI user action | User dismissed suggestion (not deployed) |
+| `FIXED` | spacecat-api-service (post-deploy validation) | Suggestion deployed and validated |
+| `ERROR` | spacecat-api-service | Deploy failed |
+| `OUTDATED` | Audit worker (`syncSuggestions`) | URL was re-scraped and no longer needs prerender, OR conditions changed |
+| `PENDING_VALIDATION` | spacecat-api-service | Deployed, awaiting edge validation |
+| `REJECTED` | UI user action | User rejected suggestion |
+
+---
+
+## What the Audit Worker Writes
+
+| Write | Field / Status | Handler | When |
+|-------|---------------|---------|------|
+| Status `NEW` | `Suggestion.status` | `handler.js` | Only on **new suggestion creation** via `syncSuggestions` |
+| Status `OUTDATED` | `Suggestion.status` | `handler.js` | Only on **existing suggestions** that are re-scraped and no longer need prerender |
+| `data.coveredByDomainWide` | `Suggestion.data` | `handler.js` | Only when `isDeployedAtEdge=true` for the URL AND a domain-wide suggestion with `edgeDeployed` is active |
+| Core `data.*` fields | `Suggestion.data` | `handler.js` | On **new suggestion creation** via `mapSuggestionData`. Also updated via `mergeDataFunction` when the same URL is re-scraped: spreads existing data then overlays new — so `scrapeJobId`, word counts, S3 keys, `citabilityScore` ARE updated on re-discovery (the c8-ignored branch in the merge function) |
+| `data.aiSummary` | `Suggestion.data` | `guidance-handler.js` | Updated only when `aiSummary` is truthy AND `!== 'not available'` (case-insensitive). Otherwise preserves existing value (`currentData.aiSummary ?? ''`) — note the fallback is empty string `''`, not `undefined`. OUTDATED suggestions are skipped entirely before the URL map is built. |
+| `data.valuable` | `Suggestion.data` | `guidance-handler.js` | Updated atomically with `aiSummary` (same condition). If Mystique sends a non-boolean `valuable`, it defaults to `true`. If aiSummary is invalid (not updated), existing `valuable` is preserved (`currentData.valuable ?? true`). Never updated independently. |
+
+**The audit worker NEVER writes**:
+- `data.edgeDeployed` — set exclusively by user deploy action via UI (spacecat-api-service)
+- `data.aiSummary`, `data.valuable` — written only by guidance-handler.js, never by main handler
+- Any status other than `NEW` or `OUTDATED`
+
+**guidance-handler.js also skips**: OUTDATED suggestions are excluded before the URL→suggestion map is built — Mystique responses never update stale suggestions.
+
+### isDeployedAtEdge=true Behavior (3-Part Invariant)
+
+1. **Step 2**: URL excluded from scraper submission — not re-audited
+2. **Step 3**: URL's existing suggestion excluded from `OUTDATED` marking — never falsely staled
+3. **Step 3**: If a domain-wide suggestion has `edgeDeployed` set → audit writes `coveredByDomainWide` on that URL's suggestion (the only data mutation the audit makes on existing suggestions)
+
+Note: If no domain-wide suggestion with `edgeDeployed` exists, the URL's suggestion is simply left unchanged (not marked OUTDATED, not modified). It is the UI/api-service's responsibility to set `edgeDeployed` after a deploy action.
+
+---
+
+## Domain-Wide Suggestion Preservation Logic
+
+The function `shouldPreserveDomainWideSuggestion()` (`handler.js:130`) decides whether to keep an existing domain-wide suggestion across audit runs:
+
+```javascript
+const ACTIVE_STATUSES = [
+  Suggestion.STATUSES.NEW,
+  Suggestion.STATUSES.FIXED,
+  Suggestion.STATUSES.PENDING_VALIDATION,
+  Suggestion.STATUSES.SKIPPED,
+];
+
+return ACTIVE_STATUSES.includes(status) || !!data?.edgeDeployed;
+```
+
+**Preserved when**:
+
+| Condition | Reason |
+|-----------|--------|
+| Status = `NEW` | Suggestion is live and unacted on; preserve it for the user |
+| Status = `FIXED` | Already deployed and validated; don't recreate |
+| Status = `PENDING_VALIDATION` | Deployment in flight; don't recreate |
+| Status = `SKIPPED` | User dismissed it; respect that decision |
+| `data.edgeDeployed` is set | Was deployed at some point (regardless of status); deployment state must persist |
+
+**NOT preserved** (audit creates fresh): `APPROVED`, `OUTDATED`, `ERROR`, `REJECTED`, `IN_PROGRESS`
+
+**Note**: `APPROVED` is intentionally not preserved — if a user approved but hasn't deployed yet, the next audit run will recreate the domain-wide suggestion with updated metrics. The `edgeDeployed` check covers the post-deploy path regardless of what status was set.
+
+**Locked**: Do not change this function's logic without confirming with the UI team — the tab display in project-elmo-ui depends on these states.
+
+---
+
+## OUTDATED Marking Protection
+
+URLs are marked OUTDATED only if ALL conditions met:
+
+```
+- URL is in scrapedUrlsSet (was actually scraped)
+- data.edgeDeployed is falsy (no prerender needed for edge-deployed URLs)
+- data.coveredByDomainWide is null/falsy (no domain-wide suggestion covers it)
+- data.isDomainWide is not true (not the domain-wide suggestion itself)
+- URL is NOT in failed scrapes (error during scraping)
+```
+
+**Rationale**: Prevent false OUTDATED marking that causes user confusion.
+
+---
+
+## Domain-Wide Suggestion Edge Cases
+
+1. **edgeDeployed** (timestamp ms): Set by **user action from the UI** when deploying a suggestion — NOT set by the audit worker. Two deploy paths:
+   - **Individual URL deploy** → `edgeDeployed` timestamp written to that URL's suggestion only
+   - **Domain-wide suggestion deploy** → `edgeDeployed` written to the domain-wide suggestion only; individual URL suggestions that fall under the pattern get `coveredByDomainWide` (UUID) set — done by `spacecat-api-service`
+   - Audit worker reads `data.edgeDeployed` only to preserve suggestions (not mark OUTDATED); it never writes this field
+
+2. **coveredByDomainWide** (UUID string of the domain-wide suggestion): Set in two ways:
+   - By `spacecat-api-service` when user deploys the domain-wide suggestion
+   - By **prerender audit** itself: when a new scrape detects `isDeployedAtEdge=true` for a URL and there is already an active domain-wide suggestion deployed — audit sets `coveredByDomainWide` on that URL's suggestion
+   - **Why `coveredByDomainWide` instead of setting status=SKIPPED**: The SKIPPED approach was tried but abandoned because rollback only clears `coveredByDomainWide` — it doesn't touch status. With SKIPPED, the UI had to manually call `bulkUpdateSuggestionsStatus(NEW)` after rollback. With `coveredByDomainWide`, clearing the field on rollback auto-returns suggestions to the Current tab with no UI changes needed.
+
+3. **isDomainWide=true**: This IS the domain-wide suggestion (url=baseUrl+`/* (All Domain URLs)`, pathPattern=`/*`)
+
+**isDeployedAtEdge vs edgeDeployed — critical distinction:**
+
+| Field | Source | Type | Set by | Meaning |
+|-------|--------|------|--------|---------|
+| `isDeployedAtEdge` | scrape.json → status.json pages[] | boolean | content-scraper | CDN/Tokowaka edge optimization detected in HTTP headers |
+| `edgeDeployed` | Suggestion.data | number (ms epoch timestamp) | user action via UI | User has deployed a suggestion from the project-elmo-ui |
+
+---
+
+## Domain-Wide Aggregate — How Metrics Are Computed
+
+`prepareDomainWideAggregateSuggestion()` builds one domain-wide suggestion from all per-URL suggestions that need prerender:
+
+```
+contentGainRatio    = SUM of all per-URL contentGainRatios
+wordCountBefore     = SUM of all per-URL wordCountBefore
+wordCountAfter      = SUM of all per-URL wordCountAfter
+aiReadablePercent   = SUM of per-URL round((wordCountBefore / wordCountAfter) * 100)
+```
+
+`aiReadablePercent` is a sum of per-URL percentages, **not an average** — it can exceed 100. The UI interprets it accordingly. `agenticTraffic` is intentionally omitted from this object (computed by the UI from fresh CDN log data).

--- a/src/prerender/.claude/system-interactions.md
+++ b/src/prerender/.claude/system-interactions.md
@@ -1,0 +1,591 @@
+# System Interactions Reference — Prerender Audit
+
+Indexed Q&A answers for the 7 cross-system interaction questions. Each section can be
+read independently. Companion to CLAUDE.md (which covers internal mechanics).
+
+---
+
+## 1 · Import Worker Interaction
+
+**How step 1 triggers the import worker and how step 2 consumes its output**
+
+### Trigger mechanism
+
+Step 1 (`importTopPages`) returns a plain object:
+```js
+{
+  type: 'top-pages',
+  siteId: site.getId(),
+  auditResult: { status: 'preparing', finalUrl },
+  fullAuditRef: `scrapes/${site.getId()}/`,
+  // auditContext.urls is forwarded if CSV mode
+}
+```
+
+The AuditBuilder (via `AUDIT_STEP_DESTINATIONS.IMPORT_WORKER`) enqueues this to
+`IMPORT_WORKER_QUEUE_URL` (from `context.env`) formatted as:
+```js
+{
+  type: 'top-pages',
+  siteId,
+  auditContext: {
+    next: 'submitForScraping',   // step 2 step name
+    auditId, auditType, fullAuditRef,
+    urls: [...],                  // only present in CSV mode
+  },
+}
+```
+
+### Import worker's job
+
+The import worker receives `type: 'top-pages'`, fetches GSC organic keyword data for
+the site, and writes rows into the `SiteTopPage` DB table. When done it enqueues
+a message to resume the audit at step 2 (`submit-for-scraping`).
+
+### Step 2 consumption
+
+`getTopOrganicUrlsFromSeo()` reads the freshly populated table:
+```js
+SiteTopPage.allBySiteIdAndSourceAndGeo(siteId, 'seo', 'global')
+```
+Returns up to `TOP_ORGANIC_URLS_LIMIT=200` pages sorted by organic traffic.
+
+**Why step 1 cannot fetch URLs itself**: `SiteTopPage` is stale before the import worker
+completes. Reading it in step 1 returns data from the previous import run.
+
+---
+
+## 2 · Content-Scraper (spacecat-content-scraper) Interaction
+
+**How scraper jobs are submitted, what they produce, and how step 3 consumes them**
+
+### Job submission (step 2)
+
+```js
+ScrapeClient.createScrapeJob({
+  urls: filteredUrls.map((url) => ({ url })),
+  siteId,
+  processingType: 'prerender',   // exact string — scraper routes on this
+  maxScrapeAge: 0,
+  options: { pageLoadTimeout: 20000, storagePrefix: 'prerender' },
+})
+```
+
+`processingType: 'prerender'` is checked by `PrerenderHandler.accepts()` in the scraper.
+Changing this string breaks routing.
+
+### S3 output (written by scraper per URL)
+
+```
+prerender/scrapes/{scrapeJobId}/{sanitizedPath}/server-side.html
+prerender/scrapes/{scrapeJobId}/{sanitizedPath}/client-side.html
+prerender/scrapes/{scrapeJobId}/{sanitizedPath}/server-side-html.md
+prerender/scrapes/{scrapeJobId}/{sanitizedPath}/markdown-diff.md
+prerender/scrapes/{scrapeJobId}/{sanitizedPath}/scrape.json
+```
+
+`sanitizedPath` uses the canonical regex in `PrerenderHandler.sanitizeImportPath()` —
+see CLAUDE.md for the exact regex. The audit worker must replicate it to rebuild S3 paths.
+
+### Step 3 input (AuditBuilder pre-population)
+
+`step-audit.js:177` calls `scrapeClient.getScrapeResultPaths(scrapeJobId)` before
+step 3 fires and stores the result as `context.scrapeResultPaths: Map<url, pathInfo>`.
+
+Step 3's `compareHtmlContent()` iterates this map to download and compare HTML files.
+
+### scrape.json schema (key fields)
+
+```json
+{
+  "status": "COMPLETE | FAILED",
+  "isDeployedAtEdge": true,
+  "usedEarlyClientSideHtml": false,
+  "error": { "message": "...", "type": "HttpError", "statusCode": 403 }
+}
+```
+
+`isDeployedAtEdge` = scraper detected Tokowaka/edge-optimize response headers.
+NOT the same as `Suggestion.data.edgeDeployed` (set by user deploy action in UI).
+
+---
+
+## 3 · URL Fetching and Daily Batch Preparation
+
+**How step 2 selects URLs from three sources and caps the batch**
+
+### Three modes
+
+| Mode | Trigger | URL sources | Filters |
+|------|---------|-------------|---------|
+| `csv` | `auditContext.urls` present | `auditContext.urls` rebased to preferredBase | dedup + HTML-only |
+| `slack` | `slackContext.channelId` set | organic + includedURLs | dedup + HTML-only; no PageCitability, no edge filter |
+| `normal` | scheduled run | organic + agentic + includedURLs | PageCitability dedup + edge-deployed filter + DAILY_BATCH_SIZE cap |
+
+### Normal-mode pipeline (actual execution order)
+
+```
+1. Read siteStatus from S3 (status.json)
+2. isStickyBotBlocked(siteStatus)             → if blocked within 3 days → return { urls: [], domainBlocked: true }
+3. getTopOrganicUrlsFromSeo()                 → up to TOP_ORGANIC_URLS_LIMIT=200
+4. getTopAgenticUrls()                        → up to TOP_AGENTIC_URLS_LIMIT=2000
+5. site.getConfig().getIncludedURLs()         → manually configured URLs
+6. Rebase all three to preferredBase
+7. getRecentlyProcessedPathnames(siteId)      → Set<pathname> from PageCitability (7-day window, uses updatedAt)
+8. getEdgeDeployedPathnames(siteStatus)       → Set<pathname> from status.json pages[].isDeployedAtEdge
+9. Filter each source independently:
+   filteredOrganic  = organic.filter(notRecent AND notEdgeDeployed)
+   filteredIncluded = included.filter(notRecent AND notEdgeDeployed)
+   filteredAgentic  = agentic.filter(notRecent AND notEdgeDeployed)
+10. Concatenate in priority order (NOT sorted — concat IS the priority):
+    candidates = [...filteredOrganic, ...filteredIncluded, ...filteredAgentic]
+11. Slice to DAILY_BATCH_SIZE=320
+12. mergeAndGetUniqueHtmlUrls(batchedUrls)    → final www/non-www dedup + HTML-only filter
+```
+
+**Critical**: bot-block check (step 2) fires before any URL fetching. The current Selection
+Algorithm in CLAUDE.md previously had this in the wrong position.
+
+### Athena query details (`getTopAgenticLiveUrlsFromAthena`)
+
+- Queries last 1 week of CDN log data (via `weeklyBreakdownQueries.createTopUrlsQueryWithLimit`)
+- Filters to HTTP 200 responses only (excludes 404s, 410s, 429s, etc.)
+- Excludes URL suffixes: `.pdf`, `.xml`, `/sitemap.xml`, `/robots.txt`, `.ico`, `.xls`, etc.
+- Requires `cdn-logs-analysis` handler to be enabled for the site in Configuration
+- Falls back to `[]` if Athena unavailable or query fails (warn logged)
+- Results are rebased to the site's `preferredBaseUrl`
+
+### PageCitability dedup query
+
+```js
+PageCitability.allByIndexKeys(
+  { siteId },
+  { where: (attrs, op) => op.gte(attrs.updatedAt, recentWindowStart.toISOString()) }
+)
+// recentWindowStart = subDays(new Date(), 7)
+```
+
+Returns a `Set<pathname>`. Any URL whose pathname appears in this set is skipped for
+the current batch.
+
+---
+
+## 4 · Error Handling
+
+**How the audit handles partial and complete failures at each stage**
+
+### URL source failures
+
+| Source | Failure | Behavior |
+|--------|---------|---------|
+| Athena (agentic) | Any error | `getTopAgenticUrls()` returns `[]`; warn logged; audit continues with organic only |
+| PageCitability query | Any error | Returns `new Set()`; all URLs submitted (no dedup); warn logged |
+| SiteTopPage unavailable | No rows | Returns `[]`; warn logged |
+| `cdn-logs-analysis` disabled | Config check | Returns `[]`; info logged |
+
+### Scrape failures (step 3)
+
+- **Zero successful scrapes** (`scrapeResultPaths.size === 0`): Fallback path fires — re-fetches
+  organic + agentic + included URLs and calls `compareHtmlContent` using HTML from a **previous**
+  scrape run on S3. This silently processes stale data. A known observability gap: the fallback
+  is not covered by tests (`/* c8 ignore */`) but IS reachable in production.
+- **Per-URL scrape failure**: URL absent from `scrapeResultPaths`; counted as missing in
+  `getScrapeJobStats()`; appears in `status.json pages[]` with `scrapingStatus: 'failed'`
+- **403 bot-block**: Counted by `getScrapeJobStats()` via two paths:
+  - COMPLETE-status 403s: from in-memory `comparisonResults` (scrape.json `error.statusCode=403`)
+  - FAILED-status 403s: from `ScrapeUrl` DB + S3 `scrape.json` (slower path, added in #2245)
+
+### Bot-block response
+
+If 403 ratio ≥ 0.5 AND confidence ≥ 0.99:
+```
+→ Sets scrapeForbidden=true in status.json
+→ Sets scrapeForbiddenSince=now
+→ Next step 2 reads these flags; if within 3 days → skips scraping entirely
+```
+
+### Complete domain block (isDomainBlocked)
+
+```
+step 3 receives isDomainBlocked=true from status.json
+→ Creates dummy opportunity (so UI shows blocked state)
+→ Uploads error status.json
+→ Skips syncSuggestions, markNewSuggestionsAsCovered, Mystique queueing
+→ Exits cleanly
+```
+
+### status.json upload on error (D-12)
+
+`status.json` is uploaded even when `syncSuggestions` throws. This ensures the UI
+always shows accurate status (including partial-failure state) rather than stale success data.
+
+---
+
+## 5 · Audit Data Maintenance Across Multiple Runs
+
+**How the audit preserves correct suggestion state across daily batch runs**
+
+### Suggestion diff logic (syncSuggestions)
+
+Each run compares current scrape results against existing DB suggestions:
+
+```
+Current scrape: URL A, B, C (all need prerender)
+Existing suggestions: URL A (NEW), URL B (APPROVED), URL D (NEW)
+
+→ URL A: matches existing → preserve as-is (no mutation)
+→ URL B: matches existing → preserve as-is (user approved, respect that)
+→ URL C: new URL → create suggestion with status NEW
+→ URL D: was in previous batch, not in current → mark OUTDATED
+         (only if: in scrapedUrlsSet AND not edgeDeployed AND not coveredByDomainWide)
+```
+
+### OUTDATED protection rules (all must be true to mark OUTDATED)
+
+1. URL was in `scrapedUrlsSet` (was actually scraped this run)
+2. `data.edgeDeployed` is falsy (user hasn't deployed it)
+3. `data.coveredByDomainWide` is null/falsy (not covered by domain-wide deployment)
+4. `data.isDomainWide` is not true (not the domain-wide suggestion itself)
+5. URL not in failed scrapes
+
+**Rationale**: If a URL was not scraped (missed by dedup, outside batch window), it must NOT
+be marked OUTDATED — we simply have no data about it. Only mark OUTDATED when we have
+evidence the URL no longer needs prerender.
+
+### Domain-wide suggestion preservation
+
+Preserved across runs if status is NEW, FIXED, PENDING_VALIDATION, SKIPPED, OR `data.edgeDeployed` is set.
+NOT preserved for: APPROVED, OUTDATED, ERROR, REJECTED, IN_PROGRESS.
+
+See `shouldPreserveDomainWideSuggestion()` in `handler.js:130`.
+
+### PageCitability record maintenance
+
+After each successful scrape, `writeCitabilityMetrics()` upserts a `PageCitability` record
+per URL. This record's `updatedAt` timestamp is what the next run's 7-day dedup reads.
+URLs processed today won't be in the next 7 days of batches.
+
+---
+
+## 6 · Database Interactions
+
+**Which DB entities are read and written, in which step, and with what bulk semantics**
+
+### Read operations
+
+| Entity | Method | Step | Purpose |
+|--------|--------|------|---------|
+| `SiteTopPage` | `allBySiteIdAndSourceAndGeo(siteId, 'seo', 'global')` | Step 2 | Organic URL source |
+| `PageCitability` | `allByIndexKeys({ siteId }, { where: gte(updatedAt, 7dAgo) })` | Step 2 | Dedup recently processed URLs |
+| `Opportunity` | `allBySiteIdAndType(siteId, 'prerender')` | Step 3 | Find/create opportunity |
+| `Suggestion` | `allByOpportunityId(opportunityId)` | Step 3 | Diff against existing suggestions |
+| `ScrapeUrl` | `allByScrapeJobId(scrapeJobId)` | Step 3 | Failed-status URL 403 detection |
+| `Configuration` | `findLatest()` | Step 2 | Check cdn-logs-analysis enabled |
+
+### Write operations
+
+| Entity | Method | Step | Trigger |
+|--------|--------|------|---------|
+| `Opportunity` | `create()` / `save()` | Step 3 | New opportunity or data update |
+| `Suggestion` | `Suggestion.saveMany(newSuggestions)` | Step 3 | Batch create new suggestions (status=NEW) |
+| `Suggestion` | `s.setStatus(OUTDATED); Suggestion.saveMany(stale)` | Step 3 | Batch mark stale suggestions OUTDATED |
+| `Suggestion` | `s.setData({ coveredByDomainWide: id }); saveMany(covered)` | Step 3 | Only data field written on existing suggestions |
+| `PageCitability` | `create()` / `save()` | Step 3 | Upsert per-URL citability record after scrape |
+| `Suggestion.data.aiSummary` + `valuable` | atomic update | guidance-handler | Mystique AI response |
+
+### Bulk operation discipline
+
+N+1 is prohibited — connection pool is 200 connections (10 tasks × 20). Correct patterns:
+
+```js
+await Suggestion.saveMany(suggestionsToCreate);    // new suggestions
+await Suggestion.saveMany(suggestionsToOutdate);   // OUTDATED marking
+await Suggestion.removeByIds(ids);                 // removal
+```
+
+---
+
+## 7 · Mystique (AI Summarizer) Interaction
+
+**How step 3 queues AI work and how guidance-handler.js processes responses**
+
+### Queuing (step 3)
+
+`sendPrerenderGuidanceRequestToMystique()` is called after syncSuggestions.
+
+**Skip conditions** (suggestions excluded from Mystique queue):
+- Status `OUTDATED` (guidance-handler.js filters these first)
+- Status `FIXED`
+- `data.edgeDeployed` is truthy
+
+**Payload shape** (one SQS message per batch):
+```json
+{
+  "type": "guidance:prerender",
+  "siteId": "...",
+  "suggestions": [
+    {
+      "suggestionId": "uuid",          // REQUIRED — Pydantic validates this
+      "url": "https://...",
+      "scrapeJobId": "...",            // per-suggestion, not current run's ID
+      "wordCountBefore": 181,
+      "wordCountAfter": 5450,
+      "contentGainRatio": 30.11
+    }
+  ]
+}
+```
+
+**Batch limit**: `MYSTIQUE_BATCH_SIZE=100` suggestions per SQS message. D-14 explains why:
+lenscrafters.com had 1,700+ suggestions — a single message exceeded AWS's 256 KB SQS limit.
+
+**`suggestionId` requirement**: D-08 — Mystique's Pydantic model requires `suggestion_id: str`.
+If absent, the entire message is dropped silently. Always build the `urlToSuggestionId` map
+using `preferredBase`-normalized URLs to avoid www/non-www mismatch.
+
+**`scrapeJobId` per suggestion**: Uses `data.scrapeJobId` from when the suggestion was first
+created (not the current run's job ID). Mystique builds S3 paths using this ID — using the
+wrong ID causes `NoSuchKey` errors.
+
+### Response processing (guidance-handler.js)
+
+Mystique calls back asynchronously. `guidance-handler.js` processes the response:
+
+1. Filters out OUTDATED suggestions (no updates for stale records)
+2. Builds `suggestionId → suggestion` map
+3. For each Mystique result:
+   - If `aiSummary` is valid (non-null, not "Not available") → update both `aiSummary` + `valuable`
+   - If `aiSummary` is invalid → preserve existing `aiSummary` + `valuable` (D-15: they're a pair)
+4. `Suggestion.saveMany(updated)` — bulk write
+
+---
+
+## 8 · Content Gain Calculation
+
+**How server-side vs client-side HTML are compared to determine prerender need**
+
+### Call chain
+
+```
+handler.js:compareHtmlContent()
+  → For each URL in scrapeResultPaths:
+    → Download server-side.html from S3  (directHtml)
+    → Download client-side.html from S3  (scrapedHtml)
+    → analyzeHtmlForPrerender(directHtml, scrapedHtml, CONTENT_GAIN_THRESHOLD=1.1)
+      → @adobe/spacecat-shared-html-analyzer: calculateStats(directHtml, scrapedHtml, true)
+        → returns: {
+             contentIncreaseRatio,   ← mapped to contentGainRatio
+             wordCountBefore,
+             wordCountAfter,
+             citationReadability,    ← mapped to citabilityScore
+             wordDiff,
+           }
+      → needsPrerender = contentIncreaseRatio >= 1.1
+```
+
+### Threshold
+
+`CONTENT_GAIN_THRESHOLD = 1.1` (from `src/prerender/utils/constants.js`).
+
+Passed explicitly to `analyzeHtmlForPrerender()`. The wrapper's default is 1.2 but the
+caller overrides it with the 1.1 constant — the constant is authoritative.
+
+A ratio of 1.1 means client-rendered HTML has at least 10% more content than server-rendered.
+
+### Field name mapping
+
+| shared-html-analyzer | handler.js / status.json | Suggestion.data |
+|---------------------|-------------------------|-----------------|
+| `contentIncreaseRatio` | `contentGainRatio` | `contentGainRatio` |
+| `wordCountBefore` | `wordCountBefore` | `wordCountBefore` |
+| `wordCountAfter` | `wordCountAfter` | `wordCountAfter` |
+| `citationReadability` | `citabilityScore` | `citabilityScore` |
+
+### Wrapper purpose (D-20)
+
+`html-comparator.js` is a thin wrapper (no additional logic beyond threshold application
+and field renaming). It exists to:
+1. Decouple prerender-specific threshold from the shared package's generic API
+2. Keep the shared package independently mockable in tests
+
+### Error handling
+
+If `directHtml` or `scrapedHtml` is missing → `analyzeHtmlForPrerender` throws
+`'Missing HTML content for comparison'`. `compareHtmlContent` catches per-URL and
+sets `result.error = true` (URL counted as failed, not as needing prerender).
+
+### `usedEarlyClientSideHtml` flag
+
+When the scraper falls back to early JS execution HTML (before full page load),
+`scrape.json.usedEarlyClientSideHtml = true`. This flag propagates to `status.json pages[]`.
+The word count comparison is less reliable in this case — the UI can caveat display
+(D-19 explains why this was added).
+
+---
+
+## 9 · S3 Schemas & Locked Path Contracts
+
+**Full schemas for scraper-written files and status.json, plus path construction rules.**
+
+### sanitizeImportPath Regex (Locked Contract)
+
+The regex lives in **`spacecat-content-scraper/src/handlers/prerender-handler.js`** and is the canonical definition. The audit worker replicates it exactly to reconstruct S3 paths:
+
+```js
+// Canonical definition (PrerenderHandler.sanitizeImportPath)
+importPath
+  .replace(/^\/+|\/+$/g, '')  // Remove leading/trailing slashes
+  .replace(/[/._]/g, '-')     // Replace /, ., _ with hyphens
+  .replace(/-+/g, '-')        // Collapse multiple hyphens to one
+  .replace(/^-|-$/g, '');     // Remove leading/trailing hyphens
+// Example: "/static/manuals/2021/cx-5/contents/04091000.html"
+//       → "static-manuals-2021-cx-5-contents-04091000-html"
+```
+
+All existing S3 keys depend on this exact regex. Modifying it invalidates all historical path lookups and requires a data migration.
+
+### S3 Files Written by the Scraper (per URL)
+
+```
+prerender/scrapes/{scrapeJobId}/{sanitizedPath}/server-side.html      ← raw HTML before JS
+prerender/scrapes/{scrapeJobId}/{sanitizedPath}/client-side.html      ← HTML after JS execution
+prerender/scrapes/{scrapeJobId}/{sanitizedPath}/server-side-html.md   ← markdown of server-side (for Mystique)
+prerender/scrapes/{scrapeJobId}/{sanitizedPath}/markdown-diff.md      ← added markdown blocks only (for Mystique)
+prerender/scrapes/{scrapeJobId}/{sanitizedPath}/scrape.json           ← per-URL metadata
+prerender/scrapes/{siteId}/status.json                                ← written by audit worker, not scraper
+```
+
+### Reading Scraper Outputs (Step 3)
+
+Step 3 receives `context.scrapeResultPaths: Map<url, pathInfo>` pre-populated by AuditBuilder. `compareHtmlContent(url, pathInfo)` uses this to:
+
+1. Download `server-side.html` → `directHtml` (baseline, before JS)
+2. Download `client-side.html` → `scrapedHtml` (post-JS)
+3. Download `scrape.json` → `isDeployedAtEdge`, `usedEarlyClientSideHtml`, `error`
+4. Pass `directHtml` + `scrapedHtml` to `analyzeHtmlForPrerender()` → `contentGainRatio`
+
+For **Mystique** processing, step 3 reads `originalHtmlMarkdownKey` and `markdownDiffKey` from Suggestion.data — these point to the `.md` files in the same scrapeJobId path.
+
+**Bot-blocked URLs**: When `botProtection.blocked = true`, the scraper does NOT call `#store()` — no `scrape.json` is written. The audit worker detects this as a missing S3 key (counted as a failed scrape, may trigger bot-block reactive check).
+
+### scrape.json — Full Schema
+
+Written by `PrerenderHandler.#store()` in spacecat-content-scraper:
+
+```json
+{
+  "url": "string (finalUrl after redirects)",
+  "urlId": "string",
+  "status": "COMPLETE | FAILED",
+  "scrapedAt": 1747000000000,
+  "scrapeTime": 1234,
+  "userAgent": "string",
+  "hasServerSideHtml": true,
+  "hasClientSideHtml": true,
+  "hasMarkdownDiffFile": true,
+  "isDeployedAtEdge": true,
+  "jobMetadata": {},
+  "usedEarlyClientSideHtml": false,
+  "edgeDeploymentDetectionFailed": { "error": "..." },
+  "error": { "message": "...", "type": "HttpError", "statusCode": 403 },
+  "markdownAnalysisError": { "message": "...", "type": "Error" }
+}
+```
+
+**`isDeployedAtEdge`** is a boolean set when Tokowaka/edge-optimize response headers are detected. It is forwarded to `status.json pages[].isDeployedAtEdge`. It is **not** the same as `Suggestion.data.edgeDeployed` (a timestamp set by user deploy action).
+
+### Edge Deployment Detection (in scraper)
+
+The scraper makes a separate HTTP GET with:
+```
+User-Agent: Mozilla/5.0 ... Tokowaka-AI Tokowaka/1.0 AdobeEdgeOptimize-AI AdobeEdgeOptimize/1.0
+```
+If any of these response headers are present → `isDeployedAtEdge = true`:
+- `x-edgeoptimize-cache`
+- `x-edgeoptimize-proxy`
+- `x-tokowaka-cache`
+- `x-tokowaka-proxy`
+
+### status.json — Full Schema (Locked Contract)
+
+**Location**: `prerender/scrapes/{siteId}/status.json`
+**Written by**: audit worker (`uploadStatusSummaryToS3`)
+**Consumers**: project-elmo-ui, spacecat-api-service
+**Cannot change field names or semantics without UI coordination**
+
+```json
+{
+  "auditResult": { "status": "complete", "finalUrl": "string" },
+  "auditType": "prerender",
+  "auditedAt": "ISO timestamp",
+  "fullAuditRef": "scrapes/{siteId}/",
+  "isLive": false,
+  "isError": false,
+  "siteId": "string",
+  "invocationId": "string (Lambda invocation ID)",
+  "baseUrl": "string",
+  "scrapeJobId": "string (fallback chain — see below)",
+  "lastUpdated": "ISO timestamp",
+  "urlsNeedingPrerender": 2920,
+  "urlsScrapedSuccessfully": 3522,
+  "urlsSubmittedForScraping": 3646,
+  "scrapingErrorRate": 3.4,
+  "scrapeForbidden": false,
+  "scrapeForbiddenSince": "ISO timestamp (only present when scrapeForbidden=true)",
+  "scrapeForbiddenCount": 0,
+  "isDomainBlocked": false,
+  "lastAuditSuccess": true,
+  "pages": [
+    {
+      "url": "string",
+      "scrapingStatus": "success | failed | forbidden",
+      "needsPrerender": true,
+      "isDeployedAtEdge": true,
+      "usedEarlyClientSideHtml": false,
+      "wordCountBefore": 181,
+      "wordCountAfter": 5450,
+      "contentGainRatio": 30.11,
+      "scrapedAt": "ISO timestamp",
+      "scrapeJobId": "string"
+    }
+  ]
+}
+```
+
+**Key semantics:**
+- `urlsNeedingPrerender`: **Count (number)**, not an array — grows cumulatively across daily batches (merge behavior, see below)
+- `scrapingErrorRate`: **Percentage** (e.g., 3.4 = 3.4% error rate), not a 0.0–1.0 ratio
+- `scrapeForbidden`: Sticky bot-block flag; read by next step 2 run; expires after 3-day window
+- `isDomainBlocked`: Hard block — step 3 skips syncSuggestions entirely when true
+- `pages[].contentGainRatio` threshold ≥ 1.1 → `needsPrerender = true`
+
+### uploadStatusSummaryToS3 — Merge Behaviour
+
+Does NOT simply overwrite. Each run:
+
+1. Reads the existing status.json from S3
+2. Builds `currentPages` from the current run's `comparisonResults` + `missingPages`
+3. Merges: existing pages for URLs NOT in the current run are appended unchanged
+4. Computes `urlsNeedingPrerender`, `urlsScrapedSuccessfully`, `scrapingErrorRate` from the **merged** page set
+5. Per-page `scrapeJobId`: URLs in `submittedUrlSet` (from ScrapeUrl DB) get the current `scrapeJobId`; fallback URLs not in `submittedUrlSet` preserve their old `scrapeJobId`
+
+This means `urlsNeedingPrerender` grows over time as batches process — it reflects the cumulative state across all batches since the last full-site reset.
+
+### scrapeJobId Fallback Chain (3-Level, Order Is Locked)
+
+```
+1. data.scrapeJobId        — primary (set by ScrapeClient on creation)
+2. path segment [2] from originalHtmlKey  — fallback (extract from S3 key)
+3. null                    — final fallback
+```
+
+Never reorder. Mystique constructs S3 paths using the scrapeJobId from when the suggestion was *first created* — using the wrong ID causes `NoSuchKey`.
+
+### URL Normalization for Suggestion Lookup
+
+All URL comparisons against Suggestion.data must use the normalized `preferredBase` domain. Production data showed `https://www.micron.com/...` and `https://micron.com/...` variants coexisting from different audit runs — exact string match silently missed, causing 8/13 suggestions to be sent to Mystique without `suggestionId`. Always normalize to the site's preferred base before map lookups.
+
+### normalizePathname Function
+
+- **Location**: `src/utils/utils.js` (SHARED, referenced by 10+ audits — GSC, lighthouse, etc.)
+- **Do not move** without coordinating updates across all importing audits

--- a/src/prerender/.claude/ui-data-map.md
+++ b/src/prerender/.claude/ui-data-map.md
@@ -1,0 +1,252 @@
+# UI Data Map — project-elmo-ui
+
+Understanding how the UI consumes `status.json` and `Suggestion.data` is critical — any audit worker change that modifies these fields affects the UI.
+
+---
+
+## Source Files
+
+| File | Role |
+|------|------|
+| `src/hooks/usePrerenderGains.ts` | Data fetching, thresholds, score calculations |
+| `src/components/dashboards/opportunities/PrerenderOpportunitySection.tsx` | Main opportunity card and deploy UX |
+| `src/utils/techGeoOpportunityUtils.ts` | Card creation, `allOptimized` detection |
+| `src/components/ui/ExpandableURLSuggestionsTable.tsx` | Tab filter logic, status column rendering |
+
+---
+
+## Data Flow Overview
+
+```
+status.json (S3)
+  └─► usePrerenderGains.ts
+        ├─ Pages[] processing → rcvScoreByUrl (Map<url, score>), deployedAtEdgeUrls (Set<url>)
+        ├─ Score aggregation → avgLlmVisibilityScore
+        ├─ Error detection → scrapingErrorRateHigh, scrapeForbidden
+        └─ Returns computed values ─────────────────────────────────────────┐
+                                                                            ▼
+Opportunity API (REST)                                      PrerenderOpportunitySection.tsx
+  └─► Suggestions[] with Suggestion.data fields             ├─ Renders opportunity card header
+        ├─ edgeDeployed, coveredByDomainWide               ├─ affectedPagesCount, estimatedContentGain
+        ├─ wordCountBefore, wordCountAfter                 ├─ Deploy / Rollback buttons
+        └─► ExpandableURLSuggestionsTable.tsx              └─► techGeoOpportunityUtils.ts (card setup)
+               ├─ Current tab (active work)
+               ├─ Fixed tab (deployed/optimized)
+               └─ Ignored tab (skipped)
+```
+
+---
+
+## `usePrerenderGains.ts` — Full Data Map
+
+**S3 key consumed:** `prerender/scrapes/${siteId}/status.json`
+
+### Constants
+```ts
+PRERENDER_STATUS_JSON_KEY        = 'prerender'
+SCRAPING_ERROR_RATE_THRESHOLD    = 30   // % (matches status.json scrapingErrorRate field)
+MIN_SCRAPED_PAGES_THRESHOLD      = 50   // absolute count of urlsScrapedSuccessfully
+```
+
+### Per-URL Score Function
+```ts
+getLlmVisibilityScore(wordCountBefore, wordCountAfter):
+  Returns 100 if isDeployed OR !!coveredByDomainWide    // already handled
+  Returns min(100, round(wordCountBefore / wordCountAfter * 100))  // raw visibility
+```
+This function is **exported** — consumed by ExpandableURLSuggestionsTable for per-row score display.
+
+### status.json → Derived URL Sets
+
+| Derived set | Definition from `status.json pages[]` |
+|-------------|--------------------------------------|
+| `pagesNotNeedingPrerender` | `needsPrerender === false && scrapingStatus === 'success'` |
+| `pagesDeployedAtEdge` | `isDeployedAtEdge === true && needsPrerender === true` |
+| `deployedAtEdgeSet` | `isDeployedAtEdge === true && needsPrerender === true` (used for `deployedAtEdgeUrls` Set) |
+
+**Note:** `pagesDeployedAtEdge` intentionally excludes pages where `needsPrerender === false` — these are already good without edge deployment and count in `pagesNotNeedingPrerender` instead.
+
+### `avgLlmVisibilityScore` — Full Calculation
+
+This is the primary "LLM Visibility" score shown in the card header.
+
+```
+Step 1: score each non-domain-wide suggestion:
+  if (edgeDeployed || coveredByDomainWide || isDeployed) → 100
+  else → min(100, round(wordCountBefore / wordCountAfter * 100))
+
+Step 2: add pagesNotNeedingPrerender × 100
+  (these pages already have full visibility)
+
+Step 3: divide by (scoredSuggestions + pagesNotNeedingPrerender)
+  = weighted average across all URL types
+
+Special case:
+  if (isDomainWideDeployed && noOfUrlsNotNeedingPrerender === 0) → return 100
+  (entire domain deployed and everything needs prerender → 100%)
+```
+
+**Where `avgLlmVisibilityScore` is consumed:**
+- `PrerenderOpportunitySection.tsx` — renders as the headline "LLM Visibility" metric in the card
+- `techGeoOpportunityUtils.ts` — `allOptimized = avgLlmVisibilityScore === 100` controls `totalUrls` display
+- `usePrerenderGains.ts` itself — returned as part of hook result object
+
+### `scrapingErrorRateHigh` Logic
+
+```
+hasEnoughScrapedPages = urlsScrapedSuccessfully >= MIN_SCRAPED_PAGES_THRESHOLD (50)
+
+scrapingErrorRateHigh =
+  !hasEnoughScrapedPages
+  AND (lastAuditSuccess === false OR scrapingErrorRate >= SCRAPING_ERROR_RATE_THRESHOLD (30))
+
+EXCEPTION: if isDomainWideDeployed === true → scrapingErrorRateHigh forced to false
+  (don't show error banner when domain is already deployed)
+```
+
+**Maps to status.json fields:** `urlsScrapedSuccessfully`, `lastAuditSuccess`, `scrapingErrorRate`
+
+### `scrapeForbidden` Source
+
+Comes from **two sources** (OR logic):
+1. `prerenderStatus?.scrapeForbidden` — from `status.json` (scraper detected bot-block)
+2. `query.data.scrapeForbidden` — from opportunity REST API response (`Opportunity.data.scrapeForbidden`)
+
+If either is true, `isScrapeForbidden` is set and the UI shows a "scrape forbidden" warning.
+
+### Hook Return Values
+
+```ts
+{
+  data,                           // raw opportunity data from API
+  loading,
+  error,
+  refetch,
+  rcvScoreByUrl: Map<string, number>,  // per-URL LLM score (consumed by table for per-row display)
+  deployedAtEdgeUrls: Set<string>,     // URLs from status.json where isDeployedAtEdge=true && needsPrerender=true
+  computeFilteredScore,               // function: recomputes avgLlmVisibilityScore for a filtered URL subset
+  // also: avgLlmVisibilityScore, scrapingErrorRateHigh, scrapeForbidden, isDomainWideDeployed, ...
+}
+```
+
+---
+
+## `PrerenderOpportunitySection.tsx` — Card Metrics & UX
+
+Consumes `usePrerenderGains(true)` hook (the `true` parameter enables full data loading).
+
+### Computed Metrics
+
+| Metric | Calculation | Notes |
+|--------|-------------|-------|
+| `affectedPagesCount` | Count of suggestions where `!isDeployed && !coveredByDomainWide && !isDomainWide` | Set to 0 when `avgReadability === 100` |
+| `estimatedContentGain` | Average `contentGainRatio` across non-deployed URLs | Shown as "X× content gain" |
+| `showScoreUnavailable` | `isScrapeForbidden \|\| isScrapingErrorRateHigh \|\| (avgReadability === 0 && suggestionsCount === 0)` | Replaces score with unavailable state |
+
+### UX Flows by Tab
+
+**Current tab:**
+- Each row has a **Preview** button — opens HTML diff modal comparing `originalHtmlKey` (server-side) vs `prerenderedHtmlKey` (client-side) from `Suggestion.data`
+- Both S3 keys are used for the diff view; if either is missing, Preview is disabled
+
+**Fixed tab:**
+- Each deployed row has a **Live Preview** button — makes a live request to the Tokowaka edge URL to show optimized content
+- Status column displays deployment date from `edgeDeployed` ms timestamp
+- `edgeOptimizeStatus === 'STALE'` shows "Content Changed" warning (content has changed since deploy)
+
+**Rollback button:**
+- Only rendered when `siteHasEdgeOptimizeConfig === true` (site has an active edge optimize config)
+- Calls `rollbackSuggestions()` in the API → sets `prerender: false` in Tokowaka S3 config
+
+### Free-Tier Domain-Wide Row
+
+```
+shouldDisableDomainWideRow = isFreeTier && !enableUnlimitedUrlDeploys (feature flag)
+```
+
+Free-tier sites without the `enableUnlimitedUrlDeploys` LaunchDarkly flag cannot deploy domain-wide. The domain-wide row renders as disabled with an upgrade prompt.
+
+### Per-Batch Deploy Cap
+
+`PAID_TIER_MAX_DEPLOY_BATCH` — hard cap on suggestions per deploy call. Enforced in the component to prevent API timeouts on large sites. Selecting more than this limit shows a warning and clips the selection.
+
+---
+
+## `techGeoOpportunityUtils.ts` — Card Creation
+
+### `createPrerenderGainsOpportunity()` Behavior
+
+| Condition | Effect |
+|-----------|--------|
+| `scrapeForbidden === true` | Card is **still shown** — no suggestions needed; shows scrape-forbidden message |
+| `avgLlmVisibilityScore === 100` | `allOptimized = true` → `totalUrls = 0` (card shows "all optimized" state) |
+| `prerenderOpportunity.id` available | Uses actual DB opportunity ID for the card |
+| No DB opportunity ID | Falls back to static ID `'techgeo-prerender'` |
+
+### `nonDeployedUrls` Filter
+
+```ts
+nonDeployedUrls = suggestions.filter(s =>
+  !s.data.isDeployed &&
+  !s.data.coveredByDomainWide &&
+  !s.data.isDomainWide
+)
+```
+
+Used to calculate the "X pages need prerender" count displayed on the card.
+
+### `allOptimized` → `totalUrls = 0`
+
+When `avgLlmVisibilityScore === 100`, `totalUrls` is set to 0. This makes the card show a "fully optimized" state rather than a count of affected pages. This is different from having 0 suggestions — the score being 100 is the signal.
+
+---
+
+## `ExpandableURLSuggestionsTable.tsx` — Tab Logic & Status Column
+
+This is a **generic** reusable table component. The prerender-specific logic is injected via props (filter functions, status helpers).
+
+### Three-Tab Filter Helpers (Prerender-Specific)
+
+```ts
+isSuggestionFixed(suggestion):
+  status === 'FIXED'
+  OR data.edgeDeployed is truthy      // user deployed via UI
+  OR data.isDeployed is truthy        // alternative deploy flag
+
+isSuggestionIgnored(suggestion):
+  status === 'SKIPPED'
+
+isCoveredByDomainWideDeployment(suggestion):
+  !!data.coveredByDomainWide && !data.edgeDeployed
+  // covered by domain-wide BUT not individually deployed
+```
+
+### Tab Membership Rules
+
+| Tab | Inclusion condition | Notes |
+|-----|---------------------|-------|
+| **Current** | NOT `isCoveredByDomainWideDeployment` AND NOT `isSuggestionFixed` AND NOT `isSuggestionIgnored` | Unless `currentTabStatusFilter` overrides |
+| **Fixed** | `isSuggestionFixed === true` | `edgeDeployed` or `isDeployed` truthy qualifies |
+| **Ignored** | `isSuggestionIgnored === true` | Only `SKIPPED` status |
+| **Hidden** (no tab) | `isCoveredByDomainWideDeployment === true` AND not fixed | Covered by domain-wide, not individually deployed — disappears from all tabs |
+
+**Hidden suggestion audit worker implication:** When the audit writes `coveredByDomainWide` to a suggestion (after detecting `isDeployedAtEdge=true` for a URL under an active domain-wide pattern), that suggestion immediately disappears from the Current tab. Only set this field when the URL genuinely falls under an active domain-wide pattern.
+
+### Fixed Tab: Status Column Sort & Display
+
+When the "Status" column sort is active in the Fixed tab:
+```
+Sort order (highest priority first):
+  1. edgeOptimizeStatus === 'STALE'   → "Content Changed" warning
+  2. edgeDeployed is truthy           → "Optimized on [date]"
+  3. fallback                         → "Marked as Fixed"
+```
+
+Status cell rendering:
+- `edgeDeployed` (number, ms epoch) → formatted deployment date, tooltip "Optimized"
+- `edgeOptimizeStatus === 'STALE'` → warning icon + "Content Changed" (content changed after deploy)
+- No `edgeDeployed` → plain "Fixed" label
+
+### `rcvScoreByUrl` Consumption
+
+The `rcvScoreByUrl` Map (returned by `usePrerenderGains`) is passed to the table as a prop. Each row uses its URL key to display the per-URL LLM visibility score in the score column.

--- a/src/prerender/CLAUDE.md
+++ b/src/prerender/CLAUDE.md
@@ -1,0 +1,389 @@
+# CLAUDE.md — SpaceCat Prerender Audit Handler
+
+This file provides guidance to Claude Code when working with the prerender audit system (`spacecat-audit-worker/src/prerender/`).
+
+## Repository Context
+
+The prerender audit is a **3-step StepAudit** that analyzes whether Edge Delivery Services sites need prerendering for search engine visibility. It compares server-rendered HTML with client-rendered HTML and generates opportunities/suggestions when content gaps exceed thresholds.
+
+**Naming**: The internal code name is `prerender`. The user-facing opportunity name shown in the UI is **"Recover content visibility"** (abbreviated **RCV**). The three terms — `prerender`, `Recover content visibility`, and `RCV` — are used interchangeably across code, docs, Jira tickets, and team conversations.
+
+**Handler Location**: `src/prerender/handler.js` (1,875 lines, 8 exported functions)  
+**Folder**: `src/prerender/` (7 files, 2,415 lines total)
+
+---
+
+## Navigation Guide — Which File to Read
+
+**This file** covers the core audit mechanics: 3-step flow, bot-block detection, AI-only mode, key invariants, testing strategy, and development constraints.
+
+**Sub-files** — read only when the task specifically involves:
+
+| Sub-file | Read when working on... |
+|----------|------------------------|
+| [batch-mechanics.md](.claude/batch-mechanics.md) | The three `submitForScraping` URL paths (CSV/Slack/Normal), PageCitability dedup, DAILY_BATCH_SIZE, `isFirstRunOfCycle`, `prerender_submit/ai_summary_metrics` logs, `handleAiOnlyMode` flow, `writeToCitabilityRecords` |
+| [suggestion-lifecycle.md](.claude/suggestion-lifecycle.md) | Per-URL and domain-wide Suggestion.data field schemas, Golden Rules, all suggestion statuses, audit worker writes table, OUTDATED protection, domain-wide preservation logic, `prepareDomainWideAggregateSuggestion` SUM logic |
+| [system-interactions.md](.claude/system-interactions.md) | Cross-system Q&A: import worker trigger, Athena CDN-log query, content-scraper job lifecycle, URL batch pipeline, PageCitability dedup query, Mystique payload/response, content gain calculation, **S3 schemas** (scrape.json, status.json), sanitizeImportPath regex, scrapeJobId fallback chain |
+| [scraper-internals.md](.claude/scraper-internals.md) | Scraper output format, bot-protection detection, edge deployment detection, markdown file generation, shadow DOM handling |
+| [shared-packages.md](.claude/shared-packages.md) | `html-analyzer` word counting, `ScrapeClient` job submission, `PageCitability`/`ScrapeJob`/`ScrapeUrl` DB entities, `TokowakaClient.deployToEdge()` and S3 config structure |
+| [ui-data-map.md](.claude/ui-data-map.md) | `status.json` consumption in UI, `Suggestion.data` field display, tab filter logic, `avgLlmVisibilityScore` formula, `PrerenderOpportunitySection` UX flows |
+| [api-service-deploy-rollback.md](.claude/api-service-deploy-rollback.md) | `POST /suggestions/edge-deploy` and `POST /suggestions/edge-rollback` routes, what fields they write/clear on Suggestion.data, access control, geo-experiment mode |
+| [decision-log.md](.claude/decision-log.md) | WHY non-obvious invariants exist; full evolution of design decisions with commit refs; supersession history |
+| [coding-guidelines.md](.claude/coding-guidelines.md) | PR checklist: invariant rules, KISS/DRY/YAGNI/SOLID, TDD for refactoring, N+1 prevention, locked-contract checklist, log levels, coverage, doc update rules |
+| [refactoring-proposal.md](.claude/refactoring-proposal.md) | Proposed restructuring of handler.js: step 2 three-path cleanup, step 3 fallback replacement with getScrapeJobStats, module extraction plan, TDD entry points |
+| [handler-reference.md](.claude/handler-reference.md) | **Test writing reference** — S3 key format + examples, all constants, step execution order, error handling table (caught vs propagated), stubs needed per step, helpers quick-reference. Read this before writing behavioural tests instead of re-reading handler.js. |
+
+---
+
+## 3-Step Audit Flow
+
+### Step 1: importTopPages (Immediate)
+- **Entry point**: AuditBuilder step 1
+- **What it actually does**: Returns a trigger config object `{ type: 'top-pages', siteId, fullAuditRef }` — fetches **no URLs itself**
+- **Import worker boundary**: The `type: 'top-pages'` return value signals the framework to run the `spacecat-import-worker` before step 2 fires. The import worker fetches top pages from GSC and writes them to the `SiteTopPage` DB table. Step 2 then reads this freshly populated table via `getTopOrganicUrlsFromSeo`.
+- **Why URLs cannot be fetched in step 1**: `SiteTopPage` is only fresh after the import worker completes. Reading it in step 1 would return stale data from the previous import run.
+- **CSV + AI-only exception**: If `auditContext.urls` is set (CSV mode), those URLs are passed forward in `auditContext`. If `mode === MODE_AI_ONLY`, step 1 handles it entirely and exits early (no import needed).
+
+### Step 2: submitForScraping (Deferred via SQS, fires after import worker completes)
+- **Entry point**: AuditBuilder step 2 (if auditContext.next === "submitForScraping")
+- **Three code paths** (each handles URL sourcing and filtering differently):
+  1. **CSV path**: `auditContext.urls` present → rebase to preferredBase → mergeAndGetUniqueHtmlUrls → return. Does NOT read status.json.
+  2. **Slack path**: `auditContext.slackContext.channelId` set → organic + includedURLs only → mergeAndGetUniqueHtmlUrls. No PageCitability dedup, no edge-deployed filter, no DAILY_BATCH_SIZE cap, no bot-block check.
+  3. **Normal scheduled path**: bot-block sticky check first → organic + agentic + includedURLs → filter each source independently by PageCitability 7-day dedup AND edgeDeployedPathnames → concat in priority order (organic → included → agentic) → slice to DAILY_BATCH_SIZE=320 → mergeAndGetUniqueHtmlUrls
+- **Bot-block sticky check**: Normal path only, happens BEFORE any URL fetching. Slack bypasses so operators can force re-scrape.
+- **edgeDeployedPathnames**: Read from `status.json pages[].isDeployedAtEdge` (previous scrape result on S3) — not from DB
+- **Priority ordering**: URL sources are concatenated in order `[organic, includedURLs, agentic]` — not sorted. Slice to 320 preserves this ordering.
+- **Scrape job creation**: Uses `ScrapeClient.createScrapeJob()` (spacecat-content-scraper)
+- **S3 results**: Stored as `prerender/scrapes/{scrapeJobId}/{sanitizedPath}/scrape.json` + HTML files
+
+### Step 3: processContentAndGenerateOpportunities (Deferred via SQS)
+- **Entry point**: AuditBuilder step 3 (if auditContext.next === "processContentAndGenerateOpportunities")
+- **Primary input**: `context.scrapeResultPaths` — a `Map<url, pathInfo>` populated automatically by AuditBuilder via `scrapeClient.getScrapeResultPaths(scrapeJobId)` before this step fires.
+- **Fallback when scrapeResultPaths is empty**: Re-fetches organic + agentic + included URLs and runs `compareHtmlContent` using HTML already on S3 from a **previous** scrape run. Fires when current scrape returned zero successful results. Not covered by tests (`/* c8 ignore */`) and silently processes stale HTML — known observability gap.
+- **Operations** (actual execution order):
+  1. **`detectWrongEdgeDeployedStatus`** (diagnostic): Warns if any non-NEW suggestions have `edgeDeployed` set — runs unconditionally at step entry, even when no prerender URLs are found
+  2. **`isPaidLLMOCustomer`** check: read once, used in all subsequent logs
+  3. **isDomainBlocked short-circuit**: If `auditContext.domainBlocked=true`, skip HTML comparison and set `comparisonResults = []`
+  4. **HTML comparison** (`compareHtmlContent` per URL in parallel): downloads server-side.html + client-side.html + scrape.json from S3; computes contentGainRatio; content gain ≥ 1.1 → needsPrerender
+  5. **`writeToCitabilityRecords`**: Writes ALL comparison fields to PageCitability (citabilityScore, contentRatio, wordDifference, botWords, normalWords, isDeployedAtEdge) in batches of 10. Only non-error results written.
+  6. **`getScrapeJobStats`**: Computes urlsSubmittedForScraping + scrapeForbiddenCount + missingPages + submittedUrlSet. Returns `submittedUrlSet` (Set of URLs from ScrapeUrl DB) used later by uploadStatusSummaryToS3 to assign scrapeJobId per page.
+  7. **Bot-block reactive check**: `ratio403 = scrapeForbiddenCount / urlsSubmittedForScraping`. If `ratio403 ≥ 0.5` → call `detectBotBlocker()` → check `isKnownBotBlockerResult()` (confidence ≥ 0.99 AND type in `KNOWN_BOT_BLOCKER_TYPES`). If confirmed → `scrapeForbidden=true`, `scrapeForbiddenSince=now`.
+  8. **`scrapedUrlsSet` construction**: `successfulComparisons.filter(r => !r.isDeployedAtEdge)` — edge-deployed URLs are excluded from OUTDATED eligibility even when successfully scraped.
+  9. **Three-way opportunity branch**:
+     - **Branch A** (`urlsNeedingPrerender.length > 0`): Call `processOpportunityAndSuggestions` (find/create opportunity, domain-wide aggregate, syncSuggestions), then send to Mystique
+     - **Branch B** (`scrapeForbidden=true`, no URLs needing prerender): Call `createScrapeForbiddenOpportunity` — dummy opportunity with no suggestions so UI can display blocked state
+     - **Branch C** (no URLs, not blocked): Look for existing NEW opportunity. If found, call `syncSuggestions` with `newData=[]` and `scrapedUrlsSet` augmented with the domain-wide URL — this marks all currently-found suggestions OUTDATED
+  10. **`markNewSuggestionsAsCovered`**: Find domain-wide suggestion with `edgeDeployed` set → mark NEW suggestions for edge-deployed URLs as `coveredByDomainWide`
+  11. **`uploadStatusSummaryToS3`**: Reads existing status.json, merges current pages with prior pages (URLs not in current run are preserved), computes aggregate metrics from merged page set, writes to S3
+  12. **Error path**: On any uncaught exception → uploads `lastAuditSuccess=false` status.json before returning error result (D-12)
+
+---
+
+## Cross-Repo Interactions
+
+### spacecat-content-scraper (ScrapeClient → PrerenderHandler)
+- **Used in**: step 2 (submitForScraping)
+- **Method**: `ScrapeClient.createScrapeJob({ urls, processingType: 'prerender', maxScrapeAge, metaData })`
+- **processingType MUST be `'prerender'`** — the scraper's `PrerenderHandler.accepts()` checks for this exact string
+- **S3 outcomes**: scraper writes per-URL at `prerender/scrapes/{scrapeJobId}/{sanitizedPath}/{file}`
+- **Risk**: scrapeJobId derivation — fallback chain (data.scrapeJobId → extract from originalHtmlKey path[2] → null) must be preserved exactly
+- **Integration point**: step 2 → step 3 via scrapeJobId stored in status.json
+
+### mystique (AI Summarizer)
+- **Used in**: step 3 (processContentAndGenerateOpportunities)
+- **Outbound queue**: SQS `guidance:prerender` — audit sends candidates list; non-blocking
+- **Batch interface**: `MYSTIQUE_BATCH_SIZE` (config value, constraint-based, not DAILY_BATCH_SIZE)
+- **Payload**: URLs + context for `ai-summary` generation; **must include `suggestionId`** — Mystique parses it via Pydantic and fails validation if absent
+- **Response delivery (inbound)**: Mystique writes AI summaries to S3, then sends an SQS message back to the audit worker with `{ siteId, data: { presignedUrl, opportunityId } }`. The handler (`guidance-handler.js`) downloads the payload from the presigned URL — the AI summaries are NOT in the SQS body.
+- **Presigned URL safety**: `fetchAnalysisFromPresignedUrl` enforces: SSRF guard (S3 allowlist, HTTPS only), 10 MB DoS cap on response body, and query-string scrub before any CloudWatch logging so `X-Amz-Signature` never leaks
+- **S3 key construction**: Mystique uses `scrapeJobId` from when the suggestion was first created to build markdown S3 paths — always pass per-suggestion scrapeJobId, never the current run's ID
+- **Limitation**: Known TODO — batch size constraints affect throughput for sites with 200+ opportunities
+- **AI-only mode**: `MODE_AI_ONLY=true` skips scraping, uses existing HTML, respects `MYSTIQUE_BATCH_SIZE` only
+
+### spacecat-api-service (Domain-Wide Suggestion Rollback)
+- **Used in**: step 3 (syncSuggestions)
+- **Scenario**: User marks a domain-wide suggestion APPROVED via UI → API calls PUT /sites/:id/suggestions/:id
+- **Handler receives**: `data.isDomainWide=true` in rollback check
+- **Logic**: If domain-wide suggestion has status NEW/FIXED/PENDING_VALIDATION/SKIPPED or `edgeDeployed` set, subsequent audit runs preserve it (see `shouldPreserveDomainWideSuggestion`)
+- **Locked contract**: Cannot change domain-wide suggestion data.url, data.isDomainWide, data.coveredByDomainWide fields
+
+### project-elmo-ui (Status & Suggestion Display)
+- **Reads**: status.json from S3 (prerender/scrapes/{siteId}/status.json)
+- **Fields consumed**: `urlsNeedingPrerender[]`, `scrapingErrorRate`, `pages[]` (per-URL status/metadata)
+- **Also reads**: Suggestion.data fields from Spacecat DB (15 fields, listed below)
+- **Locked contract**: Cannot change any of these fields without coordinating UI update
+
+---
+
+## Database Entities
+
+### PageCitability (Core)
+- **Purpose**: 7-day dedup window for URLs submitted to scraper
+- **Fields**: siteId, url, timestamp (created)
+- **TTL**: 7 days (hardcoded in step 2 filter logic)
+- **Cleanup**: Handled externally (not in prerender handler)
+- **Usage**: Step 2 queries recent PageCitability records to exclude URLs from daily batch
+
+### Opportunity
+- **Link**: Created/updated during step 3 (processContentAndGenerateOpportunities)
+- **Statuses**: NEW, APPROVED, FIXED, OUTDATED
+- **Lifecycle**: One per site (domain-wide aggregate for prerender audit)
+- **Protection**: OUTDATED only if URL in scrapedUrlsSet AND not edgeDeployed AND not coveredByDomainWide AND not isDomainWide
+
+### Suggestion (Domain-Wide Aggregate)
+- **Type**: `prerender`
+- **Pattern**: Special case — single site-wide suggestion with url=baseUrl+`/*` and pathPattern=`/*`
+- **Key**: DOMAIN_WIDE_SUGGESTION_KEY (internal constant)
+- **Lifecycle states**: NEW → FIXED/PENDING_VALIDATION (after deploy) → preserved in future audits; OUTDATED if replaced
+- **Locked fields** (15 total, cannot change without multi-repo coordination):
+  - `url` — baseUrl (cannot be modified)
+  - `contentGainRatio` — word count ratio metric
+  - `wordCountBefore` — server-rendered word count
+  - `wordCountAfter` — client-rendered word count
+  - `edgeDeployed` — site uses edge deployment
+  - `isDomainWide` — always true for this suggestion
+  - `coveredByDomainWide` — set if another domain-wide suggestion applies
+  - `scrapeJobId` — ID for audit run that generated this
+  - `originalHtmlKey` — S3 path to server-rendered baseline
+  - `prerenderedHtmlKey` — S3 path to client-rendered result
+  - `aiSummary` — AI-generated summary from Mystique
+  - `valuable` — boolean indicating business value
+  - Plus 3 internal fields: `pathPattern`, `isDomainWide`, `edgeDeployed` (metadata)
+
+### Audit
+- **Logs**: Audit start/end times, result summary
+- **Referenced by**: Domain-wide suggestion createdBy/updatedBy (audit ID)
+
+---
+
+## Daily Batch Mechanics
+
+→ See [batch-mechanics.md](.claude/batch-mechanics.md)  
+Read when: the three `submitForScraping` paths (CSV/Slack/Normal), PageCitability dedup window, DAILY_BATCH_SIZE, `isFirstRunOfCycle`, metrics logs, or `handleAiOnlyMode` internals.
+
+---
+
+## Bot-Block Detection
+
+Two-stage protection against scraped domains blocking requests. Root cause analysis of 311,086 scrape failures showed 10.4% (32,333) were HTTP 403 bot-blocks with no per-domain detection — this drove the two-stage approach.
+
+### Stage 1: Sticky Check (Pre-Scrape)
+- **Trigger**: Step 2 (submitForScraping) reads status.json from previous audit
+- **Condition**: If `scrapeForbidden=true` AND `scrapeForbiddenSince` within 3 days, skip scraping
+- **Rationale**: Domain remains hostile; don't waste quota
+- **Reset**: After 3 days, bot-block flag expires and site re-evaluated
+
+### Stage 2: Reactive Detection (Post-Scrape)
+- **Trigger**: Step 3 (processContentAndGenerateOpportunities)
+- **Two-step check** (both conditions must be satisfied):
+  1. `scrapeForbiddenCount / urlsSubmittedForScraping >= 0.5` (rate gate — fast, no network call)
+  2. Only if rate gate passes: call `detectBotBlocker({ baseUrl })` from `@adobe/spacecat-shared-utils`, then check `isKnownBotBlockerResult()`:
+     - `crawlable === false`
+     - `confidence >= 0.99`
+     - `type` is in `KNOWN_BOT_BLOCKER_TYPES = ['cloudflare', 'imperva', 'akamai', 'fastly', 'cloudfront']`
+- **Action**: If both conditions pass → `scrapeForbidden=true`, `scrapeForbiddenSince=new Date().toISOString()`
+- **Storage**: Persisted in status.json; sticky check reads these in next step 2
+
+### getScrapeJobStats() Internals
+- **COMPLETE status, 403 errors**: Counted from in-memory scrape job metadata
+- **FAILED status, 403 errors**: Loaded from DB + S3 scrape.json (slower path) — added in #2245 because `getScrapeResultPaths` only returns COMPLETE URLs; FAILED-status 403s were invisible to bot-block detection until this path was added
+- **Known limitation**: Mystique batch size may cause timeouts for sites with 200+ opportunities (TODO documented in code)
+
+### isDomainBlocked Flag
+- **Set by**: Previous audit, if domain-wide bot-block detected
+- **Effect**: Step 3 receives flag and **skips all syncSuggestions** (hard stop)
+- **Rationale**: If domain is completely blocked, generating suggestions is noise
+- **Recovery**: isDomainBlocked persists until manually cleared or 3-day window expires
+
+---
+
+## S3 Schemas & Locked Path Contracts
+
+→ See [system-interactions.md](.claude/system-interactions.md) § 9  
+Read when: `sanitizeImportPath` regex, `scrape.json` or `status.json` full schemas, `scrapeJobId` fallback chain, `uploadStatusSummaryToS3` merge behaviour, URL normalization for suggestion lookup.
+
+---
+
+## Suggestion Data Fields & Lifecycle
+
+→ See [suggestion-lifecycle.md](.claude/suggestion-lifecycle.md)  
+Read when: per-URL or domain-wide Suggestion.data field schemas, Golden Rules, all suggestion statuses, audit worker writes, OUTDATED marking, domain-wide preservation logic, or domain-wide aggregate SUM computation.
+
+---
+
+## AI-Only Mode (MODE_AI_ONLY)
+
+**Config**: `MODE_AI_ONLY=true` environment variable  
+**Effect**: Skips step 2 entirely, processes existing HTML through Mystique only.
+
+### Flow
+```
+Step 1: importTopPages (normal)
+Step 2: SKIPPED (no scraping)
+Step 3: processContentAndGenerateOpportunities (uses cached HTML, queues all URLs to Mystique)
+```
+
+### Batch Size Switch
+- **Normal mode**: `DAILY_BATCH_SIZE=320` (limits scraper submission)
+- **AI-only mode**: `MYSTIQUE_BATCH_SIZE` only (AI throughput constraint)
+- **Rationale**: Without scraping quota pressure, AI batch size is the limiting factor
+
+### Use Cases
+1. Testing AI summarizer without consuming scrape quota
+2. Re-processing a site after Mystique updates (e.g., new prompt, model change)
+3. Rapid iteration on suggestion text/criteria without scraping overhead
+4. Quota exhaustion recovery (re-analyze with existing HTML)
+
+---
+
+## Key Invariants (Must Not Change)
+
+These invariants ensure data consistency across the audit system:
+
+1. **scrapedUrlsSet excludes edge-deployed URLs**: `isDeployedAtEdge=true` filtered before scraping; excluded from OUTDATED checks — root cause of 37.8% of all scrape failures was queuing URLs already 404/deployed
+2. **scrapeJobId 3-level fallback**: Always check (data.scrapeJobId → extract from path → null) in this order — Mystique constructs S3 paths using the scrapeJobId from when the suggestion was *first created*, not the current run; using the wrong ID causes NoSuchKey
+3. **scrapeJobId on Suggestion.data is write-once**: Never overwrite an existing scrapeJobId; fallback mode was stamping the current run's ID on all suggestions including ones from previous batches, breaking their S3 lookups
+4. **Domain-wide suggestion preservation**: NEW, FIXED, PENDING_VALIDATION, SKIPPED, or edgeDeployed set → not overwritten by new audit (see `shouldPreserveDomainWideSuggestion`)
+5. **isDomainBlocked skips syncSuggestions entirely**: Hard stop; no partial logic, no edge cases
+6. **status.json sticky flags**: scrapeForbidden + scrapeForbiddenSince must persist across audits (read in next step 2)
+7. **PageCitability dedup window**: 7 days, hardcoded (not configurable); changing requires data model migration
+8. **Bot-block thresholds**: 403 ratio ≥ 0.5 AND confidence ≥ 0.99 (both required; neither is negotiable) — calibrated from 311K failure analysis
+9. **isAllDomainDeployedAtEdge must skip OUTDATED suggestions**: Production had 14 OUTDATED domain-wide suggestions before the 1 active NEW one; `find()` without OUTDATED filter returned the wrong suggestion → `edgeDeployed` was undefined → function returned false incorrectly
+10. **Don't send FIXED or edgeDeployed suggestions to Mystique**: UI never displays AI summaries for deployed/fixed suggestions; sending them generates summaries that are never surfaced
+
+---
+
+---
+
+## Testing Strategy & Entry Points
+
+### Behavioral Contract Tests
+These 10 test cases verify observable behavior. Any change to the system must keep all 10 green:
+
+1. **Bot-block detection**: ratio403 ≥ 0.5 + confidence ≥ 0.99 → sets scrapeForbidden
+2. **Sticky bot-block**: scrapeForbiddenSince within 3-day window → skips scraping, S3 PUT with scrapeForbidden=true
+3. **isDomainBlocked forwarding**: step 3 receives isDomainBlocked → skips syncSuggestions
+4. **Domain-wide suggestion preserved**: ACTIVE_STATUSES → suggestion not overwritten
+5. **Domain-wide suggestion preserved (edgeDeployed)**: edgeDeployed=true → suggestion preserved
+6. **scrapedUrlsSet exclusion**: isDeployedAtEdge URLs excluded → prevents false-positive OUTDATED
+7. **Daily batch dedup**: URLs processed in last 7 days skipped
+8. **scrapeJobId 3-level fallback**: Order preserved (data → path extract → null)
+9. **AI-only mode batch sizing**: MODE_AI_ONLY=true uses MYSTIQUE_BATCH_SIZE not DAILY_BATCH_SIZE
+10. **getScrapeJobStats() counting**: COMPLETE-status + FAILED-status + S3 scrape.json reads
+
+### Test Taxonomy
+- **Unit**: Single function with stubs (fastest, most esmock churn)
+- **Module contract**: Extracted module + handler stub (medium coupling)
+- **Integration**: 2-3 modules + real data structures (validates handoffs)
+- **E2E**: Full 3-step audit + mock ScrapeClient + mock Mystique (slowest, highest confidence)
+
+---
+
+## Key Internal Function Behaviours
+
+### Mystique candidateId in Normal Audit Runs
+
+In `processOpportunityAndSuggestions`, `auditRunCandidates` is built as:
+```js
+{ suggestionId: s.url, url: s.url, originalHtmlMarkdownKey, markdownDiffKey }
+```
+`suggestionId` is set to the **URL string**, not a DB UUID. The guidance-handler matches Mystique responses back to suggestions by URL. Only in ai-only mode (`handleAiOnlyMode`) is `suggestionId` the actual DB suggestion UUID (because ai-only derives candidates from existing DB suggestions).
+
+### detectWrongEdgeDeployedStatus — Diagnostic Guard
+
+Called unconditionally at step 3 entry before any comparison:
+```js
+Opportunity.allBySiteIdAndStatus(siteId, 'NEW')
+  → find prerender opportunity
+  → getSuggestions()
+  → count suggestions where status !== NEW && data.edgeDeployed
+  → if count > 0 → log.warn (invariant violation)
+```
+This is a diagnostic-only function — it logs but does not modify any data. It fires even when the domain is bot-blocked or when scrapeResultPaths is empty.
+
+---
+
+## Locked External Contracts Summary
+
+**Do NOT change without coordinated multi-repo PRs:**
+
+| Contract | Owner | Impact | Workaround |
+|----------|-------|--------|-----------|
+| status.json schema | project-elmo-ui | UI cannot parse updated fields | Deprecation period + dual-read |
+| Suggestion.data (15 fields) | spacecat-api-service | Rollback logic breaks | Versioned data structures |
+| S3 path format (sanitizeImportPath) | prerender-audit logic | Historical lookups fail | Data migration script |
+| scrapeJobId fallback chain | prerender-audit persistence | Cannot re-link audits | Maintain fallback order forever |
+| ACTIVE_STATUSES list | user approval workflows | Suggestions overwritten incorrectly | API coordination for new statuses |
+| pagePatternCitability 7-day window | dedup logic | Breaks idempotency | Data model migration required |
+| Bot-block thresholds (0.5 / 0.99) | domain protection | Too strict/permissive | Feature flag + gradual rollout |
+
+---
+
+## Key Decision Points for Future Development
+
+### When Adding AI-Only Mode Feature
+1. Check all 4 places where MODE_AI_ONLY is checked (centralize if possible)
+2. Switch batch size logic from DAILY_BATCH_SIZE → MYSTIQUE_BATCH_SIZE
+3. Ensure step 2 is completely skipped (no partial scraping)
+4. Add test for mode override behavior
+
+### When Changing Suggestion Lifecycle
+1. Verify ACTIVE_STATUSES is not hardcoded elsewhere
+2. Coordinate with spacecat-api-service team (they read .isDomainWide field)
+3. Update project-elmo-ui if status display logic changes
+4. Test domain-wide suggestion preservation across audit runs
+
+---
+
+## Codebase Organization
+
+```
+src/prerender/
+├── handler.js (1,875 lines, 3-step StepAudit)
+├── utils/
+│   ├── utils.js (shared utilities, normalizePathname here)
+│   ├── bot-block-detector.js
+│   └── suggestion-filtering.js
+├── test/
+│   ├── handler.test.js (335 test cases)
+│   ├── ... (audit-specific tests)
+```
+
+---
+
+## spacecat-content-scraper Internals
+
+→ See [scraper-internals.md](.claude/scraper-internals.md)  
+Read when: debugging scraper output format, bot-protection detection, edge deployment detection, markdown file generation, shadow DOM handling.
+
+---
+
+## Shared Packages
+
+→ See [shared-packages.md](.claude/shared-packages.md)  
+Read when: `html-analyzer` word counting, `ScrapeClient` job submission API, `PageCitability`/`ScrapeJob`/`ScrapeUrl` DB entities, `TokowakaClient.deployToEdge()` and Tokowaka S3 config structure.
+
+---
+
+## UI Data Map
+
+→ See [ui-data-map.md](.claude/ui-data-map.md)  
+Read when: changing `status.json` schema, `Suggestion.data` field names, tab filter logic, `avgLlmVisibilityScore` formula, or `PrerenderOpportunitySection` UX flows.
+
+---
+
+## API Service — Deploy & Rollback
+
+→ See [api-service-deploy-rollback.md](.claude/api-service-deploy-rollback.md)  
+Read when: understanding what writes `edgeDeployed` / `coveredByDomainWide` / `tokowakaDeployed`, how rollback clears them, access control guards, or geo-experiment mode behavior.
+
+---
+
+## Contacts & Escalation
+
+**Mystique Integration Issues**: Check mystique/CLAUDE.md for batch size constraints and SQS failure scenarios.  
+**S3 Storage Issues**: Validate S3 path format matches sanitizeImportPath regex before storage.  
+**Test Infrastructure Issues**: 115 esmock instantiations in `handler.test.js` — any path or export name change requires updating all affected stubs.  
+**Database Model Changes**: Cannot modify Suggestion.data without spacecat-api-service and project-elmo-ui coordination.
+
+---

--- a/src/prerender/handler.js
+++ b/src/prerender/handler.js
@@ -1596,7 +1596,6 @@ export async function processContentAndGenerateOpportunities(context) {
 
   const siteId = site.getId();
   const startTime = process.hrtime();
-  const isSlackTriggered = !!(auditContext?.slackContext?.channelId);
   const isDomainBlocked = auditContext?.domainBlocked === true;
 
   // Diagnostic: detect non-NEW suggestions with edgeDeployed before syncing.
@@ -1614,58 +1613,19 @@ export async function processContentAndGenerateOpportunities(context) {
 
   try {
     let urlsToCheck = [];
-    /* c8 ignore next */
-    let agenticUrls = [];
 
     // Skip expensive URL fetching and comparison when domain is known to be bot-blocked
     if (!isDomainBlocked) {
-      // Try to get URLs from the audit context first
       if (scrapeResultPaths?.size > 0) {
         urlsToCheck = Array.from(context.scrapeResultPaths.keys());
         log.info(`${LOG_PREFIX} Found ${urlsToCheck.length} URLs from scrape results`);
       } else {
-        /* c8 ignore start */
-        // Fetch agentic URLs for URL list fallback (skipped for Slack-triggered runs)
-        if (!isSlackTriggered) {
-          try {
-            agenticUrls = await getTopAgenticUrls(site, context);
-          } catch (e) {
-            log.warn(`${LOG_PREFIX} Failed to fetch agentic URLs for fallback: ${e.message}. baseUrl=${site.getBaseURL()}`);
-          }
-        }
-
-        // Load top organic pages cache for fallback merging
-        const topPagesUrls = await getTopOrganicUrlsFromSeo(context);
-        const preferredBase = getPreferredBaseUrl(site, context);
-        const rebasedFallbackOrganicUrls = topPagesUrls
-          .map((url) => rebaseUrl(url, preferredBase, log));
-        const fallbackIncludedURLs = (
-          await site?.getConfig?.()?.getIncludedURLs?.(AUDIT_TYPE)
-        ) || [];
-        const rebasedFallbackIncludedURLs = fallbackIncludedURLs
-          .map((url) => rebaseUrl(url, preferredBase, log));
-        // Use the same normalization and filtering logic for consistency
-        const { urls: filteredUrls, filteredCount } = mergeAndGetUniqueHtmlUrls(
-          rebasedFallbackOrganicUrls,
-          agenticUrls,
-          rebasedFallbackIncludedURLs,
-        );
-        const statusData = await readSiteStatusJson(siteId, context);
-        const edgeDeployedPathnames = getEdgeDeployedPathnames(statusData);
-        urlsToCheck = edgeDeployedPathnames.size > 0
-          ? filteredUrls.filter((u) => !edgeDeployedPathnames.has(normalizePathname(u)))
-          : filteredUrls;
-
-        /* c8 ignore stop */
-        const edgeDeployedFilteredCount = filteredUrls.length - urlsToCheck.length;
-        const msg = `Fallback for baseUrl=${site.getBaseURL()}, siteId=${siteId}. `
-          + `Using agenticURLs=${agenticUrls.length}, `
-          + `topPages=${rebasedFallbackOrganicUrls.length}, `
-          + `includedURLs=${rebasedFallbackIncludedURLs.length}, `
-          + `filteredOutUrls=${filteredCount}, `
-          + `edgeDeployedFiltered=${edgeDeployedFilteredCount}, `
-          + `total=${urlsToCheck.length}`;
-        log.info(`${LOG_PREFIX} ${msg}`);
+        // scrapeResultPaths is empty — all submitted URLs had FAILED status in the scraper.
+        // getScrapeJobStats reads the ScrapeUrl DB and populates missingPages so status.json
+        // records the correct failed URLs. Running a top-page fallback here would write phantom
+        // 'error' entries for URLs that were never submitted to this scrape job.
+        log.warn(`${LOG_PREFIX} No COMPLETE scrape results for baseUrl=${site.getBaseURL()}, `
+          + `siteId=${siteId}. Skipping comparison; failed URLs recorded via ScrapeUrl DB.`);
       }
     }
 

--- a/test/audits/prerender/behaviour/ai-only-mode.test.js
+++ b/test/audits/prerender/behaviour/ai-only-mode.test.js
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Behavioural contracts: AI-only mode
+ *
+ * AI-only mode is triggered by context.data = { mode: 'ai-only' }.
+ * It bypasses scraping entirely — step 1 dispatches directly to Mystique,
+ * steps 2 and 3 return immediately with { status: 'skipped' }.
+ *
+ * Covers:
+ *   - Step 2 + Step 3 skip: no S3/DB reads, immediate return
+ *   - Step 1 happy path: scrapeJobId + NEW opportunity → complete
+ *   - Step 1 no scrapeJobId: status.json has no job → failed
+ *   - Step 1 no NEW opportunity: no matching opportunity in DB → failed
+ */
+
+/* eslint-env mocha */
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import {
+  importTopPages,
+  submitForScraping,
+  processContentAndGenerateOpportunities,
+} from '../../../../src/prerender/handler.js';
+import {
+  buildContext,
+  buildSite,
+  buildS3Client,
+  buildDataAccess,
+  buildOpportunity,
+  buildSuggestion,
+  statusKey,
+  buildStatus,
+} from './helpers.js';
+
+use(sinonChai);
+
+describe('Prerender behaviour — AI-only mode', () => {
+  let sandbox;
+
+  beforeEach(() => { sandbox = sinon.createSandbox(); });
+  afterEach(() => { sandbox.restore(); });
+
+  // ─── Step 2 + 3 skip ──────────────────────────────────────────────────────────
+
+  it('Step 2: data.mode=ai-only → returns skipped immediately, S3 never read', async () => {
+    const s3Client = buildS3Client(sandbox); // no keys — any read would NoSuchKey
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: 'site-ai-step2', baseUrl: 'https://example.com' }),
+      s3Client,
+      data: { mode: 'ai-only' },
+    });
+
+    const result = await submitForScraping(ctx);
+
+    expect(result).to.deep.include({ status: 'skipped', mode: 'ai-only' });
+    // S3 must never be touched — the step exits before any I/O
+    expect(s3Client.send).to.not.have.been.called;
+  });
+
+  it('Step 3: data.mode=ai-only → returns skipped immediately, no opportunity lookup', async () => {
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: 'site-ai-step3', baseUrl: 'https://example.com' }),
+      data: { mode: 'ai-only' },
+    });
+
+    const result = await processContentAndGenerateOpportunities(ctx);
+
+    expect(result).to.deep.include({ status: 'skipped', mode: 'ai-only' });
+    expect(ctx.dataAccess.Opportunity.allBySiteIdAndStatus).to.not.have.been.called;
+  });
+
+  // ─── Step 1 happy path ────────────────────────────────────────────────────────
+
+  it('Step 1: scrapeJobId in data + NEW opportunity found → status=complete, mode=ai-only', async () => {
+    const siteId = 'site-ai-happy';
+    const scrapeJobId = 'job-ai-123';
+
+    // Opportunity with two non-domain-wide suggestions for Mystique to process
+    const suggestion = buildSuggestion(sandbox, {
+      id: 'sug-ai-1',
+      status: 'NEW',
+      data: { url: 'https://example.com/page-1', scrapeJobId },
+    });
+    const opportunity = buildOpportunity(sandbox, {
+      id: 'opp-ai-1',
+      siteId,
+      suggestions: [suggestion],
+    });
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox),
+      dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+      data: { mode: 'ai-only', scrapeJobId },
+    });
+
+    const result = await importTopPages(ctx);
+
+    expect(result).to.have.property('status', 'complete');
+    expect(result).to.have.property('mode', 'ai-only');
+    expect(result).to.have.property('fullAuditRef').that.includes('ai-only/opp-ai-1');
+    // SQS message sent to Mystique queue
+    expect(ctx.sqs.sendMessage).to.have.been.called;
+  });
+
+  // ─── Step 1 failure paths ─────────────────────────────────────────────────────
+
+  it('Step 1: no scrapeJobId in data or status.json → status=failed', async () => {
+    const siteId = 'site-ai-no-job';
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      // status.json has no scrapeJobId field → fetchLatestScrapeJobId returns null
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(), // no scrapeJobId in status
+      }),
+      data: { mode: 'ai-only' }, // no scrapeJobId in data either
+    });
+
+    const result = await importTopPages(ctx);
+
+    expect(result).to.have.property('status', 'failed');
+    expect(result).to.have.property('fullAuditRef').that.includes(`failed-${siteId}`);
+    expect(ctx.log.error).to.have.been.called;
+  });
+
+  it('Step 1: scrapeJobId found but no NEW prerender opportunity exists → status=failed', async () => {
+    const siteId = 'site-ai-no-opp';
+    const scrapeJobId = 'job-ai-456';
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox),
+      // No NEW opportunities in DB
+      dataAccess: buildDataAccess(sandbox, { opportunities: [] }),
+      data: { mode: 'ai-only', scrapeJobId },
+    });
+
+    const result = await importTopPages(ctx);
+
+    expect(result).to.have.property('status', 'failed');
+    expect(result).to.have.property('fullAuditRef').that.includes(`failed-${siteId}`);
+    expect(ctx.log.error).to.have.been.called;
+  });
+});

--- a/test/audits/prerender/behaviour/bot-block.test.js
+++ b/test/audits/prerender/behaviour/bot-block.test.js
@@ -1,0 +1,239 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Behavioural contracts: bot-block detection
+ *
+ * Stage 1 (sticky, Step 2): status.json within 3-day window → skip scraping.
+ * Stage 2 (reactive, Step 3): ratio≥0.5 + confidence≥0.99 + known CDN → write scrapeForbidden.
+ *
+ * Stage 1 tests import submitForScraping directly (no esmock needed — detectBotBlocker not called).
+ * Stage 2 tests use esmock to control detectBotBlocker return value.
+ */
+
+/* eslint-env mocha */
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import esmock from 'esmock';
+import { submitForScraping } from '../../../../src/prerender/handler.js';
+import {
+  buildContext,
+  buildSite,
+  buildS3Client,
+  buildDataAccess,
+  buildSuggestion,
+  buildOpportunity,
+  buildUrlS3Content,
+  statusKey,
+  buildStatus,
+  daysAgo,
+  captureStatusWrite,
+} from './helpers.js';
+
+use(sinonChai);
+
+// ─── Stage 1: sticky bot-block (Step 2) ──────────────────────────────────────
+
+describe('Prerender behaviour — bot-block', () => {
+  let sandbox;
+
+  beforeEach(() => { sandbox = sinon.createSandbox(); });
+  afterEach(() => { sandbox.restore(); });
+
+  describe('Stage 1: sticky pre-scrape check (Step 2)', () => {
+    it('scrapeForbiddenSince within 3-day window → returns empty urls and domainBlocked flag', async () => {
+      const siteId = 'site-sticky-block';
+      const ctx = buildContext(sandbox, {
+        site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+        s3Client: buildS3Client(sandbox, {
+          [statusKey(siteId)]: buildStatus({
+            scrapeForbidden: true,
+            scrapeForbiddenSince: daysAgo(1),
+          }),
+        }),
+        dataAccess: buildDataAccess(sandbox),
+      });
+
+      const result = await submitForScraping(ctx);
+
+      expect(result.urls).to.deep.equal([]);
+      expect(result.auditContext.domainBlocked).to.equal(true);
+    });
+
+    it('scrapeForbiddenSince older than 3 days → sticky block expires, proceeds to scrape', async () => {
+      const siteId = 'site-expired-block';
+      const ctx = buildContext(sandbox, {
+        site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+        s3Client: buildS3Client(sandbox, {
+          [statusKey(siteId)]: buildStatus({
+            scrapeForbidden: true,
+            scrapeForbiddenSince: daysAgo(4),
+          }),
+        }),
+        dataAccess: buildDataAccess(sandbox, {
+          topPages: ['https://example.com/page-1'],
+        }),
+      });
+
+      const result = await submitForScraping(ctx);
+
+      // expired → scraping proceeds (urls list is not empty)
+      expect(result.urls).to.be.an('array').with.length.greaterThan(0);
+      expect(result).to.not.have.nested.property('auditContext.domainBlocked');
+    });
+
+    it('scrapeForbidden=false → no sticky block regardless of scrapeForbiddenSince', async () => {
+      const siteId = 'site-not-blocked';
+      const ctx = buildContext(sandbox, {
+        site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+        s3Client: buildS3Client(sandbox, {
+          [statusKey(siteId)]: buildStatus({
+            scrapeForbidden: false,
+            scrapeForbiddenSince: daysAgo(1),
+          }),
+        }),
+        dataAccess: buildDataAccess(sandbox, {
+          topPages: ['https://example.com/page-1'],
+        }),
+      });
+
+      const result = await submitForScraping(ctx);
+
+      expect(result.urls).to.be.an('array').with.length.greaterThan(0);
+    });
+
+    it('scrapeForbidden=true but scrapeForbiddenSince absent → treated as no block', async () => {
+      const siteId = 'site-no-since';
+      const ctx = buildContext(sandbox, {
+        site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+        s3Client: buildS3Client(sandbox, {
+          [statusKey(siteId)]: buildStatus({ scrapeForbidden: true }),
+        }),
+        dataAccess: buildDataAccess(sandbox, {
+          topPages: ['https://example.com/page-1'],
+        }),
+      });
+
+      const result = await submitForScraping(ctx);
+
+      expect(result.urls).to.be.an('array').with.length.greaterThan(0);
+    });
+  });
+
+  // ─── Stage 2: reactive post-scrape detection (Step 3) ──────────────────────
+
+  describe('Stage 2: reactive post-scrape detection (Step 3)', () => {
+    let processContentAndGenerateOpportunities;
+    let detectBotBlockerStub;
+
+    beforeEach(async () => {
+      detectBotBlockerStub = sandbox.stub();
+      ({ processContentAndGenerateOpportunities } = await esmock(
+        '../../../../src/prerender/handler.js',
+        {
+          '@adobe/spacecat-shared-utils': { detectBotBlocker: detectBotBlockerStub },
+        },
+      ));
+    });
+
+    function buildReactiveCtx(siteId, scrapeJobId = 'job-reactive') {
+      const url1 = 'https://example.com/page-1';
+      const url2 = 'https://example.com/page-2';
+      return buildContext(sandbox, {
+        site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+        s3Client: buildS3Client(sandbox, {
+          ...buildUrlS3Content(scrapeJobId, url1, {
+            scrapeJson: { error: { statusCode: 403 } },
+          }),
+          ...buildUrlS3Content(scrapeJobId, url2, {
+            scrapeJson: { error: { statusCode: 403 } },
+          }),
+        }),
+        dataAccess: buildDataAccess(sandbox, {
+          scrapeUrls: [url1, url2],
+        }),
+        scrapeResultPaths: new Map([[url1, {}], [url2, {}]]),
+        auditContext: { scrapeJobId },
+      });
+    }
+
+    it('ratio≥0.5 + confidence≥0.99 + known CDN → writes scrapeForbidden=true to status.json', async () => {
+      const siteId = 'site-reactive-known';
+      detectBotBlockerStub.resolves({ crawlable: false, confidence: 0.99, type: 'cloudflare' });
+
+      const ctx = buildReactiveCtx(siteId);
+      await processContentAndGenerateOpportunities(ctx);
+
+      const written = captureStatusWrite(ctx.s3Client);
+      expect(written).to.have.property('scrapeForbidden', true);
+      expect(written).to.have.property('scrapeForbiddenSince').that.is.a('string');
+    });
+
+    it('ratio≥0.5 + known CDN but confidence<0.99 → no block', async () => {
+      const siteId = 'site-low-confidence';
+      detectBotBlockerStub.resolves({ crawlable: false, confidence: 0.95, type: 'cloudflare' });
+
+      const ctx = buildReactiveCtx(siteId);
+      await processContentAndGenerateOpportunities(ctx);
+
+      const written = captureStatusWrite(ctx.s3Client);
+      expect(written).to.have.property('scrapeForbidden', false);
+    });
+
+    it('ratio<0.5 → detectBotBlocker never called, no block written', async () => {
+      const siteId = 'site-low-ratio';
+      const scrapeJobId = 'job-low-ratio';
+      // 1 out of 4 URLs is 403 → ratio = 0.25 < 0.5
+      const urls = [
+        'https://example.com/p1',
+        'https://example.com/p2',
+        'https://example.com/p3',
+        'https://example.com/p4',
+      ];
+      const s3Map = {
+        ...buildUrlS3Content(scrapeJobId, urls[0], { scrapeJson: { error: { statusCode: 403 } } }),
+        ...buildUrlS3Content(scrapeJobId, urls[1]),
+        ...buildUrlS3Content(scrapeJobId, urls[2]),
+        ...buildUrlS3Content(scrapeJobId, urls[3]),
+      };
+      const ctx = buildContext(sandbox, {
+        site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+        s3Client: buildS3Client(sandbox, s3Map),
+        dataAccess: buildDataAccess(sandbox, { scrapeUrls: urls }),
+        scrapeResultPaths: new Map(urls.map((u) => [u, {}])),
+        auditContext: { scrapeJobId },
+      });
+
+      await processContentAndGenerateOpportunities(ctx);
+
+      expect(detectBotBlockerStub).to.not.have.been.called;
+      const written = captureStatusWrite(ctx.s3Client);
+      expect(written).to.have.property('scrapeForbidden', false);
+    });
+
+    it('detectBotBlocker throws → warning logged, no block, audit completes', async () => {
+      const siteId = 'site-detector-throws';
+      detectBotBlockerStub.rejects(new Error('Network unavailable'));
+
+      const ctx = buildReactiveCtx(siteId);
+      const result = await processContentAndGenerateOpportunities(ctx);
+
+      // Audit must complete (not propagate the error)
+      expect(result).to.have.property('status', 'complete');
+      // Handler logs a warning about the detectBotBlocker failure
+      expect(ctx.log.warn).to.have.been.calledWithMatch(/detectBotBlocker failed/);
+      const written = captureStatusWrite(ctx.s3Client);
+      expect(written).to.have.property('scrapeForbidden', false);
+    });
+  });
+});

--- a/test/audits/prerender/behaviour/data-integrity.test.js
+++ b/test/audits/prerender/behaviour/data-integrity.test.js
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Behavioural contracts: data integrity in Step 3
+ *
+ * Covers the status.json merge strategy (prior pages preserved), sticky scrapeForbidden
+ * persistence, scrapeJobId written to the status, getScrapeJobStats fallback when
+ * ScrapeUrl DB is unavailable, S3 path contract for HTML reads, and PageCitability
+ * write behaviour (successful URLs written, errored URLs skipped).
+ */
+
+/* eslint-env mocha */
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import {
+  processContentAndGenerateOpportunities,
+  writeToCitabilityRecords,
+} from '../../../../src/prerender/handler.js';
+import {
+  buildContext,
+  buildSite,
+  buildS3Client,
+  buildDataAccess,
+  buildUrlS3Content,
+  statusKey,
+  buildStatus,
+  captureStatusWrite,
+  scrapeKeys,
+} from './helpers.js';
+
+use(sinonChai);
+
+describe('Prerender behaviour — data integrity (Step 3)', () => {
+  let sandbox;
+
+  beforeEach(() => { sandbox = sinon.createSandbox(); });
+  afterEach(() => { sandbox.restore(); });
+
+  it('status.json merges current pages with prior pages not in the current scrape run', async () => {
+    const siteId = 'site-merge';
+    const scrapeJobId = 'job-merge';
+    const currentUrl = 'https://example.com/current';
+    const priorUrl = 'https://example.com/prior-only';
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        // Existing status.json has a prior page not in the current run
+        [statusKey(siteId)]: buildStatus({
+          pages: [{ url: priorUrl, needsPrerender: true, scrapingStatus: 'success' }],
+        }),
+        ...buildUrlS3Content(scrapeJobId, currentUrl),
+      }),
+      dataAccess: buildDataAccess(sandbox, { scrapeUrls: [currentUrl] }),
+      scrapeResultPaths: new Map([[currentUrl, {}]]),
+      auditContext: { scrapeJobId },
+    });
+
+    await processContentAndGenerateOpportunities(ctx);
+
+    const written = captureStatusWrite(ctx.s3Client);
+    const writtenUrls = written.pages.map((p) => p.url);
+    expect(writtenUrls).to.include(currentUrl);
+    expect(writtenUrls).to.include(priorUrl);
+  });
+
+  it('scrapeForbidden=true persists in status.json when set by reactive detection (isDomainBlocked)', async () => {
+    // isDomainBlocked=true causes scrapeForbidden=true via: let scrapeForbidden = isDomainBlocked
+    const siteId = 'site-forbidden-persist';
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+      }),
+      dataAccess: buildDataAccess(sandbox),
+      scrapeResultPaths: new Map(),
+      auditContext: { domainBlocked: true },
+    });
+
+    await processContentAndGenerateOpportunities(ctx);
+
+    const written = captureStatusWrite(ctx.s3Client);
+    expect(written).to.have.property('scrapeForbidden', true);
+  });
+
+  it('scrapeJobId from auditContext is written to status.json', async () => {
+    const siteId = 'site-jobid';
+    const scrapeJobId = 'job-unique-id-123';
+    const url = 'https://example.com/page-1';
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+        ...buildUrlS3Content(scrapeJobId, url),
+      }),
+      dataAccess: buildDataAccess(sandbox, { scrapeUrls: [url] }),
+      scrapeResultPaths: new Map([[url, {}]]),
+      auditContext: { scrapeJobId },
+    });
+
+    await processContentAndGenerateOpportunities(ctx);
+
+    const written = captureStatusWrite(ctx.s3Client);
+    expect(written).to.have.property('scrapeJobId', scrapeJobId);
+  });
+
+  it('failed URL scrape is recorded with scrapingStatus=error in status.json page entry', async () => {
+    // When compareHtmlContent cannot read a URL's HTML from S3 (e.g. NoSuchKey),
+    // uploadStatusSummaryToS3 must still include that URL in pages[] with
+    // scrapingStatus='error' so the UI and operators can distinguish scrape failures
+    // from pages that genuinely have no content gap.
+    const siteId = 'site-page-error';
+    const scrapeJobId = 'job-page-error';
+    const successUrl = 'https://example.com/success-page';
+    const errorUrl = 'https://example.com/error-page';
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+        // successUrl has HTML in S3 → comparison succeeds
+        ...buildUrlS3Content(scrapeJobId, successUrl),
+        // errorUrl has no entry → NoSuchKey → comparison fails with error result
+      }),
+      dataAccess: buildDataAccess(sandbox, {
+        scrapeUrls: [successUrl, errorUrl],
+      }),
+      scrapeResultPaths: new Map([[successUrl, {}], [errorUrl, {}]]),
+      auditContext: { scrapeJobId },
+    });
+
+    await processContentAndGenerateOpportunities(ctx);
+
+    const written = captureStatusWrite(ctx.s3Client);
+    const errorPage = written?.pages?.find((p) => p.url === errorUrl);
+    expect(errorPage, 'error URL must appear in status.json pages').to.not.be.undefined;
+    expect(errorPage.scrapingStatus).to.equal('error');
+
+    const successPage = written?.pages?.find((p) => p.url === successUrl);
+    expect(successPage?.scrapingStatus).to.equal('success');
+  });
+
+  it('getScrapeJobStats falls back to urlsToCheck count when ScrapeUrl is unavailable', async () => {
+    // Remove ScrapeUrl from dataAccess → getScrapeJobStats uses fallback path
+    // (urlsSubmittedForScraping = urlsToCheck.length)
+    const siteId = 'site-scrapeurl-missing';
+    const scrapeJobId = 'job-fallback';
+    const url = 'https://example.com/page-1';
+
+    const dataAccess = buildDataAccess(sandbox, { scrapeUrls: [url] });
+    delete dataAccess.ScrapeUrl; // simulate missing ScrapeUrl entity
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+        ...buildUrlS3Content(scrapeJobId, url),
+      }),
+      dataAccess,
+      scrapeResultPaths: new Map([[url, {}]]),
+      auditContext: { scrapeJobId },
+    });
+
+    // Should complete without error — fallback is silent
+    const result = await processContentAndGenerateOpportunities(ctx);
+    expect(result).to.have.property('status', 'complete');
+
+    const written = captureStatusWrite(ctx.s3Client);
+    expect(written).to.have.property('urlsSubmittedForScraping').that.is.a('number');
+  });
+
+  it('S3 path contract: handler reads HTML from canonical scrapeJobId + sanitized-pathname keys', async () => {
+    // Verifies the key construction: prerender/scrapes/{scrapeJobId}/{sanitizedPath}/{file}
+    // Uses a URL with path segments that exercise the sanitization rules (dots, underscores, slashes)
+    // so that any drift in sanitizeImportPath would make the expected keys diverge from actual reads.
+    const siteId = 'site-s3-path';
+    const scrapeJobId = 'job-s3-path';
+    const url = 'https://example.com/some/deep.path/with_underscore';
+
+    const keys = scrapeKeys(scrapeJobId, url);
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+        ...buildUrlS3Content(scrapeJobId, url),
+      }),
+      dataAccess: buildDataAccess(sandbox, { scrapeUrls: [url] }),
+      scrapeResultPaths: new Map([[url, {}]]),
+      auditContext: { scrapeJobId },
+    });
+
+    await processContentAndGenerateOpportunities(ctx);
+
+    const readKeys = ctx.s3Client.send.getCalls()
+      .filter((c) => c.args[0]?.constructor?.name === 'GetObjectCommand')
+      .map((c) => c.args[0].input.Key);
+
+    expect(readKeys).to.include(keys.serverHtml);
+    expect(readKeys).to.include(keys.clientHtml);
+    expect(readKeys).to.include(keys.scrapeJson);
+  });
+});
+
+describe('Prerender behaviour — PageCitability writes (Step 3)', () => {
+  let sandbox;
+
+  beforeEach(() => { sandbox = sinon.createSandbox(); });
+  afterEach(() => { sandbox.restore(); });
+
+  it('successful comparison URLs are written to PageCitability as 7-day dedup records', async () => {
+    const siteId = 'site-citability-ok';
+
+    const dataAccess = buildDataAccess(sandbox);
+    dataAccess.PageCitability.allBySiteId = sandbox.stub().resolves([]);
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      dataAccess,
+    });
+
+    const comparisonResults = [
+      {
+        url: 'https://example.com/ok',
+        error: false,
+        needsPrerender: false,
+        citabilityScore: 0.9,
+        contentGainRatio: 1.0,
+        wordDifference: 0,
+        wordCountBefore: 50,
+        wordCountAfter: 50,
+        isDeployedAtEdge: false,
+      },
+      { url: 'https://example.com/err', error: true, needsPrerender: false },
+    ];
+
+    await writeToCitabilityRecords(comparisonResults, siteId, ctx);
+
+    // Only the non-error URL must be written — one create call with the correct URL + siteId.
+    expect(ctx.dataAccess.PageCitability.create).to.have.been.calledOnce;
+    const [createArgs] = ctx.dataAccess.PageCitability.create.firstCall.args;
+    expect(createArgs).to.have.property('url', 'https://example.com/ok');
+    expect(createArgs).to.have.property('siteId', siteId);
+  });
+
+  it('errored URLs are NOT written to PageCitability', async () => {
+    const siteId = 'site-citability-all-err';
+
+    const dataAccess = buildDataAccess(sandbox);
+    dataAccess.PageCitability.allBySiteId = sandbox.stub().resolves([]);
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      dataAccess,
+    });
+
+    await writeToCitabilityRecords(
+      [
+        { url: 'https://example.com/err-1', error: true, needsPrerender: false },
+        { url: 'https://example.com/err-2', error: true, needsPrerender: false },
+      ],
+      siteId,
+      ctx,
+    );
+
+    expect(ctx.dataAccess.PageCitability.create).to.not.have.been.called;
+  });
+});

--- a/test/audits/prerender/behaviour/data-integrity.test.js
+++ b/test/audits/prerender/behaviour/data-integrity.test.js
@@ -47,6 +47,56 @@ describe('Prerender behaviour — data integrity (Step 3)', () => {
   beforeEach(() => { sandbox = sinon.createSandbox(); });
   afterEach(() => { sandbox.restore(); });
 
+  it('when all submitted URLs fail scraping, status.json contains only those URLs — not phantom fallback entries', async () => {
+    // Regression: when scrapeResultPaths is empty (all scraper jobs had FAILED status),
+    // the old fallback re-fetched top-page URLs and wrote ~150 phantom 'error' entries
+    // to status.json for URLs that were never submitted to the scraper.
+    // The fix: skip the fallback; getScrapeJobStats.missingPages records the real failures.
+    const siteId = 'site-phantom';
+    const scrapeJobId = 'job-phantom';
+    const submittedUrl1 = 'https://example.com/page-a';
+    const submittedUrl2 = 'https://example.com/page-b';
+    // 10 top-page URLs that were NOT submitted to the scraper this run
+    const topPageUrls = Array.from({ length: 10 }, (_, i) => `https://example.com/top-${i}`);
+
+    const dataAccess = buildDataAccess(sandbox, {
+      // Top pages available — old fallback would have fetched these
+      topPages: [...topPageUrls, submittedUrl1, submittedUrl2],
+      // ScrapeUrl DB records the 2 URLs that were actually submitted (both FAILED)
+      scrapeUrls: [submittedUrl1, submittedUrl2],
+    });
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+        // No S3 HTML content for any URL — all scrape jobs failed
+      }),
+      dataAccess,
+      // scrapeResultPaths is empty: AuditBuilder only puts COMPLETE-status URLs here;
+      // when all jobs fail, this map is empty triggering the (now-removed) fallback
+      scrapeResultPaths: new Map(),
+      auditContext: { scrapeJobId },
+    });
+
+    await processContentAndGenerateOpportunities(ctx);
+
+    const written = captureStatusWrite(ctx.s3Client);
+    const writtenUrls = written?.pages?.map((p) => p.url) ?? [];
+
+    // Only the 2 submitted-but-failed URLs should appear (via missingPages from ScrapeUrl DB)
+    expect(writtenUrls).to.include(submittedUrl1);
+    expect(writtenUrls).to.include(submittedUrl2);
+
+    // No phantom entries for the 10 top-page URLs that were never submitted
+    for (const url of topPageUrls) {
+      expect(writtenUrls, `phantom entry for ${url}`).to.not.include(url);
+    }
+
+    // Total page count must be exactly 2 (the submitted URLs) plus any prior pages (0 here)
+    expect(written.pages).to.have.length(2);
+  });
+
   it('status.json merges current pages with prior pages not in the current scrape run', async () => {
     const siteId = 'site-merge';
     const scrapeJobId = 'job-merge';

--- a/test/audits/prerender/behaviour/early-exits.test.js
+++ b/test/audits/prerender/behaviour/early-exits.test.js
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Behavioural contracts: early exits in Step 3
+ *
+ * Covers:
+ *   - isDomainBlocked=true → skips HTML comparison, writes scrapeForbidden to status.json
+ *   - scrapeResultPaths empty + S3 returns no HTML → all comparisons error, audit still completes
+ *   - getScrapeJobStats dual-path counting (COMPLETE 403s + FAILED-status 403s)
+ */
+
+/* eslint-env mocha */
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { processContentAndGenerateOpportunities } from '../../../../src/prerender/handler.js';
+import {
+  buildContext,
+  buildSite,
+  buildS3Client,
+  buildDataAccess,
+  buildUrlS3Content,
+  scrapeKeys,
+  statusKey,
+  buildStatus,
+  captureStatusWrite,
+} from './helpers.js';
+
+use(sinonChai);
+
+describe('Prerender behaviour — early exits (Step 3)', () => {
+  let sandbox;
+
+  beforeEach(() => { sandbox = sinon.createSandbox(); });
+  afterEach(() => { sandbox.restore(); });
+
+  it('isDomainBlocked=true → S3 HTML never read, scrapeForbidden=true written to status.json', async () => {
+    const siteId = 'site-domain-blocked';
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+      }),
+      dataAccess: buildDataAccess(sandbox),
+      scrapeResultPaths: new Map(),
+      auditContext: { domainBlocked: true },
+    });
+
+    const result = await processContentAndGenerateOpportunities(ctx);
+
+    // Audit completes (does not throw)
+    expect(result).to.have.property('status', 'complete');
+
+    // No HTML GetObjectCommands should have been sent
+    const htmlReads = ctx.s3Client.send.getCalls().filter(
+      (c) => c.args[0]?.constructor?.name === 'GetObjectCommand'
+        && c.args[0]?.input?.Key?.endsWith('.html'),
+    );
+    expect(htmlReads).to.have.length(0);
+
+    const written = captureStatusWrite(ctx.s3Client);
+    expect(written).to.have.property('scrapeForbidden', true);
+  });
+
+  it('all HTML comparisons error (S3 returns null) → audit completes with zero successful scrapes', async () => {
+    const siteId = 'site-all-errors';
+    const scrapeJobId = 'job-all-error';
+    const url = 'https://example.com/page-missing';
+    // S3 keyMap is empty for HTML files → buildS3Client returns NoSuchKey for all reads
+    // → getObjectFromKey returns null → compareHtmlContent returns { error: true }
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+        // Intentionally no HTML or scrape.json for the URL
+      }),
+      dataAccess: buildDataAccess(sandbox, { scrapeUrls: [url] }),
+      scrapeResultPaths: new Map([[url, {}]]),
+      auditContext: { scrapeJobId },
+    });
+
+    const result = await processContentAndGenerateOpportunities(ctx);
+
+    // Audit completes despite all errors
+    expect(result).to.have.property('status', 'complete');
+    expect(result.auditResult).to.have.property('urlsScrapedSuccessfully', 0);
+  });
+
+  it('getScrapeJobStats counts 403s from FAILED-status URLs via S3 scrape.json', async () => {
+    // FAILED-status URLs are absent from scrapeResultPaths (getScrapeResultPaths only returns COMPLETE).
+    // getScrapeJobStats finds them by querying ScrapeUrl DB and reading their scrape.json from S3.
+    const siteId = 'site-failed-403';
+    const scrapeJobId = 'job-failed-403';
+    const completedUrl = 'https://example.com/completed';
+    const failedUrl = 'https://example.com/failed-403';
+    const failedScrapeJsonKey = scrapeKeys(scrapeJobId, failedUrl).scrapeJson;
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+        ...buildUrlS3Content(scrapeJobId, completedUrl),
+        // scrape.json for the FAILED URL shows 403
+        [failedScrapeJsonKey]: { error: { statusCode: 403, message: 'Forbidden' } },
+      }),
+      dataAccess: buildDataAccess(sandbox, {
+        // ScrapeUrl DB includes both URLs (the FAILED one is missing from scrapeResultPaths)
+        scrapeUrls: [completedUrl, failedUrl],
+      }),
+      // Only the COMPLETE URL is in scrapeResultPaths (FAILED URLs absent)
+      scrapeResultPaths: new Map([[completedUrl, {}]]),
+      auditContext: { scrapeJobId },
+    });
+
+    await processContentAndGenerateOpportunities(ctx);
+
+    const written = captureStatusWrite(ctx.s3Client);
+    // The failed 403 should appear as a missingPage with scrapeError
+    const missingWithError = (written.pages ?? []).filter((p) => p.scrapeError?.statusCode === 403);
+    expect(missingWithError).to.have.length(1);
+  });
+});

--- a/test/audits/prerender/behaviour/error-resilience.test.js
+++ b/test/audits/prerender/behaviour/error-resilience.test.js
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Behavioural contracts: error resilience in Step 3
+ *
+ * Covers:
+ *   - Partial S3 HTML failure (one of N URLs missing) → partial success, not all-or-nothing
+ *   - DB exception in Opportunity.allBySiteIdAndStatus → audit catches outer exception, completes
+ *   - ScrapeUrl.allByScrapeJobId throws → getScrapeJobStats uses fallback count, no crash
+ */
+
+/* eslint-env mocha */
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { processContentAndGenerateOpportunities } from '../../../../src/prerender/handler.js';
+import {
+  buildContext,
+  buildSite,
+  buildS3Client,
+  buildDataAccess,
+  buildUrlS3Content,
+  statusKey,
+  buildStatus,
+  captureStatusWrite,
+} from './helpers.js';
+
+use(sinonChai);
+
+describe('Prerender behaviour — error resilience (Step 3)', () => {
+  let sandbox;
+
+  beforeEach(() => { sandbox = sinon.createSandbox(); });
+  afterEach(() => { sandbox.restore(); });
+
+  it('partial S3 HTML failure — one URL missing, one present → urlsScrapedSuccessfully=1', async () => {
+    // One URL has full S3 content; the other URL is absent from the keyMap → NoSuchKey.
+    // The missing URL becomes an error result; the present URL is counted as successful.
+    // Audit must not fail entirely just because one URL's HTML is absent.
+    const siteId = 'site-partial-fail';
+    const scrapeJobId = 'job-partial';
+    const goodUrl = 'https://example.com/page-ok';
+    const badUrl = 'https://example.com/page-missing-html';
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+        ...buildUrlS3Content(scrapeJobId, goodUrl),
+        // badUrl intentionally absent → S3 returns NoSuchKey
+      }),
+      dataAccess: buildDataAccess(sandbox, {
+        scrapeUrls: [goodUrl, badUrl],
+      }),
+      scrapeResultPaths: new Map([[goodUrl, {}], [badUrl, {}]]),
+      auditContext: { scrapeJobId },
+    });
+
+    const result = await processContentAndGenerateOpportunities(ctx);
+
+    expect(result).to.have.property('status', 'complete');
+    // goodUrl was scraped; badUrl errored — only 1 should be counted as successful
+    expect(result.auditResult).to.have.property('urlsScrapedSuccessfully', 1);
+  });
+
+  it('ScrapeUrl.allByScrapeJobId throws → getScrapeJobStats falls back, audit completes', async () => {
+    // Unlike the "ScrapeUrl deleted from dataAccess" fallback test in data-integrity,
+    // here the entity exists but the DB call itself rejects (e.g., network timeout).
+    // getScrapeJobStats must catch the error and use the urlsToCheck.length fallback.
+    const siteId = 'site-scrapeurl-throws';
+    const scrapeJobId = 'job-throws';
+    const url = 'https://example.com/page-1';
+
+    const dataAccess = buildDataAccess(sandbox, { scrapeUrls: [url] });
+    // Override allByScrapeJobId to throw instead of resolve
+    dataAccess.ScrapeUrl.allByScrapeJobId = sandbox.stub().rejects(new Error('DB connection timeout'));
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+        ...buildUrlS3Content(scrapeJobId, url),
+      }),
+      dataAccess,
+      scrapeResultPaths: new Map([[url, {}]]),
+      auditContext: { scrapeJobId },
+    });
+
+    const result = await processContentAndGenerateOpportunities(ctx);
+
+    expect(result).to.have.property('status', 'complete');
+    // Fallback: urlsSubmittedForScraping equals the scrapeResultPaths size
+    const written = captureStatusWrite(ctx.s3Client);
+    expect(written).to.have.property('urlsSubmittedForScraping').that.is.a('number');
+  });
+
+  it('Opportunity.create rejects (Branch A) → handler catches error, logs it, does not crash Lambda', async () => {
+    // When prerender URLs ARE found (Branch A: needsPrerender=true) but Opportunity.create
+    // rejects, convertToOpportunity catches the error internally. The Lambda must not
+    // propagate the exception — a crash here would silently skip writing status.json
+    // and the audit would be retried indefinitely.
+    const siteId = 'site-create-throws';
+    const scrapeJobId = 'job-create-throw';
+    const url = 'https://example.com/page-1';
+
+    const dataAccess = buildDataAccess(sandbox, { scrapeUrls: [url] });
+    // No existing opportunity found → handler will try to create one, which fails
+    dataAccess.Opportunity.allBySiteIdAndStatus = sandbox.stub().resolves([]);
+    dataAccess.Opportunity.create = sandbox.stub().rejects(new Error('DB write failed'));
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+        // server-sparse + client-rich → ratio > 1.1 → needsPrerender=true → Branch A
+        ...buildUrlS3Content(scrapeJobId, url, {
+          serverHtml: '<html><body><p>few words</p></body></html>',
+          clientHtml: `<html><body><p>${'word '.repeat(60).trim()}</p></body></html>`,
+        }),
+      }),
+      dataAccess,
+      scrapeResultPaths: new Map([[url, {}]]),
+      auditContext: { scrapeJobId },
+    });
+
+    // Must not throw — if it threw, the test would fail here and that would be the regression
+    await processContentAndGenerateOpportunities(ctx);
+
+    // Failure must be observable — silent swallow is as dangerous as a crash
+    expect(ctx.log.error).to.have.been.called;
+  });
+});

--- a/test/audits/prerender/behaviour/helpers.js
+++ b/test/audits/prerender/behaviour/helpers.js
@@ -1,0 +1,343 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Shared factory helpers for prerender behavioural contract tests.
+ *
+ * Rule: helpers mock only EXTERNAL dependencies — S3, SQS, DB entities.
+ * They never stub internal handler functions (convertToOpportunity,
+ * getObjectFromKey, syncSuggestions, etc.). That keeps these tests
+ * green through any internal refactoring or module extraction.
+ */
+
+// ─── HTML fixtures ────────────────────────────────────────────────────────────
+
+/** Identical server/client HTML — ratio = 1.0, needsPrerender = false. */
+export const HTML_SAME = '<html><body><p>identical content for both server and client sides testing</p></body></html>';
+
+/** Server-side with few words; pair with HTML_CLIENT_NEEDS_PRERENDER for ratio >> 1.1. */
+export const HTML_SERVER_SPARSE = '<html><body><p>few words here</p></body></html>';
+
+/** Client-side with many words — ratio vs HTML_SERVER_SPARSE well above 1.1 threshold. */
+export const HTML_CLIENT_NEEDS_PRERENDER = `<html><body><p>${'word '.repeat(60).trim()}</p></body></html>`;
+
+// ─── S3 key helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Mirrors handler.js sanitizeImportPath + getS3Path to compute canonical S3 keys
+ * for a given scrapeJobId + URL triple (server-side.html, client-side.html, scrape.json).
+ *
+ * Used in test keyMaps so there's a single source of truth for the expected key format.
+ */
+export function scrapeKeys(scrapeJobId, url) {
+  const { pathname } = new URL(url);
+  const sanitized = pathname
+    .replace(/^\/+|\/+$/g, '')
+    .replace(/[/._]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  const segment = sanitized ? `/${sanitized}` : '';
+  const base = `prerender/scrapes/${scrapeJobId}${segment}`;
+  return {
+    serverHtml: `${base}/server-side.html`,
+    clientHtml: `${base}/client-side.html`,
+    scrapeJson: `${base}/scrape.json`,
+  };
+}
+
+/**
+ * Builds a partial S3 keyMap for one URL — ready to spread into the full keyMap.
+ *
+ * @param {string} scrapeJobId
+ * @param {string} url
+ * @param {Object} options
+ * @param {string} [options.serverHtml=HTML_SAME]
+ * @param {string} [options.clientHtml=HTML_SAME]
+ * @param {Object} [options.scrapeJson={ isDeployedAtEdge: false }]
+ */
+export function buildUrlS3Content(scrapeJobId, url, {
+  serverHtml = HTML_SAME,
+  clientHtml = HTML_SAME,
+  scrapeJson = { isDeployedAtEdge: false },
+} = {}) {
+  const keys = scrapeKeys(scrapeJobId, url);
+  return {
+    [keys.serverHtml]: serverHtml,
+    [keys.clientHtml]: clientHtml,
+    [keys.scrapeJson]: scrapeJson,
+  };
+}
+
+// ─── Site ─────────────────────────────────────────────────────────────────────
+
+export function buildSite({
+  id = 'test-site-id',
+  baseUrl = 'https://example.com',
+  includedUrls = [],
+  overrideBaseURL = null,
+} = {}) {
+  const fetchConfig = overrideBaseURL ? { getFetchConfig: () => ({ overrideBaseURL }) } : {};
+  return {
+    getId: () => id,
+    getBaseURL: () => baseUrl,
+    getDeliveryType: () => 'aem_edge',
+    getConfig: () => ({
+      getIncludedURLs: () => Promise.resolve(includedUrls),
+      ...fetchConfig,
+    }),
+  };
+}
+
+// ─── Logger ───────────────────────────────────────────────────────────────────
+
+export function buildLog(sandbox) {
+  return {
+    info: sandbox.stub(),
+    warn: sandbox.stub(),
+    error: sandbox.stub(),
+    debug: sandbox.stub(),
+  };
+}
+
+// ─── S3 client ────────────────────────────────────────────────────────────────
+
+/** Convenience: creates the NoSuchKey error S3 SDK throws for missing objects. */
+export function noSuchKeyError() {
+  const err = new Error('The specified key does not exist.');
+  err.name = 'NoSuchKey';
+  return err;
+}
+
+/**
+ * Builds an S3 client stub that dispatches by key.
+ *
+ * keyMap values:
+ *   - string       → raw body (no ContentType) — use for HTML
+ *   - plain object → JSON body with ContentType: application/json
+ *   - Error        → rejected (use noSuchKeyError() for missing keys)
+ *   - absent key   → rejects with NoSuchKey automatically
+ *
+ * PutObjectCommand always resolves; use captureStatusWrite(s3Client) to inspect.
+ */
+export function buildS3Client(sandbox, keyMap = {}) {
+  const send = sandbox.stub().callsFake((cmd) => {
+    if (cmd.constructor.name === 'GetObjectCommand') {
+      const { Key } = cmd.input;
+      if (Object.hasOwn(keyMap, Key)) {
+        const value = keyMap[Key];
+        if (value instanceof Error) {
+          return Promise.reject(value);
+        }
+        const isString = typeof value === 'string';
+        const body = isString ? value : JSON.stringify(value);
+        return Promise.resolve({
+          Body: { transformToString: () => Promise.resolve(body) },
+          ...(isString ? {} : { ContentType: 'application/json' }),
+        });
+      }
+      return Promise.reject(noSuchKeyError());
+    }
+    if (cmd.constructor.name === 'PutObjectCommand') {
+      return Promise.resolve({});
+    }
+    return Promise.reject(new Error(`Unexpected S3 command: ${cmd.constructor.name}`));
+  });
+  return { send };
+}
+
+/** Canonical S3 key for a site's status.json. */
+export function statusKey(siteId) {
+  return `prerender/scrapes/${siteId}/status.json`;
+}
+
+// ─── Status.json shape ────────────────────────────────────────────────────────
+
+/**
+ * Builds a valid status.json object.
+ * pages[] entries follow the shape: { url, pathname, needsPrerender, isDeployedAtEdge }
+ */
+export function buildStatus({
+  scrapeForbidden = false,
+  scrapeForbiddenSince = undefined,
+  scrapeJobId = undefined,
+  pages = [],
+} = {}) {
+  const status = { scrapeForbidden, pages };
+  if (scrapeForbiddenSince !== undefined) {
+    status.scrapeForbiddenSince = scrapeForbiddenSince;
+  }
+  if (scrapeJobId !== undefined) {
+    status.scrapeJobId = scrapeJobId;
+  }
+  return status;
+}
+
+/** Returns a scrapeForbiddenSince timestamp N days in the past. */
+export function daysAgo(n) {
+  return new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString();
+}
+
+// ─── Suggestion ───────────────────────────────────────────────────────────────
+
+export function buildSuggestion(sandbox, {
+  id = 'suggestion-id',
+  siteId = 'test-site-id',
+  status = 'NEW',
+  data = {},
+} = {}) {
+  return {
+    getId: () => id,
+    getSiteId: () => siteId,
+    getStatus: () => status,
+    getData: () => data,
+    setData: sandbox.stub(),
+    setStatus: sandbox.stub(),
+    setUpdatedBy: sandbox.stub(),
+    save: sandbox.stub().resolvesThis(),
+  };
+}
+
+// ─── Opportunity ──────────────────────────────────────────────────────────────
+
+export function buildOpportunity(sandbox, {
+  id = 'opportunity-id',
+  siteId = 'test-site-id',
+  type = 'prerender',
+  status = 'NEW',
+  suggestions = [],
+  data = {},
+} = {}) {
+  return {
+    getId: () => id,
+    getSiteId: () => siteId,
+    getType: () => type,
+    getStatus: () => status,
+    getAuditId: () => 'audit-id',
+    getData: () => data,
+    setAuditId: sandbox.stub(),
+    setData: sandbox.stub(),
+    setStatus: sandbox.stub(),
+    setUpdatedBy: sandbox.stub(),
+    getSuggestions: sandbox.stub().resolves(suggestions),
+    // addSuggestions is called by syncSuggestions when new suggestions are created
+    addSuggestions: sandbox.stub().callsFake((newSuggestions) => Promise.resolve(newSuggestions)),
+    save: sandbox.stub().resolvesThis(),
+  };
+}
+
+// ─── DataAccess ───────────────────────────────────────────────────────────────
+
+/**
+ * Builds a dataAccess stub covering all entities the handler touches.
+ *
+ * Pass pre-built entities via overrides to control specific return values:
+ *   buildDataAccess(sandbox, { opportunities: [myOpp], topPages: [{ url, traffic }] })
+ */
+export function buildDataAccess(sandbox, {
+  opportunities = [],
+  topPages = [],
+  citabilityRecords = [],
+  scrapeUrls = [],
+} = {}) {
+  return {
+    Opportunity: {
+      allBySiteIdAndStatus: sandbox.stub().resolves(opportunities),
+      findById: sandbox.stub().resolves(opportunities[0] ?? null),
+      create: sandbox.stub().callsFake((data) => Promise.resolve(
+        buildOpportunity(sandbox, { siteId: data.siteId ?? 'test-site-id' }),
+      )),
+    },
+    SiteTopPage: {
+      allBySiteIdAndSourceAndGeo: sandbox.stub().resolves(
+        topPages.map((p) => ({
+          getUrl: () => (typeof p === 'string' ? p : p.url),
+          getTraffic: () => (typeof p === 'string' ? 100 : (p.traffic ?? 100)),
+        })),
+      ),
+    },
+    PageCitability: {
+      allByIndexKeys: sandbox.stub().resolves(citabilityRecords),
+      findByIndexKeys: sandbox.stub().resolves(null),
+      create: sandbox.stub().resolvesThis(),
+    },
+    ScrapeUrl: {
+      allByScrapeJobId: sandbox.stub().resolves(
+        scrapeUrls.map((u) => ({
+          getUrl: () => u,
+          getStatus: () => 'COMPLETE',
+          getStatusCode: () => 200,
+        })),
+      ),
+    },
+    Suggestion: {
+      saveMany: sandbox.stub().resolves([]),
+      bulkUpdateStatus: sandbox.stub().resolves([]),
+      allByOpportunityIdAndStatus: sandbox.stub().resolves([]),
+    },
+  };
+}
+
+// ─── SQS ──────────────────────────────────────────────────────────────────────
+
+export function buildSqs(sandbox) {
+  return { sendMessage: sandbox.stub().resolves() };
+}
+
+// ─── Full context ─────────────────────────────────────────────────────────────
+
+/**
+ * Assembles a complete handler context.
+ * All dependencies default to safe stubs; pass overrides for the ones your test cares about.
+ *
+ * @example
+ * const ctx = buildContext(sandbox, {
+ *   site: buildSite({ id: 'blocked-site' }),
+ *   s3Client: buildS3Client(sandbox, {
+ *     [statusKey('blocked-site')]: buildStatus({
+ *       scrapeForbidden: true, scrapeForbiddenSince: daysAgo(1),
+ *     }),
+ *   }),
+ * });
+ */
+export function buildContext(sandbox, overrides = {}) {
+  const site = overrides.site ?? buildSite();
+  return {
+    site,
+    log: buildLog(sandbox),
+    s3Client: buildS3Client(sandbox),
+    dataAccess: buildDataAccess(sandbox),
+    sqs: buildSqs(sandbox),
+    env: {
+      S3_SCRAPER_BUCKET_NAME: 'test-bucket',
+      QUEUE_SPACECAT_TO_MYSTIQUE: 'https://sqs.us-east-1.amazonaws.com/test-queue',
+    },
+    finalUrl: site.getBaseURL(),
+    audit: { getId: () => 'audit-id' },
+    auditContext: {},
+    scrapeResultPaths: new Map(),
+    data: null,
+    ...overrides,
+  };
+}
+
+// ─── S3 inspection helpers ────────────────────────────────────────────────────
+
+/** Returns the parsed body of the first PutObjectCommand sent to an s3Client stub. */
+export function captureStatusWrite(s3Client) {
+  const put = s3Client.send.getCalls().find(
+    (c) => c.args[0]?.constructor?.name === 'PutObjectCommand',
+  );
+  if (!put) {
+    return null;
+  }
+  return JSON.parse(put.args[0].input.Body);
+}

--- a/test/audits/prerender/behaviour/mode-routing.test.js
+++ b/test/audits/prerender/behaviour/mode-routing.test.js
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Behavioural contracts: mode routing
+ *
+ * Covers how each step detects its operating mode and branches accordingly.
+ * Mocks only external I/O (S3, DB) — never internal handler functions —
+ * so these tests stay green through module extraction and refactoring.
+ *
+ * AI-only mode routing is fully covered in ../ai-only-mode.test.js which
+ * already follows the external-mock-only pattern. Tests here focus on the
+ * normal, CSV, and Slack paths that currently rely on esmock in handler.test.js.
+ */
+
+/* eslint-env mocha */
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import {
+  importTopPages,
+  submitForScraping,
+} from '../../../../src/prerender/handler.js';
+import {
+  buildContext,
+  buildSite,
+  buildS3Client,
+  buildDataAccess,
+  statusKey,
+  buildStatus,
+  daysAgo,
+} from './helpers.js';
+
+use(sinonChai);
+
+// ─── Step 1 ───────────────────────────────────────────────────────────────────
+
+describe('Prerender behaviour — mode routing', () => {
+  let sandbox;
+
+  beforeEach(() => { sandbox = sinon.createSandbox(); });
+  afterEach(() => { sandbox.restore(); });
+
+  describe('Step 1: importTopPages', () => {
+    it('normal mode returns a top-pages trigger object', async () => {
+      const ctx = buildContext(sandbox, {
+        site: buildSite({ id: 'site-abc', baseUrl: 'https://example.com' }),
+        finalUrl: 'https://example.com',
+      });
+
+      const result = await importTopPages(ctx);
+
+      expect(result.type).to.equal('top-pages');
+      expect(result.siteId).to.equal('site-abc');
+      expect(result.fullAuditRef).to.equal('scrapes/site-abc/');
+      expect(result.auditResult).to.deep.equal({ status: 'preparing', finalUrl: 'https://example.com' });
+      // auditContext must NOT be present when no CSV urls given
+      expect(result).to.not.have.property('auditContext');
+    });
+
+    it('CSV mode forwards urls in the trigger so the import worker preserves them', async () => {
+      const csvUrls = ['https://example.com/page-1', 'https://example.com/page-2'];
+      const ctx = buildContext(sandbox, {
+        site: buildSite({ id: 'site-csv' }),
+        finalUrl: 'https://example.com',
+        auditContext: { urls: csvUrls },
+      });
+
+      const result = await importTopPages(ctx);
+
+      expect(result.type).to.equal('top-pages');
+      expect(result.auditContext.urls).to.deep.equal(csvUrls);
+    });
+
+    it('empty auditContext.urls is treated the same as no urls (no auditContext forwarded)', async () => {
+      const ctx = buildContext(sandbox, {
+        site: buildSite({ id: 'site-empty' }),
+        finalUrl: 'https://example.com',
+        auditContext: { urls: [] },
+      });
+
+      const result = await importTopPages(ctx);
+
+      expect(result).to.not.have.property('auditContext');
+    });
+  });
+
+  // ─── Step 2 ─────────────────────────────────────────────────────────────────
+
+  describe('Step 2: submitForScraping', () => {
+    it('CSV mode returns rebased URLs immediately and never reads status.json', async () => {
+      const site = buildSite({ id: 'site-csv', baseUrl: 'https://example.com' });
+      const s3Client = buildS3Client(sandbox); // no keys configured — any S3 read would throw
+      const ctx = buildContext(sandbox, {
+        site,
+        s3Client,
+        auditContext: {
+          urls: [
+            'https://other-domain.com/page-1',
+            'https://other-domain.com/page-2',
+          ],
+        },
+      });
+
+      const result = await submitForScraping(ctx);
+
+      // URLs rebased to site's base domain
+      expect(result.urls).to.be.an('array').with.length(2);
+      result.urls.forEach(({ url }) => {
+        expect(url).to.match(/^https:\/\/example\.com\//);
+      });
+
+      // status.json was never read
+      expect(s3Client.send).to.not.have.been.called;
+    });
+
+    it('CSV mode does not set domainBlocked even when status.json would show scrapeForbidden', async () => {
+      // This confirms CSV path bypasses the sticky bot-block check entirely.
+      const siteId = 'site-csv-bypass';
+      const s3Client = buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus({
+          scrapeForbidden: true,
+          scrapeForbiddenSince: daysAgo(1),
+        }),
+      });
+      const ctx = buildContext(sandbox, {
+        site: buildSite({ id: siteId }),
+        s3Client,
+        auditContext: { urls: ['https://example.com/page-1'] },
+      });
+
+      const result = await submitForScraping(ctx);
+
+      expect(result.auditContext?.domainBlocked).to.be.undefined;
+      expect(result.urls).to.have.length(1);
+    });
+
+    it('Slack mode bypasses the sticky bot-block check so operators can force a re-scrape', async () => {
+      // Even with scrapeForbidden active, a Slack-triggered run must proceed.
+      const siteId = 'site-slack-bypass';
+      const s3Client = buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus({
+          scrapeForbidden: true,
+          scrapeForbiddenSince: daysAgo(1),
+        }),
+      });
+      const ctx = buildContext(sandbox, {
+        site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+        s3Client,
+        dataAccess: buildDataAccess(sandbox, {
+          topPages: ['https://example.com/page-1', 'https://example.com/page-2'],
+        }),
+        auditContext: {
+          slackContext: { channelId: 'C12345', threadId: 'T67890' },
+        },
+      });
+
+      const result = await submitForScraping(ctx);
+
+      expect(result.auditContext?.domainBlocked).to.be.undefined;
+      // URLs present — scraping was not skipped
+      expect(result.urls).to.be.an('array').with.length.greaterThan(0);
+    });
+
+    it('Slack mode does not apply PageCitability dedup or DAILY_BATCH_SIZE cap', async () => {
+      // Slack runs return all available URLs regardless of recent processing or batch limits.
+      // getTopOrganicUrlsFromSeo caps at TOP_ORGANIC_URLS_LIMIT=200, so we push above
+      // DAILY_BATCH_SIZE=320 by combining organic (200) with includedURLs (150).
+      const siteId = 'site-slack-all';
+      const organicUrls = Array.from({ length: 200 }, (_, i) => `https://example.com/organic-${i}`);
+      const includedUrls = Array.from({ length: 150 }, (_, i) => `https://example.com/included-${i}`);
+
+      // All organic URLs appear in PageCitability as recently processed (1 day ago).
+      // Normal mode would exclude all of them; Slack must include them.
+      const citabilityRecords = organicUrls.map((url) => ({
+        getUrl: () => url,
+        getUpdatedAt: () => new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+      }));
+
+      const s3Client = buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+      });
+      const ctx = buildContext(sandbox, {
+        site: buildSite({ id: siteId, baseUrl: 'https://example.com', includedUrls }),
+        s3Client,
+        dataAccess: buildDataAccess(sandbox, {
+          topPages: organicUrls,
+          citabilityRecords,
+        }),
+        auditContext: {
+          slackContext: { channelId: 'C12345' },
+        },
+      });
+
+      const result = await submitForScraping(ctx);
+
+      // organic(200, not deduped) + included(150) = 350 > DAILY_BATCH_SIZE(320)
+      expect(result.urls.length).to.be.greaterThan(320);
+    });
+
+    it('normal mode reads status.json before deciding whether to scrape', async () => {
+      // Confirms the normal path is taken when no CSV urls and no Slack context.
+      const siteId = 'site-normal';
+      const s3Client = buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(), // clean status — not blocked
+      });
+      const ctx = buildContext(sandbox, {
+        site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+        s3Client,
+        dataAccess: buildDataAccess(sandbox, {
+          topPages: ['https://example.com/page-1'],
+        }),
+      });
+
+      await submitForScraping(ctx);
+
+      // status.json was read (GetObjectCommand fired for the status key)
+      const reads = s3Client.send.getCalls().filter(
+        (c) => c.args[0]?.constructor?.name === 'GetObjectCommand'
+          && c.args[0]?.input?.Key === statusKey(siteId),
+      );
+      expect(reads).to.have.length.greaterThan(0);
+    });
+  });
+});

--- a/test/audits/prerender/behaviour/mystique-round-trip.test.js
+++ b/test/audits/prerender/behaviour/mystique-round-trip.test.js
@@ -1,0 +1,431 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Behavioural contracts: Mystique round-trip
+ *
+ * OUTBOUND (audit worker → Mystique via SQS):
+ *   - Branch A fires → SQS message sent to QUEUE_SPACECAT_TO_MYSTIQUE
+ *   - Message structure: type=guidance:prerender, data.opportunityId, data.suggestions[].url
+ *   - Branch C (no prerender URLs) → no SQS message sent
+ *
+ * INBOUND (Mystique → guidance-handler.js):
+ *   - Valid aiSummary → aiSummary + valuable both updated
+ *   - aiSummary absent/invalid → existing aiSummary + valuable BOTH preserved
+ *   - OUTDATED suggestion excluded from update
+ *   - URL in Mystique response not in DB → warning logged, skipped
+ *   - Missing presignedUrl or opportunityId → badRequest
+ *   - Opportunity not found → notFound
+ */
+
+/* eslint-env mocha */
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import esmock from 'esmock';
+import { processContentAndGenerateOpportunities } from '../../../../src/prerender/handler.js';
+import {
+  buildContext,
+  buildSite,
+  buildS3Client,
+  buildDataAccess,
+  buildOpportunity,
+  buildSuggestion,
+  buildUrlS3Content,
+  statusKey,
+  buildStatus,
+  HTML_SERVER_SPARSE,
+  HTML_CLIENT_NEEDS_PRERENDER,
+} from './helpers.js';
+
+use(sinonChai);
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Builds a context that will trigger Branch A (prerender URLs found) in step 3.
+ * Server HTML is sparse; client HTML is rich → contentGainRatio > 1.1.
+ */
+function buildBranchAStep3Ctx(sandbox, siteId, scrapeJobId, url) {
+  return buildContext(sandbox, {
+    site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+    s3Client: buildS3Client(sandbox, {
+      [statusKey(siteId)]: buildStatus(),
+      ...buildUrlS3Content(scrapeJobId, url, {
+        serverHtml: HTML_SERVER_SPARSE,
+        clientHtml: HTML_CLIENT_NEEDS_PRERENDER,
+      }),
+    }),
+    dataAccess: buildDataAccess(sandbox, {
+      scrapeUrls: [url],
+      opportunities: [],
+    }),
+    scrapeResultPaths: new Map([[url, {}]]),
+    auditContext: { scrapeJobId },
+  });
+}
+
+// ─── OUTBOUND ─────────────────────────────────────────────────────────────────
+
+describe('Prerender behaviour — Mystique round-trip (outbound)', () => {
+  let sandbox;
+
+  beforeEach(() => { sandbox = sinon.createSandbox(); });
+  afterEach(() => { sandbox.restore(); });
+
+  it('Branch A: SQS message sent to Mystique queue with type=guidance:prerender and data.suggestions', async () => {
+    const siteId = 'site-outbound-a';
+    const scrapeJobId = 'job-outbound-a';
+    const url = 'https://example.com/page-1';
+
+    const ctx = buildBranchAStep3Ctx(sandbox, siteId, scrapeJobId, url);
+
+    await processContentAndGenerateOpportunities(ctx);
+
+    expect(ctx.sqs.sendMessage).to.have.been.called;
+    const [queue, message] = ctx.sqs.sendMessage.firstCall.args;
+
+    // Sent to the correct Mystique queue
+    expect(queue).to.equal(ctx.env.QUEUE_SPACECAT_TO_MYSTIQUE);
+
+    // Message structure
+    expect(message).to.have.property('type', 'guidance:prerender');
+    expect(message).to.have.property('siteId', siteId);
+    expect(message.data).to.have.property('opportunityId').that.is.a('string');
+    expect(message.data).to.have.property('suggestions').that.is.an('array').with.length.greaterThan(0);
+
+    // Each suggestion carries the URL so Mystique can match it on response
+    const [firstSuggestion] = message.data.suggestions;
+    expect(firstSuggestion).to.have.property('url', url);
+  });
+
+  it('Branch B (isDomainBlocked=true / scrapeForbidden) → Mystique SQS message NOT sent', async () => {
+    const siteId = 'site-outbound-b';
+
+    // isDomainBlocked=true → scrapeForbidden=true → Branch B fires (createScrapeForbiddenOpportunity).
+    // Branch B never reaches sendPrerenderGuidanceRequestToMystique, so no SQS message is sent.
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+      }),
+      dataAccess: buildDataAccess(sandbox, {
+        opportunities: [],
+      }),
+      scrapeResultPaths: new Map(),
+      auditContext: { domainBlocked: true },
+    });
+
+    await processContentAndGenerateOpportunities(ctx);
+
+    expect(ctx.sqs.sendMessage).to.not.have.been.called;
+  });
+
+  it('Branch C (no prerender URLs): SQS message NOT sent to Mystique', async () => {
+    const siteId = 'site-outbound-c';
+    const scrapeJobId = 'job-outbound-c';
+    const url = 'https://example.com/no-prerender';
+
+    // Identical HTML → ratio = 1.0 < 1.1 → needsPrerender=false → Branch C
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+        // HTML_SAME (default) → no prerender needed
+        ...buildUrlS3Content(scrapeJobId, url),
+      }),
+      dataAccess: buildDataAccess(sandbox, {
+        scrapeUrls: [url],
+        opportunities: [],
+      }),
+      scrapeResultPaths: new Map([[url, {}]]),
+      auditContext: { scrapeJobId },
+    });
+
+    await processContentAndGenerateOpportunities(ctx);
+
+    // No SQS send — Branch C does not dispatch to Mystique
+    expect(ctx.sqs.sendMessage).to.not.have.been.called;
+  });
+});
+
+// ─── INBOUND ──────────────────────────────────────────────────────────────────
+
+describe('Prerender behaviour — Mystique round-trip (inbound: guidance-handler)', () => {
+  let sandbox;
+  let guidanceHandler;
+  let fetchAnalysisStub;
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    fetchAnalysisStub = sandbox.stub();
+    ({ default: guidanceHandler } = await esmock(
+      '../../../../src/prerender/guidance-handler.js',
+      {
+        '../../../../src/utils/analysis-fetch.js': {
+          fetchAnalysisFromPresignedUrl: fetchAnalysisStub,
+        },
+      },
+    ));
+  });
+  afterEach(() => { sandbox.restore(); });
+
+  // ─── Context builder for guidance-handler ──────────────────────────────────
+
+  function buildGuidanceCtx(overrides = {}) {
+    const site = buildSite({ id: overrides.siteId ?? 'site-guidance', baseUrl: 'https://example.com' });
+    return {
+      log: {
+        info: sandbox.stub(),
+        warn: sandbox.stub(),
+        error: sandbox.stub(),
+        debug: sandbox.stub(),
+      },
+      dataAccess: {
+        Site: {
+          findById: sandbox.stub().resolves(site),
+        },
+        Opportunity: {
+          findById: sandbox.stub().resolves(overrides.opportunity ?? null),
+        },
+        Suggestion: {
+          saveMany: sandbox.stub().resolves([]),
+        },
+      },
+      env: { QUEUE_SPACECAT_TO_MYSTIQUE: 'https://sqs.us-east-1.amazonaws.com/test' },
+      ...overrides.ctxOverrides,
+    };
+  }
+
+  function buildMessage(siteId, opportunityId, overrides = {}) {
+    return {
+      siteId,
+      data: {
+        presignedUrl: 'https://s3.amazonaws.com/bucket/results.json?X-Amz-Signature=abc',
+        opportunityId,
+        ...overrides,
+      },
+    };
+  }
+
+  // ─── aiSummary / valuable coupling ────────────────────────────────────────
+
+  it('valid aiSummary → aiSummary AND valuable both updated in DB', async () => {
+    const siteId = 'site-inbound-summary';
+    const oppId = 'opp-summary-1';
+    const url = 'https://example.com/page-1';
+
+    const suggestion = buildSuggestion(sandbox, {
+      id: 'sug-1',
+      status: 'NEW',
+      data: { url, wordCountBefore: 10, wordCountAfter: 100 },
+    });
+    suggestion.setData = sandbox.stub();
+
+    const opportunity = buildOpportunity(sandbox, {
+      id: oppId,
+      siteId,
+      suggestions: [suggestion],
+    });
+
+    fetchAnalysisStub.resolves({
+      suggestions: [{ url, aiSummary: 'Great page with rich content.', valuable: true }],
+    });
+
+    const ctx = buildGuidanceCtx({ siteId, opportunity });
+    await guidanceHandler(buildMessage(siteId, oppId), ctx);
+
+    expect(suggestion.setData).to.have.been.called;
+    const [updatedData] = suggestion.setData.firstCall.args;
+    expect(updatedData).to.have.property('aiSummary', 'Great page with rich content.');
+    expect(updatedData).to.have.property('valuable', true);
+    expect(ctx.dataAccess.Suggestion.saveMany).to.have.been.called;
+  });
+
+  it('valid aiSummary with valuable=false → both updated, valuable=false persisted', async () => {
+    const siteId = 'site-inbound-not-valuable';
+    const oppId = 'opp-nv-1';
+    const url = 'https://example.com/page-2';
+
+    const suggestion = buildSuggestion(sandbox, {
+      id: 'sug-nv',
+      status: 'NEW',
+      data: { url, aiSummary: 'old', valuable: true },
+    });
+    suggestion.setData = sandbox.stub();
+
+    const opportunity = buildOpportunity(sandbox, {
+      id: oppId,
+      siteId,
+      suggestions: [suggestion],
+    });
+
+    fetchAnalysisStub.resolves({
+      suggestions: [{ url, aiSummary: 'Thin page, little value.', valuable: false }],
+    });
+
+    const ctx = buildGuidanceCtx({ siteId, opportunity });
+    await guidanceHandler(buildMessage(siteId, oppId), ctx);
+
+    const [updatedData] = suggestion.setData.firstCall.args;
+    expect(updatedData).to.have.property('aiSummary', 'Thin page, little value.');
+    expect(updatedData).to.have.property('valuable', false);
+  });
+
+  it('aiSummary absent in response → existing aiSummary AND valuable both preserved', async () => {
+    // When Mystique sends "Not Available", the handler preserves the previously stored
+    // aiSummary and valuable — it still calls setData/saveMany but with the old values intact.
+    const siteId = 'site-inbound-preserve';
+    const oppId = 'opp-preserve-1';
+    const url = 'https://example.com/page-3';
+
+    const suggestion = buildSuggestion(sandbox, {
+      id: 'sug-preserve',
+      status: 'NEW',
+      data: { url, aiSummary: 'Previously computed summary', valuable: true },
+    });
+    suggestion.setData = sandbox.stub();
+
+    const opportunity = buildOpportunity(sandbox, {
+      id: oppId,
+      siteId,
+      suggestions: [suggestion],
+    });
+
+    // Mystique returns "Not Available" — treated as no summary
+    fetchAnalysisStub.resolves({
+      suggestions: [{ url, aiSummary: 'Not Available', valuable: false }],
+    });
+
+    const ctx = buildGuidanceCtx({ siteId, opportunity });
+    await guidanceHandler(buildMessage(siteId, oppId), ctx);
+
+    // setData IS called but with the preserved (old) values — not the "Not Available" response
+    expect(suggestion.setData).to.have.been.called;
+    const [updatedData] = suggestion.setData.firstCall.args;
+    expect(updatedData).to.have.property('aiSummary', 'Previously computed summary');
+    expect(updatedData).to.have.property('valuable', true);
+  });
+
+  // ─── Filtering ────────────────────────────────────────────────────────────
+
+  it('OUTDATED suggestion is excluded from update even when URL matches', async () => {
+    const siteId = 'site-inbound-outdated';
+    const oppId = 'opp-outdated-1';
+    const url = 'https://example.com/page-outdated';
+
+    const outdatedSuggestion = buildSuggestion(sandbox, {
+      id: 'sug-outdated',
+      status: 'OUTDATED',
+      data: { url },
+    });
+    outdatedSuggestion.setData = sandbox.stub();
+
+    const activeSuggestion = buildSuggestion(sandbox, {
+      id: 'sug-active',
+      status: 'NEW',
+      data: { url: 'https://example.com/page-active' },
+    });
+    activeSuggestion.setData = sandbox.stub();
+
+    const opportunity = buildOpportunity(sandbox, {
+      id: oppId,
+      siteId,
+      suggestions: [outdatedSuggestion, activeSuggestion],
+    });
+
+    fetchAnalysisStub.resolves({
+      suggestions: [
+        { url, aiSummary: 'Summary for outdated page', valuable: true },
+        { url: 'https://example.com/page-active', aiSummary: 'Active summary', valuable: true },
+      ],
+    });
+
+    const ctx = buildGuidanceCtx({ siteId, opportunity });
+    await guidanceHandler(buildMessage(siteId, oppId), ctx);
+
+    // OUTDATED suggestion must not have been updated
+    expect(outdatedSuggestion.setData).to.not.have.been.called;
+    // Active suggestion was updated
+    expect(activeSuggestion.setData).to.have.been.called;
+  });
+
+  it('URL in Mystique response not in DB → warning logged, other suggestions still processed', async () => {
+    const siteId = 'site-inbound-unknown-url';
+    const oppId = 'opp-unknown-1';
+    const knownUrl = 'https://example.com/known';
+    const unknownUrl = 'https://example.com/ghost-page';
+
+    const knownSuggestion = buildSuggestion(sandbox, {
+      id: 'sug-known',
+      status: 'NEW',
+      data: { url: knownUrl },
+    });
+    knownSuggestion.setData = sandbox.stub();
+
+    const opportunity = buildOpportunity(sandbox, {
+      id: oppId,
+      siteId,
+      suggestions: [knownSuggestion],
+    });
+
+    fetchAnalysisStub.resolves({
+      suggestions: [
+        { url: unknownUrl, aiSummary: 'Stale response for deleted page', valuable: true },
+        { url: knownUrl, aiSummary: 'Good summary', valuable: true },
+      ],
+    });
+
+    const ctx = buildGuidanceCtx({ siteId, opportunity });
+    await guidanceHandler(buildMessage(siteId, oppId), ctx);
+
+    // Unknown URL is skipped with a warning
+    expect(ctx.log.warn).to.have.been.calledWithMatch(new RegExp(unknownUrl));
+    // Known URL is still processed
+    expect(knownSuggestion.setData).to.have.been.called;
+  });
+
+  // ─── Early exits ──────────────────────────────────────────────────────────
+
+  it('missing presignedUrl in message → badRequest response', async () => {
+    const ctx = buildGuidanceCtx({ siteId: 'site-bad-req' });
+    const message = buildMessage('site-bad-req', 'opp-1', { presignedUrl: undefined });
+
+    const result = await guidanceHandler(message, ctx);
+
+    expect(result.status).to.equal(400);
+  });
+
+  it('missing opportunityId in message → badRequest response', async () => {
+    const ctx = buildGuidanceCtx({ siteId: 'site-bad-opp' });
+    const message = { siteId: 'site-bad-opp', data: { presignedUrl: 'https://s3.amazonaws.com/x.json' } };
+
+    const result = await guidanceHandler(message, ctx);
+
+    expect(result.status).to.equal(400);
+  });
+
+  it('opportunity not found in DB → notFound response', async () => {
+    const siteId = 'site-no-opp';
+    fetchAnalysisStub.resolves({ suggestions: [] });
+
+    const ctx = buildGuidanceCtx({
+      siteId,
+      opportunity: null, // Opportunity.findById returns null
+    });
+    ctx.dataAccess.Opportunity.findById = sandbox.stub().resolves(null);
+
+    const result = await guidanceHandler(buildMessage(siteId, 'opp-missing'), ctx);
+
+    expect(result.status).to.equal(404);
+  });
+});

--- a/test/audits/prerender/behaviour/opportunity-creation.test.js
+++ b/test/audits/prerender/behaviour/opportunity-creation.test.js
@@ -1,0 +1,240 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Behavioural contracts: opportunity and suggestion creation
+ *
+ * Branch A (urlsNeedingPrerender > 0): correct suggestion data shape written to DB,
+ * including domain-wide aggregate suggestion.
+ *
+ * Branch B (scrapeForbidden, no prerender URLs): createScrapeForbiddenOpportunity
+ * runs convertToOpportunity without creating per-URL suggestions.
+ *
+ * Tests call the exported processOpportunityAndSuggestions and
+ * createScrapeForbiddenOpportunity directly — these will become the
+ * opportunity-syncer.js module after refactoring.
+ */
+
+/* eslint-env mocha */
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import {
+  processOpportunityAndSuggestions,
+  createScrapeForbiddenOpportunity,
+  processContentAndGenerateOpportunities,
+} from '../../../../src/prerender/handler.js';
+import {
+  buildContext,
+  buildSite,
+  buildS3Client,
+  buildDataAccess,
+  buildUrlS3Content,
+  statusKey,
+  buildStatus,
+  scrapeKeys,
+} from './helpers.js';
+
+use(sinonChai);
+
+describe('Prerender behaviour — opportunity creation (Branch A + B)', () => {
+  let sandbox;
+
+  beforeEach(() => { sandbox = sinon.createSandbox(); });
+  afterEach(() => { sandbox.restore(); });
+
+  // ─── Branch A helpers ─────────────────────────────────────────────────────────
+
+  function buildBranchAContext(siteId, scrapeJobId, url) {
+    return buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox),
+      // No existing opportunities → Opportunity.create will be called
+      dataAccess: buildDataAccess(sandbox, { opportunities: [] }),
+    });
+  }
+
+  function buildBranchAAuditData(siteId, scrapeJobId, url, overrides = {}) {
+    const result = {
+      url,
+      needsPrerender: true,
+      contentGainRatio: 8.4,
+      wordCountBefore: 10,
+      wordCountAfter: 84,
+      citabilityScore: 1,
+      isDeployedAtEdge: false,
+      ...overrides,
+    };
+    return {
+      siteId,
+      id: 'audit-id',
+      auditId: 'audit-id',
+      auditResult: {
+        urlsNeedingPrerender: 1,
+        results: [result],
+      },
+      scrapeJobId,
+      scrapedUrlsSet: new Set([url]),
+    };
+  }
+
+  // ─── Branch A: correct suggestion data shape ──────────────────────────────────
+
+  it('Branch A: suggestion data contains url, word counts, contentGainRatio, and S3 HTML keys', async () => {
+    const siteId = 'site-branch-a';
+    const scrapeJobId = 'job-branch-a';
+    const url = 'https://example.com/page-1';
+    const keys = scrapeKeys(scrapeJobId, url);
+
+    const ctx = buildBranchAContext(siteId, scrapeJobId, url);
+    const auditData = buildBranchAAuditData(siteId, scrapeJobId, url);
+
+    await processOpportunityAndSuggestions('https://example.com', auditData, ctx, false);
+
+    // syncSuggestions calls opportunity.addSuggestions with new suggestions
+    const opp = ctx.dataAccess.Opportunity.create.firstCall?.returnValue
+      ?? await ctx.dataAccess.Opportunity.create.firstCall?.returnValue;
+    // Retrieve the resolved opportunity from the create stub
+    const createdOpp = await ctx.dataAccess.Opportunity.create.firstCall.returnValue;
+    expect(createdOpp.addSuggestions).to.have.been.called;
+
+    const [newSuggestions] = createdOpp.addSuggestions.firstCall.args;
+    const urlSuggestion = newSuggestions.find((s) => s.data?.url === url);
+    expect(urlSuggestion, `suggestion for ${url} must exist`).to.not.be.undefined;
+
+    const { data } = urlSuggestion;
+    expect(data).to.have.property('wordCountBefore', 10);
+    expect(data).to.have.property('wordCountAfter', 84);
+    expect(data).to.have.property('contentGainRatio', 8.4);
+    expect(data).to.have.property('scrapeJobId', scrapeJobId);
+    // HTML keys must point to the canonical S3 paths
+    expect(data).to.have.property('originalHtmlKey', keys.serverHtml);
+    expect(data).to.have.property('prerenderedHtmlKey', keys.clientHtml);
+  });
+
+  it('Branch A: domain-wide aggregate suggestion is included alongside per-URL suggestions', async () => {
+    const siteId = 'site-domain-wide';
+    const scrapeJobId = 'job-domain-wide';
+    const url = 'https://example.com/page-1';
+
+    const ctx = buildBranchAContext(siteId, scrapeJobId, url);
+    const auditData = buildBranchAAuditData(siteId, scrapeJobId, url);
+
+    await processOpportunityAndSuggestions('https://example.com', auditData, ctx, false);
+
+    const createdOpp = await ctx.dataAccess.Opportunity.create.firstCall.returnValue;
+    const [newSuggestions] = createdOpp.addSuggestions.firstCall.args;
+
+    // Domain-wide suggestion has isDomainWide=true in its data
+    const domainWideSuggestion = newSuggestions.find((s) => s.data?.isDomainWide === true);
+    expect(domainWideSuggestion, 'domain-wide suggestion must be included').to.not.be.undefined;
+    expect(domainWideSuggestion.data).to.have.property('url').that.includes('All Domain URLs');
+  });
+
+  // ─── Branch B: scrapeForbidden opportunity data ───────────────────────────────
+
+  it('Branch B: opportunity created with scrapeForbidden=true and scrapeForbiddenCount in data', async () => {
+    // createOpportunityData maps auditResult.scrapeForbidden → opportunity.data.scrapeForbidden.
+    // This field drives the UI's "scraping blocked" banner and must be written correctly.
+    const siteId = 'site-branch-b-data';
+    const scrapeJobId = 'job-branch-b-data';
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox),
+      dataAccess: buildDataAccess(sandbox, { opportunities: [] }),
+    });
+
+    await createScrapeForbiddenOpportunity(
+      'https://example.com',
+      {
+        siteId,
+        id: 'audit-id',
+        auditId: 'audit-id',
+        auditResult: { scrapeForbidden: true, scrapeForbiddenCount: 2 },
+        scrapeJobId,
+      },
+      ctx,
+      false,
+    );
+
+    expect(ctx.dataAccess.Opportunity.create).to.have.been.called;
+    const [opportunityData] = ctx.dataAccess.Opportunity.create.firstCall.args;
+    expect(opportunityData.data).to.have.property('scrapeForbidden', true);
+    expect(opportunityData.data).to.have.property('scrapeForbiddenCount', 2);
+  });
+
+  it('Branch C with no existing opportunity: no OUTDATED marking attempted', async () => {
+    // When no prerender URLs are found AND no opportunity exists in the DB,
+    // syncSuggestions must not be called — there are no suggestions to OUTDATED.
+    // allBySiteIdAndStatus is still called (the lookup must happen) but returns nothing.
+    const siteId = 'site-branch-c-noopp';
+    const scrapeJobId = 'job-branch-c-noopp';
+    const url = 'https://example.com/page-1';
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+        // identical HTML → contentGainRatio ≈ 1.0 → needsPrerender=false → Branch C
+        ...buildUrlS3Content(scrapeJobId, url),
+      }),
+      dataAccess: buildDataAccess(sandbox, {
+        opportunities: [], // no existing opportunity
+        scrapeUrls: [url],
+      }),
+      scrapeResultPaths: new Map([[url, {}]]),
+      auditContext: { scrapeJobId },
+    });
+
+    await processContentAndGenerateOpportunities(ctx);
+
+    // The DB was consulted to look for an existing opportunity
+    expect(ctx.dataAccess.Opportunity.allBySiteIdAndStatus).to.have.been.called;
+    // No existing opportunity → nothing to OUTDATED → bulkUpdateStatus never called
+    expect(ctx.dataAccess.Suggestion.bulkUpdateStatus).to.not.have.been.called;
+  });
+
+  // ─── Branch B: scrapeForbidden opportunity (structural) ───────────────────────
+
+  it('Branch B: createScrapeForbiddenOpportunity runs convertToOpportunity without per-URL suggestions', async () => {
+    const siteId = 'site-branch-b';
+    const scrapeJobId = 'job-branch-b';
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox),
+      dataAccess: buildDataAccess(sandbox, { opportunities: [] }),
+    });
+
+    await createScrapeForbiddenOpportunity(
+      'https://example.com',
+      {
+        siteId,
+        id: 'audit-id',
+        auditId: 'audit-id',
+        auditResult: { scrapeForbidden: true, scrapeForbiddenCount: 2 },
+        scrapeJobId,
+      },
+      ctx,
+      false,
+    );
+
+    // convertToOpportunity must look for existing + potentially create one
+    expect(ctx.dataAccess.Opportunity.allBySiteIdAndStatus).to.have.been.called;
+    // No per-URL suggestions — addSuggestions must NOT have been called
+    const createdOpp = await ctx.dataAccess.Opportunity.create.firstCall?.returnValue;
+    if (createdOpp) {
+      expect(createdOpp.addSuggestions).to.not.have.been.called;
+    }
+  });
+});

--- a/test/audits/prerender/behaviour/scrape-error-safety.test.js
+++ b/test/audits/prerender/behaviour/scrape-error-safety.test.js
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Behavioural contracts: scrape error safety
+ *
+ * Verifies that errored URLs (S3 NoSuchKey / missing HTML) never cause their
+ * suggestions to be marked OUTDATED, while successfully scraped URLs are still
+ * eligible for OUTDATED marking.
+ */
+
+/* eslint-env mocha */
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { processContentAndGenerateOpportunities } from '../../../../src/prerender/handler.js';
+import {
+  buildContext,
+  buildSite,
+  buildS3Client,
+  buildDataAccess,
+  buildOpportunity,
+  buildSuggestion,
+  buildUrlS3Content,
+  buildStatus,
+  statusKey,
+} from './helpers.js';
+
+use(sinonChai);
+
+describe('Prerender behaviour — scrape error safety', () => {
+  let sandbox;
+
+  beforeEach(() => { sandbox = sinon.createSandbox(); });
+  afterEach(() => { sandbox.restore(); });
+
+  it('100% scraping error → no suggestions marked OUTDATED', async () => {
+    const siteId = 'site-all-error';
+    const scrapeJobId = 'job-all-error';
+    const url1 = 'https://example.com/error-page-1';
+    const url2 = 'https://example.com/error-page-2';
+
+    // Both URLs have NO S3 content — every GetObjectCommand for these keys
+    // will reject with NoSuchKey (buildS3Client default for absent keys).
+    // Only the status.json key is present so the handler can read/write it.
+    const s3Client = buildS3Client(sandbox, {
+      [statusKey(siteId)]: buildStatus(),
+    });
+
+    const url1Suggestion = buildSuggestion(sandbox, {
+      id: 'sug-err-1',
+      siteId,
+      status: 'NEW',
+      data: { url: url1 },
+    });
+    const url2Suggestion = buildSuggestion(sandbox, {
+      id: 'sug-err-2',
+      siteId,
+      status: 'NEW',
+      data: { url: url2 },
+    });
+
+    const opportunity = buildOpportunity(sandbox, {
+      id: 'opp-all-error',
+      siteId,
+      type: 'prerender',
+      status: 'NEW',
+      suggestions: [url1Suggestion, url2Suggestion],
+    });
+
+    const dataAccess = buildDataAccess(sandbox, {
+      opportunities: [opportunity],
+      scrapeUrls: [url1, url2],
+    });
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client,
+      dataAccess,
+      scrapeResultPaths: new Map([[url1, {}], [url2, {}]]),
+      auditContext: { scrapeJobId },
+    });
+
+    await processContentAndGenerateOpportunities(ctx);
+
+    // scrapedUrlsSet is empty because all comparisons errored → no URLs are
+    // eligible for OUTDATED, so bulkUpdateStatus must never be called.
+    expect(ctx.dataAccess.Suggestion.bulkUpdateStatus).to.not.have.been.called;
+  });
+
+  it('Partial error — errored URL suggestion NOT OUTDATED, successfully scraped URL IS OUTDATED', async () => {
+    const siteId = 'site-partial-error';
+    const scrapeJobId = 'job-partial-error';
+    const url1 = 'https://example.com/ok-page';
+    const url2 = 'https://example.com/error-page';
+
+    // url1 has full S3 content (HTML_SAME → needsPrerender=false, successful comparison).
+    // url2 has NO S3 content → compareHtmlContent returns { error: true, ... }.
+    const s3Client = buildS3Client(sandbox, {
+      [statusKey(siteId)]: buildStatus(),
+      ...buildUrlS3Content(scrapeJobId, url1), // HTML_SAME default → no prerender needed
+    });
+
+    const url1Suggestion = buildSuggestion(sandbox, {
+      id: 'sug-ok-1',
+      siteId,
+      status: 'NEW',
+      data: { url: url1 },
+    });
+    const url2Suggestion = buildSuggestion(sandbox, {
+      id: 'sug-err-2',
+      siteId,
+      status: 'NEW',
+      data: { url: url2 },
+    });
+
+    const opportunity = buildOpportunity(sandbox, {
+      id: 'opp-partial-error',
+      siteId,
+      type: 'prerender',
+      status: 'NEW',
+      suggestions: [url1Suggestion, url2Suggestion],
+    });
+
+    const dataAccess = buildDataAccess(sandbox, {
+      opportunities: [opportunity],
+      scrapeUrls: [url1, url2],
+    });
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client,
+      dataAccess,
+      scrapeResultPaths: new Map([[url1, {}], [url2, {}]]),
+      auditContext: { scrapeJobId },
+    });
+
+    await processContentAndGenerateOpportunities(ctx);
+
+    // bulkUpdateStatus should have been called because url1 was successfully scraped
+    // (needsPrerender=false → it belongs to scrapedUrlsSet → its suggestion is OUTDATED).
+    expect(ctx.dataAccess.Suggestion.bulkUpdateStatus).to.have.been.called;
+
+    // Collect all suggestions passed to bulkUpdateStatus across all calls.
+    const allUpdatedSuggestions = ctx.dataAccess.Suggestion.bulkUpdateStatus.args
+      .flatMap(([suggestions]) => suggestions);
+
+    const updatedIds = allUpdatedSuggestions.map((s) => s.getId());
+
+    // url1's suggestion IS in the outdated set (successfully scraped, no longer needs prerender).
+    expect(updatedIds).to.include(url1Suggestion.getId());
+
+    // url2's suggestion is NOT in the outdated set (errored → excluded from scrapedUrlsSet).
+    expect(updatedIds).to.not.include(url2Suggestion.getId());
+  });
+});

--- a/test/audits/prerender/behaviour/suggestion-lifecycle.test.js
+++ b/test/audits/prerender/behaviour/suggestion-lifecycle.test.js
@@ -1,0 +1,558 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Behavioural contracts: suggestion lifecycle in Step 3
+ *
+ * Covers Branch C (no prerender URLs → OUTDATED), edge-deployed URL exclusion from
+ * scrapedUrlsSet (prevents false-positive OUTDATED), domain-wide suggestion preservation,
+ * and detectWrongEdgeDeployedStatus unconditional execution.
+ *
+ * All tests use a scrapeResultPaths map + S3 HTML stubs so compareHtmlContent runs
+ * without esmock.  detectBotBlocker is never reached (ratio < 0.5 in all setups).
+ */
+
+/* eslint-env mocha */
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { processContentAndGenerateOpportunities } from '../../../../src/prerender/handler.js';
+import {
+  processOpportunityAndSuggestions,
+} from '../../../../src/prerender/handler.js';
+import {
+  buildContext,
+  buildSite,
+  buildS3Client,
+  buildDataAccess,
+  buildSuggestion,
+  buildOpportunity,
+  buildUrlS3Content,
+  statusKey,
+  buildStatus,
+  HTML_SERVER_SPARSE,
+  HTML_CLIENT_NEEDS_PRERENDER,
+} from './helpers.js';
+
+use(sinonChai);
+
+describe('Prerender behaviour — suggestion lifecycle (Step 3)', () => {
+  let sandbox;
+
+  beforeEach(() => { sandbox = sinon.createSandbox(); });
+  afterEach(() => { sandbox.restore(); });
+
+  /**
+   * Builds a minimal step-3 context for a single URL that produces no prerender result.
+   * Server and client HTML are identical → contentGainRatio ≈ 1.0 < 1.1 threshold.
+   * scrape.json has isDeployedAtEdge: false → URL lands in scrapedUrlsSet.
+   */
+  function buildNoPreRenderCtx(siteId, scrapeJobId, url, overrides = {}) {
+    return buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+        ...buildUrlS3Content(scrapeJobId, url),
+        ...overrides.extraS3,
+      }),
+      dataAccess: buildDataAccess(sandbox, {
+        scrapeUrls: [url],
+        ...overrides.dataAccess,
+      }),
+      scrapeResultPaths: new Map([[url, {}]]),
+      auditContext: { scrapeJobId },
+      ...overrides.ctx,
+    });
+  }
+
+  it('Branch C: no prerender URLs + existing opportunity → suggestions marked OUTDATED', async () => {
+    const siteId = 'site-outdated';
+    const scrapeJobId = 'job-outdated';
+    const url = 'https://example.com/page-1';
+
+    const suggestion = buildSuggestion(sandbox, {
+      id: 'sug-1',
+      status: 'NEW',
+      data: { url },
+    });
+    const opportunity = buildOpportunity(sandbox, {
+      suggestions: [suggestion],
+    });
+
+    const ctx = buildNoPreRenderCtx(siteId, scrapeJobId, url, {
+      dataAccess: {
+        opportunities: [opportunity],
+        scrapeUrls: [url],
+      },
+    });
+
+    await processContentAndGenerateOpportunities(ctx);
+
+    // syncSuggestions calls bulkUpdateStatus to mark outdated suggestions
+    expect(ctx.dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledOnce;
+    const [outdatedSuggestions] = ctx.dataAccess.Suggestion.bulkUpdateStatus.firstCall.args;
+    expect(outdatedSuggestions).to.deep.include(suggestion);
+  });
+
+  it('edge-deployed URL excluded from scrapedUrlsSet → its suggestion NOT marked OUTDATED', async () => {
+    const siteId = 'site-edge-not-outdated';
+    const scrapeJobId = 'job-edge';
+    const deployedUrl = 'https://example.com/deployed-page';
+
+    const suggestion = buildSuggestion(sandbox, {
+      id: 'sug-deployed',
+      status: 'NEW',
+      data: { url: deployedUrl },
+    });
+    const opportunity = buildOpportunity(sandbox, { suggestions: [suggestion] });
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+        // scrape.json reports isDeployedAtEdge: true → excluded from scrapedUrlsSet
+        ...buildUrlS3Content(scrapeJobId, deployedUrl, {
+          scrapeJson: { isDeployedAtEdge: true },
+        }),
+      }),
+      dataAccess: buildDataAccess(sandbox, {
+        opportunities: [opportunity],
+        scrapeUrls: [deployedUrl],
+      }),
+      scrapeResultPaths: new Map([[deployedUrl, {}]]),
+      auditContext: { scrapeJobId },
+    });
+
+    await processContentAndGenerateOpportunities(ctx);
+
+    // bulkUpdateStatus must NOT be called with the edge-deployed suggestion
+    const bulkCalls = ctx.dataAccess.Suggestion.bulkUpdateStatus.getCalls();
+    const markedOutdated = bulkCalls.flatMap((c) => c.args[0]);
+    expect(markedOutdated).to.not.deep.include(suggestion);
+  });
+
+  it('domain-wide suggestion with status=NEW is preserved across audit runs (Branch C)', async () => {
+    const siteId = 'site-dw-preserved';
+    const scrapeJobId = 'job-dw-preserve';
+    const url = 'https://example.com/page-1';
+
+    const domainWideSuggestion = buildSuggestion(sandbox, {
+      id: 'sug-dw',
+      status: 'NEW',
+      // isDomainWide=true → handleOutdatedSuggestions skips this suggestion
+      data: {
+        url: 'https://example.com/* (All Domain URLs)',
+        isDomainWide: true,
+      },
+    });
+    const regularSuggestion = buildSuggestion(sandbox, {
+      id: 'sug-regular',
+      status: 'NEW',
+      data: { url },
+    });
+    const opportunity = buildOpportunity(sandbox, {
+      suggestions: [domainWideSuggestion, regularSuggestion],
+    });
+
+    const ctx = buildNoPreRenderCtx(siteId, scrapeJobId, url, {
+      dataAccess: {
+        opportunities: [opportunity],
+        scrapeUrls: [url],
+      },
+    });
+
+    await processContentAndGenerateOpportunities(ctx);
+
+    // Domain-wide suggestion must NOT appear in the outdated list
+    const bulkCalls = ctx.dataAccess.Suggestion.bulkUpdateStatus.getCalls();
+    const markedOutdated = bulkCalls.flatMap((c) => c.args[0]);
+    expect(markedOutdated).to.not.deep.include(domainWideSuggestion);
+    // Regular suggestion (URL in scrapedUrlsSet) IS marked outdated
+    expect(markedOutdated).to.deep.include(regularSuggestion);
+  });
+
+  // ─── Suggestion update vs create ────────────────────────────────────────────
+
+  // ─── Suggestion merge contracts ───────────────────────────────────────────────
+
+  it('Branch A merge: Mystique fields (aiSummary, valuable) survive a re-scrape audit', async () => {
+    // mergeDataFunction for individual suggestions = { ...existingData, ...mapSuggestionData(new) }
+    // mapSuggestionData only maps word-count + S3-key fields — aiSummary and valuable
+    // are NOT in it, so they must be preserved from existingData on every re-scrape.
+    // (This path is marked /* c8 ignore next 5 */ in handler.js — zero prior coverage.)
+    const siteId = 'site-merge-ai';
+    const scrapeJobId = 'job-merge-ai';
+    const url = 'https://example.com/page-merge';
+
+    const existingSuggestion = buildSuggestion(sandbox, {
+      id: 'sug-with-ai',
+      status: 'NEW',
+      data: {
+        url,
+        wordCountBefore: 5,
+        wordCountAfter: 50,
+        contentGainRatio: 2.0,
+        aiSummary: 'Previously set by Mystique',
+        valuable: true,
+        scrapeJobId: 'old-job-id',
+      },
+    });
+
+    const opportunity = buildOpportunity(sandbox, {
+      siteId,
+      suggestions: [existingSuggestion],
+    });
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox),
+      dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+    });
+
+    // Re-scrape produces updated word counts but no aiSummary
+    await processOpportunityAndSuggestions('https://example.com', {
+      siteId,
+      id: 'audit-id',
+      auditId: 'audit-id',
+      auditResult: {
+        urlsNeedingPrerender: 1,
+        results: [{
+          url, needsPrerender: true, contentGainRatio: 10.0,
+          wordCountBefore: 8, wordCountAfter: 90, citabilityScore: 1, isDeployedAtEdge: false,
+        }],
+      },
+      scrapeJobId,
+      scrapedUrlsSet: new Set([url]),
+    }, ctx, false);
+
+    expect(existingSuggestion.setData).to.have.been.called;
+    const [mergedData] = existingSuggestion.setData.firstCall.args;
+
+    // New scrape data overwrites metric fields
+    expect(mergedData).to.have.property('wordCountBefore', 8);
+    expect(mergedData).to.have.property('wordCountAfter', 90);
+    expect(mergedData).to.have.property('contentGainRatio', 10.0);
+
+    // Mystique-set fields MUST be preserved — not wiped by re-scrape
+    expect(mergedData).to.have.property('aiSummary', 'Previously set by Mystique');
+    expect(mergedData).to.have.property('valuable', true);
+  });
+
+  it('Branch A merge: domain-wide suggestion data is fully replaced (not merged) on update', async () => {
+    // mergeDataFunction for domain-wide = { ...newDataItem.data } — complete replacement.
+    // Any field that only existed in the old domain-wide data must NOT survive the merge.
+    const siteId = 'site-merge-dw';
+    const scrapeJobId = 'job-merge-dw';
+    const url = 'https://example.com/page-dw-merge';
+
+    const existingDomainWideSuggestion = buildSuggestion(sandbox, {
+      id: 'sug-dw-old',
+      // Must be OUTDATED (not NEW/FIXED/PENDING_VALIDATION/SKIPPED) so that
+      // shouldPreserveDomainWideSuggestion returns false and a fresh domain-wide
+      // item is created — triggering the merge path.
+      status: 'OUTDATED',
+      data: {
+        key: 'domain-wide-aggregate|prerender',
+        url: 'https://example.com/* (All Domain URLs)',
+        isDomainWide: true,
+        wordCountBefore: 100,
+        wordCountAfter: 200,
+        signalField: 'must-not-survive', // canary — proves replacement, not merge
+      },
+    });
+
+    const opportunity = buildOpportunity(sandbox, {
+      siteId,
+      suggestions: [existingDomainWideSuggestion],
+    });
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox),
+      dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+    });
+
+    await processOpportunityAndSuggestions('https://example.com', {
+      siteId,
+      id: 'audit-id',
+      auditId: 'audit-id',
+      auditResult: {
+        urlsNeedingPrerender: 1,
+        results: [{
+          url, needsPrerender: true, contentGainRatio: 8.0,
+          wordCountBefore: 10, wordCountAfter: 80, citabilityScore: 1, isDeployedAtEdge: false,
+        }],
+      },
+      scrapeJobId,
+      scrapedUrlsSet: new Set([url]),
+    }, ctx, false);
+
+    expect(existingDomainWideSuggestion.setData).to.have.been.called;
+    const [mergedData] = existingDomainWideSuggestion.setData.firstCall.args;
+
+    // canary field must be gone — domain-wide merge is a full replacement
+    expect(mergedData).to.not.have.property('signalField');
+    // new data is present
+    expect(mergedData).to.have.property('isDomainWide', true);
+  });
+
+  it('Branch A: existing suggestion matched by URL key is updated in-place, not duplicated', async () => {
+    // syncSuggestions uses buildKey = url|prerender for per-URL suggestions.
+    // When an existing suggestion has the same URL, it must be updated via saveMany,
+    // not re-created via addSuggestions — otherwise each audit run duplicates rows.
+    const siteId = 'site-update-key';
+    const scrapeJobId = 'job-update';
+    const url = 'https://example.com/page-1';
+
+    const existingSuggestion = buildSuggestion(sandbox, {
+      id: 'sug-existing',
+      status: 'NEW',
+      data: { url, wordCountBefore: 5, wordCountAfter: 50, scrapeJobId },
+    });
+
+    const opportunity = buildOpportunity(sandbox, {
+      siteId,
+      suggestions: [existingSuggestion],
+    });
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox),
+      dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+    });
+
+    await processOpportunityAndSuggestions('https://example.com', {
+      siteId,
+      id: 'audit-id',
+      auditId: 'audit-id',
+      auditResult: {
+        urlsNeedingPrerender: 1,
+        results: [{
+          url, needsPrerender: true, contentGainRatio: 8.4,
+          wordCountBefore: 10, wordCountAfter: 84, citabilityScore: 1, isDeployedAtEdge: false,
+        }],
+      },
+      scrapeJobId,
+      scrapedUrlsSet: new Set([url]),
+    }, ctx, false);
+
+    // saveMany was called → existing suggestion was updated
+    expect(ctx.dataAccess.Suggestion.saveMany).to.have.been.called;
+
+    // addSuggestions was NOT called with a new suggestion for the same URL
+    // (it may be called once for the domain-wide aggregate, never for page-1)
+    const newlyAdded = opportunity.addSuggestions.called
+      ? opportunity.addSuggestions.firstCall.args[0]
+      : [];
+    const duplicateForUrl = newlyAdded.find((s) => s.data?.url === url);
+    expect(duplicateForUrl, 'existing URL must not produce a duplicate suggestion').to.be.undefined;
+  });
+
+  it('audit worker does not change suggestion status during a normal Branch A update', async () => {
+    // defaultMergeStatusFunction returns null for APPROVED/NEW/FIXED (all non-OUTDATED,
+    // non-REJECTED statuses) → setStatus is never called on those suggestions.
+    // Only the system-initiated OUTDATED transition and regression recovery change status.
+    const siteId = 'site-status-invariant';
+    const scrapeJobId = 'job-status';
+    const url = 'https://example.com/page-approved';
+
+    const approvedSuggestion = buildSuggestion(sandbox, {
+      id: 'sug-approved',
+      status: 'APPROVED',
+      data: { url, wordCountBefore: 5, wordCountAfter: 80, scrapeJobId },
+    });
+
+    const opportunity = buildOpportunity(sandbox, {
+      siteId,
+      suggestions: [approvedSuggestion],
+    });
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox),
+      dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+    });
+
+    await processOpportunityAndSuggestions('https://example.com', {
+      siteId,
+      id: 'audit-id',
+      auditId: 'audit-id',
+      auditResult: {
+        urlsNeedingPrerender: 1,
+        results: [{
+          url, needsPrerender: true, contentGainRatio: 9.0,
+          wordCountBefore: 5, wordCountAfter: 80, citabilityScore: 1, isDeployedAtEdge: false,
+        }],
+      },
+      scrapeJobId,
+      scrapedUrlsSet: new Set([url]),
+    }, ctx, false);
+
+    // setStatus must NOT have been called — audit worker only updates data, not status
+    expect(approvedSuggestion.setStatus).to.not.have.been.called;
+  });
+
+  it('needsPrerender=false for a scraped URL — its existing suggestion is marked OUTDATED', async () => {
+    // Branch A fires (prerenderUrl needs prerender).
+    // noPreRenderUrl was scraped (in scrapedUrlsSet) but its ratio < 1.1 → needsPrerender=false.
+    // Its existing suggestion is NOT in urlsNeedingPrerender → syncSuggestions marks it OUTDATED.
+    const siteId = 'site-mixed-prerender';
+    const scrapeJobId = 'job-mixed';
+    const prerenderUrl = 'https://example.com/needs-prerender';
+    const noPreRenderUrl = 'https://example.com/no-prerender';
+
+    const noPreRenderSuggestion = buildSuggestion(sandbox, {
+      id: 'sug-no-prerender',
+      status: 'NEW',
+      data: { url: noPreRenderUrl },
+    });
+
+    const opportunity = buildOpportunity(sandbox, {
+      siteId,
+      suggestions: [noPreRenderSuggestion],
+    });
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+        // prerenderUrl: sparse server + rich client → needsPrerender=true
+        ...buildUrlS3Content(scrapeJobId, prerenderUrl, {
+          serverHtml: HTML_SERVER_SPARSE,
+          clientHtml: HTML_CLIENT_NEEDS_PRERENDER,
+        }),
+        // noPreRenderUrl: identical HTML → contentGainRatio ≈ 1.0 → needsPrerender=false
+        ...buildUrlS3Content(scrapeJobId, noPreRenderUrl),
+      }),
+      dataAccess: buildDataAccess(sandbox, {
+        scrapeUrls: [prerenderUrl, noPreRenderUrl],
+        opportunities: [opportunity],
+      }),
+      scrapeResultPaths: new Map([[prerenderUrl, {}], [noPreRenderUrl, {}]]),
+      auditContext: { scrapeJobId },
+    });
+
+    await processContentAndGenerateOpportunities(ctx);
+
+    // noPreRenderUrl is in scrapedUrlsSet but not in urlsNeedingPrerender → OUTDATED
+    const bulkCalls = ctx.dataAccess.Suggestion.bulkUpdateStatus.getCalls();
+    const markedOutdated = bulkCalls.flatMap((c) => c.args[0]);
+    expect(markedOutdated).to.deep.include(noPreRenderSuggestion);
+  });
+
+  it('detectWrongEdgeDeployedStatus runs unconditionally even when isDomainBlocked=true', async () => {
+    // This diagnostic function fires before the domainBlocked short-circuit so
+    // invariant violations are always surfaced regardless of scrape state.
+    const siteId = 'site-invariant';
+
+    const violatingSuggestion = buildSuggestion(sandbox, {
+      id: 'sug-bad',
+      status: 'APPROVED', // non-NEW
+      data: {
+        url: 'https://example.com/page-1',
+        edgeDeployed: new Date().toISOString(), // non-NEW + edgeDeployed = invariant violation
+      },
+    });
+    const opportunity = buildOpportunity(sandbox, { suggestions: [violatingSuggestion] });
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox),
+      dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+      auditContext: { domainBlocked: true },
+    });
+
+    await processContentAndGenerateOpportunities(ctx);
+
+    // detectWrongEdgeDeployedStatus emits this specific warning
+    expect(ctx.log.warn).to.have.been.calledWithMatch(/nonNewEdgeDeployedCount=1/);
+  });
+});
+
+describe('Prerender behaviour — coveredByDomainWide marking (Step 3)', () => {
+  let sandbox;
+
+  beforeEach(() => { sandbox = sinon.createSandbox(); });
+  afterEach(() => { sandbox.restore(); });
+
+  it('NEW suggestion for edge-deployed URL is marked coveredByDomainWide when domain-wide suggestion has edgeDeployed set', async () => {
+    const siteId = 'site-covered-dw';
+    const scrapeJobId = 'job-covered-dw';
+    const prerenderUrl = 'https://example.com/needs-prerender';
+    const deployedUrl = 'https://example.com/deployed-page';
+    const domainWideSugId = 'dw-sug-edge-deployed';
+
+    // Domain-wide suggestion: NEW + isDomainWide=true + edgeDeployed → triggers the marking
+    const domainWideSuggestion = buildSuggestion(sandbox, {
+      id: domainWideSugId,
+      status: 'NEW',
+      data: {
+        url: 'https://example.com/* (All Domain URLs)',
+        isDomainWide: true,
+        edgeDeployed: new Date().toISOString(),
+      },
+    });
+
+    // Regular suggestion for the edge-deployed URL — to be marked coveredByDomainWide
+    const deployedPageSuggestion = buildSuggestion(sandbox, {
+      id: 'page-sug-deployed',
+      status: 'NEW',
+      data: { url: deployedUrl },
+    });
+
+    const opportunity = buildOpportunity(sandbox, {
+      siteId,
+      suggestions: [domainWideSuggestion],
+    });
+
+    const dataAccess = buildDataAccess(sandbox, {
+      opportunities: [opportunity],
+      scrapeUrls: [prerenderUrl, deployedUrl],
+    });
+
+    // allByOpportunityIdAndStatus(NEW) is called by markDeployedUrlSuggestionsAsCovered
+    dataAccess.Suggestion.allByOpportunityIdAndStatus = sandbox.stub().resolves([deployedPageSuggestion]);
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+        // prerenderUrl: sparse server + rich client → needsPrerender=true → Branch A fires
+        ...buildUrlS3Content(scrapeJobId, prerenderUrl, {
+          serverHtml: HTML_SERVER_SPARSE,
+          clientHtml: HTML_CLIENT_NEEDS_PRERENDER,
+        }),
+        // deployedUrl: any HTML but scrape.json reports isDeployedAtEdge=true
+        ...buildUrlS3Content(scrapeJobId, deployedUrl, {
+          scrapeJson: { isDeployedAtEdge: true },
+        }),
+      }),
+      dataAccess,
+      scrapeResultPaths: new Map([[prerenderUrl, {}], [deployedUrl, {}]]),
+      auditContext: { scrapeJobId },
+    });
+
+    await processContentAndGenerateOpportunities(ctx);
+
+    // deployedPageSuggestion.setData should have been called with coveredByDomainWide
+    expect(deployedPageSuggestion.setData).to.have.been.called;
+    const [updatedData] = deployedPageSuggestion.setData.firstCall.args;
+    expect(updatedData).to.have.property('coveredByDomainWide', domainWideSugId);
+
+    // saveMany must be called with the covered suggestion
+    const allSaveManyCalls = dataAccess.Suggestion.saveMany.getCalls();
+    const coveredSaveCall = allSaveManyCalls.find(
+      (c) => c.args[0]?.some?.((s) => s === deployedPageSuggestion),
+    );
+    expect(coveredSaveCall, 'saveMany must be called with the covered suggestion').to.not.be.undefined;
+  });
+});

--- a/test/audits/prerender/behaviour/url-selection.test.js
+++ b/test/audits/prerender/behaviour/url-selection.test.js
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Behavioural contracts: URL processing in Step 2 (submitForScraping)
+ *
+ * Normal mode: PageCitability 7-day dedup, edge-deployed URL exclusion, includedURLs,
+ * and DAILY_BATCH_SIZE=320 cap.  No esmock required: getTopAgenticLiveUrlsFromAthena
+ * throws when Athena is not configured; getTopAgenticUrls silently catches it and
+ * returns [], leaving organic + included URLs as the only sources.
+ *
+ * CSV mode: non-HTML extension filtering, same-pathname deduplication, overrideBaseURL
+ * rebasing.  Tests call submitForScraping directly with auditContext.urls set.
+ */
+
+/* eslint-env mocha */
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { submitForScraping } from '../../../../src/prerender/handler.js';
+import {
+  buildContext,
+  buildSite,
+  buildS3Client,
+  buildDataAccess,
+  statusKey,
+  buildStatus,
+  daysAgo,
+} from './helpers.js';
+
+use(sinonChai);
+
+describe('Prerender behaviour — URL selection (Step 2, normal mode)', () => {
+  let sandbox;
+
+  beforeEach(() => { sandbox = sinon.createSandbox(); });
+  afterEach(() => { sandbox.restore(); });
+
+  it('URL processed within 7-day window (PageCitability) is excluded from the batch', async () => {
+    const siteId = 'site-dedup';
+    const recentUrl = 'https://example.com/recent-page';
+    const freshUrl = 'https://example.com/fresh-page';
+
+    const citabilityRecords = [
+      {
+        // recently processed — should be excluded
+        getUrl: () => recentUrl,
+        getUpdatedAt: () => new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString(),
+      },
+    ];
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+      }),
+      dataAccess: buildDataAccess(sandbox, {
+        topPages: [recentUrl, freshUrl],
+        citabilityRecords,
+      }),
+    });
+
+    const result = await submitForScraping(ctx);
+
+    const submittedUrls = result.urls.map((u) => u.url);
+    expect(submittedUrls).to.not.include(recentUrl);
+    expect(submittedUrls).to.include(freshUrl);
+  });
+
+  it('URL absent from PageCitability (outside dedup window) is included in the batch', async () => {
+    // The real DB query filters by updatedAt >= 7 days ago, so expired records are not returned.
+    // Stub models this by returning no records for that URL — result: URL is included.
+    const siteId = 'site-dedup-expired';
+    const oldUrl = 'https://example.com/stale-page';
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+      }),
+      dataAccess: buildDataAccess(sandbox, {
+        topPages: [oldUrl],
+        citabilityRecords: [], // DB returns nothing (record outside 7-day window)
+      }),
+    });
+
+    const result = await submitForScraping(ctx);
+
+    const submittedUrls = result.urls.map((u) => u.url);
+    expect(submittedUrls).to.include(oldUrl);
+  });
+
+  it('URL marked isDeployedAtEdge in status.json pages is excluded from the batch', async () => {
+    const siteId = 'site-edge-excl';
+    const deployedUrl = 'https://example.com/deployed-page';
+    const normalUrl = 'https://example.com/normal-page';
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus({
+          pages: [
+            { url: deployedUrl, isDeployedAtEdge: true },
+          ],
+        }),
+      }),
+      dataAccess: buildDataAccess(sandbox, {
+        topPages: [deployedUrl, normalUrl],
+      }),
+    });
+
+    const result = await submitForScraping(ctx);
+
+    const submittedUrls = result.urls.map((u) => u.url);
+    expect(submittedUrls).to.not.include(deployedUrl);
+    expect(submittedUrls).to.include(normalUrl);
+  });
+
+  it('includedURLs from site config are added to the batch alongside organic URLs', async () => {
+    const siteId = 'site-included-urls';
+    const organicUrl = 'https://example.com/organic';
+    const includedUrl = 'https://example.com/included-special';
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({
+        id: siteId,
+        baseUrl: 'https://example.com',
+        includedUrls: [includedUrl],
+      }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+      }),
+      dataAccess: buildDataAccess(sandbox, {
+        topPages: [organicUrl],
+      }),
+    });
+
+    const result = await submitForScraping(ctx);
+
+    const submittedUrls = result.urls.map((u) => u.url);
+    expect(submittedUrls).to.include(organicUrl);
+    expect(submittedUrls).to.include(includedUrl);
+  });
+
+  it('normal mode caps submitted URL count at DAILY_BATCH_SIZE=320', async () => {
+    // Organic is capped internally at TOP_ORGANIC_URLS_LIMIT=200.
+    // Adding 150 includedURLs (no overlap) makes the combined pool 350 > 320.
+    // Normal mode must slice to exactly 320.
+    const siteId = 'site-batch-cap';
+    const organicUrls = Array.from({ length: 200 }, (_, i) => `https://example.com/organic-${i}`);
+    const includedUrls = Array.from({ length: 150 }, (_, i) => `https://example.com/included-${i}`);
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com', includedUrls }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+      }),
+      dataAccess: buildDataAccess(sandbox, { topPages: organicUrls }),
+    });
+
+    const result = await submitForScraping(ctx);
+
+    expect(result.urls).to.have.length(320);
+  });
+});
+
+describe('Prerender behaviour — URL filtering (Step 2, CSV mode)', () => {
+  let sandbox;
+
+  beforeEach(() => { sandbox = sinon.createSandbox(); });
+  afterEach(() => { sandbox.restore(); });
+
+  it('non-HTML URLs (jpg, pdf, mp3) are filtered out before submission', async () => {
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: 'site-html-filter', baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox),
+      auditContext: {
+        urls: [
+          'https://example.com/page',          // kept — no non-HTML extension
+          'https://example.com/article.html',  // kept — .html is fine
+          'https://example.com/image.jpg',     // filtered — image
+          'https://example.com/doc.pdf',       // filtered — document
+          'https://example.com/sound.mp3',     // filtered — media
+        ],
+      },
+    });
+
+    const result = await submitForScraping(ctx);
+
+    expect(result.urls).to.have.length(2);
+    const returnedUrls = result.urls.map(({ url }) => url);
+    expect(returnedUrls.some((u) => u.includes('.jpg'))).to.be.false;
+    expect(returnedUrls.some((u) => u.includes('.pdf'))).to.be.false;
+    expect(returnedUrls.some((u) => u.includes('.mp3'))).to.be.false;
+  });
+
+  it('URLs with the same pathname (one with trailing slash) are deduplicated', async () => {
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: 'site-dedup', baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox),
+      auditContext: {
+        urls: [
+          'https://example.com/page-1',    // first occurrence kept
+          'https://example.com/page-1/',   // trailing slash → same path → deduplicated
+          'https://example.com/page-2',    // distinct path, kept
+        ],
+      },
+    });
+
+    const result = await submitForScraping(ctx);
+
+    expect(result.urls).to.have.length(2);
+    const returnedPaths = result.urls.map(({ url }) => new URL(url).pathname.replace(/\/+$/, ''));
+    expect(returnedPaths.filter((p) => p === '/page-1')).to.have.length(1);
+    expect(returnedPaths).to.include('/page-2');
+  });
+
+  it('CSV mode rebases URLs to overrideBaseURL when set in site fetch config', async () => {
+    // When a site configures overrideBaseURL (e.g. preview → prod domain swap),
+    // CSV URLs from any origin must be rebased to that override domain.
+    const ctx = buildContext(sandbox, {
+      site: buildSite({
+        id: 'site-override',
+        baseUrl: 'https://primary.com',
+        overrideBaseURL: 'https://override.example.com',
+      }),
+      s3Client: buildS3Client(sandbox),
+      auditContext: {
+        urls: ['https://other-origin.com/some/path'],
+      },
+    });
+
+    const result = await submitForScraping(ctx);
+
+    expect(result.urls).to.have.length(1);
+    const { url } = result.urls[0];
+    expect(url).to.equal('https://override.example.com/some/path');
+    expect(url).to.not.include('primary.com');
+    expect(url).to.not.include('other-origin.com');
+  });
+});


### PR DESCRIPTION
## Summary

- When `scrapeResultPaths` is empty (all submitted URLs had FAILED status in the scraper), the old fallback re-fetched top-page URLs (~150+) and ran `compareHtmlContent` against them
- All 150 fallback URLs return `{error: true}` (no S3 data for the current scrapeJobId) and were written to `status.json` as `scrapingStatus='error'` — despite never being submitted to the scraper that run
- `getScrapeJobStats` already populates `missingPages` from the `ScrapeUrl` DB with the genuinely-failed URLs; the fallback was redundant and harmful
- Also removes the now-unused `isSlackTriggered` declaration from step 3

## Root Cause

`getScrapeResultPaths` only returns **COMPLETE-status** URLs. When all submitted URLs have FAILED status, `scrapeResultPaths.size === 0`, triggering the fallback. The fallback was introduced before `getScrapeJobStats` had the FAILED-status path (added in #2245). It is now obsolete.

Observed in production logs for `hesta.com.au`: 3 URLs submitted, 153 URLs written to status.json as errors.

## Fix

Remove the fallback URL-fetch block. When `scrapeResultPaths` is empty, `urlsToCheck` stays `[]`, `comparisonResults` stays `[]`, and `getScrapeJobStats → missingPages` records the correct failed URLs in status.json.

## Test Plan

- [x] New regression test in `data-integrity.test.js`: verifies that when `scrapeResultPaths` is empty and 2 URLs were submitted (via `ScrapeUrl` DB), only those 2 appear in status.json — not the 10+ top-page URLs that were never submitted
- [x] Full behaviour suite: 72 passing, 0 failing
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)