### PR TITLE
feat(paid-keyword-optimizer): pass adAnalysis through to suggestion.data

### DIFF
--- a/src/paid-keyword-optimizer/guidance-opportunity-mapper.js
+++ b/src/paid-keyword-optimizer/guidance-opportunity-mapper.js
@@ -181,6 +181,7 @@ export function mapClusterToSuggestion(context, opportunityId, cluster) {
     gapAnalysis,
     overallAlignmentScore,
     keywordAnalysis,
+    adAnalysis,
     recommendation,
     rank,
   } = cluster;
@@ -214,6 +215,12 @@ export function mapClusterToSuggestion(context, opportunityId, cluster) {
         gapAnalysis: gapAnalysis || {},
         overallAlignmentScore: overallAlignmentScore || null,
         keywordAnalysis: keywordAnalysis || [],
+        // `?? null` (not `|| {}`): mystique emits an explicit `null` when the
+        // cluster lacks sufficient ad-copy signal, and the UI hides the
+        // "What the ad promises" block on that signal. Coercing null to {}
+        // would silently break the hide-when-missing branch. See spec
+        // products/aso/ad-intent-cluster-ad-analysis.md (B.1 + Decision #3).
+        adAnalysis: adAnalysis ?? null,
       },
       ...(recommendationType && { recommendationType }),
       ...(cleanedRecommendation && { recommendation: cleanedRecommendation }),

--- a/test/audits/paid-keyword-optimizer/opportunity-mapper.test.js
+++ b/test/audits/paid-keyword-optimizer/opportunity-mapper.test.js
@@ -786,6 +786,11 @@ describe('Paid Keyword Optimizer opportunity mapper (cluster format)', () => {
           overallAlignmentScore: 'fair',
           keywordAnalysis: [{ keyword: 'buy shoes', score: 0.5 }],
         }),
+        adAnalysis: {
+          isBranded: true,
+          intentType: 'navigational',
+          adPromise: 'Promotes the Twilio brand',
+        },
         rank: 2,
       };
 
