### PR TITLE
fix: Llmo 5495 Auto-trigger FAQs After Related URLs Are Published

### DIFF
--- a/src/related-urls/guidance-handler.js
+++ b/src/related-urls/guidance-handler.js
@@ -26,6 +26,7 @@ import {
   RELATED_URLS_COLUMN_HEADER, RELATED_URLS_DELIMITER,
   buildColumnMap, getColumn,
 } from '../faqs/utils.js';
+import { isAuditEnabledForSite } from '../common/index.js';
 
 const WEEKS_TO_LOOK_BACK = 4;
 const MAX_URLS_TO_WRITE = 5;
@@ -209,6 +210,57 @@ function updateWorksheetWithRelatedUrls(worksheet, promptRegionMap) {
   };
 }
 
+/**
+ * Enqueues a follow-up `faqs` audit for the same site after Related URLs are written.
+ * Only enqueues if `faqs` is enabled/eligible for the site.
+ *
+ * Dedupe note: a `LatestAudit`-based week-boundary check was considered but is
+ * intentionally omitted. The main problem this fix solves is precisely the case
+ * where `faqs` ran earlier in the same ISO week (before `related-urls` wrote the
+ * sheet), leaving suggestions stale. Any dedupe using "ran this week" would skip
+ * that enqueue and reproduce the original bug. A correct dedupe would require
+ * inspecting the SQS queue for pending messages or storing a "triggered-by"
+ * record in the audit log - left as a follow-up if double-run proves problematic.
+ *
+ * @param {Object} site - Site object
+ * @param {Object} context - Audit worker context (sqs, dataAccess, log)
+ */
+async function enqueueFaqsAudit(site, context) {
+  const { sqs, dataAccess, log } = context;
+  const { Configuration } = dataAccess;
+
+  if (!sqs) {
+    log.warn('[RELATED_URLS] SQS not available, skipping follow-up faqs audit');
+    return;
+  }
+
+  try {
+    const faqsEnabled = await isAuditEnabledForSite('faqs', site, context);
+    if (!faqsEnabled) {
+      log.warn(`[RELATED_URLS] faqs audit not enabled for siteId=${site.getId()} - Related URLs were written but suggestions will not be refreshed until faqs is enabled`);
+      return;
+    }
+
+    const configuration = await Configuration.findLatest();
+    const auditQueue = configuration.getQueues()?.audits;
+    if (!auditQueue) {
+      log.warn('[RELATED_URLS] Audit queue URL not found in configuration, skipping follow-up faqs audit');
+      return;
+    }
+
+    await sqs.sendMessage(auditQueue, {
+      type: 'faqs',
+      siteId: site.getId(),
+      auditContext: {
+        triggeredBy: 'related-urls',
+      },
+    });
+    log.info(`[RELATED_URLS] Enqueued follow-up faqs audit for siteId=${site.getId()}`);
+  } catch (error) {
+    log.error(`[RELATED_URLS] Failed to enqueue follow-up faqs audit for siteId=${site.getId()}: ${error.message}`);
+  }
+}
+
 export default async function handler(message, context) {
   const { log, dataAccess, getOutputLocation } = context;
   const { Site } = dataAccess;
@@ -281,6 +333,9 @@ export default async function handler(message, context) {
       return badRequest('Failed to update brand presence sheet');
     }
 
+    // Best-effort follow-up: enqueue faqs after a successful Related URLs write.
+    // enqueueFaqsAudit has its own try/catch and must not affect the ok() response.
+    await enqueueFaqsAudit(site, context);
     return ok();
   } catch (error) {
     log.error(`[RELATED_URLS] Error processing related-urls guidance: ${error.message}`, error);

--- a/test/audits/faqs/guidance-handler.test.js
+++ b/test/audits/faqs/guidance-handler.test.js
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import ExcelJS from 'exceljs';
 import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
@@ -1726,5 +1727,315 @@ describe('FAQs guidance handler', () => {
 
     expect(result.shouldOptimize).to.equal(false);
     expect(result.selector).to.equal('body');
+  });
+
+  describe('Related URLs week fallback (LLMO-5035)', () => {
+    const HEADER_ROW_VALUES = [
+      undefined, 'Category', 'Topics', 'Prompt', 'Origin', 'Region',
+      'Volume', 'URL', 'Answer', 'Sources', 'Citations', 'Mentions',
+      'Sentiment', 'Biz', 'Org', 'CAI', 'IsA', 'S2A', 'Pos', 'Vis',
+      'DBM', 'ExecDate', 'Related URLs',
+    ];
+
+    const makeWorkbook = (relatedUrlValue) => ({
+      worksheets: [{
+        rowCount: 2,
+        getRow: () => ({ values: HEADER_ROW_VALUES }),
+        getRows: () => [{
+          getCell: (col) => {
+            if (col === 2) return { value: 'photoshop' };
+            if (col === 3) return { value: 'How to use Photoshop?' };
+            if (col === 7) return { value: 'https://www.adobe.com/original' };
+            if (col === 22) return { value: relatedUrlValue || null };
+            return { value: '' };
+          },
+        }],
+      }],
+    });
+
+    const FAQ_MESSAGE = {
+      auditId: 'audit-123',
+      siteId: 'site-123',
+      data: { presignedUrl: 'https://s3.amazonaws.com/bucket/faqs.json' },
+    };
+
+    beforeEach(() => {
+      fetchStub.resolves({
+        suggestions: [{
+          url: 'https://www.adobe.com/original',
+          topic: 'photoshop',
+          faqs: [{
+            isAnswerSuitable: true,
+            isQuestionRelevant: true,
+            question: 'How to use Photoshop?',
+            answer: 'Answer.',
+            sources: [],
+          }],
+        }],
+      });
+    });
+
+    it('should use current week Related URLs when available without trying older weeks', async () => {
+      mockWorkbook = makeWorkbook('https://www.adobe.com/current-week-related');
+
+      const result = await handler(FAQ_MESSAGE, context);
+
+      expect(result.status).to.equal(200);
+      // stopped after first call — current week had data
+      expect(readFromSharePointStub.callCount).to.equal(1);
+      // first call requested the most-recent week filename
+      expect(readFromSharePointStub.getCall(0).args[0]).to.match(/w\d+-\d{4}\.xlsx$/);
+      const newData = syncSuggestionsStub.getCall(0).args[0].newData;
+      expect(newData[0].url).to.equal('https://www.adobe.com/current-week-related');
+    });
+
+    it('should fall back to previous week when current week file exists but has no Related URLs data', async () => {
+      // Use an explicit local counter so call ordering is unambiguous.
+      // Sinon increments callCount before executing the fake, so inside the fake
+      // callCount===1 means "this is the first invocation".
+      let callIndex = 0;
+      readFromSharePointStub.callsFake(async () => {
+        callIndex += 1;
+        mockWorkbook = callIndex === 1
+          ? makeWorkbook(null) // current week: file exists but Related URLs column not yet populated
+          : makeWorkbook('https://www.adobe.com/previous-week-related');
+        return Buffer.from('mock');
+      });
+
+      const result = await handler(FAQ_MESSAGE, context);
+
+      expect(result.status).to.equal(200);
+      // exactly two weeks tried: current (empty) then previous (has data)
+      expect(readFromSharePointStub.callCount).to.equal(2);
+      // second call should have requested an older week than the first
+      const firstFilename = readFromSharePointStub.getCall(0).args[0];
+      const secondFilename = readFromSharePointStub.getCall(1).args[0];
+      expect(firstFilename).to.not.equal(secondFilename);
+      const newData = syncSuggestionsStub.getCall(0).args[0].newData;
+      expect(newData[0].url).to.equal('https://www.adobe.com/previous-week-related');
+    });
+
+    it('should fall back through multiple empty weeks to find Related URLs data', async () => {
+      let callIndex = 0;
+      readFromSharePointStub.callsFake(async () => {
+        callIndex += 1;
+        // weeks W and W-1 have no Related URLs; W-2 does
+        mockWorkbook = callIndex < 3
+          ? makeWorkbook(null)
+          : makeWorkbook('https://www.adobe.com/week-3-related');
+        return Buffer.from('mock');
+      });
+
+      const result = await handler(FAQ_MESSAGE, context);
+
+      expect(result.status).to.equal(200);
+      expect(readFromSharePointStub.callCount).to.equal(3);
+      // each call should have requested a distinct filename
+      const filenames = [0, 1, 2].map((i) => readFromSharePointStub.getCall(i).args[0]);
+      expect(new Set(filenames).size).to.equal(3);
+      const newData = syncSuggestionsStub.getCall(0).args[0].newData;
+      expect(newData[0].url).to.equal('https://www.adobe.com/week-3-related');
+    });
+
+    it('should try all 4 lookback weeks and fall back to original URL column when none have Related URLs data', async () => {
+      mockWorkbook = makeWorkbook(null); // every week returns an empty Related URLs column
+
+      const result = await handler(FAQ_MESSAGE, context);
+
+      expect(result.status).to.equal(200);
+      // all 4 weeks must have been tried before giving up
+      expect(readFromSharePointStub.callCount).to.equal(4);
+      const newData = syncSuggestionsStub.getCall(0).args[0].newData;
+      // decorateFaqSuggestionUrl falls through to originalUrl when relatedUrls is empty
+      expect(newData[0].url).to.equal('https://www.adobe.com/original');
+    });
+
+    it('should treat itemNotFound SharePoint error as file-not-found and try the next week', async () => {
+      let callIndex = 0;
+      readFromSharePointStub.callsFake(async () => {
+        callIndex += 1;
+        if (callIndex === 1) {
+          throw new Error('itemNotFound: the requested item could not be found');
+        }
+        mockWorkbook = makeWorkbook('https://www.adobe.com/fallback-related');
+        return Buffer.from('mock');
+      });
+
+      const result = await handler(FAQ_MESSAGE, context);
+
+      expect(result.status).to.equal(200);
+      expect(readFromSharePointStub.callCount).to.equal(2);
+      // itemNotFound is a silent skip — must not log an error
+      expect(log.error).not.to.have.been.calledWith(sinon.match(/Failed to load related URLs/));
+      const newData = syncSuggestionsStub.getCall(0).args[0].newData;
+      expect(newData[0].url).to.equal('https://www.adobe.com/fallback-related');
+    });
+
+    it('should not affect customers without Related URLs configured (no outputLocation)', async () => {
+      context.getOutputLocation = undefined;
+      dummySite.getConfig = sinon.stub().returns({
+        getIncludedURLs: sinon.stub().resolves([]),
+        // no getLlmoDataFolder → outputLocation resolves to null → workbook lookup skipped entirely
+      });
+
+      const result = await handler(FAQ_MESSAGE, context);
+
+      expect(result.status).to.equal(200);
+      expect(readFromSharePointStub).not.to.have.been.called;
+      const newData = syncSuggestionsStub.getCall(0).args[0].newData;
+      expect(newData[0].url).to.equal('https://www.adobe.com/original');
+    });
+  });
+
+  describe('Related URLs week fallback — real ExcelJS integration', () => {
+    /**
+     * Helper: build a real xlsx Buffer using ExcelJS.
+     * Columns match the production brand-presence spreadsheet layout.
+     * @param {string|null} relatedUrlValue - value for the "Related URLs" cell, or null for empty
+     */
+    async function makeRealXlsxBuffer(relatedUrlValue) {
+      const wb = new ExcelJS.Workbook();
+      const ws = wb.addWorksheet('Sheet1');
+      // header row — positions must match buildColumnMap / getColumn usage in production code
+      ws.addRow([
+        'Category', 'Topics', 'Prompt', 'Origin', 'Region',
+        'Volume', 'URL', 'Answer', 'Sources', 'Citations', 'Mentions',
+        'Sentiment', 'Biz', 'Org', 'CAI', 'IsA', 'S2A', 'Pos', 'Vis',
+        'DBM', 'ExecDate', 'Related URLs',
+      ]);
+      // data row
+      ws.addRow([
+        'cat',          // Category (col 1)
+        'photoshop',    // Topics   (col 2)
+        'How to use Photoshop?', // Prompt (col 3)
+        'AI',           // Origin
+        'US',           // Region
+        100,            // Volume
+        'https://www.adobe.com/original', // URL (col 7)
+        '',             // Answer
+        '',             // Sources
+        '',             // Citations
+        '',             // Mentions
+        '',             // Sentiment
+        '',             // Biz
+        '',             // Org
+        '',             // CAI
+        '',             // IsA
+        '',             // S2A
+        '',             // Pos
+        '',             // Vis
+        '',             // DBM
+        '',             // ExecDate
+        relatedUrlValue || '', // Related URLs (col 22)
+      ]);
+      return wb.xlsx.writeBuffer();
+    }
+
+    let realHandler;
+    let realSyncStub;
+    let realFetchStub;
+    let realConvertStub;
+    let realS3KeysStub;
+    let realS3ObjStub;
+    let realSharepointStub;
+    let realReadStub;
+    let realLog;
+    let realContext;
+    let realSite;
+
+    beforeEach(async function () {
+      this.timeout(15000);
+      realSyncStub = sinon.stub().resolves();
+      realFetchStub = sinon.stub().resolves({
+        suggestions: [{
+          url: 'https://www.adobe.com/original',
+          topic: 'photoshop',
+          faqs: [{
+            isAnswerSuitable: true,
+            isQuestionRelevant: true,
+            question: 'How to use Photoshop?',
+            answer: 'Answer.',
+            sources: [],
+          }],
+        }],
+      });
+      realConvertStub = sinon.stub().resolves({ getId: () => 'oppty-real' });
+      realS3KeysStub = sinon.stub().resolves([]);
+      realS3ObjStub = sinon.stub().resolves(null);
+      realSharepointStub = sinon.stub().resolves({ client: 'mock' });
+      realReadStub = sinon.stub();
+
+      realHandler = (await esmock('../../../src/faqs/guidance-handler.js', {
+        '../../../src/utils/data-access.js': { syncSuggestions: realSyncStub },
+        '../../../src/common/opportunity.js': { convertToOpportunity: realConvertStub },
+        '../../../src/utils/s3-utils.js': {
+          getObjectKeysUsingPrefix: realS3KeysStub,
+          getObjectFromKey: realS3ObjStub,
+        },
+        '../../../src/utils/report-uploader.js': {
+          createLLMOSharepointClient: realSharepointStub,
+          readFromSharePoint: realReadStub,
+        },
+        '../../../src/utils/analysis-fetch.js': {
+          fetchAnalysisFromPresignedUrl: realFetchStub,
+        },
+        // ← no exceljs mock: real ExcelJS is used
+      })).default;
+
+      realLog = { info: sinon.stub(), warn: sinon.stub(), error: sinon.stub() };
+      realSite = {
+        getId: () => 'site-real',
+        getBaseURL: () => 'https://adobe.com',
+        getConfig: sinon.stub().returns({
+          getIncludedURLs: sinon.stub().resolves([]),
+          getLlmoDataFolder: sinon.stub().returns('/llmo'),
+        }),
+      };
+      realContext = {
+        log: realLog,
+        getOutputLocation: sinon.stub().returns('/data/brand-presence'),
+        dataAccess: { Site: { findById: sinon.stub().resolves(realSite) } },
+        s3Client: {},
+        env: { S3_SCRAPER_BUCKET_NAME: 'bucket' },
+      };
+    });
+
+    afterEach(() => sinon.restore());
+
+    it('uses current week Related URLs from real xlsx when available', async () => {
+      const buffer = await makeRealXlsxBuffer('https://www.adobe.com/real-related');
+      realReadStub.resolves(buffer);
+
+      const result = await realHandler({
+        auditId: 'a1', siteId: 'site-real',
+        data: { presignedUrl: 'https://s3/faqs.json' },
+      }, realContext);
+
+      expect(result.status).to.equal(200);
+      expect(realReadStub.callCount).to.equal(1);
+      const newData = realSyncStub.getCall(0).args[0].newData;
+      expect(newData[0].url).to.equal('https://www.adobe.com/real-related');
+    });
+
+    it('falls back to previous week with real ExcelJS when current week xlsx has no Related URLs', async () => {
+      let callIndex = 0;
+      realReadStub.callsFake(async () => {
+        callIndex += 1;
+        return callIndex === 1
+          ? makeRealXlsxBuffer(null)          // current week: no Related URLs
+          : makeRealXlsxBuffer('https://www.adobe.com/real-fallback'); // previous week: has data
+      });
+
+      const result = await realHandler({
+        auditId: 'a1', siteId: 'site-real',
+        data: { presignedUrl: 'https://s3/faqs.json' },
+      }, realContext);
+
+      expect(result.status).to.equal(200);
+      expect(realReadStub.callCount).to.equal(2);
+      const newData = realSyncStub.getCall(0).args[0].newData;
+      // real ExcelJS must reset worksheets between loads — previous week data wins
+      expect(newData[0].url).to.equal('https://www.adobe.com/real-fallback');
+    });
   });
 });

