### PR TITLE
fix: prepare Sitemap error codes for UI consistency

### DIFF
--- a/src/sitemap-product-coverage/handler.js
+++ b/src/sitemap-product-coverage/handler.js
@@ -20,11 +20,17 @@ import { syncSuggestions } from '../utils/data-access.js';
 import { convertToOpportunity } from '../common/opportunity.js';
 import { ProductsQuery, CategoriesQuery, ProductCountQuery } from './queries.js';
 import {
-  ERROR_CODES,
+  ERROR_CODES as SITEMAP_ERROR_CODES,
   getSitemapUrls,
 } from '../sitemap/common.js';
 
 const auditType = 'sitemap-product-coverage';
+
+export const ERROR_CODES = Object.freeze({
+  MISSING_PRODUCT_URL_TEMPLATE: 'MISSING PRODUCT URL TEMPLATE IN THE SITE CONFIGURATION',
+  COLLECTING_PRODUCTS_BACKEND_FAILED: 'COLLECTING PRODUCTS FROM BACKEND FAILED',
+  UNSUPPORTED_DELIVERY_TYPE: 'UNSUPPORTED DELIVERY TYPE',
+});
 
 /**
  * Maximum number of products per category.
@@ -233,7 +239,7 @@ async function sitemapProductCoverageAudit(inputUrl, context, site) {
     success: false,
     reasons: [{
       value: filteredSitemapUrls[0],
-      error: ERROR_CODES.NO_VALID_PATHS_EXTRACTED,
+      error: SITEMAP_ERROR_CODES.NO_VALID_PATHS_EXTRACTED,
     }],
     url: inputUrl,
     details: { issues: notCoveredProduct },

--- a/src/sitemap/common.js
+++ b/src/sitemap/common.js
@@ -22,7 +22,7 @@ import {
 } from '../support/utils.js';
 
 // ----- version ----------------------------------------------------------------
-export const COMMON_VERSION = 100; // manually update as needed
+export const COMMON_VERSION = 101; // manually update as needed
 
 // ----- performance tuning constants ------------------------------------------
 
@@ -52,16 +52,16 @@ export const SLOW_PAGE_URL_BATCH_DELAY_MS = 100; // 0.1 of a second delay betwee
 
 // ----- internal constants ----------------------------------------------------
 export const ERROR_CODES = Object.freeze({
-  INVALID_URL: 'INVALID URL',
+  // ... codes applicable for the /robots.txt file ...
+  CANNOT_READ_ROBOTS: 'CANNOT READ ROBOTS',
   NO_SITEMAP_IN_ROBOTS: 'NO SITEMAP FOUND IN ROBOTS',
-  NO_VALID_PATHS_EXTRACTED: 'NO VALID URLs FOUND IN SITEMAP',
+  // ... codes applicable for a specific sitemap.xml URL ...
   SITEMAP_NOT_FOUND: 'NO SITEMAP FOUND',
-  SITEMAP_EMPTY: 'EMPTY SITEMAP',
-  SITEMAP_FORMAT: 'INVALID SITEMAP FORMAT',
-  FETCH_ERROR: 'ERROR FETCHING DATA',
-  MISSING_PRODUCT_URL_TEMPLATE: 'MISSING PRODUCT URL TEMPLATE IN THE SITE CONFIGURATION',
-  COLLECTING_PRODUCTS_BACKEND_FAILED: 'COLLECTING PRODUCTS FROM BACKEND FAILED',
-  UNSUPPORTED_DELIVERY_TYPE: 'UNSUPPORTED DELIVERY TYPE',
+  CANNOT_READ_SITEMAP: 'ERROR FETCHING DATA',
+  INVALID_SITEMAP_FORMAT: 'INVALID SITEMAP FORMAT',
+  NO_VALID_PATHS_EXTRACTED: 'NO VALID URLs FOUND IN SITEMAP',
+  // ... audit-level codes ...
+  GENERAL_ERROR: 'INVALID URL', // the customer's URL provided for the audit is not valid
 });
 
 const VALID_MIME_TYPES = Object.freeze([
@@ -1008,6 +1008,10 @@ export async function checkRobotsForSitemap(protocol, domain) {
     }
   }
 
+  // note: If `sitemapPaths` is empty, then this is not necessarily an error condition ... yet;
+  //       it just means that there are no sitemap URLs declared in robots.txt.
+  //       If `sitemapPath` is empty, then we will need to look at other common places for
+  //       sitemap URLs, such as the root-level sitemap.xml file.
   return {
     paths: sitemapPaths,
     reasons: sitemapPaths.length ? [] : [ERROR_CODES.NO_SITEMAP_IN_ROBOTS],
@@ -1038,7 +1042,7 @@ export async function checkSitemap(sitemapUrl, log) {
     if (!isValidFormat) {
       return {
         existsAndIsValid: false,
-        reasons: [ERROR_CODES.SITEMAP_FORMAT],
+        reasons: [ERROR_CODES.INVALID_SITEMAP_FORMAT],
       };
     }
 
@@ -1053,7 +1057,7 @@ export async function checkSitemap(sitemapUrl, log) {
     const isNotFound = error.message.includes('404');
     return {
       existsAndIsValid: false,
-      reasons: [isNotFound ? ERROR_CODES.SITEMAP_NOT_FOUND : ERROR_CODES.FETCH_ERROR],
+      reasons: [isNotFound ? ERROR_CODES.SITEMAP_NOT_FOUND : ERROR_CODES.CANNOT_READ_SITEMAP],
     };
   }
 }
@@ -1132,7 +1136,7 @@ export async function getSitemapUrls(inputUrl, log) {
     log?.error(`Sitemap: Invalid URL provided: ${inputUrl}`);
     return {
       success: false,
-      reasons: [{ value: inputUrl, error: ERROR_CODES.INVALID_URL }],
+      reasons: [{ value: inputUrl, error: ERROR_CODES.GENERAL_ERROR }],
     };
   }
 
@@ -1153,7 +1157,7 @@ export async function getSitemapUrls(inputUrl, log) {
     // If robots.txt fails, return error immediately (since something is horribly wrong)
     return {
       success: false,
-      reasons: [{ value: `${error.message}`, error: ERROR_CODES.FETCH_ERROR }],
+      reasons: [{ value: `${error.message}`, error: ERROR_CODES.CANNOT_READ_ROBOTS }],
     };
   }
 
@@ -1171,6 +1175,7 @@ export async function getSitemapUrls(inputUrl, log) {
     });
 
     if (!sitemapUrls.ok?.length) {
+      // Since we cannot find any sitemap.xml URLs whatsoever, return an error.
       return {
         success: false,
         reasons: [{

--- a/test/audits/sitemap-product-coverage.test.js
+++ b/test/audits/sitemap-product-coverage.test.js
@@ -21,9 +21,10 @@ import {
   sitemapProductCoverageAuditRunner,
   generateSuggestions,
   generateOpportunity,
+  ERROR_CODES,
 } from '../../src/sitemap-product-coverage/handler.js';
 import { createOpportunityData } from '../../src/sitemap-product-coverage/opportunity-data-mapper.js';
-import { ERROR_CODES } from '../../src/sitemap/common.js';
+import { ERROR_CODES as SITEMAP_ERROR_CODES } from '../../src/sitemap/common.js';
 import { DATA_SOURCES } from '../../src/common/constants.js';
 import { MockContextBuilder } from '../shared.js';
 
@@ -203,7 +204,6 @@ describe('Sitemap Product Coverage Audit', () => {
         },
       },
       '../../src/sitemap/common.js': {
-        ERROR_CODES,
         getSitemapUrls: async (url) => {
           if (global.mockEmptySitemap) {
             return {
@@ -489,7 +489,7 @@ describe('Sitemap Product Coverage Audit', () => {
       global.mockEmptySitemap = false;
 
       expect(result.auditResult.success).to.be.false;
-      expect(result.auditResult.reasons[0].error).to.equal(ERROR_CODES.NO_VALID_PATHS_EXTRACTED);
+      expect(result.auditResult.reasons[0].error).to.equal(SITEMAP_ERROR_CODES.NO_VALID_PATHS_EXTRACTED);
     });
 
     it('should handle large catalog with category traversal', async () => {
@@ -554,7 +554,7 @@ describe('Sitemap Product Coverage Audit', () => {
       global.mockEmptySitemap = false;
 
       expect(result.auditResult.success).to.be.false;
-      expect(result.auditResult.reasons[0].error).to.equal(ERROR_CODES.NO_VALID_PATHS_EXTRACTED);
+      expect(result.auditResult.reasons[0].error).to.equal(SITEMAP_ERROR_CODES.NO_VALID_PATHS_EXTRACTED);
     });
   });
 
@@ -888,7 +888,7 @@ describe('Sitemap Product Coverage Audit', () => {
       global.mockMissingDetails = false;
 
       expect(result.auditResult.success).to.be.false;
-      expect(result.auditResult.reasons[0].error).to.equal(ERROR_CODES.NO_VALID_PATHS_EXTRACTED);
+      expect(result.auditResult.reasons[0].error).to.equal(SITEMAP_ERROR_CODES.NO_VALID_PATHS_EXTRACTED);
       // Should handle missing extractedPaths and filteredSitemapUrls gracefully
     });
 

--- a/test/audits/sitemap.test.js
+++ b/test/audits/sitemap.test.js
@@ -236,7 +236,7 @@ describe('Sitemap Audit', () => {
         auditResult: {
           reasons: [
             {
-              error: ERROR_CODES.FETCH_ERROR,
+              error: ERROR_CODES.CANNOT_READ_ROBOTS,
               value:
                 'Fetch error for https://some-domain.adobe/robots.txt Status: 404',
             },
@@ -263,7 +263,7 @@ describe('Sitemap Audit', () => {
         auditResult: {
           reasons: [
             {
-              error: ERROR_CODES.FETCH_ERROR,
+              error: ERROR_CODES.CANNOT_READ_ROBOTS,
               value:
                 'Fetch error for https://some-domain.adobe/robots.txt Status: 404',
             },
@@ -413,12 +413,12 @@ describe('Sitemap Audit', () => {
       expect(resp.reasons).to.include(ERROR_CODES.SITEMAP_NOT_FOUND);
     });
 
-    it('should return FETCH_ERROR when there is a network error', async () => {
+    it('should return CANNOT_READ_SITEMAP when there is a network error', async () => {
       nock(url).get('/sitemap.xml').replyWithError('Network error');
 
       const resp = await checkSitemap();
       expect(resp.existsAndIsValid).to.equal(false);
-      expect(resp.reasons).to.include(ERROR_CODES.FETCH_ERROR);
+      expect(resp.reasons).to.include(ERROR_CODES.CANNOT_READ_SITEMAP);
     });
 
     it('checkSitemap returns INVALID_SITEMAP_FORMAT when sitemap is not valid xml', async () => {
@@ -428,7 +428,7 @@ describe('Sitemap Audit', () => {
 
       const resp = await checkSitemap(`${url}/sitemap.xml`);
       expect(resp.existsAndIsValid).to.equal(false);
-      expect(resp.reasons).to.include(ERROR_CODES.SITEMAP_FORMAT);
+      expect(resp.reasons).to.include(ERROR_CODES.INVALID_SITEMAP_FORMAT);
     });
 
     it('checkSitemap returns invalid result for non-existing sitemap', async () => {
@@ -571,7 +571,7 @@ describe('Sitemap Audit', () => {
       expect(result.success).to.equal(false);
       expect(result.reasons).to.deep.equal([
         {
-          error: ERROR_CODES.INVALID_URL,
+          error: ERROR_CODES.GENERAL_ERROR,
           value: 'not a valid url',
         },
       ]);
@@ -1485,7 +1485,7 @@ describe('Sitemap Audit', () => {
     });
 
     it('shallow-merges type error without stripping error string', () => {
-      const existing = { type: 'error', error: ERROR_CODES.FETCH_ERROR, extra: 1 };
+      const existing = { type: 'error', error: ERROR_CODES.CANNOT_READ_SITEMAP, extra: 1 };
       const newData = {
         type: 'error',
         error: ERROR_CODES.NO_SITEMAP_IN_ROBOTS,


### PR DESCRIPTION
 * rearrange Sitemap error codes for future use, initially for BackOffice UI

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
