### PR TITLE
feat(forms): use camelCase keys in messages to/from mystique (FORMS-20458)

### DIFF
--- a/src/forms-opportunities/form-details-handler/detect-form-details.js
+++ b/src/forms-opportunities/form-details-handler/detect-form-details.js
@@ -20,7 +20,7 @@ export default async function handler(message, context) {
   } = context;
   const { Opportunity } = dataAccess;
   const { data, auditId: id } = message;
-  const { form_details: formDetails } = data;
+  const { formDetails } = data;
 
   const opportunity = await Opportunity.findById(id);
   if (opportunity) {
@@ -30,11 +30,11 @@ export default async function handler(message, context) {
       const opportunityData = opportunity.getData();
       const updatedAccessibility = opportunityData.accessibility.map((item) => {
         // eslint-disable-next-line max-len
-        const matchingFormDetail = formDetails.find((detail) => detail.url === item.form && detail.form_source === item.formSource);
+        const matchingFormDetail = formDetails.find((detail) => detail.url === item.form && detail.formSource === item.formSource);
         if (matchingFormDetail) {
           log.info(`Matching form details : ${JSON.stringify(matchingFormDetail)}`);
           // eslint-disable-next-line
-          const { url, form_source, ...cleanedFormDetail } = matchingFormDetail;
+          const { url, formSource, ...cleanedFormDetail } = matchingFormDetail;
           const formTitle = getFormTitle(cleanedFormDetail, opportunity);
           return { ...item, formTitle, formDetails: cleanedFormDetail };
         }
@@ -46,10 +46,10 @@ export default async function handler(message, context) {
     } else {
       const opportunityData = opportunity.getData();
       // eslint-disable-next-line max-len
-      const matchingFormDetail = formDetails.find((detail) => detail.url === opportunityData.form && detail.form_source === opportunityData.formsource);
+      const matchingFormDetail = formDetails.find((detail) => detail.url === opportunityData.form && detail.formSource === opportunityData.formsource);
       if (matchingFormDetail) {
         // eslint-disable-next-line
-        const { form, form_source, ...cleanedFormDetail } = matchingFormDetail;
+        const { form, formSource, ...cleanedFormDetail } = matchingFormDetail;
         const formTitle = getFormTitle(cleanedFormDetail, opportunity);
 
         // Check if this form should be ignored

--- a/src/forms-opportunities/guidance-handlers/guidance-high-form-views-low-conversions.js
+++ b/src/forms-opportunities/guidance-handlers/guidance-high-form-views-low-conversions.js
@@ -21,7 +21,7 @@ export default async function handler(message, context) {
   const {
     url,
     guidance,
-    form_source: formsource,
+    formSource: formsource,
     suggestions,
   } = data;
   log.info(`[Form Opportunity] [Site Id: ${siteId}] message received in high-form-views-low-conversions guidance handler: ${JSON.stringify(message, null, 2)}`);

--- a/src/forms-opportunities/guidance-handlers/guidance-high-page-views-low-form-nav.js
+++ b/src/forms-opportunities/guidance-handlers/guidance-high-page-views-low-form-nav.js
@@ -21,7 +21,7 @@ export default async function handler(message, context) {
   const {
     url,
     guidance,
-    form_source: formsource,
+    formSource: formsource,
     suggestions,
   } = data;
   log.info(`[Form Opportunity] [Site Id: ${siteId}] message received in high-page-views-low-form-nav guidance handler: ${JSON.stringify(message, null, 2)}`);

--- a/src/forms-opportunities/guidance-handlers/guidance-high-page-views-low-form-views.js
+++ b/src/forms-opportunities/guidance-handlers/guidance-high-page-views-low-form-views.js
@@ -20,7 +20,7 @@ export default async function handler(message, context) {
   const { auditId, siteId, data } = message;
   const {
     url,
-    form_source: formsource,
+    formSource: formsource,
     guidance, suggestions,
   } = data;
   log.info(`[Form Opportunity] [Site Id: ${siteId}] message received in high-page-views-low-form-views guidance handler: ${JSON.stringify(message, null, 2)}`);

--- a/src/forms-opportunities/utils.js
+++ b/src/forms-opportunities/utils.js
@@ -442,9 +442,9 @@ export async function sendMessageToFormsQualityAgent(context, opportunity, forms
 
     const data = {
       url: site ? site.getBaseURL() : formsList[0]?.form,
-      form_details: formsList.map(({ form, formSource }) => ({
+      formDetails: formsList.map(({ form, formSource }) => ({
         url: form,
-        form_source: formSource,
+        formSource,
       })),
     };
 
@@ -478,25 +478,23 @@ export async function sendMessageToMystiqueForGuidance(context, opportunity, opt
       auditId: opptyData.auditId,
       deliveryType: site ? site.getDeliveryType() : 'aem_cs',
       time: new Date().toISOString(),
-      // keys inside data should follow snake case and outside should follow camel case
       data: {
         url: opptyData.data?.form,
         cr: opptyData.data?.trackedFormKPIValue || 0,
         metrics: opptyData.data?.metrics || [],
-        cta_source: opptyData.data?.formNavigation?.source || '',
-        cta_text: opptyData.data?.formNavigation?.text || '',
+        ctaSource: opptyData.data?.formNavigation?.source || '',
+        ctaText: opptyData.data?.formNavigation?.text || '',
         opportunityId: opptyData.opportunityId || '',
-        form_source: opptyData.data?.formsource || '',
-        // form_details: opptyData.data?.formDetails,
+        formSource: opptyData.data?.formsource || '',
         // eslint-disable-next-line max-len,no-nested-ternary
-        form_details: Array.isArray(opptyData.data?.formDetails) ? opptyData.data.formDetails : (opptyData.data?.formDetails ? [opptyData.data.formDetails] : []),
-        page_views: opptyData.data?.pageViews,
-        form_views: opptyData.data?.formViews,
-        form_navigation: {
+        formDetails: Array.isArray(opptyData.data?.formDetails) ? opptyData.data.formDetails : (opptyData.data?.formDetails ? [opptyData.data.formDetails] : []),
+        pageViews: opptyData.data?.pageViews,
+        formViews: opptyData.data?.formViews,
+        formNavigation: {
           url: opptyData.data?.formNavigation?.url || '',
           source: opptyData.data?.formNavigation?.source || '',
-          cta_clicks: opptyData.data?.formNavigation?.clicksOnCTA || 0,
-          page_views: opptyData.data?.formNavigation?.pageViews || 0,
+          ctaClicks: opptyData.data?.formNavigation?.clicksOnCTA || 0,
+          pageViews: opptyData.data?.formNavigation?.pageViews || 0,
         },
       },
     };

--- a/src/forms-opportunities/utils.js
+++ b/src/forms-opportunities/utils.js
@@ -323,17 +323,17 @@ export function shouldExcludeForm(scrapedFormData) {
  * Forms are ignored if they match certain form types (defined in FORM_TYPES_TO_IGNORE)
  * and are not lead generation forms.
  *
- * @param {Object} formDetails - The form details object containing form_type and is_lead_gen
+ * @param {Object} formDetails - The form details object containing formType and isLeadGen
  * @returns {boolean} - True if the form should be ignored, false otherwise
  */
 export function shouldIgnoreFormByDetails(formDetails) {
   if (!formDetails || typeof formDetails !== 'object') {
     return false;
   }
-  // Normalize form_type to lowercase for case-insensitive comparison
-  const formType = formDetails.form_type?.toLowerCase();
+  // Normalize formType to lowercase for case-insensitive comparison
+  const formType = formDetails.formType?.toLowerCase();
   // Ignore forms that match specified types and are not lead generation (boolean check)
-  return FORM_TYPES_TO_IGNORE.includes(formType) && formDetails.is_lead_gen === false;
+  return FORM_TYPES_TO_IGNORE.includes(formType) && formDetails.isLeadGen === false;
 }
 
 /**

--- a/test/audits/forms/accessibility-handler.test.js
+++ b/test/audits/forms/accessibility-handler.test.js
@@ -2162,10 +2162,10 @@ describe('Forms Opportunities - Accessibility Handler', () => {
                     accessibility: [{
                       form: 'test-form-2',
                       formDetails: {
-                        is_lead_gen: true,
+                        isLeadGen: true,
                         industry: 'Insurance',
-                        form_type: 'Quote Request Form',
-                        form_category: 'B2C',
+                        formType: 'Quote Request Form',
+                        formCategory: 'B2C',
                         cpl: 230.6,
                       },
                       formsource: 'test-source',

--- a/test/audits/forms/form-details-handler/detect-form-details.test.js
+++ b/test/audits/forms/form-details-handler/detect-form-details.test.js
@@ -102,9 +102,9 @@ describe('Detect Form Details Handler', () => {
       {
         url: 'testUrl1',
         formSource: 'formSource1',
-        is_lead_gen: true,
-        form_type: 'Contact Form',
-        form_category: 'B2B',
+        isLeadGen: true,
+        formType: 'Contact Form',
+        formCategory: 'B2B',
         industry: 'Telecommunications',
         cpl: 94.0,
       },
@@ -121,9 +121,9 @@ describe('Detect Form Details Handler', () => {
         samples: 987,
         projectedConversionValue: 8789.0,
         formDetails: {
-          is_lead_gen: true,
-          form_type: 'Contact Form',
-          form_category: 'B2B',
+          isLeadGen: true,
+          formType: 'Contact Form',
+          formCategory: 'B2B',
           industry: 'Telecommunications',
           cpl: 94.0,
         },
@@ -222,9 +222,9 @@ describe('Detect Form Details Handler', () => {
       {
         url: 'testUrl1',
         formSource: 'formSource1',
-        is_lead_gen: true,
-        form_type: 'Contact Form',
-        form_category: 'B2B',
+        isLeadGen: true,
+        formType: 'Contact Form',
+        formCategory: 'B2B',
         industry: 'Telecommunications',
         cpl: 94.0,
       },
@@ -242,9 +242,9 @@ describe('Detect Form Details Handler', () => {
           a11yIssues: [],
           formTitle: 'Forms missing key accessibility attributes — enhancements prepared to support all users',
           formDetails: {
-            is_lead_gen: true,
-            form_type: 'Contact Form',
-            form_category: 'B2B',
+            isLeadGen: true,
+            formType: 'Contact Form',
+            formCategory: 'B2B',
             industry: 'Telecommunications',
             cpl: 94,
           },
@@ -276,9 +276,9 @@ describe('Detect Form Details Handler', () => {
       {
         url: 'testUrl1',
         formSource: 'formSource1',
-        is_lead_gen: false,
-        form_type: 'search form',
-        form_category: 'B2B',
+        isLeadGen: false,
+        formType: 'search form',
+        formCategory: 'B2B',
         industry: 'Telecommunications',
         cpl: 94.0,
       },
@@ -311,8 +311,8 @@ describe('Detect Form Details Handler', () => {
       {
         url: 'testUrl1',
         formSource: 'formSource1',
-        is_lead_gen: false,
-        form_type: 'SEARCH form',
+        isLeadGen: false,
+        formType: 'SEARCH form',
       },
     ];
 
@@ -342,8 +342,8 @@ describe('Detect Form Details Handler', () => {
       {
         url: 'testUrl1',
         formSource: 'formSource1',
-        is_lead_gen: true,
-        form_type: 'search form',
+        isLeadGen: true,
+        formType: 'search form',
       },
     ];
 

--- a/test/audits/forms/form-details-handler/detect-form-details.test.js
+++ b/test/audits/forms/form-details-handler/detect-form-details.test.js
@@ -68,9 +68,9 @@ describe('Detect Form Details Handler', () => {
       auditId: 'testAuditId',
       siteId: 'testSiteId',
       data: {
-        form_details: [
-          { url: 'testUrl1', form_source: 'formSource1', testKey: 'testValue1' },
-          { url: 'testUrl2', form_source: 'formSource2', testKey: 'testValue1' },
+        formDetails: [
+          { url: 'testUrl1', formSource: 'formSource1', testKey: 'testValue1' },
+          { url: 'testUrl2', formSource: 'formSource2', testKey: 'testValue1' },
         ],
       },
     };
@@ -98,10 +98,10 @@ describe('Detect Form Details Handler', () => {
       save: sinon.stub().resolvesThis(),
     });
 
-    message.data.form_details = [
+    message.data.formDetails = [
       {
         url: 'testUrl1',
-        form_source: 'formSource1',
+        formSource: 'formSource1',
         is_lead_gen: true,
         form_type: 'Contact Form',
         form_category: 'B2B',
@@ -218,10 +218,10 @@ describe('Detect Form Details Handler', () => {
       save: sinon.stub().resolvesThis(),
     });
 
-    message.data.form_details = [
+    message.data.formDetails = [
       {
         url: 'testUrl1',
-        form_source: 'formSource1',
+        formSource: 'formSource1',
         is_lead_gen: true,
         form_type: 'Contact Form',
         form_category: 'B2B',
@@ -272,10 +272,10 @@ describe('Detect Form Details Handler', () => {
       save: sinon.stub().resolvesThis(),
     });
 
-    message.data.form_details = [
+    message.data.formDetails = [
       {
         url: 'testUrl1',
-        form_source: 'formSource1',
+        formSource: 'formSource1',
         is_lead_gen: false,
         form_type: 'search form',
         form_category: 'B2B',
@@ -307,10 +307,10 @@ describe('Detect Form Details Handler', () => {
       save: sinon.stub().resolvesThis(),
     });
 
-    message.data.form_details = [
+    message.data.formDetails = [
       {
         url: 'testUrl1',
-        form_source: 'formSource1',
+        formSource: 'formSource1',
         is_lead_gen: false,
         form_type: 'SEARCH form',
       },
@@ -338,10 +338,10 @@ describe('Detect Form Details Handler', () => {
       save: sinon.stub().resolvesThis(),
     });
 
-    message.data.form_details = [
+    message.data.formDetails = [
       {
         url: 'testUrl1',
-        form_source: 'formSource1',
+        formSource: 'formSource1',
         is_lead_gen: true,
         form_type: 'search form',
       },

--- a/test/audits/forms/guidance-handlers/guidance-high-form-views-low-conversions.test.js
+++ b/test/audits/forms/guidance-handlers/guidance-high-form-views-low-conversions.test.js
@@ -51,7 +51,7 @@ describe('Guidance High Form Views Low Conversions Handler', () => {
       siteId: 'site-id',
       data: {
         url: 'https://example.com',
-        form_source: '.form',
+        formSource: '.form',
         guidance: 'Some guidance',
         suggestions: ['Suggestion 1', 'Suggestion 2'],
       },
@@ -132,7 +132,7 @@ describe('Guidance High Form Views Low Conversions Handler', () => {
       siteId: 'site-id',
       data: {
         url: 'https://example.com',
-        form_source: '.form',
+        formSource: '.form',
         guidance: 'Some guidance'
       },
     };
@@ -159,7 +159,7 @@ describe('Guidance High Form Views Low Conversions Handler', () => {
       siteId: 'site-id',
       data: {
         url: 'https://example.com',
-        form_source: '.form',
+        formSource: '.form',
         guidance: 'Some guidance'
       },
     };
@@ -218,7 +218,7 @@ describe('Guidance High Form Views Low Conversions Handler', () => {
       siteId: 'site-id',
       data: {
         url: 'https://example.com',
-        form_source: '.form',
+        formSource: '.form',
         guidance: 'Some guidance',
         suggestions: newSuggestion
       },
@@ -279,7 +279,7 @@ describe('Guidance High Form Views Low Conversions Handler', () => {
       siteId: 'site-id',
       data: {
         url: 'https://example.com',
-        form_source: '.form',
+        formSource: '.form',
         guidance: 'Some guidance',
         suggestions: newSuggestion
       },

--- a/test/audits/forms/guidance-handlers/guidance-high-page-views-low-form-nav.test.js
+++ b/test/audits/forms/guidance-handlers/guidance-high-page-views-low-form-nav.test.js
@@ -48,7 +48,7 @@ describe('Guidance High Page Views Low Form Navigation Handler', () => {
       siteId: 'site-id',
       data: {
         url: 'https://example.com',
-        form_source: '.form',
+        formSource: '.form',
         guidance: 'Some guidance',
         suggestions: ['Suggestion 1', 'Suggestion 2'],
       },
@@ -126,7 +126,7 @@ describe('Guidance High Page Views Low Form Navigation Handler', () => {
       siteId: 'site-id',
       data: {
         url: 'https://example.com',
-        form_source: '.form',
+        formSource: '.form',
         guidance: 'Some guidance'
       },
     };
@@ -153,7 +153,7 @@ describe('Guidance High Page Views Low Form Navigation Handler', () => {
       siteId: 'site-id',
       data: {
         url: 'https://example.com',
-        form_source: '.form',
+        formSource: '.form',
         guidance: 'Some guidance'
       },
     };
@@ -212,7 +212,7 @@ describe('Guidance High Page Views Low Form Navigation Handler', () => {
       siteId: 'site-id',
       data: {
         url: 'https://example.com',
-        form_source: '.form',
+        formSource: '.form',
         guidance: 'Some guidance',
         suggestions: newSuggestion
       },

--- a/test/audits/forms/guidance-handlers/guidance-high-page-views-low-form-views.test.js
+++ b/test/audits/forms/guidance-handlers/guidance-high-page-views-low-form-views.test.js
@@ -47,7 +47,7 @@ describe('Guidance High Page Views Low Form Views Handler', () => {
       auditId: 'audit-id',
       siteId: 'site-id',
       data: {
-        form_source: '.form',
+        formSource: '.form',
         url: 'https://example.com',
         guidance: 'Some guidance',
         suggestions: ['Suggestion 1', 'Suggestion 2'],
@@ -126,7 +126,7 @@ describe('Guidance High Page Views Low Form Views Handler', () => {
       siteId: 'site-id',
       data: {
         url: 'https://example.com',
-        form_source: '.form',
+        formSource: '.form',
         guidance: 'Some guidance'
       },
     };
@@ -154,7 +154,7 @@ describe('Guidance High Page Views Low Form Views Handler', () => {
       siteId: 'site-id',
       data: {
         url: 'https://example.com',
-        form_source: '.form',
+        formSource: '.form',
         guidance: 'Some guidance'
       },
     };
@@ -213,7 +213,7 @@ describe('Guidance High Page Views Low Form Views Handler', () => {
       siteId: 'site-id',
       data: {
         url: 'https://example.com',
-        form_source: '.form',
+        formSource: '.form',
         guidance: 'Some guidance',
         suggestions: newSuggestion
       },

--- a/test/audits/forms/oppty-handlers/low-conv-oppoty-handler.test.js
+++ b/test/audits/forms/oppty-handlers/low-conv-oppoty-handler.test.js
@@ -171,10 +171,10 @@ describe('createLowConversionOpportunities handler method', () => {
       pageViews: 5000,
       samples: 5000,
       formDetails: {
-        is_lead_gen: true,
+        isLeadGen: true,
         industry: 'Insurance',
-        form_type: 'Quote Request Form',
-        form_category: 'B2C',
+        formType: 'Quote Request Form',
+        formCategory: 'B2C',
         cpl: 230.6,
       },
     });
@@ -202,8 +202,8 @@ describe('createLowConversionOpportunities handler method', () => {
       pageViews: 5000,
       samples: 5000,
       formDetails: {
-        is_lead_gen: true,
-        form_type: 'Quote Request Form',
+        isLeadGen: true,
+        formType: 'Quote Request Form',
       },
     });
     await createLowConversionOpportunities(
@@ -228,8 +228,8 @@ describe('createLowConversionOpportunities handler method', () => {
       pageViews: 5000,
       samples: 5000,
       formDetails: {
-        is_lead_gen: false,
-        form_type: 'search form',
+        isLeadGen: false,
+        formType: 'search form',
       },
     });
     await createLowConversionOpportunities(

--- a/test/audits/forms/oppty-handlers/low-conv-oppoty-handler.test.js
+++ b/test/audits/forms/oppty-handlers/low-conv-oppoty-handler.test.js
@@ -240,10 +240,10 @@ describe('createLowConversionOpportunities handler method', () => {
     );
     const [, message] = context.sqs.sendMessage.getCall(0).args;
     expect(message.type).to.equal('detect:form-details');
-    expect(message.data.form_details).to.have.lengthOf(1);
-    expect(message.data.form_details[0]).to.deep.include({
+    expect(message.data.formDetails).to.have.lengthOf(1);
+    expect(message.data.formDetails[0]).to.deep.include({
       url: 'https://www.surest.com/info/win-1',
-      form_source: '',
+      formSource: '',
     });
   });
 

--- a/test/audits/forms/oppty-handlers/low-nav-oppoty-handler.test.js
+++ b/test/audits/forms/oppty-handlers/low-nav-oppoty-handler.test.js
@@ -284,10 +284,10 @@ describe('createLowNavigationOpportunities handler method', () => {
       pageViews: 5000,
       samples: 5000,
       formDetails: {
-        is_lead_gen: true,
+        isLeadGen: true,
         industry: 'Insurance',
-        form_type: 'Quote Request Form',
-        form_category: 'B2C',
+        formType: 'Quote Request Form',
+        formCategory: 'B2C',
         cpl: 230.6,
       },
     });
@@ -309,8 +309,8 @@ describe('createLowNavigationOpportunities handler method', () => {
       pageViews: 5000,
       samples: 5000,
       formDetails: {
-        is_lead_gen: true,
-        form_type: 'Quote Request Form',
+        isLeadGen: true,
+        formType: 'Quote Request Form',
       },
     });
     await createLowNavigationOpportunities(auditUrl, auditData, undefined, context);
@@ -329,8 +329,8 @@ describe('createLowNavigationOpportunities handler method', () => {
       pageViews: 5000,
       samples: 5000,
       formDetails: {
-        is_lead_gen: false,
-        form_type: 'search form',
+        isLeadGen: false,
+        formType: 'search form',
       },
     });
     await createLowNavigationOpportunities(auditUrl, auditData, undefined, context);

--- a/test/audits/forms/oppty-handlers/low-views-oppoty-handler.test.js
+++ b/test/audits/forms/oppty-handlers/low-views-oppoty-handler.test.js
@@ -297,10 +297,10 @@ describe('createLowFormViewsOpportunities handler method', () => {
     await createLowViewsOpportunities(auditUrl, auditData, undefined, context);
     const [, message] = context.sqs.sendMessage.getCall(0).args;
     expect(message.type).to.equal('detect:form-details');
-    expect(message.data.form_details).to.have.lengthOf(1);
-    expect(message.data.form_details[0]).to.deep.include({
+    expect(message.data.formDetails).to.have.lengthOf(1);
+    expect(message.data.formDetails[0]).to.deep.include({
       url: 'https://www.surest.com/existing-opportunity',
-      form_source: '',
+      formSource: '',
     });
   });
 

--- a/test/audits/forms/oppty-handlers/low-views-oppoty-handler.test.js
+++ b/test/audits/forms/oppty-handlers/low-views-oppoty-handler.test.js
@@ -233,10 +233,10 @@ describe('createLowFormViewsOpportunities handler method', () => {
       pageViews: 5000,
       samples: 5000,
       formDetails: {
-        is_lead_gen: true,
+        isLeadGen: true,
         industry: 'Insurance',
-        form_type: 'Quote Request Form',
-        form_category: 'B2C',
+        formType: 'Quote Request Form',
+        formCategory: 'B2C',
         cpl: 230.6,
       },
     });
@@ -270,8 +270,8 @@ describe('createLowFormViewsOpportunities handler method', () => {
       pageViews: 5000,
       samples: 5000,
       formDetails: {
-        is_lead_gen: true,
-        form_type: 'Quote Request Form',
+        isLeadGen: true,
+        formType: 'Quote Request Form',
       },
     });
     await createLowViewsOpportunities(auditUrl, auditData, undefined, context);
@@ -290,8 +290,8 @@ describe('createLowFormViewsOpportunities handler method', () => {
       pageViews: 5000,
       samples: 5000,
       formDetails: {
-        is_lead_gen: false,
-        form_type: 'search form',
+        isLeadGen: false,
+        formType: 'search form',
       },
     });
     await createLowViewsOpportunities(auditUrl, auditData, undefined, context);

--- a/test/audits/forms/utils.test.js
+++ b/test/audits/forms/utils.test.js
@@ -645,8 +645,8 @@ describe('sendMessageToMystiqueForGuidance', () => {
     expect(message.type).to.equal('guidance:other-type');
     expect(message.data.url).to.equal('https://example.com/form2');
     expect(message.data.cr).to.equal(0.85);
-    expect(message.data.form_source).to.equal('source2');
-    expect(message.data.form_details).to.deep.equal([{ detail: 'detail2' }]);
+    expect(message.data.formSource).to.equal('source2');
+    expect(message.data.formDetails).to.deep.equal([{ detail: 'detail2' }]);
   });
 
   it('should handle empty formDetails gracefully', async () => {
@@ -672,7 +672,7 @@ describe('sendMessageToMystiqueForGuidance', () => {
 
     expect(sqsStub.calledOnce).to.be.true;
     const message = sqsStub.firstCall.args[1];
-    expect(message.data.form_details).to.deep.equal([]);
+    expect(message.data.formDetails).to.deep.equal([]);
   });
 
   it('should send message with default deliveryType when site is not available', async () => {
@@ -723,11 +723,11 @@ describe('sendMessageToMystiqueForGuidance', () => {
 
     expect(sqsStub.calledOnce).to.be.true;
     const message = sqsStub.firstCall.args[1];
-    expect(message.data.form_navigation).to.deep.equal({
+    expect(message.data.formNavigation).to.deep.equal({
       url: '',
       source: '',
-      cta_clicks: 0,
-      page_views: 0,
+      ctaClicks: 0,
+      pageViews: 0,
     });
   });
 
@@ -755,7 +755,7 @@ describe('sendMessageToMystiqueForGuidance', () => {
 
     expect(sqsStub.calledOnce).to.be.true;
     const message = sqsStub.firstCall.args[1];
-    expect(message.data.form_details).to.deep.equal([{ detail: 'detail1' }, { detail: 'detail2' }]);
+    expect(message.data.formDetails).to.deep.equal([{ detail: 'detail1' }, { detail: 'detail2' }]);
   });
 
 });

--- a/test/audits/forms/utils.test.js
+++ b/test/audits/forms/utils.test.js
@@ -1230,38 +1230,38 @@ describe('sendCodeFixMessagesToImporter', () => {
 });
 
 describe('shouldIgnoreFormByDetails', () => {
-  it('should return true for search form with is_lead_gen false', () => {
-    const formDetails = { form_type: 'search form', is_lead_gen: false };
+  it('should return true for search form with isLeadGen false', () => {
+    const formDetails = { formType: 'search form', isLeadGen: false };
     expect(shouldIgnoreFormByDetails(formDetails)).to.be.true;
   });
 
-  it('should return true for search form with is_lead_gen false (case insensitive)', () => {
-    const formDetails = { form_type: 'Search form', is_lead_gen: false };
+  it('should return true for search form with isLeadGen false (case insensitive)', () => {
+    const formDetails = { formType: 'Search form', isLeadGen: false };
     expect(shouldIgnoreFormByDetails(formDetails)).to.be.true;
   });
 
-  it('should return true for SEARCH form with is_lead_gen false (uppercase)', () => {
-    const formDetails = { form_type: 'SEARCH form', is_lead_gen: false };
+  it('should return true for SEARCH form with isLeadGen false (uppercase)', () => {
+    const formDetails = { formType: 'SEARCH form', isLeadGen: false };
     expect(shouldIgnoreFormByDetails(formDetails)).to.be.true;
   });
 
-  it('should return false for search form with is_lead_gen true', () => {
-    const formDetails = { form_type: 'search form', is_lead_gen: true };
+  it('should return false for search form with isLeadGen true', () => {
+    const formDetails = { formType: 'search form', isLeadGen: true };
     expect(shouldIgnoreFormByDetails(formDetails)).to.be.false;
   });
 
-  it('should return false for search form with is_lead_gen null', () => {
-    const formDetails = { form_type: 'search form', is_lead_gen: null };
+  it('should return false for search form with isLeadGen null', () => {
+    const formDetails = { formType: 'search form', isLeadGen: null };
     expect(shouldIgnoreFormByDetails(formDetails)).to.be.false;
   });
 
-  it('should return false for search form with is_lead_gen undefined', () => {
-    const formDetails = { form_type: 'search form', is_lead_gen: undefined };
+  it('should return false for search form with isLeadGen undefined', () => {
+    const formDetails = { formType: 'search form', isLeadGen: undefined };
     expect(shouldIgnoreFormByDetails(formDetails)).to.be.false;
   });
 
-  it('should return false for contact form with is_lead_gen false', () => {
-    const formDetails = { form_type: 'contact form', is_lead_gen: false };
+  it('should return false for contact form with isLeadGen false', () => {
+    const formDetails = { formType: 'contact form', isLeadGen: false };
     expect(shouldIgnoreFormByDetails(formDetails)).to.be.false;
   });
 
@@ -1277,13 +1277,13 @@ describe('shouldIgnoreFormByDetails', () => {
     expect(shouldIgnoreFormByDetails('string')).to.be.false;
   });
 
-  it('should return false when form_type is undefined', () => {
-    const formDetails = { is_lead_gen: false };
+  it('should return false when formType is undefined', () => {
+    const formDetails = { isLeadGen: false };
     expect(shouldIgnoreFormByDetails(formDetails)).to.be.false;
   });
 
   it('should return true for order form formDetails', () => {
-    const formDetails = { is_lead_gen: false, form_type: 'order form' };
+    const formDetails = { isLeadGen: false, formType: 'order form' };
     expect(shouldIgnoreFormByDetails(formDetails)).to.be.true;
   });
 });

--- a/test/fixtures/forms/high-form-views-low-conversions.js
+++ b/test/fixtures/forms/high-form-views-low-conversions.js
@@ -905,8 +905,8 @@ const testData = {
   mystiqueMessageForFormDetails:
     {
       url: 'test-base-url',
-      form_details: [{
-        form_source: 'form',
+      formDetails: [{
+        formSource: 'form',
         url: 'https://www.surest.com/info/win',
       }],
     },


### PR DESCRIPTION
## Summary

- Replace all snake_case message keys (`form_source`, `cta_text`, `cta_source`, `form_details`, `form_navigation`, `page_views`, `form_views`, `cta_clicks`) with camelCase equivalents in SQS messages sent to mystique via `sendMessageToFormsQualityAgent` and `sendMessageToMystiqueForGuidance`
- Update `detect-form-details.js` to read `formSource` and `formDetails` from incoming mystique responses
- Update the three guidance handlers to destructure `formSource` instead of `form_source` from incoming mystique guidance messages
- Update all affected tests and fixtures to match the new camelCase keys

## Motivation

Consistent camelCase convention for all SQS message keys across the audit-worker ↔ mystique boundary. Jira: [FORMS-20458](https://jira.corp.adobe.com/browse/FORMS-20458)

## Test plan

- [x] All 13 affected source/test files updated
- [x] Full test suite passes with 100% coverage (`npm test`)
- [ ] Coordinate deploy with companion mystique PR: https://git.corp.adobe.com/experience-platform/mystique/pull/2421

## Co-authors

- Rahul Kumar Singh <rahulksi@adobe.com>
- Claude Sonnet 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)