### PR TITLE
feat(strategic-recommendations-semrush): DRS result handler + Semrush row merge + publish read-back

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,3 +245,22 @@ await Suggestion.removeByIds(suggestionsToRemove.map((s) => s.getId()));
 4. Add `test/audits/[audit-name].test.js` (or a sub-directory for complex audits).
 5. Add fixtures to `test/fixtures/[audit-name]/`.
 6. Ensure 100% coverage on all new source files.
+
+### Non-AuditBuilder handlers (`drs:` / `guidance:` prefixes)
+
+Not every entry in the `HANDLERS` map is an `AuditBuilder` audit. Two recognized
+conventions register a plain `async (message, context) => Response` handler keyed
+by a namespaced `type`:
+
+- **`guidance:*`** — handlers that consume Mystique AI guidance responses.
+- **`drs:*`** — handlers that consume DRS (Data Retrieval Service) job-completion
+  notifications (e.g. `drs:strategic_recommendations_semrush`). These are not
+  triggered by a scheduled audit run; they react to an external SNS→SQS event,
+  fetch the referenced result, and write/publish downstream artifacts.
+
+Such handlers skip the `AuditBuilder` lifecycle (no `withRunner`, no
+`Audit.create()` persistence, no opportunity/suggestion sync) and instead export
+the handler function directly. They still register in `src/index.js` `HANDLERS`,
+still require 100% coverage, and the message they receive is the normalized shape
+produced by the dispatcher (see `normalizeDrsMessage` in `src/index.js` for the
+`drs:` envelope).

--- a/package.json
+++ b/package.json
@@ -65,7 +65,9 @@
       "src/llm-error-pages/sql",
       "src/llmo-customer-analysis/sql",
       "src/page-citability/sql",
-      "src/strategic-recommendations-semrush/shared-semrush-row.schema.v1.json"
+      "src/strategic-recommendations-semrush/shared-semrush-row.schema.v1.json",
+      "src/strategic-recommendations-semrush/shared-citation-row.schema.v1.json",
+      "src/strategic-recommendations-semrush/shared-persona-row.schema.v1.json"
     ]
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
       "src/page-intent/sql",
       "src/llm-error-pages/sql",
       "src/llmo-customer-analysis/sql",
-      "src/page-citability/sql"
+      "src/page-citability/sql",
+      "src/strategic-recommendations-semrush/shared-semrush-row.schema.v1.json"
     ]
   },
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -121,6 +121,7 @@ import frescopaDataGeneration from './frescopa-data-generation/handler.js';
 import semanticValueVisibility from './semantic-value-visibility/handler.js';
 import semanticValueVisibilityGuidance from './semantic-value-visibility/guidance-handler.js';
 import drsPromptGeneration from './drs-prompt-generation/handler.js';
+import strategicRecommendationsSemrush from './strategic-recommendations-semrush/handler.js';
 import offsiteBrandPresence from './offsite-brand-presence/handler.js';
 import { refreshGeoBrandPresenceSheetsHandler } from './geo-brand-presence/geo-brand-presence-refresh-handler.js';
 import { refreshGeoBrandPresenceDailyHandler } from './geo-brand-presence-daily/geo-brand-presence-refresh-handler.js';
@@ -227,6 +228,7 @@ const HANDLERS = {
   'semantic-value-visibility': semanticValueVisibility,
   'guidance:semantic-value-visibility': semanticValueVisibilityGuidance,
   'drs:prompt_generation_base_url': drsPromptGeneration,
+  'drs:strategic_recommendations_semrush': strategicRecommendationsSemrush,
   'offsite-brand-presence': offsiteBrandPresence,
   'geo-brand-presence-trigger-refresh': refreshGeoBrandPresenceSheetsHandler,
   'refresh:geo-brand-presence-daily': refreshGeoBrandPresenceDailyHandler,

--- a/src/strategic-recommendations-semrush/constants.js
+++ b/src/strategic-recommendations-semrush/constants.js
@@ -14,10 +14,23 @@
 // HLX strips the `.xlsx` and publishes `strategic-recommendations.json`.
 export const WORKBOOK_FILENAME = 'strategic-recommendations.xlsx';
 
-// The fully-populated worksheet this handler owns. The other two `shared-*`
-// worksheets (Citation Attempt, Synthetic Personas) and any non-shared sheets
-// (Notes) are byte-preserved — we never touch them.
+// The three `shared-*` worksheets this handler owns. All three are written on
+// every run from the DRS result envelope's `sheets` map (HLX strips the
+// `shared-` prefix, so the envelope keys are the un-prefixed names). The legacy
+// `Notes` sheet is intentionally dropped — elmo-ui does not consume it.
 export const SEMRUSH_SHEET = 'shared-Semrush';
+export const CITATION_SHEET = 'shared-Citation Attempt';
+export const PERSONAS_SHEET = 'shared-Synthetic Personas';
+
+// Un-prefixed sheet names — the keys in the DRS result `sheets` map, and the
+// keys HLX surfaces in the published multi-sheet JSON.
+export const SEMRUSH_JSON_KEY = 'Semrush';
+export const CITATION_JSON_KEY = 'Citation Attempt';
+export const PERSONAS_JSON_KEY = 'Synthetic Personas';
+
+// The legacy worksheet we now remove on every write (confirmed unconsumed by
+// elmo-ui). Kept as a named constant so the drop is explicit and testable.
+export const NOTES_SHEET = 'Notes';
 
 // Canonical column order for `shared-Semrush`, matching the reference template
 // strategic_recommendations_template.xlsx and the row schema property order.
@@ -39,5 +52,41 @@ export const SEMRUSH_COLUMNS = [
   'competitor_3_mentions',
   'category',
   'prompt',
+  'deleted',
+];
+
+// Canonical column order for `shared-Citation Attempt`, matching the property
+// order of `shared-citation-row.schema.v1.json`. Eight columns map 1:1 from the
+// brand's prompt-suggestions workbook; tag/strategy/strategy_reasoning are
+// generated. `source_url` is the citation grouping key.
+export const CITATION_COLUMNS = [
+  'tag',
+  'strategy',
+  'strategy_reasoning',
+  'prompt',
+  'topic',
+  'category',
+  'region',
+  'intent',
+  'type',
+  'source_url',
+  'prompt_reasoning',
+  'deleted',
+];
+
+// Canonical column order for `shared-Synthetic Personas`, matching the property
+// order of `shared-persona-row.schema.v1.json`. Same as the citation columns
+// minus `source_url`; `category` is the persona grouping key.
+export const PERSONA_COLUMNS = [
+  'tag',
+  'strategy',
+  'strategy_reasoning',
+  'prompt',
+  'topic',
+  'category',
+  'region',
+  'intent',
+  'type',
+  'prompt_reasoning',
   'deleted',
 ];

--- a/src/strategic-recommendations-semrush/constants.js
+++ b/src/strategic-recommendations-semrush/constants.js
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// The workbook filename inside `{dataFolder}/strategic-recommendations-template/`.
+// HLX strips the `.xlsx` and publishes `strategic-recommendations.json`.
+export const WORKBOOK_FILENAME = 'strategic-recommendations.xlsx';
+
+// The fully-populated worksheet this handler owns. The other two `shared-*`
+// worksheets (Citation Attempt, Synthetic Personas) and any non-shared sheets
+// (Notes) are byte-preserved — we never touch them.
+export const SEMRUSH_SHEET = 'shared-Semrush';
+
+// Canonical column order for `shared-Semrush`, matching the reference template
+// strategic_recommendations_template.xlsx and the row schema property order.
+// `prompt_id` is reserved (nullable, emitted null in v1) and is NOT a workbook
+// column in v1 — the template has no such column.
+export const SEMRUSH_COLUMNS = [
+  'tag',
+  'strategy',
+  'strategy_reasoning',
+  'topic_id',
+  'topic',
+  'volume',
+  'adobe_mentions',
+  'competitor_1',
+  'competitor_1_mentions',
+  'competitor_2',
+  'competitor_2_mentions',
+  'competitor_3',
+  'competitor_3_mentions',
+  'category',
+  'prompt',
+  'deleted',
+];

--- a/src/strategic-recommendations-semrush/handler.js
+++ b/src/strategic-recommendations-semrush/handler.js
@@ -1,0 +1,358 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { ok, internalServerError } from '@adobe/spacecat-shared-http-utils';
+import { tracingFetch } from '@adobe/spacecat-shared-utils';
+import ExcelJS from 'exceljs';
+import {
+  createLLMOSharepointClient,
+  readFromSharePoint,
+  uploadToSharePoint,
+} from '../utils/report-uploader.js';
+import { scrubUrlForLog } from '../utils/analysis-fetch.js';
+import { assertResultLocation } from './result-location.js';
+import { publishWorkbookWithReadback } from './publish.js';
+import { mergeSemrushRows } from './merge.js';
+import { validateSemrushRows } from './schema-validate.js';
+import {
+  SEMRUSH_SHEET,
+  SEMRUSH_COLUMNS,
+  WORKBOOK_FILENAME,
+} from './constants.js';
+import { postMessageSafe } from '../utils/slack-utils.js';
+
+const AUDIT_NAME = 'STRATEGIC_RECOMMENDATIONS_SEMRUSH';
+const MAX_RESULT_BYTES = 25 * 1024 * 1024; // 25 MB
+const RESULT_FETCH_TIMEOUT_MS = 30_000;
+
+/**
+ * Sends a Slack alert to the LLMO onboarding channel when the strategy run or its
+ * publish step fails. Best-effort — never throws.
+ *
+ * @param {object} context
+ * @param {string} siteId
+ * @param {string} drsJobId
+ * @param {string} reason
+ */
+async function alertFailure(context, siteId, drsJobId, reason) {
+  const channelId = context.env?.SLACK_CHANNEL_LLMO_ONBOARDING_ID;
+  if (!channelId) {
+    return;
+  }
+  await postMessageSafe(context, channelId, '', {
+    attachments: [{
+      color: '#CB3837',
+      blocks: [
+        {
+          type: 'header',
+          text: { type: 'plain_text', text: 'Strategic Recommendations (Semrush) Failed', emoji: true },
+        },
+        {
+          type: 'section',
+          fields: [
+            { type: 'mrkdwn', text: `*Site ID:*\n\`${siteId}\`` },
+            { type: 'mrkdwn', text: `*DRS Job:*\n\`${drsJobId || 'N/A'}\`` },
+          ],
+        },
+        { type: 'section', text: { type: 'mrkdwn', text: `*Reason:* ${reason}` } },
+        { type: 'divider' },
+      ],
+    }],
+  });
+}
+
+/**
+ * Fetches and parses the DRS result envelope from the provided result location.
+ * The location is SSRF-guarded by the caller before this runs.
+ *
+ * @param {string} resultLocation
+ * @param {object} log
+ * @returns {Promise<object>} Parsed result envelope.
+ */
+async function fetchResult(resultLocation, log) {
+  const safeUrl = scrubUrlForLog(resultLocation);
+  log.info(`%s: Fetching DRS result from ${safeUrl}`, AUDIT_NAME);
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), RESULT_FETCH_TIMEOUT_MS);
+  let response;
+  try {
+    response = await tracingFetch(resultLocation, { signal: controller.signal });
+  } catch (err) {
+    if (err?.name === 'AbortError') {
+      throw new Error(`DRS result fetch timed out after ${RESULT_FETCH_TIMEOUT_MS}ms`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch DRS result: ${response.status} ${response.statusText}`);
+  }
+
+  const declared = Number.parseInt(response.headers?.get?.('content-length') ?? '', 10);
+  if (Number.isFinite(declared) && declared > MAX_RESULT_BYTES) {
+    throw new Error(`DRS result too large: declared ${declared} bytes exceeds cap ${MAX_RESULT_BYTES}`);
+  }
+
+  const text = await response.text();
+  if (text.length > MAX_RESULT_BYTES) {
+    throw new Error(`DRS result too large: ${text.length} bytes exceeds cap ${MAX_RESULT_BYTES}`);
+  }
+  try {
+    return JSON.parse(text);
+  } catch (err) {
+    throw new Error(`DRS result is not JSON: ${err.message}`);
+  }
+}
+
+/**
+ * Reads `shared-Semrush` rows out of a workbook as plain objects keyed by the
+ * schema column names (in template column order).
+ *
+ * @param {ExcelJS.Workbook} workbook
+ * @returns {Array<object>}
+ */
+function readSemrushRows(workbook) {
+  const sheet = workbook.getWorksheet(SEMRUSH_SHEET);
+  if (!sheet) {
+    return [];
+  }
+  const headerRow = sheet.getRow(1);
+  /* c8 ignore next -- ExcelJS row.values is always an array; `|| []` is defensive */
+  const headers = (headerRow.values || []).slice(1).map((h) => (h == null ? '' : String(h)));
+  const rows = [];
+  sheet.eachRow((row, rowNumber) => {
+    if (rowNumber === 1) {
+      return;
+    }
+    /* c8 ignore next -- ExcelJS row.values is always an array; `|| []` is defensive */
+    const values = (row.values || []).slice(1);
+    const obj = {};
+    headers.forEach((header, idx) => {
+      if (header) {
+        obj[header] = values[idx] ?? null;
+      }
+    });
+    rows.push(obj);
+  });
+  return rows;
+}
+
+/**
+ * Reads the currently published workbook from SharePoint, returning the loaded
+ * ExcelJS workbook and the existing `shared-Semrush` rows. If no workbook exists
+ * yet (first run), starts a fresh workbook seeded from the template-shaped header.
+ *
+ * @param {string} dataFolder
+ * @param {object} sharepointClient
+ * @param {object} log
+ * @returns {Promise<{ workbook: ExcelJS.Workbook, existingRows: Array<object> }>}
+ */
+async function loadWorkbook(dataFolder, sharepointClient, log) {
+  const outputLocation = `${dataFolder}/strategic-recommendations-template`;
+  const workbook = new ExcelJS.Workbook();
+  try {
+    const buffer = await readFromSharePoint(
+      WORKBOOK_FILENAME,
+      outputLocation,
+      sharepointClient,
+      log,
+    );
+    await workbook.xlsx.load(buffer);
+    const existingRows = readSemrushRows(workbook);
+    return { workbook, existingRows };
+  } catch (error) {
+    const notFound = error.message?.includes('resource could not be found')
+      || error.message?.includes('itemNotFound');
+    if (!notFound) {
+      throw error;
+    }
+    log.info(`%s: No existing workbook at ${outputLocation}/${WORKBOOK_FILENAME}; starting fresh`, AUDIT_NAME);
+    return { workbook: null, existingRows: [] };
+  }
+}
+
+/**
+ * Replaces the `shared-Semrush` worksheet contents with the merged rows, one row
+ * per prompt, in the canonical template column order. The two other `shared-*`
+ * worksheets (and any non-shared sheets such as Notes) are left byte-preserved by
+ * only touching the Semrush sheet.
+ *
+ * @param {ExcelJS.Workbook} workbook
+ * @param {Array<object>} rows
+ */
+function writeSemrushSheet(workbook, rows) {
+  let sheet = workbook.getWorksheet(SEMRUSH_SHEET);
+  if (!sheet) {
+    sheet = workbook.addWorksheet(SEMRUSH_SHEET);
+  }
+  // Clear existing rows by spliceing everything below the header, then rewrite.
+  if (sheet.rowCount > 0) {
+    sheet.spliceRows(1, sheet.rowCount);
+  }
+  sheet.addRow(SEMRUSH_COLUMNS);
+  for (const row of rows) {
+    sheet.addRow(SEMRUSH_COLUMNS.map((col) => {
+      const value = row[col];
+      return value === undefined ? null : value;
+    }));
+  }
+}
+
+/**
+ * Handles `drs:strategic_recommendations_semrush` job completion notifications.
+ *
+ * On JOB_FAILED: Slack alert, leave the prior sheet untouched, return ok().
+ * On JOB_COMPLETED: SSRF-guard the result location, fetch + schema-validate the
+ * rows, cross-tenant guard, load + merge with the existing workbook (preserving
+ * `deleted` markers by (topic_id, prompt)), then upload and publish. Publish
+ * failures and post-publish read-back mismatches are surfaced (handler does NOT
+ * return ok() on those).
+ *
+ * @param {object} message - Normalized SQS message with DRS notification data.
+ * @param {object} context - Universal context.
+ * @returns {Promise<Response>}
+ */
+export default async function strategicRecommendationsSemrushHandler(message, context) {
+  const { log, dataAccess } = context;
+  const { Site } = dataAccess;
+  const { siteId, auditContext = {} } = message;
+  const { drsEventType, drsJobId, resultLocation } = auditContext;
+
+  if (!siteId) {
+    log.error('%s: notification missing site_id in metadata', AUDIT_NAME);
+    return ok();
+  }
+
+  if (drsEventType === 'JOB_FAILED') {
+    log.error(`%s: DRS job ${drsJobId} FAILED for site ${siteId}; leaving prior sheet in place`, AUDIT_NAME);
+    await alertFailure(context, siteId, drsJobId, 'DRS job failed');
+    return ok();
+  }
+
+  if (drsEventType !== 'JOB_COMPLETED') {
+    log.warn(`%s: unexpected DRS event type ${drsEventType} for site ${siteId}`, AUDIT_NAME);
+    return ok();
+  }
+
+  // SSRF guard — reject any result location not under the expected results
+  // bucket/prefix BEFORE any network call.
+  try {
+    assertResultLocation(resultLocation, context.env);
+  } catch (e) {
+    log.error(`%s: rejected result location for site ${siteId}: ${e.message}`, AUDIT_NAME);
+    await alertFailure(context, siteId, drsJobId, `Invalid result location: ${e.message}`);
+    return internalServerError(`Invalid result location: ${e.message}`);
+  }
+
+  let result;
+  try {
+    result = await fetchResult(resultLocation, log);
+  } catch (e) {
+    log.error(`%s: failed to fetch DRS result for site ${siteId}, job ${drsJobId}: ${e.message}`, AUDIT_NAME);
+    await alertFailure(context, siteId, drsJobId, `Failed to fetch result: ${e.message}`);
+    return internalServerError(`Failed to fetch result: ${e.message}`);
+  }
+
+  // Cross-tenant guard — the result must be for the site this message targets.
+  if (result.siteId && result.siteId !== siteId) {
+    const msg = `cross-tenant mismatch: result.siteId=${result.siteId} != message.siteId=${siteId}`;
+    log.error(`%s: ${msg}`, AUDIT_NAME);
+    await alertFailure(context, siteId, drsJobId, msg);
+    return internalServerError(msg);
+  }
+
+  const newRows = Array.isArray(result.rows) ? result.rows : [];
+  const validation = validateSemrushRows(newRows);
+  if (!validation.valid) {
+    const msg = `schema validation failed: ${validation.errors.slice(0, 5).join('; ')}`;
+    log.error(`%s: ${msg} for site ${siteId}`, AUDIT_NAME);
+    await alertFailure(context, siteId, drsJobId, msg);
+    return internalServerError(msg);
+  }
+  if (newRows.length === 0) {
+    const msg = 'DRS result contained zero rows';
+    log.error(`%s: ${msg} for site ${siteId}`, AUDIT_NAME);
+    await alertFailure(context, siteId, drsJobId, msg);
+    return internalServerError(msg);
+  }
+
+  const site = await Site.findById(siteId);
+  if (!site) {
+    const msg = `site not found: ${siteId}`;
+    log.error(`%s: ${msg}`, AUDIT_NAME);
+    return internalServerError(msg);
+  }
+  const dataFolder = site.getConfig?.()?.getLlmoDataFolder?.();
+  if (!dataFolder) {
+    const msg = `no LLMO data folder configured for site ${siteId}`;
+    log.error(`%s: ${msg}`, AUDIT_NAME);
+    await alertFailure(context, siteId, drsJobId, msg);
+    return internalServerError(msg);
+  }
+
+  const sharepointClient = await createLLMOSharepointClient(context);
+  const outputLocation = `${dataFolder}/strategic-recommendations-template`;
+
+  let workbook;
+  let existingRows;
+  try {
+    ({ workbook, existingRows } = await loadWorkbook(dataFolder, sharepointClient, log));
+  } catch (e) {
+    const msg = `failed to read existing workbook: ${e.message}`;
+    log.error(`%s: ${msg} for site ${siteId}`, AUDIT_NAME);
+    await alertFailure(context, siteId, drsJobId, msg);
+    return internalServerError(msg);
+  }
+
+  if (!workbook) {
+    const msg = `no published workbook found at ${outputLocation}/${WORKBOOK_FILENAME}; cannot preserve template structure`;
+    log.error(`%s: ${msg} for site ${siteId}`, AUDIT_NAME);
+    await alertFailure(context, siteId, drsJobId, msg);
+    return internalServerError(msg);
+  }
+
+  const mergedRows = mergeSemrushRows(existingRows, newRows);
+  writeSemrushSheet(workbook, mergedRows);
+
+  const buffer = await workbook.xlsx.writeBuffer();
+  try {
+    await uploadToSharePoint(buffer, WORKBOOK_FILENAME, outputLocation, sharepointClient, log);
+  } catch (e) {
+    const msg = `SharePoint upload failed: ${e.message}`;
+    log.error(`%s: ${msg} for site ${siteId}`, AUDIT_NAME);
+    await alertFailure(context, siteId, drsJobId, msg);
+    return internalServerError(msg);
+  }
+
+  // Publish with NET-NEW failure surfacing + post-publish read-back.
+  try {
+    await publishWorkbookWithReadback({
+      filename: WORKBOOK_FILENAME,
+      outputLocation,
+      expectedRowCount: mergedRows.length,
+      expectedGeneratedAt: result.generated_at ?? null,
+      log,
+      fetchImpl: tracingFetch,
+    });
+  } catch (e) {
+    const msg = `publish failed: ${e.message}`;
+    log.error(`%s: ${msg} for site ${siteId}`, AUDIT_NAME);
+    await alertFailure(context, siteId, drsJobId, msg);
+    return internalServerError(msg);
+  }
+
+  log.info(`%s: published ${mergedRows.length} Semrush rows for site ${siteId}, job ${drsJobId}`, AUDIT_NAME);
+  return ok();
+}

--- a/src/strategic-recommendations-semrush/handler.js
+++ b/src/strategic-recommendations-semrush/handler.js
@@ -21,11 +21,19 @@ import {
 import { scrubUrlForLog } from '../utils/analysis-fetch.js';
 import { assertResultLocation } from './result-location.js';
 import { publishWorkbookWithReadback } from './publish.js';
-import { mergeSemrushRows } from './merge.js';
-import { validateSemrushRows } from './schema-validate.js';
+import { mergeRowsByKey } from './merge.js';
+import { validateSemrushRows, validateCitationRows, validatePersonaRows } from './schema-validate.js';
 import {
   SEMRUSH_SHEET,
+  CITATION_SHEET,
+  PERSONAS_SHEET,
+  NOTES_SHEET,
+  SEMRUSH_JSON_KEY,
+  CITATION_JSON_KEY,
+  PERSONAS_JSON_KEY,
   SEMRUSH_COLUMNS,
+  CITATION_COLUMNS,
+  PERSONA_COLUMNS,
   WORKBOOK_FILENAME,
 } from './constants.js';
 import { postMessageSafe } from '../utils/slack-utils.js';
@@ -33,6 +41,81 @@ import { postMessageSafe } from '../utils/slack-utils.js';
 const AUDIT_NAME = 'STRATEGIC_RECOMMENDATIONS_SEMRUSH';
 const MAX_RESULT_BYTES = 25 * 1024 * 1024; // 25 MB
 const RESULT_FETCH_TIMEOUT_MS = 30_000;
+
+/**
+ * The three worksheets written on every run. `jsonKey` is the key in the DRS
+ * result `sheets` map (the un-prefixed, HLX-stripped name); `sheetName` is the
+ * `shared-*` worksheet name. `primary: true` marks the Semrush sheet — the only
+ * one whose emptiness fails the run (the auxiliary sheets are best-effort and a
+ * header-only sheet is a valid "no data yet" outcome). Each sheet preserves the
+ * UI's `deleted` markers across refreshes by its own `matchKeyFields`.
+ */
+const SHEET_SPECS = [
+  {
+    jsonKey: SEMRUSH_JSON_KEY,
+    sheetName: SEMRUSH_SHEET,
+    columns: SEMRUSH_COLUMNS,
+    matchKeyFields: ['topic_id', 'prompt'],
+    validate: validateSemrushRows,
+    primary: true,
+  },
+  {
+    jsonKey: CITATION_JSON_KEY,
+    sheetName: CITATION_SHEET,
+    columns: CITATION_COLUMNS,
+    matchKeyFields: ['source_url', 'prompt'],
+    validate: validateCitationRows,
+    primary: false,
+  },
+  {
+    jsonKey: PERSONAS_JSON_KEY,
+    sheetName: PERSONAS_SHEET,
+    columns: PERSONA_COLUMNS,
+    matchKeyFields: ['category', 'prompt'],
+    validate: validatePersonaRows,
+    primary: false,
+  },
+];
+
+/**
+ * Normalizes the DRS result into the `{ jsonKey: rows }` sheets map. New
+ * producers emit `result.sheets`; older producers only emit `result.rows` (the
+ * Semrush sheet) — that transition shape is mapped to `{ Semrush: rows }`.
+ *
+ * @param {object} result
+ * @returns {object} A sheets map keyed by un-prefixed sheet name.
+ */
+function normalizeSheets(result) {
+  if (result.sheets && typeof result.sheets === 'object' && !Array.isArray(result.sheets)) {
+    return result.sheets;
+  }
+  return { [SEMRUSH_JSON_KEY]: Array.isArray(result.rows) ? result.rows : [] };
+}
+
+/**
+ * Validates each known sheet against its vendored contract and returns the
+ * per-sheet new-row arrays keyed by jsonKey. Pure (no IO, no alerting) so the
+ * caller owns the single failure path. The Semrush sheet additionally fails when
+ * empty; auxiliary sheets may be empty (header-only).
+ *
+ * @param {object} sheets - The normalized sheets map.
+ * @returns {{ byKey?: object, error?: string }}
+ */
+function collectAndValidateSheets(sheets) {
+  const byKey = {};
+  for (const spec of SHEET_SPECS) {
+    const rows = Array.isArray(sheets[spec.jsonKey]) ? sheets[spec.jsonKey] : [];
+    const validation = spec.validate(rows);
+    if (!validation.valid) {
+      return { error: `schema validation failed for sheet '${spec.jsonKey}': ${validation.errors.slice(0, 5).join('; ')}` };
+    }
+    if (spec.primary && rows.length === 0) {
+      return { error: 'DRS result contained zero Semrush rows' };
+    }
+    byKey[spec.jsonKey] = rows;
+  }
+  return { byKey };
+}
 
 /**
  * Sends a Slack alert to the LLMO onboarding channel when the strategy run or its
@@ -118,14 +201,15 @@ async function fetchResult(resultLocation, log) {
 }
 
 /**
- * Reads `shared-Semrush` rows out of a workbook as plain objects keyed by the
- * schema column names (in template column order).
+ * Reads a worksheet's rows out of a workbook as plain objects keyed by the
+ * header cell values (template column order). Returns [] when the sheet is absent.
  *
  * @param {ExcelJS.Workbook} workbook
+ * @param {string} sheetName
  * @returns {Array<object>}
  */
-function readSemrushRows(workbook) {
-  const sheet = workbook.getWorksheet(SEMRUSH_SHEET);
+function readSheetRows(workbook, sheetName) {
+  const sheet = workbook.getWorksheet(sheetName);
   if (!sheet) {
     return [];
   }
@@ -152,13 +236,15 @@ function readSemrushRows(workbook) {
 
 /**
  * Reads the currently published workbook from SharePoint, returning the loaded
- * ExcelJS workbook and the existing `shared-Semrush` rows. If no workbook exists
- * yet (first run), starts a fresh workbook seeded from the template-shaped header.
+ * ExcelJS workbook and the existing rows of each `shared-*` worksheet (keyed by
+ * jsonKey, used to preserve `deleted` markers). If no workbook exists yet (first
+ * run), returns `{ workbook: null, existingRowsByKey: {} }` — the caller builds a
+ * fresh workbook rather than failing closed.
  *
  * @param {string} dataFolder
  * @param {object} sharepointClient
  * @param {object} log
- * @returns {Promise<{ workbook: ExcelJS.Workbook, existingRows: Array<object> }>}
+ * @returns {Promise<{ workbook: ExcelJS.Workbook|null, existingRowsByKey: object }>}
  */
 async function loadWorkbook(dataFolder, sharepointClient, log) {
   const outputLocation = `${dataFolder}/strategic-recommendations-template`;
@@ -171,43 +257,60 @@ async function loadWorkbook(dataFolder, sharepointClient, log) {
       log,
     );
     await workbook.xlsx.load(buffer);
-    const existingRows = readSemrushRows(workbook);
-    return { workbook, existingRows };
+    const existingRowsByKey = {};
+    for (const spec of SHEET_SPECS) {
+      existingRowsByKey[spec.jsonKey] = readSheetRows(workbook, spec.sheetName);
+    }
+    return { workbook, existingRowsByKey };
   } catch (error) {
     const notFound = error.message?.includes('resource could not be found')
       || error.message?.includes('itemNotFound');
     if (!notFound) {
       throw error;
     }
-    log.info(`%s: No existing workbook at ${outputLocation}/${WORKBOOK_FILENAME}; starting fresh`, AUDIT_NAME);
-    return { workbook: null, existingRows: [] };
+    log.info(`%s: No existing workbook at ${outputLocation}/${WORKBOOK_FILENAME}; building fresh`, AUDIT_NAME);
+    return { workbook: null, existingRowsByKey: {} };
   }
 }
 
 /**
- * Replaces the `shared-Semrush` worksheet contents with the merged rows, one row
- * per prompt, in the canonical template column order. The two other `shared-*`
- * worksheets (and any non-shared sheets such as Notes) are left byte-preserved by
- * only touching the Semrush sheet.
+ * Replaces a worksheet's contents with the given rows, one row per prompt, in the
+ * canonical column order. Creates the sheet if absent (so a first-run build, or a
+ * workbook missing a sheet, is handled). Empty `rows` yields a header-only sheet.
  *
  * @param {ExcelJS.Workbook} workbook
+ * @param {string} sheetName
+ * @param {string[]} columns
  * @param {Array<object>} rows
  */
-function writeSemrushSheet(workbook, rows) {
-  let sheet = workbook.getWorksheet(SEMRUSH_SHEET);
+function writeSheet(workbook, sheetName, columns, rows) {
+  let sheet = workbook.getWorksheet(sheetName);
   if (!sheet) {
-    sheet = workbook.addWorksheet(SEMRUSH_SHEET);
+    sheet = workbook.addWorksheet(sheetName);
   }
   // Clear existing rows by spliceing everything below the header, then rewrite.
   if (sheet.rowCount > 0) {
     sheet.spliceRows(1, sheet.rowCount);
   }
-  sheet.addRow(SEMRUSH_COLUMNS);
+  sheet.addRow(columns);
   for (const row of rows) {
-    sheet.addRow(SEMRUSH_COLUMNS.map((col) => {
+    sheet.addRow(columns.map((col) => {
       const value = row[col];
       return value === undefined ? null : value;
     }));
+  }
+}
+
+/**
+ * Removes the legacy `Notes` worksheet if present. elmo-ui does not consume it,
+ * and carrying it forward bloats every published workbook. No-op when absent.
+ *
+ * @param {ExcelJS.Workbook} workbook
+ */
+function dropNotesSheet(workbook) {
+  const notes = workbook.getWorksheet(NOTES_SHEET);
+  if (notes) {
+    workbook.removeWorksheet(notes.id);
   }
 }
 
@@ -274,19 +377,14 @@ export default async function strategicRecommendationsSemrushHandler(message, co
     return internalServerError(msg);
   }
 
-  const newRows = Array.isArray(result.rows) ? result.rows : [];
-  const validation = validateSemrushRows(newRows);
-  if (!validation.valid) {
-    const msg = `schema validation failed: ${validation.errors.slice(0, 5).join('; ')}`;
-    log.error(`%s: ${msg} for site ${siteId}`, AUDIT_NAME);
-    await alertFailure(context, siteId, drsJobId, msg);
-    return internalServerError(msg);
-  }
-  if (newRows.length === 0) {
-    const msg = 'DRS result contained zero rows';
-    log.error(`%s: ${msg} for site ${siteId}`, AUDIT_NAME);
-    await alertFailure(context, siteId, drsJobId, msg);
-    return internalServerError(msg);
+  // Resolve + validate all three sheets. The new contract carries them in
+  // `result.sheets`; an older producer's `result.rows` maps to the Semrush sheet.
+  const sheets = normalizeSheets(result);
+  const { byKey: newRowsByKey, error: sheetError } = collectAndValidateSheets(sheets);
+  if (sheetError) {
+    log.error(`%s: ${sheetError} for site ${siteId}`, AUDIT_NAME);
+    await alertFailure(context, siteId, drsJobId, sheetError);
+    return internalServerError(sheetError);
   }
 
   const site = await Site.findById(siteId);
@@ -307,9 +405,9 @@ export default async function strategicRecommendationsSemrushHandler(message, co
   const outputLocation = `${dataFolder}/strategic-recommendations-template`;
 
   let workbook;
-  let existingRows;
+  let existingRowsByKey;
   try {
-    ({ workbook, existingRows } = await loadWorkbook(dataFolder, sharepointClient, log));
+    ({ workbook, existingRowsByKey } = await loadWorkbook(dataFolder, sharepointClient, log));
   } catch (e) {
     const msg = `failed to read existing workbook: ${e.message}`;
     log.error(`%s: ${msg} for site ${siteId}`, AUDIT_NAME);
@@ -317,15 +415,28 @@ export default async function strategicRecommendationsSemrushHandler(message, co
     return internalServerError(msg);
   }
 
+  // First run (no published workbook yet): build a fresh one rather than failing
+  // closed — the runner is the source of truth for all `shared-*` sheets.
   if (!workbook) {
-    const msg = `no published workbook found at ${outputLocation}/${WORKBOOK_FILENAME}; cannot preserve template structure`;
-    log.error(`%s: ${msg} for site ${siteId}`, AUDIT_NAME);
-    await alertFailure(context, siteId, drsJobId, msg);
-    return internalServerError(msg);
+    workbook = new ExcelJS.Workbook();
+    existingRowsByKey = {};
   }
 
-  const mergedRows = mergeSemrushRows(existingRows, newRows);
-  writeSemrushSheet(workbook, mergedRows);
+  // Drop the legacy Notes sheet, then (re)write every shared sheet from the
+  // merged rows. Auxiliary sheets with no rows become header-only.
+  dropNotesSheet(workbook);
+  let semrushRowCount = 0;
+  for (const spec of SHEET_SPECS) {
+    const merged = mergeRowsByKey(
+      existingRowsByKey[spec.jsonKey] || [],
+      newRowsByKey[spec.jsonKey],
+      spec.matchKeyFields,
+    );
+    writeSheet(workbook, spec.sheetName, spec.columns, merged);
+    if (spec.primary) {
+      semrushRowCount = merged.length;
+    }
+  }
 
   const buffer = await workbook.xlsx.writeBuffer();
   try {
@@ -342,7 +453,7 @@ export default async function strategicRecommendationsSemrushHandler(message, co
     await publishWorkbookWithReadback({
       filename: WORKBOOK_FILENAME,
       outputLocation,
-      expectedRowCount: mergedRows.length,
+      expectedRowCount: semrushRowCount,
       expectedGeneratedAt: result.generated_at ?? null,
       adminApiKey: context.env?.ADMIN_HLX_API_KEY,
       log,
@@ -355,6 +466,6 @@ export default async function strategicRecommendationsSemrushHandler(message, co
     return internalServerError(msg);
   }
 
-  log.info(`%s: published ${mergedRows.length} Semrush rows for site ${siteId}, job ${drsJobId}`, AUDIT_NAME);
+  log.info(`%s: published ${semrushRowCount} Semrush rows for site ${siteId}, job ${drsJobId}`, AUDIT_NAME);
   return ok();
 }

--- a/src/strategic-recommendations-semrush/handler.js
+++ b/src/strategic-recommendations-semrush/handler.js
@@ -106,8 +106,9 @@ async function fetchResult(resultLocation, log) {
   }
 
   const text = await response.text();
-  if (text.length > MAX_RESULT_BYTES) {
-    throw new Error(`DRS result too large: ${text.length} bytes exceeds cap ${MAX_RESULT_BYTES}`);
+  const byteLength = Buffer.byteLength(text, 'utf8');
+  if (byteLength > MAX_RESULT_BYTES) {
+    throw new Error(`DRS result too large: ${byteLength} bytes exceeds cap ${MAX_RESULT_BYTES}`);
   }
   try {
     return JSON.parse(text);
@@ -343,6 +344,7 @@ export default async function strategicRecommendationsSemrushHandler(message, co
       outputLocation,
       expectedRowCount: mergedRows.length,
       expectedGeneratedAt: result.generated_at ?? null,
+      adminApiKey: context.env?.ADMIN_HLX_API_KEY,
       log,
       fetchImpl: tracingFetch,
     });

--- a/src/strategic-recommendations-semrush/handler.js
+++ b/src/strategic-recommendations-semrush/handler.js
@@ -146,7 +146,10 @@ async function alertFailure(context, siteId, drsJobId, reason) {
             { type: 'mrkdwn', text: `*DRS Job:*\n\`${drsJobId || 'N/A'}\`` },
           ],
         },
