### PR TITLE
feat(csp): run CSP audit for Crosswalk sites with valid hlxConfig

### DIFF
--- a/src/csp/csp.js
+++ b/src/csp/csp.js
@@ -55,6 +55,26 @@ export function buildKey(data) {
   return key;
 }
 
+/**
+ * Determines whether the CSP opportunity applies to a site.
+ *
+ * The opportunity targets Edge Delivery (helix) sites. These are normally
+ * flagged with the AEM_EDGE delivery type, but some Crosswalk environments are
+ * labelled AEM_CS while still being edge-delivered. Those sites carry a valid
+ * hlxConfig (an rso identifying the backing repo), so accept them as well.
+ *
+ * @param {Object} site - The site object.
+ * @returns {boolean} True if the CSP opportunity should be evaluated.
+ */
+export function isCspApplicable(site) {
+  if (site.getDeliveryType() === Site.DELIVERY_TYPES.AEM_EDGE) {
+    return true;
+  }
+
+  const hlxConfig = site.getHlxConfig?.();
+  return Boolean(hlxConfig?.rso?.owner && hlxConfig?.rso?.site);
+}
+
 function flattenCSP(csp) {
   return csp.flatMap((item) => {
     if (item.subItems?.items) {
@@ -129,8 +149,9 @@ export async function cspOpportunityAndSuggestions(auditUrl, auditData, context,
     return { ...auditData };
   }
 
-  // this opportunity is only relevant for aem_edge delivery type at the moment
-  if (site.getDeliveryType() !== Site.DELIVERY_TYPES.AEM_EDGE) {
+  // this opportunity is only relevant for edge-delivered (helix) sites: either
+  // the AEM_EDGE delivery type or a Crosswalk site (e.g. AEM_CS) with a valid hlxConfig
+  if (!isCspApplicable(site)) {
     log.debug(`[${AUDIT_TYPE}] [Site: ${site.getId()}] skipping CSP opportunity as it is of delivery type ${site.getDeliveryType()}`);
     return { ...auditData };
   }

--- a/test/audits/csp/csp.test.js
+++ b/test/audits/csp/csp.test.js
@@ -674,6 +674,48 @@ describe('CSP Post-processor', () => {
     expect(cspOpportunity.addSuggestions).to.not.have.been.called;
   });
 
+  it('should extract opportunity for a Crosswalk (AEM_CS) site with a valid hlxConfig', async () => {
+    sinon.replace(configuration, 'isHandlerEnabledForSite', (toggle) => toggle === 'security-csp');
+    auditData.auditResult.csp = [
+      {
+        severity: 'High',
+        description: 'No CSP found in enforcement mode',
+      },
+    ];
+    cspSite.getDeliveryType = () => Site.DELIVERY_TYPES.AEM_CS;
+    cspSite.getHlxConfig = () => ({
+      hlxVersion: 5,
+      rso: { owner: 'myorg', site: 'mysite', ref: 'main' },
+    });
+
+    const cspAuditData = await cspOpportunityAndSuggestions(siteUrl, auditData, context, cspSite);
+    assertAuditData(cspAuditData);
+
+    expect(opportunityStub.create).to.have.been.calledWith(sinon.match({
+      type: Audit.AUDIT_TYPES.SECURITY_CSP,
+    }));
+    expect(cspOpportunity.addSuggestions).to.have.been.calledOnce;
+  });
+
+  it('should not extract opportunity for AEM_CS site without a valid hlxConfig', async () => {
+    sinon.replace(configuration, 'isHandlerEnabledForSite', (toggle) => toggle === 'security-csp');
+    auditData.auditResult.csp = [
+      {
+        severity: 'High',
+        description: 'No CSP found in enforcement mode',
+      },
+    ];
+    cspSite.getDeliveryType = () => Site.DELIVERY_TYPES.AEM_CS;
+    // empty rso: not actionable
+    cspSite.getHlxConfig = () => ({ hlxVersion: 5, rso: {} });
+
+    const cspAuditData = await cspOpportunityAndSuggestions(siteUrl, auditData, context, cspSite);
+    assertAuditData(cspAuditData);
+
+    expect(opportunityStub.create).to.not.have.been.called;
+    expect(cspOpportunity.addSuggestions).to.not.have.been.called;
+  });
+
   it('should not extract opportunity if audit failed', async () => {
     sinon.replace(configuration, 'isHandlerEnabledForSite', (toggle) => toggle === 'security-csp');
     auditData.auditResult.csp = [


### PR DESCRIPTION
## Problem

The CSP opportunity was gated solely on the `AEM_EDGE` delivery type:

```js
if (site.getDeliveryType() !== Site.DELIVERY_TYPES.AEM_EDGE) {
  return { ...auditData };
}
```

Some **Crosswalk** environments are labelled `AEM_CS` while still being edge-delivered (helix). Those sites were incorrectly skipped, so they never got a CSP opportunity.

## Change

Introduced `isCspApplicable(site)` which gates the audit on either:
- delivery type `AEM_EDGE` (unchanged behavior), **or**
- a valid `hlxConfig` — an `rso` carrying both `owner` and `site`, which identifies the backing Edge Delivery repo for Crosswalk (`AEM_CS`) sites.

## Tests

- `should extract opportunity for a Crosswalk (AEM_CS) site with a valid hlxConfig` — `AEM_CS` + valid `rso` → opportunity created.
- `should not extract opportunity for AEM_CS site without a valid hlxConfig` — `AEM_CS` + empty `rso` → skipped.
- Existing "other delivery types" test (no `hlxConfig`) still skips as before.

100% coverage on `src/csp/csp.js`; full lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)