### PR TITLE
feat(cdn-analysis): include llms.txt in agentic aggregate inserts

### DIFF
--- a/src/cdn-analysis/sql/akamai/insert-aggregated.sql
+++ b/src/cdn-analysis/sql/akamai/insert-aggregated.sql
@@ -31,8 +31,7 @@ WHERE year  = '{{year}}'
     REGEXP_LIKE(lower(rspContentType), '^(text/html|application/pdf|text/markdown)')
     OR REGEXP_LIKE(lower(reqPath), '\.md(\?.*)?$')
     OR reqPath LIKE '%robots.txt'
-    OR reqPath LIKE '%llms.txt'
-    OR reqPath LIKE '%llms-full.txt'
+    OR REGEXP_LIKE(lower(reqPath), 'llms(-full)?\.txt$')
     OR reqPath LIKE '%sitemap%'
   )
 

--- a/src/cdn-analysis/sql/akamai/insert-aggregated.sql
+++ b/src/cdn-analysis/sql/akamai/insert-aggregated.sql
@@ -26,11 +26,13 @@ WHERE year  = '{{year}}'
   -- match known LLM-related user-agents
   AND REGEXP_LIKE(ua, '(?i)(ChatGPT|GPTBot|OAI-SearchBot|OAI-AdsBot|Perplexity|Claude|Anthropic|Gemini|Copilot|MistralAI-User|Google-NotebookLM|Google-?Agent|Google-Extended|Googlebot|bingbot|Amzn-User|^Google$)')
 
-  -- only count HTML/PDF/Markdown responses, plus .md paths, robots.txt and sitemaps
+  -- only count HTML/PDF/Markdown responses, plus .md paths, robots.txt, llms.txt and sitemaps
   AND (
     REGEXP_LIKE(lower(rspContentType), '^(text/html|application/pdf|text/markdown)')
     OR REGEXP_LIKE(lower(reqPath), '\.md(\?.*)?$')
     OR reqPath LIKE '%robots.txt'
+    OR reqPath LIKE '%llms.txt'
+    OR reqPath LIKE '%llms-full.txt'
     OR reqPath LIKE '%sitemap%'
   )
 

--- a/src/cdn-analysis/sql/cloudflare/insert-aggregated.sql
+++ b/src/cdn-analysis/sql/cloudflare/insert-aggregated.sql
@@ -32,8 +32,7 @@ WHERE date = '{{year}}{{month}}{{day}}'
     REGEXP_LIKE(lower(EdgeResponseContentType), '^(text/html|application/pdf|text/markdown)')
     OR REGEXP_LIKE(lower(ClientRequestURI), '\.md(\?.*)?$')
     OR ClientRequestURI LIKE '%robots.txt'
-    OR ClientRequestURI LIKE '%llms.txt'
-    OR ClientRequestURI LIKE '%llms-full.txt'
+    OR REGEXP_LIKE(lower(ClientRequestURI), 'llms(-full)?\.txt$')
     OR ClientRequestURI LIKE '%sitemap%'
   )
 

--- a/src/cdn-analysis/sql/cloudflare/insert-aggregated.sql
+++ b/src/cdn-analysis/sql/cloudflare/insert-aggregated.sql
@@ -27,11 +27,13 @@ WHERE date = '{{year}}{{month}}{{day}}'
   -- match known LLM-related user-agents
   AND REGEXP_LIKE(ClientRequestUserAgent, '(?i)(ChatGPT|GPTBot|OAI-SearchBot|OAI-AdsBot|Perplexity|Claude|Anthropic|Gemini|Copilot|MistralAI-User|Google-NotebookLM|Google-?Agent|Google-Extended|Googlebot|bingbot|Amzn-User|^Google$)')
 
-  -- only count HTML/PDF/Markdown responses, plus .md paths, robots.txt and sitemaps
+  -- only count HTML/PDF/Markdown responses, plus .md paths, robots.txt, llms.txt and sitemaps
   AND (
     REGEXP_LIKE(lower(EdgeResponseContentType), '^(text/html|application/pdf|text/markdown)')
     OR REGEXP_LIKE(lower(ClientRequestURI), '\.md(\?.*)?$')
     OR ClientRequestURI LIKE '%robots.txt'
+    OR ClientRequestURI LIKE '%llms.txt'
+    OR ClientRequestURI LIKE '%llms-full.txt'
     OR ClientRequestURI LIKE '%sitemap%'
   )
 

