### PR TITLE
fix(preflight): heading-empty duplicate cards when multiple empty headings exist

### DIFF
--- a/src/preflight/headings.js
+++ b/src/preflight/headings.js
@@ -45,7 +45,7 @@ function getSeoImpact(checkType) {
  * @param {Object} check - The check result from validatePageHeadingFromScrapeJson
  * @returns {Object} Element targets with selectors
  */
-function getElementsFromCheck(scrapeJsonObject, check) {
+function getElementsFromCheck(scrapeJsonObject, check, log) {
   if (!scrapeJsonObject?.scrapeResult?.rawBody) {
     return {};
   }
@@ -100,6 +100,8 @@ function getElementsFromCheck(scrapeJsonObject, check) {
             selectors.push(resolvedSelector);
           }
         }
+      } else {
+        log.debug(`[preflight-headings] heading-empty check has no transformRules.selector — element target will be omitted (check: ${JSON.stringify(check.transformRules)})`);
       }
       break;
     }
@@ -284,7 +286,7 @@ export default async function headings(context, auditContext) {
 
           // Generate selectors from the scraped HTML
           if (scrapeJsonObject) {
-            const elementData = getElementsFromCheck(scrapeJsonObject, check);
+            const elementData = getElementsFromCheck(scrapeJsonObject, check, log);
             if (elementData?.elements?.length > 0) {
               Object.assign(opportunity, elementData);
             }

--- a/src/preflight/headings.js
+++ b/src/preflight/headings.js
@@ -88,15 +88,18 @@ function getElementsFromCheck(scrapeJsonObject, check) {
     }
 
     case 'heading-empty': {
-      // Find empty headings - extract tag name from check
-      const tagName = check.tagName?.toLowerCase();
-      if (tagName && /^h[1-6]$/.test(tagName)) {
-        const headingsArray = $(tagName).toArray();
-        // Find empty ones
-        const emptyHeadings = headingsArray.filter((h) => $(h).text().trim().length === 0);
-        selectors = emptyHeadings
-          .map((h) => getDomElementSelector(h))
-          .filter(Boolean);
+      // Use the specific element selector from the check rather than re-querying all empty
+      // headings — re-querying attaches every empty heading's selector to every card, making
+      // N empty headings produce N cards each showing "1 of N instances found".
+      const selector = check.transformRules?.selector;
+      if (selector) {
+        const element = $(selector).get(0);
+        if (element) {
+          const resolvedSelector = getDomElementSelector(element);
+          if (resolvedSelector) {
+            selectors.push(resolvedSelector);
+          }
+        }
       }
       break;
     }

--- a/test/preflight/headings-selectors.test.js
+++ b/test/preflight/headings-selectors.test.js
@@ -434,6 +434,8 @@ describe('Preflight Headings - Selector Coverage Tests', function () {
       // Each check produces exactly one selector (its own), not all empty headings
       expect(mockDomSelector.toElementTargets).to.have.been.calledWith(['body > h2:nth-of-type(1)']);
       expect(mockDomSelector.toElementTargets).to.have.been.calledWith(['body > h2:nth-of-type(2)']);
+      // Called exactly twice — once per check, no spurious extra invocations
+      expect(mockDomSelector.toElementTargets).to.have.been.calledTwice;
       // toElementTargets is never called with both selectors together
       expect(mockDomSelector.toElementTargets).to.not.have.been.calledWith(
         ['body > h2:nth-of-type(1)', 'body > h2:nth-of-type(2)'],

--- a/test/preflight/headings-selectors.test.js
+++ b/test/preflight/headings-selectors.test.js
@@ -273,23 +273,26 @@ describe('Preflight Headings - Selector Coverage Tests', () => {
       );
     });
 
-    it('should generate selectors for heading-empty check when tagName is provided', async () => {
-      // Setup heading-empty check with tagName
-      const checkWithTagName = {
+    it('should generate selector for heading-empty check using transformRules.selector', async () => {
+      const checkWithTransformRules = {
         success: false,
         check: 'heading-empty',
         checkTitle: 'Empty Heading',
         description: 'Heading is empty',
         explanation: 'Add content to heading',
-        tagName: 'h1',
+        tagName: 'H1',
+        transformRules: {
+          action: 'replace',
+          selector: 'body > h1',
+          currValue: '',
+        },
       };
 
       mockHeadingsHandler.validatePageHeadingFromScrapeJson.resolves({
         url: 'https://main--example--page.aem.page/page1',
-        checks: [checkWithTagName],
+        checks: [checkWithTransformRules],
       });
 
-      // Mock getDomElementSelector to return a selector for the empty h1
       mockDomSelector.getDomElementSelector.returns('body > h1');
       mockDomSelector.toElementTargets.returns({
         elements: [{ selector: 'body > h1' }],
@@ -333,10 +336,158 @@ describe('Preflight Headings - Selector Coverage Tests', () => {
 
       await headingsModule.default(context, auditContext);
 
-      // Verify getDomElementSelector was called for the empty heading
       expect(mockDomSelector.getDomElementSelector).to.have.been.called;
-      // Verify toElementTargets was called with the generated selector
       expect(mockDomSelector.toElementTargets).to.have.been.calledWith(['body > h1']);
+    });
+
+    it('should generate one selector per empty heading when multiple empty headings exist (no duplicates)', async () => {
+      // Two separate heading-empty checks, each with its own selector — this is what the
+      // headings handler produces when there are 2 empty H2s on the page.
+      const check1 = {
+        success: false,
+        check: 'heading-empty',
+        checkTitle: 'Empty Heading',
+        description: 'H2 heading is empty',
+        explanation: 'Add content to heading',
+        tagName: 'H2',
+        transformRules: {
+          action: 'replace',
+          selector: 'body > h2:nth-of-type(1)',
+          currValue: '',
+        },
+      };
+      const check2 = {
+        success: false,
+        check: 'heading-empty',
+        checkTitle: 'Empty Heading',
+        description: 'H2 heading is empty',
+        explanation: 'Add content to heading',
+        tagName: 'H2',
+        transformRules: {
+          action: 'replace',
+          selector: 'body > h2:nth-of-type(2)',
+          currValue: '',
+        },
+      };
+
+      mockHeadingsHandler.validatePageHeadingFromScrapeJson.resolves({
+        url: 'https://main--example--page.aem.page/page1',
+        checks: [check1, check2],
+      });
+
+      // getDomElementSelector returns different values for each element
+      mockDomSelector.getDomElementSelector
+        .onFirstCall().returns('body > h2:nth-of-type(1)')
+        .onSecondCall().returns('body > h2:nth-of-type(2)');
+      mockDomSelector.toElementTargets
+        .onFirstCall().returns({ elements: [{ selector: 'body > h2:nth-of-type(1)' }] })
+        .onSecondCall().returns({ elements: [{ selector: 'body > h2:nth-of-type(2)' }] });
+
+      const headingsModule = await esmock('../../src/preflight/headings.js', {
+        '../../src/preflight/utils/dom-selector.js': mockDomSelector,
+        '../../src/headings/handler.js': mockHeadingsHandler,
+        '../../src/metatags/seo-checks.js': {
+          default: class {
+            // eslint-disable-next-line class-methods-use-this
+            getFewHealthyTags() {
+              return { title: [], description: [], h1: [] };
+            }
+          },
+        },
+      });
+
+      const auditContext = {
+        previewUrls: ['https://main--example--page.aem.page/page1'],
+        step: 'identify',
+        audits: new Map([
+          ['https://main--example--page.aem.page/page1', {
+            audits: [],
+          }],
+        ]),
+        auditsResult: [{
+          pageUrl: 'https://main--example--page.aem.page/page1',
+          audits: [],
+        }],
+        scrapedObjects: [{
+          data: {
+            scrapeResult: {
+              rawBody: '<body><h1>Title</h1><h2></h2><h2></h2></body>',
+            },
+            finalUrl: 'https://main--example--page.aem.page/page1',
+          },
+        }],
+        timeExecutionBreakdown: [],
+      };
+
+      await headingsModule.default(context, auditContext);
+
+      // Each check produces exactly one selector (its own), not all empty headings
+      expect(mockDomSelector.toElementTargets).to.have.been.calledWith(['body > h2:nth-of-type(1)']);
+      expect(mockDomSelector.toElementTargets).to.have.been.calledWith(['body > h2:nth-of-type(2)']);
+      // toElementTargets is never called with both selectors together
+      expect(mockDomSelector.toElementTargets).to.not.have.been.calledWith(
+        ['body > h2:nth-of-type(1)', 'body > h2:nth-of-type(2)'],
+      );
+    });
+
+    it('should produce no selectors for heading-empty check without transformRules.selector', async () => {
+      // heading-empty check missing transformRules — produces no selector rather than
+      // falling back to re-querying all empty headings (which caused the duplicate-card bug).
+      const checkNoSelector = {
+        success: false,
+        check: 'heading-empty',
+        checkTitle: 'Empty Heading',
+        description: 'Heading is empty',
+        explanation: 'Add content to heading',
+        tagName: 'H2',
+      };
+
+      mockHeadingsHandler.validatePageHeadingFromScrapeJson.resolves({
+        url: 'https://main--example--page.aem.page/page1',
+        checks: [checkNoSelector],
+      });
+
+      mockDomSelector.toElementTargets.returns({});
+
+      const headingsModule = await esmock('../../src/preflight/headings.js', {
+        '../../src/preflight/utils/dom-selector.js': mockDomSelector,
+        '../../src/headings/handler.js': mockHeadingsHandler,
+        '../../src/metatags/seo-checks.js': {
+          default: class {
+            // eslint-disable-next-line class-methods-use-this
+            getFewHealthyTags() {
+              return { title: [], description: [], h1: [] };
+            }
+          },
+        },
+      });
+
+      const auditContext = {
+        previewUrls: ['https://main--example--page.aem.page/page1'],
+        step: 'identify',
+        audits: new Map([
+          ['https://main--example--page.aem.page/page1', {
+            audits: [],
+          }],
+        ]),
+        auditsResult: [{
+          pageUrl: 'https://main--example--page.aem.page/page1',
+          audits: [],
+        }],
+        scrapedObjects: [{
+          data: {
+            scrapeResult: {
+              rawBody: '<body><h2></h2></body>',
+            },
+            finalUrl: 'https://main--example--page.aem.page/page1',
+          },
+        }],
+        timeExecutionBreakdown: [],
+      };
+
+      await headingsModule.default(context, auditContext);
+
+      expect(mockDomSelector.toElementTargets).to.have.been.calledWith([]);
     });
 
     it('should produce no selectors for unknown check types', async () => {

--- a/test/preflight/headings-selectors.test.js
+++ b/test/preflight/headings-selectors.test.js
@@ -20,7 +20,9 @@ import { MockContextBuilder } from '../shared.js';
 
 use(sinonChai);
 
-describe('Preflight Headings - Selector Coverage Tests', () => {
+describe('Preflight Headings - Selector Coverage Tests', function () {
+  this.timeout(10000);
+
   let context;
   let site;
   let job;
@@ -28,6 +30,7 @@ describe('Preflight Headings - Selector Coverage Tests', () => {
   let configuration;
   let mockDomSelector;
   let mockHeadingsHandler;
+  let mockSharedUtils;
 
   beforeEach(async () => {
     mockDomSelector = {
@@ -35,10 +38,13 @@ describe('Preflight Headings - Selector Coverage Tests', () => {
       toElementTargets: sinon.stub(),
     };
 
+    mockSharedUtils = {
+      getBrandGuidelines: sinon.stub().resolves({}),
+    };
+
     // Mock headings handler to return checks with transformRules
     mockHeadingsHandler = {
       validatePageHeadingFromScrapeJson: sinon.stub(),
-      getBrandGuidelines: sinon.stub().resolves({}),
       getH1HeadingASuggestion: sinon.stub().resolves('AI suggestion'),
       HEADINGS_CHECKS: {
         HEADING_MISSING_H1: { check: 'heading-missing-h1' },
@@ -161,6 +167,7 @@ describe('Preflight Headings - Selector Coverage Tests', () => {
       const headingsModule = await esmock('../../src/preflight/headings.js', {
         '../../src/preflight/utils/dom-selector.js': mockDomSelector,
         '../../src/headings/handler.js': mockHeadingsHandler,
+        '../../src/headings/shared-utils.js': mockSharedUtils,
         '../../src/metatags/seo-checks.js': {
           default: class {
             // eslint-disable-next-line class-methods-use-this
@@ -230,6 +237,7 @@ describe('Preflight Headings - Selector Coverage Tests', () => {
       const headingsModule = await esmock('../../src/preflight/headings.js', {
         '../../src/preflight/utils/dom-selector.js': mockDomSelector,
         '../../src/headings/handler.js': mockHeadingsHandler,
+        '../../src/headings/shared-utils.js': mockSharedUtils,
         '../../src/metatags/seo-checks.js': {
           default: class {
             // eslint-disable-next-line class-methods-use-this
@@ -301,6 +309,7 @@ describe('Preflight Headings - Selector Coverage Tests', () => {
       const headingsModule = await esmock('../../src/preflight/headings.js', {
         '../../src/preflight/utils/dom-selector.js': mockDomSelector,
         '../../src/headings/handler.js': mockHeadingsHandler,
+        '../../src/headings/shared-utils.js': mockSharedUtils,
         '../../src/metatags/seo-checks.js': {
           default: class {
             // eslint-disable-next-line class-methods-use-this
@@ -386,6 +395,7 @@ describe('Preflight Headings - Selector Coverage Tests', () => {
       const headingsModule = await esmock('../../src/preflight/headings.js', {
         '../../src/preflight/utils/dom-selector.js': mockDomSelector,
         '../../src/headings/handler.js': mockHeadingsHandler,
+        '../../src/headings/shared-utils.js': mockSharedUtils,
         '../../src/metatags/seo-checks.js': {
           default: class {
             // eslint-disable-next-line class-methods-use-this
@@ -452,6 +462,7 @@ describe('Preflight Headings - Selector Coverage Tests', () => {
       const headingsModule = await esmock('../../src/preflight/headings.js', {
         '../../src/preflight/utils/dom-selector.js': mockDomSelector,
         '../../src/headings/handler.js': mockHeadingsHandler,
+        '../../src/headings/shared-utils.js': mockSharedUtils,
         '../../src/metatags/seo-checks.js': {
           default: class {
             // eslint-disable-next-line class-methods-use-this
@@ -513,6 +524,7 @@ describe('Preflight Headings - Selector Coverage Tests', () => {
       const headingsModule = await esmock('../../src/preflight/headings.js', {
         '../../src/preflight/utils/dom-selector.js': mockDomSelector,
         '../../src/headings/handler.js': mockHeadingsHandler,
+        '../../src/headings/shared-utils.js': mockSharedUtils,
         '../../src/metatags/seo-checks.js': {
           default: class {
             // eslint-disable-next-line class-methods-use-this
@@ -575,6 +587,7 @@ describe('Preflight Headings - Selector Coverage Tests', () => {
       const headingsModule = await esmock('../../src/preflight/headings.js', {
         '../../src/preflight/utils/dom-selector.js': mockDomSelector,
         '../../src/headings/handler.js': mockHeadingsHandler,
+        '../../src/headings/shared-utils.js': mockSharedUtils,
         '../../src/metatags/seo-checks.js': {
           default: class {
             // eslint-disable-next-line class-methods-use-this
@@ -641,6 +654,7 @@ describe('Preflight Headings - Selector Coverage Tests', () => {
       const headingsModule = await esmock('../../src/preflight/headings.js', {
         '../../src/preflight/utils/dom-selector.js': mockDomSelector,
         '../../src/headings/handler.js': mockHeadingsHandler,
+        '../../src/headings/shared-utils.js': mockSharedUtils,
         '../../src/metatags/seo-checks.js': {
           default: class {
             // eslint-disable-next-line class-methods-use-this
@@ -707,6 +721,7 @@ describe('Preflight Headings - Selector Coverage Tests', () => {
       const headingsModule = await esmock('../../src/preflight/headings.js', {
         '../../src/preflight/utils/dom-selector.js': mockDomSelector,
         '../../src/headings/handler.js': mockHeadingsHandler,
+        '../../src/headings/shared-utils.js': mockSharedUtils,
         '../../src/metatags/seo-checks.js': {
           default: class {
             // eslint-disable-next-line class-methods-use-this
@@ -780,6 +795,7 @@ describe('Preflight Headings - Selector Coverage Tests', () => {
       const headingsModule = await esmock('../../src/preflight/headings.js', {
         '../../src/preflight/utils/dom-selector.js': mockDomSelector,
         '../../src/headings/handler.js': mockHeadingsHandler,
+        '../../src/headings/shared-utils.js': mockSharedUtils,
         '../../src/metatags/seo-checks.js': {
           default: class {
             // eslint-disable-next-line class-methods-use-this
@@ -844,6 +860,7 @@ describe('Preflight Headings - Selector Coverage Tests', () => {
       const headingsModule = await esmock('../../src/preflight/headings.js', {
         '../../src/preflight/utils/dom-selector.js': mockDomSelector,
         '../../src/headings/handler.js': mockHeadingsHandler,
+        '../../src/headings/shared-utils.js': mockSharedUtils,
         '../../src/metatags/seo-checks.js': {
           default: class {
             // eslint-disable-next-line class-methods-use-this


### PR DESCRIPTION
## Summary

The Micron `markets-industries/ai` page had two carousel components with blank heading fields. Each rendered an empty `<h2 class="cmp-carousel-v2__heading"></h2>` in the preflight scrape. This triggered two separate `heading-empty` checks — but a bug in `getElementsFromCheck` caused both cards to receive selectors for *all* empty H2s on the page, making them look identical.

**Root cause:** In `src/preflight/headings.js`, the `heading-empty` case re-queried every empty heading and attached all their selectors to every card. With N empty H2s, N cards were each labelled "1 of N instances found" and appeared as duplicates.

**Fix:** Use `check.transformRules.selector` — already set by the headings handler for the specific element that triggered each check — instead of re-querying. Each card now resolves exactly its own element.

**Confirmed via S3:** The prod scrape for this site (`spacecat-prod-scraper`, site `7b8f919a`, path `markets-industries/ai/scrape.json`, dated 2026-03-21) contains exactly two empty `cmp-carousel-v2__heading` H2s at positions #14 and #15 — matching the two duplicate cards Micron reported. The Micron page has since been updated (carousel headings filled in), but the fix is needed for any page with multiple empty headings.

## Changes

- `src/preflight/headings.js`: `heading-empty` case now uses `check.transformRules.selector` to target the specific element rather than re-querying all empty headings

## Test plan

- [ ] Updated existing `heading-empty` test to include `transformRules.selector` (matches actual handler behavior)
- [ ] Added regression test: 2 empty H2s → 2 checks → each card gets exactly 1 selector (no duplicates)
- [ ] Added test: `heading-empty` without `transformRules.selector` produces no selectors (no fallback to re-query all)
- [ ] `npm run test:spec -- test/preflight/headings-selectors.test.js` → 10 passing, 1 pre-existing timeout unrelated to this change

Closes SITES-46108

🤖 Generated with [Claude Code](https://claude.com/claude-code)