### PR TITLE
fix(cdn-logs-report): pin daily export S3 client to correct region (PermanentRedirect)

### DIFF
--- a/src/cdn-logs-report/agentic-daily-export.js
+++ b/src/cdn-logs-report/agentic-daily-export.js
@@ -16,11 +16,6 @@ import { loadSql, IMPORTER_BUCKET_REGION } from './utils/report-utils.js';
 import { weeklyBreakdownQueries } from './utils/query-builder.js';
 import { mapToAgenticTrafficBundle } from './utils/agentic-traffic-mapper.js';
 
-// The agentic bundle is always written to the importer bucket (S3_IMPORTER_BUCKET_NAME),
-// which lives in us-east-1 (IMPORTER_BUCKET_REGION). The injected CDN S3 client is
-// regionalized to the site's CDN region, so reusing it triggers S3 PermanentRedirect (301)
-// for non-us-east-1 sites. Always talk to the importer bucket through a us-east-1 client.
-
 export function getPreviousUtcDate(referenceDate = new Date()) {
   const previous = new Date(referenceDate);
   previous.setUTCDate(previous.getUTCDate() - 1);
@@ -264,6 +259,7 @@ export async function runDailyAgenticExport({
   const keyPrefix = getAgenticBundleKeyPrefix(site.getId(), trafficDate, bundleId);
   const bundleUri = `s3://${bundleBucket}/${keyPrefix}`;
   const uploadedFiles = buildBundleFileKeys(keyPrefix);
+  // Importer bucket is us-east-1, not the site's CDN region; reusing the CDN client 301s.
   const s3Client = new S3Client({ region: IMPORTER_BUCKET_REGION });
   let dispatch;
 

--- a/src/cdn-logs-report/agentic-daily-export.js
+++ b/src/cdn-logs-report/agentic-daily-export.js
@@ -12,15 +12,14 @@
 
 import { DeleteObjectsCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { v4 as uuidv4 } from 'uuid';
-import { loadSql } from './utils/report-utils.js';
+import { loadSql, IMPORTER_BUCKET_REGION } from './utils/report-utils.js';
 import { weeklyBreakdownQueries } from './utils/query-builder.js';
 import { mapToAgenticTrafficBundle } from './utils/agentic-traffic-mapper.js';
 
 // The agentic bundle is always written to the importer bucket (S3_IMPORTER_BUCKET_NAME),
-// which lives in us-east-1. The injected CDN S3 client is regionalized to the site's CDN
-// region, so reusing it triggers S3 PermanentRedirect (301) for non-us-east-1 sites.
-// Always talk to the importer bucket through a dedicated us-east-1 client.
-const AGENTIC_EXPORT_S3_REGION = 'us-east-1';
+// which lives in us-east-1 (IMPORTER_BUCKET_REGION). The injected CDN S3 client is
+// regionalized to the site's CDN region, so reusing it triggers S3 PermanentRedirect (301)
+// for non-us-east-1 sites. Always talk to the importer bucket through a us-east-1 client.
 
 export function getPreviousUtcDate(referenceDate = new Date()) {
   const previous = new Date(referenceDate);
@@ -265,7 +264,7 @@ export async function runDailyAgenticExport({
   const keyPrefix = getAgenticBundleKeyPrefix(site.getId(), trafficDate, bundleId);
   const bundleUri = `s3://${bundleBucket}/${keyPrefix}`;
   const uploadedFiles = buildBundleFileKeys(keyPrefix);
-  const s3Client = new S3Client({ region: AGENTIC_EXPORT_S3_REGION });
+  const s3Client = new S3Client({ region: IMPORTER_BUCKET_REGION });
   let dispatch;
 
   try {

--- a/src/cdn-logs-report/agentic-daily-export.js
+++ b/src/cdn-logs-report/agentic-daily-export.js
@@ -10,11 +10,17 @@
  * governing permissions and limitations under the License.
  */
 
-import { DeleteObjectsCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import { DeleteObjectsCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { v4 as uuidv4 } from 'uuid';
 import { loadSql } from './utils/report-utils.js';
 import { weeklyBreakdownQueries } from './utils/query-builder.js';
 import { mapToAgenticTrafficBundle } from './utils/agentic-traffic-mapper.js';
+
+// The agentic bundle is always written to the importer bucket (S3_IMPORTER_BUCKET_NAME),
+// which lives in us-east-1. The injected CDN S3 client is regionalized to the site's CDN
+// region, so reusing it triggers S3 PermanentRedirect (301) for non-us-east-1 sites.
+// Always talk to the importer bucket through a dedicated us-east-1 client.
+const AGENTIC_EXPORT_S3_REGION = 'us-east-1';
 
 export function getPreviousUtcDate(referenceDate = new Date()) {
   const previous = new Date(referenceDate);
@@ -200,7 +206,6 @@ export const testHelpers = {
 
 export async function runDailyAgenticExport({
   athenaClient,
-  s3Client,
   s3Config,
   site,
   context,
@@ -260,6 +265,7 @@ export async function runDailyAgenticExport({
   const keyPrefix = getAgenticBundleKeyPrefix(site.getId(), trafficDate, bundleId);
   const bundleUri = `s3://${bundleBucket}/${keyPrefix}`;
   const uploadedFiles = buildBundleFileKeys(keyPrefix);
+  const s3Client = new S3Client({ region: AGENTIC_EXPORT_S3_REGION });
   let dispatch;
 
   try {

--- a/src/cdn-logs-report/handler.js
+++ b/src/cdn-logs-report/handler.js
@@ -174,7 +174,6 @@ async function runCdnLogsReport(url, context, site, auditContext) {
       try {
         dailyReferralExport = await runDailyReferralExport({
           athenaClient,
-          s3Client,
           s3Config,
           site,
           context,

--- a/src/cdn-logs-report/handler.js
+++ b/src/cdn-logs-report/handler.js
@@ -158,7 +158,6 @@ async function runCdnLogsReport(url, context, site, auditContext) {
 
   const agenticDbExportResult = await runAgenticDbExports({
     athenaClient,
-    s3Client,
     s3Config,
     site,
     context,

--- a/src/cdn-logs-report/referral-daily-export.js
+++ b/src/cdn-logs-report/referral-daily-export.js
@@ -18,11 +18,6 @@ import { joinBaseAndPath } from '../utils/url-utils.js';
 import { loadSql, IMPORTER_BUCKET_REGION } from './utils/report-utils.js';
 import { weeklyBreakdownQueries } from './utils/query-builder.js';
 
-// The referral CSV is always written to the importer bucket (S3_IMPORTER_BUCKET_NAME),
-// which lives in us-east-1 (IMPORTER_BUCKET_REGION). The injected CDN S3 client is
-// regionalized to the site's CDN region, so reusing it triggers S3 PermanentRedirect (301)
-// for non-us-east-1 sites. Always talk to the importer bucket through a us-east-1 client.
-
 const CDN_REFERRAL_CSV_COLUMNS = [
   'traffic_date', 'host', 'url_path', 'trf_platform', 'device', 'region',
   'pageviews', 'referrer', 'utm_source', 'utm_medium', 'tracking_param',
@@ -219,6 +214,7 @@ export async function runDailyReferralExport({
   }
 
   const messageGroupId = `referral_traffic_cdn:${siteId}`;
+  // Importer bucket is us-east-1, not the site's CDN region; reusing the CDN client 301s.
   const s3Client = new S3Client({ region: IMPORTER_BUCKET_REGION });
 
   try {

--- a/src/cdn-logs-report/referral-daily-export.js
+++ b/src/cdn-logs-report/referral-daily-export.js
@@ -12,11 +12,17 @@
 
 /* eslint-disable camelcase */
 import { createHash } from 'crypto';
-import { DeleteObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import { DeleteObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { classifyTrafficSource } from '@adobe/spacecat-shared-rum-api-client/src/common/traffic.js';
 import { joinBaseAndPath } from '../utils/url-utils.js';
 import { loadSql } from './utils/report-utils.js';
 import { weeklyBreakdownQueries } from './utils/query-builder.js';
+
+// The referral CSV is always written to the importer bucket (S3_IMPORTER_BUCKET_NAME),
+// which lives in us-east-1. The injected CDN S3 client is regionalized to the site's CDN
+// region, so reusing it triggers S3 PermanentRedirect (301) for non-us-east-1 sites.
+// Always talk to the importer bucket through a dedicated us-east-1 client.
+const REFERRAL_EXPORT_S3_REGION = 'us-east-1';
 
 const CDN_REFERRAL_CSV_COLUMNS = [
   'traffic_date', 'host', 'url_path', 'trf_platform', 'device', 'region',
@@ -142,7 +148,6 @@ export const testHelpers = {
 
 export async function runDailyReferralExport({
   athenaClient,
-  s3Client,
   s3Config,
   site,
   context,
@@ -215,6 +220,7 @@ export async function runDailyReferralExport({
   }
 
   const messageGroupId = `referral_traffic_cdn:${siteId}`;
+  const s3Client = new S3Client({ region: REFERRAL_EXPORT_S3_REGION });
 
   try {
     await s3Client.send(new PutObjectCommand({

--- a/src/cdn-logs-report/referral-daily-export.js
+++ b/src/cdn-logs-report/referral-daily-export.js
@@ -15,14 +15,13 @@ import { createHash } from 'crypto';
 import { DeleteObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { classifyTrafficSource } from '@adobe/spacecat-shared-rum-api-client/src/common/traffic.js';
 import { joinBaseAndPath } from '../utils/url-utils.js';
-import { loadSql } from './utils/report-utils.js';
+import { loadSql, IMPORTER_BUCKET_REGION } from './utils/report-utils.js';
 import { weeklyBreakdownQueries } from './utils/query-builder.js';
 
 // The referral CSV is always written to the importer bucket (S3_IMPORTER_BUCKET_NAME),
-// which lives in us-east-1. The injected CDN S3 client is regionalized to the site's CDN
-// region, so reusing it triggers S3 PermanentRedirect (301) for non-us-east-1 sites.
-// Always talk to the importer bucket through a dedicated us-east-1 client.
-const REFERRAL_EXPORT_S3_REGION = 'us-east-1';
+// which lives in us-east-1 (IMPORTER_BUCKET_REGION). The injected CDN S3 client is
+// regionalized to the site's CDN region, so reusing it triggers S3 PermanentRedirect (301)
+// for non-us-east-1 sites. Always talk to the importer bucket through a us-east-1 client.
 
 const CDN_REFERRAL_CSV_COLUMNS = [
   'traffic_date', 'host', 'url_path', 'trf_platform', 'device', 'region',
@@ -220,7 +219,7 @@ export async function runDailyReferralExport({
   }
 
   const messageGroupId = `referral_traffic_cdn:${siteId}`;
-  const s3Client = new S3Client({ region: REFERRAL_EXPORT_S3_REGION });
+  const s3Client = new S3Client({ region: IMPORTER_BUCKET_REGION });
 
   try {
     await s3Client.send(new PutObjectCommand({

--- a/src/cdn-logs-report/utils/agentic-db-export.js
+++ b/src/cdn-logs-report/utils/agentic-db-export.js
@@ -82,7 +82,6 @@ function getDateBasedReferenceDate(auditContext, siteId, context) {
 
 async function runAgenticDbExportForReferenceDate({
   athenaClient,
-  s3Client,
   s3Config,
   site,
   context,
@@ -93,7 +92,6 @@ async function runAgenticDbExportForReferenceDate({
   try {
     return await runDailyAgenticExport({
       athenaClient,
-      s3Client,
       s3Config,
       site,
       context,
@@ -113,7 +111,6 @@ async function runAgenticDbExportForReferenceDate({
 
 async function runDateBasedAgenticDbExport({
   athenaClient,
-  s3Client,
   s3Config,
   site,
   context,
@@ -126,7 +123,6 @@ async function runDateBasedAgenticDbExport({
   return {
     dailyAgenticExport: await runAgenticDbExportForReferenceDate({
       athenaClient,
-      s3Client,
       s3Config,
       site,
       context,
@@ -256,7 +252,6 @@ async function queueWeeklyAgenticDbExports({
 
 export async function runAgenticDbExports({
   athenaClient,
-  s3Client,
   s3Config,
   site,
   context,
@@ -273,7 +268,6 @@ export async function runAgenticDbExports({
   if (!hasWeekOffset(auditContext)) {
     return runDateBasedAgenticDbExport({
       athenaClient,
-      s3Client,
       s3Config,
       site,
       context,

--- a/src/cdn-logs-report/utils/report-utils.js
+++ b/src/cdn-logs-report/utils/report-utils.js
@@ -13,6 +13,12 @@
 import { getStaticContent, isoCalendarWeek } from '@adobe/spacecat-shared-utils';
 import { uploadToSharePoint } from '../../utils/report-uploader.js';
 
+// The agentic + referral daily exports write to the importer bucket
+// (S3_IMPORTER_BUCKET_NAME), which lives in us-east-1. Their S3 client must be
+// pinned to this region regardless of the site's CDN bucket region, otherwise
+// S3 returns PermanentRedirect (301). Shared so new export types don't drift.
+export const IMPORTER_BUCKET_REGION = 'us-east-1';
+
 const ISO_3166_ALPHA2_COUNTRY_CODES = new Set([
   'AD', 'AE', 'AF', 'AG', 'AI', 'AL', 'AM', 'AO', 'AQ', 'AR', 'AS', 'AT', 'AU', 'AW', 'AX', 'AZ',
   'BA', 'BB', 'BD', 'BE', 'BF', 'BG', 'BH', 'BI', 'BJ', 'BL', 'BM', 'BN', 'BO', 'BQ', 'BR', 'BS',

--- a/src/cdn-logs-report/utils/report-utils.js
+++ b/src/cdn-logs-report/utils/report-utils.js
@@ -13,10 +13,7 @@
 import { getStaticContent, isoCalendarWeek } from '@adobe/spacecat-shared-utils';
 import { uploadToSharePoint } from '../../utils/report-uploader.js';
 
-// The agentic + referral daily exports write to the importer bucket
-// (S3_IMPORTER_BUCKET_NAME), which lives in us-east-1. Their S3 client must be
-// pinned to this region regardless of the site's CDN bucket region, otherwise
-// S3 returns PermanentRedirect (301). Shared so new export types don't drift.
+// Region of the importer bucket (S3_IMPORTER_BUCKET_NAME) the daily exports write to.
 export const IMPORTER_BUCKET_REGION = 'us-east-1';
 
 const ISO_3166_ALPHA2_COUNTRY_CODES = new Set([

--- a/test/audits/cdn-logs-report/agentic-daily-export.test.js
+++ b/test/audits/cdn-logs-report/agentic-daily-export.test.js
@@ -450,7 +450,6 @@ describe('agentic daily export', () => {
 
     expect(athenaClient.execute).to.not.have.been.called;
     expect(athenaClient.query).to.not.have.been.called;
-    // No importer-bucket S3 client is even constructed on early exit.
     expect(S3ClientStub).to.not.have.been.called;
   });
 
@@ -711,7 +710,6 @@ describe('agentic daily export', () => {
     })).to.be.rejectedWith('Athena unavailable');
 
     expect(athenaClient.query).to.not.have.been.called;
-    // No importer-bucket S3 client is even constructed on early exit.
     expect(S3ClientStub).to.not.have.been.called;
   });
 });

--- a/test/audits/cdn-logs-report/agentic-daily-export.test.js
+++ b/test/audits/cdn-logs-report/agentic-daily-export.test.js
@@ -384,6 +384,7 @@ describe('agentic daily export', () => {
   });
 
   it('fails before Athena or S3 work when the analytics queue is missing', async () => {
+    const S3ClientStub = sandbox.stub().returns({ send: sandbox.stub().resolves({}) });
     const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js', {
       '../../../src/cdn-logs-report/utils/report-utils.js': {
         loadSql: sandbox.stub().resolves('CREATE DATABASE'),
@@ -398,6 +399,9 @@ describe('agentic daily export', () => {
           trafficRows: [],
           classificationRows: [],
         }),
+      },
+      '@aws-sdk/client-s3': {
+        S3Client: S3ClientStub,
       },
     });
 
@@ -446,6 +450,8 @@ describe('agentic daily export', () => {
 
     expect(athenaClient.execute).to.not.have.been.called;
     expect(athenaClient.query).to.not.have.been.called;
+    // No importer-bucket S3 client is even constructed on early exit.
+    expect(S3ClientStub).to.not.have.been.called;
   });
 
   it('cleans up uploaded files when analytics dispatch fails', async () => {
@@ -642,6 +648,7 @@ describe('agentic daily export', () => {
   });
 
   it('propagates Athena database setup failures without touching S3', async () => {
+    const S3ClientStub = sandbox.stub().returns({ send: sandbox.stub().resolves({}) });
     const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js', {
       '../../../src/cdn-logs-report/utils/report-utils.js': {
         loadSql: sandbox.stub().resolves('CREATE DATABASE'),
@@ -656,6 +663,9 @@ describe('agentic daily export', () => {
           trafficRows: [],
           classificationRows: [],
         }),
+      },
+      '@aws-sdk/client-s3': {
+        S3Client: S3ClientStub,
       },
     });
 
@@ -701,5 +711,7 @@ describe('agentic daily export', () => {
     })).to.be.rejectedWith('Athena unavailable');
 
     expect(athenaClient.query).to.not.have.been.called;
+    // No importer-bucket S3 client is even constructed on early exit.
+    expect(S3ClientStub).to.not.have.been.called;
   });
 });

--- a/test/audits/cdn-logs-report/agentic-daily-export.test.js
+++ b/test/audits/cdn-logs-report/agentic-daily-export.test.js
@@ -71,6 +71,11 @@ describe('agentic daily export', () => {
       }),
     };
 
+    const s3Client = {
+      send: sandbox.stub().resolves({}),
+    };
+    const S3ClientStub = sandbox.stub().returns(s3Client);
+
     const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js', {
       '../../../src/cdn-logs-report/utils/report-utils.js': {
         loadSql: sandbox.stub().resolves('CREATE DATABASE IF NOT EXISTS test_db'),
@@ -79,6 +84,9 @@ describe('agentic daily export', () => {
         weeklyBreakdownQueries: queryBuilder,
       },
       '../../../src/cdn-logs-report/utils/agentic-traffic-mapper.js': mapper,
+      '@aws-sdk/client-s3': {
+        S3Client: S3ClientStub,
+      },
       uuid: {
         v4: () => 'batch-123',
       },
@@ -87,9 +95,6 @@ describe('agentic daily export', () => {
     const athenaClient = {
       execute: sandbox.stub().resolves(),
       query: sandbox.stub().resolves([{ raw: true }]),
-    };
-    const s3Client = {
-      send: sandbox.stub().resolves({}),
     };
     const context = {
       env: {
@@ -118,7 +123,6 @@ describe('agentic daily export', () => {
 
     const result = await module.runDailyAgenticExport({
       athenaClient,
-      s3Client,
       s3Config: {
         bucket: 'spacecat-dev-cdn-logs-aggregates-us-east-1',
         databaseName: 'cdn_logs_example',
@@ -139,6 +143,7 @@ describe('agentic daily export', () => {
       'cdn_logs_example',
       '[Athena Query] agentic_daily_flat_data',
     );
+    expect(S3ClientStub).to.have.been.calledOnceWith({ region: 'us-east-1' });
     expect(s3Client.send).to.have.been.calledTwice;
     expect(s3Client.send.firstCall.args[0].input.Bucket).to.equal('spacecat-dev-importer');
     expect(s3Client.send.secondCall.args[0].input.Bucket).to.equal('spacecat-dev-importer');
@@ -400,13 +405,9 @@ describe('agentic daily export', () => {
       execute: sandbox.stub().resolves(),
       query: sandbox.stub().resolves([]),
     };
-    const s3Client = {
-      send: sandbox.stub().resolves({}),
-    };
 
     await expect(module.runDailyAgenticExport({
       athenaClient,
-      s3Client,
       s3Config: {
         bucket: 'bucket',
         databaseName: 'db',
@@ -445,10 +446,14 @@ describe('agentic daily export', () => {
 
     expect(athenaClient.execute).to.not.have.been.called;
     expect(athenaClient.query).to.not.have.been.called;
-    expect(s3Client.send).to.not.have.been.called;
   });
 
   it('cleans up uploaded files when analytics dispatch fails', async () => {
+    const s3Client = {
+      send: sandbox.stub().resolves({}),
+    };
+    const S3ClientStub = sandbox.stub().returns(s3Client);
+
     const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js', {
       '../../../src/cdn-logs-report/utils/report-utils.js': {
         loadSql: sandbox.stub().resolves('CREATE DATABASE'),
@@ -485,21 +490,19 @@ describe('agentic daily export', () => {
           }],
         }),
       },
+      '@aws-sdk/client-s3': {
+        S3Client: S3ClientStub,
+      },
       uuid: {
         v4: () => 'batch-123',
       },
     });
-
-    const s3Client = {
-      send: sandbox.stub().resolves({}),
-    };
 
     await expect(module.runDailyAgenticExport({
       athenaClient: {
         execute: sandbox.stub().resolves(),
         query: sandbox.stub().resolves([]),
       },
-      s3Client,
       s3Config: {
         bucket: 'bucket',
         databaseName: 'db',
@@ -535,11 +538,20 @@ describe('agentic daily export', () => {
       referenceDate: new Date('2026-04-01T10:00:00Z'),
     })).to.be.rejectedWith('SQS unavailable');
 
+    expect(S3ClientStub).to.have.been.calledOnceWith({ region: 'us-east-1' });
     expect(s3Client.send).to.have.callCount(3);
     expect(s3Client.send.lastCall.args[0].constructor.name).to.equal('DeleteObjectsCommand');
   });
 
   it('cleans up uploaded files when an S3 upload fails', async () => {
+    const s3Client = {
+      send: sandbox.stub(),
+    };
+    s3Client.send.onCall(0).rejects(new Error('S3 upload failed'));
+    s3Client.send.onCall(1).resolves({});
+    s3Client.send.onCall(2).resolves({});
+    const S3ClientStub = sandbox.stub().returns(s3Client);
+
     const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js', {
       '../../../src/cdn-logs-report/utils/report-utils.js': {
         loadSql: sandbox.stub().resolves('CREATE DATABASE'),
@@ -576,24 +588,19 @@ describe('agentic daily export', () => {
           }],
         }),
       },
+      '@aws-sdk/client-s3': {
+        S3Client: S3ClientStub,
+      },
       uuid: {
         v4: () => 'batch-123',
       },
     });
-
-    const s3Client = {
-      send: sandbox.stub(),
-    };
-    s3Client.send.onCall(0).rejects(new Error('S3 upload failed'));
-    s3Client.send.onCall(1).resolves({});
-    s3Client.send.onCall(2).resolves({});
 
     await expect(module.runDailyAgenticExport({
       athenaClient: {
         execute: sandbox.stub().resolves(),
         query: sandbox.stub().resolves([]),
       },
-      s3Client,
       s3Config: {
         bucket: 'bucket',
         databaseName: 'db',
@@ -629,6 +636,7 @@ describe('agentic daily export', () => {
       referenceDate: new Date('2026-04-01T10:00:00Z'),
     })).to.be.rejectedWith('S3 upload failed');
 
+    expect(S3ClientStub).to.have.been.calledOnceWith({ region: 'us-east-1' });
     expect(s3Client.send).to.have.callCount(3);
     expect(s3Client.send.lastCall.args[0].constructor.name).to.equal('DeleteObjectsCommand');
   });
@@ -655,13 +663,9 @@ describe('agentic daily export', () => {
       execute: sandbox.stub().rejects(new Error('Athena unavailable')),
       query: sandbox.stub().resolves([]),
     };
-    const s3Client = {
-      send: sandbox.stub().resolves({}),
-    };
 
     await expect(module.runDailyAgenticExport({
       athenaClient,
-      s3Client,
       s3Config: {
         bucket: 'bucket',
         databaseName: 'db',
@@ -697,6 +701,5 @@ describe('agentic daily export', () => {
     })).to.be.rejectedWith('Athena unavailable');
 
     expect(athenaClient.query).to.not.have.been.called;
-    expect(s3Client.send).to.not.have.been.called;
   });
 });

--- a/test/audits/cdn-logs-report/referral-daily-export.test.js
+++ b/test/audits/cdn-logs-report/referral-daily-export.test.js
@@ -24,9 +24,15 @@ use(sinonChai);
 describe('referral daily export', function referralDailyExportTests() {
   this.timeout(10000);
   let sandbox;
+  // runDailyReferralExport now builds its own us-east-1 S3 client; tests assert on
+  // this shared mock, which the mocked S3Client constructor returns.
+  let s3ClientMock;
+  let S3ClientStub;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+    s3ClientMock = { send: sandbox.stub().resolves({}) };
+    S3ClientStub = sandbox.stub().callsFake(() => s3ClientMock);
   });
 
   afterEach(() => {
@@ -82,6 +88,9 @@ describe('referral daily export', function referralDailyExportTests() {
           ...queryBuilderOverrides,
         },
       },
+      '@aws-sdk/client-s3': {
+        S3Client: S3ClientStub,
+      },
     });
   }
 
@@ -104,7 +113,7 @@ describe('referral daily export', function referralDailyExportTests() {
         pageviews: 5,
       }]),
     };
-    const s3Client = { send: sandbox.stub().resolves({}) };
+    const s3Client = s3ClientMock;
     const context = makeContext();
     const site = makeSite();
 
@@ -128,6 +137,7 @@ describe('referral daily export', function referralDailyExportTests() {
       'cdn_db',
       '[Athena Query] referral_daily_flat_data',
     );
+    expect(S3ClientStub).to.have.been.calledOnceWith({ region: 'us-east-1' });
     expect(s3Client.send).to.have.been.calledOnce;
     expect(s3Client.send.firstCall.args[0].input.Bucket).to.equal('spacecat-importer-bucket');
     expect(s3Client.send.firstCall.args[0].input.Key).to.equal(
@@ -204,7 +214,7 @@ describe('referral daily export', function referralDailyExportTests() {
     const classifyStub = sandbox.stub().returns({ type: 'paid', category: 'search', vendor: 'google' });
     const module = await loadModule(classifyStub);
 
-    const s3Client = { send: sandbox.stub().resolves({}) };
+    const s3Client = s3ClientMock;
     const context = makeContext();
 
     const result = await module.runDailyReferralExport({
@@ -260,7 +270,7 @@ describe('referral daily export', function referralDailyExportTests() {
       date: '2026-03-31',
       region: 'US',
     };
-    const s3Client = { send: sandbox.stub().resolves({}) };
+    const s3Client = s3ClientMock;
 
     await module.runDailyReferralExport({
       athenaClient: {
@@ -289,7 +299,7 @@ describe('referral daily export', function referralDailyExportTests() {
     const classifyStub = sandbox.stub().returns({ type: 'earned', category: 'llm', vendor: 'claude' });
     const module = await loadModule(classifyStub);
 
-    const s3Client = { send: sandbox.stub().resolves({}) };
+    const s3Client = s3ClientMock;
 
     await module.runDailyReferralExport({
       athenaClient: {
@@ -323,7 +333,7 @@ describe('referral daily export', function referralDailyExportTests() {
     const classifyStub = sandbox.stub().returns({ type: 'earned', category: 'llm', vendor: 'chatgpt' });
     const module = await loadModule(classifyStub);
 
-    const s3Client = { send: sandbox.stub().resolves({}) };
+    const s3Client = s3ClientMock;
 
     await module.runDailyReferralExport({
       athenaClient: {
@@ -358,7 +368,7 @@ describe('referral daily export', function referralDailyExportTests() {
     const classifyStub = sandbox.stub().returns({ type: 'earned', category: 'llm', vendor: 'chatgpt' });
     const module = await loadModule(classifyStub);
 
-    const s3Client = { send: sandbox.stub().resolves({}) };
+    const s3Client = s3ClientMock;
 
     await module.runDailyReferralExport({
       athenaClient: {
@@ -423,7 +433,7 @@ describe('referral daily export', function referralDailyExportTests() {
 
   it('propagates Athena failures without touching S3', async () => {
     const module = await loadModule(sandbox.stub());
-    const s3Client = { send: sandbox.stub().resolves({}) };
+    const s3Client = s3ClientMock;
 
     await expect(module.runDailyReferralExport({
       athenaClient: {
@@ -444,7 +454,7 @@ describe('referral daily export', function referralDailyExportTests() {
   it('cleans up uploaded CSV when SQS dispatch fails', async () => {
     const classifyStub = sandbox.stub().returns({ type: 'earned', category: 'llm', vendor: 'chatgpt' });
     const module = await loadModule(classifyStub);
-    const s3Client = { send: sandbox.stub().resolves({}) };
+    const s3Client = s3ClientMock;
 
     await expect(module.runDailyReferralExport({
       athenaClient: {
@@ -478,7 +488,7 @@ describe('referral daily export', function referralDailyExportTests() {
   it('cleans up uploaded CSV when S3 upload itself fails', async () => {
     const classifyStub = sandbox.stub().returns({ type: 'earned', category: 'llm', vendor: 'chatgpt' });
     const module = await loadModule(classifyStub);
-    const s3Client = { send: sandbox.stub() };
+    const s3Client = s3ClientMock;
     s3Client.send.onCall(0).rejects(new Error('S3 upload failed'));
     s3Client.send.onCall(1).resolves({});
 
@@ -545,7 +555,7 @@ describe('referral daily export', function referralDailyExportTests() {
   it('handles null/missing optional row fields gracefully', async () => {
     const classifyStub = sandbox.stub().returns({ type: 'earned', category: 'llm', vendor: null });
     const module = await loadModule(classifyStub);
-    const s3Client = { send: sandbox.stub().resolves({}) };
+    const s3Client = s3ClientMock;
 
     await module.runDailyReferralExport({
       athenaClient: {
@@ -586,7 +596,7 @@ describe('referral daily export', function referralDailyExportTests() {
   it('includes actual referrer and UTM values in CSV output', async () => {
     const classifyStub = sandbox.stub().returns({ type: 'earned', category: 'llm', vendor: 'chatgpt' });
     const module = await loadModule(classifyStub);
-    const s3Client = { send: sandbox.stub().resolves({}) };
+    const s3Client = s3ClientMock;
 
     await module.runDailyReferralExport({
       athenaClient: {
@@ -623,7 +633,7 @@ describe('referral daily export', function referralDailyExportTests() {
   it('normalizes mixed-date rows to the same group key', async () => {
     const classifyStub = sandbox.stub().returns({ type: 'earned', category: 'llm', vendor: 'chatgpt' });
     const module = await loadModule(classifyStub);
-    const s3Client = { send: sandbox.stub().resolves({}) };
+    const s3Client = s3ClientMock;
 
     const sharedFields = {
       host: 'www.example.com',
@@ -663,7 +673,7 @@ describe('referral daily export', function referralDailyExportTests() {
     classifyStub.onCall(0).returns({ type: 'earned', category: 'llm', vendor: undefined });
     classifyStub.onCall(1).returns({ type: 'earned', category: 'llm', vendor: '' });
     const module = await loadModule(classifyStub);
-    const s3Client = { send: sandbox.stub().resolves({}) };
+    const s3Client = s3ClientMock;
 
     const sharedFields = {
       host: 'www.example.com',
@@ -701,7 +711,7 @@ describe('referral daily export', function referralDailyExportTests() {
   it('handles trailing slash in baseURL without producing a double-slash URL', async () => {
     const classifyStub = sandbox.stub().returns({ type: 'earned', category: 'llm', vendor: 'chatgpt' });
     const module = await loadModule(classifyStub);
-    const s3Client = { send: sandbox.stub().resolves({}) };
+    const s3Client = s3ClientMock;
 
     await module.runDailyReferralExport({
       athenaClient: {
@@ -769,7 +779,7 @@ describe('referral daily export', function referralDailyExportTests() {
     const classifyStub = sandbox.stub().returns({ type: 'earned', category: 'llm', vendor: 'chatgpt' });
     const module = await loadModule(classifyStub);
 
-    const s3Client = { send: sandbox.stub().resolves({}) };
+    const s3Client = s3ClientMock;
 
     await module.runDailyReferralExport({
       athenaClient: {

--- a/test/audits/cdn-logs-report/referral-daily-export.test.js
+++ b/test/audits/cdn-logs-report/referral-daily-export.test.js
@@ -24,8 +24,6 @@ use(sinonChai);
 describe('referral daily export', function referralDailyExportTests() {
   this.timeout(10000);
   let sandbox;
-  // runDailyReferralExport now builds its own us-east-1 S3 client; tests assert on
-  // this shared mock, which the mocked S3Client constructor returns.
   let s3ClientMock;
   let S3ClientStub;
 

--- a/test/audits/cdn-logs-report/utils/agentic-db-export.test.js
+++ b/test/audits/cdn-logs-report/utils/agentic-db-export.test.js
@@ -27,7 +27,6 @@ describe('agentic DB export orchestration', () => {
   function createArgs(overrides = {}) {
     return {
       athenaClient: {},
-      s3Client: {},
       s3Config: { databaseName: 'cdn_logs_example' },
       site: {
         getId: () => 'site-1',


### PR DESCRIPTION
## Problem

The daily **agentic** and **referral** exports were failing in production with:

> The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint. **PermanentRedirect** (HTTP 301)

Stack trace pointed at `uploadBundleToS3` → `runDailyAgenticExport`.

### Root cause

Both exports write their output (CSV bundle / referral CSV) to the **importer bucket** (`S3_IMPORTER_BUCKET_NAME`), which lives in **us-east-1**. But they reused the S3 client returned by `getCdnAwsRuntime`, which is regionalized to the **site's CDN bucket region** (`resolveSiteCdnRegion`):

```js
const s3Client = region === runtimeRegion ? context.s3Client : new S3Client({ region });
```

For any site whose configured CDN region is not `us-east-1`, the importer-bucket write hit the wrong regional endpoint and S3 returned `PermanentRedirect`, failing the export (e.g. site `69f318ca-bfd0-401a-a854-ca4619a7dacb`).

## Fix

Construct a dedicated `us-east-1` S3 client inside `runDailyAgenticExport` and `runDailyReferralExport` for the importer-bucket upload/cleanup, and drop the now-unused `s3Client` threading from the export call chain (`agentic-db-export.js`, `handler.js`). The Athena query path keeps using the site-region runtime — only the importer-bucket writes are pinned to `us-east-1`.

## Validation

- `agentic-daily-export.test.js`, `agentic-db-export.test.js`, `referral-daily-export.test.js`, `handler.test.js` — all green
- New assertions verify the S3 client is constructed with `{ region: 'us-east-1' }`
- 100% line/branch/statement coverage maintained on all changed source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)