### PR TITLE
fix(toc): filter unrendered AEM template placeholder headings (LLMO-5322)

### DIFF
--- a/src/headings/utils.js
+++ b/src/headings/utils.js
@@ -316,6 +316,9 @@ export function extractTocData($, getHeadingSelectorFn) {
       if (!text) {
         return false;
       }
+      if (/^\{[^}]+\}$/.test(text)) {
+        return false;
+      }
       if (isHeadingInExcludedContainer(h, $)) {
         return false;
       }

--- a/test/audits/toc.test.js
+++ b/test/audits/toc.test.js
@@ -3075,6 +3075,29 @@ describe('TOC (Table of Contents) Audit', () => {
         expect(result).to.have.lengthOf(3);
         expect(result.map((r) => r.text)).to.deep.equal(['Coverage Options', 'Section One', 'Section Two']);
       });
+      it('excludes headings whose entire text is an unrendered template placeholder', () => {
+        const $ = cheerioLoad(
+          '<body>'
+          + '<h1 id="a">PlayStation</h1>'
+          + '<h2 id="b">PS5 Games</h2>'
+          + '<h2 id="c" class="txt-style-{STYLE} txt-block-title__title">{TITLE}</h2>'
+          + '</body>',
+        );
+        const result = extractTocData($, stubGetHeadingSelector);
+        expect(result).to.have.lengthOf(2);
+        expect(result.map((r) => r.text)).to.deep.equal(['PlayStation', 'PS5 Games']);
+      });
+      it('does not exclude headings that merely contain curly braces alongside other text', () => {
+        const $ = cheerioLoad(
+          '<body>'
+          + '<h1 id="a">Welcome to {Brand}</h1>'
+          + '<h2 id="b">{TITLE} and more</h2>'
+          + '</body>',
+        );
+        const result = extractTocData($, stubGetHeadingSelector);
+        expect(result).to.have.lengthOf(2);
+        expect(result.map((r) => r.text)).to.deep.equal(['Welcome to {Brand}', '{TITLE} and more']);
+      });
     });
 
     describe('tocArrayToHast', () => {


### PR DESCRIPTION
## Summary

- Adds a guard in `extractTocData()` (`src/headings/utils.js`) to exclude headings whose entire text is an unrendered AEM template placeholder (e.g. `{TITLE}`, `{STYLE}`)
- Discovered on playstation.com: every scraped page contained an `<h2>` with literal text `{TITLE}` inside an `interactive-wizard` banner component, causing all 125 TOC suggestions to include a spurious nav item
- The 125 affected PlayStation suggestions were patched manually via SpaceCat PATCH API on 2026-06-04

## Root Cause

The PlayStation site publishes pages with unrendered AEM component variables:
```html
<h2 class="txt-style-{STYLE} txt-block-title__title">{TITLE}</h2>
```
The existing heading filters (cookie/consent containers, nav containers, consent phrases) had no guard for template placeholder text. The `interactive-wizard__banner__title-block` container matches no exclusion selector, and `{TITLE}` matches no consent phrase.

## Fix

One-line regex guard in `extractTocData()`, applied after the empty-text check:
```js
if (/^\{[^}]+\}$/.test(text)) {
  return false;
}
```
Intentionally narrow — only excludes headings whose **complete text** is a single `{PLACEHOLDER}` token. Headings like `"Welcome to {Brand}"` or `"{TITLE} and more"` are kept.

## Test Plan

- [x] `excludes headings whose entire text is an unrendered template placeholder` — verifies `{TITLE}` h2 is dropped, real headings kept
- [x] `does not exclude headings that merely contain curly braces alongside other text` — verifies narrow regex does not over-filter
- [x] All 172 existing toc.test.js tests still pass

## Jira

[LLMO-5322](https://jira.corp.adobe.com/browse/LLMO-5322)

---
🤖 Generated with [OrcaFix](https://wiki.corp.adobe.com/spaces/AEMSites/pages/3880474747/OrcaFix+SpaceCat+Jira+Analysis+Status) via [Claude Code](https://claude.ai/claude-code)