### PR TITLE
fix(preflight): detect broken links rewritten by AEM cq-LinkChecker (SITES-46032)

### DIFF
--- a/src/preflight/links-checks.js
+++ b/src/preflight/links-checks.js
@@ -244,6 +244,47 @@ export async function runLinksChecks(urls, scrapedObjects, context, options = {
         log.debug('[preflight-audit] Found internal links:', internalLinks);
         log.debug('[preflight-audit] Found external links:', externalLinks);
 
+        // AEM's server-side cq-LinkChecker rewrites broken <a> tags to <img> elements
+        // before the HTML is served, removing the anchor entirely. The broken URL is
+        // preserved in the alt attribute as "invalid link: <url>". Extract these directly
+        // without HTTP probing — AEM has already validated them as broken (404).
+        const seenCqUrls = new Set();
+        $('img.cq-LinkChecker--prefix.cq-LinkChecker--invalid').each((i, img) => {
+          const alt = $(img).attr('alt') || '';
+          const match = alt.match(/^invalid link:\s*(.+)$/);
+          if (!match) {
+            return;
+          }
+          try {
+            const parsed = new URL(match[1].trim(), pageUrl);
+            // Mirror the protocol guard in checkLinkStatus — non-web schemes
+            // (mailto:, tel:, javascript:, etc.) are not navigable links.
+            if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+              return;
+            }
+            const abs = parsed.toString();
+            // Deduplicate: same URL may appear in multiple cq-LinkChecker images.
+            if (seenCqUrls.has(abs)) {
+              return;
+            }
+            seenCqUrls.add(abs);
+            const selector = getDomElementSelector(img);
+            const result = {
+              urlTo: abs,
+              href: pageUrl,
+              status: 404,
+              ...toElementTargets([selector].filter(Boolean)),
+            };
+            if (parsed.origin === pageOrigin) {
+              brokenInternalLinks.push(result);
+            } else {
+              brokenExternalLinks.push(result);
+            }
+          } catch {
+            // skip unparseable URLs
+          }
+        });
+
         // Check internal links
         const internalResults = await Promise.all(
           Array.from(internalLinks.entries()).map(async ([href, selectorSet]) => checkLinkStatus(

--- a/test/preflight/links-checks.test.js
+++ b/test/preflight/links-checks.test.js
@@ -704,4 +704,167 @@ describe('preflight/links-checks - runLinksChecks', () => {
       ]);
     });
   });