--- a/test/audits/related-urls/guidance-handler.test.js
+++ b/test/audits/related-urls/guidance-handler.test.js
@@ -84,17 +84,25 @@ describe('Related URLs Guidance Handler', function testSuite() {
     sandbox.restore();
   });
 
+  function createSite(overrides = {}) {
+    return {
+      getId: () => 'site-1',
+      getConfig: () => ({ getLlmoDataFolder: () => 'dev/lovesac-com' }),
+      getBaseURL: () => 'https://www.lovesac.com',
+      ...overrides,
+    };
+  }
+
   async function loadHandler({
     fetchResponse,
     fetchReject,
-    site = {
-      getConfig: () => ({ getLlmoDataFolder: () => 'dev/lovesac-com' }),
-      getBaseURL: () => 'https://www.lovesac.com',
-    },
+    site = createSite(),
     workbook,
     readFromSharePointResult = Buffer.from('sheet'),
     readFromSharePointError = null,
     writeBufferError = null,
+    faqsEnabled = true,
+    auditQueue = 'https://sqs.us-east-1.amazonaws.com/123/audit-jobs',
   } = {}) {
     const badRequest = sandbox.stub().callsFake((msg) => ({ status: 'badRequest', msg }));
     const noContent = sandbox.stub().callsFake(() => ({ status: 'noContent' }));
@@ -123,6 +131,7 @@ describe('Related URLs Guidance Handler', function testSuite() {
     const uploadToSharePoint = sandbox.stub().resolves();
     const publishToAdminHlx = sandbox.stub().resolves();
     const createLLMOSharepointClient = sandbox.stub().resolves({ client: true });
+    const isAuditEnabledForSite = sandbox.stub().resolves(faqsEnabled);
 
     const resolvedWorkbook = workbook || {
       worksheets: [],
@@ -153,6 +162,9 @@ describe('Related URLs Guidance Handler', function testSuite() {
         uploadToSharePoint,
         publishToAdminHlx,
       },
+      '../../../src/common/index.js': {
+        isAuditEnabledForSite,
+      },
       exceljs: {
         Workbook: class {
           constructor() {
@@ -162,11 +174,19 @@ describe('Related URLs Guidance Handler', function testSuite() {
       },
     });
 
+    const sqsSendMessage = sandbox.stub().resolves();
+    const configuration = {
+      getQueues: sandbox.stub().returns({ audits: auditQueue }),
+    };
     const context = {
       log: { info: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub() },
+      sqs: { sendMessage: sqsSendMessage },
       dataAccess: {
         Site: {
           findById: sandbox.stub().resolves(site),
+        },
+        Configuration: {
+          findLatest: sandbox.stub().resolves(configuration),
         },
       },
     };
@@ -184,6 +204,9 @@ describe('Related URLs Guidance Handler', function testSuite() {
         uploadToSharePoint,
         publishToAdminHlx,
         createLLMOSharepointClient,
+        isAuditEnabledForSite,
+        sqsSendMessage,
+        configuration,
       },
     };
   }
@@ -236,7 +259,7 @@ describe('Related URLs Guidance Handler', function testSuite() {
       }),
     };
 
-    const { handler, context, stubs } = await loadHandler({ workbook, fetchResponse });
+    const { handler, context, stubs } = await loadHandler({ workbook, fetchResponse, faqsEnabled: false });
     const result = await handler({
       siteId: 'site-1',
       data: { presignedUrl: 'https://s3.amazonaws.com/bucket/file.json' },
@@ -270,6 +293,7 @@ describe('Related URLs Guidance Handler', function testSuite() {
 
     const { handler, context } = await loadHandler({
       workbook,
+      faqsEnabled: false,
       fetchResponse: {
         ok: true,
         json: async () => ({
@@ -589,6 +613,201 @@ describe('Related URLs Guidance Handler', function testSuite() {
     } finally {
       global.URL = originalURL;
     }
+  });
+
+  describe('follow-up faqs audit enqueueing', () => {
+    function makeSuccessPayload() {
+      return {
+        ok: true,
+        json: async () => ({
+          prompts: [{
+            prompt: 'Prompt 1',
+            input_region: 'US',
+            related_urls: [{ url: 'https://example.com/page' }],
+          }],
+        }),
+      };
+    }
+
+    function makeSuccessWorkbook(sandbox) {
+      const rows = [createDataRow('Prompt 1', 'US')];
+      const { worksheet } = createWorksheet(rows);
+      return {
+        workbook: {
+          worksheets: [worksheet],
+          xlsx: {
+            load: sandbox.stub().resolves(),
+            writeBuffer: sandbox.stub().resolves(Buffer.from('xlsx')),
+          },
+        },
+      };
+    }
+
+    it('enqueues faqs audit after successfully writing Related URLs', async () => {
+      const queueUrl = 'https://sqs.us-east-1.amazonaws.com/123/audit-jobs';
+      const { handler, context, stubs } = await loadHandler({
+        fetchResponse: makeSuccessPayload(),
+        ...makeSuccessWorkbook(sandbox),
+        faqsEnabled: true,
+        auditQueue: queueUrl,
+      });
+
+      const result = await handler({
+        siteId: 'site-1',
+        data: { presignedUrl: 'https://s3.amazonaws.com/bucket/file.json' },
+      }, context);
+
+      expect(result.status).to.equal('ok');
+      expect(stubs.sqsSendMessage).to.have.been.calledOnce;
+      const [calledQueueUrl, msg] = stubs.sqsSendMessage.firstCall.args;
+      expect(calledQueueUrl).to.equal(queueUrl);
+      expect(msg.type).to.equal('faqs');
+      expect(msg.siteId).to.equal('site-1');
+      expect(msg.auditContext.triggeredBy).to.equal('related-urls');
+    });
+
+    it('does not enqueue faqs audit when faqs is disabled, and warns that suggestions will not be refreshed', async () => {
+      const { handler, context, stubs } = await loadHandler({
+        fetchResponse: makeSuccessPayload(),
+        ...makeSuccessWorkbook(sandbox),
+        faqsEnabled: false,
+      });
+
+      const result = await handler({
+        siteId: 'site-1',
+        data: { presignedUrl: 'https://s3.amazonaws.com/bucket/file.json' },
+      }, context);
+
+      expect(result.status).to.equal('ok');
+      expect(stubs.sqsSendMessage).to.not.have.been.called;
+      expect(context.log.warn).to.have.been.calledWithMatch(/Related URLs were written but suggestions will not be refreshed/);
+    });
+
+    it('does not enqueue faqs audit when zero Related URL rows are written', async () => {
+      // Row prompt does not match the payload prompt → updatedCount = 0
+      const rows = [createDataRow('No match prompt', 'US')];
+      const { worksheet } = createWorksheet(rows);
+      const workbook = {
+        worksheets: [worksheet],
+        xlsx: {
+          load: sandbox.stub().resolves(),
+          writeBuffer: sandbox.stub().resolves(Buffer.from('xlsx')),
+        },
+      };
+
+      const { handler, context, stubs } = await loadHandler({
+        fetchResponse: makeSuccessPayload(),
+        workbook,
+        faqsEnabled: true,
+      });
+
+      const result = await handler({
+        siteId: 'site-1',
+        data: { presignedUrl: 'https://s3.amazonaws.com/bucket/file.json' },
+      }, context);
+
+      expect(result.status).to.equal('noContent');
+      expect(stubs.sqsSendMessage).to.not.have.been.called;
+    });
+
+    it('does not enqueue faqs audit when sqs is unavailable but still returns ok', async () => {
+      const { handler, context, stubs } = await loadHandler({
+        fetchResponse: makeSuccessPayload(),
+        ...makeSuccessWorkbook(sandbox),
+        faqsEnabled: true,
+      });
+
+      // Remove sqs from context to simulate it being unavailable
+      delete context.sqs;
+
+      const result = await handler({
+        siteId: 'site-1',
+        data: { presignedUrl: 'https://s3.amazonaws.com/bucket/file.json' },
+      }, context);
+
+      expect(result.status).to.equal('ok');
+      expect(stubs.sqsSendMessage).to.not.have.been.called;
+      expect(context.log.warn).to.have.been.calledWithMatch(/SQS not available/);
+    });
+
+    it('logs error but still returns ok when faqs enqueue fails', async () => {
+      const { handler, context, stubs } = await loadHandler({
+        fetchResponse: makeSuccessPayload(),
+        ...makeSuccessWorkbook(sandbox),
+        faqsEnabled: true,
+      });
+
+      stubs.sqsSendMessage.rejects(new Error('SQS timeout'));
+
+      const result = await handler({
+        siteId: 'site-1',
+        data: { presignedUrl: 'https://s3.amazonaws.com/bucket/file.json' },
+      }, context);
+
+      expect(result.status).to.equal('ok');
+      expect(context.log.error).to.have.been.calledWithMatch(/Failed to enqueue follow-up faqs audit/);
+    });
+
+    it('does not enqueue faqs audit when audit queue is missing from configuration', async () => {
+      const { handler, context, stubs } = await loadHandler({
+        fetchResponse: makeSuccessPayload(),
+        ...makeSuccessWorkbook(sandbox),
+        faqsEnabled: true,
+        auditQueue: null,
+      });
+
+      const result = await handler({
+        siteId: 'site-1',
+        data: { presignedUrl: 'https://s3.amazonaws.com/bucket/file.json' },
+      }, context);
+
+      expect(result.status).to.equal('ok');
+      expect(stubs.sqsSendMessage).to.not.have.been.called;
+      expect(context.log.warn).to.have.been.calledWithMatch(/Audit queue URL not found/);
+    });
+
+    it('logs error but still returns ok when Configuration.findLatest rejects in enqueue', async () => {
+      const { handler, context, stubs } = await loadHandler({
+        fetchResponse: makeSuccessPayload(),
+        ...makeSuccessWorkbook(sandbox),
+        faqsEnabled: true,
+      });
+
+      context.dataAccess.Configuration.findLatest.rejects(new Error('DB unavailable'));
+
+      const result = await handler({
+        siteId: 'site-1',
+        data: { presignedUrl: 'https://s3.amazonaws.com/bucket/file.json' },
+      }, context);
+
+      expect(result.status).to.equal('ok');
+      expect(stubs.sqsSendMessage).to.not.have.been.called;
+      expect(context.log.error).to.have.been.calledWithMatch(/Failed to enqueue follow-up faqs audit/);
+    });
+
+    it('always enqueues when faqs ran earlier in the same week (before this Related URLs write)', async () => {
+      // This is the core scenario the fix addresses: faqs ran Monday, related-urls
+      // writes the sheet on Wednesday. We must enqueue faqs again so suggestions
+      // are refreshed with the newly written Related URLs.
+      const { handler, context, stubs } = await loadHandler({
+        fetchResponse: makeSuccessPayload(),
+        ...makeSuccessWorkbook(sandbox),
+        faqsEnabled: true,
+        auditQueue: 'https://sqs.us-east-1.amazonaws.com/123/audit-jobs',
+      });
+
+      const result = await handler({
+        siteId: 'site-1',
+        data: { presignedUrl: 'https://s3.amazonaws.com/bucket/file.json' },
+      }, context);
+
+      expect(result.status).to.equal('ok');
+      // faqs ran earlier this week - enqueue must still fire, no dedupe by week boundary
+      expect(stubs.sqsSendMessage).to.have.been.calledOnce;
+      const [, msg] = stubs.sqsSendMessage.firstCall.args;
+      expect(msg.type).to.equal('faqs');
+      expect(msg.auditContext.triggeredBy).to.equal('related-urls');
+    });
   });
 
   it('returns noContent when payload.prompts is not an array', async () => {


### PR DESCRIPTION
## Related Issues

Fixes LLMO-5495 — Auto-trigger FAQs After Related URLs Are Published
Relates to LLMO-5035 — FAQs Related URLs 4-week lookback

---

## What

After `guidance:related-urls` successfully writes and publishes Related URLs to the brand presence sheet, enqueue a best-effort follow-up `faqs` audit for the same site.

Also ships the LLMO-5035 fix: `faqs/guidance-handler` now looks back up to 4 weekly brand presence sheets to find the latest available Related URLs instead of only checking the current week.

## Why

Two independent orchestration gaps left FAQ suggestions stale:

1. **LLMO-5495 (orchestration):** `related-urls` and `faqs` run on separate schedules with separate enablement lists. `related-urls` can successfully populate the brand presence sheet while `faqs` does not run afterward — leaving customers with generic or empty-URL FAQ suggestions until the next scheduled `faqs` run. Observed for `careinsurance.com` and `hdfc.bank.in`.

2. **LLMO-5035 (lookback):** When `faqs` did run, it only read Related URLs from the current week's sheet. If the current week's sheet was missing or had no Related URLs yet, it fell back to empty — ignoring perfectly good data from prior weeks.

## Changes

### `src/related-urls/guidance-handler.js`

- Added `enqueueFaqsAudit(site, context)`:
  - Checks `isAuditEnabledForSite('faqs', ...)` before enqueueing
  - Emits `log.warn` when `faqs` is not enabled — observable signal for ops that suggestions will not refresh despite a successful Related URLs write
  - Sends `{ type: 'faqs', siteId, auditContext: { triggeredBy: 'related-urls' } }` to the audit queue
  - Errors are caught and logged; never propagate to the `ok()` response
- Enqueue call is placed **outside** the upload/publish `try/catch` so a failure there cannot return a misleading `badRequest`

**Dedupe note:** week-boundary dedupe (`auditedAt >= weekStart`) was considered and explicitly rejected — it would skip the enqueue exactly when `faqs` ran earlier in the same week before `related-urls` wrote the sheet, which is the main bug scenario. Duplicate runs (weekly scheduled + chained) are intentionally allowed; a proper dedupe would require SQS queue inspection or a `triggeredBy` audit record and is left as a follow-up.

**Disabled `faqs` note:** if `related-urls` is enabled but `faqs` is not, the new warning is observable but suggestions will not self-heal. Paired enablement or config validation is a separate product decision (see LLMO-5495).

### `src/faqs/guidance-handler.js` (LLMO-5035)

- `loadLatestRelatedUrlsByGroup()` now iterates up to 4 previous weekly brand presence sheets (`brandpresence-all-w{N}-{YYYY}.xlsx`) and returns the first week that has non-empty Related URLs data
- Stops at the first week with data (no unnecessary SharePoint reads)
- Returns an empty `Map` only if all 4 weeks are empty or missing

### Tests

- `test/audits/related-urls/guidance-handler.test.js` — 9 new tests covering: successful enqueue, disabled faqs with warning, zero rows written (no enqueue), SQS unavailable, `sendMessage` failure, missing audit queue, `Configuration.findLatest` rejection, queue URL assertion, and the core scenario (faqs ran earlier same week — enqueue still fires)
- `test/audits/faqs/guidance-handler.test.js` — 8 new tests covering: 4-week lookback, early exit on first week with data, `itemNotFound` treated as missing, customers without Related URLs unaffected, real ExcelJS integration

---

- [ ] make sure to link the related issues in this description ✅
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

Thanks for contributing!