--- a/src/cdn-analysis/sql/cloudfront/insert-aggregated.sql
+++ b/src/cdn-analysis/sql/cloudfront/insert-aggregated.sql
@@ -24,11 +24,13 @@ WHERE year  = '{{year}}'
    -- match known LLM-related user-agents
   AND REGEXP_LIKE("cs(user-agent)", '(?i)(ChatGPT|GPTBot|OAI-SearchBot|OAI-AdsBot|Perplexity|Claude|Anthropic|Gemini|Copilot|MistralAI-User|Google-NotebookLM|Google-?Agent|Google-Extended|Googlebot|bingbot|Amzn-User|^Google$)')
 
-  -- only count HTML/PDF/Markdown responses, plus .md paths, robots.txt and sitemaps
+  -- only count HTML/PDF/Markdown responses, plus .md paths, robots.txt, llms.txt and sitemaps
   AND (
     REGEXP_LIKE(lower("sc-content-type"), '^(text/html|application/pdf|text/markdown)')
     OR REGEXP_LIKE(lower("cs-uri-stem"), '\.md(\?.*)?$')
-    OR "cs-uri-stem" LIKE '%robots.txt' 
+    OR "cs-uri-stem" LIKE '%robots.txt'
+    OR "cs-uri-stem" LIKE '%llms.txt'
+    OR "cs-uri-stem" LIKE '%llms-full.txt'
     OR "cs-uri-stem" LIKE '%sitemap%'
   )
 

--- a/src/cdn-analysis/sql/cloudfront/insert-aggregated.sql
+++ b/src/cdn-analysis/sql/cloudfront/insert-aggregated.sql
@@ -29,8 +29,7 @@ WHERE year  = '{{year}}'
     REGEXP_LIKE(lower("sc-content-type"), '^(text/html|application/pdf|text/markdown)')
     OR REGEXP_LIKE(lower("cs-uri-stem"), '\.md(\?.*)?$')
     OR "cs-uri-stem" LIKE '%robots.txt'
-    OR "cs-uri-stem" LIKE '%llms.txt'
-    OR "cs-uri-stem" LIKE '%llms-full.txt'
+    OR REGEXP_LIKE(lower("cs-uri-stem"), 'llms(-full)?\.txt$')
     OR "cs-uri-stem" LIKE '%sitemap%'
   )
 

--- a/src/cdn-analysis/sql/fastly/insert-aggregated.sql
+++ b/src/cdn-analysis/sql/fastly/insert-aggregated.sql
@@ -29,8 +29,7 @@ WHERE year  = '{{year}}'
     REGEXP_LIKE(lower(response_content_type), '^(text/html|application/pdf|text/markdown)')
     OR REGEXP_LIKE(lower(url), '\.md(\?.*)?$')
     OR url LIKE '%robots.txt'
-    OR url LIKE '%llms.txt'
-    OR url LIKE '%llms-full.txt'
+    OR REGEXP_LIKE(lower(url), 'llms(-full)?\.txt$')
     OR url LIKE '%sitemap%'
   )
 

--- a/src/cdn-analysis/sql/fastly/insert-aggregated.sql
+++ b/src/cdn-analysis/sql/fastly/insert-aggregated.sql
@@ -24,11 +24,13 @@ WHERE year  = '{{year}}'
    -- match known LLM-related user-agents
   AND REGEXP_LIKE(request_user_agent, '(?i)(ChatGPT|GPTBot|OAI-SearchBot|OAI-AdsBot|Perplexity|Claude|Anthropic|Gemini|Copilot|MistralAI-User|Google-NotebookLM|Google-?Agent|Google-Extended|Googlebot|bingbot|Amzn-User|^Google$)')
 
-  -- only count HTML/PDF/Markdown responses, plus .md paths, robots.txt and sitemaps
+  -- only count HTML/PDF/Markdown responses, plus .md paths, robots.txt, llms.txt and sitemaps
   AND (
     REGEXP_LIKE(lower(response_content_type), '^(text/html|application/pdf|text/markdown)')
     OR REGEXP_LIKE(lower(url), '\.md(\?.*)?$')
-    OR url LIKE '%robots.txt' 
+    OR url LIKE '%robots.txt'
+    OR url LIKE '%llms.txt'
+    OR url LIKE '%llms-full.txt'
     OR url LIKE '%sitemap%'
   )
 

