### PR TITLE
fix(cdn-logs-report): agentic weekly rollup on empty Sunday + date-based pattern sampling

### DIFF
--- a/src/cdn-logs-report/handler.js
+++ b/src/cdn-logs-report/handler.js
@@ -37,8 +37,8 @@ import { getPreviousUtcDate } from './agentic-daily-export.js';
  * sites whose logs only cover an earlier period — e.g. backfilling May data in June
  * must not sample the (empty) current week, which would yield no URLs.
  *
- * Otherwise an explicit `weekOffset` wins (the `weeks=N` backfill path); failing that,
- * the previous full week on Mondays, else the current week.
+ * Without a date (normal scheduled run) the period is the previous full week on
+ * Mondays, else the current week.
  */
 function resolvePatternPeriods(auditContext) {
   if (auditContext?.date) {
@@ -46,9 +46,6 @@ function resolvePatternPeriods(auditContext) {
     if (!Number.isNaN(referenceDate.getTime())) {
       return generateReportingPeriods(getPreviousUtcDate(referenceDate), 0);
     }
-  }
-  if (auditContext?.weekOffset !== undefined && auditContext?.weekOffset !== null) {
-    return generateReportingPeriods(new Date(), auditContext.weekOffset);
   }
   return generateReportingPeriods(new Date(), new Date().getUTCDay() === 1 ? -1 : 0);
 }

--- a/src/cdn-logs-report/handler.js
+++ b/src/cdn-logs-report/handler.js
@@ -29,16 +29,9 @@ import { runDailyReferralExport } from './referral-daily-export.js';
 import { getPreviousUtcDate } from './agentic-daily-export.js';
 
 /**
- * Resolves the reporting period used to sample CDN logs for pattern generation.
- *
- * A date-based (backfill) run carries an explicit `auditContext.date`; the period is
- * derived from that run's traffic date (`date - 1`, matching the daily export) so
- * patterns are sampled from the week that actually has uploaded data. This matters for
- * sites whose logs only cover an earlier period — e.g. backfilling May data in June
- * must not sample the (empty) current week, which would yield no URLs.
- *
- * Without a date (normal scheduled run) the period is the previous full week on
- * Mondays, else the current week.
+ * Reporting period for sampling CDN logs for pattern generation. A date-based run uses
+ * that run's traffic day (`date - 1`, like the daily export) so backfills sample the
+ * uploaded week, not today's. Otherwise: previous full week on Mondays, else this week.
  */
 function resolvePatternPeriods(auditContext) {
   if (auditContext?.date) {

--- a/src/cdn-logs-report/handler.js
+++ b/src/cdn-logs-report/handler.js
@@ -40,7 +40,8 @@ function resolvePatternPeriods(auditContext) {
       return generateReportingPeriods(getPreviousUtcDate(referenceDate), 0);
     }
   }
-  return generateReportingPeriods(new Date(), new Date().getUTCDay() === 1 ? -1 : 0);
+  const now = new Date();
+  return generateReportingPeriods(now, now.getUTCDay() === 1 ? -1 : 0);
 }
 
 /**

--- a/src/cdn-logs-report/handler.js
+++ b/src/cdn-logs-report/handler.js
@@ -26,17 +26,31 @@ import { getConfigs } from './constants/report-configs.js';
 import { generatePatternsWorkbook } from './patterns/patterns-uploader.js';
 import { runAgenticDbExports } from './utils/agentic-db-export.js';
 import { runDailyReferralExport } from './referral-daily-export.js';
+import { getPreviousUtcDate } from './agentic-daily-export.js';
 
 /**
- * Picks the single week offset used to sample CDN logs for pattern generation.
- * An explicit weekOffset wins; otherwise the previous full week on Mondays,
- * else the current week.
+ * Resolves the reporting period used to sample CDN logs for pattern generation.
+ *
+ * A date-based (backfill) run carries an explicit `auditContext.date`; the period is
+ * derived from that run's traffic date (`date - 1`, matching the daily export) so
+ * patterns are sampled from the week that actually has uploaded data. This matters for
+ * sites whose logs only cover an earlier period — e.g. backfilling May data in June
+ * must not sample the (empty) current week, which would yield no URLs.
+ *
+ * Otherwise an explicit `weekOffset` wins (the `weeks=N` backfill path); failing that,
+ * the previous full week on Mondays, else the current week.
  */
-function resolvePatternWeekOffset(auditContext) {
-  if (auditContext?.weekOffset !== undefined && auditContext?.weekOffset !== null) {
-    return auditContext.weekOffset;
+function resolvePatternPeriods(auditContext) {
+  if (auditContext?.date) {
+    const referenceDate = new Date(auditContext.date);
+    if (!Number.isNaN(referenceDate.getTime())) {
+      return generateReportingPeriods(getPreviousUtcDate(referenceDate), 0);
+    }
   }
-  return new Date().getUTCDay() === 1 ? -1 : 0;
+  if (auditContext?.weekOffset !== undefined && auditContext?.weekOffset !== null) {
+    return generateReportingPeriods(new Date(), auditContext.weekOffset);
+  }
+  return generateReportingPeriods(new Date(), new Date().getUTCDay() === 1 ? -1 : 0);
 }
 
 /**
@@ -83,7 +97,7 @@ async function generateAgenticPatterns({
       log.info(`Skipping fresh patterns generation for ${site.getId()}; DB rule fetch failed`);
     } else if (!hasExistingPatterns) {
       log.info('Agentic URL classification rules not found, generating DB rules...');
-      const periods = generateReportingPeriods(new Date(), resolvePatternWeekOffset(auditContext));
+      const periods = resolvePatternPeriods(auditContext);
 
       await generatePatternsWorkbook({
         site,

--- a/src/cdn-logs-report/utils/agentic-db-export.js
+++ b/src/cdn-logs-report/utils/agentic-db-export.js
@@ -11,6 +11,76 @@
  */
 
 import { runDailyAgenticExport } from '../agentic-daily-export.js';
+import { generateReportingPeriods } from './report-utils.js';
+
+const WEEKLY_REFRESH_RPC = 'wrpc_refresh_agentic_traffic_weekly';
+
+function toUtcDateString(date) {
+  return date.toISOString().split('T')[0];
+}
+
+/**
+ * A daily agentic export is "week-closing" when its traffic date is a Sunday — the
+ * last day of the ISO week. Only then does triggering a weekly rollup make sense.
+ * Invalid/missing dates yield `NaN`, which is never `0`, so this safely returns false.
+ */
+function isWeekClosingSunday(trafficDate) {
+  return new Date(`${trafficDate}T00:00:00.000Z`).getUTCDay() === 0;
+}
+
+/**
+ * Triggers the weekly agentic rollup RPC for the ISO week ending on `trafficDate`,
+ * mirroring the api-service `backfill-llmo mode=weekly-db` path.
+ *
+ * The weekly rollup is normally a side-effect of the Sunday daily import completing.
+ * When a site has no traffic on Sunday the daily export is skipped and no
+ * `batch.completed` event is emitted, so the projector never fires the weekly refresh
+ * and the week's earlier days (e.g. Mon–Fri) never roll up. Calling the RPC directly
+ * fills the week from whatever was already imported.
+ *
+ * Best-effort: never throws, so a refresh failure cannot block the rest of the audit.
+ */
+async function refreshWeeklyAgenticRollup({ site, context, trafficDate }) {
+  const siteId = site.getId();
+  const { log } = context;
+  const postgrestClient = context?.dataAccess?.services?.postgrestClient;
+
+  if (!postgrestClient?.rpc) {
+    log.warn(`Skipping weekly agentic rollup for ${siteId}: PostgREST client unavailable`);
+    return { success: false, error: 'postgrest-client-unavailable' };
+  }
+
+  const [{ startDate, endDate }] = generateReportingPeriods(
+    new Date(`${trafficDate}T00:00:00.000Z`),
+    0,
+  ).weeks;
+  const weekStart = toUtcDateString(startDate);
+  const weekEnd = toUtcDateString(endDate);
+
+  try {
+    const { error } = await postgrestClient.rpc(WEEKLY_REFRESH_RPC, {
+      p_site_id: siteId,
+      p_start_date: weekStart,
+      p_end_date: weekEnd,
+      p_updated_by: 'audit-worker:cdn-logs-report-weekly-refresh',
+    });
+
+    if (error) {
+      log.error(`Failed weekly agentic rollup for ${siteId} (${weekStart}..${weekEnd}): ${error.message}`);
+      return {
+        success: false, weekStart, weekEnd, error: error.message,
+      };
+    }
+
+    log.info(`Triggered weekly agentic rollup for ${siteId} (${weekStart}..${weekEnd}) after empty Sunday export`);
+    return { success: true, weekStart, weekEnd };
+  } catch (error) {
+    log.error(`Failed weekly agentic rollup for ${siteId} (${weekStart}..${weekEnd}): ${error.message}`, error);
+    return {
+      success: false, weekStart, weekEnd, error: error.message,
+    };
+  }
+}
 
 /**
  * Resolves the reference date for the daily export from auditContext.date.
@@ -84,14 +154,27 @@ export async function runAgenticDbExports({
   }
 
   const referenceDate = getDateBasedReferenceDate(auditContext, siteId, context);
-  return {
-    dailyAgenticExport: await runAgenticDbExportForReferenceDate({
-      athenaClient,
-      s3Config,
+  const dailyAgenticExport = await runAgenticDbExportForReferenceDate({
+    athenaClient,
+    s3Config,
+    site,
+    context,
+    reportConfig: agenticReportConfig,
+    ...(referenceDate ? { referenceDate } : {}),
+  });
+
+  const result = { dailyAgenticExport };
+
+  // A Sunday with no traffic skips the daily export and emits no batch event, so the
+  // projector never fires the weekly rollup for that ISO week. Trigger it directly so
+  // any earlier days already imported still roll up into the weekly view.
+  if (dailyAgenticExport?.skipped && isWeekClosingSunday(dailyAgenticExport.trafficDate)) {
+    result.weeklyAgenticRefresh = await refreshWeeklyAgenticRollup({
       site,
       context,
-      reportConfig: agenticReportConfig,
-      ...(referenceDate ? { referenceDate } : {}),
-    }),
-  };
+      trafficDate: dailyAgenticExport.trafficDate,
+    });
+  }
+
+  return result;
 }

--- a/src/cdn-logs-report/utils/agentic-db-export.js
+++ b/src/cdn-logs-report/utils/agentic-db-export.js
@@ -19,26 +19,16 @@ function toUtcDateString(date) {
   return date.toISOString().split('T')[0];
 }
 
-/**
- * A daily agentic export is "week-closing" when its traffic date is a Sunday — the
- * last day of the ISO week. Only then does triggering a weekly rollup make sense.
- * Invalid/missing dates yield `NaN`, which is never `0`, so this safely returns false.
- */
+// Sunday is the last day of the ISO week; invalid/missing dates yield NaN (never 0).
 function isWeekClosingSunday(trafficDate) {
   return new Date(`${trafficDate}T00:00:00.000Z`).getUTCDay() === 0;
 }
 
 /**
- * Triggers the weekly agentic rollup RPC for the ISO week ending on `trafficDate`,
- * mirroring the api-service `backfill-llmo mode=weekly-db` path.
- *
- * The weekly rollup is normally a side-effect of the Sunday daily import completing.
- * When a site has no traffic on Sunday the daily export is skipped and no
- * `batch.completed` event is emitted, so the projector never fires the weekly refresh
- * and the week's earlier days (e.g. Mon–Fri) never roll up. Calling the RPC directly
- * fills the week from whatever was already imported.
- *
- * Best-effort: never throws, so a refresh failure cannot block the rest of the audit.
+ * Triggers the weekly agentic rollup RPC for the ISO week containing `trafficDate`.
+ * The rollup normally rides on the Sunday daily import; an empty Sunday is skipped and
+ * emits no batch event, so we call the RPC directly to roll up the earlier days.
+ * Best-effort: never throws.
  */
 async function refreshWeeklyAgenticRollup({ site, context, trafficDate }) {
   const siteId = site.getId();
@@ -165,9 +155,7 @@ export async function runAgenticDbExports({
 
   const result = { dailyAgenticExport };
 
-  // A Sunday with no traffic skips the daily export and emits no batch event, so the
-  // projector never fires the weekly rollup for that ISO week. Trigger it directly so
-  // any earlier days already imported still roll up into the weekly view.
+  // An empty Sunday emits no batch event, so roll up the week's earlier days directly.
   if (dailyAgenticExport?.skipped && isWeekClosingSunday(dailyAgenticExport.trafficDate)) {
     result.weeklyAgenticRefresh = await refreshWeeklyAgenticRollup({
       site,

--- a/src/cdn-logs-report/utils/agentic-db-export.js
+++ b/src/cdn-logs-report/utils/agentic-db-export.js
@@ -67,7 +67,7 @@ async function refreshWeeklyAgenticRollup({ site, context, trafficDate }) {
     log.info(`Triggered weekly agentic rollup for ${siteId} (${weekStart}..${weekEnd}) after empty Sunday export`);
     return { success: true, weekStart, weekEnd };
   } catch (error) {
-    log.error(`Failed weekly agentic rollup for ${siteId} (${weekStart}..${weekEnd}): ${error.message}`, error);
+    log.error(`Failed weekly agentic rollup for ${siteId} (${weekStart ?? '?'}..${weekEnd ?? '?'}): ${error.message}`, error);
     return {
       success: false, weekStart, weekEnd, error: error.message,
     };

--- a/src/cdn-logs-report/utils/agentic-db-export.js
+++ b/src/cdn-logs-report/utils/agentic-db-export.js
@@ -40,14 +40,16 @@ async function refreshWeeklyAgenticRollup({ site, context, trafficDate }) {
     return { success: false, error: 'postgrest-client-unavailable' };
   }
 
-  const [{ startDate, endDate }] = generateReportingPeriods(
-    new Date(`${trafficDate}T00:00:00.000Z`),
-    0,
-  ).weeks;
-  const weekStart = toUtcDateString(startDate);
-  const weekEnd = toUtcDateString(endDate);
-
+  let weekStart;
+  let weekEnd;
   try {
+    const [{ startDate, endDate }] = generateReportingPeriods(
+      new Date(`${trafficDate}T00:00:00.000Z`),
+      0,
+    ).weeks;
+    weekStart = toUtcDateString(startDate);
+    weekEnd = toUtcDateString(endDate);
+
     const { error } = await postgrestClient.rpc(WEEKLY_REFRESH_RPC, {
       p_site_id: siteId,
       p_start_date: weekStart,

--- a/test/audits/cdn-logs-report/handler.test.js
+++ b/test/audits/cdn-logs-report/handler.test.js
@@ -309,6 +309,39 @@ describe('CDN Logs Report Handler', function test() {
 
       expect(mocks.generatePatternsWorkbook).to.have.been.calledOnce;
     });
+
+    it('derives the pattern sampling week from auditContext.date (date - 1), not from today', async () => {
+      mocks.fetchAgenticUrlClassificationRules = sandbox.stub().resolves({ pagePatterns: [], topicPatterns: [] });
+      // Today (Jun 10) is far from the uploaded data (early May). The sampling week
+      // must come from the backfill date's traffic day, not the empty current week.
+      const clock = sinon.useFakeTimers({ now: new Date('2026-06-10'), toFake: ['Date'] });
+
+      try {
+        await runAudit({ date: '2026-05-07T10:00:00Z' });
+      } finally {
+        clock.restore();
+      }
+
+      expect(mocks.generatePatternsWorkbook).to.have.been.calledOnce;
+      const [refDate, offset] = mocks.generateReportingPeriods.firstCall.args;
+      // date - 1 = 2026-05-06 (UTC midnight); current week of that date (offset 0).
+      expect(refDate.toISOString()).to.equal('2026-05-06T00:00:00.000Z');
+      expect(offset).to.equal(0);
+    });
+
+    it('falls back to the current-week offset when auditContext.date is invalid', async () => {
+      mocks.fetchAgenticUrlClassificationRules = sandbox.stub().resolves({ pagePatterns: [], topicPatterns: [] });
+      const clock = sinon.useFakeTimers({ now: new Date('2025-01-07'), toFake: ['Date'] }); // Tuesday
+
+      try {
+        await runAudit({ date: 'not-a-real-date' });
+      } finally {
+        clock.restore();
+      }
+
+      expect(mocks.generatePatternsWorkbook).to.have.been.calledOnce;
+      expect(mocks.generateReportingPeriods).to.have.been.calledWithMatch(sinon.match.any, 0);
+    });
   });
 
   describe('daily referral export', () => {

--- a/test/audits/cdn-logs-report/handler.test.js
+++ b/test/audits/cdn-logs-report/handler.test.js
@@ -233,14 +233,6 @@ describe('CDN Logs Report Handler', function test() {
       expect(mocks.generatePatternsWorkbook).to.have.been.calledOnce;
     });
 
-    it('uses the explicit weekOffset for pattern sampling when provided', async () => {
-      mocks.fetchAgenticUrlClassificationRules = sandbox.stub().resolves({ pagePatterns: [], topicPatterns: [] });
-
-      await runAudit({ weekOffset: -3 });
-
-      expect(mocks.generateReportingPeriods).to.have.been.calledWithMatch(sinon.match.any, -3);
-    });
-
     it('skips regeneration when the DB rule fetch fails', async () => {
       mocks.fetchAgenticUrlClassificationRules = sandbox.stub().resolves({ error: true, source: 'postgres' });
 

--- a/test/audits/cdn-logs-report/handler.test.js
+++ b/test/audits/cdn-logs-report/handler.test.js
@@ -334,6 +334,20 @@ describe('CDN Logs Report Handler', function test() {
       expect(mocks.generatePatternsWorkbook).to.have.been.calledOnce;
       expect(mocks.generateReportingPeriods).to.have.been.calledWithMatch(sinon.match.any, 0);
     });
+
+    it('falls back to the previous-week offset on Mondays when auditContext.date is invalid', async () => {
+      mocks.fetchAgenticUrlClassificationRules = sandbox.stub().resolves({ pagePatterns: [], topicPatterns: [] });
+      const clock = sinon.useFakeTimers({ now: new Date('2025-01-06'), toFake: ['Date'] }); // Monday
+
+      try {
+        await runAudit({ date: 'not-a-real-date' });
+      } finally {
+        clock.restore();
+      }
+
+      expect(mocks.generatePatternsWorkbook).to.have.been.calledOnce;
+      expect(mocks.generateReportingPeriods).to.have.been.calledWithMatch(sinon.match.any, -1);
+    });
   });
 
   describe('daily referral export', () => {

--- a/test/audits/cdn-logs-report/utils/agentic-db-export.test.js
+++ b/test/audits/cdn-logs-report/utils/agentic-db-export.test.js
@@ -136,4 +136,116 @@ describe('agentic DB export orchestration', () => {
       error: 'daily export failed',
     });
   });
+
+  describe('weekly agentic rollup on empty Sunday export', () => {
+    // 2026-04-26 is a Sunday; its ISO week runs Mon 2026-04-20 .. Sun 2026-04-26.
+    const SUNDAY = '2026-04-26';
+    const WEEK_START = '2026-04-20';
+    const WEEK_END = '2026-04-26';
+
+    function withPostgrest(args, rpc) {
+      args.context.dataAccess = { services: { postgrestClient: { rpc } } };
+      return args;
+    }
+
+    it('triggers the weekly rollup RPC when the Sunday export is skipped', async () => {
+      runDailyAgenticExportStub.resolves({
+        enabled: true, success: true, skipped: true, trafficDate: SUNDAY, rowCount: 0,
+      });
+      const rpc = sandbox.stub().resolves({ data: [{ rows_inserted: 5 }], error: null });
+      const args = withPostgrest(createArgs(), rpc);
+
+      const result = await module.runAgenticDbExports(args);
+
+      expect(rpc).to.have.been.calledOnceWith('wrpc_refresh_agentic_traffic_weekly', {
+        p_site_id: 'site-1',
+        p_start_date: WEEK_START,
+        p_end_date: WEEK_END,
+        p_updated_by: 'audit-worker:cdn-logs-report-weekly-refresh',
+      });
+      expect(result.weeklyAgenticRefresh).to.deep.equal({
+        success: true, weekStart: WEEK_START, weekEnd: WEEK_END,
+      });
+      expect(args.context.log.info).to.have.been.calledWith(
+        'Triggered weekly agentic rollup for site-1 (2026-04-20..2026-04-26) after empty Sunday export',
+      );
+    });
+
+    it('does not trigger the weekly rollup when a non-Sunday export is skipped', async () => {
+      runDailyAgenticExportStub.resolves({
+        enabled: true, success: true, skipped: true, trafficDate: '2026-04-29', rowCount: 0,
+      });
+      const rpc = sandbox.stub();
+      const args = withPostgrest(createArgs(), rpc);
+
+      const result = await module.runAgenticDbExports(args);
+
+      expect(rpc).to.not.have.been.called;
+      expect(result.weeklyAgenticRefresh).to.equal(undefined);
+    });
+
+    it('does not trigger the weekly rollup when the Sunday export has data', async () => {
+      runDailyAgenticExportStub.resolves({
+        enabled: true, success: true, trafficDate: SUNDAY, batchId: 'batch-1',
+      });
+      const rpc = sandbox.stub();
+      const args = withPostgrest(createArgs(), rpc);
+
+      const result = await module.runAgenticDbExports(args);
+
+      expect(rpc).to.not.have.been.called;
+      expect(result.weeklyAgenticRefresh).to.equal(undefined);
+    });
+
+    it('skips the weekly rollup when the PostgREST client is unavailable', async () => {
+      runDailyAgenticExportStub.resolves({
+        enabled: true, success: true, skipped: true, trafficDate: SUNDAY, rowCount: 0,
+      });
+      const args = createArgs();
+
+      const result = await module.runAgenticDbExports(args);
+
+      expect(result.weeklyAgenticRefresh).to.deep.equal({
+        success: false, error: 'postgrest-client-unavailable',
+      });
+      expect(args.context.log.warn).to.have.been.calledWith(
+        'Skipping weekly agentic rollup for site-1: PostgREST client unavailable',
+      );
+    });
+
+    it('records an RPC error without failing the caller', async () => {
+      runDailyAgenticExportStub.resolves({
+        enabled: true, success: true, skipped: true, trafficDate: SUNDAY, rowCount: 0,
+      });
+      const rpc = sandbox.stub().resolves({ data: null, error: { message: 'boom' } });
+      const args = withPostgrest(createArgs(), rpc);
+
+      const result = await module.runAgenticDbExports(args);
+
+      expect(result.weeklyAgenticRefresh).to.deep.equal({
+        success: false, weekStart: WEEK_START, weekEnd: WEEK_END, error: 'boom',
+      });
+      expect(args.context.log.error).to.have.been.calledWith(
+        'Failed weekly agentic rollup for site-1 (2026-04-20..2026-04-26): boom',
+      );
+    });
+
+    it('catches a thrown RPC error without failing the caller', async () => {
+      runDailyAgenticExportStub.resolves({
+        enabled: true, success: true, skipped: true, trafficDate: SUNDAY, rowCount: 0,
+      });
+      const rpc = sandbox.stub().rejects(new Error('network down'));
+      const args = withPostgrest(createArgs(), rpc);
+
+      const result = await module.runAgenticDbExports(args);
+
+      expect(result.weeklyAgenticRefresh).to.deep.equal({
+        success: false, weekStart: WEEK_START, weekEnd: WEEK_END, error: 'network down',
+      });
+      expect(args.context.log.error).to.have.been.calledWith(
+        'Failed weekly agentic rollup for site-1 (2026-04-20..2026-04-26): network down',
+        sinon.match.instanceOf(Error),
+      );
+    });
+  });
 });

--- a/test/audits/cdn-logs-report/utils/agentic-db-export.test.js
+++ b/test/audits/cdn-logs-report/utils/agentic-db-export.test.js
@@ -247,5 +247,30 @@ describe('agentic DB export orchestration', () => {
         sinon.match.instanceOf(Error),
       );
     });
+
+    it('logs "?..?" when the period calculation throws before the dates are resolved', async () => {
+      const throwingModule = await esmock('../../../../src/cdn-logs-report/utils/agentic-db-export.js', {
+        '../../../../src/cdn-logs-report/agentic-daily-export.js': {
+          runDailyAgenticExport: sandbox.stub().resolves({
+            enabled: true, success: true, skipped: true, trafficDate: SUNDAY, rowCount: 0,
+          }),
+        },
+        '../../../../src/cdn-logs-report/utils/report-utils.js': {
+          generateReportingPeriods: sandbox.stub().throws(new Error('bad period')),
+        },
+      });
+      const rpc = sandbox.stub();
+      const args = withPostgrest(createArgs(), rpc);
+
+      const result = await throwingModule.runAgenticDbExports(args);
+
+      expect(rpc).to.not.have.been.called;
+      expect(result.weeklyAgenticRefresh.success).to.equal(false);
+      expect(result.weeklyAgenticRefresh.error).to.equal('bad period');
+      expect(args.context.log.error).to.have.been.calledWith(
+        'Failed weekly agentic rollup for site-1 (?..?): bad period',
+        sinon.match.instanceOf(Error),
+      );
+    });
   });
 });


### PR DESCRIPTION
## What

Two related fixes to the `cdn-logs-report` agentic pipeline, plus a small cleanup.

### 1. Trigger the weekly agentic rollup on an empty Sunday export
The weekly agentic rollup (`wrpc_refresh_agentic_traffic_weekly`) normally fires only as a side-effect of the Sunday daily batch import completing. Sites with traffic Mon–Fri but **no Sunday data** have their Sunday daily export skipped (0 rows), so no `batch.completed` event is emitted and the projector never rolls up the week — the earlier days never appear in the weekly view.

Fix: when the daily export is skipped *and* its traffic date is a week-closing Sunday, call the weekly rollup RPC directly (mirroring the api-service `backfill-llmo mode=weekly-db` path). Best-effort — never throws, so it can't block the rest of the audit.

### 2. Derive pattern sampling week from `auditContext.date`
`generateAgenticPatterns` sampled CDN logs using `generateReportingPeriods(new Date(), ...)` — always anchored to *today*. On a date-based backfill (e.g. today is Jun 10 but the customer only uploaded early-May logs), it sampled the empty current week and fetched zero URLs.

Fix: when `auditContext.date` is present, derive the sampling period from that run's traffic date (`date - 1`, matching the daily export) so patterns are sampled from the week that actually has uploaded data.

### 3. Remove dead `weekOffset` branch
The api-service `backfill-llmo` path for `cdn-logs-report` now always sends an explicit `date` (never `weekOffset`); `weekOffset` is only used by the separate `llm-error-pages` audit. The `weekOffset` fallback in pattern-period resolution was unreachable for this audit and has been removed.

## Testing
- `npm run lint` — clean
- `npm run test:spec -- test/audits/cdn-logs-report/handler.test.js test/audits/cdn-logs-report/utils/agentic-db-export.test.js` — 30 passing
- 100% line/branch/function/statement coverage on both `src/cdn-logs-report/handler.js` and `src/cdn-logs-report/utils/agentic-db-export.js`

## Related Issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)