### PR TITLE
fix(prerender): auto-batch all suggestions to Mystique (LLMO-5446)

### DIFF
--- a/src/prerender/handler.js
+++ b/src/prerender/handler.js
@@ -699,32 +699,43 @@ async function sendPrerenderGuidanceRequestToMystique(
 
     const deliveryType = site?.getDeliveryType?.() || 'unknown';
 
-    // SQS has a 256 KB message size limit. Chunk suggestions into batches to stay safely under it.
-    // TODO: send all batches once Mystique multi-batch handling is fully deployed.
-    const firstBatch = suggestionsPayload.slice(0, MYSTIQUE_BATCH_SIZE);
-
+    // SQS has a 256 KB message size limit. Chunk suggestions into batches of MYSTIQUE_BATCH_SIZE
+    // and send every batch so no suggestions are silently dropped (LLMO-5446). Each message
+    // carries its batchIndex/totalBatches so Mystique can reassemble the full set.
+    const totalBatches = Math.ceil(suggestionsPayload.length / MYSTIQUE_BATCH_SIZE);
     const time = new Date().toISOString();
     const queue = env.QUEUE_SPACECAT_TO_MYSTIQUE;
-    await sqs.sendMessage(queue, {
-      type: 'guidance:prerender',
-      url: baseUrl,
-      siteId,
-      auditId,
-      deliveryType,
-      time,
-      data: {
-        opportunityId,
-        suggestions: firstBatch,
-        batchIndex: 0,
-        totalBatches: 1,
-        generatePrompts,
-        siteRegion: site.getRegion() ?? '',
-      },
-    });
+    const siteRegion = site.getRegion() ?? '';
 
-    log.info(`${LOG_PREFIX} Queued guidance:prerender message to Mystique for baseUrl=${baseUrl}, `
-      + `siteId=${siteId}, opportunityId=${opportunityId}, suggestions=${firstBatch.length} (capped to 1 batch of ${MYSTIQUE_BATCH_SIZE})`);
-    return firstBatch.length;
+    for (let batchIndex = 0; batchIndex < totalBatches; batchIndex += 1) {
+      const batchStart = batchIndex * MYSTIQUE_BATCH_SIZE;
+      const batch = suggestionsPayload.slice(batchStart, batchStart + MYSTIQUE_BATCH_SIZE);
+
+      // eslint-disable-next-line no-await-in-loop
+      await sqs.sendMessage(queue, {
+        type: 'guidance:prerender',
+        url: baseUrl,
+        siteId,
+        auditId,
+        deliveryType,
+        time,
+        data: {
+          opportunityId,
+          suggestions: batch,
+          batchIndex,
+          totalBatches,
+          generatePrompts,
+          siteRegion,
+        },
+      });
+
+      log.info(`${LOG_PREFIX} Queued guidance:prerender batch ${batchIndex + 1}/${totalBatches} `
+        + `(${batch.length} suggestion(s)) to Mystique for baseUrl=${baseUrl}, siteId=${siteId}, opportunityId=${opportunityId}`);
+    }
+
+    log.info(`${LOG_PREFIX} Queued all ${totalBatches} batch(es) (${suggestionsPayload.length} suggestion(s) total) `
+      + `to Mystique for baseUrl=${baseUrl}, siteId=${siteId}, opportunityId=${opportunityId}`);
+    return suggestionsPayload.length;
   /* c8 ignore next 8 - Error handling for SQS failures when sending to Mystique,
    * difficult to test reliably */
   } catch (error) {

--- a/test/audits/prerender/ai-only-mode.test.js
+++ b/test/audits/prerender/ai-only-mode.test.js
@@ -19,6 +19,7 @@ import {
   processContentAndGenerateOpportunities,
   handleAiOnlyMode,
 } from '../../../src/prerender/handler.js';
+import { MYSTIQUE_BATCH_SIZE } from '../../../src/prerender/utils/constants.js';
 
 use(sinonChai);
 
@@ -868,6 +869,46 @@ describe('Prerender AI-Only Mode', () => {
       const message = mockSqs.sendMessage.getCall(0).args[1];
       expect(message.data.batchIndex).to.equal(0);
       expect(message.data.totalBatches).to.equal(1);
+    });
+
+    it('should send all suggestions across multiple batches when they exceed MYSTIQUE_BATCH_SIZE', async () => {
+      // One more than a single batch forces exactly two batches.
+      const total = MYSTIQUE_BATCH_SIZE + 1;
+      mockSuggestions.length = 0;
+      for (let i = 0; i < total; i += 1) {
+        mockSuggestions.push({
+          getId: sandbox.stub().returns(`suggestion-${i}`),
+          getData: sandbox.stub().returns({
+            url: `https://example.com/page${i}`,
+            isDomainWide: false,
+            scrapeJobId: 'test-scrape-job',
+          }),
+          getStatus: sandbox.stub().returns('NEW'),
+        });
+      }
+
+      const result = await importTopPages(context);
+
+      expect(result.status).to.equal('complete');
+      expect(result.auditResult.suggestionCount).to.equal(total);
+      // Two SQS messages — no suggestion is dropped (LLMO-5446).
+      expect(mockSqs.sendMessage.callCount).to.equal(2);
+
+      const firstBatch = mockSqs.sendMessage.getCall(0).args[1].data;
+      const secondBatch = mockSqs.sendMessage.getCall(1).args[1].data;
+      expect(firstBatch.batchIndex).to.equal(0);
+      expect(firstBatch.totalBatches).to.equal(2);
+      expect(firstBatch.suggestions).to.have.length(MYSTIQUE_BATCH_SIZE);
+      expect(secondBatch.batchIndex).to.equal(1);
+      expect(secondBatch.totalBatches).to.equal(2);
+      expect(secondBatch.suggestions).to.have.length(1);
+
+      // Every suggestion is accounted for exactly once across the batches.
+      const sentUrls = [
+        ...firstBatch.suggestions.map((s) => s.url),
+        ...secondBatch.suggestions.map((s) => s.url),
+      ];
+      expect(new Set(sentUrls).size).to.equal(total);
     });
   });
 