--- a/src/cdn-analysis/sql/frontdoor/insert-aggregated.sql
+++ b/src/cdn-analysis/sql/frontdoor/insert-aggregated.sql
@@ -24,10 +24,10 @@ WHERE year  = '{{year}}'
    -- match known LLM-related user-agents
   AND REGEXP_LIKE(properties.userAgent, '(?i)(ChatGPT|GPTBot|OAI-SearchBot|OAI-AdsBot|Perplexity|Claude|Anthropic|Gemini|Copilot|MistralAI-User|Google-NotebookLM|Google-?Agent|Google-Extended|Googlebot|bingbot|Amzn-User|^Google$)')
 
-  -- exclude static assets, but always include HTML, PDF, robots.txt, and sitemaps
+  -- exclude static assets, but always include HTML, PDF, robots.txt, llms.txt, and sitemaps
   AND (
       NOT REGEXP_LIKE(url_extract_path(properties.requestUri), '(?i)\.(css|js|png|jpg|jpeg|gif|webp|php|svg|ico|woff|woff2|otf|ttf|eot|mp4|mp3|avi|mov|zip|tar|gz|json|xml|txt)(\?.*)?$')
-      OR REGEXP_LIKE(url_extract_path(properties.requestUri), '(?i)(\.htm|\.pdf|robots\.txt|sitemap)')
+      OR REGEXP_LIKE(url_extract_path(properties.requestUri), '(?i)(\.htm|\.pdf|robots\.txt|llms(-full)?\.txt|sitemap)')
   )
 
   -- agentic and LLM-attributed traffic never has self-referer 

--- a/src/cdn-analysis/sql/imperva/insert-aggregated.sql
+++ b/src/cdn-analysis/sql/imperva/insert-aggregated.sql
@@ -23,10 +23,10 @@ WHERE
   -- match known LLM-related user-agents
   AND REGEXP_LIKE(cs_user_agent, '(?i)(ChatGPT|GPTBot|OAI-SearchBot|OAI-AdsBot|Perplexity|Claude|Anthropic|Gemini|Copilot|MistralAI-User|Google-NotebookLM|Google-?Agent|Google-Extended|Googlebot|bingbot|Amzn-User|^Google$)')
 
-  -- only count HTML/PDF/Markdown responses, plus .md paths, robots.txt and sitemaps
+  -- only count HTML/PDF/Markdown responses, plus .md paths, robots.txt, llms.txt and sitemaps
   AND (
     NOT REGEXP_LIKE(url_extract_path(cs_uri), '(?i)\.(css|js|png|jpg|jpeg|gif|webp|php|svg|ico|woff|woff2|otf|ttf|eot|mp4|mp3|avi|mov|zip|tar|gz|json|xml|txt)$')
-    OR REGEXP_LIKE(url_extract_path(cs_uri), '(?i)((\.html?|\.pdf|\.md|robots\.txt)$|sitemap)')
+    OR REGEXP_LIKE(url_extract_path(cs_uri), '(?i)((\.html?|\.pdf|\.md|robots\.txt|llms(-full)?\.txt)$|sitemap)')
   )
 
   -- agentic and LLM-attributed traffic never has self-referer

--- a/src/cdn-analysis/sql/other/insert-aggregated.sql
+++ b/src/cdn-analysis/sql/other/insert-aggregated.sql
@@ -31,6 +31,8 @@ WHERE year  = '{{year}}'
         REGEXP_LIKE(lower(response_content_type), '^(text/html|application/pdf|text/markdown)')
         OR REGEXP_LIKE(lower(url), '\.md(\?.*)?$')
         OR url LIKE '%robots.txt'
+        OR url LIKE '%llms.txt'
+        OR url LIKE '%llms-full.txt'
         OR url LIKE '%sitemap%'
       )
     )
