### PR TITLE
fix(llm-error-pages): drop malformed URLs from categorized results

### DIFF
--- a/src/llm-error-pages/handler.js
+++ b/src/llm-error-pages/handler.js
@@ -23,7 +23,6 @@ import {
   categorizeErrorsByStatusCode,
   SPREADSHEET_COLUMNS,
   toPathOnly,
-  isValidUrlPath,
 } from './utils.js';
 import { wwwUrlResolver } from '../common/index.js';
 import { createLLMOSharepointClient, saveExcelReport } from '../utils/report-uploader.js';
@@ -187,15 +186,12 @@ export async function runAuditAndSendToMystique(context) {
         const processedResults = processErrorPagesResults(results);
         const categorizedResults = categorizeErrorsByStatusCode(processedResults.errorPages);
 
-        // Drop malformed URLs (e.g. '/brandshttps://...', '/),') emitted by
-        // bot impersonators that slip through the user-agent filter upstream.
-        for (const code of Object.keys(categorizedResults)) {
-          const before = categorizedResults[code].length;
-          categorizedResults[code] = categorizedResults[code].filter((e) => isValidUrlPath(e.url));
-          const dropped = before - categorizedResults[code].length;
-          if (dropped > 0) {
-            log.info(`[LLM-ERROR-PAGES] Filtered ${dropped} malformed URL(s) from status ${code}`);
-          }
+        // Malformed URLs (e.g. '/brandshttps://...', '/),') are dropped inside
+        // processErrorPagesResults so every downstream view stays consistent.
+        // Log a sample so false positives are diagnosable from Coralogix.
+        if (processedResults.droppedUrls?.length > 0) {
+          const sample = processedResults.droppedUrls.slice(0, 5);
+          log.info(`[LLM-ERROR-PAGES] Filtered ${processedResults.droppedUrls.length} malformed URL(s); sample: ${JSON.stringify(sample)}`);
         }
 
         const buildFilename = (code) => `agentictraffic-errors-${code}-${periodIdentifier}.xlsx`;

--- a/src/llm-error-pages/handler.js
+++ b/src/llm-error-pages/handler.js
@@ -23,6 +23,7 @@ import {
   categorizeErrorsByStatusCode,
   SPREADSHEET_COLUMNS,
   toPathOnly,
+  isValidUrlPath,
 } from './utils.js';
 import { wwwUrlResolver } from '../common/index.js';
 import { createLLMOSharepointClient, saveExcelReport } from '../utils/report-uploader.js';
@@ -185,6 +186,17 @@ export async function runAuditAndSendToMystique(context) {
 
         const processedResults = processErrorPagesResults(results);
         const categorizedResults = categorizeErrorsByStatusCode(processedResults.errorPages);
+
+        // Drop malformed URLs (e.g. '/brandshttps://...', '/),') emitted by
+        // bot impersonators that slip through the user-agent filter upstream.
+        for (const code of Object.keys(categorizedResults)) {
+          const before = categorizedResults[code].length;
+          categorizedResults[code] = categorizedResults[code].filter((e) => isValidUrlPath(e.url));
+          const dropped = before - categorizedResults[code].length;
+          if (dropped > 0) {
+            log.info(`[LLM-ERROR-PAGES] Filtered ${dropped} malformed URL(s) from status ${code}`);
+          }
+        }
 
         const buildFilename = (code) => `agentictraffic-errors-${code}-${periodIdentifier}.xlsx`;
 

--- a/src/llm-error-pages/utils.js
+++ b/src/llm-error-pages/utils.js
@@ -452,6 +452,41 @@ export function toPathOnly(maybeUrl, baseUrl) {
   }
 }
 
+/**
+ * Conservative validity check for URLs surfaced from CDN logs. Bot impersonators
+ * that pass the user-agent regex sometimes request malformed paths (e.g.
+ * `/brandshttps://...`, `/),`, `/%2522`). Those add noise to the 404 opportunity
+ * without being actionable, so we drop them before building suggestions.
+ */
+export function isValidUrlPath(url) {
+  if (typeof url !== 'string') {
+    return false;
+  }
+  const trimmed = url.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  try {
+    // eslint-disable-next-line no-new
+    new URL(trimmed, 'https://example.com');
+  } catch {
+    return false;
+  }
+
+  if (/.+https?:\/\//i.test(trimmed)) {
+    return false;
+  }
+  if (/["']|%2[27]|%252[27]/i.test(trimmed)) {
+    return false;
+  }
+  if (/,$/.test(trimmed)) {
+    return false;
+  }
+
+  return true;
+}
+
 export const SPREADSHEET_COLUMNS = [
   'Agent Type',
   'User Agent',

--- a/src/llm-error-pages/utils.js
+++ b/src/llm-error-pages/utils.js
@@ -319,11 +319,85 @@ export function generateReportingPeriods(referenceDate = new Date(), weekOffsets
 // PROCESSING RESULTS
 // ============================================================================
 
+/**
+ * Conservative validity check for URLs surfaced from CDN logs. Bot impersonators
+ * that pass the user-agent regex sometimes request malformed paths (e.g.
+ * `/brandshttps://...`, `/),`, `/%2522`). Those add noise to the 404 opportunity
+ * without being actionable, so we drop them before building suggestions.
+ *
+ * Tracked stopgap: the right long-term fix is upstream UA / IP-fingerprint
+ * hardening so impersonators are rejected before ingestion. See LLMO-5282.
+ *
+ * Rejects:
+ *   - non-strings / empty / whitespace
+ *   - URLs the `URL` constructor cannot parse
+ *   - non-http(s) schemes (javascript:, data:, etc.)
+ *   - leading characters Excel re-interprets as formulas (`= + - @`)
+ *   - paths with an http(s) scheme glued to a path segment (`/foohttps://bar`),
+ *     while still allowing query-embedded schemes (`/redirect?to=https://...`)
+ *   - paths containing double-encoded quote characters (`%2522`, `%2527`)
+ *   - paths whose final non-whitespace char is a comma or semicolon
+ */
+export function isValidUrlPath(url) {
+  if (typeof url !== 'string') {
+    return false;
+  }
+  const trimmed = url.trim();
+  if (!trimmed) {
+    return false;
+  }
+
+  // Excel / Sheets / Calc treat a leading =, +, -, @ as a formula. URLs
+  // beginning with those characters get re-interpreted on open and have been
+  // used for exfiltration via WEBSERVICE/HYPERLINK. Reject at the validity
+  // boundary so we don't have to remember to sentinel them at every sink.
+  if (/^[=+\-@]/.test(trimmed)) {
+    return false;
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(trimmed, 'https://example.com');
+  } catch {
+    return false;
+  }
+
+  // The base in the constructor lets relative paths parse; restrict the
+  // resulting protocol so javascript:, data:, file:, etc. are rejected even
+  // when supplied as absolute URLs.
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return false;
+  }
+
+  // Embedded http(s):// glued to a path segment (e.g. `/brandshttps://...`).
+  // The negative class before the scheme keeps legitimate query-embedded
+  // URLs like `/redirect?to=https://example.com` allowed.
+  if (/[^/?&=#]https?:\/\//i.test(trimmed)) {
+    return false;
+  }
+
+  // Double-encoded quote characters never appear in legitimate browser or
+  // crawler URLs. Raw and single-encoded quotes can legitimately occur in
+  // paths like `/products/o'reilly` so we leave those alone.
+  if (/%2522|%2527/i.test(trimmed)) {
+    return false;
+  }
+
+  // Trailing comma / semicolon catches copy-paste fragments like `/foo),`
+  // or `/foo];` without rejecting legitimate Wikipedia-style `/foo_(disambig)`.
+  if (/[,;]$/.test(trimmed)) {
+    return false;
+  }
+
+  return true;
+}
+
 export function processErrorPagesResults(results) {
   if (!results || results.length === 0) {
     return {
       totalErrors: 0,
       errorPages: [],
+      droppedUrls: [],
       summary: {
         uniqueUrls: 0,
         uniqueUserAgents: 0,
@@ -332,11 +406,24 @@ export function processErrorPagesResults(results) {
     };
   }
 
+  // Filter malformed URLs at the data boundary so `errorPages`, the per-status
+  // categorization, the Excel export, the opportunity sync, and the Mystique
+  // payload all share one consistent view.
+  const errorPages = [];
+  const droppedUrls = [];
+  results.forEach((row) => {
+    if (isValidUrlPath(row.url)) {
+      errorPages.push(row);
+    } else {
+      droppedUrls.push(row.url);
+    }
+  });
+
   const statusCodes = {};
   const uniqueUrls = new Set();
   const uniqueUserAgents = new Set();
 
-  results.forEach((row) => {
+  errorPages.forEach((row) => {
     const totalRequestsParsed = parseInt(row.total_requests, 10);
     // eslint-disable-next-line no-param-reassign
     row.total_requests = Number.isNaN(totalRequestsParsed) ? 0 : totalRequestsParsed;
@@ -350,7 +437,8 @@ export function processErrorPagesResults(results) {
 
   return {
     totalErrors,
-    errorPages: results,
+    errorPages,
+    droppedUrls,
     summary: {
       uniqueUrls: uniqueUrls.size,
       uniqueUserAgents: uniqueUserAgents.size,
@@ -450,41 +538,6 @@ export function toPathOnly(maybeUrl, baseUrl) {
   } catch {
     return maybeUrl;
   }
-}
-
-/**
- * Conservative validity check for URLs surfaced from CDN logs. Bot impersonators
- * that pass the user-agent regex sometimes request malformed paths (e.g.
- * `/brandshttps://...`, `/),`, `/%2522`). Those add noise to the 404 opportunity
- * without being actionable, so we drop them before building suggestions.
- */
-export function isValidUrlPath(url) {
-  if (typeof url !== 'string') {
-    return false;
-  }
-  const trimmed = url.trim();
-  if (!trimmed) {
-    return false;
-  }
-
-  try {
-    // eslint-disable-next-line no-new
-    new URL(trimmed, 'https://example.com');
-  } catch {
-    return false;
-  }
-
-  if (/.+https?:\/\//i.test(trimmed)) {
-    return false;
-  }
-  if (/["']|%2[27]|%252[27]/i.test(trimmed)) {
-    return false;
-  }
-  if (/,$/.test(trimmed)) {
-    return false;
-  }
-
-  return true;
 }
 
 export const SPREADSHEET_COLUMNS = [

--- a/test/audits/llm-error-pages/handler.test.js
+++ b/test/audits/llm-error-pages/handler.test.js
@@ -365,15 +365,17 @@ describe('LLM Error Pages Handler', function () {
       );
     });
 
-    it('filters malformed URLs from categorized results and logs the drop count', async () => {
+    it('logs a sample of malformed URLs filtered upstream in processErrorPagesResults', async () => {
       mockProcessResults.returns({
-        totalErrors: 3,
+        totalErrors: 1,
         errorPages: [
           { user_agent: 'ChatGPT', url: '/legit-page', status: 404, total_requests: 10 },
-          { user_agent: 'GPTBot', url: '/brandshttps://example.com/brands', status: 404, total_requests: 7 },
-          { user_agent: 'Claude', url: '/),', status: 404, total_requests: 3 },
         ],
-        summary: { uniqueUrls: 3, uniqueUserAgents: 3, statusCodes: { 404: 20 } },
+        droppedUrls: [
+          '/brandshttps://example.com/brands',
+          '/),',
+        ],
+        summary: { uniqueUrls: 1, uniqueUserAgents: 1, statusCodes: { 404: 10 } },
       });
 
       const result = await runAuditAndSendToMystique(context);
@@ -382,7 +384,7 @@ describe('LLM Error Pages Handler', function () {
       expect(result.auditResult[0].categorizedResults[404]).to.have.lengthOf(1);
       expect(result.auditResult[0].categorizedResults[404][0].url).to.equal('/legit-page');
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/Filtered 2 malformed URL\(s\) from status 404/),
+        sinon.match(/Filtered 2 malformed URL\(s\); sample: \[.*brandshttps.*\]/),
       );
     });
 

--- a/test/audits/llm-error-pages/handler.test.js
+++ b/test/audits/llm-error-pages/handler.test.js
@@ -365,6 +365,27 @@ describe('LLM Error Pages Handler', function () {
       );
     });
 
+    it('filters malformed URLs from categorized results and logs the drop count', async () => {
+      mockProcessResults.returns({
+        totalErrors: 3,
+        errorPages: [
+          { user_agent: 'ChatGPT', url: '/legit-page', status: 404, total_requests: 10 },
+          { user_agent: 'GPTBot', url: '/brandshttps://example.com/brands', status: 404, total_requests: 7 },
+          { user_agent: 'Claude', url: '/),', status: 404, total_requests: 3 },
+        ],
+        summary: { uniqueUrls: 3, uniqueUserAgents: 3, statusCodes: { 404: 20 } },
+      });
+
+      const result = await runAuditAndSendToMystique(context);
+
+      expect(result.auditResult[0].success).to.be.true;
+      expect(result.auditResult[0].categorizedResults[404]).to.have.lengthOf(1);
+      expect(result.auditResult[0].categorizedResults[404][0].url).to.equal('/legit-page');
+      expect(context.log.info).to.have.been.calledWith(
+        sinon.match(/Filtered 2 malformed URL\(s\) from status 404/),
+      );
+    });
+
     it('should produce two weeks when run on a Monday without weekOffset', async () => {
       const monday = new Date('2025-08-18T12:00:00Z'); // Monday
       const clock = sinon.useFakeTimers(monday.getTime());

--- a/test/audits/llm-error-pages/utils.test.js
+++ b/test/audits/llm-error-pages/utils.test.js
@@ -1056,6 +1056,17 @@ describe('LLM Error Pages Utils', () => {
       expect(isValidUrlPath('/wiki/Article_(disambiguation)')).to.equal(true);
     });
 
+    it("accepts legitimate paths containing apostrophes (e.g. /products/o'reilly)", () => {
+      expect(isValidUrlPath("/products/o'reilly")).to.equal(true);
+      expect(isValidUrlPath("/authors/o'brien")).to.equal(true);
+    });
+
+    it('accepts query-embedded schemes (e.g. /redirect?to=https://...)', () => {
+      expect(isValidUrlPath('/redirect?to=https://example.com')).to.equal(true);
+      expect(isValidUrlPath('/auth/callback?return=https://example.com/x')).to.equal(true);
+      expect(isValidUrlPath('/share?url=https://other.com')).to.equal(true);
+    });
+
     it('rejects non-string inputs', () => {
       expect(isValidUrlPath(null)).to.equal(false);
       expect(isValidUrlPath(undefined)).to.equal(false);
@@ -1068,22 +1079,34 @@ describe('LLM Error Pages Utils', () => {
       expect(isValidUrlPath('   ')).to.equal(false);
     });
 
-    it('rejects paths with an embedded http(s) scheme', () => {
+    it('rejects non-http(s) schemes (javascript:, data:, file:)', () => {
+      expect(isValidUrlPath('javascript:alert(1)')).to.equal(false);
+      expect(isValidUrlPath('data:text/html,<script>alert(1)</script>')).to.equal(false);
+      expect(isValidUrlPath('file:///etc/passwd')).to.equal(false);
+    });
+
+    it('rejects URLs starting with characters Excel treats as formulas', () => {
+      expect(isValidUrlPath('=WEBSERVICE("https://evil")')).to.equal(false);
+      expect(isValidUrlPath('+1234')).to.equal(false);
+      expect(isValidUrlPath('-foo')).to.equal(false);
+      expect(isValidUrlPath('@import')).to.equal(false);
+    });
+
+    it('rejects paths with an embedded http(s) scheme glued to a path segment', () => {
       expect(isValidUrlPath('/brandshttps://www.coca-colacompany.com/brands')).to.equal(false);
       expect(isValidUrlPath('/foohttp://bar')).to.equal(false);
-      expect(isValidUrlPath('/HTTPS://x')).to.equal(false);
+      expect(isValidUrlPath('/aHTTPS://x')).to.equal(false);
     });
 
-    it('rejects URLs containing raw or encoded quote characters', () => {
+    it('rejects URLs containing double-encoded quote characters', () => {
       expect(isValidUrlPath('https://example.com/%2522')).to.equal(false);
-      expect(isValidUrlPath('https://example.com/%22')).to.equal(false);
-      expect(isValidUrlPath('/foo"bar')).to.equal(false);
-      expect(isValidUrlPath("/foo'bar")).to.equal(false);
+      expect(isValidUrlPath('https://example.com/foo%2527bar')).to.equal(false);
     });
 
-    it('rejects URLs with trailing commas', () => {
+    it('rejects URLs with trailing comma or semicolon', () => {
       expect(isValidUrlPath('https://example.com/),')).to.equal(false);
       expect(isValidUrlPath('/foo,')).to.equal(false);
+      expect(isValidUrlPath('/foo];')).to.equal(false);
     });
 
     it('rejects URLs the URL constructor cannot parse', () => {
@@ -1229,7 +1252,8 @@ describe('LLM Error Pages Utils', () => {
 
       const processed = processErrorPagesResults(results);
       expect(processed.totalErrors).to.equal(18);
-      expect(processed.errorPages).to.equal(results);
+      expect(processed.errorPages).to.deep.equal(results);
+      expect(processed.droppedUrls).to.deep.equal([]);
       expect(processed.summary.uniqueUrls).to.equal(2);
       expect(processed.summary.uniqueUserAgents).to.equal(2);
       expect(processed.summary.statusCodes).to.deep.equal({ 404: 15, 403: 3 });
@@ -1240,6 +1264,7 @@ describe('LLM Error Pages Utils', () => {
       expect(processed).to.deep.equal({
         totalErrors: 0,
         errorPages: [],
+        droppedUrls: [],
         summary: {
           uniqueUrls: 0,
           uniqueUserAgents: 0,
@@ -1264,6 +1289,23 @@ describe('LLM Error Pages Utils', () => {
       const processed = processErrorPagesResults(results);
       expect(processed.totalErrors).to.equal(2);
       expect(processed.summary.statusCodes).to.deep.equal({ Unknown: 2 });
+    });
+
+    it('drops malformed URLs from errorPages, reports them in droppedUrls, and excludes them from totals', () => {
+      const results = [
+        { url: '/legit', total_requests: '5', status: '404', user_agent: 'bot' },
+        { url: '/brandshttps://example.com/x', total_requests: '7', status: '404', user_agent: 'bot' },
+        { url: '/foo,', total_requests: '3', status: '403', user_agent: 'bot' },
+      ];
+      const processed = processErrorPagesResults(results);
+      expect(processed.errorPages).to.have.lengthOf(1);
+      expect(processed.errorPages[0].url).to.equal('/legit');
+      expect(processed.droppedUrls).to.deep.equal([
+        '/brandshttps://example.com/x',
+        '/foo,',
+      ]);
+      expect(processed.totalErrors).to.equal(5);
+      expect(processed.summary.statusCodes).to.deep.equal({ 404: 5 });
     });
   });
 

--- a/test/audits/llm-error-pages/utils.test.js
+++ b/test/audits/llm-error-pages/utils.test.js
@@ -28,6 +28,7 @@ import {
   consolidateErrorsByUrl,
   sortErrorsByTrafficVolume,
   toPathOnly,
+  isValidUrlPath,
   downloadExistingCdnSheet,
   matchErrorsWithCdnData,
   EXCLUDED_URL_SUFFIXES,
@@ -1040,6 +1041,53 @@ describe('LLM Error Pages Utils', () => {
       // Null input also triggers catch block
       const result2 = toPathOnly(null, 'invalid');
       expect(result2).to.equal(null);
+    });
+  });
+
+  describe('isValidUrlPath', () => {
+    it('accepts well-formed absolute URLs', () => {
+      expect(isValidUrlPath('https://example.com/foo/bar')).to.equal(true);
+      expect(isValidUrlPath('https://example.com/foo?x=1')).to.equal(true);
+    });
+
+    it('accepts well-formed relative paths', () => {
+      expect(isValidUrlPath('/foo/bar')).to.equal(true);
+      expect(isValidUrlPath('/foo/bar?x=1&y=2')).to.equal(true);
+      expect(isValidUrlPath('/wiki/Article_(disambiguation)')).to.equal(true);
+    });
+
+    it('rejects non-string inputs', () => {
+      expect(isValidUrlPath(null)).to.equal(false);
+      expect(isValidUrlPath(undefined)).to.equal(false);
+      expect(isValidUrlPath(42)).to.equal(false);
+      expect(isValidUrlPath({})).to.equal(false);
+    });
+
+    it('rejects empty and whitespace-only strings', () => {
+      expect(isValidUrlPath('')).to.equal(false);
+      expect(isValidUrlPath('   ')).to.equal(false);
+    });
+
+    it('rejects paths with an embedded http(s) scheme', () => {
+      expect(isValidUrlPath('/brandshttps://www.coca-colacompany.com/brands')).to.equal(false);
+      expect(isValidUrlPath('/foohttp://bar')).to.equal(false);
+      expect(isValidUrlPath('/HTTPS://x')).to.equal(false);
+    });
+
+    it('rejects URLs containing raw or encoded quote characters', () => {
+      expect(isValidUrlPath('https://example.com/%2522')).to.equal(false);
+      expect(isValidUrlPath('https://example.com/%22')).to.equal(false);
+      expect(isValidUrlPath('/foo"bar')).to.equal(false);
+      expect(isValidUrlPath("/foo'bar")).to.equal(false);
+    });
+
+    it('rejects URLs with trailing commas', () => {
+      expect(isValidUrlPath('https://example.com/),')).to.equal(false);
+      expect(isValidUrlPath('/foo,')).to.equal(false);
+    });
+
+    it('rejects URLs the URL constructor cannot parse', () => {
+      expect(isValidUrlPath('http://[invalid')).to.equal(false);
     });
   });
 


### PR DESCRIPTION
## Summary
- Bot impersonators that pass the aggregated-logs UA filter occasionally emit malformed paths (e.g. `/brandshttps://...`, `/),`, `/%2522`). These add noise to the 404 opportunity without being actionable.
- Adds a conservative `isValidUrlPath` check in `utils.js` and applies it to `categorizedResults` right after categorization, so Excel exports, opportunity sync, and the Mystique payload all see the filtered set.
- Drops are logged per status bucket for visibility.

Context: [Slack thread](#) - confirmed that the upstream aggregated-logs table is already UA-filtered; the impersonators slip through because we don't store IPs/TLS fingerprints. This is a downstream noise filter, not a replacement for upstream verification.

## Test plan
- [x] `npm run lint`
- [x] Targeted coverage: 100% on `src/llm-error-pages/utils.js` and `src/llm-error-pages/handler.js`
- [x] 8 new unit tests for `isValidUrlPath` (valid URLs, non-strings, empty, embedded scheme, quote chars, trailing comma, unparseable)
- [x] New handler test verifying malformed URLs are dropped from categorized results and the drop is logged