### PR TITLE
fix: canonical - exclude noindex url and excludeUrl

### DIFF
--- a/src/canonical/handler.js
+++ b/src/canonical/handler.js
@@ -541,8 +541,9 @@ export async function processScrapedContent(context) {
       const rawBody = scrapedObject?.scrapeResult?.rawBody || '';
       if (rawBody) {
         const $page = cheerio.load(rawBody);
-        const robotsMeta = $page('meta[name="robots"], meta[name="googlebot"]').attr('content') || '';
-        if (robotsMeta.toLowerCase().includes('noindex')) {
+        const hasNoindex = $page('meta[name="robots"], meta[name="googlebot"]').toArray()
+          .some((el) => ($page(el).attr('content') || '').toLowerCase().includes('noindex'));
+        if (hasNoindex) {
           log.info(`[canonical] Skipping ${finalUrl} - noindex page`);
           return null;
         }

--- a/src/canonical/handler.js
+++ b/src/canonical/handler.js
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import * as cheerio from 'cheerio';
 import {
   composeBaseURL, hasText, isString, tracingFetch as fetch,
 } from '@adobe/spacecat-shared-utils';
@@ -107,9 +108,19 @@ export async function submitForScraping(context) {
   // Filter out auth pages (non-HTML/PDFs already filtered by getMergedAuditInputUrls)
   const filteredUrls = allUrls.filter((url) => !isAuthUrl(url));
 
+  // Filter out site-configured excluded URLs for the canonical audit
+  const excludedURLs = site.getConfig?.().getExcludedURLs?.('canonical') || [];
+  const allowedBeforeRobots = excludedURLs.length > 0
+    ? filteredUrls.filter((url) => !excludedURLs.includes(url))
+    : filteredUrls;
+
+  if (excludedURLs.length > 0) {
+    log.info(`[canonical] Excluded ${filteredUrls.length - allowedBeforeRobots.length} URLs based on site config excludedURLs`);
+  }
+
   // Filter out pages disallowed by robots.txt
   const robots = await fetchRobotsTxt(site.getBaseURL(), log);
-  const allowedUrls = filterUrlsByRobots(robots, filteredUrls, log);
+  const allowedUrls = filterUrlsByRobots(robots, allowedBeforeRobots, log);
 
   log.info(`[canonical] After filtering: ${allowedUrls.length} pages will be scraped - ${JSON.stringify(allowedUrls)}`);
 
@@ -470,6 +481,9 @@ export async function processScrapedContent(context) {
   // Fetch robots.txt once for use across all scraped pages
   const robots = await fetchRobotsTxt(baseURL, log);
 
+  // Fetch site-configured excluded URLs for the canonical audit once
+  const excludedURLs = site.getConfig?.().getExcludedURLs?.('canonical') || [];
+
   // Process each scraped page
   const auditPromises = scrapeKeys.map(async (key) => {
     try {
@@ -515,6 +529,23 @@ export async function processScrapedContent(context) {
       if (isDisallowedByRobots(robots, finalUrl)) {
         log.info(`[canonical] Skipping ${finalUrl} - disallowed by robots.txt`);
         return null;
+      }
+
+      // Filter out site-configured excluded URLs
+      if (excludedURLs.includes(finalUrl)) {
+        log.info(`[canonical] Skipping ${finalUrl} - excluded by site config`);
+        return null;
+      }
+
+      // Skip pages that explicitly opt out of indexing via meta robots noindex tag
+      const rawBody = scrapedObject?.scrapeResult?.rawBody || '';
+      if (rawBody) {
+        const $page = cheerio.load(rawBody);
+        const robotsMeta = $page('meta[name="robots"], meta[name="googlebot"]').attr('content') || '';
+        if (robotsMeta.toLowerCase().includes('noindex')) {
+          log.info(`[canonical] Skipping ${finalUrl} - noindex page`);
+          return null;
+        }
       }
       const canonicalUrl = canonicalMetadata.href || null;
       const canonicalTagChecks = [];

--- a/test/audits/canonical.test.js
+++ b/test/audits/canonical.test.js
@@ -4793,6 +4793,98 @@ describe('Canonical URL Tests', () => {
         );
       });
 
+      it('should detect noindex when multiple meta robots tags are present', async () => {
+        const scrapedContent = {
+          url: 'https://example.com/multi-meta',
+          finalUrl: 'https://example.com/multi-meta',
+          scrapeResult: {
+            canonical: {
+              exists: false, count: 0, href: null, inHead: false,
+            },
+            rawBody: createValidRawBody('<html><head><meta name="robots" content="follow"><meta name="googlebot" content="noindex"><title>Multi</title></head><body><p>First meta allows, second meta blocks — should still be skipped.</p></body></html>'),
+          },
+        };
+
+        const mockGetObjectFromKey = sinon.stub().resolves(scrapedContent);
+
+        const testContext = {
+          ...context,
+          site,
+          s3Client: {},
+          scrapeResultPaths: new Map([
+            ['https://example.com/multi-meta', 'scrapes/job-id/multi-meta/scrape.json'],
+          ]),
+          audit: { getId: () => 'test-audit-id' },
+        };
+
+        const { processScrapedContent: processScrapedContentMocked } = await esmock(
+          '../../src/canonical/handler.js',
+          {
+            '../../src/utils/s3-utils.js': {
+              getObjectFromKey: mockGetObjectFromKey,
+            },
+            '../../src/common/opportunity-utils.js': {
+              checkGoogleConnection: sinon.stub().resolves(false),
+            },
+          },
+        );
+
+        const result = await processScrapedContentMocked(testContext);
+
+        expect(result.auditResult).to.deep.equal({
+          status: 'success',
+          message: 'No canonical issues detected',
+        });
+        expect(context.log.info).to.have.been.calledWith(
+          '[canonical] Skipping https://example.com/multi-meta - noindex page',
+        );
+      });
+
+      it('should not skip pages when meta robots tag has no content attribute', async () => {
+        const scrapedContent = {
+          url: 'https://example.com/no-content-attr',
+          finalUrl: 'https://example.com/no-content-attr',
+          scrapeResult: {
+            canonical: { exists: true, count: 1, href: 'https://example.com/no-content-attr', inHead: true },
+            rawBody: createValidRawBody('<html><head><meta name="robots"><title>No content attr</title></head><body><p>Meta tag present but has no content attribute — should not be skipped.</p></body></html>'),
+          },
+        };
+
+        const mockGetObjectFromKey = sinon.stub().resolves(scrapedContent);
+
+        const testContext = {
+          ...context,
+          site,
+          s3Client: {},
+          scrapeResultPaths: new Map([
+            ['https://example.com/no-content-attr', 'scrapes/job-id/no-content-attr/scrape.json'],
+          ]),
+          audit: { getId: () => 'test-audit-id' },
+        };
+
+        const { processScrapedContent: processScrapedContentMocked } = await esmock(
+          '../../src/canonical/handler.js',
+          {
+            '../../src/utils/s3-utils.js': {
+              getObjectFromKey: mockGetObjectFromKey,
+            },
+            '../../src/common/opportunity-utils.js': {
+              checkGoogleConnection: sinon.stub().resolves(false),
+            },
+          },
+        );
+
+        const result = await processScrapedContentMocked(testContext);
+
+        expect(result.auditResult).to.deep.equal({
+          status: 'success',
+          message: 'No canonical issues detected',
+        });
+        expect(context.log.info).to.not.have.been.calledWith(
+          sinon.match(/Skipping.*noindex/),
+        );
+      });
+
       it('should handle site with no getConfig in processScrapedContent gracefully', async () => {
         const scrapedContent = {
           url: 'https://example.com/page1',

--- a/test/audits/canonical.test.js
+++ b/test/audits/canonical.test.js
@@ -2077,6 +2077,7 @@ describe('Canonical URL Tests', () => {
         getBaseURL: sinon.stub().returns('https://example.com'),
         getConfig: sinon.stub().returns({
           getAuditTargetURLs: sinon.stub().returns([]),
+          getExcludedURLs: sinon.stub().returns([]),
         }),
       };
     });
@@ -2317,6 +2318,58 @@ describe('Canonical URL Tests', () => {
         expect(result.urls[3]).to.deep.equal({ url: 'https://example.com/page2' });
       });
 
+      it('should filter out site-config excludedURLs before scraping', async () => {
+        context.dataAccess.SiteTopPage.allBySiteIdAndSourceAndGeo.resolves([
+          { getUrl: () => 'https://example.com/page1' },
+          { getUrl: () => 'https://example.com/verify' },
+          { getUrl: () => 'https://example.com/es_us/tools' },
+          { getUrl: () => 'https://example.com/page2' },
+        ]);
+        site.getConfig.returns({
+          getAuditTargetURLs: sinon.stub().returns([]),
+          getExcludedURLs: sinon.stub().returns([
+            'https://example.com/verify',
+            'https://example.com/es_us/tools',
+          ]),
+        });
+
+        const testContext = {
+          ...context,
+          site,
+          finalUrl: 'https://example.com',
+        };
+
+        const result = await submitForScraping(testContext);
+
+        expect(result.urls).to.have.lengthOf(2);
+        expect(result.urls[0]).to.deep.equal({ url: 'https://example.com/page1' });
+        expect(result.urls[1]).to.deep.equal({ url: 'https://example.com/page2' });
+        expect(context.log.info).to.have.been.calledWith(
+          '[canonical] Excluded 2 URLs based on site config excludedURLs',
+        );
+      });
+
+      it('should not filter any URLs when excludedURLs is empty', async () => {
+        context.dataAccess.SiteTopPage.allBySiteIdAndSourceAndGeo.resolves([
+          { getUrl: () => 'https://example.com/page1' },
+          { getUrl: () => 'https://example.com/page2' },
+        ]);
+        site.getConfig.returns({
+          getAuditTargetURLs: sinon.stub().returns([]),
+          getExcludedURLs: sinon.stub().returns([]),
+        });
+
+        const testContext = {
+          ...context,
+          site,
+          finalUrl: 'https://example.com',
+        };
+
+        const result = await submitForScraping(testContext);
+
+        expect(result.urls).to.have.lengthOf(2);
+      });
+
       it('should merge custom audit target URLs with SEO top pages', async () => {
         context.dataAccess.SiteTopPage.allBySiteIdAndSourceAndGeo.resolves([
           { getUrl: () => 'https://example.com/page1' },
@@ -2327,6 +2380,7 @@ describe('Canonical URL Tests', () => {
             { url: 'https://example.com/custom1' },
             { url: 'https://example.com/custom2' },
           ]),
+          getExcludedURLs: sinon.stub().returns([]),
         });
 
         const testContext = {
@@ -2357,6 +2411,7 @@ describe('Canonical URL Tests', () => {
             { url: 'https://example.com/page1' },
             { url: 'https://example.com/custom1' },
           ]),
+          getExcludedURLs: sinon.stub().returns([]),
         });
 
         const testContext = {
@@ -2379,6 +2434,7 @@ describe('Canonical URL Tests', () => {
           getAuditTargetURLs: sinon.stub().returns([
             { url: 'https://example.com/custom1' },
           ]),
+          getExcludedURLs: sinon.stub().returns([]),
         });
 
         const testContext = {
@@ -4579,6 +4635,247 @@ describe('Canonical URL Tests', () => {
         const result = await processScrapedContentMocked(testContext);
 
         // Page is allowed through and audited (self-referenced canonical = no issues)
+        expect(result.auditResult).to.deep.equal({
+          status: 'success',
+          message: 'No canonical issues detected',
+        });
+      });
+
+      it('should skip pages that are in the site config excludedURLs', async () => {
+        const scrapedContent = {
+          url: 'https://example.com/verify',
+          finalUrl: 'https://example.com/verify',
+          scrapeResult: {
+            canonical: {
+              exists: false, count: 0, href: null, inHead: false,
+            },
+            rawBody: createValidRawBody(),
+          },
+        };
+
+        const mockGetObjectFromKey = sinon.stub().resolves(scrapedContent);
+
+        const siteWithExclusions = {
+          ...site,
+          getConfig: sinon.stub().returns({
+            getAuditTargetURLs: sinon.stub().returns([]),
+            getExcludedURLs: sinon.stub().returns([
+              'https://example.com/verify',
+              'https://example.com/es_us/tools',
+            ]),
+          }),
+        };
+
+        const testContext = {
+          ...context,
+          site: siteWithExclusions,
+          s3Client: {},
+          scrapeResultPaths: new Map([
+            ['https://example.com/verify', 'scrapes/job-id/verify/scrape.json'],
+          ]),
+          audit: { getId: () => 'test-audit-id' },
+        };
+
+        const { processScrapedContent: processScrapedContentMocked } = await esmock(
+          '../../src/canonical/handler.js',
+          {
+            '../../src/utils/s3-utils.js': {
+              getObjectFromKey: mockGetObjectFromKey,
+            },
+            '../../src/common/opportunity-utils.js': {
+              checkGoogleConnection: sinon.stub().resolves(false),
+            },
+          },
+        );
+
+        const result = await processScrapedContentMocked(testContext);
+
+        expect(result.auditResult).to.deep.equal({
+          status: 'success',
+          message: 'No canonical issues detected',
+        });
+        expect(context.log.info).to.have.been.calledWith(
+          '[canonical] Skipping https://example.com/verify - excluded by site config',
+        );
+      });
+
+      it('should skip pages with noindex meta robots tag', async () => {
+        const scrapedContent = {
+          url: 'https://example.com/internal-page',
+          finalUrl: 'https://example.com/internal-page',
+          scrapeResult: {
+            canonical: {
+              exists: false, count: 0, href: null, inHead: false,
+            },
+            rawBody: createValidRawBody('<html><head><meta name="robots" content="noindex, nofollow"><title>Internal</title></head><body><p>This page should not be indexed by search engines.</p></body></html>'),
+          },
+        };
+
+        const mockGetObjectFromKey = sinon.stub().resolves(scrapedContent);
+
+        const testContext = {
+          ...context,
+          site,
+          s3Client: {},
+          scrapeResultPaths: new Map([
+            ['https://example.com/internal-page', 'scrapes/job-id/internal-page/scrape.json'],
+          ]),
+          audit: { getId: () => 'test-audit-id' },
+        };
+
+        const { processScrapedContent: processScrapedContentMocked } = await esmock(
+          '../../src/canonical/handler.js',
+          {
+            '../../src/utils/s3-utils.js': {
+              getObjectFromKey: mockGetObjectFromKey,
+            },
+            '../../src/common/opportunity-utils.js': {
+              checkGoogleConnection: sinon.stub().resolves(false),
+            },
+          },
+        );
+
+        const result = await processScrapedContentMocked(testContext);
+
+        expect(result.auditResult).to.deep.equal({
+          status: 'success',
+          message: 'No canonical issues detected',
+        });
+        expect(context.log.info).to.have.been.calledWith(
+          '[canonical] Skipping https://example.com/internal-page - noindex page',
+        );
+      });
+
+      it('should skip pages with googlebot noindex meta tag', async () => {
+        const scrapedContent = {
+          url: 'https://example.com/no-google',
+          finalUrl: 'https://example.com/no-google',
+          scrapeResult: {
+            canonical: {
+              exists: false, count: 0, href: null, inHead: false,
+            },
+            rawBody: createValidRawBody('<html><head><meta name="googlebot" content="noindex"><title>No Google</title></head><body><p>This page should not be indexed by Googlebot and requires enough padding.</p></body></html>'),
+          },
+        };
+
+        const mockGetObjectFromKey = sinon.stub().resolves(scrapedContent);
+
+        const testContext = {
+          ...context,
+          site,
+          s3Client: {},
+          scrapeResultPaths: new Map([
+            ['https://example.com/no-google', 'scrapes/job-id/no-google/scrape.json'],
+          ]),
+          audit: { getId: () => 'test-audit-id' },
+        };
+
+        const { processScrapedContent: processScrapedContentMocked } = await esmock(
+          '../../src/canonical/handler.js',
+          {
+            '../../src/utils/s3-utils.js': {
+              getObjectFromKey: mockGetObjectFromKey,
+            },
+            '../../src/common/opportunity-utils.js': {
+              checkGoogleConnection: sinon.stub().resolves(false),
+            },
+          },
+        );
+
+        const result = await processScrapedContentMocked(testContext);
+
+        expect(result.auditResult).to.deep.equal({
+          status: 'success',
+          message: 'No canonical issues detected',
+        });
+        expect(context.log.info).to.have.been.calledWith(
+          '[canonical] Skipping https://example.com/no-google - noindex page',
+        );
+      });
+
+      it('should handle site with no getConfig in processScrapedContent gracefully', async () => {
+        const scrapedContent = {
+          url: 'https://example.com/page1',
+          finalUrl: 'https://example.com/page1',
+          scrapeResult: {
+            canonical: { exists: true, count: 1, href: 'https://example.com/page1', inHead: true },
+            rawBody: createValidRawBody(),
+          },
+        };
+
+        const mockGetObjectFromKey = sinon.stub().resolves(scrapedContent);
+
+        const siteWithoutConfig = {
+          getId: sinon.stub().returns('test-site-id'),
+          getBaseURL: sinon.stub().returns('https://example.com'),
+        };
+
+        const testContext = {
+          ...context,
+          site: siteWithoutConfig,
+          s3Client: {},
+          scrapeResultPaths: new Map([
+            ['https://example.com/page1', 'scrapes/job-id/page1/scrape.json'],
+          ]),
+          audit: { getId: () => 'test-audit-id' },
+        };
+
+        const { processScrapedContent: processScrapedContentMocked } = await esmock(
+          '../../src/canonical/handler.js',
+          {
+            '../../src/utils/s3-utils.js': {
+              getObjectFromKey: mockGetObjectFromKey,
+            },
+            '../../src/common/opportunity-utils.js': {
+              checkGoogleConnection: sinon.stub().resolves(false),
+            },
+          },
+        );
+
+        const result = await processScrapedContentMocked(testContext);
+
+        expect(result.auditResult).to.deep.equal({
+          status: 'success',
+          message: 'No canonical issues detected',
+        });
+      });
+
+      it('should handle undefined rawBody without crashing in noindex check', async () => {
+        const scrapedContent = {
+          url: 'https://example.com/page1',
+          finalUrl: 'https://example.com/page1',
+          scrapeResult: {
+            canonical: { exists: true, count: 1, href: 'https://example.com/page1', inHead: true },
+            rawBody: undefined,
+          },
+        };
+
+        const mockGetObjectFromKey = sinon.stub().resolves(scrapedContent);
+
+        const testContext = {
+          ...context,
+          site,
+          s3Client: {},
+          scrapeResultPaths: new Map([
+            ['https://example.com/page1', 'scrapes/job-id/page1/scrape.json'],
+          ]),
+          audit: { getId: () => 'test-audit-id' },
+        };
+
+        const { processScrapedContent: processScrapedContentMocked } = await esmock(
+          '../../src/canonical/handler.js',
+          {
+            '../../src/utils/s3-utils.js': {
+              getObjectFromKey: mockGetObjectFromKey,
+            },
+            '../../src/common/opportunity-utils.js': {
+              checkGoogleConnection: sinon.stub().resolves(false),
+            },
+          },
+        );
+
+        const result = await processScrapedContentMocked(testContext);
+
         expect(result.auditResult).to.deep.equal({
           status: 'success',
           message: 'No canonical issues detected',


### PR DESCRIPTION
Reduces canonical audit noise by skipping two categories of pages:
- noindex — pages with <meta name="robots/googlebot" content="noindex"> are skipped using cheerio to parse the scraped rawBody
- Site config exclusions — reads excludedURLs from handlers.canonical in site config, same pattern as broken-backlinks. Configure via PATCH /sites/{siteId}/canonical

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