@@ -38,7 +40,7 @@ WHERE year  = '{{year}}'
       NULLIF(trim(response_content_type), '') IS NULL
       AND (
         NOT REGEXP_LIKE(url_extract_path(COALESCE(url, '')), '(?i)\.(css|js|mjs|png|jpg|jpeg|gif|webp|avif|php|svg|ico|woff|woff2|otf|ttf|eot|mp4|mp3|avi|mov|zip|tar|gz|json|xml|txt)(\?.*)?$')
-        OR REGEXP_LIKE(url_extract_path(COALESCE(url, '')), '(?i)(\.htm|\.pdf|\.md|robots\.txt|sitemap)')
+        OR REGEXP_LIKE(url_extract_path(COALESCE(url, '')), '(?i)(\.htm|\.pdf|\.md|robots\.txt|llms(-full)?\.txt|sitemap)')
       )
     )
   )

--- a/src/cdn-analysis/sql/other/insert-aggregated.sql
+++ b/src/cdn-analysis/sql/other/insert-aggregated.sql
@@ -31,8 +31,7 @@ WHERE year  = '{{year}}'
         REGEXP_LIKE(lower(response_content_type), '^(text/html|application/pdf|text/markdown)')
         OR REGEXP_LIKE(lower(url), '\.md(\?.*)?$')
         OR url LIKE '%robots.txt'
-        OR url LIKE '%llms.txt'
-        OR url LIKE '%llms-full.txt'
+        OR REGEXP_LIKE(lower(url), 'llms(-full)?\.txt$')
         OR url LIKE '%sitemap%'
       )
     )

--- a/test/audits/cdn-analysis/handler.test.js
+++ b/test/audits/cdn-analysis/handler.test.js
@@ -608,7 +608,7 @@ describe('CDN Analysis Handler', () => {
       expect(aggregatedCall.args[0]).to.include("NULLIF(trim(response_content_type), '') IS NOT NULL");
       expect(aggregatedCall.args[0]).to.include("NULLIF(trim(response_content_type), '') IS NULL");
       expect(aggregatedCall.args[0]).to.include("NOT REGEXP_LIKE(url_extract_path(COALESCE(url, ''))");
-      expect(aggregatedCall.args[0]).to.include("REGEXP_LIKE(url_extract_path(COALESCE(url, '')), '(?i)(\\.htm|\\.pdf|\\.md|robots\\.txt|sitemap)')");
+      expect(aggregatedCall.args[0]).to.include("REGEXP_LIKE(url_extract_path(COALESCE(url, '')), '(?i)(\\.htm|\\.pdf|\\.md|robots\\.txt|llms(-full)?\\.txt|sitemap)')");
 
       expect(referralCall.args[0]).to.include("lower(response_content_type) LIKE 'text/html%'");
       expect(referralCall.args[0]).to.include("NULLIF(trim(response_content_type), '') IS NULL");


### PR DESCRIPTION
## Summary

The CDN-analysis aggregate insert excluded all `.txt` files and re-included only `robots.txt` and sitemaps. As a result, AI-agent requests to `/llms.txt` (and `/llms-full.txt`) were dropped before reaching the `agentic_traffic` pipeline — so we had no record of llms.txt agent traffic in the DB even when a site serves one.

This adds `llms.txt` and `llms-full.txt` to the inclusion filter across **all 7 CDN providers**, treating them the same way `robots.txt` is already treated.

### How
A single `llms(-full)?\.txt` expression is used per provider (no separate clause per filename):

- **Regex-based providers** (`frontdoor`, `imperva`, `other` URL-heuristic branch): added `llms(-full)?\.txt` into the existing include regex.
- **LIKE-based providers** (`akamai`, `cloudflare`, `cloudfront`, `fastly`, `other` content-type branch): added one `REGEXP_LIKE(lower(col), 'llms(-full)?\.txt$')` clause, matching the existing `.md` regex style in the same blocks.

### Scope notes
- Only the **agentic** insert (`insert-aggregated.sql`) is changed. The `insert-aggregated-referral.sql` files are intentionally untouched — they capture human referral traffic and explicitly exclude bots/crawlers (the agents that fetch llms.txt) and filter to HTML only.
- This captures llms.txt hits from the LLM/agent user-agents the query already filters on (ChatGPT, GPTBot, Perplexity, etc.), consistent with robots.txt handling.
- No schema/DDL changes. Once these rows land in the aggregated Athena table they flow downstream into `agentic_traffic` like any other path. Existing/backfilled partitions are not reprocessed.

## Test plan
- [x] `npm run test:spec -- test/audits/cdn-analysis/handler.test.js` — 39 passing
- [x] Updated the `other`-provider regex assertion in the handler test to match the new include pattern

## Related Issues