### PR TITLE
fix(wikipedia): handle branded TLDs in extractBrandFromUrl

### DIFF
--- a/src/wikipedia-analysis/handler.js
+++ b/src/wikipedia-analysis/handler.js
@@ -22,6 +22,7 @@ const REGION_SUFFIXES_RE = /(?:usa|us|uk|eu|de|fr|es|it|nl|be|at|ch|au|ca|jp|kr|
 
 const MULTI_PART_TLD_PREFIXES = new Set([
   'co', 'com', 'org', 'net', 'ac', 'gov', 'edu', 'mil',
+  'bank', 'firm', 'gen', 'ind', 'res', 'nic',
 ]);
 
 /**

--- a/test/audits/wikipedia-analysis/handler.test.js
+++ b/test/audits/wikipedia-analysis/handler.test.js
@@ -807,5 +807,16 @@ describe('Wikipedia Analysis Handler', () => {
       expect(extractBrandFromUrl('https://a.b.walmart.com')).to.equal('walmart');
       expect(extractBrandFromUrl('https://dev.blog.google.com')).to.equal('google');
     });
+
+    it('should handle branded TLDs like .bank.in', () => {
+      expect(extractBrandFromUrl('https://hdfc.bank.in')).to.equal('hdfc');
+      expect(extractBrandFromUrl('https://icici.bank.in')).to.equal('icici');
+    });
+
+    it('should handle other industry-specific ccSLDs', () => {
+      expect(extractBrandFromUrl('https://acme.firm.in')).to.equal('acme');
+      expect(extractBrandFromUrl('https://iitd.res.in')).to.equal('iitd');
+      expect(extractBrandFromUrl('https://example.nic.in')).to.equal('example');
+    });
   });
 });


### PR DESCRIPTION
## Summary
- `extractBrandFromUrl('hdfc.bank.in')` was returning `bank` instead of `hdfc` because `.bank` wasn't recognized as a multi-part TLD prefix
- Added `bank`, `firm`, `gen`, `ind`, `res`, `nic` to `MULTI_PART_TLD_PREFIXES` — these are India's registered ccSLD patterns (similar to `.co.uk`)
- Root cause of HDFC Bank Wikipedia opportunity not being created (site `14558535-f7ff-4abc-b0c3-12962ba5e0ec`)

## Test plan
- [x] Existing 60 tests still pass
- [x] New test: `hdfc.bank.in` → `hdfc`, `icici.bank.in` → `icici`
- [x] New test: `acme.firm.in` → `acme`, `iitd.res.in` → `iitd`, `example.nic.in` → `example`
- [ ] Re-run wikipedia-analysis audit for hdfc.bank.in after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)