@@ -802,6 +807,12 @@ describe('Paid Keyword Optimizer opportunity mapper (cluster format)', () => {
       expect(result.data.cluster.gapAnalysis).to.deep.equal({ severity: 'medium' });
       expect(result.data.cluster.overallAlignmentScore).to.equal('fair');
       expect(result.data.cluster.keywordAnalysis).to.deep.equal([{ keyword: 'buy shoes', score: 0.5 }]);
+      // adAnalysis passed through verbatim (spec B.3-(1))
+      expect(result.data.cluster.adAnalysis).to.deep.equal({
+        isBranded: true,
+        intentType: 'navigational',
+        adPromise: 'Promotes the Twilio brand',
+      });
     });
 
     it('lifts recommendation.type to recommendationType and removes type from nested object', () => {
@@ -852,6 +863,28 @@ describe('Paid Keyword Optimizer opportunity mapper (cluster format)', () => {
       expect(result.data.cluster.gapAnalysis).to.deep.equal({});
       expect(result.data.cluster.overallAlignmentScore).to.be.null;
       expect(result.data.cluster.keywordAnalysis).to.deep.equal([]);
+      // adAnalysis is undefined on rolling-deploy clusters (older mystique
+      // omits the key). Mapper MUST coerce to null. Spec B.3-(2).
+      expect(result.data.cluster).to.have.property('adAnalysis');
+      expect(result.data.cluster.adAnalysis).to.be.null;
+    });
+
+    it('preserves explicit null adAnalysis without coercion (spec B.3-(3))', () => {
+      // Mystique emits explicit null when the cluster lacks ad-copy signal
+      // (see spec Decision #3 — producer-internal threshold). The mapper MUST
+      // NOT coerce that null to `{}` because the UI relies on the null to
+      // hide the "What the ad promises" block.
+      const context = { site: { requiresValidation: false } };
+      const cluster = {
+        ...makeCluster(),
+        adAnalysis: null,
+        rank: 1,
+      };
+
+      const result = mapClusterToSuggestion(context, 'oppty-id', cluster);
+
+      expect(result.data.cluster).to.have.property('adAnalysis');
+      expect(result.data.cluster.adAnalysis).to.be.null;
     });
 
     it('uses rank from cluster', () => {


### PR DESCRIPTION
## Summary

Reads the new `cluster.adAnalysis` field (emitted by mystique PR #2420 — see [`mysticat-architecture#97`](https://github.com/adobe/mysticat-architecture/pull/97) for the cross-repo wire-schema contract) in `mapClusterToSuggestion` and passes it through verbatim to `data.cluster.adAnalysis` on each suggestion.

Per the spec:
- `cluster.adAnalysis = { isBranded, intentType, adPromise } | null`
- `null` is a deliberate value (mystique emits it when the cluster lacks ad-copy signal), not a missing-key default. The UI relies on the null to hide the "What the ad promises" block.

## Why `?? null` and not `|| {}`

The mapper uses nullish coalescing so both cases collapse to the same wire shape:
- **`undefined`** — older mystique deployments don't emit the key. Coerces to `null`.
- **`null`** — explicit; mystique declined to produce a block for this cluster (insufficient ad-copy signal per the spec's Decision #3). Stays `null`.

`|| {}` would silently coerce the deliberate `null` to `{}` and break the UI's hide-when-missing branch. The pre-existing `keywordAnalysis: keywordAnalysis || []` line in this same function is a known latent oddity (defaults an object to an array); explicitly not touching it here to keep this PR's diff scoped — see the mystique PR #2420 spec comment on the same point.

## Files changed

- **`src/paid-keyword-optimizer/guidance-opportunity-mapper.js`** — destructure `adAnalysis` from the SQS cluster body and append it to `data.cluster.adAnalysis` with the `?? null` guard. 7 lines added.

## Tests (3 new + 1 existing extended)

- `"includes all cluster fields"` extended to assert `adAnalysis` pass-through with a populated `{isBranded, intentType, adPromise}` block (spec B.3-(1)).
- `"defaults missing optional fields"` extended to assert `adAnalysis` defaults to `null` when the cluster omits the key — older mystique on a rolling-deploy window (spec B.3-(2)).
- New `"preserves explicit null adAnalysis without coercion (spec B.3-(3))"` — pins the `?? null` vs. `|| {}` contract.
- The extended `"includes all cluster fields"` assertion also serves as the B.3-(4) regression guard for existing keys.

52 tests passing in `opportunity-mapper.test.js` (was 51, +1).

## Test plan

- [x] `npx mocha test/audits/paid-keyword-optimizer/opportunity-mapper.test.js` — 52 passing
- [x] `npm run lint` on the touched files — clean (pre-commit lint-staged passed on the diff)
- [ ] Full suite + 100% coverage — left to CI. **Local verification was constrained** by a stale `.claude/worktrees/page-context-fields/` git worktree that c8's `"all": true` config picks up as duplicate `src/**/*.js` (inflating the coverage denominator) and ESLint walks into (inflating the error count). CI runs against a clean checkout so neither effect applies there.

## Spec / cross-repo coordination

- Spec: [`mysticat-architecture#97`](https://github.com/adobe/mysticat-architecture/pull/97) — Part B (this PR), Decision #3 (producer-internal threshold), B.2 (no shared validator).
- Producer side: [`mystique#2420`](https://git.corp.adobe.com/experience-platform/mystique/pull/2420) (Adobe GHE).
- Upstream wire data: [`spacecat-import-worker#760`](https://github.com/adobe/spacecat-import-worker/pull/760) (merged) — surfaces the `serpDescription` + `visibleUrl` per-keyword fields mystique now feeds to its prompt.

## Backwards compatibility

Purely additive. No existing field is renamed, removed, or retyped. Old opportunities created before this ships will simply lack `adAnalysis`; UI consumers MUST treat as optional (same hide-when-missing pattern v3 already uses for `resolvedPageHeading`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)