### PR TITLE
fix(cdn-reports-bulk-publish): reject folders containing '--'

### DIFF
--- a/src/cdn-reports-bulk-publish/handler.js
+++ b/src/cdn-reports-bulk-publish/handler.js
@@ -28,13 +28,14 @@ export default async function cdnReportsBulkPublish(message, context) {
 
   const configuration = await dataAccess.Configuration.findLatest();
   const allSites = await dataAccess.Site.all();
-  // Folders must be a single safe path segment; anything with slashes / dots
-  // breaks admin.hlx.page bulk-preview and poisons the whole batch.
+  // Folders must be a single safe path segment without `--` (Helix uses `--`
+  // as the {branch}--{repo}--{owner} separator). Anything else breaks
+  // admin.hlx.page bulk-preview and poisons the whole batch.
   const VALID_FOLDER = /^[a-z0-9][a-z0-9_-]*$/i;
   const llmoFolders = allSites
     .filter((s) => configuration?.isHandlerEnabledForSite('cdn-logs-report', s))
     .map((s) => s.getConfig()?.getLlmoDataFolder())
-    .filter((f) => f && VALID_FOLDER.test(f));
+    .filter((f) => f && VALID_FOLDER.test(f) && !f.includes('--'));
 
   const now = new Date();
   const periods = [generateReportingPeriods(now, 0).periodIdentifier];

--- a/test/audits/cdn-reports-bulk-publish/handler.test.js
+++ b/test/audits/cdn-reports-bulk-publish/handler.test.js
@@ -129,8 +129,9 @@ describe('cdn-reports-bulk-publish handler', () => {
         makeSite('with-slash', 'dev/main--project-elmo-ui-demo-data'),
         makeSite('with-dot', '..'),
         makeSite('with-space', 'has space'),
+        makeSite('with-double-dash', 'samsung-com--sec'),
       ],
-      ['good', 'with-slash', 'with-dot', 'with-space'],
+      ['good', 'with-slash', 'with-dot', 'with-space', 'with-double-dash'],
     );
 
     const [reports] = bulkPublishStub.firstCall.args;


### PR DESCRIPTION
## Summary

Filter out sites whose \`llmoDataFolder\` contains \`--\`. Helix uses \`--\` as the \`{branch}--{repo}--{owner}\` separator, so admin.hlx.page rejects any bulk-preview/publish path that has double-hyphen in a segment - and one bad path poisons the whole batch with a 400.

## Why

Without this filter, today's prod run failed with:
\`\`\`
[admin] bulk-preview path not valid: /samsung-com--sec/agentic-traffic/agentictraffic-w21-2026.json
\`\`\`
and on the next attempt:
\`\`\`
[admin] bulk-preview path not valid: /main--frescopa-dba--ktzmishra-aem-live/agentic-traffic/agentictraffic-w21-2026.json
\`\`\`

A survey of prod (3,195 sites with \`llmoDataFolder\` set) found exactly one site with \`--\` in its folder: \`samsung.com/sec\` (folder: \`samsung-com--sec\`). The frescopa-dba one is a dev/demo site. Both are now skipped instead of breaking the whole consolidated POST.

## Changes

\`src/cdn-reports-bulk-publish/handler.js\` - add \`!f.includes('--')\` to the folder filter and update the rationale comment.

\`test/audits/cdn-reports-bulk-publish/handler.test.js\` - add a \`samsung-com--sec\` fixture to the existing safe-segment filter test.

## Test plan
- [x] \`npx mocha test/audits/cdn-reports-bulk-publish/handler.test.js\` - 9 passing
- [ ] After merge + deploy: trigger \`run cdn reports bulk publish\` in Slack, confirm Coralogix shows \`bulk-publishing N paths across M sites\` followed by \`preview job started\` (not a 400).

🤖 Generated with [Claude Code](https://claude.com/claude-code)