### PR TITLE
fix(csp): skip backward-compatible CSP findings

### DIFF
--- a/src/csp/csp.js
+++ b/src/csp/csp.js
@@ -141,6 +141,9 @@ export async function cspOpportunityAndSuggestions(auditUrl, auditData, context,
   csp = flattenCSP(csp);
   log.debug(`[${AUDIT_TYPE}] [Site: ${site.getId()}] CSP information from lighthouse report: ${JSON.stringify(csp)}`);
 
+  // all modern browsers support `strict-dynamic` directive, we don't need related suggestions
+  csp = csp.filter((item) => !item.description?.includes('backward compatible'));
+
   csp.forEach((item) => {
     if (item.description && item.description.includes('nonces or hashes')) {
       // eslint-disable-next-line no-param-reassign

--- a/test/audits/csp/csp.test.js
+++ b/test/audits/csp/csp.test.js
@@ -476,6 +476,81 @@ describe('CSP Post-processor', () => {
     ));
   });
 
+  it('should skip backward compatible findings', async () => {
+    sinon.replace(configuration, 'isHandlerEnabledForSite', (toggle) => toggle === 'security-csp');
+    // Mirrors a real Lighthouse `csp-xss` audit `details.items` array.
+    auditData.auditResult.csp = [
+      {
+        directive: 'script-src',
+        description: 'Host allowlists can frequently be bypassed. Consider using CSP nonces or hashes instead, along with `\'strict-dynamic\'` if necessary.',
+        severity: 'High',
+      },
+      {
+        directive: 'script-src',
+        description: 'Consider adding `\'unsafe-inline\'` (ignored by browsers supporting nonces/hashes) to be backward compatible with older browsers.',
+        severity: 'Medium',
+      },
+      {
+        severity: 'Medium',
+        description: 'The page contains a CSP defined in a `<meta>` tag. Consider moving the CSP to an HTTP header or defining another strict CSP in an HTTP header.',
+      },
+    ];
+
+    const cspAuditData = await cspOpportunityAndSuggestions(siteUrl, auditData, context, cspSite);
+    assertAuditData(cspAuditData);
+
+    expect(opportunityStub.create).to.have.been.calledWith(sinon.match({
+      siteId: 'test-site-id',
+      auditId: 'test-audit-id',
+      runbook: 'https://wiki.corp.adobe.com/display/WEM/Security+Success',
+      type: Audit.AUDIT_TYPES.SECURITY_CSP,
+      origin: 'AUTOMATION',
+      title: 'XSS vulnerabilities on your site have been detected — patch them for stronger security',
+      description: 'Unpatched vulnerabilities expose visitors to attacks — fixing them protects users and preserves brand integrity.',
+      data: {
+        securityScoreImpact: 10,
+        howToFix: '### ⚠ **Warning**\nThis solution requires testing before deployment. Customer code and configurations vary, so please validate in a test branch first.\nSee https://www.aem.live/docs/csp-strict-dynamic-cached-nonce for more details.',
+        dataSources: [
+          'Page',
+        ],
+        securityType: 'EDS-CSP',
+        mainMetric: {
+          name: 'Issues',
+          value: 2,
+        },
+      },
+      tags: [
+        'CSP',
+        'Security',
+      ],
+    }));
+    expect(cspOpportunity.addSuggestions).to.have.been.calledOnce;
+    expect(cspOpportunity.addSuggestions).to.have.been.calledWith(sinon.match(
+      [
+        // "nonces or hashes" is normalized to "nonces".
+        sinon.match({
+          type: 'CODE_CHANGE',
+          rank: 0,
+          data: {
+            severity: 'High',
+            directive: 'script-src',
+            description: 'Host allowlists can frequently be bypassed. Consider using CSP nonces instead, along with `\'strict-dynamic\'` if necessary.',
+          },
+        }),
+        // Meta tag finding has no directive.
+        sinon.match({
+          type: 'CODE_CHANGE',
+          rank: 0,
+          data: {
+            severity: 'Medium',
+            directive: undefined,
+            description: 'The page contains a CSP defined in a `<meta>` tag. Consider moving the CSP to an HTTP header or defining another strict CSP in an HTTP header.',
+          },
+        }),
+      ],
+    ));
+  });
+
   it('should extract multiple suggestions with subitems', async () => {
     sinon.replace(configuration, 'isHandlerEnabledForSite', (toggle) => toggle === 'security-csp');
     auditData.auditResult.csp = [


### PR DESCRIPTION
## Problem

Lighthouse's `csp-xss` audit emits a `Medium`-severity finding suggesting that `'unsafe-inline'` be added to `script-src` to remain *backward compatible with older browsers*:

> Consider adding `'unsafe-inline'` (ignored by browsers supporting nonces/hashes) to be backward compatible with older browsers.

All modern browsers support CSP nonces/hashes and `'strict-dynamic'`, so this is not an actionable improvement for our AEM Edge customers — it just adds noise to the CSP opportunity.

## Change

`cspOpportunityAndSuggestions` now filters out any flattened CSP item whose `description` contains `"backward compatible"` before building the opportunity and suggestions.

## Test

Added a `should skip backward compatible findings` test that feeds a realistic `csp-xss` `details.items` array (host-allowlist High finding, the backward-compat Medium finding, and a `<meta>`-tag Medium finding) and asserts:
- only **2** suggestions are produced (`mainMetric.value === 2`), the backward-compat item dropped;
- `"nonces or hashes"` is still normalized to `"nonces"`;
- the `<meta>`-tag finding flows through with `directive: undefined`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)