### PR TITLE
feat(paid-keyword-optimizer): pass resolvedPageHeading and pageTopics through to opportunity.data

### DIFF
--- a/src/paid-keyword-optimizer/guidance-opportunity-mapper.js
+++ b/src/paid-keyword-optimizer/guidance-opportunity-mapper.js
@@ -87,6 +87,21 @@ export function mapToKeywordOptimizerOpportunity(siteId, audit, message) {
     clusterResults = [],
     portfolioMetrics = {},
   } = guidanceBody;
+  /**
+   * Page-level context fields emitted by mystique (additive, both optional).
+   *
+   * Distinct from per-cluster
+   * `gapAnalysis.{keywordToPageGap,adToPageGap}.relevantExtractedTopics`,
+   * which are LLM-filtered subsets of `pageTopics` filtered for cluster-
+   * specific intent relevance. `pageTopics` here is the full page-level set.
+   *
+   * Use `??` (nullish coalescing) instead of ES destructure defaults so that
+   * a future regression emitting `pageTopics: null` (instead of omitting the
+   * key) still results in an empty array on the consumer side. ES destructure
+   * defaults only fire for `undefined`, not `null`.
+   */
+  const resolvedPageHeading = guidanceBody.resolvedPageHeading ?? null;
+  const pageTopics = guidanceBody.pageTopics ?? [];
   const { langfuseTraceId, langfuseTraceUrl } = guidanceBody?.observability || {};
 
   const hasConflictingHeadlineRecommendations = clusterResults.filter(
@@ -132,6 +147,8 @@ export function mapToKeywordOptimizerOpportunity(siteId, audit, message) {
       totalClusters,
       misalignedClusters,
       totalMisalignedSpend,
+      resolvedPageHeading,
+      pageTopics,
     },
     status: 'NEW',
     tags: [

--- a/test/audits/paid-keyword-optimizer/opportunity-mapper.test.js
+++ b/test/audits/paid-keyword-optimizer/opportunity-mapper.test.js
@@ -58,6 +58,7 @@ function createClusterMessage({
   portfolioMetrics = { totalSpend: 1000 },
   langfuseTraceId = 'trace-123',
   langfuseTraceUrl = 'https://langfuse.example.com/trace/123',
+  extraBody,
 } = {}) {
   return {
     auditId: 'audit-id-123',
@@ -72,6 +73,7 @@ function createClusterMessage({
             langfuseTraceId,
             langfuseTraceUrl,
           },
+          ...(extraBody || {}),
         },
       }],
     },
@@ -618,6 +620,122 @@ describe('Paid Keyword Optimizer opportunity mapper (cluster format)', () => {
 
       // c1 is failed so not counted as misaligned even though it has a recommendation
       expect(result.data.misalignedClusters).to.equal(1);
+    });
+
+    it('passes resolvedPageHeading and pageTopics through to opportunity.data', () => {
+      const pageTopics = [
+        {
+          topic: 'Email API overview',
+          context: 'Overview of the SendGrid Email API and core capabilities.',
+          supportingQuote: 'Build with our extensible platforms for customers, workforce, and non-human identities.',
+          paragraphIndex: 5,
+        },
+        {
+          topic: 'Deliverability',
+          context: 'Deliverability features and analytics.',
+          supportingQuote: 'Real-time deliverability metrics and reputation monitoring.',
+          paragraphIndex: 12,
+        },
+      ];
+      const audit = createMockAudit();
+      const message = createClusterMessage({
+        extraBody: {
+          resolvedPageHeading: 'Fast, reliable email delivery',
+          pageTopics,
+        },
+      });
+
+      const result = mapToKeywordOptimizerOpportunity(TEST_SITE_ID, audit, message);
+
+      expect(result.data.resolvedPageHeading).to.equal('Fast, reliable email delivery');
+      expect(result.data.pageTopics).to.have.lengthOf(2);
+      expect(result.data.pageTopics[0]).to.deep.equal({
+        topic: 'Email API overview',
+        context: 'Overview of the SendGrid Email API and core capabilities.',
+        supportingQuote: 'Build with our extensible platforms for customers, workforce, and non-human identities.',
+        paragraphIndex: 5,
+      });
+      expect(result.data.pageTopics[1].topic).to.equal('Deliverability');
+      expect(result.data.pageTopics[1].paragraphIndex).to.equal(12);
+    });
+
+    it('defaults resolvedPageHeading to null and pageTopics to [] when fields are absent (old mystique)', () => {
+      const audit = createMockAudit();
+      // No extraBody — guidanceBody has neither resolvedPageHeading nor pageTopics
+      const message = createClusterMessage();
+
+      const result = mapToKeywordOptimizerOpportunity(TEST_SITE_ID, audit, message);
+
+      expect(result.data.resolvedPageHeading).to.be.null;
+      expect(result.data.pageTopics).to.be.an('array').that.is.empty;
+    });
+
+    it('collapses explicit null pageTopics to [] (future regression guard)', () => {
+      const audit = createMockAudit();
+      const message = createClusterMessage({
+        extraBody: {
+          resolvedPageHeading: null,
+          pageTopics: null,
+        },
+      });
+
+      const result = mapToKeywordOptimizerOpportunity(TEST_SITE_ID, audit, message);
+
+      expect(result.data.resolvedPageHeading).to.be.null;
+      expect(result.data.pageTopics).to.be.an('array').that.is.empty;
+    });
+
+    it('preserves all existing opportunity.data keys when new fields are present', () => {
+      const clusters = [
+        makeCluster({ clusterId: 'c1', recommendation: { type: 'modify_heading' }, clusterMisalignedSpend: 200 }),
+        makeCluster({ clusterId: 'c2', clusterMisalignedSpend: 50 }),
+      ];
+      const portfolioMetrics = { totalSpend: 5000, avgCpc: 2.5 };
+      const audit = createMockAudit();
+      const message = createClusterMessage({
+        clusterResults: clusters,
+        portfolioMetrics,
+        langfuseTraceId: 'trace-xyz',
+        langfuseTraceUrl: 'https://langfuse.example.com/trace/xyz',
+        extraBody: {
+          resolvedPageHeading: 'Headline',
+          pageTopics: [{
+            topic: 'T', context: 'C', supportingQuote: 'Q', paragraphIndex: 0,
+          }],
+        },
+      });
+
+      const result = mapToKeywordOptimizerOpportunity(TEST_SITE_ID, audit, message);
+
+      // All existing data keys still present with expected values.
+      expect(result.data.url).to.equal(TEST_URL);
+      expect(result.data.page).to.equal(TEST_URL);
+      expect(result.data.portfolioMetrics).to.deep.equal(portfolioMetrics);
+      expect(result.data.hasConflictingHeadlineRecommendations).to.be.false;
+      expect(result.data.langfuseTraceId).to.equal('trace-xyz');
+      expect(result.data.langfuseTraceUrl).to.equal('https://langfuse.example.com/trace/xyz');
+      expect(result.data.totalClusters).to.equal(2);
+      expect(result.data.misalignedClusters).to.equal(1);
+      expect(result.data.totalMisalignedSpend).to.equal(250);
+      expect(result.data.dataSources).to.deep.equal(['Site', 'RUM', 'Page', 'SEO']);
+      // New fields present alongside.
+      expect(result.data.resolvedPageHeading).to.equal('Headline');
+      expect(result.data.pageTopics).to.have.lengthOf(1);
+    });
+
+    it('preserves opportunity.title and opportunity.guidance values from the existing branch', () => {
+      const audit = createMockAudit();
+      const message = createClusterMessage({
+        extraBody: {
+          resolvedPageHeading: 'Fast, reliable email delivery',
+          pageTopics: [],
+        },
+      });
+
+      const result = mapToKeywordOptimizerOpportunity(TEST_SITE_ID, audit, message);
+
+      expect(result.title).to.equal('Ad intent mismatch detected across keyword clusters');
+      expect(result.guidance).to.be.null;
     });
   });
 