-        { type: 'section', text: { type: 'mrkdwn', text: `*Reason:* ${reason}` } },
+        // plain_text (not mrkdwn): `reason` can carry attacker-influenced content
+        // (e.g. a crafted result location in the SSRF-rejection path), so render it
+        // verbatim rather than letting it inject Slack formatting or mentions.
+        { type: 'section', text: { type: 'plain_text', text: `Reason: ${reason}`, emoji: false } },
         { type: 'divider' },
       ],
     }],
@@ -370,7 +373,10 @@ export default async function strategicRecommendationsSemrushHandler(message, co
   }
 
   // Cross-tenant guard — the result must be for the site this message targets.
-  if (result.siteId && result.siteId !== siteId) {
+  // Fail closed: a result missing siteId is rejected too. DRS always emits
+  // siteId on the result envelope, so an absent value signals a malformed or
+  // spoofed payload, not a legitimate older producer.
+  if (!result.siteId || result.siteId !== siteId) {
     const msg = `cross-tenant mismatch: result.siteId=${result.siteId} != message.siteId=${siteId}`;
     log.error(`%s: ${msg}`, AUDIT_NAME);
     await alertFailure(context, siteId, drsJobId, msg);

--- a/src/strategic-recommendations-semrush/merge.js
+++ b/src/strategic-recommendations-semrush/merge.js
@@ -11,62 +11,70 @@
  */
 
 /**
- * Builds the deleted-preservation match key for a row, or null if the row lacks
- * the fields needed to match. `topic_id` and `prompt` are coerced to strings and
- * joined with the ASCII Unit Separator (U+001F) — a control char that cannot
- * appear in the human-authored prompt/topic text, so it removes the delimiter
- * ambiguity a printable separator (e.g. a space) would carry when a `topic_id`
- * ends with, or a `prompt` starts with, that character.
+ * Builds the deleted-preservation match key for a row from an ordered list of
+ * key fields, or null if the row lacks any of them. Each field value is coerced
+ * to a string and joined with the ASCII Unit Separator (U+001F) — a control char
+ * that cannot appear in the human-authored prompt/topic text, so it removes the
+ * delimiter ambiguity a printable separator (e.g. a space) would carry when one
+ * field ends with, or the next starts with, that character.
  *
  * @param {object} row
+ * @param {string[]} keyFields
  * @returns {string|null}
  */
 const MATCH_KEY_DELIMITER = '\x1F';
 
-function matchKey(row) {
-  const topicId = row.topic_id;
-  const { prompt } = row;
-  if (topicId === undefined || topicId === null || prompt === undefined || prompt === null) {
-    return null;
+function matchKey(row, keyFields) {
+  const parts = [];
+  for (const field of keyFields) {
+    const value = row[field];
+    if (value === undefined || value === null) {
+      return null;
+    }
+    parts.push(String(value));
   }
-  return `${String(topicId)}${MATCH_KEY_DELIMITER}${String(prompt)}`;
+  return parts.join(MATCH_KEY_DELIMITER);
 }
 
 /**
- * Pure row-merge helper for the `shared-Semrush` worksheet.
+ * Pure, sheet-agnostic row-merge helper.
  *
- * The DRS runner emits a fresh, complete set of `shared-Semrush` rows on every run.
- * The UI lets users soft-delete (dismiss / manually-add) individual prompt rows by
- * stamping a `deleted` marker ('ignored' / 'added'). Because the runner does not know
- * about those user edits, a naive replace-all would wipe them out on every refresh.
+ * The DRS runner emits a fresh, complete set of rows for each `shared-*` worksheet
+ * on every run. The UI lets users soft-delete (dismiss / manually-add) individual
+ * prompt rows by stamping a `deleted` marker ('ignored' / 'added'). Because the
+ * runner does not know about those user edits, a naive replace-all would wipe them
+ * out on every refresh.
  *
- * `mergeSemrushRows` re-applies the user's `deleted` markers from the previously
- * published rows onto the newly generated rows.
+ * `mergeRowsByKey` re-applies the user's `deleted` markers from the previously
+ * published rows onto the newly generated rows, matching on `keyFields`.
  *
- * MATCH KEY = `(topic_id, prompt)` - see the row contract
- * `shared-semrush-row.schema.v1.json` `x-contract.match_key_for_deleted_preservation`.
+ * MATCH KEY per sheet (see each row contract's
+ * `x-contract.match_key_for_deleted_preservation`):
+ *   - Semrush:            (topic_id, prompt)
+ *   - Citation Attempt:   (source_url, prompt)
+ *   - Synthetic Personas: (category, prompt)
  *
- * BEST-EFFORT (v1): the match is on the stable `topic_id` plus the verbatim `prompt`
- * text. If a regeneration rephrases the prompt text, the match misses and a prior
- * dismissal lapses (the card may reappear). This is ACCEPTED for v1 and the UI states
- * that dismissals are best-effort across refreshes. Forward hardening: populate the
- * reserved `prompt_id` field (nullable, emitted null in v1) and switch the match key
- * to it - an additive value change, not a schema bump.
+ * BEST-EFFORT (v1): the match includes the verbatim `prompt` text. If a regeneration
+ * rephrases the prompt, the match misses and a prior dismissal lapses (the card may
+ * reappear). This is ACCEPTED for v1 and the UI states dismissals are best-effort
+ * across refreshes. Forward hardening (Semrush): populate the reserved `prompt_id`
+ * field and switch the key to it — an additive value change, not a schema bump.
  *
  * This function performs no IO and never mutates its inputs.
  *
  * @param {Array<object>} existingRows - Rows parsed from the currently published workbook.
  * @param {Array<object>} newRows - Freshly generated rows from the DRS result.
+ * @param {string[]} keyFields - Ordered match-key fields for this sheet.
  * @returns {Array<object>} New rows, with `deleted` markers carried over by match key.
  */
-export function mergeSemrushRows(existingRows, newRows) {
+export function mergeRowsByKey(existingRows, newRows, keyFields) {
   const safeNew = Array.isArray(newRows) ? newRows : [];
   const safeExisting = Array.isArray(existingRows) ? existingRows : [];
 
-  // Build a lookup of prior `deleted` markers keyed on (topic_id, prompt).
-  // Only carry over a non-empty marker; '' / null / undefined mean "active" and
-  // are the default anyway, so there is nothing to preserve for them. First write
-  // wins, so a duplicate (topic_id, prompt) keeps the earliest marker.
+  // Build a lookup of prior `deleted` markers keyed on `keyFields`. Only carry
+  // over a non-empty marker; '' / null / undefined mean "active" and are the
+  // default anyway, so there is nothing to preserve for them. First write wins,
+  // so a duplicate key keeps the earliest marker.
   const priorDeleted = new Map();
   safeExisting.forEach((row) => {
     if (!row || typeof row !== 'object') {
@@ -76,7 +84,7 @@ export function mergeSemrushRows(existingRows, newRows) {
     if (marker === undefined || marker === null || marker === '') {
       return;
     }
-    const key = matchKey(row);
+    const key = matchKey(row, keyFields);
     if (key !== null && !priorDeleted.has(key)) {
       priorDeleted.set(key, marker);
     }
@@ -86,7 +94,7 @@ export function mergeSemrushRows(existingRows, newRows) {
     if (!row || typeof row !== 'object') {
       return row;
     }
-    const key = matchKey(row);
+    const key = matchKey(row, keyFields);
     const carried = key !== null ? priorDeleted.get(key) : undefined;
     if (carried !== undefined) {
       return { ...row, deleted: carried };
@@ -94,6 +102,17 @@ export function mergeSemrushRows(existingRows, newRows) {
     // No prior match - return a shallow copy so callers never see input aliasing.
     return { ...row };
   });
+}
+
+/**
+ * Semrush convenience wrapper — merges on the `(topic_id, prompt)` match key.
+ *
+ * @param {Array<object>} existingRows
+ * @param {Array<object>} newRows
+ * @returns {Array<object>}
+ */
+export function mergeSemrushRows(existingRows, newRows) {
+  return mergeRowsByKey(existingRows, newRows, ['topic_id', 'prompt']);
 }
 
 export default mergeSemrushRows;

--- a/src/strategic-recommendations-semrush/merge.js
+++ b/src/strategic-recommendations-semrush/merge.js
@@ -13,18 +13,23 @@
 /**
  * Builds the deleted-preservation match key for a row, or null if the row lacks
  * the fields needed to match. `topic_id` and `prompt` are coerced to strings and
- * joined with a delimiter.
+ * joined with the ASCII Unit Separator (U+001F) — a control char that cannot
+ * appear in the human-authored prompt/topic text, so it removes the delimiter
+ * ambiguity a printable separator (e.g. a space) would carry when a `topic_id`
+ * ends with, or a `prompt` starts with, that character.
  *
  * @param {object} row
  * @returns {string|null}
  */
+const MATCH_KEY_DELIMITER = '\x1F';
+
 function matchKey(row) {
   const topicId = row.topic_id;
   const { prompt } = row;
   if (topicId === undefined || topicId === null || prompt === undefined || prompt === null) {
     return null;
   }
-  return `${String(topicId)} ${String(prompt)}`;
+  return `${String(topicId)}${MATCH_KEY_DELIMITER}${String(prompt)}`;
 }
 
 /**

--- a/src/strategic-recommendations-semrush/merge.js
+++ b/src/strategic-recommendations-semrush/merge.js
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Builds the deleted-preservation match key for a row, or null if the row lacks
+ * the fields needed to match. `topic_id` and `prompt` are coerced to strings and
+ * joined with a delimiter.
+ *
+ * @param {object} row
+ * @returns {string|null}
+ */
+function matchKey(row) {
+  const topicId = row.topic_id;
+  const { prompt } = row;
+  if (topicId === undefined || topicId === null || prompt === undefined || prompt === null) {
+    return null;
+  }
+  return `${String(topicId)} ${String(prompt)}`;
+}
+
+/**
+ * Pure row-merge helper for the `shared-Semrush` worksheet.
+ *
+ * The DRS runner emits a fresh, complete set of `shared-Semrush` rows on every run.
+ * The UI lets users soft-delete (dismiss / manually-add) individual prompt rows by
+ * stamping a `deleted` marker ('ignored' / 'added'). Because the runner does not know
+ * about those user edits, a naive replace-all would wipe them out on every refresh.
+ *
+ * `mergeSemrushRows` re-applies the user's `deleted` markers from the previously
+ * published rows onto the newly generated rows.
+ *
+ * MATCH KEY = `(topic_id, prompt)` - see the row contract
+ * `shared-semrush-row.schema.v1.json` `x-contract.match_key_for_deleted_preservation`.
+ *
+ * BEST-EFFORT (v1): the match is on the stable `topic_id` plus the verbatim `prompt`
+ * text. If a regeneration rephrases the prompt text, the match misses and a prior
+ * dismissal lapses (the card may reappear). This is ACCEPTED for v1 and the UI states
+ * that dismissals are best-effort across refreshes. Forward hardening: populate the
+ * reserved `prompt_id` field (nullable, emitted null in v1) and switch the match key
+ * to it - an additive value change, not a schema bump.
+ *
+ * This function performs no IO and never mutates its inputs.
+ *
+ * @param {Array<object>} existingRows - Rows parsed from the currently published workbook.
+ * @param {Array<object>} newRows - Freshly generated rows from the DRS result.
+ * @returns {Array<object>} New rows, with `deleted` markers carried over by match key.
+ */
+export function mergeSemrushRows(existingRows, newRows) {
+  const safeNew = Array.isArray(newRows) ? newRows : [];
+  const safeExisting = Array.isArray(existingRows) ? existingRows : [];
+
+  // Build a lookup of prior `deleted` markers keyed on (topic_id, prompt).
+  // Only carry over a non-empty marker; '' / null / undefined mean "active" and
+  // are the default anyway, so there is nothing to preserve for them. First write
+  // wins, so a duplicate (topic_id, prompt) keeps the earliest marker.
+  const priorDeleted = new Map();
+  safeExisting.forEach((row) => {
+    if (!row || typeof row !== 'object') {
+      return;
+    }
+    const marker = row.deleted;
+    if (marker === undefined || marker === null || marker === '') {
+      return;
+    }
+    const key = matchKey(row);
+    if (key !== null && !priorDeleted.has(key)) {
+      priorDeleted.set(key, marker);
+    }
+  });
+
+  return safeNew.map((row) => {
+    if (!row || typeof row !== 'object') {
+      return row;
+    }
+    const key = matchKey(row);
+    const carried = key !== null ? priorDeleted.get(key) : undefined;
+    if (carried !== undefined) {
+      return { ...row, deleted: carried };
+    }
+    // No prior match - return a shallow copy so callers never see input aliasing.
+    return { ...row };
+  });
+}
+
+export default mergeSemrushRows;

--- a/src/strategic-recommendations-semrush/publish.js
+++ b/src/strategic-recommendations-semrush/publish.js
@@ -179,9 +179,14 @@ export async function publishWorkbookWithReadback({
     { name: 'live', url: `${ADMIN_BASE}/live/${ORG}/${SITE}/${REF}/${path}` },
   ];
 
-  for (const endpoint of endpoints) {
-    // eslint-disable-next-line no-await-in-loop
-    await sleep(PUBLISH_STEP_DELAY_MS);
+  for (const [i, endpoint] of endpoints.entries()) {
+    // Delay only BETWEEN steps — nothing precedes the first (preview) POST, so
+    // sleeping before it just adds latency. The gap lets preview settle before
+    // the live publish reads it.
+    if (i > 0) {
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(PUBLISH_STEP_DELAY_MS);
+    }
     log.info(`STRATEGIC_RECOMMENDATIONS_SEMRUSH: publishing to ${endpoint.name}: ${endpoint.url}`);
     // eslint-disable-next-line no-await-in-loop
     const response = await fetchImpl(endpoint.url, { method: 'POST', headers });

--- a/src/strategic-recommendations-semrush/publish.js
+++ b/src/strategic-recommendations-semrush/publish.js
@@ -60,7 +60,20 @@ export function extractSemrushRows(json) {
   if (!json || typeof json !== 'object') {
     return null;
   }
-  const sheet = json[SEMRUSH_JSON_KEY] ?? json;
+  // A multi-sheet HLX document carries a `:names`/`:type` envelope. In that shape
+  // the Semrush rows MUST live under the `Semrush` key — we deliberately do NOT
+  // fall through to the envelope itself, otherwise any multi-sheet doc that
+  // happens to expose some other top-level `data` array would masquerade as a
+  // successful read-back. Single-sheet docs ({ data: [...] }) still pass through.
+  const isMultiSheet = Array.isArray(json[':names']) || json[':type'] === 'multi-sheet';
+  let sheet;
+  if (Object.prototype.hasOwnProperty.call(json, SEMRUSH_JSON_KEY)) {
+    sheet = json[SEMRUSH_JSON_KEY];
+  } else if (isMultiSheet) {
+    return null;
+  } else {
+    sheet = json;
+  }
   if (sheet && Array.isArray(sheet.data)) {
     return sheet.data;
   }
@@ -75,7 +88,6 @@ export function extractSemrushRows(json) {
 async function readBack({
   path, expectedRowCount, expectedGeneratedAt, log, fetchImpl,
 }) {
-  const url = `${LIVE_BASE}/${path}`;
   let lastReason = 'unknown';
 
   for (let attempt = 1; attempt <= READBACK_MAX_ATTEMPTS; attempt += 1) {
@@ -83,6 +95,9 @@ async function readBack({
       // eslint-disable-next-line no-await-in-loop
       await sleep(READBACK_DELAY_MS);
     }
+    // Cache-bust per attempt so a retry never re-hits the same stale CDN edge that
+    // served the pre-publish document on the previous attempt.
+    const url = `${LIVE_BASE}/${path}?cb=${Date.now()}-${attempt}`;
     let json;
     try {
       // eslint-disable-next-line no-await-in-loop
@@ -139,20 +154,25 @@ async function readBack({
  * @param {string} params.outputLocation - SharePoint folder path (relative).
  * @param {number} params.expectedRowCount - Number of Semrush rows just written.
  * @param {string|null} params.expectedGeneratedAt - Stamp to confirm on read-back, if any.
+ * @param {string} params.adminApiKey - admin.hlx.page auth token (context.env.ADMIN_HLX_API_KEY).
  * @param {object} params.log - Logger.
  * @param {Function} params.fetchImpl - fetch implementation (injectable for tests).
- * @throws {Error} on any publish non-2xx or a read-back mismatch.
+ * @throws {Error} on a missing admin API key, any publish non-2xx, or a read-back mismatch.
  */
 export async function publishWorkbookWithReadback({
   filename,
   outputLocation,
   expectedRowCount,
   expectedGeneratedAt,
+  adminApiKey,
   log,
   fetchImpl,
 }) {
+  if (!adminApiKey || typeof adminApiKey !== 'string') {
+    throw new Error('publish aborted: ADMIN_HLX_API_KEY is not configured');
+  }
   const path = toJsonPath(filename, outputLocation);
-  const headers = { Cookie: `auth_token=${process.env.ADMIN_HLX_API_KEY}` };
+  const headers = { Cookie: `auth_token=${adminApiKey}` };
 
   const endpoints = [
     { name: 'preview', url: `${ADMIN_BASE}/preview/${ORG}/${SITE}/${REF}/${path}` },

--- a/src/strategic-recommendations-semrush/publish.js
+++ b/src/strategic-recommendations-semrush/publish.js
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * NET-NEW publish path for the strategic-recommendations workbook.
+ *
+ * The shared `report-uploader.publishToAdminHlx` SWALLOWS non-200 responses
+ * (logs and returns, never throws) — so a failed CDN publish would look like a
+ * success. This module deliberately does NOT reuse it. Instead it:
+ *
+ *  1. POSTs to admin.hlx.page preview + live and THROWS on any non-2xx, so a
+ *     publish failure is surfaced to the handler (which must not return ok()).
+ *  2. Performs a post-publish READ-BACK: GETs the freshly published live JSON and
+ *     confirms the row count (and `generated_at`, when available) matches what we
+ *     just wrote. This catches the "200-but-stale-CDN" case where the publish
+ *     call succeeded but the edge is still serving the old document.
+ */
+
+import { sleep } from '../support/utils.js';
+
+const ORG = 'adobe';
+const SITE = 'project-elmo-ui-data';
+const REF = 'main';
+const ADMIN_BASE = 'https://admin.hlx.page';
+const LIVE_BASE = `https://${REF}--${SITE}--${ORG}.hlx.live`;
+const PUBLISH_STEP_DELAY_MS = 2000;
+const READBACK_MAX_ATTEMPTS = 3;
+const READBACK_DELAY_MS = 3000;
+
+/**
+ * HLX strips the `shared-` worksheet prefix when building the JSON; the
+ * `shared-Semrush` sheet surfaces under the `Semrush` key. The multi-sheet JSON
+ * is `{ ":names": [...], "Semrush": { data: [...] }, ... }`.
+ */
+const SEMRUSH_JSON_KEY = 'Semrush';
+
+function toJsonPath(filename, outputLocation) {
+  const jsonFilename = `${filename.replace(/\.[^/.]+$/, '')}.json`;
+  return `${outputLocation}/${jsonFilename}`;
+}
+
+/**
+ * Extracts the Semrush rows out of the published multi-sheet HLX JSON, tolerating
+ * both the single-sheet shape ({ data: [...] }) and the multi-sheet shape
+ * ({ Semrush: { data: [...] } }).
+ *
+ * @param {object} json
+ * @returns {Array<object>|null} rows, or null if the Semrush sheet is absent.
+ */
+export function extractSemrushRows(json) {
+  if (!json || typeof json !== 'object') {
+    return null;
+  }
+  const sheet = json[SEMRUSH_JSON_KEY] ?? json;
+  if (sheet && Array.isArray(sheet.data)) {
+    return sheet.data;
+  }
+  return null;
+}
+
+/**
+ * Fetches the published live JSON and confirms it reflects what we wrote. Retries
+ * a few times to absorb edge-propagation latency before declaring a stale-CDN
+ * failure.
+ */
+async function readBack({
+  path, expectedRowCount, expectedGeneratedAt, log, fetchImpl,
+}) {
+  const url = `${LIVE_BASE}/${path}`;
+  let lastReason = 'unknown';
+
+  for (let attempt = 1; attempt <= READBACK_MAX_ATTEMPTS; attempt += 1) {
+    if (attempt > 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await sleep(READBACK_DELAY_MS);
+    }
+    let json;
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      const response = await fetchImpl(url, { method: 'GET' });
+      if (!response.ok) {
+        lastReason = `read-back fetch failed: ${response.status} ${response.statusText}`;
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      // eslint-disable-next-line no-await-in-loop
+      json = await response.json();
+    } catch (e) {
+      lastReason = `read-back fetch error: ${e.message}`;
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
+    const rows = extractSemrushRows(json);
+    if (rows === null) {
+      lastReason = 'read-back JSON did not contain a Semrush sheet';
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    if (rows.length !== expectedRowCount) {
+      lastReason = `read-back row count ${rows.length} != expected ${expectedRowCount} (stale CDN?)`;
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    if (expectedGeneratedAt) {
+      const seen = json.generated_at
+        ?? json[SEMRUSH_JSON_KEY]?.generated_at
+        ?? (rows[0] && rows[0].generated_at);
+      if (seen && seen !== expectedGeneratedAt) {
+        lastReason = `read-back generated_at ${seen} != expected ${expectedGeneratedAt} (stale CDN?)`;
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+    }
+
+    log.info(`STRATEGIC_RECOMMENDATIONS_SEMRUSH: post-publish read-back OK (${rows.length} rows) on attempt ${attempt}`);
+    return;
+  }
+
+  throw new Error(`post-publish read-back failed after ${READBACK_MAX_ATTEMPTS} attempts: ${lastReason}`);
+}
+
+/**
+ * Publishes a workbook to admin.hlx.page (preview + live), surfacing any non-2xx
+ * by throwing, then reads the published live JSON back to confirm the write
+ * landed.
+ *
+ * @param {object} params
+ * @param {string} params.filename - Workbook filename (e.g. strategic-recommendations.xlsx).
+ * @param {string} params.outputLocation - SharePoint folder path (relative).
+ * @param {number} params.expectedRowCount - Number of Semrush rows just written.
+ * @param {string|null} params.expectedGeneratedAt - Stamp to confirm on read-back, if any.
+ * @param {object} params.log - Logger.
+ * @param {Function} params.fetchImpl - fetch implementation (injectable for tests).
+ * @throws {Error} on any publish non-2xx or a read-back mismatch.
+ */
+export async function publishWorkbookWithReadback({
+  filename,
+  outputLocation,
+  expectedRowCount,
+  expectedGeneratedAt,
+  log,
+  fetchImpl,
+}) {
+  const path = toJsonPath(filename, outputLocation);
+  const headers = { Cookie: `auth_token=${process.env.ADMIN_HLX_API_KEY}` };
+
+  const endpoints = [
+    { name: 'preview', url: `${ADMIN_BASE}/preview/${ORG}/${SITE}/${REF}/${path}` },
+    { name: 'live', url: `${ADMIN_BASE}/live/${ORG}/${SITE}/${REF}/${path}` },
+  ];
+
+  for (const endpoint of endpoints) {
+    // eslint-disable-next-line no-await-in-loop
+    await sleep(PUBLISH_STEP_DELAY_MS);
+    log.info(`STRATEGIC_RECOMMENDATIONS_SEMRUSH: publishing to ${endpoint.name}: ${endpoint.url}`);
+    // eslint-disable-next-line no-await-in-loop
+    const response = await fetchImpl(endpoint.url, { method: 'POST', headers });
+    if (!response.ok) {
+      // SURFACE the failure — unlike publishToAdminHlx, do not swallow it.
+      throw new Error(`publish to ${endpoint.name} failed: ${response.status} ${response.statusText}`);
+    }
+    log.info(`STRATEGIC_RECOMMENDATIONS_SEMRUSH: published to ${endpoint.name}`);
+  }
+
+  await readBack({
+    path, expectedRowCount, expectedGeneratedAt, log, fetchImpl,
+  });
+}
+
+export default publishWorkbookWithReadback;

--- a/src/strategic-recommendations-semrush/result-location.js
+++ b/src/strategic-recommendations-semrush/result-location.js
@@ -23,12 +23,18 @@
  *  - an `https://` S3 presigned URL (virtual-hosted or path style), or
  *  - an `s3://<bucket>/<key>` URI.
  *
- * In both cases the bucket must equal `env.DRS_RESULTS_BUCKET` and the object key
- * must start with `env.DRS_RESULTS_PREFIX`. The prefix defaults to
+ * The object key must start with `env.DRS_RESULTS_PREFIX`, which defaults to
  * `strategic_recommendations_semrush/` — the fixed `{PROVIDER_ID}/` key prefix the
- * DRS producer writes under (runner.py `_save_results`) — so the guard works
- * out of the box without deploy config; override only if the producer changes it.
- * The expected bucket is required — if it is not configured we fail closed.
+ * DRS producer writes under (runner.py `_save_results`) — so the guard works out
+ * of the box with no deploy config.
+ *
+ * `env.DRS_RESULTS_BUCKET` tightens the guard to a single bucket when it is
+ * configured. When it is NOT configured we still fail closed on anything we
+ * cannot bound: only the presigned `https://` form is accepted (its hostname is
+ * S3-allowlisted below), and the bare `s3://` form is rejected. The DRS producer
+ * emits a presigned URL (it presigns before publishing JOB_COMPLETED so the
+ * consumer needs no cross-account S3 access), so the happy path needs no deploy
+ * config; provisioning DRS_RESULTS_BUCKET later only narrows the guard further.
  */
 
 // Matches both virtual-hosted-style (bucket.s3[.region].amazonaws.com)
@@ -95,21 +101,27 @@ function parseS3Location(resultLocation) {
  *
  * @param {string} resultLocation
  * @param {object} env
- * @param {string} env.DRS_RESULTS_BUCKET - Required expected bucket name.
+ * @param {string} [env.DRS_RESULTS_BUCKET] - Expected bucket; pins the guard to it
+ *   when set. When unset, only the S3-allowlisted presigned https form is accepted.
  * @param {string} [env.DRS_RESULTS_PREFIX='strategic_recommendations_semrush/'] - Key prefix.
  * @throws {Error} if the location is malformed or outside the bucket/prefix.
  */
 export function assertResultLocation(resultLocation, env = {}) {
   const expectedBucket = env.DRS_RESULTS_BUCKET;
-  if (!expectedBucket) {
-    throw new Error('DRS_RESULTS_BUCKET is not configured; refusing to fetch result (fail closed)');
-  }
   const expectedPrefix = normalizePrefix(env.DRS_RESULTS_PREFIX);
 
   const { bucket, key } = parseS3Location(resultLocation);
 
-  if (bucket !== expectedBucket) {
-    throw new Error(`resultLocation bucket ${bucket} is not the expected results bucket ${expectedBucket}`);
+  if (expectedBucket) {
+    if (bucket !== expectedBucket) {
+      throw new Error(`resultLocation bucket ${bucket} is not the expected results bucket ${expectedBucket}`);
+    }
+  } else if (resultLocation.startsWith('s3://')) {
+    // No expected bucket configured: the bare s3:// form has no hostname to
+    // allowlist, so we cannot bound which bucket it targets — fail closed. The
+    // producer emits a presigned https URL (hostname allowlisted in
+    // parseS3Location), which remains accepted under the prefix check below.
+    throw new Error('resultLocation s3:// form requires DRS_RESULTS_BUCKET to be configured');
   }
   if (!key.startsWith(expectedPrefix)) {
     throw new Error(`resultLocation key ${key} is not under the expected prefix ${expectedPrefix}`);

--- a/src/strategic-recommendations-semrush/result-location.js
+++ b/src/strategic-recommendations-semrush/result-location.js
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * SSRF guard for the DRS-supplied `resultLocation`.
+ *
+ * The result location is attacker-influenceable (it rides in an inbound SNS→SQS
+ * message). Before we make any network call we MUST confirm it points at the
+ * expected DRS results bucket/prefix. Without this guard a malformed or hostile
+ * message could redirect the worker at an internal metadata endpoint (SSRF) or an
+ * unrelated bucket (content injection).
+ *
+ * Two location forms are accepted:
+ *  - an `https://` S3 presigned URL (virtual-hosted or path style), or
+ *  - an `s3://<bucket>/<key>` URI.
+ *
+ * In both cases the bucket must equal `env.DRS_RESULTS_BUCKET` and the object key
+ * must start with `env.DRS_RESULTS_PREFIX` (default `results/`). The expected
+ * bucket is required — if it is not configured we fail closed.
+ */
+
+// Matches both virtual-hosted-style (bucket.s3[.region].amazonaws.com)
+// and path-style (s3[.region].amazonaws.com) presigned URL hostnames.
+const S3_HOSTNAME_RE = /^(?<bucket>[a-z0-9.-]+\.)?s3(\.[a-z0-9-]+)?\.amazonaws\.com$/;
+
+function normalizePrefix(prefix) {
+  const p = (prefix || 'results/').replace(/^\/+/, '');
+  return p.endsWith('/') ? p : `${p}/`;
+}
+
+/**
+ * Parses the bucket + key out of a result location, regardless of form.
+ *
+ * @param {string} resultLocation
+ * @returns {{ bucket: string, key: string }}
+ * @throws {Error} if the location is unparseable or not an S3 location.
+ */
+function parseS3Location(resultLocation) {
+  if (typeof resultLocation !== 'string' || resultLocation.length === 0) {
+    throw new Error('resultLocation is missing');
+  }
+
+  if (resultLocation.startsWith('s3://')) {
+    const without = resultLocation.slice('s3://'.length);
+    const slash = without.indexOf('/');
+    if (slash <= 0 || slash === without.length - 1) {
+      throw new Error(`resultLocation is not a valid s3 URI: ${resultLocation}`);
+    }
+    return { bucket: without.slice(0, slash), key: without.slice(slash + 1) };
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(resultLocation);
+  } catch {
+    throw new Error(`resultLocation is not a valid URL: ${resultLocation}`);
+  }
+  if (parsed.protocol !== 'https:') {
+    throw new Error(`resultLocation must use https or s3, got: ${parsed.protocol}`);
+  }
+  const match = S3_HOSTNAME_RE.exec(parsed.hostname);
+  if (!match) {
+    throw new Error(`resultLocation hostname is not an allowlisted S3 hostname: ${parsed.hostname}`);
+  }
+
+  const path = decodeURIComponent(parsed.pathname).replace(/^\/+/, '');
+  // Virtual-hosted style: bucket is the hostname label before `.s3`. The key is
+  // the whole path. Path style: hostname is `s3...`, bucket is the first path
+  // segment and the key is the remainder.
+  const vhostBucket = match.groups.bucket ? match.groups.bucket.replace(/\.$/, '') : null;
+  if (vhostBucket) {
+    return { bucket: vhostBucket, key: path };
+  }
+  const slash = path.indexOf('/');
+  if (slash <= 0 || slash === path.length - 1) {
+    throw new Error(`resultLocation path does not contain a bucket and key: ${resultLocation}`);
+  }
+  return { bucket: path.slice(0, slash), key: path.slice(slash + 1) };
+}
+
+/**
+ * Asserts the result location is under the configured DRS results bucket/prefix.
+ *
+ * @param {string} resultLocation
+ * @param {object} env
+ * @param {string} env.DRS_RESULTS_BUCKET - Required expected bucket name.
+ * @param {string} [env.DRS_RESULTS_PREFIX='results/'] - Required key prefix.
+ * @throws {Error} if the location is malformed or outside the bucket/prefix.
+ */
+export function assertResultLocation(resultLocation, env = {}) {
+  const expectedBucket = env.DRS_RESULTS_BUCKET;
+  if (!expectedBucket) {
+    throw new Error('DRS_RESULTS_BUCKET is not configured; refusing to fetch result (fail closed)');
+  }
+  const expectedPrefix = normalizePrefix(env.DRS_RESULTS_PREFIX);
+
+  const { bucket, key } = parseS3Location(resultLocation);
+
+  if (bucket !== expectedBucket) {
+    throw new Error(`resultLocation bucket ${bucket} is not the expected results bucket ${expectedBucket}`);
+  }
+  if (!key.startsWith(expectedPrefix)) {
+    throw new Error(`resultLocation key ${key} is not under the expected prefix ${expectedPrefix}`);
+  }
+}
+
+export default assertResultLocation;

--- a/src/strategic-recommendations-semrush/result-location.js
+++ b/src/strategic-recommendations-semrush/result-location.js
@@ -24,8 +24,11 @@
  *  - an `s3://<bucket>/<key>` URI.
  *
  * In both cases the bucket must equal `env.DRS_RESULTS_BUCKET` and the object key
- * must start with `env.DRS_RESULTS_PREFIX` (default `results/`). The expected
- * bucket is required — if it is not configured we fail closed.
+ * must start with `env.DRS_RESULTS_PREFIX`. The prefix defaults to
+ * `strategic_recommendations_semrush/` — the fixed `{PROVIDER_ID}/` key prefix the
+ * DRS producer writes under (runner.py `_save_results`) — so the guard works
+ * out of the box without deploy config; override only if the producer changes it.
+ * The expected bucket is required — if it is not configured we fail closed.
  */
 
 // Matches both virtual-hosted-style (bucket.s3[.region].amazonaws.com)
@@ -33,7 +36,7 @@
 const S3_HOSTNAME_RE = /^(?<bucket>[a-z0-9.-]+\.)?s3(\.[a-z0-9-]+)?\.amazonaws\.com$/;
 
 function normalizePrefix(prefix) {
-  const p = (prefix || 'results/').replace(/^\/+/, '');
+  const p = (prefix || 'strategic_recommendations_semrush/').replace(/^\/+/, '');
   return p.endsWith('/') ? p : `${p}/`;
 }
 
@@ -93,7 +96,7 @@ function parseS3Location(resultLocation) {
  * @param {string} resultLocation
  * @param {object} env
  * @param {string} env.DRS_RESULTS_BUCKET - Required expected bucket name.
- * @param {string} [env.DRS_RESULTS_PREFIX='results/'] - Required key prefix.
+ * @param {string} [env.DRS_RESULTS_PREFIX='strategic_recommendations_semrush/'] - Key prefix.
  * @throws {Error} if the location is malformed or outside the bucket/prefix.
  */
 export function assertResultLocation(resultLocation, env = {}) {

--- a/src/strategic-recommendations-semrush/schema-derived.js
+++ b/src/strategic-recommendations-semrush/schema-derived.js
@@ -47,3 +47,17 @@ export const TAG_VALUES = ['Hidden Win', 'Coverage Gap', 'Strategic Blindspot'];
 // null/undefined as the active default and accepts the string markers, so the
 // full enum is exposed.
 export const DELETED_VALUES = ['', 'ignored', 'added', null];
+
+// schema.properties[*].maxLength — only the fields that declare one. Kept in the
+// drift-guard chain by schema-checksum.test.js (asserted == the vendored JSON).
+export const MAX_LENGTHS = {
+  strategy: 200,
+  strategy_reasoning: 2000,
+  topic: 300,
+  competitor_1: 200,
+  competitor_2: 200,
+  competitor_3: 200,
+  category: 120,
+  prompt: 600,
+  prompt_id: 128,
+};

--- a/src/strategic-recommendations-semrush/schema-derived.js
+++ b/src/strategic-recommendations-semrush/schema-derived.js
@@ -61,3 +61,49 @@ export const MAX_LENGTHS = {
   prompt: 600,
   prompt_id: 128,
 };
+
+/* ------------------------------------------------------------------------- *
+ * Auxiliary sheets: shared-citation-row + shared-persona-row.
+ *
+ * These two contracts are derived from the brand's published prompt-suggestions
+ * workbook. Unlike Semrush: `tag` is free-form (no enum), and `strategy` /
+ * `strategy_reasoning` are `required` (the key is always present) but MAY be the
+ * empty string — the product rule is "if data is unavailable, leave it empty",
+ * not drop the row. Only `prompt` carries `minLength: 1`. All three constant
+ * groups are pinned to the vendored JSON by schema-checksum.test.js.
+ * ------------------------------------------------------------------------- */
+
+// schema.required — identical for both auxiliary schemas.
+export const AUX_REQUIRED_FIELDS = ['tag', 'strategy', 'strategy_reasoning', 'prompt'];
+
+// schema.properties.deleted.enum — identical for both auxiliary schemas.
+export const AUX_DELETED_VALUES = ['', 'ignored', 'added', null];
+
+// shared-citation-row.schema.v1.json — properties[*].maxLength.
+export const CITATION_MAX_LENGTHS = {
+  tag: 120,
+  strategy: 200,
+  strategy_reasoning: 2000,
+  prompt: 600,
+  topic: 300,
+  category: 120,
+  region: 120,
+  intent: 120,
+  type: 120,
+  source_url: 2048,
+  prompt_reasoning: 2000,
+};
+
+// shared-persona-row.schema.v1.json — properties[*].maxLength (no source_url).
+export const PERSONA_MAX_LENGTHS = {
+  tag: 120,
+  strategy: 200,
+  strategy_reasoning: 2000,
+  prompt: 600,
+  topic: 300,
+  category: 120,
+  region: 120,
+  intent: 120,
+  type: 120,
+  prompt_reasoning: 2000,
+};

--- a/src/strategic-recommendations-semrush/schema-derived.js
+++ b/src/strategic-recommendations-semrush/schema-derived.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Loads enum/required values directly from the vendored schema JSON so the
+ * validator can never drift from the contract within this repo. (The vendored
+ * copy itself is kept in sync with the authoritative DRS copy by the
+ * checksum-drift test.)
+ */
+
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+const schemaPath = fileURLToPath(new URL('./shared-semrush-row.schema.v1.json', import.meta.url));
+
+export const SCHEMA = JSON.parse(readFileSync(schemaPath, 'utf8'));
+export const REQUIRED_FIELDS = SCHEMA.required;
+export const TAG_VALUES = SCHEMA.properties.tag.enum;
+// The `deleted` enum includes null; the validator treats null/undefined as the
+// active default and accepts the string markers, so expose the full enum.
+export const DELETED_VALUES = SCHEMA.properties.deleted.enum;

--- a/src/strategic-recommendations-semrush/schema-derived.js
+++ b/src/strategic-recommendations-semrush/schema-derived.js
@@ -11,20 +11,39 @@
  */
 
 /**
- * Loads enum/required values directly from the vendored schema JSON so the
- * validator can never drift from the contract within this repo. (The vendored
- * copy itself is kept in sync with the authoritative DRS copy by the
- * checksum-drift test.)
+ * Validator inputs derived from the row contract
+ * `shared-semrush-row.schema.v1.json`.
+ *
+ * These are INLINED as constants rather than read from the JSON at runtime. The
+ * vendored JSON is a `wsk.static` asset, and reading it via an
+ * `import.meta.url`-relative path threw `ENOENT` under `validateBundle` (the
+ * bundled module resolves next to `dist/`, not to the source tree where the
+ * asset lands) — i.e. the Lambda failed at cold start, not just in CI. Inlining
+ * removes the module-eval-time disk dependency entirely.
+ *
+ * The drift chain is preserved without a runtime read:
+ *  - inlined constants == vendored JSON  -> asserted by `schema-checksum.test.js`
+ *  - vendored JSON == DRS authoritative  -> asserted by `schema-checksum.test.js`
+ * So a contract change must touch the JSON (changing its sha) AND these
+ * constants in the same commit, or a test fails.
  */
 
-import { readFileSync } from 'fs';
-import { fileURLToPath } from 'url';
+// schema.required
+export const REQUIRED_FIELDS = [
+  'tag',
+  'strategy',
+  'strategy_reasoning',
+  'topic_id',
+  'topic',
+  'volume',
+  'adobe_mentions',
+  'prompt',
+];
 
-const schemaPath = fileURLToPath(new URL('./shared-semrush-row.schema.v1.json', import.meta.url));
+// schema.properties.tag.enum
+export const TAG_VALUES = ['Hidden Win', 'Coverage Gap', 'Strategic Blindspot'];
 
-export const SCHEMA = JSON.parse(readFileSync(schemaPath, 'utf8'));
-export const REQUIRED_FIELDS = SCHEMA.required;
-export const TAG_VALUES = SCHEMA.properties.tag.enum;
-// The `deleted` enum includes null; the validator treats null/undefined as the
-// active default and accepts the string markers, so expose the full enum.
-export const DELETED_VALUES = SCHEMA.properties.deleted.enum;
+// schema.properties.deleted.enum — includes '' and null; the validator treats
+// null/undefined as the active default and accepts the string markers, so the
+// full enum is exposed.
+export const DELETED_VALUES = ['', 'ignored', 'added', null];

--- a/src/strategic-recommendations-semrush/schema-validate.js
+++ b/src/strategic-recommendations-semrush/schema-validate.js
@@ -22,7 +22,9 @@
  * reject.
  */
 
-import { TAG_VALUES, DELETED_VALUES, REQUIRED_FIELDS } from './schema-derived.js';
+import {
+  TAG_VALUES, DELETED_VALUES, REQUIRED_FIELDS, MAX_LENGTHS,
+} from './schema-derived.js';
 
 const INTEGER_FIELDS = [
   'volume',
@@ -67,6 +69,14 @@ function validateRow(row, index) {
   STRING_FIELDS.forEach((field) => {
     if (typeof row[field] === 'string' && row[field].length === 0) {
       errors.push(`row[${index}] '${field}' must be non-empty`);
+    }
+  });
+  // maxLength bounds from the contract (applies to any present string field,
+  // including the nullable competitor_*/category/prompt_id columns).
+  Object.entries(MAX_LENGTHS).forEach(([field, max]) => {
+    const value = row[field];
+    if (typeof value === 'string' && value.length > max) {
+      errors.push(`row[${index}] '${field}' exceeds maxLength ${max}`);
     }
   });
 

--- a/src/strategic-recommendations-semrush/schema-validate.js
+++ b/src/strategic-recommendations-semrush/schema-validate.js
@@ -24,6 +24,7 @@
 
 import {
   TAG_VALUES, DELETED_VALUES, REQUIRED_FIELDS, MAX_LENGTHS,
+  AUX_REQUIRED_FIELDS, AUX_DELETED_VALUES, CITATION_MAX_LENGTHS, PERSONA_MAX_LENGTHS,
 } from './schema-derived.js';
 
 const INTEGER_FIELDS = [
@@ -112,6 +113,98 @@ export function validateSemrushRows(rows) {
     errors.push(...validateRow(row, index));
   });
   return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Validates one auxiliary-sheet row (Citation Attempt / Synthetic Personas).
+ *
+ * The auxiliary contracts differ from Semrush: `tag` is free-form (no enum),
+ * there are no integer columns, and `strategy` / `strategy_reasoning` are
+ * required-present but may be EMPTY (the "leave it empty" rule). Only `prompt`
+ * carries minLength 1. Every string column is type- and maxLength-checked.
+ *
+ * @param {object} row
+ * @param {number} index
+ * @param {{ required: string[], deletedValues: Array, maxLengths: object }} spec
+ * @returns {string[]}
+ */
+function validateAuxRow(row, index, spec) {
+  if (!row || typeof row !== 'object' || Array.isArray(row)) {
+    return [`row[${index}] is not an object`];
+  }
+  const errors = [];
+
+  spec.required.forEach((field) => {
+    if (row[field] === undefined || row[field] === null) {
+      errors.push(`row[${index}] missing required field '${field}'`);
+    }
+  });
+
+  if (row.deleted !== undefined && !spec.deletedValues.includes(row.deleted)) {
+    errors.push(`row[${index}] deleted '${row.deleted}' not in enum`);
+  }
+
+  Object.entries(spec.maxLengths).forEach(([field, max]) => {
+    const value = row[field];
+    if (value === undefined || value === null) {
+      return;
+    }
+    if (typeof value !== 'string') {
+      errors.push(`row[${index}] '${field}' must be a string`);
+    } else if (value.length > max) {
+      errors.push(`row[${index}] '${field}' exceeds maxLength ${max}`);
+    }
+  });
+
+  // Only `prompt` carries minLength 1; strategy/strategy_reasoning may be empty.
+  if (typeof row.prompt === 'string' && row.prompt.length === 0) {
+    errors.push(`row[${index}] 'prompt' must be non-empty`);
+  }
+
+  return errors;
+}
+
+function validateAuxRows(rows, spec) {
+  if (!Array.isArray(rows)) {
+    return { valid: false, errors: ['rows is not an array'] };
+  }
+  const errors = [];
+  rows.forEach((row, index) => {
+    errors.push(...validateAuxRow(row, index, spec));
+  });
+  return { valid: errors.length === 0, errors };
+}
+
+const CITATION_SPEC = {
+  required: AUX_REQUIRED_FIELDS,
+  deletedValues: AUX_DELETED_VALUES,
+  maxLengths: CITATION_MAX_LENGTHS,
+};
+
+const PERSONA_SPEC = {
+  required: AUX_REQUIRED_FIELDS,
+  deletedValues: AUX_DELETED_VALUES,
+  maxLengths: PERSONA_MAX_LENGTHS,
+};
+
+/**
+ * Validates an array of `shared-Citation Attempt` rows.
+ *
+ * @param {Array<object>} rows
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateCitationRows(rows) {
+  return validateAuxRows(rows, CITATION_SPEC);
+}
+
+/**
+ * Validates an array of `shared-Synthetic Personas` rows.
+ *
+ * @param {Array<object>} rows
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validatePersonaRows(rows) {
+  return validateAuxRows(rows, PERSONA_SPEC);
 }
 
 export default validateSemrushRows;

--- a/src/strategic-recommendations-semrush/schema-validate.js
+++ b/src/strategic-recommendations-semrush/schema-validate.js
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Validates `shared-Semrush` rows against the vendored row contract.
+ *
+ * The authoritative schema lives in DRS
+ * (`docs/contracts/shared-semrush-row.schema.v1.json`); a sha-pinned copy is
+ * vendored here and the checksum-drift test fails CI if the two diverge. This
+ * validator enforces the parts of that draft-07 schema that matter at ingest:
+ * required keys, the `tag`/`deleted` enums, and the integer/string types. It is
+ * intentionally dependency-free so the writer never accepts rows the schema would
+ * reject.
+ */
+
+import { TAG_VALUES, DELETED_VALUES, REQUIRED_FIELDS } from './schema-derived.js';
+
+const INTEGER_FIELDS = [
+  'volume',
+  'adobe_mentions',
+  'competitor_1_mentions',
+  'competitor_2_mentions',
+  'competitor_3_mentions',
+];
+
+const STRING_FIELDS = ['strategy', 'strategy_reasoning', 'topic_id', 'topic', 'prompt'];
+
+function isInteger(value) {
+  return typeof value === 'number' && Number.isInteger(value);
+}
+
+function validateRow(row, index) {
+  const errors = [];
+  if (!row || typeof row !== 'object' || Array.isArray(row)) {
+    return [`row[${index}] is not an object`];
+  }
+
+  REQUIRED_FIELDS.forEach((field) => {
+    if (row[field] === undefined || row[field] === null) {
+      errors.push(`row[${index}] missing required field '${field}'`);
+    }
+  });
+
+  if (row.tag !== undefined && !TAG_VALUES.includes(row.tag)) {
+    errors.push(`row[${index}] tag '${row.tag}' not in enum`);
+  }
+
+  if (row.deleted !== undefined && !DELETED_VALUES.includes(row.deleted)) {
+    errors.push(`row[${index}] deleted '${row.deleted}' not in enum`);
+  }
+
+  STRING_FIELDS.forEach((field) => {
+    if (row[field] !== undefined && row[field] !== null && typeof row[field] !== 'string') {
+      errors.push(`row[${index}] '${field}' must be a string`);
+    }
+  });
+  // minLength: 1 on the required string fields.
+  STRING_FIELDS.forEach((field) => {
+    if (typeof row[field] === 'string' && row[field].length === 0) {
+      errors.push(`row[${index}] '${field}' must be non-empty`);
+    }
+  });
+
+  // adobe_mentions/volume are required (caught above); competitor_* are nullable,
+  // so only type-check integer fields that are actually present.
+  INTEGER_FIELDS.forEach((field) => {
+    const value = row[field];
+    if (value === undefined || value === null) {
+      return;
+    }
+    if (!isInteger(value)) {
+      errors.push(`row[${index}] '${field}' must be an integer`);
+    } else if (value < 0) {
+      errors.push(`row[${index}] '${field}' must be >= 0`);
+    }
+  });
+
+  return errors;
+}
+
+/**
+ * Validates an array of rows.
+ *
+ * @param {Array<object>} rows
+ * @returns {{ valid: boolean, errors: string[] }}
+ */
+export function validateSemrushRows(rows) {
+  if (!Array.isArray(rows)) {
+    return { valid: false, errors: ['rows is not an array'] };
+  }
+  const errors = [];
+  rows.forEach((row, index) => {
+    errors.push(...validateRow(row, index));
+  });
+  return { valid: errors.length === 0, errors };
+}
+
+export default validateSemrushRows;

--- a/src/strategic-recommendations-semrush/shared-citation-row.schema.v1.json
+++ b/src/strategic-recommendations-semrush/shared-citation-row.schema.v1.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "shared-citation-row.schema.v1.json",
+  "title": "SharedCitationRow",
+  "description": "One PROMPT row in the `shared-Citation Attempt` worksheet of strategic-recommendations.xlsx. Built from the brand's published prompt-suggestions workbook: eight columns map 1:1 from the prompt row, and the `tag` / `strategy` / `strategy_reasoning` gap columns are generated the SAME WAY as the Semrush strategy columns (LLM synthesis per prompt group, grouped by `source_url`). Single source of truth shared by the DRS runner row-emitter (Pydantic SharedCitationRow) and the spacecat-audit-worker sheet writer (validates on ingest). schema_version is carried on the result envelope, not per row.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["tag", "strategy", "strategy_reasoning", "prompt"],
+  "properties": {
+    "tag": { "type": "string", "maxLength": 120, "description": "Generated archetype. Always \"Coverage Gap\" in v1 — elmo-ui's TAG_TO_ARCHETYPE maps any non-Semrush tag to coverage_gap and tolerates a blank strategy." },
+    "strategy": { "type": "string", "maxLength": 200, "description": "Generated card headline; repeated on every row in the group. GROUPING KEY. EMPTY (\"\") when the group could not be synthesized — the prompt is still emitted (product rule: if data is unavailable, leave it empty)." },
+    "strategy_reasoning": { "type": "string", "maxLength": 2000, "description": "Generated situation + evidence + recommended action. Repeated per group. May be empty (see strategy)." },
+    "prompt": { "type": "string", "minLength": 1, "maxLength": 600, "description": "One trackable customer prompt. Row grain = one row per prompt. Passthrough 1:1 from the prompt-suggestions row." },
+    "topic": { "type": ["string", "null"], "maxLength": 300, "description": "Passthrough 1:1 from the prompt row." },
+    "category": { "type": ["string", "null"], "maxLength": 120, "description": "Passthrough 1:1 from the prompt row." },
+    "region": { "type": ["string", "null"], "maxLength": 120, "description": "Passthrough 1:1 from the prompt row." },
+    "intent": { "type": ["string", "null"], "maxLength": 120, "description": "Passthrough 1:1 from the prompt row." },
+    "type": { "type": ["string", "null"], "maxLength": 120, "description": "Passthrough 1:1 from the prompt row." },
+    "source_url": { "type": ["string", "null"], "maxLength": 2048, "description": "Citation source URL. GROUPING KEY (synthesis + UI). Passthrough 1:1 from the prompt row's `url` column." },
+    "prompt_reasoning": { "type": ["string", "null"], "maxLength": 2000, "description": "Passthrough of the prompt row's `Reasoning` column (why the prompt was generated) — distinct from the generated `strategy_reasoning`." },
+    "deleted": { "type": ["string", "null"], "enum": ["", "ignored", "added", null], "description": "UI soft-delete marker. ''/null = active, 'ignored' = dismissed, 'added' = manually tracked. Writer MUST preserve existing values by match key (source_url, prompt) — best-effort in v1, mirroring the Semrush sheet." }
+  },
+  "x-contract": {
+    "worksheet": "shared-Citation Attempt",
+    "source_workbook": "{dataFolder}/prompt-suggestions/prompt-suggestions.json -> tab `shared-Citation Attempt`",
+    "sharepoint_path": "/sites/elmo-ui-data/{dataFolder}/strategic-recommendations-template/strategic-recommendations.xlsx",
+    "hlx_publish": "{dataFolder}/strategic-recommendations-template/strategic-recommendations.json (preview+live; HLX strips 'shared-' prefix -> JSON key 'Citation Attempt')",
+    "row_grain": "one row per (source_url, prompt)",
+    "grouping_keys": ["source_url"],
+    "generated_columns": ["tag", "strategy", "strategy_reasoning"],
+    "passthrough_columns": ["prompt", "topic", "category", "region", "intent", "type", "source_url", "prompt_reasoning"],
+    "generated_columns_note": "tag/strategy/strategy_reasoning are produced by the SAME LLM synthesis path as the Semrush strategy columns, one call per source_url group. When a group's synthesis is unavailable, strategy + strategy_reasoning are emitted EMPTY (\"\") and the prompt row is still emitted — the product requirement is 'if data is not available, just leave it empty', not drop the row. tag stays 'Coverage Gap' regardless.",
+    "match_key_for_deleted_preservation": ["source_url", "prompt"],
+    "match_key_note": "v1 = BEST-EFFORT, mirroring the Semrush sheet. The audit-worker merge re-applies `deleted` by matching on `source_url` + `prompt` text. A rephrased prompt lapses a prior dismissal; ACCEPTED for v1."
+  }
+}

--- a/src/strategic-recommendations-semrush/shared-persona-row.schema.v1.json
+++ b/src/strategic-recommendations-semrush/shared-persona-row.schema.v1.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "shared-persona-row.schema.v1.json",
+  "title": "SharedPersonaRow",
+  "description": "One PROMPT row in the `shared-Synthetic Personas` worksheet of strategic-recommendations.xlsx. Built from the brand's published prompt-suggestions workbook: seven columns map 1:1 from the prompt row, and the `tag` / `strategy` / `strategy_reasoning` gap columns are generated the SAME WAY as the Semrush strategy columns (LLM synthesis per prompt group, grouped by `category`). Single source of truth shared by the DRS runner row-emitter (Pydantic SharedPersonaRow) and the spacecat-audit-worker sheet writer (validates on ingest). schema_version is carried on the result envelope, not per row.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["tag", "strategy", "strategy_reasoning", "prompt"],
+  "properties": {
+    "tag": { "type": "string", "maxLength": 120, "description": "Generated archetype. Always \"Coverage Gap\" in v1 — elmo-ui's TAG_TO_ARCHETYPE maps any non-Semrush tag to coverage_gap and tolerates a blank strategy." },
+    "strategy": { "type": "string", "maxLength": 200, "description": "Generated card headline; repeated on every row in the group. GROUPING KEY. EMPTY (\"\") when the group could not be synthesized — the prompt is still emitted (product rule: if data is unavailable, leave it empty)." },
+    "strategy_reasoning": { "type": "string", "maxLength": 2000, "description": "Generated situation + evidence + recommended action. Repeated per group. May be empty (see strategy)." },
+    "prompt": { "type": "string", "minLength": 1, "maxLength": 600, "description": "One trackable customer prompt. Row grain = one row per prompt. Passthrough 1:1 from the prompt-suggestions row." },
+    "topic": { "type": ["string", "null"], "maxLength": 300, "description": "Passthrough 1:1 from the prompt row." },
+    "category": { "type": ["string", "null"], "maxLength": 120, "description": "Persona category. GROUPING KEY (synthesis + UI). Passthrough 1:1 from the prompt row." },
+    "region": { "type": ["string", "null"], "maxLength": 120, "description": "Passthrough 1:1 from the prompt row." },
+    "intent": { "type": ["string", "null"], "maxLength": 120, "description": "Passthrough 1:1 from the prompt row." },
+    "type": { "type": ["string", "null"], "maxLength": 120, "description": "Passthrough 1:1 from the prompt row." },
+    "prompt_reasoning": { "type": ["string", "null"], "maxLength": 2000, "description": "Passthrough of the prompt row's `Reasoning` column (why the prompt was generated) — distinct from the generated `strategy_reasoning`." },
+    "deleted": { "type": ["string", "null"], "enum": ["", "ignored", "added", null], "description": "UI soft-delete marker. ''/null = active, 'ignored' = dismissed, 'added' = manually tracked. Writer MUST preserve existing values by match key (category, prompt) — best-effort in v1, mirroring the Semrush sheet." }
+  },
+  "x-contract": {
+    "worksheet": "shared-Synthetic Personas",
+    "source_workbook": "{dataFolder}/prompt-suggestions/prompt-suggestions.json -> tab `shared-Synthetic Personas`",
+    "sharepoint_path": "/sites/elmo-ui-data/{dataFolder}/strategic-recommendations-template/strategic-recommendations.xlsx",
+    "hlx_publish": "{dataFolder}/strategic-recommendations-template/strategic-recommendations.json (preview+live; HLX strips 'shared-' prefix -> JSON key 'Synthetic Personas')",
+    "row_grain": "one row per (category, prompt)",
+    "grouping_keys": ["category"],
+    "generated_columns": ["tag", "strategy", "strategy_reasoning"],
+    "passthrough_columns": ["prompt", "topic", "category", "region", "intent", "type", "prompt_reasoning"],
+    "generated_columns_note": "tag/strategy/strategy_reasoning are produced by the SAME LLM synthesis path as the Semrush strategy columns, one call per category group. When a group's synthesis is unavailable, strategy + strategy_reasoning are emitted EMPTY (\"\") and the prompt row is still emitted — the product requirement is 'if data is not available, just leave it empty', not drop the row. tag stays 'Coverage Gap' regardless.",
+    "match_key_for_deleted_preservation": ["category", "prompt"],
+    "match_key_note": "v1 = BEST-EFFORT, mirroring the Semrush sheet. The audit-worker merge re-applies `deleted` by matching on `category` + `prompt` text. A rephrased prompt lapses a prior dismissal; ACCEPTED for v1."
+  }
+}

--- a/src/strategic-recommendations-semrush/shared-semrush-row.schema.v1.json
+++ b/src/strategic-recommendations-semrush/shared-semrush-row.schema.v1.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "shared-semrush-row.schema.v1.json",
+  "title": "SharedSemrushRow",
+  "description": "One PROMPT row in the `shared-Semrush` worksheet of strategic-recommendations-template.xlsx. Single source of truth shared by the DRS runner row-emitter (Pydantic) and the spacecat-audit-worker sheet writer (validates on ingest). Mirrors project-elmo-ui SRApiSemrushRow. schema_version is carried on the result envelope, not per row.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["tag", "strategy", "strategy_reasoning", "topic_id", "topic", "volume", "adobe_mentions", "prompt"],
+  "properties": {
+    "tag": { "type": "string", "enum": ["Hidden Win", "Coverage Gap", "Strategic Blindspot"], "description": "Customer-facing archetype. v1 mapping: topics_you_win->Hidden Win, coverage_gap->Coverage Gap, ai_engine_gaps->Strategic Blindspot." },
+    "strategy": { "type": "string", "minLength": 1, "maxLength": 200, "description": "Card headline; repeated on every row in the recommendation group. GROUPING KEY." },
+    "strategy_reasoning": { "type": "string", "minLength": 1, "maxLength": 2000, "description": "Situation + evidence + recommended action (joined). Repeated per group." },
+    "topic_id": { "type": "string", "minLength": 1, "description": "Semrush topic id. GROUPING KEY (within strategy)." },
+    "topic": { "type": "string", "minLength": 1, "maxLength": 300 },
+    "volume": { "type": "integer", "minimum": 0 },
+    "adobe_mentions": { "type": "integer", "minimum": 0 },
+    "competitor_1": { "type": ["string", "null"], "maxLength": 200 },
+    "competitor_1_mentions": { "type": ["integer", "null"], "minimum": 0 },
+    "competitor_2": { "type": ["string", "null"], "maxLength": 200 },
+    "competitor_2_mentions": { "type": ["integer", "null"], "minimum": 0 },
+    "competitor_3": { "type": ["string", "null"], "maxLength": 200 },
+    "competitor_3_mentions": { "type": ["integer", "null"], "minimum": 0 },
+    "category": { "type": ["string", "null"], "maxLength": 120, "description": "Adobe product/cloud. Derived from LLMO config category; LLM-inferred fallback." },
+    "prompt": { "type": "string", "minLength": 1, "maxLength": 600, "description": "One trackable customer prompt. Row grain = one row per prompt. Deleted-preservation MATCH KEY = (topic_id, prompt) — see x-contract.match_key_for_deleted_preservation; forward path is the reserved prompt_id." },
+    "prompt_id": { "type": ["string", "null"], "maxLength": 128, "description": "RESERVED forward-compat seam. v1: runner emits null, writer ignores. When populated in a future version it becomes the stable deleted-preservation match key, replacing the best-effort (topic_id, prompt) text match — making that hardening an additive VALUE change, not a v2/schema bump. Optional + nullable so reserving it now keeps the strict schema valid and does not force a consumer re-vendor." },
+    "deleted": { "type": ["string", "null"], "enum": ["", "ignored", "added", null], "description": "UI soft-delete marker. ''/null = active, 'ignored' = dismissed, 'added' = manually tracked. Writer MUST preserve existing values by match key (topic_id, prompt) — best-effort in v1; see match_key_note." }
+  },
+  "x-contract": {
+    "worksheet": "shared-Semrush",
+    "sharepoint_path": "/sites/elmo-ui-data/{dataFolder}/strategic-recommendations-template/strategic-recommendations.xlsx",
+    "hlx_publish": "{dataFolder}/strategic-recommendations-template/strategic-recommendations.json (preview+live; HLX strips 'shared-' prefix -> JSON key 'Semrush')",
+    "row_grain": "one row per (strategy, topic_id, prompt)",
+    "grouping_keys": ["strategy", "topic_id"],
+    "match_key_for_deleted_preservation": ["topic_id", "prompt"],
+    "match_key_note": "v1 = BEST-EFFORT (user decision 2026-06-09). The audit-worker merge re-applies `deleted` by matching on the stable `topic_id` + `prompt` text. If a regeneration rephrases the prompt text, the match misses and a prior dismissal lapses (the card may reappear) — this is ACCEPTED for v1 and MUST be stated honestly in the UI (dismissals are best-effort, not guaranteed across refreshes). No UI change and no verbatim-reseed are required for v1. Future hardening: populate the RESERVED `prompt_id` field (nullable, emitted null in v1) and move the UI dismiss + merge to id-based matching — an additive value change, NOT a v2 bump, because the seam already exists in v1.",
+    "archetype_to_tag_v1": {
+      "topics_you_win": "Hidden Win",
+      "coverage_gap": "Coverage Gap",
+      "ai_engine_gaps": "Strategic Blindspot"
+    },
+    "deferred_archetypes_v1": ["losing_ground", "citation_gaps"]
+  }
+}

--- a/test/strategic-recommendations-semrush/handler.test.js
+++ b/test/strategic-recommendations-semrush/handler.test.js
@@ -16,7 +16,11 @@ import sinonChai from 'sinon-chai';
 import esmock from 'esmock';
 import ExcelJS from 'exceljs';
 import { MockContextBuilder } from '../shared.js';
-import { SEMRUSH_COLUMNS } from '../../src/strategic-recommendations-semrush/constants.js';
+import {
+  SEMRUSH_COLUMNS,
+  CITATION_COLUMNS,
+  PERSONA_COLUMNS,
+} from '../../src/strategic-recommendations-semrush/constants.js';
 
 use(sinonChai);
 
@@ -42,6 +46,29 @@ function validRow(overrides = {}) {
     deleted: '',
     ...overrides,
   };
+}
+
+function validCitation(overrides = {}) {
+  return {
+    tag: 'Coverage Gap',
+    strategy: 'Own the sofa-care topic',
+    strategy_reasoning: 'No first-party coverage today.',
+    prompt: 'how to clean a modular sofa',
+    topic: 'sofa care',
+    category: 'Furniture',
+    region: 'US',
+    intent: 'informational',
+    type: 'howto',
+    source_url: 'https://lovesac.com/care',
+    prompt_reasoning: 'high-intent gap',
+    deleted: '',
+    ...overrides,
+  };
+}
+
+function validPersona(overrides = {}) {
+  const { source_url: _, ...rest } = validCitation(overrides);
+  return rest;
 }
 
 /**
@@ -175,10 +202,10 @@ describe('Strategic Recommendations Semrush Handler', function describeHandler()
     const headers = sheet.getRow(1).values.slice(1);
     const deletedCol = headers.indexOf('deleted') + 1;
     expect(sheet.getRow(2).getCell(deletedCol).value).to.equal('ignored');
-    // other shared sheets preserved
+    // all three shared sheets are written; the legacy Notes sheet is dropped
     expect(wb.getWorksheet('shared-Citation Attempt')).to.not.equal(undefined);
     expect(wb.getWorksheet('shared-Synthetic Personas')).to.not.equal(undefined);
-    expect(wb.getWorksheet('Notes')).to.not.equal(undefined);
+    expect(wb.getWorksheet('Notes')).to.equal(undefined);
   });
 
   it('returns ok and alerts on JOB_FAILED without touching the sheet', async () => {
@@ -391,13 +418,19 @@ describe('Strategic Recommendations Semrush Handler', function describeHandler()
     expect(result.status).to.equal(500);
   });
 
-  it('surfaces when no existing workbook is found (cannot preserve template)', async () => {
+  it('builds a fresh workbook on first run (no existing workbook) with all 3 sheets', async () => {
     readFromSharePointStub.rejects(new Error('itemNotFound: resource could not be found'));
 
     const result = await handler.default(completedMessage(), context);
-    expect(result.status).to.equal(500);
-    expect(uploadToSharePointStub).to.not.have.been.called;
-    expect(JSON.stringify(mockPostMessageSafe.firstCall.args[3])).to.include('no published workbook');
+
+    expect(result.status).to.equal(200);
+    expect(uploadToSharePointStub).to.have.been.calledOnce;
+    const wb = new ExcelJS.Workbook();
+    await wb.xlsx.load(uploadToSharePointStub.firstCall.args[0]);
+    expect(wb.getWorksheet('shared-Semrush')).to.not.equal(undefined);
+    expect(wb.getWorksheet('shared-Citation Attempt')).to.not.equal(undefined);
+    expect(wb.getWorksheet('shared-Synthetic Personas')).to.not.equal(undefined);
+    expect(wb.getWorksheet('Notes')).to.equal(undefined);
   });
 
   it('surfaces when reading the existing workbook fails for other reasons', async () => {
@@ -556,7 +589,7 @@ describe('Strategic Recommendations Semrush Handler', function describeHandler()
 
     const result = await handler.default(completedMessage(), context);
     expect(result.status).to.equal(500);
-    expect(JSON.stringify(mockPostMessageSafe.firstCall.args[3])).to.include('zero rows');
+    expect(JSON.stringify(mockPostMessageSafe.firstCall.args[3])).to.include('zero Semrush rows');
   });
 
   it('handles a result with no generated_at (read-back skips stamp check)', async () => {
@@ -579,5 +612,136 @@ describe('Strategic Recommendations Semrush Handler', function describeHandler()
 
     const result = await handler.default(completedMessage(), context);
     expect(result.status).to.equal(200);
+  });
+
+  it('writes all three sheets from a result.sheets envelope', async () => {
+    fetchStub.callsFake(async (url, opts = {}) => {
+      if (url === RESULT_LOCATION) {
+        return {
+          ok: true,
+          headers: { get: () => null },
+          text: async () => JSON.stringify({
+            siteId: 'site-123',
+            generated_at: '2026-06-09T00:00:00Z',
+            sheets: {
+              Semrush: [validRow()],
+              'Citation Attempt': [validCitation(), validCitation({ prompt: 'second prompt' })],
+              'Synthetic Personas': [validPersona()],
+            },
+          }),
+        };
+      }
+      if (url.startsWith('https://admin.hlx.page/')) {
+        return { ok: true, status: 200, statusText: 'OK' };
+      }
+      if (url.startsWith(LIVE_JSON_URL) && opts.method === 'GET') {
+        return {
+          ok: true,
+          json: async () => ({ generated_at: '2026-06-09T00:00:00Z', Semrush: { data: [validRow()] } }),
+        };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const result = await handler.default(completedMessage(), context);
+
+    expect(result.status).to.equal(200);
+    const wb = new ExcelJS.Workbook();
+    await wb.xlsx.load(uploadToSharePointStub.firstCall.args[0]);
+    // header + 2 citation rows, header + 1 persona row
+    expect(wb.getWorksheet('shared-Citation Attempt').rowCount).to.equal(3);
+    expect(wb.getWorksheet('shared-Synthetic Personas').rowCount).to.equal(2);
+    // headers match the canonical column order
+    expect(wb.getWorksheet('shared-Citation Attempt').getRow(1).values.slice(1))
+      .to.deep.equal(CITATION_COLUMNS);
+    expect(wb.getWorksheet('shared-Synthetic Personas').getRow(1).values.slice(1))
+      .to.deep.equal(PERSONA_COLUMNS);
+  });
+
+  it('writes header-only auxiliary sheets when result.sheets omits them', async () => {
+    // Transition shape (result.rows only) → Citation/Personas have no rows → header-only.
+    const result = await handler.default(completedMessage(), context);
+
+    expect(result.status).to.equal(200);
+    const wb = new ExcelJS.Workbook();
+    await wb.xlsx.load(uploadToSharePointStub.firstCall.args[0]);
+    expect(wb.getWorksheet('shared-Citation Attempt').rowCount).to.equal(1); // header only
+    expect(wb.getWorksheet('shared-Synthetic Personas').rowCount).to.equal(1);
+  });
+
+  it('surfaces schema-invalid Citation Attempt rows and names the sheet', async () => {
+    fetchStub.callsFake(async (url) => {
+      if (url === RESULT_LOCATION) {
+        return {
+          ok: true,
+          headers: { get: () => null },
+          text: async () => JSON.stringify({
+            siteId: 'site-123',
+            sheets: {
+              Semrush: [validRow()],
+              'Citation Attempt': [{ tag: 'Coverage Gap', prompt: '' }], // missing strategy*, empty prompt
+            },
+          }),
+        };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const result = await handler.default(completedMessage(), context);
+
+    expect(result.status).to.equal(500);
+    expect(uploadToSharePointStub).to.not.have.been.called;
+    expect(JSON.stringify(mockPostMessageSafe.firstCall.args[3])).to.include('Citation Attempt');
+  });
+
+  it('preserves an existing Citation Attempt "ignored" marker via merge', async () => {
+    readFromSharePointStub.callsFake(async () => {
+      const wb = new ExcelJS.Workbook();
+      const semrush = wb.addWorksheet('shared-Semrush');
+      semrush.addRow(SEMRUSH_COLUMNS);
+      const cit = wb.addWorksheet('shared-Citation Attempt');
+      cit.addRow(CITATION_COLUMNS);
+      const ignored = validCitation({ deleted: 'ignored' });
+      cit.addRow(CITATION_COLUMNS.map((c) => ignored[c] ?? null));
+      wb.addWorksheet('shared-Synthetic Personas').addRow(PERSONA_COLUMNS);
+      return wb.xlsx.writeBuffer();
+    });
+
+    fetchStub.callsFake(async (url, opts = {}) => {
+      if (url === RESULT_LOCATION) {
+        return {
+          ok: true,
+          headers: { get: () => null },
+          text: async () => JSON.stringify({
+            siteId: 'site-123',
+            generated_at: '2026-06-09T00:00:00Z',
+            sheets: {
+              Semrush: [validRow()],
+              'Citation Attempt': [validCitation({ deleted: '' })], // same (source_url, prompt)
+            },
+          }),
+        };
+      }
+      if (url.startsWith('https://admin.hlx.page/')) {
+        return { ok: true, status: 200, statusText: 'OK' };
+      }
+      if (url.startsWith(LIVE_JSON_URL) && opts.method === 'GET') {
+        return {
+          ok: true,
+          json: async () => ({ generated_at: '2026-06-09T00:00:00Z', Semrush: { data: [validRow()] } }),
+        };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const result = await handler.default(completedMessage(), context);
+
+    expect(result.status).to.equal(200);
+    const wb = new ExcelJS.Workbook();
+    await wb.xlsx.load(uploadToSharePointStub.firstCall.args[0]);
+    const cit = wb.getWorksheet('shared-Citation Attempt');
+    const headers = cit.getRow(1).values.slice(1);
+    const deletedCol = headers.indexOf('deleted') + 1;
+    expect(cit.getRow(2).getCell(deletedCol).value).to.equal('ignored');
   });
 });

--- a/test/strategic-recommendations-semrush/handler.test.js
+++ b/test/strategic-recommendations-semrush/handler.test.js
@@ -1,0 +1,570 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import esmock from 'esmock';
+import ExcelJS from 'exceljs';
+import { MockContextBuilder } from '../shared.js';
+import { SEMRUSH_COLUMNS } from '../../src/strategic-recommendations-semrush/constants.js';
+
+use(sinonChai);
+
+const RESULTS_BUCKET = 'drs-results-bucket';
+const RESULT_LOCATION = `https://${RESULTS_BUCKET}.s3.us-east-1.amazonaws.com/results/job-1/result.json?X-Amz-Signature=abc`;
+const DATA_FOLDER = 'customer-data';
+const OUTPUT_LOCATION = `${DATA_FOLDER}/strategic-recommendations-template`;
+const LIVE_JSON_URL = `https://main--project-elmo-ui-data--adobe.hlx.live/${OUTPUT_LOCATION}/strategic-recommendations.json`;
+
+function validRow(overrides = {}) {
+  return {
+    tag: 'Hidden Win',
+    strategy: 'Defend the lead',
+    strategy_reasoning: 'evidence and action',
+    topic_id: 't-1',
+    topic: 'Online Image Editing',
+    volume: 1000,
+    adobe_mentions: 50,
+    competitor_1: 'Canva',
+    competitor_1_mentions: 40,
+    category: 'Creative Cloud',
+    prompt: 'best free online photo editor?',
+    deleted: '',
+    ...overrides,
+  };
+}
+
+/**
+ * Builds an ExcelJS workbook buffer with the 3 shared sheets + Notes, the Semrush
+ * sheet seeded with the given rows.
+ */
+async function buildExistingWorkbookBuffer(semrushRows = []) {
+  const wb = new ExcelJS.Workbook();
+  const semrush = wb.addWorksheet('shared-Semrush');
+  semrush.addRow(SEMRUSH_COLUMNS);
+  semrushRows.forEach((r) => semrush.addRow(SEMRUSH_COLUMNS.map((c) => r[c] ?? null)));
+  wb.addWorksheet('shared-Citation Attempt').addRow(['tag', 'strategy']);
+  wb.addWorksheet('shared-Synthetic Personas').addRow(['tag', 'strategy']);
+  wb.addWorksheet('Notes').addRow(['Signal Source Sheets']);
+  return wb.xlsx.writeBuffer();
+}
+
+describe('Strategic Recommendations Semrush Handler', function describeHandler() {
+  this.timeout(15000);
+  let sandbox;
+  let context;
+  let handler;
+  let mockPostMessageSafe;
+  let createClientStub;
+  let readFromSharePointStub;
+  let uploadToSharePointStub;
+  let sharepointClient;
+  let fetchStub;
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    mockPostMessageSafe = sandbox.stub().resolves({ success: true });
+    sharepointClient = { id: 'sp-client' };
+    createClientStub = sandbox.stub().resolves(sharepointClient);
+    readFromSharePointStub = sandbox.stub();
+    uploadToSharePointStub = sandbox.stub().resolves();
+
+    // Default: existing workbook with one ignored row (so we exercise merge).
+    readFromSharePointStub.callsFake(async () => buildExistingWorkbookBuffer([
+      validRow({ deleted: 'ignored' }),
+    ]));
+
+    // Single injectable fetch used for: result download, publish POSTs, read-back GET.
+    fetchStub = sandbox.stub();
+    fetchStub.callsFake(async (url, opts = {}) => {
+      if (url === RESULT_LOCATION) {
+        return {
+          ok: true,
+          headers: { get: () => null },
+          text: async () => JSON.stringify({
+            siteId: 'site-123',
+            generated_at: '2026-06-09T00:00:00Z',
+            rows: [validRow()],
+          }),
+        };
+      }
+      if (url.startsWith('https://admin.hlx.page/')) {
+        return { ok: true, status: 200, statusText: 'OK' };
+      }
+      if (url === LIVE_JSON_URL && opts.method === 'GET') {
+        return {
+          ok: true,
+          json: async () => ({
+            generated_at: '2026-06-09T00:00:00Z',
+            Semrush: { data: [validRow()] },
+          }),
+        };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    handler = await esmock('../../src/strategic-recommendations-semrush/handler.js', {
+      '@adobe/spacecat-shared-utils': { tracingFetch: fetchStub },
+      '../../src/utils/report-uploader.js': {
+        createLLMOSharepointClient: createClientStub,
+        readFromSharePoint: readFromSharePointStub,
+        uploadToSharePoint: uploadToSharePointStub,
+      },
+      '../../src/utils/slack-utils.js': { postMessageSafe: mockPostMessageSafe },
+    }, {
+      // global mock: the transitively-imported publish.js uses the real sleep,
+      // which would add multi-second delays — stub it out everywhere.
+      '../../src/support/utils.js': { sleep: async () => {} },
+    });
+
+    context = new MockContextBuilder().withSandbox(sandbox).build();
+    context.env.DRS_RESULTS_BUCKET = RESULTS_BUCKET;
+    context.env.DRS_RESULTS_PREFIX = 'results/';
+    context.env.SLACK_CHANNEL_LLMO_ONBOARDING_ID = 'C-TEST';
+    process.env.ADMIN_HLX_API_KEY = 'test-token';
+
+    context.dataAccess.Site.findById.resolves({
+      getConfig: () => ({ getLlmoDataFolder: () => DATA_FOLDER }),
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+    delete process.env.ADMIN_HLX_API_KEY;
+  });
+
+  const completedMessage = (overrides = {}) => ({
+    siteId: 'site-123',
+    auditContext: {
+      drsEventType: 'JOB_COMPLETED',
+      drsJobId: 'job-1',
+      resultLocation: RESULT_LOCATION,
+      ...overrides,
+    },
+  });
+
+  it('publishes the merged workbook and returns ok on the happy path', async () => {
+    const result = await handler.default(completedMessage(), context);
+
+    expect(result.status).to.equal(200);
+    expect(uploadToSharePointStub).to.have.been.calledOnce;
+    // upload args: (buffer, filename, outputLocation, client, log)
+    expect(uploadToSharePointStub.firstCall.args[1]).to.equal('strategic-recommendations.xlsx');
+    expect(uploadToSharePointStub.firstCall.args[2]).to.equal(OUTPUT_LOCATION);
+    // preview + live POST + read-back GET all went through fetch
+    expect(fetchStub.getCalls().some((c) => c.args[0].includes('/preview/'))).to.equal(true);
+    expect(fetchStub.getCalls().some((c) => c.args[0].includes('/live/'))).to.equal(true);
+  });
+
+  it('preserves the existing "ignored" marker via merge on the written sheet', async () => {
+    await handler.default(completedMessage(), context);
+
+    const buffer = uploadToSharePointStub.firstCall.args[0];
+    const wb = new ExcelJS.Workbook();
+    await wb.xlsx.load(buffer);
+    const sheet = wb.getWorksheet('shared-Semrush');
+    const headers = sheet.getRow(1).values.slice(1);
+    const deletedCol = headers.indexOf('deleted') + 1;
+    expect(sheet.getRow(2).getCell(deletedCol).value).to.equal('ignored');
+    // other shared sheets preserved
+    expect(wb.getWorksheet('shared-Citation Attempt')).to.not.equal(undefined);
+    expect(wb.getWorksheet('shared-Synthetic Personas')).to.not.equal(undefined);
+    expect(wb.getWorksheet('Notes')).to.not.equal(undefined);
+  });
+
+  it('returns ok and alerts on JOB_FAILED without touching the sheet', async () => {
+    const result = await handler.default(completedMessage({ drsEventType: 'JOB_FAILED' }), context);
+
+    expect(result.status).to.equal(200);
+    expect(uploadToSharePointStub).to.not.have.been.called;
+    expect(mockPostMessageSafe).to.have.been.calledOnce;
+  });
+
+  it('returns ok and logs on unexpected event type', async () => {
+    const result = await handler.default(completedMessage({ drsEventType: 'JOB_PENDING' }), context);
+    expect(result.status).to.equal(200);
+    expect(uploadToSharePointStub).to.not.have.been.called;
+  });
+
+  it('returns ok when siteId is missing', async () => {
+    const result = await handler.default({ auditContext: { drsEventType: 'JOB_COMPLETED' } }, context);
+    expect(result.status).to.equal(200);
+    expect(context.log.error).to.have.been.called;
+  });
+
+  it('SSRF guard rejects an out-of-prefix result location (does not ok, no fetch)', async () => {
+    const msg = completedMessage({
+      resultLocation: `https://${RESULTS_BUCKET}.s3.us-east-1.amazonaws.com/other/job-1/result.json`,
+    });
+
+    const result = await handler.default(msg, context);
+
+    expect(result.status).to.equal(500);
+    expect(fetchStub).to.not.have.been.called;
+    expect(mockPostMessageSafe).to.have.been.calledOnce;
+  });
+
+  it('SSRF guard rejects a non-S3 hostname', async () => {
+    const result = await handler.default(
+      completedMessage({ resultLocation: 'https://evil.example.com/results/x.json' }),
+      context,
+    );
+    expect(result.status).to.equal(500);
+    expect(fetchStub).to.not.have.been.called;
+  });
+
+  it('SSRF guard rejects a foreign bucket', async () => {
+    const result = await handler.default(
+      completedMessage({ resultLocation: 'https://other-bucket.s3.amazonaws.com/results/x.json' }),
+      context,
+    );
+    expect(result.status).to.equal(500);
+    expect(fetchStub).to.not.have.been.called;
+  });
+
+  it('does NOT ok() when the publish POST returns non-200 (failure surfaced)', async () => {
+    fetchStub.callsFake(async (url) => {
+      if (url === RESULT_LOCATION) {
+        return {
+          ok: true,
+          headers: { get: () => null },
+          text: async () => JSON.stringify({ siteId: 'site-123', generated_at: 'g', rows: [validRow()] }),
+        };
+      }
+      if (url.startsWith('https://admin.hlx.page/')) {
+        return { ok: false, status: 503, statusText: 'Service Unavailable' };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const result = await handler.default(completedMessage(), context);
+
+    expect(result.status).to.equal(500);
+    expect(mockPostMessageSafe).to.have.been.calledOnce;
+    expect(JSON.stringify(mockPostMessageSafe.firstCall.args[3])).to.include('publish');
+  });
+
+  it('does NOT ok() when post-publish read-back row count mismatches (stale CDN)', async () => {
+    fetchStub.callsFake(async (url, opts = {}) => {
+      if (url === RESULT_LOCATION) {
+        return {
+          ok: true,
+          headers: { get: () => null },
+          text: async () => JSON.stringify({ siteId: 'site-123', generated_at: 'g', rows: [validRow()] }),
+        };
+      }
+      if (url.startsWith('https://admin.hlx.page/')) {
+        return { ok: true, status: 200, statusText: 'OK' };
+      }
+      if (url === LIVE_JSON_URL && opts.method === 'GET') {
+        // stale: zero rows instead of the 1 we wrote
+        return { ok: true, json: async () => ({ Semrush: { data: [] } }) };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const result = await handler.default(completedMessage(), context);
+
+    expect(result.status).to.equal(500);
+    expect(JSON.stringify(mockPostMessageSafe.firstCall.args[3])).to.include('read-back');
+  });
+
+  it('does NOT ok() when read-back generated_at mismatches', async () => {
+    fetchStub.callsFake(async (url, opts = {}) => {
+      if (url === RESULT_LOCATION) {
+        return {
+          ok: true,
+          headers: { get: () => null },
+          text: async () => JSON.stringify({
+            siteId: 'site-123', generated_at: '2026-06-09T00:00:00Z', rows: [validRow()],
+          }),
+        };
+      }
+      if (url.startsWith('https://admin.hlx.page/')) {
+        return { ok: true, status: 200, statusText: 'OK' };
+      }
+      if (url === LIVE_JSON_URL && opts.method === 'GET') {
+        return {
+          ok: true,
+          json: async () => ({ generated_at: '1999-01-01T00:00:00Z', Semrush: { data: [validRow()] } }),
+        };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const result = await handler.default(completedMessage(), context);
+    expect(result.status).to.equal(500);
+  });
+
+  it('surfaces a cross-tenant mismatch (result.siteId != message.siteId)', async () => {
+    fetchStub.callsFake(async (url) => {
+      if (url === RESULT_LOCATION) {
+        return {
+          ok: true,
+          headers: { get: () => null },
+          text: async () => JSON.stringify({ siteId: 'OTHER-SITE', rows: [validRow()] }),
+        };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const result = await handler.default(completedMessage(), context);
+
+    expect(result.status).to.equal(500);
+    expect(uploadToSharePointStub).to.not.have.been.called;
+  });
+
+  it('surfaces schema-invalid rows and does not write', async () => {
+    fetchStub.callsFake(async (url) => {
+      if (url === RESULT_LOCATION) {
+        return {
+          ok: true,
+          headers: { get: () => null },
+          // missing required fields / bad tag
+          text: async () => JSON.stringify({ siteId: 'site-123', rows: [{ tag: 'Nope', prompt: '' }] }),
+        };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const result = await handler.default(completedMessage(), context);
+
+    expect(result.status).to.equal(500);
+    expect(uploadToSharePointStub).to.not.have.been.called;
+    expect(JSON.stringify(mockPostMessageSafe.firstCall.args[3])).to.include('schema validation failed');
+  });
+
+  it('surfaces zero rows from the result', async () => {
+    fetchStub.callsFake(async (url) => {
+      if (url === RESULT_LOCATION) {
+        return {
+          ok: true,
+          headers: { get: () => null },
+          text: async () => JSON.stringify({ siteId: 'site-123', rows: [] }),
+        };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const result = await handler.default(completedMessage(), context);
+    expect(result.status).to.equal(500);
+    expect(uploadToSharePointStub).to.not.have.been.called;
+  });
+
+  it('surfaces a result fetch failure (non-OK)', async () => {
+    fetchStub.callsFake(async (url) => {
+      if (url === RESULT_LOCATION) {
+        return {
+          ok: false, status: 403, statusText: 'Forbidden', headers: { get: () => null },
+        };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const result = await handler.default(completedMessage(), context);
+    expect(result.status).to.equal(500);
+  });
+
+  it('surfaces when the site has no LLMO data folder configured', async () => {
+    context.dataAccess.Site.findById.resolves({
+      getConfig: () => ({ getLlmoDataFolder: () => null }),
+    });
+
+    const result = await handler.default(completedMessage(), context);
+    expect(result.status).to.equal(500);
+    expect(uploadToSharePointStub).to.not.have.been.called;
+  });
+
+  it('surfaces when the site is not found', async () => {
+    context.dataAccess.Site.findById.resolves(null);
+
+    const result = await handler.default(completedMessage(), context);
+    expect(result.status).to.equal(500);
+  });
+
+  it('surfaces when no existing workbook is found (cannot preserve template)', async () => {
+    readFromSharePointStub.rejects(new Error('itemNotFound: resource could not be found'));
+
+    const result = await handler.default(completedMessage(), context);
+    expect(result.status).to.equal(500);
+    expect(uploadToSharePointStub).to.not.have.been.called;
+    expect(JSON.stringify(mockPostMessageSafe.firstCall.args[3])).to.include('no published workbook');
+  });
+
+  it('surfaces when reading the existing workbook fails for other reasons', async () => {
+    readFromSharePointStub.rejects(new Error('boom network'));
+
+    const result = await handler.default(completedMessage(), context);
+    expect(result.status).to.equal(500);
+  });
+
+  it('surfaces a SharePoint upload failure', async () => {
+    uploadToSharePointStub.rejects(new Error('upload boom'));
+
+    const result = await handler.default(completedMessage(), context);
+    expect(result.status).to.equal(500);
+    expect(JSON.stringify(mockPostMessageSafe.firstCall.args[3])).to.include('upload');
+  });
+
+  it('rejects when DRS_RESULTS_BUCKET is not configured (fail closed)', async () => {
+    delete context.env.DRS_RESULTS_BUCKET;
+
+    const result = await handler.default(completedMessage(), context);
+    expect(result.status).to.equal(500);
+    expect(fetchStub).to.not.have.been.called;
+  });
+
+  it('surfaces a result fetch timeout (AbortError)', async () => {
+    fetchStub.callsFake(async (url) => {
+      if (url === RESULT_LOCATION) {
+        const err = new Error('aborted');
+        err.name = 'AbortError';
+        throw err;
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const result = await handler.default(completedMessage(), context);
+    expect(result.status).to.equal(500);
+    expect(JSON.stringify(mockPostMessageSafe.firstCall.args[3])).to.include('timed out');
+  });
+
+  it('surfaces a generic result fetch error', async () => {
+    fetchStub.callsFake(async (url) => {
+      if (url === RESULT_LOCATION) {
+        throw new Error('connection reset');
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const result = await handler.default(completedMessage(), context);
+    expect(result.status).to.equal(500);
+  });
+
+  it('surfaces a declared content-length exceeding the cap', async () => {
+    fetchStub.callsFake(async (url) => {
+      if (url === RESULT_LOCATION) {
+        return {
+          ok: true,
+          headers: { get: (h) => (h === 'content-length' ? String(100 * 1024 * 1024) : null) },
+          text: async () => '{}',
+        };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const result = await handler.default(completedMessage(), context);
+    expect(result.status).to.equal(500);
+    expect(JSON.stringify(mockPostMessageSafe.firstCall.args[3])).to.include('too large');
+  });
+
+  it('surfaces an actual body exceeding the cap', async () => {
+    fetchStub.callsFake(async (url) => {
+      if (url === RESULT_LOCATION) {
+        return {
+          ok: true,
+          headers: { get: () => null },
+          text: async () => 'x'.repeat(26 * 1024 * 1024),
+        };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const result = await handler.default(completedMessage(), context);
+    expect(result.status).to.equal(500);
+    expect(JSON.stringify(mockPostMessageSafe.firstCall.args[3])).to.include('too large');
+  });
+
+  it('surfaces a non-JSON result body', async () => {
+    fetchStub.callsFake(async (url) => {
+      if (url === RESULT_LOCATION) {
+        return { ok: true, headers: { get: () => null }, text: async () => 'not-json' };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const result = await handler.default(completedMessage(), context);
+    expect(result.status).to.equal(500);
+    expect(JSON.stringify(mockPostMessageSafe.firstCall.args[3])).to.include('not JSON');
+  });
+
+  it('creates the Semrush sheet when the existing workbook lacks one', async () => {
+    readFromSharePointStub.callsFake(async () => {
+      const wb = new ExcelJS.Workbook();
+      wb.addWorksheet('shared-Citation Attempt').addRow(['tag']);
+      wb.addWorksheet('Notes').addRow(['x']);
+      return wb.xlsx.writeBuffer();
+    });
+
+    const result = await handler.default(completedMessage(), context);
+    expect(result.status).to.equal(200);
+    const wb = new ExcelJS.Workbook();
+    await wb.xlsx.load(uploadToSharePointStub.firstCall.args[0]);
+    expect(wb.getWorksheet('shared-Semrush')).to.not.equal(undefined);
+  });
+
+  it('does not alert when the Slack channel env var is unset', async () => {
+    delete context.env.SLACK_CHANNEL_LLMO_ONBOARDING_ID;
+    const result = await handler.default(completedMessage({ drsEventType: 'JOB_FAILED' }), context);
+    expect(result.status).to.equal(200);
+    expect(mockPostMessageSafe).to.not.have.been.called;
+  });
+
+  it('alerts with N/A job id when drsJobId is absent on JOB_FAILED', async () => {
+    const result = await handler.default(
+      { siteId: 'site-123', auditContext: { drsEventType: 'JOB_FAILED' } },
+      context,
+    );
+    expect(result.status).to.equal(200);
+    expect(JSON.stringify(mockPostMessageSafe.firstCall.args[3])).to.include('N/A');
+  });
+
+  it('treats a result with no rows array as zero rows (surfaced)', async () => {
+    fetchStub.callsFake(async (url) => {
+      if (url === RESULT_LOCATION) {
+        return {
+          ok: true,
+          headers: { get: () => null },
+          text: async () => JSON.stringify({ siteId: 'site-123' }),
+        };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const result = await handler.default(completedMessage(), context);
+    expect(result.status).to.equal(500);
+    expect(JSON.stringify(mockPostMessageSafe.firstCall.args[3])).to.include('zero rows');
+  });
+
+  it('handles a result with no generated_at (read-back skips stamp check)', async () => {
+    fetchStub.callsFake(async (url, opts = {}) => {
+      if (url === RESULT_LOCATION) {
+        return {
+          ok: true,
+          headers: { get: () => null },
+          text: async () => JSON.stringify({ siteId: 'site-123', rows: [validRow()] }),
+        };
+      }
+      if (url.startsWith('https://admin.hlx.page/')) {
+        return { ok: true, status: 200, statusText: 'OK' };
+      }
+      if (url === LIVE_JSON_URL && opts.method === 'GET') {
+        return { ok: true, json: async () => ({ Semrush: { data: [validRow()] } }) };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const result = await handler.default(completedMessage(), context);
+    expect(result.status).to.equal(200);
+  });
+});

--- a/test/strategic-recommendations-semrush/handler.test.js
+++ b/test/strategic-recommendations-semrush/handler.test.js
@@ -350,6 +350,24 @@ describe('Strategic Recommendations Semrush Handler', function describeHandler()
     expect(uploadToSharePointStub).to.not.have.been.called;
   });
 
+  it('fails closed on a result missing siteId (cross-tenant guard)', async () => {
+    fetchStub.callsFake(async (url) => {
+      if (url === RESULT_LOCATION) {
+        return {
+          ok: true,
+          headers: { get: () => null },
+          text: async () => JSON.stringify({ rows: [validRow()] }),
+        };
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+
+    const result = await handler.default(completedMessage(), context);
+
+    expect(result.status).to.equal(500);
+    expect(uploadToSharePointStub).to.not.have.been.called;
+  });
+
   it('surfaces schema-invalid rows and does not write', async () => {
     fetchStub.callsFake(async (url) => {
       if (url === RESULT_LOCATION) {

--- a/test/strategic-recommendations-semrush/handler.test.js
+++ b/test/strategic-recommendations-semrush/handler.test.js
@@ -416,10 +416,24 @@ describe('Strategic Recommendations Semrush Handler', function describeHandler()
     expect(JSON.stringify(mockPostMessageSafe.firstCall.args[3])).to.include('upload');
   });
 
-  it('rejects when DRS_RESULTS_BUCKET is not configured (fail closed)', async () => {
+  it('processes a presigned https result with no DRS_RESULTS_BUCKET configured', async () => {
+    // Merge-critical: the producer presigns before publishing, and the bucket env
+    // is external Secrets-Manager config absent at first deploy. The S3-hostname
+    // allowlist + provider prefix still bound the location, so the happy path runs.
     delete context.env.DRS_RESULTS_BUCKET;
+    context.env.DRS_RESULTS_PREFIX = 'results/';
 
     const result = await handler.default(completedMessage(), context);
+    expect(result.status).to.equal(200);
+  });
+
+  it('rejects the bare s3:// form when DRS_RESULTS_BUCKET is not configured (fail closed)', async () => {
+    delete context.env.DRS_RESULTS_BUCKET;
+
+    const result = await handler.default(
+      completedMessage({ resultLocation: 's3://drs-results-bucket/results/job-1/result.json' }),
+      context,
+    );
     expect(result.status).to.equal(500);
     expect(fetchStub).to.not.have.been.called;
   });

--- a/test/strategic-recommendations-semrush/handler.test.js
+++ b/test/strategic-recommendations-semrush/handler.test.js
@@ -101,7 +101,7 @@ describe('Strategic Recommendations Semrush Handler', function describeHandler()
       if (url.startsWith('https://admin.hlx.page/')) {
         return { ok: true, status: 200, statusText: 'OK' };
       }
-      if (url === LIVE_JSON_URL && opts.method === 'GET') {
+      if (url.startsWith(LIVE_JSON_URL) && opts.method === 'GET') {
         return {
           ok: true,
           json: async () => ({
@@ -131,7 +131,7 @@ describe('Strategic Recommendations Semrush Handler', function describeHandler()
     context.env.DRS_RESULTS_BUCKET = RESULTS_BUCKET;
     context.env.DRS_RESULTS_PREFIX = 'results/';
     context.env.SLACK_CHANNEL_LLMO_ONBOARDING_ID = 'C-TEST';
-    process.env.ADMIN_HLX_API_KEY = 'test-token';
+    context.env.ADMIN_HLX_API_KEY = 'test-token';
 
     context.dataAccess.Site.findById.resolves({
       getConfig: () => ({ getLlmoDataFolder: () => DATA_FOLDER }),
@@ -140,7 +140,6 @@ describe('Strategic Recommendations Semrush Handler', function describeHandler()
 
   afterEach(() => {
     sandbox.restore();
-    delete process.env.ADMIN_HLX_API_KEY;
   });
 
   const completedMessage = (overrides = {}) => ({
@@ -266,7 +265,7 @@ describe('Strategic Recommendations Semrush Handler', function describeHandler()
       if (url.startsWith('https://admin.hlx.page/')) {
         return { ok: true, status: 200, statusText: 'OK' };
       }
-      if (url === LIVE_JSON_URL && opts.method === 'GET') {
+      if (url.startsWith(LIVE_JSON_URL) && opts.method === 'GET') {
         // stale: zero rows instead of the 1 we wrote
         return { ok: true, json: async () => ({ Semrush: { data: [] } }) };
       }
@@ -293,7 +292,7 @@ describe('Strategic Recommendations Semrush Handler', function describeHandler()
       if (url.startsWith('https://admin.hlx.page/')) {
         return { ok: true, status: 200, statusText: 'OK' };
       }
-      if (url === LIVE_JSON_URL && opts.method === 'GET') {
+      if (url.startsWith(LIVE_JSON_URL) && opts.method === 'GET') {
         return {
           ok: true,
           json: async () => ({ generated_at: '1999-01-01T00:00:00Z', Semrush: { data: [validRow()] } }),
@@ -572,7 +571,7 @@ describe('Strategic Recommendations Semrush Handler', function describeHandler()
       if (url.startsWith('https://admin.hlx.page/')) {
         return { ok: true, status: 200, statusText: 'OK' };
       }
-      if (url === LIVE_JSON_URL && opts.method === 'GET') {
+      if (url.startsWith(LIVE_JSON_URL) && opts.method === 'GET') {
         return { ok: true, json: async () => ({ Semrush: { data: [validRow()] } }) };
       }
       throw new Error(`unexpected fetch: ${url}`);

--- a/test/strategic-recommendations-semrush/merge.test.js
+++ b/test/strategic-recommendations-semrush/merge.test.js
@@ -11,7 +11,7 @@
  */
 
 import { expect } from 'chai';
-import { mergeSemrushRows } from '../../src/strategic-recommendations-semrush/merge.js';
+import { mergeSemrushRows, mergeRowsByKey } from '../../src/strategic-recommendations-semrush/merge.js';
 
 const baseRow = (overrides = {}) => ({
   tag: 'Hidden Win',
@@ -155,6 +155,55 @@ describe('mergeSemrushRows', () => {
     const incoming = [baseRow({ topic_id: 't-1', prompt: 'p', deleted: '' })];
 
     const merged = mergeSemrushRows(existing, incoming);
+
+    expect(merged[0].deleted).to.equal('ignored');
+  });
+});
+
+describe('mergeRowsByKey (auxiliary sheets)', () => {
+  it('preserves a Citation Attempt marker by (source_url, prompt)', () => {
+    const existing = [{ source_url: 'https://a/c', prompt: 'p1', deleted: 'ignored' }];
+    const incoming = [{ source_url: 'https://a/c', prompt: 'p1', deleted: '' }];
+
+    const merged = mergeRowsByKey(existing, incoming, ['source_url', 'prompt']);
+
+    expect(merged[0].deleted).to.equal('ignored');
+  });
+
+  it('does NOT carry a Citation marker across a different source_url', () => {
+    const existing = [{ source_url: 'https://a/c', prompt: 'p1', deleted: 'ignored' }];
+    const incoming = [{ source_url: 'https://b/c', prompt: 'p1', deleted: '' }];
+
+    const merged = mergeRowsByKey(existing, incoming, ['source_url', 'prompt']);
+
+    expect(merged[0].deleted).to.equal('');
+  });
+
+  it('preserves a Synthetic Personas marker by (category, prompt)', () => {
+    const existing = [{ category: 'Buyer', prompt: 'why elmo', deleted: 'added' }];
+    const incoming = [{ category: 'Buyer', prompt: 'why elmo', deleted: '' }];
+
+    const merged = mergeRowsByKey(existing, incoming, ['category', 'prompt']);
+
+    expect(merged[0].deleted).to.equal('added');
+  });
+
+  it('treats a null key field as no-match (best-effort)', () => {
+    // An incoming row with a null source_url cannot match any prior marker.
+    const existing = [{ source_url: 'https://a/c', prompt: 'p1', deleted: 'ignored' }];
+    const incoming = [{ source_url: null, prompt: 'p1', deleted: '' }];
+
+    const merged = mergeRowsByKey(existing, incoming, ['source_url', 'prompt']);
+
+    expect(merged[0].deleted).to.equal('');
+    expect(merged[0]).to.not.equal(incoming[0]); // fresh copy
+  });
+
+  it('matches on an empty-string key bucket (\'\' is matchable, null is not)', () => {
+    const existing = [{ source_url: '', prompt: 'p1', deleted: 'ignored' }];
+    const incoming = [{ source_url: '', prompt: 'p1', deleted: '' }];
+
+    const merged = mergeRowsByKey(existing, incoming, ['source_url', 'prompt']);
 
     expect(merged[0].deleted).to.equal('ignored');
   });

--- a/test/strategic-recommendations-semrush/merge.test.js
+++ b/test/strategic-recommendations-semrush/merge.test.js
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { mergeSemrushRows } from '../../src/strategic-recommendations-semrush/merge.js';
+
+const baseRow = (overrides = {}) => ({
+  tag: 'Hidden Win',
+  strategy: 'Defend the lead',
+  strategy_reasoning: 'because',
+  topic_id: 't-1',
+  topic: 'Online Image Editing',
+  volume: 1000,
+  adobe_mentions: 50,
+  category: 'Creative Cloud',
+  prompt: 'best free online photo editor?',
+  deleted: '',
+  ...overrides,
+});
+
+describe('mergeSemrushRows', () => {
+  it('preserves an existing "ignored" marker by (topic_id, prompt)', () => {
+    const existing = [baseRow({ deleted: 'ignored' })];
+    const incoming = [baseRow({ deleted: '' })];
+
+    const merged = mergeSemrushRows(existing, incoming);
+
+    expect(merged).to.have.length(1);
+    expect(merged[0].deleted).to.equal('ignored');
+  });
+
+  it('preserves an existing "added" marker by (topic_id, prompt)', () => {
+    const existing = [baseRow({ deleted: 'added' })];
+    const incoming = [baseRow({ deleted: '' })];
+
+    const merged = mergeSemrushRows(existing, incoming);
+
+    expect(merged[0].deleted).to.equal('added');
+  });
+
+  it('adds brand-new rows that have no prior match', () => {
+    const existing = [baseRow({ topic_id: 't-1', prompt: 'old prompt', deleted: 'ignored' })];
+    const incoming = [
+      baseRow({ topic_id: 't-1', prompt: 'old prompt' }),
+      baseRow({ topic_id: 't-2', prompt: 'a wholly new prompt', deleted: '' }),
+    ];
+
+    const merged = mergeSemrushRows(existing, incoming);
+
+    expect(merged).to.have.length(2);
+    expect(merged[0].deleted).to.equal('ignored');
+    // the new row keeps its active default
+    expect(merged[1].deleted).to.equal('');
+  });
+
+  it('does NOT inherit deletion when the prompt text is rephrased (best-effort)', () => {
+    // Same topic_id, but a regeneration rephrased the prompt — match misses.
+    const existing = [baseRow({ topic_id: 't-1', prompt: 'best free online photo editor?', deleted: 'ignored' })];
+    const incoming = [baseRow({ topic_id: 't-1', prompt: 'which free online photo editor is best?', deleted: '' })];
+
+    const merged = mergeSemrushRows(existing, incoming);
+
+    expect(merged[0].deleted).to.equal('');
+  });
+
+  it('does NOT inherit deletion across different topic_id even with same prompt', () => {
+    const existing = [baseRow({ topic_id: 't-1', prompt: 'same prompt', deleted: 'ignored' })];
+    const incoming = [baseRow({ topic_id: 't-2', prompt: 'same prompt', deleted: '' })];
+
+    const merged = mergeSemrushRows(existing, incoming);
+
+    expect(merged[0].deleted).to.equal('');
+  });
+
+  it('ignores empty/null markers on existing rows (nothing to preserve)', () => {
+    const existing = [
+      baseRow({ topic_id: 't-1', prompt: 'p1', deleted: '' }),
+      baseRow({ topic_id: 't-2', prompt: 'p2', deleted: null }),
+    ];
+    const incoming = [
+      baseRow({ topic_id: 't-1', prompt: 'p1', deleted: 'added' }),
+      baseRow({ topic_id: 't-2', prompt: 'p2', deleted: 'ignored' }),
+    ];
+
+    const merged = mergeSemrushRows(existing, incoming);
+
+    // existing had no marker, so incoming rows keep their own values
+    expect(merged[0].deleted).to.equal('added');
+    expect(merged[1].deleted).to.equal('ignored');
+  });
+
+  it('is a pure function — does not mutate inputs and returns fresh objects', () => {
+    const existingRow = baseRow({ deleted: 'ignored' });
+    const incomingRow = baseRow({ deleted: '' });
+    const existing = [existingRow];
+    const incoming = [incomingRow];
+
+    const merged = mergeSemrushRows(existing, incoming);
+
+    expect(incomingRow.deleted).to.equal(''); // input untouched
+    expect(merged[0]).to.not.equal(incomingRow); // fresh object
+  });
+
+  it('handles non-array / nullish inputs gracefully', () => {
+    expect(mergeSemrushRows(null, null)).to.deep.equal([]);
+    expect(mergeSemrushRows(undefined, [baseRow()])).to.have.length(1);
+    expect(mergeSemrushRows([baseRow({ deleted: 'ignored' })], null)).to.deep.equal([]);
+  });
+
+  it('tolerates malformed rows (missing keys / non-objects) without throwing', () => {
+    const existing = [null, { deleted: 'ignored' }, baseRow({ deleted: 'ignored' })];
+    const incoming = [null, 42, baseRow({ deleted: '' })];
+
+    const merged = mergeSemrushRows(existing, incoming);
+
+    expect(merged[0]).to.equal(null);
+    expect(merged[1]).to.equal(42);
+    expect(merged[2].deleted).to.equal('ignored');
+  });
+
+  it('returns a fresh copy for an incoming row that lacks match-key fields', () => {
+    const existing = [baseRow({ deleted: 'ignored' })];
+    // incoming object row missing topic_id -> matchKey is null, no carry-over
+    const incoming = [{ prompt: 'orphan', deleted: '' }];
+
+    const merged = mergeSemrushRows(existing, incoming);
+
+    expect(merged[0].deleted).to.equal('');
+    expect(merged[0]).to.not.equal(incoming[0]);
+  });
+
+  it('skips an existing row that lacks match-key fields when collecting markers', () => {
+    const existing = [{ deleted: 'ignored', prompt: 'no-topic-id' }];
+    const incoming = [baseRow({ deleted: '' })];
+
+    const merged = mergeSemrushRows(existing, incoming);
+
+    expect(merged[0].deleted).to.equal('');
+  });
+
+  it('first marker wins on duplicate (topic_id, prompt) existing rows', () => {
+    const existing = [
+      baseRow({ topic_id: 't-1', prompt: 'p', deleted: 'ignored' }),
+      baseRow({ topic_id: 't-1', prompt: 'p', deleted: 'added' }),
+    ];
+    const incoming = [baseRow({ topic_id: 't-1', prompt: 'p', deleted: '' })];
+
+    const merged = mergeSemrushRows(existing, incoming);
+
+    expect(merged[0].deleted).to.equal('ignored');
+  });
+});

--- a/test/strategic-recommendations-semrush/publish.test.js
+++ b/test/strategic-recommendations-semrush/publish.test.js
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
+import esmock from 'esmock';
+
+use(sinonChai);
+use(chaiAsPromised);
+
+const OUTPUT_LOCATION = 'customer-data/strategic-recommendations-template';
+const LIVE_JSON_URL = `https://main--project-elmo-ui-data--adobe.hlx.live/${OUTPUT_LOCATION}/strategic-recommendations.json`;
+
+describe('publishWorkbookWithReadback / extractSemrushRows', () => {
+  let sandbox;
+  let log;
+  let mod;
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    log = { info: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub() };
+    mod = await esmock('../../src/strategic-recommendations-semrush/publish.js', {
+      '../../src/support/utils.js': { sleep: async () => {} },
+    });
+  });
+
+  afterEach(() => sandbox.restore());
+
+  const baseArgs = (fetchImpl) => ({
+    filename: 'strategic-recommendations.xlsx',
+    outputLocation: OUTPUT_LOCATION,
+    expectedRowCount: 2,
+    expectedGeneratedAt: 'g1',
+    log,
+    fetchImpl,
+  });
+
+  it('publishes preview+live and confirms via read-back', async () => {
+    const fetchImpl = sandbox.stub();
+    fetchImpl.withArgs(sinon.match(/admin\.hlx\.page/)).resolves({ ok: true, status: 200, statusText: 'OK' });
+    fetchImpl.withArgs(LIVE_JSON_URL).resolves({
+      ok: true,
+      json: async () => ({ generated_at: 'g1', Semrush: { data: [{}, {}] } }),
+    });
+
+    await mod.publishWorkbookWithReadback(baseArgs(fetchImpl));
+
+    expect(fetchImpl.getCalls().some((c) => c.args[0].includes('/preview/'))).to.equal(true);
+    expect(fetchImpl.getCalls().some((c) => c.args[0].includes('/live/'))).to.equal(true);
+  });
+
+  it('throws on a non-200 publish', async () => {
+    const fetchImpl = sandbox.stub().resolves({ ok: false, status: 500, statusText: 'Err' });
+    await expect(mod.publishWorkbookWithReadback(baseArgs(fetchImpl)))
+      .to.be.rejectedWith('publish to preview failed: 500');
+  });
+
+  it('retries read-back then succeeds (absorbs edge latency)', async () => {
+    const fetchImpl = sandbox.stub();
+    fetchImpl.withArgs(sinon.match(/admin\.hlx\.page/)).resolves({ ok: true, status: 200, statusText: 'OK' });
+    let call = 0;
+    fetchImpl.withArgs(LIVE_JSON_URL).callsFake(async () => {
+      call += 1;
+      if (call === 1) {
+        return { ok: false, status: 404, statusText: 'Not Found' };
+      }
+      return { ok: true, json: async () => ({ generated_at: 'g1', Semrush: { data: [{}, {}] } }) };
+    });
+
+    await mod.publishWorkbookWithReadback(baseArgs(fetchImpl));
+    expect(call).to.equal(2);
+  });
+
+  it('throws after exhausting read-back retries on row-count mismatch', async () => {
+    const fetchImpl = sandbox.stub();
+    fetchImpl.withArgs(sinon.match(/admin\.hlx\.page/)).resolves({ ok: true, status: 200, statusText: 'OK' });
+    fetchImpl.withArgs(LIVE_JSON_URL)
+      .resolves({ ok: true, json: async () => ({ Semrush: { data: [] } }) });
+
+    await expect(mod.publishWorkbookWithReadback(baseArgs(fetchImpl)))
+      .to.be.rejectedWith('post-publish read-back failed');
+  });
+
+  it('throws when read-back JSON has no Semrush sheet', async () => {
+    const fetchImpl = sandbox.stub();
+    fetchImpl.withArgs(sinon.match(/admin\.hlx\.page/)).resolves({ ok: true, status: 200, statusText: 'OK' });
+    fetchImpl.withArgs(LIVE_JSON_URL).resolves({ ok: true, json: async () => ({ foo: 'bar' }) });
+
+    await expect(mod.publishWorkbookWithReadback(baseArgs(fetchImpl)))
+      .to.be.rejectedWith('post-publish read-back failed');
+  });
+
+  it('throws when read-back fetch itself errors on every attempt', async () => {
+    const fetchImpl = sandbox.stub();
+    fetchImpl.withArgs(sinon.match(/admin\.hlx\.page/)).resolves({ ok: true, status: 200, statusText: 'OK' });
+    fetchImpl.withArgs(LIVE_JSON_URL).rejects(new Error('network down'));
+
+    await expect(mod.publishWorkbookWithReadback(baseArgs(fetchImpl)))
+      .to.be.rejectedWith('post-publish read-back failed');
+  });
+
+  it('passes read-back when no expectedGeneratedAt is provided', async () => {
+    const fetchImpl = sandbox.stub();
+    fetchImpl.withArgs(sinon.match(/admin\.hlx\.page/)).resolves({ ok: true, status: 200, statusText: 'OK' });
+    fetchImpl.withArgs(LIVE_JSON_URL)
+      .resolves({ ok: true, json: async () => ({ Semrush: { data: [{}, {}] } }) });
+
+    await mod.publishWorkbookWithReadback({ ...baseArgs(fetchImpl), expectedGeneratedAt: null });
+  });
+
+  it('extractSemrushRows handles the single-sheet shape and missing/garbage input', () => {
+    expect(mod.extractSemrushRows({ data: [1, 2] })).to.deep.equal([1, 2]);
+    expect(mod.extractSemrushRows({ Semrush: { data: [1] } })).to.deep.equal([1]);
+    expect(mod.extractSemrushRows(null)).to.equal(null);
+    expect(mod.extractSemrushRows({ foo: 'bar' })).to.equal(null);
+    expect(mod.extractSemrushRows({ Semrush: {} })).to.equal(null);
+  });
+
+  it('matches generated_at carried on a row instead of the envelope', async () => {
+    const fetchImpl = sandbox.stub();
+    fetchImpl.withArgs(sinon.match(/admin\.hlx\.page/)).resolves({ ok: true, status: 200, statusText: 'OK' });
+    fetchImpl.withArgs(LIVE_JSON_URL).resolves({
+      ok: true,
+      json: async () => ({ Semrush: { data: [{ generated_at: 'g1' }, { generated_at: 'g1' }] } }),
+    });
+
+    await mod.publishWorkbookWithReadback(baseArgs(fetchImpl));
+  });
+});

--- a/test/strategic-recommendations-semrush/publish.test.js
+++ b/test/strategic-recommendations-semrush/publish.test.js
@@ -42,6 +42,7 @@ describe('publishWorkbookWithReadback / extractSemrushRows', () => {
     outputLocation: OUTPUT_LOCATION,
     expectedRowCount: 2,
     expectedGeneratedAt: 'g1',
+    adminApiKey: 'test-token',
     log,
     fetchImpl,
   });
@@ -49,7 +50,7 @@ describe('publishWorkbookWithReadback / extractSemrushRows', () => {
   it('publishes preview+live and confirms via read-back', async () => {
     const fetchImpl = sandbox.stub();
     fetchImpl.withArgs(sinon.match(/admin\.hlx\.page/)).resolves({ ok: true, status: 200, statusText: 'OK' });
-    fetchImpl.withArgs(LIVE_JSON_URL).resolves({
+    fetchImpl.withArgs(sinon.match(LIVE_JSON_URL)).resolves({
       ok: true,
       json: async () => ({ generated_at: 'g1', Semrush: { data: [{}, {}] } }),
     });
@@ -66,11 +67,41 @@ describe('publishWorkbookWithReadback / extractSemrushRows', () => {
       .to.be.rejectedWith('publish to preview failed: 500');
   });
 
+  it('throws before any fetch when adminApiKey is missing', async () => {
+    const fetchImpl = sandbox.stub();
+    const args = { ...baseArgs(fetchImpl), adminApiKey: undefined };
+    await expect(mod.publishWorkbookWithReadback(args))
+      .to.be.rejectedWith('ADMIN_HLX_API_KEY is not configured');
+    expect(fetchImpl).to.not.have.been.called;
+  });
+
+  it('busts the CDN cache with a fresh query param on each read-back attempt', async () => {
+    const fetchImpl = sandbox.stub();
+    fetchImpl.withArgs(sinon.match(/admin\.hlx\.page/)).resolves({ ok: true, status: 200, statusText: 'OK' });
+    let call = 0;
+    fetchImpl.withArgs(sinon.match(LIVE_JSON_URL)).callsFake(async () => {
+      call += 1;
+      if (call === 1) {
+        return { ok: false, status: 404, statusText: 'Not Found' };
+      }
+      return { ok: true, json: async () => ({ Semrush: { data: [{}, {}] } }) };
+    });
+
+    await mod.publishWorkbookWithReadback(baseArgs(fetchImpl));
+
+    const readbackUrls = fetchImpl.getCalls()
+      .map((c) => c.args[0])
+      .filter((u) => u.startsWith(LIVE_JSON_URL));
+    expect(readbackUrls).to.have.lengthOf(2);
+    readbackUrls.forEach((u) => expect(u).to.match(/\?cb=\d+-\d+$/));
+    expect(readbackUrls[0]).to.not.equal(readbackUrls[1]);
+  });
+
   it('retries read-back then succeeds (absorbs edge latency)', async () => {
     const fetchImpl = sandbox.stub();
     fetchImpl.withArgs(sinon.match(/admin\.hlx\.page/)).resolves({ ok: true, status: 200, statusText: 'OK' });
     let call = 0;
-    fetchImpl.withArgs(LIVE_JSON_URL).callsFake(async () => {
+    fetchImpl.withArgs(sinon.match(LIVE_JSON_URL)).callsFake(async () => {
       call += 1;
       if (call === 1) {
         return { ok: false, status: 404, statusText: 'Not Found' };
@@ -85,7 +116,7 @@ describe('publishWorkbookWithReadback / extractSemrushRows', () => {
   it('throws after exhausting read-back retries on row-count mismatch', async () => {
     const fetchImpl = sandbox.stub();
     fetchImpl.withArgs(sinon.match(/admin\.hlx\.page/)).resolves({ ok: true, status: 200, statusText: 'OK' });
-    fetchImpl.withArgs(LIVE_JSON_URL)
+    fetchImpl.withArgs(sinon.match(LIVE_JSON_URL))
       .resolves({ ok: true, json: async () => ({ Semrush: { data: [] } }) });
 
     await expect(mod.publishWorkbookWithReadback(baseArgs(fetchImpl)))
@@ -95,7 +126,7 @@ describe('publishWorkbookWithReadback / extractSemrushRows', () => {
   it('throws when read-back JSON has no Semrush sheet', async () => {
     const fetchImpl = sandbox.stub();
     fetchImpl.withArgs(sinon.match(/admin\.hlx\.page/)).resolves({ ok: true, status: 200, statusText: 'OK' });
-    fetchImpl.withArgs(LIVE_JSON_URL).resolves({ ok: true, json: async () => ({ foo: 'bar' }) });
+    fetchImpl.withArgs(sinon.match(LIVE_JSON_URL)).resolves({ ok: true, json: async () => ({ foo: 'bar' }) });
 
     await expect(mod.publishWorkbookWithReadback(baseArgs(fetchImpl)))
       .to.be.rejectedWith('post-publish read-back failed');
@@ -104,7 +135,7 @@ describe('publishWorkbookWithReadback / extractSemrushRows', () => {
   it('throws when read-back fetch itself errors on every attempt', async () => {
     const fetchImpl = sandbox.stub();
     fetchImpl.withArgs(sinon.match(/admin\.hlx\.page/)).resolves({ ok: true, status: 200, statusText: 'OK' });
-    fetchImpl.withArgs(LIVE_JSON_URL).rejects(new Error('network down'));
+    fetchImpl.withArgs(sinon.match(LIVE_JSON_URL)).rejects(new Error('network down'));
 
     await expect(mod.publishWorkbookWithReadback(baseArgs(fetchImpl)))
       .to.be.rejectedWith('post-publish read-back failed');
@@ -113,7 +144,7 @@ describe('publishWorkbookWithReadback / extractSemrushRows', () => {
   it('passes read-back when no expectedGeneratedAt is provided', async () => {
     const fetchImpl = sandbox.stub();
     fetchImpl.withArgs(sinon.match(/admin\.hlx\.page/)).resolves({ ok: true, status: 200, statusText: 'OK' });
-    fetchImpl.withArgs(LIVE_JSON_URL)
+    fetchImpl.withArgs(sinon.match(LIVE_JSON_URL))
       .resolves({ ok: true, json: async () => ({ Semrush: { data: [{}, {}] } }) });
 
     await mod.publishWorkbookWithReadback({ ...baseArgs(fetchImpl), expectedGeneratedAt: null });
@@ -127,10 +158,24 @@ describe('publishWorkbookWithReadback / extractSemrushRows', () => {
     expect(mod.extractSemrushRows({ Semrush: {} })).to.equal(null);
   });
 
+  it('extractSemrushRows returns null for a multi-sheet doc missing the Semrush sheet', () => {
+    // `:names` envelope present but no Semrush key — must NOT fall through to a
+    // sibling sheet's `data` array.
+    expect(mod.extractSemrushRows({
+      ':names': ['Other'],
+      ':type': 'multi-sheet',
+      Other: { data: [1, 2, 3] },
+    })).to.equal(null);
+    expect(mod.extractSemrushRows({
+      ':type': 'multi-sheet',
+      data: [1, 2, 3],
+    })).to.equal(null);
+  });
+
   it('matches generated_at carried on a row instead of the envelope', async () => {
     const fetchImpl = sandbox.stub();
     fetchImpl.withArgs(sinon.match(/admin\.hlx\.page/)).resolves({ ok: true, status: 200, statusText: 'OK' });
-    fetchImpl.withArgs(LIVE_JSON_URL).resolves({
+    fetchImpl.withArgs(sinon.match(LIVE_JSON_URL)).resolves({
       ok: true,
       json: async () => ({ Semrush: { data: [{ generated_at: 'g1' }, { generated_at: 'g1' }] } }),
     });

--- a/test/strategic-recommendations-semrush/publish.test.js
+++ b/test/strategic-recommendations-semrush/publish.test.js
@@ -59,6 +59,16 @@ describe('publishWorkbookWithReadback / extractSemrushRows', () => {
 
     expect(fetchImpl.getCalls().some((c) => c.args[0].includes('/preview/'))).to.equal(true);
     expect(fetchImpl.getCalls().some((c) => c.args[0].includes('/live/'))).to.equal(true);
+
+    // Each admin.hlx publish POST must carry the auth cookie — without it the
+    // edge silently 401s and the read-back failure would be the only signal.
+    const publishCalls = fetchImpl.getCalls()
+      .filter((c) => /admin\.hlx\.page/.test(c.args[0]));
+    expect(publishCalls).to.have.lengthOf(2);
+    publishCalls.forEach((c) => {
+      expect(c.args[1].method).to.equal('POST');
+      expect(c.args[1].headers.Cookie).to.equal('auth_token=test-token');
+    });
   });
 
   it('throws on a non-200 publish', async () => {

--- a/test/strategic-recommendations-semrush/result-location.test.js
+++ b/test/strategic-recommendations-semrush/result-location.test.js
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { assertResultLocation } from '../../src/strategic-recommendations-semrush/result-location.js';
+
+const ENV = { DRS_RESULTS_BUCKET: 'drs-results', DRS_RESULTS_PREFIX: 'results/' };
+
+describe('assertResultLocation', () => {
+  it('accepts a virtual-hosted-style presigned URL under the bucket/prefix', () => {
+    expect(() => assertResultLocation(
+      'https://drs-results.s3.us-east-1.amazonaws.com/results/job-1/r.json?X-Amz-Signature=x',
+      ENV,
+    )).to.not.throw();
+  });
+
+  it('accepts a virtual-hosted URL with no region', () => {
+    expect(() => assertResultLocation(
+      'https://drs-results.s3.amazonaws.com/results/job-1/r.json',
+      ENV,
+    )).to.not.throw();
+  });
+
+  it('accepts a path-style presigned URL under the bucket/prefix', () => {
+    expect(() => assertResultLocation(
+      'https://s3.us-east-1.amazonaws.com/drs-results/results/job-1/r.json',
+      ENV,
+    )).to.not.throw();
+  });
+
+  it('accepts an s3:// URI under the bucket/prefix', () => {
+    expect(() => assertResultLocation('s3://drs-results/results/job-1/r.json', ENV)).to.not.throw();
+  });
+
+  it('defaults the prefix to results/ when not configured', () => {
+    expect(() => assertResultLocation(
+      's3://drs-results/results/job-1/r.json',
+      { DRS_RESULTS_BUCKET: 'drs-results' },
+    )).to.not.throw();
+  });
+
+  it('normalizes a prefix without a trailing slash', () => {
+    expect(() => assertResultLocation(
+      's3://drs-results/out/job-1/r.json',
+      { DRS_RESULTS_BUCKET: 'drs-results', DRS_RESULTS_PREFIX: '/out' },
+    )).to.not.throw();
+  });
+
+  it('fails closed when DRS_RESULTS_BUCKET is not configured', () => {
+    expect(() => assertResultLocation('s3://drs-results/results/x.json', {}))
+      .to.throw('DRS_RESULTS_BUCKET is not configured');
+  });
+
+  it('rejects an empty / non-string location', () => {
+    expect(() => assertResultLocation('', ENV)).to.throw('resultLocation is missing');
+    expect(() => assertResultLocation(undefined, ENV)).to.throw('resultLocation is missing');
+  });
+
+  it('rejects a malformed s3:// URI (no key)', () => {
+    expect(() => assertResultLocation('s3://drs-results', ENV)).to.throw('not a valid s3 URI');
+    expect(() => assertResultLocation('s3://drs-results/', ENV)).to.throw('not a valid s3 URI');
+  });
+
+  it('rejects an unparseable URL', () => {
+    expect(() => assertResultLocation('http://[bad', ENV)).to.throw('not a valid URL');
+  });
+
+  it('rejects a non-https protocol', () => {
+    expect(() => assertResultLocation('http://drs-results.s3.amazonaws.com/results/x.json', ENV))
+      .to.throw('must use https');
+  });
+
+  it('rejects a non-S3 hostname', () => {
+    expect(() => assertResultLocation('https://evil.example.com/results/x.json', ENV))
+      .to.throw('not an allowlisted S3 hostname');
+  });
+
+  it('rejects a path-style URL with no key', () => {
+    expect(() => assertResultLocation('https://s3.amazonaws.com/drs-results', ENV))
+      .to.throw('does not contain a bucket and key');
+  });
+
+  it('rejects a foreign bucket (virtual-hosted)', () => {
+    expect(() => assertResultLocation('https://other.s3.amazonaws.com/results/x.json', ENV))
+      .to.throw('not the expected results bucket');
+  });
+
+  it('rejects a key outside the expected prefix', () => {
+    expect(() => assertResultLocation('s3://drs-results/elsewhere/x.json', ENV))
+      .to.throw('not under the expected prefix');
+  });
+});

--- a/test/strategic-recommendations-semrush/result-location.test.js
+++ b/test/strategic-recommendations-semrush/result-location.test.js
@@ -64,9 +64,19 @@ describe('assertResultLocation', () => {
     )).to.not.throw();
   });
 
-  it('fails closed when DRS_RESULTS_BUCKET is not configured', () => {
-    expect(() => assertResultLocation('s3://drs-results/results/x.json', {}))
-      .to.throw('DRS_RESULTS_BUCKET is not configured');
+  it('accepts a presigned https URL under the prefix with no DRS_RESULTS_BUCKET configured', () => {
+    // Merge-critical: the producer presigns the result before publishing, and the
+    // bucket env is external Secrets-Manager config not present at first deploy.
+    // The S3-hostname allowlist + provider prefix still bound the location.
+    expect(() => assertResultLocation(
+      'https://drs-results.s3.us-east-1.amazonaws.com/strategic_recommendations_semrush/2026/06/10/job-1/results.json?X-Amz-Signature=x',
+      {},
+    )).to.not.throw();
+  });
+
+  it('fails closed on the bare s3:// form when DRS_RESULTS_BUCKET is not configured', () => {
+    expect(() => assertResultLocation('s3://drs-results/strategic_recommendations_semrush/x.json', {}))
+      .to.throw('requires DRS_RESULTS_BUCKET to be configured');
   });
 
   it('rejects an empty / non-string location', () => {

--- a/test/strategic-recommendations-semrush/result-location.test.js
+++ b/test/strategic-recommendations-semrush/result-location.test.js
@@ -41,11 +41,20 @@ describe('assertResultLocation', () => {
     expect(() => assertResultLocation('s3://drs-results/results/job-1/r.json', ENV)).to.not.throw();
   });
 
-  it('defaults the prefix to results/ when not configured', () => {
+  it('defaults the prefix to the DRS producer prefix when not configured', () => {
+    // Matches the producer's hardcoded {PROVIDER_ID}/ key (runner.py _save_results),
+    // so the guard accepts real result locations with no deploy config.
+    expect(() => assertResultLocation(
+      's3://drs-results/strategic_recommendations_semrush/2026/06/10/job-1/results.json',
+      { DRS_RESULTS_BUCKET: 'drs-results' },
+    )).to.not.throw();
+  });
+
+  it('rejects the legacy results/ prefix now that the default is provider-scoped', () => {
     expect(() => assertResultLocation(
       's3://drs-results/results/job-1/r.json',
       { DRS_RESULTS_BUCKET: 'drs-results' },
-    )).to.not.throw();
+    )).to.throw('not under the expected prefix');
   });
 
   it('normalizes a prefix without a trailing slash', () => {

--- a/test/strategic-recommendations-semrush/schema-checksum.test.js
+++ b/test/strategic-recommendations-semrush/schema-checksum.test.js
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Schema checksum-drift guard.
+ *
+ * The row contract `shared-semrush-row.schema.v1.json` is AUTHORITATIVELY owned by
+ * the llmo-data-retrieval-service (DRS) repo at
+ * `docs/contracts/shared-semrush-row.schema.v1.json`. This repo vendors a copy at
+ * `src/strategic-recommendations-semrush/shared-semrush-row.schema.v1.json` so the
+ * writer/validator can run without a runtime dependency on DRS.
+ *
+ * This test pins the expected sha256 of the vendored copy. CI only checks out this
+ * repo, so it cannot reach the DRS file — instead it asserts the vendored copy
+ * still matches the pinned hash. If you intentionally re-vendor an updated schema
+ * FROM DRS, update EXPECTED_SHA256 below to the new value in the same commit.
+ *
+ * If DRS changes the authoritative schema and this copy is NOT re-vendored, this
+ * test stays green here but a matching test in DRS (and a manual re-vendor) is the
+ * intended drift signal — the two repos single-source the same file by sha.
+ */
+
+import { readFileSync, existsSync } from 'fs';
+import { createHash } from 'crypto';
+import { fileURLToPath } from 'url';
+import { expect } from 'chai';
+
+// sha256 of the authoritative DRS schema, vendored here. Update on deliberate re-vendor.
+const EXPECTED_SHA256 = '6c2d8fa69826279fbdd2e52f198ed8e19b2c5480a7185f688766e823cab97f34';
+
+const VENDORED_PATH = fileURLToPath(new URL(
+  '../../src/strategic-recommendations-semrush/shared-semrush-row.schema.v1.json',
+  import.meta.url,
+));
+
+// Best-effort cross-check against the authoritative DRS copy when this repo is
+// checked out inside the mysticat workspace (sibling repo). Skipped in CI where
+// DRS is not present.
+const DRS_AUTHORITATIVE_PATH = fileURLToPath(new URL(
+  '../../../llmo-data-retrieval-service/docs/contracts/shared-semrush-row.schema.v1.json',
+  import.meta.url,
+));
+
+function sha256(path) {
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+describe('strategic-recommendations-semrush schema checksum drift', () => {
+  it('vendored schema matches the pinned authoritative sha256', () => {
+    expect(existsSync(VENDORED_PATH), `vendored schema missing at ${VENDORED_PATH}`).to.equal(true);
+    expect(sha256(VENDORED_PATH)).to.equal(EXPECTED_SHA256);
+  });
+
+  it('vendored copy matches the DRS authoritative copy when present (sibling repo)', function checkDrs() {
+    if (!existsSync(DRS_AUTHORITATIVE_PATH)) {
+      this.skip();
+      return;
+    }
+    expect(sha256(DRS_AUTHORITATIVE_PATH)).to.equal(
+      sha256(VENDORED_PATH),
+      'vendored schema has drifted from the DRS authoritative copy — re-vendor and update EXPECTED_SHA256',
+    );
+  });
+});

--- a/test/strategic-recommendations-semrush/schema-checksum.test.js
+++ b/test/strategic-recommendations-semrush/schema-checksum.test.js
@@ -13,20 +13,19 @@
 /**
  * Schema checksum-drift guard.
  *
- * The row contract `shared-semrush-row.schema.v1.json` is AUTHORITATIVELY owned by
- * the llmo-data-retrieval-service (DRS) repo at
- * `docs/contracts/shared-semrush-row.schema.v1.json`. This repo vendors a copy at
- * `src/strategic-recommendations-semrush/shared-semrush-row.schema.v1.json` so the
- * writer/validator can run without a runtime dependency on DRS.
+ * The three row contracts (`shared-semrush-row`, `shared-citation-row`,
+ * `shared-persona-row`) are AUTHORITATIVELY owned by the llmo-data-retrieval-service
+ * (DRS) repo at `docs/contracts/`. This repo vendors byte-for-byte copies under
+ * `src/strategic-recommendations-semrush/` so the writer/validator can run without
+ * a runtime dependency on DRS.
  *
- * This test pins the expected sha256 of the vendored copy. CI only checks out this
- * repo, so it cannot reach the DRS file — instead it asserts the vendored copy
- * still matches the pinned hash. If you intentionally re-vendor an updated schema
- * FROM DRS, update EXPECTED_SHA256 below to the new value in the same commit.
+ * This test pins the expected sha256 of each vendored copy. CI only checks out this
+ * repo, so it cannot reach the DRS files — instead it asserts each vendored copy
+ * still matches its pinned hash. If you intentionally re-vendor an updated schema
+ * FROM DRS, update the EXPECTED_SHA256 entry below in the same commit.
  *
- * If DRS changes the authoritative schema and this copy is NOT re-vendored, this
- * test stays green here but a matching test in DRS (and a manual re-vendor) is the
- * intended drift signal — the two repos single-source the same file by sha.
+ * When the sibling DRS repo IS present (mysticat workspace), it additionally
+ * cross-checks the vendored copy against the authoritative copy by sha.
  */
 
 import { readFileSync, existsSync } from 'fs';
@@ -38,21 +37,38 @@ import {
   TAG_VALUES,
   DELETED_VALUES,
   MAX_LENGTHS,
+  AUX_REQUIRED_FIELDS,
+  AUX_DELETED_VALUES,
+  CITATION_MAX_LENGTHS,
+  PERSONA_MAX_LENGTHS,
 } from '../../src/strategic-recommendations-semrush/schema-derived.js';
 
-// sha256 of the authoritative DRS schema, vendored here. Update on deliberate re-vendor.
-const EXPECTED_SHA256 = '6c2d8fa69826279fbdd2e52f198ed8e19b2c5480a7185f688766e823cab97f34';
+// sha256 of the authoritative DRS schemas, vendored here. Update on deliberate re-vendor.
+const SCHEMAS = [
+  {
+    name: 'shared-semrush-row.schema.v1.json',
+    sha: '6c2d8fa69826279fbdd2e52f198ed8e19b2c5480a7185f688766e823cab97f34',
+  },
+  {
+    name: 'shared-citation-row.schema.v1.json',
+    sha: '8478774df50c8c318423845cdcc583ad6eda9d45cac64616b5ed82f10ce1285d',
+  },
+  {
+    name: 'shared-persona-row.schema.v1.json',
+    sha: '382462b15ef446663366ef4f2b1362d24bbaeb2d8e80c37a555863adb1b3dfe8',
+  },
+];
 
-const VENDORED_PATH = fileURLToPath(new URL(
-  '../../src/strategic-recommendations-semrush/shared-semrush-row.schema.v1.json',
+const vendoredPath = (name) => fileURLToPath(new URL(
+  `../../src/strategic-recommendations-semrush/${name}`,
   import.meta.url,
 ));
 
-// Best-effort cross-check against the authoritative DRS copy when this repo is
+// Best-effort cross-check against the authoritative DRS copies when this repo is
 // checked out inside the mysticat workspace (sibling repo). Skipped in CI where
 // DRS is not present.
-const DRS_AUTHORITATIVE_PATH = fileURLToPath(new URL(
-  '../../../llmo-data-retrieval-service/docs/contracts/shared-semrush-row.schema.v1.json',
+const drsPath = (name) => fileURLToPath(new URL(
+  `../../../llmo-data-retrieval-service/docs/contracts/${name}`,
   import.meta.url,
 ));
 
@@ -60,29 +76,48 @@ function sha256(path) {
   return createHash('sha256').update(readFileSync(path)).digest('hex');
 }
 
-describe('strategic-recommendations-semrush schema checksum drift', () => {
-  it('vendored schema matches the pinned authoritative sha256', () => {
-    expect(existsSync(VENDORED_PATH), `vendored schema missing at ${VENDORED_PATH}`).to.equal(true);
-    expect(sha256(VENDORED_PATH)).to.equal(EXPECTED_SHA256);
-  });
+function loadVendored(name) {
+  return JSON.parse(readFileSync(vendoredPath(name), 'utf8'));
+}
 
-  it('vendored copy matches the DRS authoritative copy when present (sibling repo)', function checkDrs() {
-    if (!existsSync(DRS_AUTHORITATIVE_PATH)) {
-      this.skip();
-      return;
+// Extracts { field: maxLength } for every property that declares a maxLength.
+function maxLengthsOf(schema) {
+  const out = {};
+  Object.entries(schema.properties).forEach(([field, def]) => {
+    if (typeof def.maxLength === 'number') {
+      out[field] = def.maxLength;
     }
-    expect(sha256(DRS_AUTHORITATIVE_PATH)).to.equal(
-      sha256(VENDORED_PATH),
-      'vendored schema has drifted from the DRS authoritative copy — re-vendor and update EXPECTED_SHA256',
-    );
+  });
+  return out;
+}
+
+describe('strategic-recommendations-semrush schema checksum drift', () => {
+  SCHEMAS.forEach(({ name, sha }) => {
+    describe(name, () => {
+      it('vendored schema matches the pinned authoritative sha256', () => {
+        expect(existsSync(vendoredPath(name)), `vendored schema missing at ${vendoredPath(name)}`).to.equal(true);
+        expect(sha256(vendoredPath(name))).to.equal(sha);
+      });
+
+      it('vendored copy matches the DRS authoritative copy when present (sibling repo)', function checkDrs() {
+        if (!existsSync(drsPath(name))) {
+          this.skip();
+          return;
+        }
+        expect(sha256(drsPath(name))).to.equal(
+          sha256(vendoredPath(name)),
+          `${name} has drifted from the DRS authoritative copy — re-vendor and update the pinned sha`,
+        );
+      });
+    });
   });
 
   // The validator inputs in schema-derived.js are inlined as constants (not read
   // from the JSON at runtime — that read broke the bundle). These assertions are
   // the other half of the drift guard: they fail if the inlined constants drift
   // from the vendored JSON, so a contract change must update both in one commit.
-  describe('inlined constants match the vendored JSON', () => {
-    const schema = JSON.parse(readFileSync(VENDORED_PATH, 'utf8'));
+  describe('inlined Semrush constants match the vendored JSON', () => {
+    const schema = loadVendored('shared-semrush-row.schema.v1.json');
 
     it('REQUIRED_FIELDS === schema.required', () => {
       expect(REQUIRED_FIELDS).to.deep.equal(schema.required);
@@ -97,13 +132,35 @@ describe('strategic-recommendations-semrush schema checksum drift', () => {
     });
 
     it('MAX_LENGTHS === schema.properties[*].maxLength', () => {
-      const fromSchema = {};
-      Object.entries(schema.properties).forEach(([field, def]) => {
-        if (typeof def.maxLength === 'number') {
-          fromSchema[field] = def.maxLength;
-        }
-      });
-      expect(MAX_LENGTHS).to.deep.equal(fromSchema);
+      expect(MAX_LENGTHS).to.deep.equal(maxLengthsOf(schema));
+    });
+  });
+
+  describe('inlined auxiliary constants match the vendored JSON', () => {
+    const citation = loadVendored('shared-citation-row.schema.v1.json');
+    const persona = loadVendored('shared-persona-row.schema.v1.json');
+
+    it('AUX_REQUIRED_FIELDS === citation.required === persona.required', () => {
+      expect(AUX_REQUIRED_FIELDS).to.deep.equal(citation.required);
+      expect(AUX_REQUIRED_FIELDS).to.deep.equal(persona.required);
+    });
+
+    it('AUX_DELETED_VALUES === both schemas\' deleted.enum', () => {
+      expect(AUX_DELETED_VALUES).to.deep.equal(citation.properties.deleted.enum);
+      expect(AUX_DELETED_VALUES).to.deep.equal(persona.properties.deleted.enum);
+    });
+
+    it('tag has NO enum in the auxiliary schemas (free-form)', () => {
+      expect(citation.properties.tag.enum).to.equal(undefined);
+      expect(persona.properties.tag.enum).to.equal(undefined);
+    });
+
+    it('CITATION_MAX_LENGTHS === citation.properties[*].maxLength', () => {
+      expect(CITATION_MAX_LENGTHS).to.deep.equal(maxLengthsOf(citation));
+    });
+
+    it('PERSONA_MAX_LENGTHS === persona.properties[*].maxLength', () => {
+      expect(PERSONA_MAX_LENGTHS).to.deep.equal(maxLengthsOf(persona));
     });
   });
 });

--- a/test/strategic-recommendations-semrush/schema-checksum.test.js
+++ b/test/strategic-recommendations-semrush/schema-checksum.test.js
@@ -37,6 +37,7 @@ import {
   REQUIRED_FIELDS,
   TAG_VALUES,
   DELETED_VALUES,
+  MAX_LENGTHS,
 } from '../../src/strategic-recommendations-semrush/schema-derived.js';
 
 // sha256 of the authoritative DRS schema, vendored here. Update on deliberate re-vendor.
@@ -93,6 +94,16 @@ describe('strategic-recommendations-semrush schema checksum drift', () => {
 
     it('DELETED_VALUES === schema.properties.deleted.enum', () => {
       expect(DELETED_VALUES).to.deep.equal(schema.properties.deleted.enum);
+    });
+
+    it('MAX_LENGTHS === schema.properties[*].maxLength', () => {
+      const fromSchema = {};
+      Object.entries(schema.properties).forEach(([field, def]) => {
+        if (typeof def.maxLength === 'number') {
+          fromSchema[field] = def.maxLength;
+        }
+      });
+      expect(MAX_LENGTHS).to.deep.equal(fromSchema);
     });
   });
 });

--- a/test/strategic-recommendations-semrush/schema-checksum.test.js
+++ b/test/strategic-recommendations-semrush/schema-checksum.test.js
@@ -33,6 +33,11 @@ import { readFileSync, existsSync } from 'fs';
 import { createHash } from 'crypto';
 import { fileURLToPath } from 'url';
 import { expect } from 'chai';
+import {
+  REQUIRED_FIELDS,
+  TAG_VALUES,
+  DELETED_VALUES,
+} from '../../src/strategic-recommendations-semrush/schema-derived.js';
 
 // sha256 of the authoritative DRS schema, vendored here. Update on deliberate re-vendor.
 const EXPECTED_SHA256 = '6c2d8fa69826279fbdd2e52f198ed8e19b2c5480a7185f688766e823cab97f34';
@@ -69,5 +74,25 @@ describe('strategic-recommendations-semrush schema checksum drift', () => {
       sha256(VENDORED_PATH),
       'vendored schema has drifted from the DRS authoritative copy — re-vendor and update EXPECTED_SHA256',
     );
+  });
+
+  // The validator inputs in schema-derived.js are inlined as constants (not read
+  // from the JSON at runtime — that read broke the bundle). These assertions are
+  // the other half of the drift guard: they fail if the inlined constants drift
+  // from the vendored JSON, so a contract change must update both in one commit.
+  describe('inlined constants match the vendored JSON', () => {
+    const schema = JSON.parse(readFileSync(VENDORED_PATH, 'utf8'));
+
+    it('REQUIRED_FIELDS === schema.required', () => {
+      expect(REQUIRED_FIELDS).to.deep.equal(schema.required);
+    });
+
+    it('TAG_VALUES === schema.properties.tag.enum', () => {
+      expect(TAG_VALUES).to.deep.equal(schema.properties.tag.enum);
+    });
+
+    it('DELETED_VALUES === schema.properties.deleted.enum', () => {
+      expect(DELETED_VALUES).to.deep.equal(schema.properties.deleted.enum);
+    });
   });
 });

--- a/test/strategic-recommendations-semrush/schema-validate.test.js
+++ b/test/strategic-recommendations-semrush/schema-validate.test.js
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { validateSemrushRows } from '../../src/strategic-recommendations-semrush/schema-validate.js';
+import {
+  TAG_VALUES, DELETED_VALUES, REQUIRED_FIELDS,
+} from '../../src/strategic-recommendations-semrush/schema-derived.js';
+
+const goodRow = (overrides = {}) => ({
+  tag: 'Hidden Win',
+  strategy: 'Defend the lead',
+  strategy_reasoning: 'evidence',
+  topic_id: 't-1',
+  topic: 'Editing',
+  volume: 100,
+  adobe_mentions: 5,
+  competitor_1: 'Canva',
+  competitor_1_mentions: 3,
+  category: 'Creative Cloud',
+  prompt: 'best editor?',
+  deleted: '',
+  ...overrides,
+});
+
+describe('validateSemrushRows', () => {
+  it('exposes the contract enums/required fields from the vendored schema', () => {
+    expect(TAG_VALUES).to.include.members(['Hidden Win', 'Coverage Gap', 'Strategic Blindspot']);
+    expect(DELETED_VALUES).to.include.members(['ignored', 'added']);
+    expect(REQUIRED_FIELDS).to.include.members(['tag', 'strategy', 'topic_id', 'prompt']);
+  });
+
+  it('accepts a fully valid row', () => {
+    expect(validateSemrushRows([goodRow()])).to.deep.equal({ valid: true, errors: [] });
+  });
+
+  it('accepts a row with nullable competitor fields and null deleted', () => {
+    const row = goodRow({
+      competitor_1: null, competitor_1_mentions: null, deleted: null,
+    });
+    expect(validateSemrushRows([row]).valid).to.equal(true);
+  });
+
+  it('rejects a non-array input', () => {
+    expect(validateSemrushRows({}).valid).to.equal(false);
+    expect(validateSemrushRows({}).errors[0]).to.include('not an array');
+  });
+
+  it('rejects a non-object row', () => {
+    const res = validateSemrushRows([42]);
+    expect(res.valid).to.equal(false);
+    expect(res.errors[0]).to.include('not an object');
+  });
+
+  it('flags missing required fields', () => {
+    const res = validateSemrushRows([{ tag: 'Hidden Win' }]);
+    expect(res.valid).to.equal(false);
+    expect(res.errors.join(' ')).to.include("missing required field 'strategy'");
+  });
+
+  it('flags a bad tag enum value', () => {
+    const res = validateSemrushRows([goodRow({ tag: 'Nope' })]);
+    expect(res.valid).to.equal(false);
+    expect(res.errors.join(' ')).to.include("tag 'Nope' not in enum");
+  });
+
+  it('flags a bad deleted enum value', () => {
+    const res = validateSemrushRows([goodRow({ deleted: 'maybe' })]);
+    expect(res.valid).to.equal(false);
+    expect(res.errors.join(' ')).to.include("deleted 'maybe' not in enum");
+  });
+
+  it('flags a non-string strategy', () => {
+    const res = validateSemrushRows([goodRow({ strategy: 123 })]);
+    expect(res.valid).to.equal(false);
+    expect(res.errors.join(' ')).to.include("'strategy' must be a string");
+  });
+
+  it('flags an empty required string', () => {
+    const res = validateSemrushRows([goodRow({ prompt: '' })]);
+    expect(res.valid).to.equal(false);
+    expect(res.errors.join(' ')).to.include("'prompt' must be non-empty");
+  });
+
+  it('flags a non-integer numeric field', () => {
+    const res = validateSemrushRows([goodRow({ volume: 1.5 })]);
+    expect(res.valid).to.equal(false);
+    expect(res.errors.join(' ')).to.include("'volume' must be an integer");
+  });
+
+  it('flags a negative numeric field', () => {
+    const res = validateSemrushRows([goodRow({ adobe_mentions: -1 })]);
+    expect(res.valid).to.equal(false);
+    expect(res.errors.join(' ')).to.include("'adobe_mentions' must be >= 0");
+  });
+});

--- a/test/strategic-recommendations-semrush/schema-validate.test.js
+++ b/test/strategic-recommendations-semrush/schema-validate.test.js
@@ -91,6 +91,22 @@ describe('validateSemrushRows', () => {
     expect(res.errors.join(' ')).to.include("'prompt' must be non-empty");
   });
 
+  it('flags a string field exceeding its maxLength', () => {
+    const res = validateSemrushRows([goodRow({ strategy: 'x'.repeat(201) })]);
+    expect(res.valid).to.equal(false);
+    expect(res.errors.join(' ')).to.include("'strategy' exceeds maxLength 200");
+  });
+
+  it('flags an over-long nullable field (competitor_1)', () => {
+    const res = validateSemrushRows([goodRow({ competitor_1: 'y'.repeat(201) })]);
+    expect(res.valid).to.equal(false);
+    expect(res.errors.join(' ')).to.include("'competitor_1' exceeds maxLength 200");
+  });
+
+  it('accepts a string field exactly at its maxLength', () => {
+    expect(validateSemrushRows([goodRow({ prompt: 'p'.repeat(600) })]).valid).to.equal(true);
+  });
+
   it('flags a non-integer numeric field', () => {
     const res = validateSemrushRows([goodRow({ volume: 1.5 })]);
     expect(res.valid).to.equal(false);

--- a/test/strategic-recommendations-semrush/schema-validate.test.js
+++ b/test/strategic-recommendations-semrush/schema-validate.test.js
@@ -11,7 +11,11 @@
  */
 
 import { expect } from 'chai';
-import { validateSemrushRows } from '../../src/strategic-recommendations-semrush/schema-validate.js';
+import {
+  validateSemrushRows,
+  validateCitationRows,
+  validatePersonaRows,
+} from '../../src/strategic-recommendations-semrush/schema-validate.js';
 import {
   TAG_VALUES, DELETED_VALUES, REQUIRED_FIELDS,
 } from '../../src/strategic-recommendations-semrush/schema-derived.js';
@@ -117,5 +121,120 @@ describe('validateSemrushRows', () => {
     const res = validateSemrushRows([goodRow({ adobe_mentions: -1 })]);
     expect(res.valid).to.equal(false);
     expect(res.errors.join(' ')).to.include("'adobe_mentions' must be >= 0");
+  });
+});
+
+const goodCitation = (overrides = {}) => ({
+  tag: 'Coverage Gap',
+  strategy: 'Own the care topic',
+  strategy_reasoning: 'No first-party coverage today.',
+  prompt: 'how to clean a modular sofa',
+  topic: 'sofa care',
+  category: 'Furniture',
+  region: 'US',
+  intent: 'informational',
+  type: 'howto',
+  source_url: 'https://lovesac.com/care',
+  prompt_reasoning: 'high-intent gap',
+  deleted: '',
+  ...overrides,
+});
+
+describe('validateCitationRows', () => {
+  it('accepts a fully valid row', () => {
+    expect(validateCitationRows([goodCitation()])).to.deep.equal({ valid: true, errors: [] });
+  });
+
+  it('accepts a free-form tag (no enum on the aux sheets)', () => {
+    expect(validateCitationRows([goodCitation({ tag: 'Anything Goes' })]).valid).to.equal(true);
+  });
+
+  it('accepts EMPTY strategy / strategy_reasoning (leave-it-empty rule)', () => {
+    const res = validateCitationRows([goodCitation({ strategy: '', strategy_reasoning: '' })]);
+    expect(res.valid).to.equal(true);
+  });
+
+  it('accepts null nullable passthrough columns', () => {
+    const row = goodCitation({
+      topic: null,
+      category: null,
+      region: null,
+      intent: null,
+      type: null,
+      source_url: null,
+      prompt_reasoning: null,
+      deleted: null,
+    });
+    expect(validateCitationRows([row]).valid).to.equal(true);
+  });
+
+  it('rejects a non-array input', () => {
+    expect(validateCitationRows('nope').valid).to.equal(false);
+    expect(validateCitationRows('nope').errors[0]).to.include('not an array');
+  });
+
+  it('rejects a non-object row', () => {
+    const res = validateCitationRows([7]);
+    expect(res.valid).to.equal(false);
+    expect(res.errors[0]).to.include('not an object');
+  });
+
+  it('flags missing required fields (strategy present-but-empty is OK, missing is not)', () => {
+    const res = validateCitationRows([{ tag: 'Coverage Gap', prompt: 'p' }]);
+    expect(res.valid).to.equal(false);
+    expect(res.errors.join(' ')).to.include("missing required field 'strategy'");
+    expect(res.errors.join(' ')).to.include("missing required field 'strategy_reasoning'");
+  });
+
+  it('flags an empty prompt (minLength 1 still applies to prompt)', () => {
+    const res = validateCitationRows([goodCitation({ prompt: '' })]);
+    expect(res.valid).to.equal(false);
+    expect(res.errors.join(' ')).to.include("'prompt' must be non-empty");
+  });
+
+  it('flags a bad deleted enum value', () => {
+    const res = validateCitationRows([goodCitation({ deleted: 'maybe' })]);
+    expect(res.valid).to.equal(false);
+    expect(res.errors.join(' ')).to.include("deleted 'maybe' not in enum");
+  });
+
+  it('flags a non-string passthrough column', () => {
+    const res = validateCitationRows([goodCitation({ topic: 42 })]);
+    expect(res.valid).to.equal(false);
+    expect(res.errors.join(' ')).to.include("'topic' must be a string");
+  });
+
+  it('flags a source_url exceeding maxLength 2048', () => {
+    const res = validateCitationRows([goodCitation({ source_url: `https://x/${'a'.repeat(2048)}` })]);
+    expect(res.valid).to.equal(false);
+    expect(res.errors.join(' ')).to.include("'source_url' exceeds maxLength 2048");
+  });
+});
+
+describe('validatePersonaRows', () => {
+  const goodPersona = (overrides = {}) => {
+    const { source_url: _, ...rest } = goodCitation(overrides);
+    return rest;
+  };
+
+  it('accepts a fully valid row (no source_url column)', () => {
+    expect(validatePersonaRows([goodPersona()]).valid).to.equal(true);
+  });
+
+  it('rejects a non-array input', () => {
+    expect(validatePersonaRows(null).valid).to.equal(false);
+  });
+
+  it('flags an empty prompt', () => {
+    const res = validatePersonaRows([goodPersona({ prompt: '' })]);
+    expect(res.valid).to.equal(false);
+    expect(res.errors.join(' ')).to.include("'prompt' must be non-empty");
+  });
+
+  it('does not impose a source_url bound on personas (source_url is not a persona column)', () => {
+    // A stray source_url longer than the citation cap is simply ignored — the
+    // persona maxLengths map has no source_url entry, so no error is raised.
+    const res = validatePersonaRows([goodPersona({ source_url: 'x'.repeat(5000) })]);
+    expect(res.valid).to.equal(true);
   });
 });


### PR DESCRIPTION
## What

Audit-worker result handler for the DRS `strategic_recommendations_semrush` provider. Consumes the provider's `JOB_COMPLETED` / `JOB_FAILED` SNS notifications and publishes the strategic-recommendations workbook — **three worksheets: `shared-Semrush`, `shared-Citation Attempt`, `shared-Synthetic Personas`** — to the customer's LLMO data folder.

> **Companion PR (cross-repo):** the DRS provider that produces these results ships in **`adobe-rnd/llmo-data-retrieval-service#2080`**. This handler validates the same row contracts, vendored here and **sha-pinned** to the DRS authoritative copies: `shared-semrush-row.schema.v1` (`6c2d8fa6…`), `shared-citation-row.schema.v1` (`8478774d…`), `shared-persona-row.schema.v1` (`382462b1…`).

## The `sheets` contract

DRS now returns a `sheets` envelope — `{ "Semrush": [...], "Citation Attempt": [...], "Synthetic Personas": [...] }` — instead of a single flat `rows` array. The handler writes one worksheet per sheet. Columns that exist on the source data map 1:1; the `tag` / `strategy` / `strategy_reasoning` "gap" columns on the Citation and Persona sheets are LLM-synthesized by DRS the same way the Semrush strategic-recommendation columns are. Where data is unavailable, the cell is left empty.

The legacy single-array envelope is still accepted (`{ Semrush: result.rows }`) as a transition path.

## Changes (`src/strategic-recommendations-semrush/`)

- **`handler.js`** — `drs:strategic_recommendations_semrush` handler. `JOB_FAILED` → Slack alert (text/plain), leave the prior sheet, `ok()`. `JOB_COMPLETED` → fetch result, **cross-tenant guard** (`result.siteId === message.siteId`), **normalize + validate each sheet**, resolve `dataFolder` via `Site.getConfig().getLlmoDataFolder()`, merge per-sheet + publish.
  - `normalizeSheets` accepts the new `sheets` object and falls back to the legacy `rows` array.
  - `collectAndValidateSheets` validates each sheet against its vendored contract. Only an **empty Semrush sheet fails the run** (it is the primary deliverable); empty Citation/Persona sheets are written **header-only**, consistent with the leave-it-empty rule.
  - **Builds a fresh workbook on first run** instead of failing closed when no published workbook exists yet.
  - **Drops the unconsumed `Notes` sheet.**
- **`merge.js`** — generalized `mergeRowsByKey(existing, new, keyFields)` (with `mergeSemrushRows` as the `(topic_id, prompt)` specialization). Citation merges on `(source_url, prompt)`, Persona on `(category, prompt)`. Preserves existing non-empty `deleted` markers (`ignored`/`added`) onto matching new rows (first-marker-wins); a null/undefined key field is a no-match; never mutates inputs. Rephrased prompts don't inherit a prior dismissal (best-effort v1).
- **`publish.js`** — does **not** reuse `publishToAdminHlx` (which swallows non-200s). POSTs preview+live and **throws on non-2xx**, then a **post-publish read-back** GETs the live Semrush JSON and throws on row-count / `generated_at` mismatch (catches the 200-but-stale-CDN case). The handler maps any publish/read-back throw to 500 — **never `ok()` on publish failure**.
- **`result-location.js`** — SSRF guard; fails closed when `DRS_RESULTS_BUCKET` is unset; accepts only the configured bucket + `DRS_RESULTS_PREFIX` key prefix.
- **`schema-validate.js`** — `validateSemrushRows` (enum-tagged) plus `validateCitationRows` / `validatePersonaRows`. The aux validators differ from Semrush: `tag` is free-form (no enum), `strategy` / `strategy_reasoning` are required-present but **may be empty**, and only `prompt` carries `minLength 1`.
- **`schema-derived.js`** — validator inputs are **inlined as constants** (reading the vendored JSON via an `import.meta.url`-relative path threw `ENOENT` under the helix-deploy bundle). The drift chain is preserved by `schema-checksum.test.js`.
- **`shared-semrush-row` / `shared-citation-row` / `shared-persona-row` `.schema.v1.json`** — vendored contracts. `schema-checksum.test.js` pins each sha256, fails CI on drift, cross-checks the DRS authoritative copies when a sibling repo is present, and asserts the inlined constants equal the vendored JSON.
- **`src/index.js`** — register `drs:strategic_recommendations_semrush` in `HANDLERS`.

## Gates
- ✅ Full suite: **8527 passing**, 0 failing; **100%** statements/branches/lines on `src/**`. 127 tests on the new directory.
- ✅ eslint clean.
- ✅ Vendored schema shas match the DRS authoritative `docs/contracts/*.schema.v1.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