### PR DESCRIPTION
## Problem

[LLMO-5446](https://jira.corp.adobe.com/browse/LLMO-5446) — In the RCV / prerender audit, `sendPrerenderGuidanceRequestToMystique` sliced the suggestions payload to the first `MYSTIQUE_BATCH_SIZE` (320) entries and hardcoded `totalBatches: 1`. Every suggestion beyond the first batch was **silently dropped**.

This was most impactful in **ai-only mode**, where all eligible DB suggestions for an opportunity are resent — e.g. for `motilaloswal.com` (300+ pages) only the first 320 suggestions ever reached Mystique, so the rest never got prompts generated.

## Fix

Loop over the full payload in `MYSTIQUE_BATCH_SIZE` chunks and send one SQS message per batch, each carrying the correct `batchIndex` / `totalBatches` so Mystique can reassemble the complete set. This mirrors the existing batching pattern in the `internal-links` audit (`src/internal-links/opportunity-suggestions.js`). The function now returns the total number of suggestions sent across all batches.

`MYSTIQUE_BATCH_SIZE` (320) is unchanged — it still keeps each SQS message safely under the 256 KB limit; it is now used as a chunk size in a loop instead of a hard cap.

## Scope notes

- The daily **scraping** batch limit (`DAILY_BATCH_SIZE`, also 320) in `submitForScraping` is intentional and untouched.
- Companion ticket LLMO-5439 (PR #2613, csv URLs in ai-only mode) added a warning when suggestions exceed the 320 cap. Once both merge, that warning becomes redundant and can be removed.

## Testing

- New test in `test/audits/prerender/ai-only-mode.test.js` drives `MYSTIQUE_BATCH_SIZE + 1` suggestions and asserts two SQS messages are sent with correct `batchIndex`/`totalBatches` and that no suggestion is dropped.
- All 386 prerender tests pass; `src/prerender/handler.js` remains at 100% line/branch/statement coverage.

Jira: LLMO-5446

🤖 Generated with [Claude Code](https://claude.com/claude-code)