### PR TITLE
fix(offsite-brand-presence): skip DRS scraping when org has no imsOrgId

### DIFF
--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -506,18 +506,24 @@ async function submitWithRetry({ domain, datasetId, params }, submitFn, log) {
  * When spacecatOrgId is provided, it is passed through to
  * drsClient.submitScrapeJob and included as spacecat_org_id in the DRS request.
  *
+ * DRS auto-resolves the customer's imsOrgId (and brand) from site_id by reading
+ * the SpaceCat organization, and rejects the job with HTTP 400 when that
+ * resolution fails (i.e. the organization has no imsOrgId). Because the caller
+ * reads imsOrgId from the same organization, an absent imsOrgId reliably
+ * predicts that DRS resolution would fail, so we skip submission rather than
+ * fire jobs that are guaranteed to 400.
+ *
  * Reddit-comments params (`commentLimit`, `sortBy`, `daysBack`,
  * `loadAllReplies`) are only attached to the `reddit_comments` dataset. When
- * they are omitted and the request goes through the DRS client, the client
- * applies its defaults (`commentLimit=150`, `sortBy='Best'`, no `daysBack`,
- * no `loadAllReplies`). On the direct-HTTP path (`spacecatOrgId` set), only
- * the params that the direct path explicitly handles (currently `daysBack`)
- * actually reach DRS.
+ * they are omitted, the DRS client applies its defaults (`commentLimit=150`,
+ * `sortBy='Best'`, no `daysBack`, no `loadAllReplies`).
  *
  * @param {object} urlsByDomain - Map of domain/bucket to array of URL strings
  * @param {string} siteId - The site ID
  * @param {object} context - Context with env and log
  * @param {string} [spacecatOrgId] - Optional SpaceCat org ID
+ * @param {string} [imsOrgId] - IMS org ID resolved from the site's organization.
+ *   When falsy, DRS scraping is skipped (see above).
  * @param {object} [redditCommentsParams] - Per-run reddit_comments scrape params
  *   (see {@link resolveRedditCommentsParams})
  * @returns {Promise<Array>} Results of DRS job creation
@@ -527,6 +533,7 @@ async function triggerDrsScraping(
   siteId,
   context,
   spacecatOrgId,
+  imsOrgId,
   redditCommentsParams = {},
 ) {
   const { log } = context;
@@ -534,6 +541,15 @@ async function triggerDrsScraping(
 
   if (!drsClient.isConfigured()) {
     log.error(`${LOG_PREFIX} DRS_API_URL or DRS_API_KEY not configured, skipping DRS scraping`);
+    return [];
+  }
+
+  // DRS rejects scrape jobs (HTTP 400) unless it can resolve the customer's
+  // imsOrgId from the site_id, which requires the SpaceCat organization to have
+  // imsOrgId set. Resolve it here as a faithful pre-flight check: if it is
+  // missing we skip rather than fire jobs that are guaranteed to fail.
+  if (!imsOrgId) {
+    log.error(`${LOG_PREFIX} Site ${siteId} organization has no imsOrgId, skipping DRS scraping. Populate imsOrgId on the SpaceCat organization to enable offsite brand presence scraping.`);
     return [];
   }
 
@@ -658,6 +674,8 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
   const { channelId, threadTs } = slackContext || {};
   const siteId = site.getId();
   const baseURL = site.getBaseURL();
+  const organization = await site.getOrganization();
+  const imsOrgId = organization?.getImsOrgId();
   const previousWeeks = getPreviousWeeks();
   const weekLabels = previousWeeks
     .map(({ week, year }) => `w${String(week).padStart(2, '0')}-${year}`)
@@ -719,6 +737,7 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
     siteId,
     context,
     spacecatOrgId,
+    imsOrgId,
     redditCommentsParams,
   );
 

--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -526,7 +526,9 @@ async function submitWithRetry({ domain, datasetId, params }, submitFn, log) {
  *   When falsy, DRS scraping is skipped (see above).
  * @param {object} [redditCommentsParams] - Per-run reddit_comments scrape params
  *   (see {@link resolveRedditCommentsParams})
- * @returns {Promise<Array>} Results of DRS job creation
+ * @returns {Promise<{skipped: (string|null), results: Array}>} `skipped` is a
+ *   human-readable reason when scraping was skipped (and `results` is empty),
+ *   otherwise `null` with the DRS job creation results.
  */
 async function triggerDrsScraping(
   urlsByDomain,
@@ -541,7 +543,7 @@ async function triggerDrsScraping(
 
   if (!drsClient.isConfigured()) {
     log.error(`${LOG_PREFIX} DRS_API_URL or DRS_API_KEY not configured, skipping DRS scraping`);
-    return [];
+    return { skipped: 'DRS is not configured (DRS_API_URL/DRS_API_KEY missing)', results: [] };
   }
 
   // DRS rejects scrape jobs (HTTP 400) unless it can resolve the customer's
@@ -550,7 +552,10 @@ async function triggerDrsScraping(
   // missing we skip rather than fire jobs that are guaranteed to fail.
   if (!imsOrgId) {
     log.warn(`${LOG_PREFIX} Site ${siteId} organization has no imsOrgId, skipping DRS scraping. Populate imsOrgId on the SpaceCat organization to enable offsite brand presence scraping.`);
-    return [];
+    return {
+      skipped: 'organization has no imsOrgId — populate imsOrgId on the SpaceCat organization to enable scraping',
+      results: [],
+    };
   }
 
   const jobs = [];
@@ -587,7 +592,7 @@ async function triggerDrsScraping(
     // eslint-disable-next-line no-await-in-loop
     results.push(await submitWithRetry(job, (p) => drsClient.submitScrapeJob(p), log));
   }
-  return results;
+  return { skipped: null, results };
 }
 
 /**
@@ -620,6 +625,23 @@ function selectTopUrls(allUrls, maxUrlsPerBucket, excludedFromTopCited) {
   }
 
   return { topByDomain, topCited };
+}
+
+/**
+ * Sends a Slack notification when DRS scraping was skipped before any jobs were
+ * triggered (e.g. DRS not configured, or the organization has no imsOrgId).
+ * Posts only when a Slack thread context is available (manual runs);
+ * postMessageOptional no-ops on scheduled runs.
+ *
+ * @param {string} reason - Human-readable reason scraping was skipped
+ * @param {string} baseURL - The site's base URL
+ * @param {object} context - The execution context
+ * @param {string} channelId - Slack channel ID
+ * @param {string} threadTs - Slack thread timestamp
+ */
+async function notifyDrsSkipped(reason, baseURL, context, channelId, threadTs) {
+  const text = `:warning: *offsite-brand-presence* DRS scraping *skipped* for *${baseURL}* — ${reason}.`;
+  await postMessageOptional(context, channelId, text, { threadTs });
 }
 
 /**
@@ -732,7 +754,7 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
   } = selectTopUrls(allUrls, DRS_URLS_LIMIT, excludedFromTopCited);
 
   const storedByDomain = await addUrlsToUrlStore(siteId, topByDomain, topCited, dataAccess, log);
-  const drsResults = await triggerDrsScraping(
+  const { skipped, results: drsResults } = await triggerDrsScraping(
     storedByDomain,
     siteId,
     context,
@@ -741,7 +763,11 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
     redditCommentsParams,
   );
 
-  await notifyDrsResults(drsResults, baseURL, context, channelId, threadTs);
+  if (skipped) {
+    await notifyDrsSkipped(skipped, baseURL, context, channelId, threadTs);
+  } else {
+    await notifyDrsResults(drsResults, baseURL, context, channelId, threadTs);
+  }
 
   // TODO: temporarily disabled
   // if (topicMap.size > 0) {

--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -549,7 +549,7 @@ async function triggerDrsScraping(
   // imsOrgId set. Resolve it here as a faithful pre-flight check: if it is
   // missing we skip rather than fire jobs that are guaranteed to fail.
   if (!imsOrgId) {
-    log.error(`${LOG_PREFIX} Site ${siteId} organization has no imsOrgId, skipping DRS scraping. Populate imsOrgId on the SpaceCat organization to enable offsite brand presence scraping.`);
+    log.warn(`${LOG_PREFIX} Site ${siteId} organization has no imsOrgId, skipping DRS scraping. Populate imsOrgId on the SpaceCat organization to enable offsite brand presence scraping.`);
     return [];
   }
 

--- a/test/audits/offsite-brand-presence.test.js
+++ b/test/audits/offsite-brand-presence.test.js
@@ -1452,13 +1452,33 @@ describe('Offsite Brand Presence Handler', () => {
       expect(callText).to.include('mock-job');
     });
 
-    it('should not send a Slack message when no DRS jobs are triggered', async () => {
+    it('should send a Slack skip notification when DRS is not configured', async () => {
       mockDrsIsConfigured.returns(false);
       stubBrandPresenceData(['https://youtube.com/shorts/v1']);
 
       await offsiteBrandPresenceRunner(FINAL_URL, context, site, AUDIT_CONTEXT_WITH_SLACK);
 
-      expect(mockPostMessageOptional).to.not.have.been.called;
+      expect(mockPostMessageOptional).to.have.been.calledOnce;
+      const [callCtx, callChannelId, callText, callOptions] = mockPostMessageOptional.firstCall.args;
+      expect(callCtx).to.equal(context);
+      expect(callChannelId).to.equal(SLACK_CHANNEL_ID);
+      expect(callOptions).to.deep.equal({ threadTs: SLACK_THREAD_TS });
+      expect(callText).to.match(/skipped/i);
+      expect(callText).to.match(/not configured/i);
+      expect(callText).to.include(BASE_URL);
+    });
+
+    it('should send a Slack skip notification when the organization has no imsOrgId', async () => {
+      site.getOrganization = sandbox.stub().resolves({ getImsOrgId: () => null });
+      stubBrandPresenceData(['https://youtube.com/shorts/v1']);
+
+      await offsiteBrandPresenceRunner(FINAL_URL, context, site, AUDIT_CONTEXT_WITH_SLACK);
+
+      expect(mockPostMessageOptional).to.have.been.calledOnce;
+      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(callText).to.match(/skipped/i);
+      expect(callText).to.include('imsOrgId');
+      expect(callText).to.include(BASE_URL);
     });
   });
 

--- a/test/audits/offsite-brand-presence.test.js
+++ b/test/audits/offsite-brand-presence.test.js
@@ -114,6 +114,9 @@ describe('Offsite Brand Presence Handler', () => {
     site = {
       getId: sandbox.stub().returns(SITE_ID),
       getBaseURL: sandbox.stub().returns(BASE_URL),
+      getOrganization: sandbox.stub().resolves({
+        getImsOrgId: () => '1234567890ABCDEF12345678@AdobeOrg',
+      }),
     };
 
     context = { dataAccess, env, log };
@@ -1284,6 +1287,32 @@ describe('Offsite Brand Presence Handler', () => {
       for (const call of mockSubmitScrapeJob.getCalls()) {
         expect(call.args[0].spacecatOrgId).to.equal('org-multi');
       }
+    });
+  });
+
+  describe('DRS Scraping imsOrgId resolution', () => {
+    it('skips DRS scraping and logs an actionable error when the organization has no imsOrgId', async () => {
+      site.getOrganization = sandbox.stub().resolves({ getImsOrgId: () => null });
+      stubBrandPresenceData(['https://youtube.com/shorts/v1']);
+
+      const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
+
+      expect(result.auditResult.success).to.be.true;
+      expect(result.auditResult.drsJobs).to.deep.equal([]);
+      expect(mockSubmitScrapeJob).to.not.have.been.called;
+      expect(log.error).to.have.been.calledWith(
+        sinon.match(/imsOrgId/),
+      );
+    });
+
+    it('skips DRS scraping when the site has no organization', async () => {
+      site.getOrganization = sandbox.stub().resolves(null);
+      stubBrandPresenceData(['https://youtube.com/shorts/v1']);
+
+      const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
+
+      expect(result.auditResult.drsJobs).to.deep.equal([]);
+      expect(mockSubmitScrapeJob).to.not.have.been.called;
     });
   });
 

--- a/test/audits/offsite-brand-presence.test.js
+++ b/test/audits/offsite-brand-presence.test.js
@@ -1291,7 +1291,7 @@ describe('Offsite Brand Presence Handler', () => {
   });
 
   describe('DRS Scraping imsOrgId resolution', () => {
-    it('skips DRS scraping and logs an actionable error when the organization has no imsOrgId', async () => {
+    it('skips DRS scraping and logs an actionable warning when the organization has no imsOrgId', async () => {
       site.getOrganization = sandbox.stub().resolves({ getImsOrgId: () => null });
       stubBrandPresenceData(['https://youtube.com/shorts/v1']);
 
@@ -1300,7 +1300,10 @@ describe('Offsite Brand Presence Handler', () => {
       expect(result.auditResult.success).to.be.true;
       expect(result.auditResult.drsJobs).to.deep.equal([]);
       expect(mockSubmitScrapeJob).to.not.have.been.called;
-      expect(log.error).to.have.been.calledWith(
+      expect(log.warn).to.have.been.calledWith(
+        sinon.match(/imsOrgId/),
+      );
+      expect(log.error).to.not.have.been.calledWith(
         sinon.match(/imsOrgId/),
       );
     });


### PR DESCRIPTION
DRS auto-resolves imsOrgId from site_id by reading the SpaceCat organization and rejects scrape jobs with HTTP 400 when that resolution fails. The offsite-brand-presence runner now resolves imsOrgId from site.getOrganization() and skips DRS submission with an actionable error when it is absent, instead of firing jobs that are guaranteed to 400.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
