### PR TITLE
fix: bucket Claude desktop/iOS clients into "Claude Clients"

### DIFF
--- a/src/common/user-agent-classification.js
+++ b/src/common/user-agent-classification.js
@@ -56,6 +56,8 @@ export const USER_AGENT_DISPLAY_PATTERNS = [
   { pattern: '%claude-user%', displayName: 'Claude-User' },
   { pattern: '%claudebot%', displayName: 'ClaudeBot' },
   { pattern: '%claude-searchbot%', displayName: 'Claude-SearchBot' },
+  { pattern: '%com.anthropic.claude%', displayName: 'Claude Clients' },
+  { pattern: '%claude/%', displayName: 'Claude Clients' },
   // MistralAI
   { pattern: '%mistralai-user%', displayName: 'MistralAI-User' },
   // Amazon
@@ -106,6 +108,8 @@ export function buildAgentTypeClassificationSQL() {
     { pattern: '%claudebot%', result: 'Training bots' },
     { pattern: '%claude-searchbot%', result: 'Web search crawlers' },
     { pattern: '%claude-user%', result: 'Chatbots' },
+    { pattern: '%com.anthropic.claude%', result: 'Media fetchers' },
+    { pattern: '%claude/%', result: 'Media fetchers' },
     // MistralAI
     { pattern: '%mistralai-user%', result: 'Chatbots' },
     // Amazon

--- a/test/audits/cdn-logs-report/user-agent-patterns.test.js
+++ b/test/audits/cdn-logs-report/user-agent-patterns.test.js
@@ -98,6 +98,14 @@ describe('User Agent Patterns', () => {
       expect(sql.toLowerCase()).to.include('google-extended');
       expect(sql.toLowerCase()).to.include('google-agent');
     });
+
+    it('classifies Claude desktop/iOS app traffic as Media fetchers', () => {
+      const { buildAgentTypeClassificationSQL } = userAgentPatterns;
+      const sql = buildAgentTypeClassificationSQL();
+
+      expect(sql).to.include("LIKE '%com.anthropic.claude%' THEN 'Media fetchers'");
+      expect(sql).to.include("LIKE '%claude/%' THEN 'Media fetchers'");
+    });
   });
 
   describe('buildUserAgentDisplaySQL', () => {
@@ -114,6 +122,14 @@ describe('User Agent Patterns', () => {
       expect(sql).to.include('GoogleBot');
       expect(sql).to.include('BingBot');
       expect(sql).to.include('Google-Extended');
+    });
+
+    it('collapses Claude desktop/iOS client UAs into a single "Claude Clients" bucket', () => {
+      const { buildUserAgentDisplaySQL } = userAgentPatterns;
+      const sql = buildUserAgentDisplaySQL();
+
+      expect(sql).to.include("LIKE '%com.anthropic.claude%' THEN 'Claude Clients'");
+      expect(sql).to.include("LIKE '%claude/%' THEN 'Claude Clients'");
     });
   });
 


### PR DESCRIPTION
## Summary

Anthropic's Claude desktop and iOS apps emit user agents like
`Claude/12345 CFNetwork/...` and `Claude%20com.anthropic.claude/1.2604...`.
None of the existing Claude SQL display patterns (`%claude-user%`, `%claudebot%`,
`%claude-searchbot%`) match these, so they fell through to the `SUBSTR(user_agent, 1, 100)`
raw fallback and surfaced as one filter option **per app version** on the
agentic-traffic 403/404/5xx opportunity dashboards et).

## Related Issues
