### PR TITLE
refactor(cdn-logs-report): remove weekOffset fan-out, dedup importer S3 client; simplify cdn-config backfill

### DIFF
--- a/src/cdn-analysis/handler.js
+++ b/src/cdn-analysis/handler.js
@@ -33,6 +33,14 @@ import { wwwUrlResolver } from '../common/base-audit.js';
 
 const ONE_HOUR_MS = 60 * 60 * 1000;
 
+// cdn-logs-report dispatch knobs. The base delay gives the cdn-logs-analysis
+// sub-audits time to finish before the matching report runs; the per-day stagger
+// then spreads the reports out instead of firing them all at the SQS max at once.
+// Both are capped at the SQS DelaySeconds hard limit.
+const SQS_MAX_DELAY_SECONDS = 900;
+const CDN_LOGS_REPORT_DELAY_SECONDS = 800;
+const CDN_LOGS_REPORT_STAGGER_SECONDS = 30;
+
 const pad2 = (n) => String(n).padStart(2, '0');
 
 function isValidAuditContext(auditContext) {
@@ -203,11 +211,16 @@ async function triggerSubAudits(context, site, detectedDays) {
   }
 
   // One date-based cdn-logs-report per detected day. cdn-logs-report exports the
-  // day BEFORE auditContext.date, so send day + 1 as the reference. Delayed 900s
-  // so the analysis sub-audits above have time to finish first.
-  for (const dayKey of detectedDays) {
+  // day BEFORE auditContext.date, so send day + 1 as the reference. Delayed by a
+  // base wait (so the analysis sub-audits above have time to finish) plus a per-day
+  // stagger, capped at the SQS max, so the reports don't all fire at once.
+  for (const [index, dayKey] of [...detectedDays].entries()) {
     const [year, month, day] = dayKey.split('/').map(Number);
     const reportDate = new Date(Date.UTC(year, month - 1, day + 1)).toISOString();
+    const delaySeconds = Math.min(
+      CDN_LOGS_REPORT_DELAY_SECONDS + (index * CDN_LOGS_REPORT_STAGGER_SECONDS),
+      SQS_MAX_DELAY_SECONDS,
+    );
 
     // eslint-disable-next-line no-await-in-loop
     await sqs.sendMessage(auditQueue, {
@@ -216,8 +229,8 @@ async function triggerSubAudits(context, site, detectedDays) {
       auditContext: {
         date: reportDate,
       },
-    }, null, 900);
-    log.info(`Triggered cdn-logs-report for siteId=${siteId} date=${reportDate}`);
+    }, null, delaySeconds);
+    log.info(`Triggered cdn-logs-report for siteId=${siteId} date=${reportDate} delay=${delaySeconds}s`);
   }
 }
 

--- a/src/cdn-analysis/handler.js
+++ b/src/cdn-analysis/handler.js
@@ -28,7 +28,6 @@ import {
   shouldRecreateTable,
 } from '../utils/cdn-utils.js';
 import { getImsOrgId } from '../utils/data-access.js';
-import { computeWeekOffset } from '../utils/date-utils.js';
 import { getConfigCdnProvider } from '../utils/llmo-config-utils.js';
 import { wwwUrlResolver } from '../common/base-audit.js';
 
