### PR TITLE
feat: read brandalf feature-flag from db instead of making API call

### DIFF
--- a/src/llmo-customer-analysis/handler.js
+++ b/src/llmo-customer-analysis/handler.js
@@ -296,7 +296,8 @@ export async function runLlmoCustomerAnalysis(finalUrl, context, site, auditCont
       log,
     });
     if (orgId) {
-      const isV2 = onboardingMode !== 'v1' && await isBrandalfEnabled(orgId, env, log);
+      const isV2 = onboardingMode !== 'v1'
+        && await isBrandalfEnabled(orgId, context.dataAccess?.services?.postgrestClient, log);
       if (isV2) {
         organizationId = orgId;
         const brand = await findActiveBrandForSite(context, { orgId, siteId });

--- a/src/utils/brandalf-utils.js
+++ b/src/utils/brandalf-utils.js
@@ -10,47 +10,45 @@
  * governing permissions and limitations under the License.
  */
 
-import { tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
+const BRANDALF_FLAG_NAME = 'brandalf';
+const FEATURE_FLAG_PRODUCT = 'LLMO';
 
 /**
- * Checks whether the brandalf feature flag is enabled for an organization
- * by calling the SpaceCat API feature-flags endpoint.
+ * Checks whether the brandalf feature flag is enabled for an organization by
+ * reading the `feature_flags` table directly via the mysticat PostgREST client
+ * (available at `context.dataAccess.services.postgrestClient`).
  *
  * @param {string} organizationId - SpaceCat org UUID
- * @param {object} env - Environment variables (needs SPACECAT_API_BASE_URL, SPACECAT_API_KEY)
+ * @param {object} postgrestClient - mysticat PostgREST client (dataAccess.services.postgrestClient)
  * @param {object} log - Logger
  * @returns {Promise<boolean|null>} true/false when the flag state is known, null when unknown
  */
-export async function isBrandalfEnabled(organizationId, env, log) {
-  const { SPACECAT_API_BASE_URL: apiBase, SPACECAT_API_KEY: apiKey } = env || {};
+export async function isBrandalfEnabled(organizationId, postgrestClient, log) {
   if (!organizationId) {
     return false;
   }
-  if (!apiBase || !apiKey) {
-    log?.warn('SPACECAT_API_BASE_URL or SPACECAT_API_KEY not configured; cannot check brandalf flag');
+  if (!postgrestClient?.from) {
+    log?.warn('PostgREST client not available; cannot check brandalf flag');
     return null;
   }
 
   try {
-    const url = `${apiBase}/organizations/${encodeURIComponent(organizationId)}/feature-flags?product=LLMO`;
-    const response = await fetch(url, {
-      headers: { 'x-api-key': apiKey },
-    });
+    const { data, error } = await postgrestClient
+      .from('feature_flags')
+      .select('flag_value')
+      .eq('organization_id', organizationId)
+      .eq('product', FEATURE_FLAG_PRODUCT)
+      .eq('flag_name', BRANDALF_FLAG_NAME)
+      .maybeSingle();
 
-    if (!response.ok) {
-      log?.warn(`Failed to fetch feature flags for org ${organizationId}: ${response.status}`);
+    if (error) {
+      log?.warn(`Failed to read brandalf flag for org ${organizationId}: ${error.message}`);
       return null;
     }
 
-    const flags = await response.json();
-    if (!Array.isArray(flags)) {
-      log?.warn(`Unexpected feature flags payload for org ${organizationId}; cannot check brandalf flag`);
-      return null;
-    }
-
-    return flags.some(
-      (flag) => flag.flagName === 'brandalf' && flag.flagValue === true,
-    );
+    // Absent row => flag not set => disabled, matching the previous behaviour
+    // where a missing flag resolved to `false`.
+    return data?.flag_value === true;
   } catch (error) {
     log?.warn(`Error checking brandalf flag for org ${organizationId}: ${error.message}`);
     return null;

--- a/src/utils/offsite-brand-presence-enrichment.js
+++ b/src/utils/offsite-brand-presence-enrichment.js
@@ -367,7 +367,7 @@ export async function loadBrandPresenceData({
   });
 
   const isBrandalfOrg = organizationId
-    ? await isBrandalfEnabled(organizationId, env, log)
+    ? await isBrandalfEnabled(organizationId, context.dataAccess?.services?.postgrestClient, log)
     : false;
 
   if (isBrandalfOrg === null) {

--- a/test/audits/llmo-customer-analysis.test.js
+++ b/test/audits/llmo-customer-analysis.test.js
@@ -1477,7 +1477,11 @@ describe('LLMO Customer Analysis Handler', () => {
         auditContext,
       );
 
-      expect(mockIsBrandalfEnabled).to.have.been.calledWith('org-123', context.env, log);
+      expect(mockIsBrandalfEnabled).to.have.been.calledWith(
+        'org-123',
+        context.dataAccess.services.postgrestClient,
+        log,
+      );
       expect(mockFetch).to.have.callCount(2);
 
       // Verify schedule was created with brand_id
@@ -1802,47 +1806,6 @@ describe('LLMO Customer Analysis Handler', () => {
       expect(body.spacecat_org_id).to.be.undefined;
     });
 
-    it('should skip brand resolution when brandalf helper warns and returns false', async () => {
-      const auditContext = {};
-      mockIsBrandalfEnabled.callsFake(async () => {
-        log.warn('Failed to fetch feature flags for org org-123: 500');
-        return false;
-      });
-
-      mockFetch.reset();
-      mockFetch.onFirstCall().resolves({
-        ok: true,
-        json: async () => ({ schedule_id: 'sched-001' }),
-      });
-      mockFetch.onSecondCall().resolves({
-        ok: true,
-        json: async () => ({}),
-      });
-
-      mockLlmoConfig.readConfig.resolves({
-        config: {
-          entities: {},
-          categories: {},
-          topics: {},
-          brands: { aliases: [] },
-          competitors: { competitors: [] },
-        },
-      });
-
-      await mockHandler.runLlmoCustomerAnalysis(
-        'https://example.com',
-        context,
-        site,
-        auditContext,
-      );
-
-      expect(log.warn).to.have.been.calledWith(sinon.match(/Failed to fetch feature flags/));
-      const createCall = mockFetch.getCalls().find((c) => c.args[0] === 'https://drs.example.com/api/schedules');
-      expect(createCall).to.exist;
-      const body = JSON.parse(createCall.args[1].body);
-      expect(body.brand_id).to.be.undefined;
-    });
-
     it('should warn when postgrestClient is not available for brandalf-enabled org', async () => {
       const auditContext = {};
       mockIsBrandalfEnabled.resolves(true);
@@ -1876,47 +1839,6 @@ describe('LLMO Customer Analysis Handler', () => {
       );
 
       expect(log.warn).to.have.been.calledWith(sinon.match(/No brand resolved for site/));
-    });
-
-    it('should continue when brandalf helper warns on error', async () => {
-      const auditContext = {};
-      mockIsBrandalfEnabled.callsFake(async () => {
-        log.warn('Error checking brandalf flag for org org-123: ECONNREFUSED');
-        return false;
-      });
-
-      mockFetch.reset();
-      mockFetch.onFirstCall().resolves({
-        ok: true,
-        json: async () => ({ schedule_id: 'sched-001' }),
-      });
-      mockFetch.onSecondCall().resolves({
-        ok: true,
-        json: async () => ({}),
-      });
-
-      mockLlmoConfig.readConfig.resolves({
-        config: {
-          entities: {},
-          categories: {},
-          topics: {},
-          brands: { aliases: [] },
-          competitors: { competitors: [] },
-        },
-      });
-
-      await mockHandler.runLlmoCustomerAnalysis(
-        'https://example.com',
-        context,
-        site,
-        auditContext,
-      );
-
-      expect(log.warn).to.have.been.calledWith(sinon.match(/Error checking brandalf flag/));
-      const createCall = mockFetch.getCalls().find((c) => c.args[0] === 'https://drs.example.com/api/schedules');
-      expect(createCall).to.exist;
-      const body = JSON.parse(createCall.args[1].body);
-      expect(body.brand_id).to.be.undefined;
     });
 
     it('should skip brandalf check and omit brand_id when onboardingMode is v1 (mixed-state org)', async () => {

--- a/test/utils/brandalf-utils.test.js
+++ b/test/utils/brandalf-utils.test.js
@@ -17,30 +17,21 @@ import esmock from 'esmock';
 
 use(sinonChai);
 
-const DEFAULT_ENV = Object.freeze({
-  SPACECAT_API_BASE_URL: 'https://spacecat.example.com',
-  SPACECAT_API_KEY: 'test-key',
-});
-
 describe('brandalf-utils', () => {
   let sandbox;
-  let mockFetch;
   let isBrandalfEnabled;
   let resolveOrganizationIdForSite;
   let log;
 
   beforeEach(async () => {
     sandbox = sinon.createSandbox();
-    mockFetch = sandbox.stub();
     log = {
       info: sandbox.stub(),
       warn: sandbox.stub(),
       error: sandbox.stub(),
     };
 
-    const mod = await esmock('../../src/utils/brandalf-utils.js', {
-      '@adobe/spacecat-shared-utils': { tracingFetch: mockFetch },
-    });
+    const mod = await esmock('../../src/utils/brandalf-utils.js', {});
 
     isBrandalfEnabled = mod.isBrandalfEnabled;
     resolveOrganizationIdForSite = mod.resolveOrganizationIdForSite;
@@ -50,91 +41,98 @@ describe('brandalf-utils', () => {
     sandbox.restore();
   });
 
-  function stubFeatureFlagsResponse(flags) {
-    mockFetch.resolves({
-      ok: true,
-      json: async () => flags,
-    });
+  /**
+   * Builds a chainable PostgREST client stub whose terminal `maybeSingle()`
+   * resolves to `{ data, error }`.
+   */
+  function stubPostgrestClient({ data = null, error = null } = {}) {
+    const query = {
+      select: sandbox.stub().returnsThis(),
+      eq: sandbox.stub().returnsThis(),
+      maybeSingle: sandbox.stub().resolves({ data, error }),
+    };
+    const from = sandbox.stub().returns(query);
+    return { client: { from }, query, from };
   }
 
   describe('isBrandalfEnabled', () => {
     it('returns true when the brandalf flag is enabled', async () => {
-      stubFeatureFlagsResponse([{ flagName: 'brandalf', flagValue: true }]);
+      const { client, from, query } = stubPostgrestClient({ data: { flag_value: true } });
 
-      const result = await isBrandalfEnabled('org-123', DEFAULT_ENV, log);
+      const result = await isBrandalfEnabled('org-123', client, log);
 
       expect(result).to.equal(true);
-      expect(mockFetch).to.have.been.calledWith(
-        'https://spacecat.example.com/organizations/org-123/feature-flags?product=LLMO',
-        sinon.match.hasNested('headers.x-api-key', 'test-key'),
-      );
+      expect(from).to.have.been.calledWith('feature_flags');
+      expect(query.select).to.have.been.calledWith('flag_value');
+      expect(query.eq).to.have.been.calledWith('organization_id', 'org-123');
+      expect(query.eq).to.have.been.calledWith('product', 'LLMO');
+      expect(query.eq).to.have.been.calledWith('flag_name', 'brandalf');
     });
 
-    it('returns false without calling the API when organizationId is missing', async () => {
-      const result = await isBrandalfEnabled(null, DEFAULT_ENV, log);
+    it('returns false without querying when organizationId is missing', async () => {
+      const { client, from } = stubPostgrestClient({ data: { flag_value: true } });
+
+      const result = await isBrandalfEnabled(null, client, log);
 
       expect(result).to.equal(false);
-      expect(mockFetch).to.not.have.been.called;
+      expect(from).to.not.have.been.called;
       expect(log.warn).to.not.have.been.called;
     });
 
-    it('returns null when API env is missing', async () => {
-      const result = await isBrandalfEnabled('org-123', {}, log);
-
-      expect(result).to.equal(null);
-      expect(mockFetch).to.not.have.been.called;
-      expect(log.warn).to.have.been.calledWithMatch(/cannot check brandalf flag/);
-    });
-
-    it('returns null when env is omitted entirely', async () => {
+    it('returns null when the PostgREST client is missing', async () => {
       const result = await isBrandalfEnabled('org-123', undefined, log);
 
       expect(result).to.equal(null);
-      expect(mockFetch).to.not.have.been.called;
       expect(log.warn).to.have.been.calledWithMatch(/cannot check brandalf flag/);
     });
 
-    it('encodes the org ID and returns false when brandalf is not enabled', async () => {
-      stubFeatureFlagsResponse([
-        { flagName: 'brandalf', flagValue: false },
-        { flagName: 'different-flag', flagValue: true },
-      ]);
+    it('returns null when the PostgREST client has no query builder', async () => {
+      const result = await isBrandalfEnabled('org-123', {}, log);
 
-      const result = await isBrandalfEnabled('org/with spaces', DEFAULT_ENV, log);
+      expect(result).to.equal(null);
+      expect(log.warn).to.have.been.calledWithMatch(/cannot check brandalf flag/);
+    });
+
+    it('returns false when no flag row exists', async () => {
+      const { client } = stubPostgrestClient({ data: null });
+
+      const result = await isBrandalfEnabled('org-123', client, log);
 
       expect(result).to.equal(false);
-      expect(mockFetch).to.have.been.calledWith(
-        'https://spacecat.example.com/organizations/org%2Fwith%20spaces/feature-flags?product=LLMO',
-        sinon.match.hasNested('headers.x-api-key', 'test-key'),
-      );
     });
 
-    it('returns null when the feature-flags endpoint responds with a non-ok status', async () => {
-      mockFetch.resolves({ ok: false, status: 503 });
+    it('returns false when the flag row is explicitly disabled', async () => {
+      const { client } = stubPostgrestClient({ data: { flag_value: false } });
 
-      const result = await isBrandalfEnabled('org-123', DEFAULT_ENV, log);
+      const result = await isBrandalfEnabled('org-123', client, log);
+
+      expect(result).to.equal(false);
+    });
+
+    it('returns null and warns when the query returns an error', async () => {
+      const { client } = stubPostgrestClient({ error: { message: 'db unavailable' } });
+
+      const result = await isBrandalfEnabled('org-123', client, log);
 
       expect(result).to.equal(null);
       expect(log.warn).to.have.been.calledWithMatch(
-        /Failed to fetch feature flags for org org-123: 503/,
+        /Failed to read brandalf flag for org org-123: db unavailable/,
       );
     });
 
-    it('returns null when the API payload is not an array', async () => {
-      stubFeatureFlagsResponse({ flagName: 'brandalf', flagValue: true });
+    it('returns null and warns when the query throws', async () => {
+      const query = {
+        select: sandbox.stub().returnsThis(),
+        eq: sandbox.stub().returnsThis(),
+        maybeSingle: sandbox.stub().rejects(new Error('connection reset')),
+      };
+      const client = { from: sandbox.stub().returns(query) };
 
-      expect(await isBrandalfEnabled('org-123', DEFAULT_ENV, log)).to.equal(null);
-      expect(log.warn).to.have.been.calledWithMatch(/Unexpected feature flags payload/);
-    });
-
-    it('returns null and warns when the feature-flag request throws', async () => {
-      mockFetch.rejects(new Error('network down'));
-
-      const result = await isBrandalfEnabled('org-123', DEFAULT_ENV, log);
+      const result = await isBrandalfEnabled('org-123', client, log);
 
       expect(result).to.equal(null);
       expect(log.warn).to.have.been.calledWithMatch(
-        /Error checking brandalf flag for org org-123: network down/,
+        /Error checking brandalf flag for org org-123: connection reset/,
       );
     });
   });


### PR DESCRIPTION
Read brandalf feature flag via dataAccess instead of the SpaceCat API

**Summary**
* replace the HTTP feature-flags API call in isBrandalfEnabled with a direct read of the feature_flags table through the mysticat PostgREST client (dataAccess.services.postgrestClient), matching the pattern already used for brand-presence data.
* update both call sites (llmo-customer-analysis/handler.js, offsite-brand-presence-enrichment.js) to pass the PostgREST client; drops the `SPACECAT_API_BASE_URL`/`SPACECAT_API_KEY` dependency for this check.
Preserve the existing three-state contract (`true`/`false`/`null`), where a missing row resolves to `false`.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