+
+  // ── cq-LinkChecker broken link detection ──────────────────────────────────
+  describe('cq-LinkChecker broken link detection', () => {
+    it('reports a same-origin cq-LinkChecker--invalid image as a broken internal link without probing', async () => {
+      const html = `
+        <p>
+          <img class="cq-LinkChecker cq-LinkChecker--prefix cq-LinkChecker--invalid"
+               alt="invalid link: /content/site/en/missing.html">
+          Missing page
+          <img class="cq-LinkChecker cq-LinkChecker--suffix cq-LinkChecker--invalid">
+        </p>
+      `;
+      const result = await runLinksChecks([pageUrl], makeScrapedObjects(html), context);
+      expect(fetchStub.callCount).to.equal(0);
+      expect(result.auditResult.brokenInternalLinks).to.have.lengthOf(1);
+      expect(result.auditResult.brokenInternalLinks[0].urlTo).to.equal('https://www.example.com/content/site/en/missing.html');
+      expect(result.auditResult.brokenInternalLinks[0].status).to.equal(404);
+      expect(result.auditResult.brokenExternalLinks).to.have.lengthOf(0);
+    });
+
+    it('reports a cross-origin cq-LinkChecker--invalid image as a broken external link', async () => {
+      const html = `
+        <img class="cq-LinkChecker cq-LinkChecker--prefix cq-LinkChecker--invalid"
+             alt="invalid link: https://external.example.com/gone">
+        <img class="cq-LinkChecker cq-LinkChecker--suffix cq-LinkChecker--invalid">
+      `;
+      const result = await runLinksChecks([pageUrl], makeScrapedObjects(html), context);
+      expect(fetchStub.callCount).to.equal(0);
+      expect(result.auditResult.brokenExternalLinks).to.have.lengthOf(1);
+      expect(result.auditResult.brokenExternalLinks[0].urlTo).to.equal('https://external.example.com/gone');
+      expect(result.auditResult.brokenExternalLinks[0].status).to.equal(404);
+    });
+
+    it('resolves a bare relative href correctly against pageUrl', async () => {
+      const html = `
+        <img class="cq-LinkChecker cq-LinkChecker--prefix cq-LinkChecker--invalid"
+             alt="invalid link: microt.com">
+        <img class="cq-LinkChecker cq-LinkChecker--suffix cq-LinkChecker--invalid">
+      `;
+      const result = await runLinksChecks([pageUrl], makeScrapedObjects(html), context);
+      expect(result.auditResult.brokenInternalLinks).to.have.lengthOf(1);
+      expect(result.auditResult.brokenInternalLinks[0].urlTo).to.equal('https://www.example.com/microt.com');
+    });
+
+    it('resolves an absolute content path against pageUrl origin', async () => {
+      const html = `
+        <img class="cq-LinkChecker cq-LinkChecker--prefix cq-LinkChecker--invalid"
+             alt="invalid link: /content/site/en/this-page-does-not-exist.html">
+        <img class="cq-LinkChecker cq-LinkChecker--suffix cq-LinkChecker--invalid">
+      `;
+      const result = await runLinksChecks([pageUrl], makeScrapedObjects(html), context);
+      expect(result.auditResult.brokenInternalLinks[0].urlTo).to.equal('https://www.example.com/content/site/en/this-page-does-not-exist.html');
+    });
+
+    it('reports both a probed broken link and a cq-LinkChecker broken link on the same page', async () => {
+      fetchStub.resolves(makeResponse(404));
+      const html = `
+        <a href="https://external.example.com/probe-me">probe this</a>
+        <img class="cq-LinkChecker cq-LinkChecker--prefix cq-LinkChecker--invalid"
+             alt="invalid link: /content/site/en/aem-broken.html">
+        <img class="cq-LinkChecker cq-LinkChecker--suffix cq-LinkChecker--invalid">
+      `;
+      const result = await runLinksChecks([pageUrl], makeScrapedObjects(html), context);
+      expect(result.auditResult.brokenExternalLinks).to.have.lengthOf(1);
+      expect(result.auditResult.brokenExternalLinks[0].urlTo).to.equal('https://external.example.com/probe-me');
+      expect(result.auditResult.brokenInternalLinks).to.have.lengthOf(1);
+      expect(result.auditResult.brokenInternalLinks[0].urlTo).to.equal('https://www.example.com/content/site/en/aem-broken.html');
+    });
+
+    it('ignores cq-LinkChecker--prefix image that does not have cq-LinkChecker--invalid class', async () => {
+      const html = `
+        <img class="cq-LinkChecker cq-LinkChecker--prefix"
+             alt="invalid link: /content/site/en/valid.html">
+      `;
+      const result = await runLinksChecks([pageUrl], makeScrapedObjects(html), context);
+      expect(result.auditResult.brokenInternalLinks).to.have.lengthOf(0);
+      expect(fetchStub.callCount).to.equal(0);
+    });
+
+    it('ignores cq-LinkChecker--invalid image whose alt does not match the expected pattern', async () => {
+      const html = `
+        <img class="cq-LinkChecker cq-LinkChecker--prefix cq-LinkChecker--invalid"
+             alt="some other text">
+        <img class="cq-LinkChecker cq-LinkChecker--prefix cq-LinkChecker--invalid">
+      `;
+      const result = await runLinksChecks([pageUrl], makeScrapedObjects(html), context);
+      expect(result.auditResult.brokenInternalLinks).to.have.lengthOf(0);
+      expect(fetchStub.callCount).to.equal(0);
+    });
+
+    it('does not report a cq-LinkChecker--invalid image inside an excludedElementClasses subtree', async () => {
+      const html = `
+        <div class="skip-me">
+          <img class="cq-LinkChecker cq-LinkChecker--prefix cq-LinkChecker--invalid"
+               alt="invalid link: /content/site/en/excluded.html">
+        </div>
+        <img class="cq-LinkChecker cq-LinkChecker--prefix cq-LinkChecker--invalid"
+             alt="invalid link: /content/site/en/included.html">
+      `;
+      const result = await runLinksChecks(
+        [pageUrl],
+        makeScrapedObjects(html),
+        context,
+        { excludedElementClasses: ['skip-me'] },
+      );
+      expect(result.auditResult.brokenInternalLinks).to.have.lengthOf(1);
+      expect(result.auditResult.brokenInternalLinks[0].urlTo).to.equal('https://www.example.com/content/site/en/included.html');
+    });
+
+    it('makes no fetch calls for cq-LinkChecker-sourced broken links', async () => {
+      const html = `
+        <img class="cq-LinkChecker cq-LinkChecker--prefix cq-LinkChecker--invalid"
+             alt="invalid link: /content/site/en/a.html">
+        <img class="cq-LinkChecker cq-LinkChecker--prefix cq-LinkChecker--invalid"
+             alt="invalid link: /content/site/en/b.html">
+      `;
+      await runLinksChecks([pageUrl], makeScrapedObjects(html), context);
+      expect(fetchStub.callCount).to.equal(0);
+    });
+
+    it('silently skips a cq-LinkChecker--invalid image whose alt contains an unparseable URL', async () => {
+      // http://[invalid triggers a URL parse error (malformed IPv6 literal)
+      const html = `
+        <img class="cq-LinkChecker cq-LinkChecker--prefix cq-LinkChecker--invalid"
+             alt="invalid link: http://[invalid">
+        <img class="cq-LinkChecker cq-LinkChecker--prefix cq-LinkChecker--invalid"
+             alt="invalid link: /content/site/en/valid.html">
+      `;
+      const result = await runLinksChecks([pageUrl], makeScrapedObjects(html), context);
+      expect(result.auditResult.brokenInternalLinks).to.have.lengthOf(1);
+      expect(result.auditResult.brokenInternalLinks[0].urlTo).to.equal('https://www.example.com/content/site/en/valid.html');
+    });
+
+    it('skips non-HTTP schemes (mailto:, tel:) to match the checkLinkStatus protocol guard', async () => {
+      const html = `
+        <img class="cq-LinkChecker cq-LinkChecker--prefix cq-LinkChecker--invalid"
+             alt="invalid link: mailto:noreply@example.com">
+        <img class="cq-LinkChecker cq-LinkChecker--prefix cq-LinkChecker--invalid"
+             alt="invalid link: tel:+15550001234">
+        <img class="cq-LinkChecker cq-LinkChecker--prefix cq-LinkChecker--invalid"
+             alt="invalid link: /content/site/en/real-broken.html">
+      `;
+      const result = await runLinksChecks([pageUrl], makeScrapedObjects(html), context);
+      expect(result.auditResult.brokenInternalLinks).to.have.lengthOf(1);
+      expect(result.auditResult.brokenInternalLinks[0].urlTo).to.equal('https://www.example.com/content/site/en/real-broken.html');
+      expect(fetchStub.callCount).to.equal(0);
+    });
+
+    it('deduplicates multiple cq-LinkChecker images pointing to the same URL', async () => {
+      const html = `
+        <img class="cq-LinkChecker cq-LinkChecker--prefix cq-LinkChecker--invalid"
+             alt="invalid link: /content/site/en/missing.html">
+        <img class="cq-LinkChecker cq-LinkChecker--prefix cq-LinkChecker--invalid"
+             alt="invalid link: /content/site/en/missing.html">
+        <img class="cq-LinkChecker cq-LinkChecker--prefix cq-LinkChecker--invalid"
+             alt="invalid link: /content/site/en/missing.html">
+      `;
+      const result = await runLinksChecks([pageUrl], makeScrapedObjects(html), context);
+      expect(result.auditResult.brokenInternalLinks).to.have.lengthOf(1);
+      expect(result.auditResult.brokenInternalLinks[0].urlTo).to.equal('https://www.example.com/content/site/en/missing.html');
+      expect(fetchStub.callCount).to.equal(0);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- AEM's server-side `cq-LinkChecker` rewrites broken `<a>` tags to `<img class="cq-LinkChecker--invalid">` elements before the HTML is served. Preflight's `$('a[href]')` pass finds no anchors for those links and reports Links ✓.
- Fix: after `filterExcludedElements`, select `img.cq-LinkChecker--prefix.cq-LinkChecker--invalid` elements and extract the broken URL from `alt="invalid link: <url>"`. Push directly to `brokenInternalLinks` / `brokenExternalLinks` without HTTP probing — AEM has already validated them.
- Confirmed on Micron's production test page and reproduced on the Ottawa preflight test environment.

## What changed

`src/preflight/links-checks.js` — new block in `runLinksChecks` after `filterExcludedElements`:
- Selects `img.cq-LinkChecker--prefix.cq-LinkChecker--invalid` elements
- Extracts URL from `alt="invalid link: <url>"`
- Protocol guard: skips non-HTTP/HTTPS schemes (`mailto:`, `tel:`, etc.) — mirrors existing guard in `checkLinkStatus`
- Deduplication: per-page `Set` prevents multiple cq-LinkChecker images for the same URL producing duplicate result objects and duplicate downstream LLM calls
- Result object shape (`{ urlTo, href, status: 404, elements }`) matches the existing HTTP-probe path exactly — no MFE or `links.js` changes required

## Test plan

- [x] 10 new unit tests in `test/preflight/links-checks.test.js` covering: internal/external classification, bare relative href resolution, absolute content path resolution, mixed probed+AEM links, non-invalid class ignored, non-matching alt ignored, excluded subtree skipped, no fetch calls made, protocol guard (mailto/tel skipped), deduplication
- [x] 100% line/branch/statement coverage on `src/preflight/links-checks.js`
- [x] 48 passing, 0 failing on the spec file
- [ ] Integration: Ottawa preflight test site (`cm-p180456-e1899464`, `sample-article-2.html`) has the `micron_style_links` component with two confirmed broken links — run preflight after merge to verify they now surface

## References

- Jira: [SITES-46032](https://jira.corp.adobe.com/browse/SITES-46032)
- Public docs: [AEM Sites Optimizer Preflight](https://experienceleague.adobe.com/en/docs/experience-manager-sites-optimizer/content/documentation/preflight/overview) — *"Catch human errors like missing H1 tags, broken links, and metadata gaps"*

🤖 Generated with [Claude Code](https://claude.com/claude-code)