@@ -168,7 +167,7 @@ export async function findRecentUploads(s3Client, bucketName, pathId, auditDate,
 
 /**
  * Triggers cdn-logs-analysis sub-audits for each detected day, and one
- * cdn-logs-report per affected week (deduplicated by weekOffset).
+ * date-based cdn-logs-report per detected day.
  *
  * Sub-audits include isSubAudit: true to prevent recursive scanning,
  * and forceReprocess: true because the same day may already have partial
@@ -182,8 +181,6 @@ async function triggerSubAudits(context, site, detectedDays) {
   const configuration = await Configuration.findLatest();
   const auditQueue = configuration.getQueues().audits;
   const siteId = site.getId();
-
-  const weekOffsets = new Set();
 
   for (const dayKey of detectedDays) {
     const [year, month, day] = dayKey.split('/').map(Number);
@@ -203,21 +200,24 @@ async function triggerSubAudits(context, site, detectedDays) {
       },
     });
     log.info(`Triggered cdn-logs-analysis sub-audit for siteId=${siteId} day=${dayKey}`);
-
-    weekOffsets.add(computeWeekOffset(year, month, day));
   }
 
-  for (const weekOffset of weekOffsets) {
+  // One date-based cdn-logs-report per detected day. cdn-logs-report exports the
+  // day BEFORE auditContext.date, so send day + 1 as the reference. Delayed 900s
+  // so the analysis sub-audits above have time to finish first.
+  for (const dayKey of detectedDays) {
+    const [year, month, day] = dayKey.split('/').map(Number);
+    const reportDate = new Date(Date.UTC(year, month - 1, day + 1)).toISOString();
+
     // eslint-disable-next-line no-await-in-loop
     await sqs.sendMessage(auditQueue, {
       type: 'cdn-logs-report',
       siteId,
       auditContext: {
-        weekOffset,
-        triggeredBy: SERVICE_PROVIDER_TYPES.BYOCDN_OTHER,
+        date: reportDate,
       },
     }, null, 900);
-    log.info(`Triggered cdn-logs-report for siteId=${siteId} weekOffset=${weekOffset}`);
+    log.info(`Triggered cdn-logs-report for siteId=${siteId} date=${reportDate}`);
   }
 }
 

--- a/src/cdn-analysis/handler.js
+++ b/src/cdn-analysis/handler.js
@@ -214,7 +214,6 @@ async function triggerSubAudits(context, site, detectedDays) {
       siteId,
       auditContext: {
         weekOffset,
-        refreshAgenticDailyExport: true,
         triggeredBy: SERVICE_PROVIDER_TYPES.BYOCDN_OTHER,
       },
     }, null, 900);

--- a/src/cdn-logs-report/agentic-daily-export.js
+++ b/src/cdn-logs-report/agentic-daily-export.js
@@ -10,9 +10,9 @@
  * governing permissions and limitations under the License.
  */
 
-import { DeleteObjectsCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { DeleteObjectsCommand, PutObjectCommand } from '@aws-sdk/client-s3';
 import { v4 as uuidv4 } from 'uuid';
-import { loadSql, IMPORTER_BUCKET_REGION } from './utils/report-utils.js';
+import { loadSql, getImporterS3Client } from './utils/report-utils.js';
 import { weeklyBreakdownQueries } from './utils/query-builder.js';
 import { mapToAgenticTrafficBundle } from './utils/agentic-traffic-mapper.js';
 
@@ -260,7 +260,7 @@ export async function runDailyAgenticExport({
   const bundleUri = `s3://${bundleBucket}/${keyPrefix}`;
   const uploadedFiles = buildBundleFileKeys(keyPrefix);
   // Importer bucket is us-east-1, not the site's CDN region; reusing the CDN client 301s.
-  const s3Client = new S3Client({ region: IMPORTER_BUCKET_REGION });
+  const s3Client = getImporterS3Client();
   let dispatch;
 
   try {

--- a/src/cdn-logs-report/handler.js
+++ b/src/cdn-logs-report/handler.js
@@ -40,11 +40,10 @@ function resolvePatternWeekOffset(auditContext) {
 }
 
 /**
- * Weekly (non-daily) step: refresh the agentic URL classification rules and sync
- * them to the database. The weekly SharePoint .xlsx reports were retired once the
- * dashboards moved to PostgreSQL, so this is the only remaining weekly work.
- *
- * @returns {Promise<{ agenticReportHasData: boolean }>} whether agentic data was found
+ * Ensures the agentic URL classification rules exist in the database, generating
+ * them only when they're missing. Existing rules (which may include customer-added
+ * categories) are never overwritten. Runs on every audit invocation so a backfill
+ * for a brand-new site bootstraps its rules; established sites just read-and-skip.
  */
 async function generateAgenticPatterns({
   site,
@@ -59,13 +58,13 @@ async function generateAgenticPatterns({
 
   if (!agenticReportConfig) {
     log.info('No agentic report config found - skipping patterns generation');
-    return { agenticReportHasData: false };
+    return;
   }
 
   try {
     if (!(await pathHasData(s3Client, agenticReportConfig.aggregatedLocation))) {
       log.info('No agentic report data found - skipping patterns generation');
-      return { agenticReportHasData: false };
+      return;
     }
 
     // Pattern generation queries Athena, so ensure the database exists first.
@@ -95,13 +94,10 @@ async function generateAgenticPatterns({
         existingPatterns,
       });
     }
-
-    return { agenticReportHasData: true };
   } catch (error) {
     // Patterns generation is best-effort: a transient Athena/DB failure here must
     // not block the daily agentic/referral DB exports, which do not depend on it.
     log.error(`Agentic patterns generation failed for ${site.getId()}: ${error.message}`, error);
-    return { agenticReportHasData: false };
   }
 }
 
@@ -145,9 +141,6 @@ async function runReferralExport({
 
 async function runCdnLogsReport(url, context, site, auditContext) {
   const { log } = context;
-  const isDailyDateRun = Boolean(auditContext?.date);
-  const isWeeklyOnlyRun = auditContext?.weekOffset !== undefined
-    && auditContext?.weekOffset !== null;
 
   const awsRuntime = getCdnAwsRuntime(site, context);
   const { s3Client } = awsRuntime;
@@ -165,19 +158,16 @@ async function runCdnLogsReport(url, context, site, auditContext) {
   const agenticReportConfig = reportConfigs.find((config) => config.name === 'agentic');
   const referralReportConfig = reportConfigs.find((config) => config.name === 'referral');
 
-  // 1. Weekly step — refresh agentic classification rules in the DB (no SharePoint).
-  let agenticReportHasData = false;
-  if (!isDailyDateRun) {
-    ({ agenticReportHasData } = await generateAgenticPatterns({
-      site,
-      context,
-      s3Client,
-      athenaClient,
-      s3Config,
-      agenticReportConfig,
-      auditContext,
-    }));
-  }
+  // 1. Ensure agentic classification rules exist in the DB (generate only if missing).
+  await generateAgenticPatterns({
+    site,
+    context,
+    s3Client,
+    athenaClient,
+    s3Config,
+    agenticReportConfig,
+    auditContext,
+  });
 
   // 2. Daily agentic export — feeds PostgreSQL.
   const agenticDbExportResult = await runAgenticDbExports({
@@ -187,20 +177,17 @@ async function runCdnLogsReport(url, context, site, auditContext) {
     context,
     agenticReportConfig,
     auditContext,
-    agenticReportHasData,
   });
 
-  // 3. Daily referral export — feeds PostgreSQL (skipped on weekly-only runs).
-  const dailyReferralExport = !isWeeklyOnlyRun
-    ? await runReferralExport({
-      site,
-      context,
-      athenaClient,
-      s3Config,
-      referralReportConfig,
-      auditContext,
-    })
-    : undefined;
+  // 3. Daily referral export — feeds PostgreSQL.
+  const dailyReferralExport = await runReferralExport({
+    site,
+    context,
+    athenaClient,
+    s3Config,
+    referralReportConfig,
+    auditContext,
+  });
 
   // 4. Assemble the audit result from the DB export outcomes.
   const auditResult = [];

--- a/src/cdn-logs-report/referral-daily-export.js
+++ b/src/cdn-logs-report/referral-daily-export.js
@@ -12,10 +12,10 @@
 
 /* eslint-disable camelcase */
 import { createHash } from 'crypto';
-import { DeleteObjectCommand, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { DeleteObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
 import { classifyTrafficSource } from '@adobe/spacecat-shared-rum-api-client/src/common/traffic.js';
 import { joinBaseAndPath } from '../utils/url-utils.js';
-import { loadSql, IMPORTER_BUCKET_REGION } from './utils/report-utils.js';
+import { loadSql, getImporterS3Client } from './utils/report-utils.js';
 import { weeklyBreakdownQueries } from './utils/query-builder.js';
 
 const CDN_REFERRAL_CSV_COLUMNS = [
@@ -215,7 +215,7 @@ export async function runDailyReferralExport({
 
   const messageGroupId = `referral_traffic_cdn:${siteId}`;
   // Importer bucket is us-east-1, not the site's CDN region; reusing the CDN client 301s.
-  const s3Client = new S3Client({ region: IMPORTER_BUCKET_REGION });
+  const s3Client = getImporterS3Client();
 
   try {
     await s3Client.send(new PutObjectCommand({

--- a/src/cdn-logs-report/utils/agentic-db-export.js
+++ b/src/cdn-logs-report/utils/agentic-db-export.js
@@ -11,61 +11,12 @@
  */
 
 import { runDailyAgenticExport } from '../agentic-daily-export.js';
-import { generateReportingPeriods } from './report-utils.js';
-import { SERVICE_PROVIDER_TYPES } from '../../utils/cdn-utils.js';
 
-const DAILY_EXPORT_MESSAGE_DELAY_SECONDS = 5;
-const ALLOWED_TRIGGERED_BY = new Set(Object.values(SERVICE_PROVIDER_TYPES));
-
-function hasWeekOffset(auditContext) {
-  return auditContext?.weekOffset !== undefined && auditContext?.weekOffset !== null;
-}
-
-function getSafeTriggeredBy(triggeredBy) {
-  return ALLOWED_TRIGGERED_BY.has(triggeredBy) ? triggeredBy : undefined;
-}
-
-function getAgenticDbExportReferenceDatesForWeek(weekOffset, referenceDate = new Date()) {
-  const { weeks } = generateReportingPeriods(referenceDate, weekOffset);
-  const weekStart = weeks[0]?.startDate;
-  if (!weekStart) {
-    return [];
-  }
-
-  // runDailyAgenticExport exports the previous UTC day, so each target
-  // traffic day uses the following midnight as its reference date.
-  const latestCompletedReferenceDate = new Date(Date.UTC(
-    referenceDate.getUTCFullYear(),
-    referenceDate.getUTCMonth(),
-    referenceDate.getUTCDate(),
-  ));
-  return Array.from({ length: 7 }, (_, index) => new Date(Date.UTC(
-    weekStart.getUTCFullYear(),
-    weekStart.getUTCMonth(),
-    weekStart.getUTCDate() + index + 1,
-  ))).filter((date) => date <= latestCompletedReferenceDate);
-}
-
-function shouldRefreshWeeklyAgenticDbExports(auditContext) {
-  // Keep Agentic DB refreshes behind one explicit signal.
-  return hasWeekOffset(auditContext)
-    && Boolean(auditContext?.refreshAgenticDailyExport);
-}
-
-function getFailureResult({
-  siteId,
-  error,
-  queued = false,
-}) {
-  return {
-    enabled: true,
-    success: false,
-    queued,
-    siteId,
-    error,
-  };
-}
-
+/**
+ * Resolves the reference date for the daily export from auditContext.date.
+ * Returns undefined (so the export defaults to "yesterday") when no valid date
+ * is provided.
+ */
 function getDateBasedReferenceDate(auditContext, siteId, context) {
   if (!auditContext?.date) {
     return undefined;
@@ -80,6 +31,10 @@ function getDateBasedReferenceDate(auditContext, siteId, context) {
   return referenceDate;
 }
 
+/**
+ * Runs the daily agentic DB export for a single reference date, returning a
+ * failure marker instead of throwing so it never blocks the rest of the audit.
+ */
 async function runAgenticDbExportForReferenceDate({
   athenaClient,
   s3Config,
@@ -109,7 +64,12 @@ async function runAgenticDbExportForReferenceDate({
   }
 }
 
-async function runDateBasedAgenticDbExport({
+/**
+ * Exports the agentic traffic for a single UTC day to PostgreSQL. The day is
+ * `auditContext.date - 1` for a date-based (backfill) run, or yesterday for a
+ * normal scheduled run.
+ */
+export async function runAgenticDbExports({
   athenaClient,
   s3Config,
   site,
@@ -118,8 +78,12 @@ async function runDateBasedAgenticDbExport({
   auditContext,
 }) {
   const siteId = site.getId();
-  const referenceDate = getDateBasedReferenceDate(auditContext, siteId, context);
+  if (!agenticReportConfig) {
+    context.log.debug(`Skipping agentic DB export for ${siteId}: agentic report config not found`);
+    return {};
+  }
 
+  const referenceDate = getDateBasedReferenceDate(auditContext, siteId, context);
   return {
     dailyAgenticExport: await runAgenticDbExportForReferenceDate({
       athenaClient,
@@ -130,164 +94,4 @@ async function runDateBasedAgenticDbExport({
       ...(referenceDate ? { referenceDate } : {}),
     }),
   };
-}
-
-async function queueDailyAgenticDbExport({
-  auditQueue,
-  siteId,
-  context,
-  auditContext,
-  referenceDate,
-  delaySeconds,
-}) {
-  try {
-    await context.sqs.sendMessage(auditQueue, {
-      type: 'cdn-logs-report',
-      siteId,
-      auditContext: {
-        date: referenceDate.toISOString(),
-        refreshAgenticDailyExport: true,
-        ...(auditContext.triggeredBy ? { triggeredBy: auditContext.triggeredBy } : {}),
-        sourceWeekOffset: auditContext.weekOffset,
-      },
-    }, null, delaySeconds);
-
-    return {
-      enabled: true,
-      success: true,
-      queued: true,
-      siteId,
-      referenceDate: referenceDate.toISOString(),
-      delaySeconds,
-    };
-  } catch (error) {
-    context.log.error(`Failed to queue daily agentic DB export for site ${siteId}: ${error.message}`, error);
-    return {
-      enabled: true,
-      success: false,
-      queued: false,
-      siteId,
-      referenceDate: referenceDate.toISOString(),
-      delaySeconds,
-      error: error.message,
-    };
-  }
-}
-
-async function resolveAuditQueue(context, siteId) {
-  const { Configuration } = context.dataAccess;
-  try {
-    const configuration = await Configuration.findLatest();
-    const auditQueue = configuration?.getQueues?.()?.audits;
-    if (!auditQueue) {
-      const error = 'Audit queue not configured';
-      context.log.error(`${error} for site ${siteId}; skipping weekly DB export queueing`);
-      return {
-        failure: getFailureResult({ siteId, error }),
-      };
-    }
-
-    return { auditQueue };
-  } catch (error) {
-    context.log.error(`Failed to resolve audit queue for site ${siteId}: ${error.message}`, error);
-    return {
-      failure: getFailureResult({ siteId, error: error.message }),
-    };
-  }
-}
-
-async function queueWeeklyAgenticDbExports({
-  site,
-  context,
-  auditContext,
-}) {
-  const siteId = site.getId();
-  const dailyAgenticExports = [];
-  const referenceDates = getAgenticDbExportReferenceDatesForWeek(
-    auditContext.weekOffset,
-  );
-  if (referenceDates.length === 0) {
-    return {
-      dailyAgenticExport: null,
-      dailyAgenticExports,
-    };
-  }
-
-  const { auditQueue, failure } = await resolveAuditQueue(context, siteId);
-  if (failure) {
-    return {
-      dailyAgenticExport: failure,
-      dailyAgenticExports,
-    };
-  }
-
-  const triggeredBy = getSafeTriggeredBy(auditContext.triggeredBy);
-  const exportAuditContext = { ...auditContext, triggeredBy };
-
-  context.log.info(`Queueing weekly agentic DB exports for ${siteId}: weekOffset=${auditContext.weekOffset}, trigger=${triggeredBy || 'refreshAgenticDailyExport'}, days=${referenceDates.length}`);
-  for (const [index, referenceDate] of referenceDates.entries()) {
-    // Keep queueing sequential and lightly staggered so the weekly report Lambda
-    // only coordinates per-day work instead of owning all seven exports.
-    // eslint-disable-next-line no-await-in-loop
-    dailyAgenticExports.push(await queueDailyAgenticDbExport({
-      auditQueue,
-      siteId,
-      context,
-      auditContext: exportAuditContext,
-      referenceDate,
-      delaySeconds: index * DAILY_EXPORT_MESSAGE_DELAY_SECONDS,
-    }));
-  }
-
-  const failedExports = dailyAgenticExports.filter((result) => result && result.success === false);
-  if (failedExports.length > 0) {
-    context.log.warn(`Partial agentic DB export queueing failure for ${siteId}: ${failedExports.length}/${dailyAgenticExports.length} days failed`);
-  }
-
-  return {
-    dailyAgenticExport: dailyAgenticExports.at(-1),
-    dailyAgenticExports,
-  };
-}
-
-export async function runAgenticDbExports({
-  athenaClient,
-  s3Config,
-  site,
-  context,
-  agenticReportConfig,
-  auditContext,
-  agenticReportHasData,
-}) {
-  const siteId = site.getId();
-  if (!agenticReportConfig) {
-    context.log.debug(`Skipping agentic DB export for ${siteId}: agentic report config not found`);
-    return {};
-  }
-
-  if (!hasWeekOffset(auditContext)) {
-    return runDateBasedAgenticDbExport({
-      athenaClient,
-      s3Config,
-      site,
-      context,
-      agenticReportConfig,
-      auditContext,
-    });
-  }
-
-  if (!shouldRefreshWeeklyAgenticDbExports(auditContext)) {
-    return {};
-  }
-
-  if (!agenticReportHasData) {
-    context.log.info(`Skipping weekly agentic DB exports for ${siteId}: no agentic report data found`);
-    return {};
-  }
-
-  return queueWeeklyAgenticDbExports({
-    site,
-    context,
-    auditContext,
-  });
 }

--- a/src/cdn-logs-report/utils/report-utils.js
+++ b/src/cdn-logs-report/utils/report-utils.js
@@ -10,10 +10,24 @@
  * governing permissions and limitations under the License.
  */
 
+import { S3Client } from '@aws-sdk/client-s3';
 import { getStaticContent, isoCalendarWeek } from '@adobe/spacecat-shared-utils';
 
 // Region of the importer bucket (S3_IMPORTER_BUCKET_NAME) the daily exports write to.
 export const IMPORTER_BUCKET_REGION = 'us-east-1';
+
+let importerS3Client;
+/**
+ * Lazily-created, shared S3 client pinned to the importer bucket region. Reused
+ * across the agentic + referral daily exports and across warm Lambda invocations,
+ * instead of constructing a new client per export.
+ */
+export function getImporterS3Client() {
+  if (!importerS3Client) {
+    importerS3Client = new S3Client({ region: IMPORTER_BUCKET_REGION });
+  }
+  return importerS3Client;
+}
 
 const ISO_3166_ALPHA2_COUNTRY_CODES = new Set([
   'AD', 'AE', 'AF', 'AG', 'AI', 'AL', 'AM', 'AO', 'AQ', 'AR', 'AS', 'AT', 'AU', 'AW', 'AX', 'AZ',

--- a/src/llmo-customer-analysis/cdn-config-handler.js
+++ b/src/llmo-customer-analysis/cdn-config-handler.js
@@ -17,7 +17,7 @@ import { getImsOrgId } from '../utils/data-access.js';
 import { SERVICE_PROVIDER_TYPES } from '../utils/cdn-utils.js';
 
 const SQS_MAX_DELAY_SECONDS = 900;
-const CDN_LOGS_ANALYSIS_DELAY_SECONDS = 5;
+const CDN_LOGS_ANALYSIS_DELAY_SECONDS = 30;
 // Base wait so cdn-logs-report fires after cdn-logs-analysis has had time to
 // complete. Kept under SQS_MAX_DELAY_SECONDS so per-day staggering can still
 // add headroom without exceeding the SQS DelaySeconds hard limit.

--- a/src/llmo-customer-analysis/cdn-config-handler.js
+++ b/src/llmo-customer-analysis/cdn-config-handler.js
@@ -143,7 +143,6 @@ async function handleAdobeFastly(
     siteId,
     auditContext: {
       date: backfillDay.reportDate,
-      refreshAgenticDailyExport: true,
     },
   }, null, Math.min(
     CDN_LOGS_REPORT_DELAY_SECONDS + (index * CDN_LOGS_ANALYSIS_DELAY_SECONDS),

--- a/src/llmo-customer-analysis/cdn-config-handler.js
+++ b/src/llmo-customer-analysis/cdn-config-handler.js
@@ -134,13 +134,10 @@ async function handleAdobeFastly(
     await Promise.all(analysisPromises);
   }
 
-  // Always queue CDN logs report with delay
-  await sqs.sendMessage(auditQueue, {
-    type: 'cdn-logs-report',
-    siteId,
-    auditContext: { weekOffset: -1 },
-  }, null, CDN_LOGS_REPORT_DELAY_SECONDS);
-
+  // Queue the per-day cdn-logs-report DB imports, delayed (base wait + per-day
+  // stagger) so they fire after cdn-logs-analysis has had time to complete. The
+  // first day-run also generates the agentic classification rules if missing, so
+  // no separate weekly trigger is needed.
   const reportPromises = backfillDays.map((backfillDay, index) => sqs.sendMessage(auditQueue, {
     type: 'cdn-logs-report',
     siteId,

--- a/test/audits/cdn-analysis/handler.test.js
+++ b/test/audits/cdn-analysis/handler.test.js
@@ -576,7 +576,6 @@ describe('CDN Analysis Handler', () => {
         .find((call) => call.args[1].type === 'cdn-logs-report');
       expect(reportCall.args[1].auditContext).to.deep.equal({
         weekOffset: computeWeekOffset(2025, 6, 14),
-        refreshAgenticDailyExport: true,
         triggeredBy: 'byocdn-other',
       });
     });

--- a/test/audits/cdn-analysis/handler.test.js
+++ b/test/audits/cdn-analysis/handler.test.js
@@ -572,12 +572,15 @@ describe('CDN Analysis Handler', () => {
         900,
       );
 
-      const reportCall = context.sqs.sendMessage.getCalls()
-        .find((call) => call.args[1].type === 'cdn-logs-report');
-      expect(reportCall.args[1].auditContext).to.deep.equal({
-        weekOffset: computeWeekOffset(2025, 6, 14),
-        triggeredBy: 'byocdn-other',
-      });
+      // One date-based report per detected day (06/14, 06/15), sent as day + 1.
+      const reportCalls = context.sqs.sendMessage.getCalls()
+        .filter((call) => call.args[1].type === 'cdn-logs-report');
+      expect(reportCalls).to.have.length(2);
+      expect(reportCalls.map((c) => c.args[1].auditContext.date)).to.have.members([
+        '2025-06-15T00:00:00.000Z',
+        '2025-06-16T00:00:00.000Z',
+      ]);
+      reportCalls.forEach((c) => expect(c.args[1].auditContext).to.have.all.keys('date'));
     });
 
     it('byocdn-other sub-audit processes logs normally without scanning', async () => {
@@ -1039,7 +1042,7 @@ describe('CDN Analysis Handler', () => {
       );
     });
 
-    it('deduplicates cdn-logs-report triggers by week', async () => {
+    it('sends one date-based cdn-logs-report per detected day', async () => {
       const auditContext = {
         year: 2025, month: 6, day: 15, hour: 23,
       };
@@ -1078,7 +1081,13 @@ describe('CDN Analysis Handler', () => {
         .filter((c) => c.args[1]?.type === 'cdn-logs-report');
 
       expect(analysisCalls).to.have.length(3);
-      expect(reportCalls.length).to.be.lessThanOrEqual(analysisCalls.length);
+      // No week dedup: one date-based report per detected day (day + 1 reference).
+      expect(reportCalls).to.have.length(3);
+      expect(reportCalls.map((c) => c.args[1].auditContext.date)).to.have.members([
+        '2025-06-10T00:00:00.000Z',
+        '2025-06-11T00:00:00.000Z',
+        '2025-06-12T00:00:00.000Z',
+      ]);
     });
 
     it('should skip provider when no raw data exists', async () => {

--- a/test/audits/cdn-analysis/handler.test.js
+++ b/test/audits/cdn-analysis/handler.test.js
@@ -565,22 +565,21 @@ describe('CDN Analysis Handler', () => {
         }),
       );
 
-      expect(context.sqs.sendMessage).to.have.been.calledWith(
-        'test-audit-queue',
-        sinon.match({ type: 'cdn-logs-report' }),
-        null,
-        900,
-      );
-
-      // One date-based report per detected day (06/14, 06/15), sent as day + 1.
+      // One date-based report per detected day (06/14, 06/15), sent as day + 1,
+      // with a staggered delay: base 800 + index * 30, capped at the SQS max (900).
       const reportCalls = context.sqs.sendMessage.getCalls()
         .filter((call) => call.args[1].type === 'cdn-logs-report');
       expect(reportCalls).to.have.length(2);
-      expect(reportCalls.map((c) => c.args[1].auditContext.date)).to.have.members([
+      expect(reportCalls.map((c) => c.args[1].auditContext.date)).to.deep.equal([
         '2025-06-15T00:00:00.000Z',
         '2025-06-16T00:00:00.000Z',
       ]);
-      reportCalls.forEach((c) => expect(c.args[1].auditContext).to.have.all.keys('date'));
+      expect(reportCalls.map((c) => c.args[3])).to.deep.equal([800, 830]);
+      reportCalls.forEach((c) => {
+        expect(c.args[0]).to.equal('test-audit-queue');
+        expect(c.args[2]).to.equal(null);
+        expect(c.args[1].auditContext).to.have.all.keys('date');
+      });
     });
 
     it('byocdn-other sub-audit processes logs normally without scanning', async () => {
@@ -1088,6 +1087,8 @@ describe('CDN Analysis Handler', () => {
         '2025-06-11T00:00:00.000Z',
         '2025-06-12T00:00:00.000Z',
       ]);
+      // Staggered delays: base 800 + index * 30.
+      expect(reportCalls.map((c) => c.args[3])).to.deep.equal([800, 830, 860]);
     });
 
     it('should skip provider when no raw data exists', async () => {

--- a/test/audits/cdn-logs-report/agentic-daily-export.test.js
+++ b/test/audits/cdn-logs-report/agentic-daily-export.test.js
@@ -74,19 +74,16 @@ describe('agentic daily export', () => {
     const s3Client = {
       send: sandbox.stub().resolves({}),
     };
-    const S3ClientStub = sandbox.stub().returns(s3Client);
 
     const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js', {
       '../../../src/cdn-logs-report/utils/report-utils.js': {
         loadSql: sandbox.stub().resolves('CREATE DATABASE IF NOT EXISTS test_db'),
+        getImporterS3Client: () => s3Client,
       },
       '../../../src/cdn-logs-report/utils/query-builder.js': {
         weeklyBreakdownQueries: queryBuilder,
       },
       '../../../src/cdn-logs-report/utils/agentic-traffic-mapper.js': mapper,
-      '@aws-sdk/client-s3': {
-        S3Client: S3ClientStub,
-      },
       uuid: {
         v4: () => 'batch-123',
       },
@@ -143,7 +140,6 @@ describe('agentic daily export', () => {
       'cdn_logs_example',
       '[Athena Query] agentic_daily_flat_data',
     );
-    expect(S3ClientStub).to.have.been.calledOnceWith({ region: 'us-east-1' });
     expect(s3Client.send).to.have.been.calledTwice;
     expect(s3Client.send.firstCall.args[0].input.Bucket).to.equal('spacecat-dev-importer');
     expect(s3Client.send.secondCall.args[0].input.Bucket).to.equal('spacecat-dev-importer');
@@ -384,10 +380,11 @@ describe('agentic daily export', () => {
   });
 
   it('fails before Athena or S3 work when the analytics queue is missing', async () => {
-    const S3ClientStub = sandbox.stub().returns({ send: sandbox.stub().resolves({}) });
+    const getImporterS3ClientStub = sandbox.stub().returns({ send: sandbox.stub().resolves({}) });
     const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js', {
       '../../../src/cdn-logs-report/utils/report-utils.js': {
         loadSql: sandbox.stub().resolves('CREATE DATABASE'),
+        getImporterS3Client: getImporterS3ClientStub,
       },
       '../../../src/cdn-logs-report/utils/query-builder.js': {
         weeklyBreakdownQueries: {
@@ -399,9 +396,6 @@ describe('agentic daily export', () => {
           trafficRows: [],
           classificationRows: [],
         }),
-      },
-      '@aws-sdk/client-s3': {
-        S3Client: S3ClientStub,
       },
     });
 
@@ -450,18 +444,18 @@ describe('agentic daily export', () => {
 
     expect(athenaClient.execute).to.not.have.been.called;
     expect(athenaClient.query).to.not.have.been.called;
-    expect(S3ClientStub).to.not.have.been.called;
+    expect(getImporterS3ClientStub).to.not.have.been.called;
   });
 
   it('cleans up uploaded files when analytics dispatch fails', async () => {
     const s3Client = {
       send: sandbox.stub().resolves({}),
     };
-    const S3ClientStub = sandbox.stub().returns(s3Client);
 
     const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js', {
       '../../../src/cdn-logs-report/utils/report-utils.js': {
         loadSql: sandbox.stub().resolves('CREATE DATABASE'),
+        getImporterS3Client: () => s3Client,
       },
       '../../../src/cdn-logs-report/utils/query-builder.js': {
         weeklyBreakdownQueries: {
@@ -494,9 +488,6 @@ describe('agentic daily export', () => {
             updated_by: 'audit-worker:agentic-daily-export',
           }],
         }),
-      },
-      '@aws-sdk/client-s3': {
-        S3Client: S3ClientStub,
       },
       uuid: {
         v4: () => 'batch-123',
@@ -543,7 +534,6 @@ describe('agentic daily export', () => {
       referenceDate: new Date('2026-04-01T10:00:00Z'),
     })).to.be.rejectedWith('SQS unavailable');
 
-    expect(S3ClientStub).to.have.been.calledOnceWith({ region: 'us-east-1' });
     expect(s3Client.send).to.have.callCount(3);
     expect(s3Client.send.lastCall.args[0].constructor.name).to.equal('DeleteObjectsCommand');
   });
@@ -555,11 +545,11 @@ describe('agentic daily export', () => {
     s3Client.send.onCall(0).rejects(new Error('S3 upload failed'));
     s3Client.send.onCall(1).resolves({});
     s3Client.send.onCall(2).resolves({});
-    const S3ClientStub = sandbox.stub().returns(s3Client);
 
     const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js', {
       '../../../src/cdn-logs-report/utils/report-utils.js': {
         loadSql: sandbox.stub().resolves('CREATE DATABASE'),
+        getImporterS3Client: () => s3Client,
       },
       '../../../src/cdn-logs-report/utils/query-builder.js': {
         weeklyBreakdownQueries: {
@@ -592,9 +582,6 @@ describe('agentic daily export', () => {
             updated_by: 'audit-worker:agentic-daily-export',
           }],
         }),
-      },
-      '@aws-sdk/client-s3': {
-        S3Client: S3ClientStub,
       },
       uuid: {
         v4: () => 'batch-123',
@@ -641,16 +628,16 @@ describe('agentic daily export', () => {
       referenceDate: new Date('2026-04-01T10:00:00Z'),
     })).to.be.rejectedWith('S3 upload failed');
 
-    expect(S3ClientStub).to.have.been.calledOnceWith({ region: 'us-east-1' });
     expect(s3Client.send).to.have.callCount(3);
     expect(s3Client.send.lastCall.args[0].constructor.name).to.equal('DeleteObjectsCommand');
   });
 
   it('propagates Athena database setup failures without touching S3', async () => {
-    const S3ClientStub = sandbox.stub().returns({ send: sandbox.stub().resolves({}) });
+    const getImporterS3ClientStub = sandbox.stub().returns({ send: sandbox.stub().resolves({}) });
     const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js', {
       '../../../src/cdn-logs-report/utils/report-utils.js': {
         loadSql: sandbox.stub().resolves('CREATE DATABASE'),
+        getImporterS3Client: getImporterS3ClientStub,
       },
       '../../../src/cdn-logs-report/utils/query-builder.js': {
         weeklyBreakdownQueries: {
@@ -662,9 +649,6 @@ describe('agentic daily export', () => {
           trafficRows: [],
           classificationRows: [],
         }),
-      },
-      '@aws-sdk/client-s3': {
-        S3Client: S3ClientStub,
       },
     });
 
@@ -710,6 +694,6 @@ describe('agentic daily export', () => {
     })).to.be.rejectedWith('Athena unavailable');
 
     expect(athenaClient.query).to.not.have.been.called;
-    expect(S3ClientStub).to.not.have.been.called;
+    expect(getImporterS3ClientStub).to.not.have.been.called;
   });
 });

--- a/test/audits/cdn-logs-report/handler.test.js
+++ b/test/audits/cdn-logs-report/handler.test.js
@@ -164,7 +164,6 @@ describe('CDN Logs Report Handler', function test() {
 
       // Both daily exports ran.
       expect(mocks.runAgenticDbExports).to.have.been.calledOnce;
-      expect(mocks.runAgenticDbExports.firstCall.args[0].agenticReportHasData).to.equal(true);
       expect(mocks.runDailyReferralExport).to.have.been.calledOnce;
 
       expect(context.log.debug).to.have.been.calledWith('Starting CDN logs report audit for https://example.com');
@@ -262,7 +261,6 @@ describe('CDN Logs Report Handler', function test() {
       expect(athenaClient.execute).to.not.have.been.called;
       expect(mocks.generatePatternsWorkbook).to.not.have.been.called;
       expect(context.log.info).to.have.been.calledWith('No agentic report config found - skipping patterns generation');
-      expect(mocks.runAgenticDbExports.firstCall.args[0].agenticReportHasData).to.equal(false);
     });
 
     it('contains patterns failures so the daily exports still run', async () => {
@@ -276,7 +274,7 @@ describe('CDN Logs Report Handler', function test() {
         sinon.match.instanceOf(Error),
       );
       // patterns failure is swallowed → daily exports still run
-      expect(mocks.runAgenticDbExports.firstCall.args[0].agenticReportHasData).to.equal(false);
+      expect(mocks.runAgenticDbExports).to.have.been.calledOnce;
       expect(mocks.runDailyReferralExport).to.have.been.calledOnce;
       expect(result.auditResult).to.deep.equal([
         { name: 'agentic-db-export', batchId: 'agentic-batch' },
@@ -294,13 +292,22 @@ describe('CDN Logs Report Handler', function test() {
       expect(context.log.info).to.have.been.calledWith('No agentic report data found - skipping patterns generation');
     });
 
-    it('skips the weekly step on date-based (daily) runs', async () => {
+    it('runs the rules step on date-based (backfill) runs too, but does not regenerate when rules exist', async () => {
       await runAudit({ date: '2026-04-01T10:00:00Z' });
 
-      expect(mocks.fetchAgenticUrlClassificationRules).to.not.have.been.called;
+      // Patterns step runs on every invocation now (generate-if-missing)...
+      expect(mocks.pathHasData).to.have.been.calledOnce;
+      expect(mocks.fetchAgenticUrlClassificationRules).to.have.been.calledOnce;
+      // ...but existing rules are never overwritten.
       expect(mocks.generatePatternsWorkbook).to.not.have.been.called;
-      expect(mocks.pathHasData).to.not.have.been.called;
-      expect(mocks.runAgenticDbExports.firstCall.args[0].agenticReportHasData).to.equal(false);
+    });
+
+    it('generates rules on a backfill run when none exist yet', async () => {
+      mocks.fetchAgenticUrlClassificationRules = sandbox.stub().resolves({ pagePatterns: [], topicPatterns: [] });
+
+      await runAudit({ date: '2026-04-01T10:00:00Z' });
+
+      expect(mocks.generatePatternsWorkbook).to.have.been.calledOnce;
     });
   });
 
@@ -312,11 +319,15 @@ describe('CDN Logs Report Handler', function test() {
         .to.equal('2026-04-01T10:00:00.000Z');
     });
 
-    it('skips the referral export on weekly-only runs', async () => {
+    it('runs the referral export on weekOffset runs (no longer gated)', async () => {
       const result = await runAudit({ weekOffset: -2 });
 
-      expect(mocks.runDailyReferralExport).to.not.have.been.called;
-      expect(result.dailyReferralExport).to.equal(undefined);
+      expect(mocks.runDailyReferralExport).to.have.been.calledOnce;
+      expect(result.dailyReferralExport).to.deep.equal({
+        enabled: true,
+        success: true,
+        batchId: 'referral-batch',
+      });
     });
 
     it('runs the referral export on categories-update runs (no longer gated)', async () => {

--- a/test/audits/cdn-logs-report/referral-daily-export.test.js
+++ b/test/audits/cdn-logs-report/referral-daily-export.test.js
@@ -25,12 +25,10 @@ describe('referral daily export', function referralDailyExportTests() {
   this.timeout(10000);
   let sandbox;
   let s3ClientMock;
-  let S3ClientStub;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     s3ClientMock = { send: sandbox.stub().resolves({}) };
-    S3ClientStub = sandbox.stub().callsFake(() => s3ClientMock);
   });
 
   afterEach(() => {
@@ -78,6 +76,7 @@ describe('referral daily export', function referralDailyExportTests() {
       },
       '../../../src/cdn-logs-report/utils/report-utils.js': {
         loadSql: sandbox.stub().resolves('CREATE DATABASE IF NOT EXISTS db'),
+        getImporterS3Client: () => s3ClientMock,
         ...reportUtilsOverrides,
       },
       '../../../src/cdn-logs-report/utils/query-builder.js': {
@@ -85,9 +84,6 @@ describe('referral daily export', function referralDailyExportTests() {
           createReferralDailyReportQuery: sandbox.stub().resolves('SELECT * FROM daily_referral'),
           ...queryBuilderOverrides,
         },
-      },
-      '@aws-sdk/client-s3': {
-        S3Client: S3ClientStub,
       },
     });
   }
@@ -135,7 +131,6 @@ describe('referral daily export', function referralDailyExportTests() {
       'cdn_db',
       '[Athena Query] referral_daily_flat_data',
     );
-    expect(S3ClientStub).to.have.been.calledOnceWith({ region: 'us-east-1' });
     expect(s3Client.send).to.have.been.calledOnce;
     expect(s3Client.send.firstCall.args[0].input.Bucket).to.equal('spacecat-importer-bucket');
     expect(s3Client.send.firstCall.args[0].input.Key).to.equal(

--- a/test/audits/cdn-logs-report/report-utils.test.js
+++ b/test/audits/cdn-logs-report/report-utils.test.js
@@ -407,4 +407,12 @@ describe('CDN Logs Report Utils', () => {
       );
     });
   });
+
+  describe('getImporterS3Client', () => {
+    it('lazily creates and caches a single importer S3 client', () => {
+      const first = reportUtils.getImporterS3Client();
+      const second = reportUtils.getImporterS3Client();
+      expect(first).to.equal(second);
+    });
+  });
 });

--- a/test/audits/cdn-logs-report/utils/agentic-db-export.test.js
+++ b/test/audits/cdn-logs-report/utils/agentic-db-export.test.js
@@ -21,7 +21,6 @@ describe('agentic DB export orchestration', () => {
   let sandbox;
   let clock;
   let runDailyAgenticExportStub;
-  let generateReportingPeriodsStub;
   let module;
 
   function createArgs(overrides = {}) {
@@ -38,23 +37,12 @@ describe('agentic DB export orchestration', () => {
           warn: sandbox.spy(),
           error: sandbox.spy(),
         },
-        dataAccess: {
-          Configuration: {
-            findLatest: sandbox.stub().resolves({
-              getQueues: () => ({ audits: 'https://sqs.us-east-1.amazonaws.com/123/audits-queue' }),
-            }),
-          },
-        },
-        sqs: {
-          sendMessage: sandbox.stub().resolves(),
-        },
       },
       agenticReportConfig: {
         name: 'agentic',
         tableName: 'aggregated_logs_example_consolidated',
       },
       auditContext: {},
-      agenticReportHasData: true,
       ...overrides,
     };
   }
@@ -70,19 +58,9 @@ describe('agentic DB export orchestration', () => {
       success: true,
       trafficDate: '2026-04-29',
     });
-    generateReportingPeriodsStub = sandbox.stub().returns({
-      weeks: [{
-        startDate: new Date('2026-03-30T00:00:00.000Z'),
-        endDate: new Date('2026-04-05T23:59:59.999Z'),
-      }],
-      periodIdentifier: 'w14-2026',
-    });
     module = await esmock('../../../../src/cdn-logs-report/utils/agentic-db-export.js', {
       '../../../../src/cdn-logs-report/agentic-daily-export.js': {
         runDailyAgenticExport: runDailyAgenticExportStub,
-      },
-      '../../../../src/cdn-logs-report/utils/report-utils.js': {
-        generateReportingPeriods: generateReportingPeriodsStub,
       },
     });
   });
@@ -104,10 +82,11 @@ describe('agentic DB export orchestration', () => {
     );
   });
 
-  it('runs a single daily export for normal non-weekly report runs', async () => {
+  it('runs a single daily export for yesterday on a normal (no-date) run', async () => {
     const result = await module.runAgenticDbExports(createArgs());
 
     expect(runDailyAgenticExportStub).to.have.been.calledOnce;
+    // No auditContext.date → reference date defaults to now (worker exports yesterday).
     expect(runDailyAgenticExportStub.firstCall.args[0].referenceDate.toISOString())
       .to.equal('2026-04-30T12:00:00.000Z');
     expect(result.dailyAgenticExport).to.deep.equal({
@@ -117,11 +96,32 @@ describe('agentic DB export orchestration', () => {
     });
   });
 
-  it('captures single daily export failures without failing the caller', async () => {
+  it('passes a valid date-based reference date through to the daily export', async () => {
+    await module.runAgenticDbExports(createArgs({
+      auditContext: { date: '2026-04-01T10:00:00.000Z' },
+    }));
+
+    expect(runDailyAgenticExportStub).to.have.been.calledOnce;
+    expect(runDailyAgenticExportStub.firstCall.args[0].referenceDate.toISOString())
+      .to.equal('2026-04-01T10:00:00.000Z');
+  });
+
+  it('logs invalid date input and falls back to the default reference date', async () => {
+    const args = createArgs({ auditContext: { date: 'not-a-real-date' } });
+
+    await module.runAgenticDbExports(args);
+
+    expect(args.context.log.error).to.have.been.calledWith(
+      'Invalid date in auditContext for site-1: not-a-real-date',
+    );
+    expect(runDailyAgenticExportStub).to.have.been.calledOnce;
+    expect(runDailyAgenticExportStub.firstCall.args[0].referenceDate.toISOString())
+      .to.equal('2026-04-30T12:00:00.000Z');
+  });
+
+  it('captures daily export failures without failing the caller', async () => {
     runDailyAgenticExportStub.rejects(new Error('daily export failed'));
-    const args = createArgs({
-      auditContext: { refreshAgenticDailyExport: true },
-    });
+    const args = createArgs();
 
     const result = await module.runAgenticDbExports(args);
 
@@ -135,254 +135,5 @@ describe('agentic DB export orchestration', () => {
       siteId: 'site-1',
       error: 'daily export failed',
     });
-  });
-
-  it('passes a valid date-based run reference date through to the daily export', async () => {
-    await module.runAgenticDbExports(createArgs({
-      auditContext: {
-        date: '2026-04-01T10:00:00.000Z',
-      },
-    }));
-
-    expect(runDailyAgenticExportStub).to.have.been.calledOnce;
-    expect(runDailyAgenticExportStub.firstCall.args[0].referenceDate.toISOString())
-      .to.equal('2026-04-01T10:00:00.000Z');
-  });
-
-  it('logs invalid date-based run input and falls back to the default daily export date', async () => {
-    const args = createArgs({
-      auditContext: {
-        date: 'not-a-real-date',
-      },
-    });
-
-    await module.runAgenticDbExports(args);
-
-    expect(args.context.log.error).to.have.been.calledWith(
-      'Invalid date in auditContext for site-1: not-a-real-date',
-    );
-    expect(runDailyAgenticExportStub).to.have.been.calledOnce;
-    expect(runDailyAgenticExportStub.firstCall.args[0].referenceDate.toISOString())
-      .to.equal('2026-04-30T12:00:00.000Z');
-  });
-
-  it('skips normal weekly report runs without a refresh flag', async () => {
-    const result = await module.runAgenticDbExports(createArgs({
-      auditContext: { weekOffset: -1 },
-    }));
-
-    expect(result).to.deep.equal({});
-    expect(runDailyAgenticExportStub).to.not.have.been.called;
-  });
-
-  it('treats null weekOffset as a non-weekly daily export run', async () => {
-    const args = createArgs({
-      auditContext: { weekOffset: null, refreshAgenticDailyExport: true },
-    });
-
-    const result = await module.runAgenticDbExports(args);
-
-    expect(runDailyAgenticExportStub).to.have.been.calledOnce;
-    expect(args.context.dataAccess.Configuration.findLatest).to.not.have.been.called;
-    expect(args.context.sqs.sendMessage).to.not.have.been.called;
-    expect(result.dailyAgenticExport).to.deep.equal({
-      enabled: true,
-      success: true,
-      trafficDate: '2026-04-29',
-    });
-  });
-
-  it('skips weekly refreshes when the agentic report has no data', async () => {
-    const args = createArgs({
-      auditContext: { weekOffset: -1, refreshAgenticDailyExport: true },
-      agenticReportHasData: false,
-    });
-
-    const result = await module.runAgenticDbExports(args);
-
-    expect(result).to.deep.equal({});
-    expect(runDailyAgenticExportStub).to.not.have.been.called;
-    expect(args.context.log.info).to.have.been.calledWith(
-      'Skipping weekly agentic DB exports for site-1: no agentic report data found',
-    );
-  });
-
-  it('queues seven date-based exports for completed weekly DB refreshes and keeps the singular result contract', async () => {
-    const args = createArgs({
-      auditContext: {
-        weekOffset: -1,
-        refreshAgenticDailyExport: true,
-      },
-    });
-
-    const result = await module.runAgenticDbExports(args);
-
-    expect(runDailyAgenticExportStub).to.not.have.been.called;
-    expect(args.context.sqs.sendMessage).to.have.callCount(7);
-    expect(args.context.sqs.sendMessage.firstCall).to.have.been.calledWith(
-      'https://sqs.us-east-1.amazonaws.com/123/audits-queue',
-      {
-        type: 'cdn-logs-report',
-        siteId: 'site-1',
-        auditContext: {
-          date: '2026-03-31T00:00:00.000Z',
-          refreshAgenticDailyExport: true,
-          sourceWeekOffset: -1,
-        },
-      },
-      null,
-      0,
-    );
-    expect(args.context.sqs.sendMessage.lastCall.args[1].auditContext.date)
-      .to.equal('2026-04-06T00:00:00.000Z');
-    expect(args.context.sqs.sendMessage.lastCall.args[3]).to.equal(30);
-    expect(result.dailyAgenticExports).to.have.length(7);
-    expect(result.dailyAgenticExport).to.deep.equal(result.dailyAgenticExports.at(-1));
-    expect(args.context.log.info).to.have.been.calledWith(
-      'Queueing weekly agentic DB exports for site-1: weekOffset=-1, trigger=refreshAgenticDailyExport, days=7',
-    );
-  });
-
-  it('runs only completed current-week exports for BYOCDN refreshes', async () => {
-    generateReportingPeriodsStub.returns({
-      weeks: [{
-        startDate: new Date('2026-04-27T00:00:00.000Z'),
-        endDate: new Date('2026-05-03T23:59:59.999Z'),
-      }],
-      periodIdentifier: 'w18-2026',
-    });
-    const args = createArgs({
-      auditContext: {
-        weekOffset: 0,
-        refreshAgenticDailyExport: true,
-        triggeredBy: 'byocdn-other',
-      },
-    });
-
-    const result = await module.runAgenticDbExports(args);
-
-    expect(runDailyAgenticExportStub).to.not.have.been.called;
-    expect(args.context.sqs.sendMessage).to.have.callCount(3);
-    expect(args.context.sqs.sendMessage.firstCall.args[1].auditContext).to.deep.equal({
-      date: '2026-04-28T00:00:00.000Z',
-      refreshAgenticDailyExport: true,
-      triggeredBy: 'byocdn-other',
-      sourceWeekOffset: 0,
-    });
-    expect(args.context.sqs.sendMessage.lastCall.args[1].auditContext.date)
-      .to.equal('2026-04-30T00:00:00.000Z');
-    expect(result.dailyAgenticExports).to.have.length(3);
-    expect(args.context.log.info).to.have.been.calledWith(
-      'Queueing weekly agentic DB exports for site-1: weekOffset=0, trigger=byocdn-other, days=3',
-    );
-  });
-
-  it('continues queueing when one date-based export message fails', async () => {
-    const args = createArgs({
-      auditContext: { weekOffset: -1, refreshAgenticDailyExport: true },
-    });
-    args.context.sqs.sendMessage.onCall(3).rejects(new Error('queue failed'));
-
-    const result = await module.runAgenticDbExports(args);
-
-    expect(args.context.sqs.sendMessage).to.have.callCount(7);
-    expect(result.dailyAgenticExports).to.have.length(7);
-    expect(result.dailyAgenticExports[3]).to.include({
-      success: false,
-      queued: false,
-      error: 'queue failed',
-    });
-    expect(args.context.log.warn).to.have.been.calledWith(
-      'Partial agentic DB export queueing failure for site-1: 1/7 days failed',
-    );
-  });
-
-  it('does not forward invalid triggeredBy values to queued date-based exports', async () => {
-    const args = createArgs({
-      auditContext: {
-        weekOffset: -1,
-        refreshAgenticDailyExport: true,
-        triggeredBy: 'bad\ntrigger',
-      },
-    });
-
-    await module.runAgenticDbExports(args);
-
-    expect(args.context.sqs.sendMessage.firstCall.args[1].auditContext).to.deep.equal({
-      date: '2026-03-31T00:00:00.000Z',
-      refreshAgenticDailyExport: true,
-      sourceWeekOffset: -1,
-    });
-    expect(args.context.log.info).to.have.been.calledWith(
-      'Queueing weekly agentic DB exports for site-1: weekOffset=-1, trigger=refreshAgenticDailyExport, days=7',
-    );
-  });
-
-  it('captures Configuration lookup failures without failing weekly report results', async () => {
-    const args = createArgs({
-      auditContext: { weekOffset: -1, refreshAgenticDailyExport: true },
-    });
-    args.context.dataAccess.Configuration.findLatest.rejects(new Error('configuration unavailable'));
-
-    const result = await module.runAgenticDbExports(args);
-
-    expect(args.context.sqs.sendMessage).to.not.have.been.called;
-    expect(args.context.log.error).to.have.been.calledWith(
-      'Failed to resolve audit queue for site site-1: configuration unavailable',
-      sinon.match.instanceOf(Error),
-    );
-    expect(result).to.deep.equal({
-      dailyAgenticExport: {
-        enabled: true,
-        success: false,
-        queued: false,
-        siteId: 'site-1',
-        error: 'configuration unavailable',
-      },
-      dailyAgenticExports: [],
-    });
-  });
-
-  it('captures missing audit queue configuration without throwing', async () => {
-    const args = createArgs({
-      auditContext: { weekOffset: -1, refreshAgenticDailyExport: true },
-    });
-    args.context.dataAccess.Configuration.findLatest.resolves({
-      getQueues: () => ({}),
-    });
-
-    const result = await module.runAgenticDbExports(args);
-
-    expect(args.context.sqs.sendMessage).to.not.have.been.called;
-    expect(args.context.log.error).to.have.been.calledWith(
-      'Audit queue not configured for site site-1; skipping weekly DB export queueing',
-    );
-    expect(result).to.deep.equal({
-      dailyAgenticExport: {
-        enabled: true,
-        success: false,
-        queued: false,
-        siteId: 'site-1',
-        error: 'Audit queue not configured',
-      },
-      dailyAgenticExports: [],
-    });
-  });
-
-  it('returns an empty weekly result when the reporting period has no week start', async () => {
-    generateReportingPeriodsStub.returns({
-      weeks: [],
-      periodIdentifier: 'w14-2026',
-    });
-    const args = createArgs({
-      auditContext: { weekOffset: -1, refreshAgenticDailyExport: true },
-    });
-
-    const result = await module.runAgenticDbExports(args);
-
-    expect(runDailyAgenticExportStub).to.not.have.been.called;
-    expect(args.context.dataAccess.Configuration.findLatest).to.not.have.been.called;
-    expect(result.dailyAgenticExport).to.equal(null);
-    expect(result.dailyAgenticExports).to.deep.equal([]);
   });
 });

--- a/test/audits/llmo-customer-analysis-cdn-config.test.js
+++ b/test/audits/llmo-customer-analysis-cdn-config.test.js
@@ -411,9 +411,7 @@ describe('CDN Config Handler', () => {
       const dailyReportCalls = getDailyReportCalls();
 
       expect(cdnLogsAnalysisCalls.length).to.be.greaterThan(0);
-      expect(weeklyReportCalls).to.have.length(1);
-      expect(weeklyReportCalls[0].args[1].auditContext).to.deep.equal({ weekOffset: -1 });
-      expect(weeklyReportCalls[0].args[3]).to.equal(800);
+      expect(weeklyReportCalls).to.have.length(0);
       expect(dailyReportCalls).to.have.length(cdnLogsAnalysisCalls.length);
 
       dailyReportCalls.forEach((call, index) => {
@@ -525,7 +523,7 @@ describe('CDN Config Handler', () => {
       const dailyReportCalls = getDailyReportCalls();
 
       expect(cdnLogsAnalysisCalls.length).to.be.greaterThan(0);
-      expect(weeklyReportCalls).to.have.length(1);
+      expect(weeklyReportCalls).to.have.length(0);
       expect(dailyReportCalls).to.have.length(cdnLogsAnalysisCalls.length);
 
       clock.restore();
@@ -597,8 +595,7 @@ describe('CDN Config Handler', () => {
       const dailyReportCalls = getDailyReportCalls();
 
       expect(cdnLogsAnalysisCalls).to.have.length(0);
-      expect(weeklyReportCalls).to.have.length(1);
-      expect(weeklyReportCalls[0].args[1].auditContext).to.deep.equal({ weekOffset: -1 });
+      expect(weeklyReportCalls).to.have.length(0);
       expect(dailyReportCalls.length).to.be.greaterThan(0);
       dailyReportCalls.forEach((call, index) => {
         expect(call.args[1].auditContext.date).to.match(/T00:00:00\.000Z$/);
@@ -640,7 +637,7 @@ describe('CDN Config Handler', () => {
       const dailyReportCalls = getDailyReportCalls();
 
       expect(cdnLogsAnalysisCalls).to.have.length(0);
-      expect(weeklyReportCalls).to.have.length(1);
+      expect(weeklyReportCalls).to.have.length(0);
       expect(dailyReportCalls.length).to.be.greaterThan(0);
       dailyReportCalls.forEach((call, index) => {
         expect(call.args[1].auditContext.date).to.match(/T00:00:00\.000Z$/);

--- a/test/audits/llmo-customer-analysis-cdn-config.test.js
+++ b/test/audits/llmo-customer-analysis-cdn-config.test.js
@@ -423,7 +423,7 @@ describe('CDN Config Handler', () => {
         });
         // Daily report delay is base (800s) + per-day staggering, capped at
         // the SQS 900s hard limit so total stays valid even for long backfills.
-        expect(call.args[3]).to.equal(Math.min(800 + (index * 5), 900));
+        expect(call.args[3]).to.equal(Math.min(800 + (index * 30), 900));
       });
     });
 
@@ -544,7 +544,7 @@ describe('CDN Config Handler', () => {
 
       expect(cdnLogsAnalysisCalls.length).to.be.greaterThan(0);
       cdnLogsAnalysisCalls.forEach((call, index) => {
-        expect(call.args[3]).to.equal(index * 5);
+        expect(call.args[3]).to.equal(index * 30);
       });
       expect(dailyReportCalls).to.have.length(cdnLogsAnalysisCalls.length);
       dailyReportCalls.forEach((call, index) => {
@@ -554,7 +554,7 @@ describe('CDN Config Handler', () => {
         });
         // Daily report delay is base (800s) + per-day staggering, capped at
         // the SQS 900s hard limit so total stays valid even for long backfills.
-        expect(call.args[3]).to.equal(Math.min(800 + (index * 5), 900));
+        expect(call.args[3]).to.equal(Math.min(800 + (index * 30), 900));
       });
 
       clock.restore();
@@ -604,7 +604,7 @@ describe('CDN Config Handler', () => {
         expect(call.args[1].auditContext.date).to.match(/T00:00:00\.000Z$/);
         // Daily report delay is base (800s) + per-day staggering, capped at
         // the SQS 900s hard limit so total stays valid even for long backfills.
-        expect(call.args[3]).to.equal(Math.min(800 + (index * 5), 900));
+        expect(call.args[3]).to.equal(Math.min(800 + (index * 30), 900));
       });
       // Verify it checked for cdn-logs-analysis
       expect(context.dataAccess.LatestAudit.findBySiteIdAndAuditType).to.have.been.calledWith(
@@ -646,7 +646,7 @@ describe('CDN Config Handler', () => {
         expect(call.args[1].auditContext.date).to.match(/T00:00:00\.000Z$/);
         // Daily report delay is base (800s) + per-day staggering, capped at
         // the SQS 900s hard limit so total stays valid even for long backfills.
-        expect(call.args[3]).to.equal(Math.min(800 + (index * 5), 900));
+        expect(call.args[3]).to.equal(Math.min(800 + (index * 30), 900));
       });
       expect(context.dataAccess.LatestAudit.findBySiteIdAndAuditType).to.have.been.calledWith(
         'site-123',

--- a/test/audits/llmo-customer-analysis-cdn-config.test.js
+++ b/test/audits/llmo-customer-analysis-cdn-config.test.js
@@ -417,7 +417,6 @@ describe('CDN Config Handler', () => {
       dailyReportCalls.forEach((call, index) => {
         expect(call.args[1].auditContext).to.deep.equal({
           date: getExpectedReportDate(cdnLogsAnalysisCalls[index]),
-          refreshAgenticDailyExport: true,
         });
         // Daily report delay is base (800s) + per-day staggering, capped at
         // the SQS 900s hard limit so total stays valid even for long backfills.
@@ -548,7 +547,6 @@ describe('CDN Config Handler', () => {
       dailyReportCalls.forEach((call, index) => {
         expect(call.args[1].auditContext).to.deep.equal({
           date: getExpectedReportDate(cdnLogsAnalysisCalls[index]),
-          refreshAgenticDailyExport: true,
         });
         // Daily report delay is base (800s) + per-day staggering, capped at
         // the SQS 900s hard limit so total stays valid even for long backfills.


### PR DESCRIPTION
## Summary

With the api-service backfill now enumerating each day directly (one date-based message per day, #2560), the worker's `weekOffset` weekly fan-out is obsolete. This removes it, simplifies the rules step, dedups the importer S3 client, and cleans up the now-dead weekly trigger machinery in the cdn-config backfill path. Builds on the SharePoint removal (#2606, merged).

## Changes

### `cdn-logs-report` audit
- **Remove the weekOffset fan-out** (`utils/agentic-db-export.js`). Deleted `queueWeeklyAgenticDbExports`, `shouldRefreshWeeklyAgenticDbExports`, `getAgenticDbExportReferenceDatesForWeek`, `hasWeekOffset`, and the queue/`triggeredBy` plumbing. `runAgenticDbExports` is now purely **date-based** — it exports `auditContext.date - 1` for a backfill, or yesterday for a scheduled run (~290 → ~95 lines).
- **Referral export runs on every run.** Dropped the `isWeeklyOnlyRun` gate in `handler.js`.
- **Rules step runs on every invocation** (scheduled and date-based backfills), but still **only generates when rules are missing** (`!hasExistingPatterns`). Existing rules — which may include customer-added categories — are never overwritten. So a backfill for a brand-new site bootstraps its rules on the way in; established sites read-and-skip.
- **`getImporterS3Client()`** (`utils/report-utils.js`): a lazy, memoized us-east-1 S3 client reused by both daily exports instead of constructing a new `S3Client` per export.

### `llmo-customer-analysis` cdn-config backfill
- **Drop the redundant `{ weekOffset: -1 }` weekly trigger.** The handler already queues one per-day `cdn-logs-report { date }` message per backfill day, and the worker now generates rules on every run when missing — so the separate weekly send is no longer needed.
- **Widen the cdn-logs-analysis backfill stagger to 30s** (was 5s) to give each analysis more headroom before the matching report import fires.

### Cross-cutting cleanup
- **Remove the dead `refreshAgenticDailyExport` auditContext flag.** Its only reader was the pre-fan-out daily-export gate removed above; the daily export now always runs when `auditContext.date` is present. Dropped from both producers (`cdn-analysis/handler.js`, the cdn-config backfill) and their tests.

## Deploy ordering

Deploy **after** the api-service per-day backfill (#2560) — no `weekOffset` producers remain once that ships. A stray `weekOffset` message degrades safely to a normal run (exports yesterday).

## Testing

`npm run lint` clean; changed files at **100% coverage**; full suite **8395 passing, 0 failing**.
