### PR TITLE
fix(money-pages): convert StepAudit to RunnerAudit to fix audit.getId() crash

### DIFF
--- a/src/money-pages/handler.js
+++ b/src/money-pages/handler.js
@@ -15,48 +15,44 @@ import { wwwUrlResolver } from '../common/index.js';
 
 const AUDIT_TYPE = 'money-pages';
 
-/**
- * Send message to Mystique for money page generation
- * @param {Object} context - The execution context containing sqs, audit, etc.
- * @returns {Object} Status object indicating completion
- */
-export async function sendToMystiqueForGeneration(context) {
-  const {
-    log, site, finalUrl, sqs, env, audit,
-  } = context;
+export function collectAuditData(auditUrl, context, site) {
+  const { log } = context;
 
-  try {
-    const message = {
-      type: 'money-pages',
-      siteId: site.getId(),
-      auditId: audit.getId(),
-      time: new Date().toISOString(),
-      data: {
-        site_url: finalUrl,
-      },
-    };
+  log.info(`[${AUDIT_TYPE}] [Site: ${site.getId()}] Collecting audit data`);
 
-    await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, message);
-    log.info(`[${AUDIT_TYPE}] Message sent to Mystique`, message);
-
-    return {
-      status: 'complete',
-    };
-  } catch (error) {
-    log.error(
-      `[${AUDIT_TYPE}] [Site: ${site.getId()}] Failed to send message to Mystique: ${
-        error.message
-      }`,
-    );
-    throw error;
-  }
+  return {
+    auditResult: { siteUrl: auditUrl },
+    fullAuditRef: auditUrl,
+  };
 }
 
-/**
- * Export the audit handler with all steps configured
- * Uses AuditBuilder to chain the steps together
- */
+export async function sendToMystiqueForGeneration(finalUrl, auditData, context, site) {
+  const {
+    log, sqs, env, audit,
+  } = context;
+  const siteId = site.getId();
+
+  if (!sqs || !env?.QUEUE_SPACECAT_TO_MYSTIQUE) {
+    log.warn(`[${AUDIT_TYPE}] [Site: ${siteId}] SQS or Mystique queue not configured, skipping`);
+    return;
+  }
+
+  const message = {
+    type: AUDIT_TYPE,
+    siteId,
+    auditId: audit.getId(),
+    time: new Date().toISOString(),
+    data: {
+      site_url: finalUrl,
+    },
+  };
+
+  await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, message);
+  log.info(`[${AUDIT_TYPE}] Message sent to Mystique`, message);
+}
+
 export default new AuditBuilder()
   .withUrlResolver(wwwUrlResolver)
-  .addStep('send-message-to-mystique', sendToMystiqueForGeneration)
+  .withRunner(collectAuditData)
+  .withPostProcessors([sendToMystiqueForGeneration])
   .build();

--- a/test/audits/money-pages/handler.test.js
+++ b/test/audits/money-pages/handler.test.js
@@ -9,13 +9,13 @@
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-/* eslint-disable */
 import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import chaiAsPromised from 'chai-as-promised';
 
 import {
+  collectAuditData,
   sendToMystiqueForGeneration,
 } from '../../../src/money-pages/handler.js';
 import { MockContextBuilder } from '../../shared.js';
@@ -60,6 +60,20 @@ describe('Money pages audit', () => {
     sinon.restore();
   });
 
+  describe('collectAuditData', () => {
+    it('should return auditResult and fullAuditRef', async () => {
+      const result = await collectAuditData('www.example.com', context, site);
+
+      expect(result).to.deep.equal({
+        auditResult: { siteUrl: 'www.example.com' },
+        fullAuditRef: 'www.example.com',
+      });
+      expect(context.log.info).to.have.been.calledWith(
+        sinon.match(`[${AUDIT_TYPE}] [Site: site-id-1] Collecting audit data`),
+      );
+    });
+  });
+
   describe('sendToMystiqueForGeneration', () => {
     let mockSqs;
     let mockAudit;
@@ -81,9 +95,8 @@ describe('Money pages audit', () => {
     });
 
     it('should successfully send message to Mystique', async () => {
-      const result = await sendToMystiqueForGeneration(context);
+      await sendToMystiqueForGeneration('www.example.com', {}, context, site);
 
-      expect(result).to.deep.equal({ status: 'complete' });
       expect(mockSqs.sendMessage).to.have.been.calledOnce;
 
       const messageArg = mockSqs.sendMessage.getCall(0).args[1];
@@ -95,16 +108,31 @@ describe('Money pages audit', () => {
       expect(messageArg.data).to.not.have.property('top_pages');
     });
 
+    it('should warn and skip when SQS is not configured', async () => {
+      context.sqs = null;
+
+      await sendToMystiqueForGeneration('www.example.com', {}, context, site);
+
+      expect(context.log.warn).to.have.been.calledWith(sinon.match('SQS or Mystique queue not configured'));
+      expect(context.log.info).to.not.have.been.called;
+    });
+
+    it('should warn and skip when Mystique queue URL is not configured', async () => {
+      context.env = {};
+
+      await sendToMystiqueForGeneration('www.example.com', {}, context, site);
+
+      expect(context.log.warn).to.have.been.calledWith(sinon.match('SQS or Mystique queue not configured'));
+      expect(mockSqs.sendMessage).to.not.have.been.called;
+    });
+
     it('should throw error when SQS message sending fails', async () => {
       mockSqs.sendMessage.rejects(new Error('SQS error'));
 
-      await expect(sendToMystiqueForGeneration(context))
+      await expect(sendToMystiqueForGeneration('www.example.com', {}, context, site))
         .to.be.rejectedWith('SQS error');
 
       expect(context.log.info).to.not.have.been.called;
-      expect(context.log.error).to.have.been.calledWith(
-        sinon.match('Failed to send message to Mystique')
-      );
     });
   });
 });


### PR DESCRIPTION
## Summary

- **Root cause**: The money-pages handler was a single-step `StepAudit`. The framework only injects `context.audit` for continuation steps (not the initial step), so `sendToMystiqueForGeneration` always crashed with `TypeError: Cannot read properties of undefined (reading 'getId')` in production.
- **Fix**: Converted to `RunnerAudit` + post-processor pattern — the framework guarantees `context.audit` is populated before any post-processor runs (`base-audit.js:144`).
- **Guard**: Added `!sqs || !env?.QUEUE_SPACECAT_TO_MYSTIQUE` early-exit with a `warn` log, consistent with `related-urls` and `summarization` handlers, so misconfigured environments surface a clear message instead of a cryptic crash.

No changes to `src/common/` — only `src/money-pages/handler.js` and its test file were modified.

## Test plan

- [ ] `npm run test:spec -- test/audits/money-pages/handler.test.js` — 5 tests, 100% coverage
- [ ] Confirm no regression in other audits: `npm test`
- [ ] Verify money-pages audit triggers Mystique message in staging after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)