### PR TITLE
chore(deps): bump @adobe/mysticat-shared-seo-client to 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@adobe/helix-shared-wrap": "2.0.2",
         "@adobe/helix-status": "10.1.5",
         "@adobe/helix-universal-logger": "3.0.29",
-        "@adobe/mysticat-shared-seo-client": "1.5.1",
+        "@adobe/mysticat-shared-seo-client": "^1.6.0",
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
         "@adobe/spacecat-shared-athena-client": "1.10.3",
         "@adobe/spacecat-shared-data-access": "3.74.0",
@@ -788,9 +788,9 @@
       }
     },
     "node_modules/@adobe/mysticat-shared-seo-client": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@adobe/mysticat-shared-seo-client/-/mysticat-shared-seo-client-1.5.1.tgz",
-      "integrity": "sha512-MnLwjC+2AYMvUrcrV9miKWHdSYVe3AdHhVPS4eP9iQ5Md+ci25MTroPBbU/ULuqv1vZrBVyeVjImJsJjvvFIBA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@adobe/mysticat-shared-seo-client/-/mysticat-shared-seo-client-1.6.0.tgz",
+      "integrity": "sha512-paGGUK49+W0Gs9vLXAN4e6rsfluR9xIXoHXCAvi3aKB3Utem6nBMDnep0Q3NsG/QyAB3CRc6b34s8Phy67NVSw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@adobe/helix-shared-wrap": "2.0.2",
     "@adobe/helix-status": "10.1.5",
     "@adobe/helix-universal-logger": "3.0.29",
-    "@adobe/mysticat-shared-seo-client": "1.5.1",
+    "@adobe/mysticat-shared-seo-client": "^1.6.0",
     "@adobe/spacecat-helix-content-sdk": "1.4.33",
     "@adobe/spacecat-shared-athena-client": "1.10.3",
     "@adobe/spacecat-shared-data-access": "3.74.0",


### PR DESCRIPTION
## Summary
- Bumps `@adobe/mysticat-shared-seo-client` from `1.5.1` → `1.6.0`
- Picks up the SITES-45983 fix for broken-backlinks Semrush quality filters

## What changed in 1.6.0
The previous implementation sent `type` field filters (`follow`, `text`, `lostlink`) to the `backlinks_pages` endpoint, which does not support that field — causing **HTTP 400 errors** for every broken-backlinks audit run.

The fix:
- Splits the single `backlinks_pages` call into **two parallel requests** (one for 404, one for 410), merges and deduplicates the results
- Moves the type quality filters to the `backlinks` call (Call B) where they are valid

## Test plan
- [ ] CI passes
- [ ] After deploy: verify no HTTP 400 errors appear in audit-worker logs for broken-backlinks audits
- [ ] Spot-check a site's broken backlinks opportunity in SpaceCat UI — suggestions should include links from 410 pages and exclude nofollow/lost-link spam

🤖 Generated with [Claude Code](https://claude.com/claude-code)