### PR TITLE
fix(cited-analysis): filter owned-domain URLs before DRS scrapping

### DIFF
--- a/src/cited-analysis/handler.js
+++ b/src/cited-analysis/handler.js
@@ -60,6 +60,69 @@ function getCitedConfig(site) {
 }
 
 /**
+ * Extracts the apex hostname from a URL or bare host string, stripping the
+ * leading ``www.`` so apex-to-apex comparison works regardless of how the
+ * brand domain is configured (``bmw.com`` vs ``https://www.bmw.com/``).
+ *
+ * Returns an empty string for unparseable input — the caller then treats the
+ * ownership check as a no-op rather than dropping URLs based on garbage.
+ * @param {string} value
+ * @returns {string}
+ */
+function toApexHost(value) {
+  if (!value) {
+    return '';
+  }
+  const trimmed = String(value).trim();
+  if (!trimmed) {
+    return '';
+  }
+  try {
+    const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+    const host = new URL(withScheme).hostname.toLowerCase();
+    return host.replace(/^www\./, '');
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Filters out cited URLs that live on the customer's own domain.
+ *
+ * Cited URLs are meant to represent 3rd-party EARNED citations. A page on
+ * ``bmw.com`` for the BMW customer is self-owned content; counting it as an
+ * earned citation skews offsite brand-perception reporting. We drop these
+ * here — before the expensive DRS lookup and before shipping the SQS payload
+ * to Mystique. The mystique flow re-applies the same filter for defense in
+ * depth.
+ *
+ * Ownership is matched on dotted suffix boundaries: ``bmw.com`` matches
+ * ``bmw.com``, ``www.bmw.com``, and ``m.bmw.com``, but NOT ``not-bmw.com``
+ * or ``bmw.com.attacker.example``.
+ * @param {Array<{url: string}>} urls
+ * @param {string} brandBaseURL
+ * @returns {{ kept: Array<{url: string}>, droppedCount: number }}
+ */
+function partitionOwnedUrls(urls, brandBaseURL) {
+  const ownedHost = toApexHost(brandBaseURL);
+  if (!ownedHost) {
+    return { kept: urls, droppedCount: 0 };
+  }
+  const kept = [];
+  let droppedCount = 0;
+  for (const entry of urls) {
+    const host = toApexHost(entry.url);
+    const isOwned = host && (host === ownedHost || host.endsWith(`.${ownedHost}`));
+    if (isOwned) {
+      droppedCount += 1;
+    } else {
+      kept.push(entry);
+    }
+  }
+  return { kept, droppedCount };
+}
+
+/**
  * Fetches all required data from stores for Cited analysis
  * @param {string} siteId - The site ID
  * @param {Object} context - The audit context
@@ -75,9 +138,31 @@ async function fetchStoreData(siteId, context, site) {
   const rawUrls = await storeClient.getUrls(siteId, URL_TYPES.CITED, { sortBy: 'createdAt', sortOrder: 'desc' });
   log.info(`${LOG_PREFIX} Retrieved ${rawUrls.length} cited URLs from URL Store`);
 
+  // Drop URLs on the customer's own domain. Cited URLs represent 3rd-party
+  // EARNED citations — pages on ``bmw.com`` for the BMW customer would
+  // skew earned-media reporting. The mystique flow re-applies the same
+  // filter for defense in depth.
+  const { kept: earnedUrls, droppedCount: ownedDroppedCount } = partitionOwnedUrls(
+    rawUrls,
+    site?.getBaseURL?.(),
+  );
+  if (ownedDroppedCount > 0) {
+    log.info(
+      `${LOG_PREFIX} Excluded ${ownedDroppedCount} owned-domain URLs `
+      + '(cited analysis is 3rd-party earned only)',
+    );
+  }
+
   const drsClient = DrsClient.createFrom(context);
   const { datasetIds } = CITED_ANALYSIS_DRS_CONFIG;
-  const urls = await filterUrlsByDrsStatus(rawUrls, datasetIds, siteId, drsClient, log, LOG_PREFIX);
+  const urls = await filterUrlsByDrsStatus(
+    earnedUrls,
+    datasetIds,
+    siteId,
+    drsClient,
+    log,
+    LOG_PREFIX,
+  );
   log.info(`${LOG_PREFIX} ${urls.length} cited URLs available in DRS`);
 
   const topics = await computeTopicsFromBrandPresence(siteId, context, site);

--- a/test/audits/cited-analysis/handler.test.js
+++ b/test/audits/cited-analysis/handler.test.js
@@ -46,9 +46,13 @@ describe('Cited Analysis Handler', () => {
   const siteId = 'test-site-id';
   const auditId = 'test-audit-id';
 
+  // Cited URLs represent 3rd-party EARNED citations — pages from blogs,
+  // press, etc. that LLMs reference when answering questions about the
+  // brand. They must NOT be on the brand's own domain (see the
+  // ``runCitedAnalysisAudit owned-domain filter`` describe block below).
   const mockUrls = [
-    { url: 'https://techblog.example.com/review-of-example', type: 'cited-analysis', metadata: {} },
-    { url: 'https://news.example.com/example-corp-article', type: 'cited-analysis', metadata: {} },
+    { url: 'https://techreview.io/review-of-example', type: 'cited-analysis', metadata: {} },
+    { url: 'https://industry-news.org/example-corp-article', type: 'cited-analysis', metadata: {} },
   ];
 
   const mockComputedTopics = [
@@ -56,7 +60,7 @@ describe('Cited Analysis Handler', () => {
       name: 'Brand Perception',
       urls: [
         {
-          url: 'https://techblog.example.com/review-of-example',
+          url: 'https://techreview.io/review-of-example',
           timesCited: 1,
           category: 'general',
           subPrompts: ['brand mentions', 'sentiment'],
@@ -390,6 +394,120 @@ describe('Cited Analysis Handler', () => {
 
       expect(result.auditResult.success).to.be.true;
       expect(result.auditResult.slackContext).to.be.undefined;
+    });
+  });
+
+  // Cited URLs are meant to represent 3rd-party EARNED citations. URLs on
+  // the customer's own domain must be filtered out before we waste a DRS
+  // lookup on them or ship them to Mystique. The mystique flow has the
+  // same filter for defense in depth, but doing it here avoids the
+  // round-trip cost.
+  describe('runCitedAnalysisAudit owned-domain filter', () => {
+    const ownedBaseURL = 'https://bmw.com';
+
+    beforeEach(() => {
+      mockSite.getBaseURL.returns(ownedBaseURL);
+      mockSite.getConfig.returns({
+        getCompanyName: sandbox.stub().returns('BMW'),
+        getCompetitors: sandbox.stub().returns(['Audi', 'Mercedes']),
+        getCompetitorRegion: sandbox.stub().returns('EU'),
+        getIndustry: sandbox.stub().returns('Automotive'),
+        getBrandKeywords: sandbox.stub().returns(['bmw']),
+      });
+    });
+
+    it('handles bare-host brand domain (no scheme)', async () => {
+      // ``site.getBaseURL()`` is normalized to include a scheme in
+      // production, but some site configs historically stored bare hosts
+      // (``bmw.com`` rather than ``https://bmw.com``). The filter must
+      // still produce the same apex match.
+      mockSite.getBaseURL.returns('bmw.com');
+      mockStoreClient.getUrls.resolves([
+        { url: 'https://bmw.com/news', type: 'cited-analysis', metadata: {} },
+        { url: 'https://caranddriver.com/bmw-review', type: 'cited-analysis', metadata: {} },
+      ]);
+
+      const result = await citedAnalysisHandler.default.runner('bmw.com', context, mockSite);
+
+      expect(result.auditResult.success).to.be.true;
+      const filtered = mockFilterUrlsByDrsStatus.firstCall.args[0];
+      expect(filtered).to.have.lengthOf(1);
+      expect(filtered[0].url).to.equal('https://caranddriver.com/bmw-review');
+    });
+
+    it('drops apex / www / subdomain URLs on the brand domain before DRS lookup', async () => {
+      mockStoreClient.getUrls.resolves([
+        { url: 'https://bmw.com/news/owned-article', type: 'cited-analysis', metadata: {} },
+        { url: 'https://www.bmw.com/configurator', type: 'cited-analysis', metadata: {} },
+        { url: 'https://m.bmw.com/owners', type: 'cited-analysis', metadata: {} },
+        { url: 'https://caranddriver.com/bmw-3-series-review', type: 'cited-analysis', metadata: {} },
+        { url: 'https://motortrend.com/bmw-x5-test', type: 'cited-analysis', metadata: {} },
+      ]);
+
+      const result = await citedAnalysisHandler.default.runner(ownedBaseURL, context, mockSite);
+
+      expect(result.auditResult.success).to.be.true;
+      const filtered = mockFilterUrlsByDrsStatus.firstCall.args[0];
+      const hosts = filtered.map((u) => new URL(u.url).hostname).sort();
+      expect(hosts).to.deep.equal(['caranddriver.com', 'motortrend.com']);
+      expect(context.log.info).to.have.been.calledWithMatch(/Excluded 3 owned-domain URLs/);
+    });
+
+    it('keeps lookalike domains that are not actually owned', async () => {
+      mockStoreClient.getUrls.resolves([
+        { url: 'https://not-bmw.com/page', type: 'cited-analysis', metadata: {} },
+        { url: 'https://bmw.com.attacker.example/x', type: 'cited-analysis', metadata: {} },
+        { url: 'https://caranddriver.com/bmw-review', type: 'cited-analysis', metadata: {} },
+      ]);
+
+      const result = await citedAnalysisHandler.default.runner(ownedBaseURL, context, mockSite);
+
+      expect(result.auditResult.success).to.be.true;
+      const filtered = mockFilterUrlsByDrsStatus.firstCall.args[0];
+      expect(filtered).to.have.lengthOf(3);
+    });
+
+    it('is a no-op when baseURL is whitespace-only', async () => {
+      mockSite.getBaseURL.returns('   ');
+      const urls = [
+        { url: 'https://caranddriver.com/bmw-review', type: 'cited-analysis', metadata: {} },
+        { url: 'https://bmw.com/news', type: 'cited-analysis', metadata: {} },
+      ];
+      mockStoreClient.getUrls.resolves(urls);
+
+      const result = await citedAnalysisHandler.default.runner('   ', context, mockSite);
+
+      expect(result.auditResult.success).to.be.true;
+      const filtered = mockFilterUrlsByDrsStatus.firstCall.args[0];
+      expect(filtered).to.have.lengthOf(2);
+    });
+
+    it('keeps URLs whose host string cannot be parsed (defensive)', async () => {
+      mockStoreClient.getUrls.resolves([
+        { url: 'http://[bad', type: 'cited-analysis', metadata: {} },
+        { url: 'https://caranddriver.com/bmw-review', type: 'cited-analysis', metadata: {} },
+      ]);
+
+      const result = await citedAnalysisHandler.default.runner(ownedBaseURL, context, mockSite);
+
+      expect(result.auditResult.success).to.be.true;
+      const filtered = mockFilterUrlsByDrsStatus.firstCall.args[0];
+      expect(filtered).to.have.lengthOf(2);
+    });
+
+    it('is a no-op when baseURL is missing (defensive — keeps everything)', async () => {
+      mockSite.getBaseURL.returns('');
+      const urls = [
+        { url: 'https://caranddriver.com/bmw-review', type: 'cited-analysis', metadata: {} },
+        { url: 'https://bmw.com/news', type: 'cited-analysis', metadata: {} },
+      ];
+      mockStoreClient.getUrls.resolves(urls);
+
+      const result = await citedAnalysisHandler.default.runner('', context, mockSite);
+
+      expect(result.auditResult.success).to.be.true;
+      const filtered = mockFilterUrlsByDrsStatus.firstCall.args[0];
+      expect(filtered).to.have.lengthOf(2);
     });
   });
 


### PR DESCRIPTION
Cited URLs are meant to represent 3rd-party EARNED citations. URLs on the customer's own domain (e.g. bmw.com/news/... for the BMW customer) were being treated as earned citations, skewing offsite brand-perception reporting.

Drop these in fetchStoreData() before the expensive DRS lookup and before shipping the SQS payload to Mystique. The mystique flow applies the same filter for defense in depth.

Matching is apex-aware:
- bmw.com matches bmw.com, www.bmw.com, m.bmw.com
- bmw.com does NOT match not-bmw.com or bmw.com.attacker.example

Tests use neutral 3rd-party hosts for mockUrls and a new describe block pins apex/www/subdomain inclusion, lookalike exclusion, and defensive no-op behavior on empty/whitespace/bare-host/unparseable inputs.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
