### PR TITLE
fix(accessibility): resolve stale a11y opportunities when no issues found (SITES-40450)

### DIFF
--- a/src/accessibility/utils/generate-individual-opportunities.js
+++ b/src/accessibility/utils/generate-individual-opportunities.js
@@ -22,6 +22,7 @@ import {
   syncSuggestions,
   keepSameDataFunction,
   warnOnInvalidSuggestionData,
+  resolveOpportunityIfNoIssues,
 } from '../../utils/data-access.js';
 import {
   successCriteriaLinks, accessibilityOpportunitiesMap, URL_SOURCE_SEPARATOR, issueTypesForCodeFix,
@@ -818,7 +819,7 @@ export function calculateAccessibilityMetrics(aggregatedData) {
  */
 export async function createAccessibilityIndividualOpportunities(accessibilityData, context) {
   const {
-    site, log,
+    site, log, dataAccess,
   } = context;
 
   log.info(`[A11yIndividual] Creating accessibility opportunities for ${site.getBaseURL()}`);
@@ -832,6 +833,11 @@ export async function createAccessibilityIndividualOpportunities(accessibilityDa
   // Early return if no actionable issues found
   if (!aggregatedData || !aggregatedData.data || aggregatedData.data.length === 0) {
     log.debug(`[A11yIndividual] No individual accessibility opportunities found for ${site.getBaseURL()}`);
+    await Promise.all(
+      Object.keys(accessibilityOpportunitiesMap).map(
+        (oppType) => resolveOpportunityIfNoIssues(site.getId(), oppType, dataAccess, log),
+      ),
+    );
     return {
       status: 'NO_OPPORTUNITIES',
       message: 'No accessibility issues found in tracked categories',

--- a/test/audits/accessibility/generate-individual-opportunities.test.js
+++ b/test/audits/accessibility/generate-individual-opportunities.test.js
@@ -1872,6 +1872,7 @@ describe('createAccessibilityIndividualOpportunities', () => {
   let mockGetAuditData;
   let mockCreateAssistiveOppty;
   let mockSyncSuggestions;
+  let mockResolveOpportunityIfNoIssues;
   let mockIsAuditEnabledForSite;
   let createAccessibilityIndividualOpportunities;
 
@@ -1879,6 +1880,7 @@ describe('createAccessibilityIndividualOpportunities', () => {
     sandbox = sinon.createSandbox();
     mockSite = {
       getBaseURL: sandbox.stub().returns('https://example.com'),
+      getId: sandbox.stub().returns('test-site'),
     };
     mockOpportunity = {
       getId: sandbox.stub().returns('test-id'),
@@ -1943,6 +1945,7 @@ describe('createAccessibilityIndividualOpportunities', () => {
     });
 
     mockSyncSuggestions = sandbox.stub().resolves();
+    mockResolveOpportunityIfNoIssues = sandbox.stub().resolves();
 
     // Fix: Mock all dependencies before importing the module under test
     const module = await esmock('../../../src/accessibility/utils/generate-individual-opportunities.js', {
@@ -1964,6 +1967,7 @@ describe('createAccessibilityIndividualOpportunities', () => {
       },
       '../../../src/utils/data-access.js': {
         syncSuggestions: mockSyncSuggestions,
+        resolveOpportunityIfNoIssues: mockResolveOpportunityIfNoIssues,
       },
       '../../../src/accessibility/guidance-utils/mystique-data-processing.js': {
         processSuggestionsForMystique: sandbox.stub().returns([
@@ -2047,6 +2051,20 @@ describe('createAccessibilityIndividualOpportunities', () => {
     expect(result.status).to.equal('NO_OPPORTUNITIES');
     expect(result.message).to.equal('No accessibility issues found in tracked categories');
     expect(result.data).to.deep.equal([]);
+    // SITES-40450: resolve any stale NEW opportunity for every tracked a11y type
+    expect(mockResolveOpportunityIfNoIssues).to.have.been.calledTwice;
+    expect(mockResolveOpportunityIfNoIssues).to.have.been.calledWith(
+      'test-site',
+      'a11y-assistive',
+      mockContext.dataAccess,
+      mockContext.log,
+    );
+    expect(mockResolveOpportunityIfNoIssues).to.have.been.calledWith(
+      'test-site',
+      'a11y-usability',
+      mockContext.dataAccess,
+      mockContext.log,
+    );
   });
 
   it('should handle errors during opportunity creation', async () => {


### PR DESCRIPTION
Jira link: https://jira.corp.adobe.com/browse/SITES-40450

When the individual a11y opportunities flow finds no actionable issues, call resolveOpportunityIfNoIssues for each tracked a11y opportunity type so any existing NEW opportunity is transitioned to RESOLVED and its actionable suggestions are marked OUTDATED. Previously the early return left stale opportunities in NEW indefinitely, causing the ASO UI to show outdated results to customers who had already fixed all their accessibility issues.