### PR DESCRIPTION
## Summary

Mystique now emits two page-level context fields in the ad-intent-mismatch SQS body: `resolvedPageHeading` (the page's vision-resolved primary heading) and `pageTopics` (the full topic list extracted from the landing page, not the per-cluster filtered subsets). Read both from the guidance body in `mapToKeywordOptimizerOpportunity` and append them to `opportunity.data` verbatim.

Backwards compatible:
- Both fields default to `null` / `[]` when the SQS message lacks them or sets them to `null`.
- Uses `??` (nullish coalescing) instead of ES destructure defaults so `undefined` and explicit `null` both collapse to safe defaults.
- No existing `opportunity.data` field is renamed, removed, or retyped.
- The UI will start consuming the new fields in a follow-up; until then it ignores them.

## Spec / Cross-repo contract

- Implementation plan (mysticat-architecture PR): https://github.com/adobe/mysticat-architecture/pull/83
- Wire-schema fixture: https://github.com/adobe/mysticat-architecture/blob/spec/ad-intent-page-context-fields/products/aso/fixtures/ad-intent-mismatch-sqs-body.json
- Companion mystique PR: see https://git.corp.adobe.com/experience-platform/mystique (Adobe GHE)

## Test plan

- [x] 5 new tests added under `'Paid Keyword Optimizer opportunity mapper (cluster format)'` covering: pass-through, `undefined` SQS keys (old mystique), explicit `null` regression guard, existing-field regression, and top-level `title`/`guidance` preservation.
- [x] `npm test` — 8220 passing, 0 failing.
- [x] `.nycrc.json` 100/100/100 coverage gate passes.
- [ ] Manual smoke once mystique companion PR is deployed to ephemeral and a fresh audit produces a new opportunity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)