### PR TITLE
feat: reuse agentic URL classification for referral-traffic topic/category enrichment

### DIFF
--- a/docs/decisions/001-reuse-agentic-url-classification-for-referral-traffic.md
+++ b/docs/decisions/001-reuse-agentic-url-classification-for-referral-traffic.md
@@ -1,0 +1,322 @@
+# 001. Reuse agentic URL classification rules for referral traffic topic/category
+
+| Field | Value |
+|-------|-------|
+| **Status** | Accepted |
+| **Date** | 2026-06-10 |
+| **Author** | Christopher Wisse |
+| **Deciders** | Christopher Wisse |
+| **Supersedes** | N/A |
+| **Superseded by** | N/A |
+
+## Context
+
+### Technical Context
+
+Referral traffic reports — the weekly `llmo-referral-traffic` (Excel) and the
+daily `llmo-referral-traffic-daily` (CSV) audits — carried no topic or
+page-type category per URL. The agentic CDN-logs report (`cdn-logs-report`)
+already derives both per URL via a **two-tier regex-rule classifier**:
+
+- **Tier A (rare, cached):** an LLM (`gpt-4o-mini`, batched) authors POSIX/Trino
+  regex rules once per site and persists them to the Postgres tables
+  `agentic_url_category_rules` (topic) and `agentic_url_page_type_rules`
+  (page type). This tier is skipped when rules already exist, so it is paid at
+  most once per site.
+- **Tier B (every run, zero LLM):** the stored rules are read back and applied
+  per URL. For Athena-backed reports this is emitted as a SQL
+  `CASE WHEN REGEXP_LIKE(...)` expression in
+  `src/cdn-logs-report/utils/query-builder.js` (`buildTopicExtractionSQL` and
+  `generatePageTypeClassification`).
+
+The deleted `page-intent` audit produced a comparable `topic` field but did so
+with N sequential per-URL LLM calls — costly — and its only live consumer
+(weekly referral) used the intent enum, not the topic.
+
+### Business Context
+
+We want topic + category on referral traffic reports without paying a per-URL
+LLM cost, and we want those labels to agree with what the agentic CDN-logs
+report assigns for the same site, so that a customer sees one consistent
+taxonomy across reports.
+
+### Constraints
+
+- No per-URL LLM cost may be reintroduced (the reason `page-intent` was
+  retired).
+- The daily audit classifies parquet rows **in JavaScript**, not via Athena, so
+  it cannot host the agentic SQL `CASE` expression.
+- The stored regex source is authored for the Trino/Athena engine (RE2J),
+  but the daily audit must evaluate it under V8's `RegExp` (Irregexp). The two
+  regex dialects are not identical.
+- Referral rows expose only a URL **path**, whereas agentic rules are authored
+  against the full `url` (scheme + host + path).
+- Downstream consumers of the daily CSV (the `referral_traffic_optel`
+  ingestion pipeline) and the existing agentic mapper read fixed column/field
+  names; changing those names risks breaking them.
+
+## Decision
+
+Reuse the existing agentic classification rules for referral traffic rather
+than generating referral-specific classifications. Concretely:
+
+1. Read the rules via the existing `fetchAgenticUrlClassificationRules`
+   (`src/common/agentic-url-classification-rules.js`).
+2. Add a **JS twin** of the agentic SQL classifier in
+   `src/common/agentic-url-classification.js` that mirrors
+   `buildTopicExtractionSQL` (topic: named `CASE` → unnamed `REGEXP_EXTRACT`
+   group 1 → `'Other'`) and `generatePageTypeClassification` (category: named
+   `CASE` → `'Other'`). The twin exposes `createClassifier` (compile-once,
+   reuse-per-row) and `hasClassificationRules` (the rules-present gate).
+   `classifyTopic` / `classifyPageType` are exported for the SQL-twin parity
+   test only; both handlers go through `createClassifier`.
+3. Wire both referral handlers to classify on the URL **path** and gate
+   enrichment on a **rules-present** check (`hasClassificationRules` /
+   `createClassifier` returning non-null): when a site has no rules — or the
+   fetch errors — skip enrichment rather than tagging every row as `'Other'`.
+
+Scope is **topic + category only**. This is not a `page-intent` replacement; the
+intent enum is not covered by the agentic regex tiers.
+
+## Rationale
+
+### Options Considered
+
+**Option A — Reuse agentic rules via a JS twin of the SQL classifier (chosen).**
+- *Pros:* zero per-URL LLM cost (Tier A already paid by the agentic pipeline);
+  labels consistent with the agentic CDN-logs report; one shared module to
+  evolve the semantics; works for both Athena (weekly) and JS/parquet (daily)
+  paths.
+- *Cons:* introduces a JS-vs-Trino regex dialect risk; classification quality
+  for referral depends on agentic rules existing for the site; path-only
+  matching drops host/scheme-dependent rules.
+
+**Option B — Generate referral-specific classifications via LLM per URL.**
+- *Pros:* self-contained; no dependency on the agentic pipeline.
+- *Cons:* reintroduces the exact per-URL LLM cost that made `page-intent`
+  expensive; would also diverge from the agentic taxonomy.
+
+**Option C — Share the SQL `CASE` expression across both audits.**
+- *Pros:* a single source of truth with no dialect risk.
+- *Cons:* not possible — the daily audit classifies parquet rows in JS, with no
+  Athena query to host the `CASE`.
+
+**Option D — Emit `'Other'` for every row at sites that have no rules.**
+- *Pros:* keeps a uniform column population.
+- *Cons:* pollutes reports with a column of meaningless values, misleading
+  consumers into thinking classification ran.
+
+### Why Option A Was Chosen
+
+Option A is the only choice that delivers consistent labels across reports at
+near-zero runtime cost while supporting both the Athena-backed weekly path and
+the JS/parquet daily path. Its principal risk (dialect divergence) is bounded
+and made observable (see Negative consequences and Implementation), and the
+rules-present gate cleanly handles sites without rules.
+
+### Why Alternatives Were Rejected
+
+- **Option B** reintroduces the per-URL LLM cost the team explicitly removed
+  with `page-intent`, and would produce labels inconsistent with the agentic
+  report.
+- **Option C** is technically infeasible for the daily audit.
+- **Option D** degrades report quality; the rules-present gate (Option A) is a
+  strictly better way to handle rule-less sites.
+
+## Consequences
+
+### Positive
+
+- Topic/category for referral is effectively free at runtime: the LLM cost is
+  paid once per site by the agentic pipeline and reused.
+- Referral and agentic reports share one classifier, so labels stay consistent
+  and a single module is the place to evolve the semantics.
+- The dialect-divergence and ReDoS risks are concentrated in one well-documented
+  module rather than spread across audits.
+
+### Negative
+
+- **Coupling to agentic rules:** referral classification quality now depends on
+  agentic rules existing for the site. Sites with referral traffic but no
+  agentic rules get no topic/category (by design — the gate avoids misleading
+  `'Other'` columns).
+- **Regex dialect drift (JS vs Trino):** the stored rules are authored for
+  Trino/Athena (RE2J / Java `re2` syntax) but the JS twin compiles them under
+  V8's Irregexp engine (ECMAScript `RegExp`). Constructs valid in Trino —
+  POSIX character classes (`[[:alpha:]]`), possessive quantifiers (`a++`),
+  scoped/mid-pattern inline flags (`(?s)`, `(?i:...)`) — either throw at
+  `new RegExp(...)` (and are dropped) or compile to a different match set. A
+  rule that is dropped or matches differently in JS while still matching in the
+  SQL report causes the JS label to **drift** from the report label for that
+  URL. Mitigation: only a leading `(?i)` is normalised to the JS `i` flag; all
+  other dropped/rejected patterns are counted and surfaced via an aggregated
+  `log.warn` so the divergence is observable, but the drift is not eliminated.
+- **No sync guarantee between runs:** referral classification and the agentic
+  output are not transactionally coupled. If the agentic rules change between an
+  agentic run and a referral run (or between the weekly and daily referral
+  runs), the labels can drift for that window. There is no locking or
+  versioning that pins a referral report to the exact rule set the agentic
+  report used.
+- **Path-only matching:** referral rows expose only the path, whereas agentic
+  rules are authored against the full `url`. Rules that depend on host/scheme do
+  not match in the referral context. The JS twin documents this and matches on
+  the path (the best available signal).
+- **ReDoS exposure on attacker-influenceable input:** URL paths can originate
+  from referral data and are fed to regexes. The input cap bounds only
+  polynomial blow-up; exponential catastrophic backtracking is independent of
+  input length and is screened only by a known-incomplete, over-broad pattern
+  heuristic (see Implementation). The mitigation reduces exposure but is **not**
+  a hard guarantee.
+
+### Neutral
+
+- The daily CSV now always emits a **stable 14-column schema**; the `topic` and
+  `category` cells are **empty** when the site has no rules (they are not filled
+  with `'Other'`). This is a fixed schema regardless of rule availability — see
+  Implementation. (This supersedes an earlier design that switched between a
+  12-column and a 14-column schema conditionally.)
+- The weekly Excel report uses an explicit, fixed column list with
+  `topic`/`category` always present (empty when not classifying), so the layout
+  cannot drift with the SQL projection or enrichment state.
+- The `category` field carries the **page type** sourced from
+  `agentic_url_page_type_rules`, not a topic sub-category. The name is retained
+  for consistency with the agentic mapper and downstream consumers; see the
+  Notes section.
+
+## Implementation
+
+### Next Steps
+
+1. Add `src/common/agentic-url-classification.js` exposing `createClassifier`,
+   `classifyTopic`, `classifyPageType`, and `hasClassificationRules`
+   (`classifyTopic` / `classifyPageType` are exported for the parity test;
+   both handlers consume `createClassifier`). Compilation mirrors the agentic
+   SQL: topic rules
+   split into named (`CASE`) and unnamed (`REGEXP_EXTRACT` group 1) arms; page
+   rules are all treated as named `CASE` arms (an empty/missing name returns
+   `''`, matching the SQL builder, not `'Other'`).
+2. Apply ReDoS guards in the JS twin **without adding a dependency**:
+   - cap each input path to `MAX_URL_LENGTH` (2048) characters before matching;
+   - reject any rule whose regex source exceeds `MAX_PATTERN_LENGTH` (1000)
+     characters or trips a catastrophic-backtracking heuristic. The heuristic
+     rejects nested unbounded quantifiers (`(a+)+`), alternation overlap
+     (`(a|a)+`, `(a|aa)+`), doubly-nested groups in both forms — the inner
+     group quantified (`(([a-z])+)+`) and the inner group merely containing an
+     unbounded quantifier (`((a+))+`, `((a*))*`) — bounded-repeat-of-greedy
+     (`(.*a){20}`), and a bounded-range group `{m,n}` that is itself repeated
+     (`(a{1,3})+`).
+
+   **Important — what the input cap does and does not bound.** The input cap
+   bounds only **polynomial** blow-up (runtime that scales with input length).
+   It does **not** bound **exponential** blow-up: catastrophic backtracking is
+   driven by the number of ambiguous ways the engine can match a fixed prefix,
+   which is independent of total input length, so a short malicious input can
+   still hang. Exponential shapes are screened **only** by the pattern
+   heuristic, which is **known-incomplete** (shapes it does not recognise pass
+   through) and **over-broad** (it rejects some safe patterns). Together the two
+   guards are a screen that reduces exposure; they are **not** a proof of
+   safety. There is also no per-match wall-clock timeout: the V8 `RegExp` runs
+   synchronously and cannot be interrupted mid-match without a worker thread or
+   a non-backtracking engine, so a catastrophic shape the heuristic does not
+   recognise still hangs the call. A hard guarantee would require a
+   non-backtracking engine (e.g. RE2), which was explicitly rejected to avoid
+   adding a dependency.
+3. Wire the weekly handler (`src/llmo-referral-traffic/handler.js`) to build a
+   `createClassifier` once and enrich each row's `topic`/`category`, defaulting
+   to `''` when the classifier is null.
+4. Wire the daily handler (`src/llmo-referral-traffic-daily/handler.js`) to
+   fetch rules, classify each row's path, and emit the fixed 14-column CSV with
+   empty `topic`/`category` cells when no rules are present.
+
+### Output schemas
+
+**Daily CSV (`llmo-referral-traffic-daily`) — fixed 14 columns, in order:**
+
+```
+traffic_date, host, url_path, trf_platform, device, region,
+topic, category,
+pageviews, consent, trf_type, trf_channel, bounced, updated_by
+```
+
+`topic` and `category` are **empty strings** when the site has no agentic rules
+(or the fetch errored); they are never `'Other'` at the row level due to absent
+rules. The schema does not change with rule availability.
+
+**Weekly Excel (`llmo-referral-traffic`) — fixed columns, in order:**
+
+```
+path, trf_type, trf_channel, trf_platform, device, date,
+pageviews, consent, bounced, page_intent, region, topic, category
+```
+
+Headers are written explicitly (never inferred from the data), so `topic` and
+`category` are always present and empty when not classifying.
+
+### Migration Path
+
+For sites that already have agentic rules, the next referral run enriches
+automatically — no backfill of historical reports is performed. Sites without
+rules see empty topic/category cells until their agentic pipeline authors rules.
+
+### Reversibility
+
+To back the change out:
+
+1. Remove the classification wiring from both handlers (the
+   `fetchAgenticUrlClassificationRules` call, the `createClassifier` usage, and
+   the row enrichment).
+2. Revert the daily CSV to its pre-change 12-column schema (drop the `topic` and
+   `category` columns) and remove the `topic`/`category` columns from the weekly
+   `WEEKLY_COLUMNS` list.
+3. Optionally delete `src/common/agentic-url-classification.js` and its tests
+   once no other audit imports it.
+
+The agentic CDN-logs pipeline is unaffected by a rollback; it owns rule
+authoring independently.
+
+### Timeline
+
+Delivered as a single focused enhancement on the
+`feat/delete-page-intent-audit` line of work; no phased rollout required.
+
+## Validation
+
+### Success Metrics
+
+- Daily CSV and weekly Excel emit populated `topic`/`category` for sites with
+  agentic rules and empty cells for sites without, with no per-URL LLM calls
+  added.
+- For a sampled site, referral labels match the agentic CDN-logs report labels
+  for the same paths (allowing for the documented path-only and dialect-drift
+  exceptions).
+- Dropped/rejected pattern counts are visible in logs (`log.warn`) so drift is
+  observable in production.
+
+### Review Date
+
+Revisit if dialect-drift warnings become frequent in production, or if a
+downstream consumer requests a hard topic/category sync guarantee.
+
+## Related Decisions
+
+- Spec: `docs/specs/referral-traffic-topic-category-enrichment.md` — the
+  proposal this ADR ratifies.
+
+## References
+
+- `src/common/agentic-url-classification.js` — the JS twin classifier.
+- `src/common/agentic-url-classification-rules.js` — rule fetch.
+- `src/cdn-logs-report/utils/query-builder.js` — the agentic SQL classifier this
+  twin mirrors (`buildTopicExtractionSQL`, `generatePageTypeClassification`).
+- `src/llmo-referral-traffic/handler.js`,
+  `src/llmo-referral-traffic-daily/handler.js` — the two enriched handlers.
+
+## Notes
+
+**Category-naming hazard (future cleanup).** The `category` field actually
+carries the **page type** produced from `agentic_url_page_type_rules`, not a
+topic sub-category. The name `category` is inherited from the agentic mapper and
+is consumed under that name by the `referral_traffic_optel` pipeline and the
+existing agentic code. Renaming it now would risk breaking those downstream
+consumers, so the name is deliberately retained. This is flagged as future
+cleanup, not a change to make as part of this work.

--- a/docs/specs/referral-traffic-topic-category-enrichment.md
+++ b/docs/specs/referral-traffic-topic-category-enrichment.md
@@ -1,0 +1,282 @@
+# Referral Traffic Topic/Category Enrichment
+
+| Field | Value |
+|-------|-------|
+| **Status** | Implemented |
+| **Author** | Christopher Wisse |
+| **Created** | 2026-06-10 |
+| **Updated** | 2026-06-10 |
+| **Decided** | 2026-06-10 |
+| **Approvers** | N/A |
+| **Jira** | N/A |
+
+## Summary
+
+Add per-URL **topic** and **page-type category** to the referral traffic reports
+(weekly `llmo-referral-traffic` Excel and daily `llmo-referral-traffic-daily`
+CSV) by **reusing** the agentic CDN-logs regex-rule classifier rather than
+generating new classifications. A JavaScript twin of the agentic SQL classifier
+applies the already-cached per-site rules to URL paths at zero per-URL LLM cost,
+keeping referral labels consistent with the agentic report.
+
+## Problem Statement
+
+### Current State
+
+Referral traffic reports list LLM-referred pageviews per URL but carry no topic
+or page-type information. Separately, the agentic CDN-logs report
+(`cdn-logs-report`) already classifies each URL into a topic and a page-type
+category using a two-tier regex-rule classifier:
+
+- **Tier A (rare):** an LLM authors POSIX/Trino regex rules once per site and
+  caches them in Postgres (`agentic_url_category_rules`,
+  `agentic_url_page_type_rules`).
+- **Tier B (every run):** the cached rules are applied per URL. For Athena
+  reports this is emitted as a SQL `CASE`/`REGEXP_EXTRACT` expression
+  (`src/cdn-logs-report/utils/query-builder.js`).
+
+The retired `page-intent` audit produced a topic but via per-URL LLM calls,
+which was expensive; it was deleted.
+
+### Desired State
+
+Both referral reports show topic and category per URL, agreeing with the agentic
+report's taxonomy for the same site, with no per-URL LLM cost added.
+
+### Gap Analysis
+
+- The weekly audit is Athena-backed and could in principle reuse the SQL `CASE`,
+  but the daily audit reads parquet and classifies **in JavaScript** — there is
+  no Athena query to host a SQL `CASE`.
+- The cached rules are authored for the Trino/Athena regex engine; applying them
+  in JS requires a compatible (and risk-aware) JS implementation.
+- Referral rows expose only a URL path, while agentic rules are authored against
+  the full `url`.
+
+## Goals and Non-Goals
+
+### Goals
+
+- Populate `topic` and `category` per URL in both referral reports using the
+  existing cached agentic rules.
+- Keep referral labels consistent with the agentic CDN-logs report for the same
+  site.
+- Add **no** per-URL LLM cost.
+- Keep both report schemas stable and predictable regardless of whether a site
+  has rules.
+- Make any rule-application divergence observable in logs.
+
+### Non-Goals
+
+- This is **not** a replacement for the deleted `page-intent` audit. The intent
+  enum is out of scope; only topic and page-type category are covered.
+- Not authoring new classification rules — rule generation remains owned by the
+  agentic pipeline (Tier A).
+- Not backfilling historical referral reports.
+- Not introducing a transactional/versioned coupling that pins a referral report
+  to the exact rule set an agentic report used.
+- Not renaming the misleadingly named `category` field (see Risks).
+
+## Proposed Solution
+
+### Overview
+
+Introduce a single shared JavaScript module,
+`src/common/agentic-url-classification.js`, that is the in-process twin of the
+agentic SQL classifier. Both referral handlers fetch the cached rules, gate on
+whether usable rules exist, and — when they do — classify each row's URL path
+into `{ topic, category }`. When no usable rules exist, enrichment is skipped and
+the topic/category cells are left empty.
+
+### Technical Design
+
+**Two-tier classifier reuse.** Tier A (LLM rule authoring) is untouched and
+remains owned by the agentic pipeline. This work only adds a new Tier-B consumer:
+the referral handlers read the cached rules via the existing
+`fetchAgenticUrlClassificationRules`
+(`src/common/agentic-url-classification-rules.js`).
+
+**JS twin of the SQL classifier.** `agentic-url-classification.js` mirrors the
+two SQL builders:
+
+- *Topic* (`buildTopicExtractionSQL`): named rules act as a `CASE` (first match
+  wins, in `sort_order`); unnamed rules act as `REGEXP_EXTRACT(url, rx, 1)`
+  inside a `COALESCE` (first non-empty capture group 1 wins); fallback `'Other'`.
+- *Category / page type* (`generatePageTypeClassification`): a `CASE` over all
+  page rules (first match wins). An empty/missing rule name returns `''` (to
+  match the SQL builder, which emits a `THEN '<name>'` arm for every rule), and
+  only a no-match falls back to `'Other'`.
+
+The module exposes:
+- `createClassifier(rules, { log })` — compiles all patterns **once**, applies
+  the ReDoS guards up front, and returns `{ classify(urlPath) }`, or `null` when
+  rules are not usable. Both handlers consume this.
+- `classifyTopic` / `classifyPageType` — single-dimension helpers, exported for
+  the mechanical SQL-twin parity test.
+- `hasClassificationRules(rules)` — the rules-present predicate.
+
+**Rules-present gate.** Enrichment runs only when `hasClassificationRules`
+returns true (equivalently, when `createClassifier` returns non-null): the result
+must exist, have no `error`, and contain at least one topic or page pattern. When
+the gate is closed (no rules, or the fetch errored), the handlers skip
+classification and leave topic/category empty rather than tagging every row
+`'Other'`. The weekly handler distinguishes the two closed-gate cases in logs
+(absent rules → `info`; fetch error → `warn`).
+
+**Path-only matching.** Agentic rules are authored against the full `url`, but
+referral rows expose only the path. The twin matches against the path (the best
+available signal); rules that depend on host/scheme will not match. This is
+documented in the module.
+
+**ReDoS guard (no new dependency).** Because URL paths can be
+attacker-influenceable, the twin applies two guards:
+- inputs are capped to `MAX_URL_LENGTH` (2048) characters before matching;
+- rule sources longer than `MAX_PATTERN_LENGTH` (1000) characters, or matching a
+  catastrophic-backtracking heuristic, are rejected (the rule is dropped, not
+  applied). The heuristic covers nested unbounded quantifiers (`(a+)+`),
+  alternation overlap (`(a|a)+`, `(a|aa)+`), doubly-nested groups in both
+  forms — inner group quantified (`(([a-z])+)+`) and inner group merely
+  containing an unbounded quantifier (`((a+))+`, `((a*))*`) —
+  bounded-repeat-of-greedy (`(.*a){20}`), and a bounded-range group `{m,n}`
+  that is itself repeated (`(a{1,3})+`).
+
+**The input cap does NOT bound exponential blow-up.** It bounds only
+**polynomial** runtime (cost that scales with input length). Exponential
+catastrophic backtracking is driven by the number of ambiguous match paths over
+a fixed prefix — independent of total input length — so a short malicious input
+can still hang. Exponential shapes are screened **only** by the pattern
+heuristic, which is **known-incomplete** (unrecognised shapes pass) and
+**over-broad** (it rejects some safe patterns). The two guards reduce exposure;
+they are **not** a hard guarantee. There is also no per-match wall-clock
+timeout: the V8 `RegExp` runs synchronously and cannot be interrupted without a
+worker thread or a non-backtracking engine, so an unrecognised catastrophic
+shape still hangs the call. A hard guarantee would need a non-backtracking
+engine (e.g. RE2) — explicitly rejected here to avoid a new dependency.
+
+**Dialect handling.** The stored regex source targets Trino/Athena (RE2J). The
+twin compiles it under V8 (Irregexp / ECMAScript `RegExp`). Only a leading
+`(?i)` is normalised to the JS `i` flag. Patterns using Trino-only constructs
+(POSIX classes, possessive quantifiers, scoped inline flags) either throw at
+compile time (and are dropped) or match differently. Dropped/rejected patterns
+are counted and surfaced via a single aggregated `log.warn` so divergence is
+observable.
+
+**Output schemas** (fixed, schema-stable regardless of rule availability):
+
+*Daily CSV — 14 columns, in order:*
+```
+traffic_date, host, url_path, trf_platform, device, region,
+topic, category,
+pageviews, consent, trf_type, trf_channel, bounced, updated_by
+```
+`topic`/`category` are empty strings when the site has no rules; the column set
+does not change with rule availability.
+
+*Weekly Excel — fixed columns, in order:*
+```
+path, trf_type, trf_channel, trf_platform, device, date,
+pageviews, consent, bounced, page_intent, region, topic, category
+```
+Headers are written explicitly (never inferred from data), so `topic`/`category`
+are always present and empty when not classifying.
+
+### Implementation Phases
+
+This is a single focused enhancement, not a phased rollout:
+
+1. Add the shared JS twin module with ReDoS guards and dialect handling.
+2. Wire the weekly handler (compile-once via `createClassifier`).
+3. Wire the daily handler (fetch rules, classify paths, fixed 14-column CSV).
+4. Tests to 100% coverage on the new module and the touched handler paths.
+
+## Alternatives Considered
+
+| Alternative | Decision | Rationale |
+|-------------|----------|-----------|
+| Reuse agentic rules via a JS twin (chosen) | Accepted | Zero per-URL LLM cost; consistent labels; works for both Athena and JS/parquet paths. |
+| Generate referral-specific classifications via per-URL LLM | Rejected | Reintroduces the per-URL cost that made `page-intent` expensive; diverges from the agentic taxonomy. |
+| Share the SQL `CASE` expression across both audits | Rejected | Infeasible — the daily audit classifies parquet rows in JS with no Athena query to host the `CASE`. |
+| Emit `'Other'` for sites lacking rules | Rejected | Pollutes reports with meaningless values; the rules-present gate is cleaner. |
+
+See `docs/decisions/001-reuse-agentic-url-classification-for-referral-traffic.md`
+for the full decision record.
+
+## Success Criteria
+
+### Functional Requirements
+
+- Sites with agentic rules get populated `topic`/`category` in both reports;
+  sites without get empty cells (never `'Other'` due to absent rules).
+- Referral labels match the agentic CDN-logs report labels for the same site's
+  paths, within the documented path-only and dialect-drift exceptions.
+- Both report schemas are stable: daily CSV always 14 columns; weekly Excel
+  always includes `topic`/`category`.
+
+### Non-Functional Requirements
+
+- No per-URL LLM calls added; runtime classification cost is regex application
+  only.
+- ReDoS magnitude is bounded by the input cap and pattern guards, with no new
+  dependency added.
+- Dropped/rejected pattern counts are emitted to logs so drift is observable.
+- 100% line/branch/statement coverage on new and touched source (project rule).
+
+### Validation Plan
+
+- Unit tests over the JS twin: named/unnamed topic arms, page-type empty-name
+  reconciliation, `'Other'` fallbacks, `(?i)` normalisation, dropped Trino-only
+  patterns, oversize/nested-quantifier rejection, input capping, and the
+  `hasClassificationRules` gate.
+- Handler tests asserting the fixed schemas and empty cells when the gate is
+  closed.
+- Manual spot-check on a sampled site comparing referral labels against the
+  agentic CDN-logs report.
+
+## Dependencies
+
+### External Dependencies
+
+- Cached agentic rules in Postgres (`agentic_url_category_rules`,
+  `agentic_url_page_type_rules`), authored by the agentic CDN-logs pipeline's
+  Tier A.
+
+### Internal Dependencies
+
+- `src/common/agentic-url-classification-rules.js` (`fetchAgenticUrlClassificationRules`).
+- `src/cdn-logs-report/utils/query-builder.js` — the SQL classifier the twin
+  must stay faithful to (`buildTopicExtractionSQL`,
+  `generatePageTypeClassification`).
+- Both referral handlers: `src/llmo-referral-traffic/handler.js`,
+  `src/llmo-referral-traffic-daily/handler.js`.
+
+## Risks and Mitigations
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Regex dialect drift (JS Irregexp vs Trino RE2J): valid-in-Trino patterns throw or match differently in JS | Medium — some URLs mislabeled or unlabeled vs the agentic report | Medium | Normalise leading `(?i)`; drop patterns that fail to compile; count + `log.warn` dropped/rejected patterns so drift is observable. Not fully eliminated. |
+| No sync guarantee between runs: rules can change between agentic and referral runs (or weekly vs daily) | Low–Medium — transient label drift for the changed window | Low | Documented; accepted. No transactional coupling. Revisit if a hard guarantee is requested. |
+| ReDoS on attacker-influenceable URL paths | High if unbounded | Low | Input cap (2048), pattern length cap (1000), nested/adjacent unbounded-quantifier + bounded-range-group rejection; no new dependency. Bounds magnitude, not a hard guarantee. |
+| Coupling to agentic rules existing | Low — rule-less sites get no enrichment | Medium | Rules-present gate leaves cells empty rather than misleading `'Other'`. |
+| Path-only matching drops host/scheme-dependent rules | Low — a subset of rules never match referral rows | Medium | Documented; path is the best available signal. |
+| `category` field actually carries page type, not a sub-category | Low — naming confusion | High (naming is in place) | Retain the name (downstream `referral_traffic_optel` + agentic mapper depend on it); flagged as future cleanup. |
+
+## Open Questions
+
+- Should a future iteration add a versioned/pinned rule set so a referral report
+  can guarantee it used the same rules as a given agentic report? (Currently out
+  of scope.)
+- Should the `category` field eventually be renamed to `page_type` once
+  downstream consumers can be coordinated? (Tracked as future cleanup.)
+
+## References
+
+- ADR: `docs/decisions/001-reuse-agentic-url-classification-for-referral-traffic.md`
+- `src/common/agentic-url-classification.js`
+- `src/common/agentic-url-classification-rules.js`
+- `src/cdn-logs-report/utils/query-builder.js`
+
+## Revision History
+
+| Date | Author | Change |
+|------|--------|--------|
+| 2026-06-10 | Christopher Wisse | Initial spec, written alongside implementation. |

--- a/src/cdn-logs-report/agentic-daily-export.js
+++ b/src/cdn-logs-report/agentic-daily-export.js
@@ -15,38 +15,38 @@ import { v4 as uuidv4 } from 'uuid';
 import { loadSql, getImporterS3Client } from './utils/report-utils.js';
 import { weeklyBreakdownQueries } from './utils/query-builder.js';
 import { mapToAgenticTrafficBundle } from './utils/agentic-traffic-mapper.js';
+import { serializeCsv } from '../common/spreadsheet-safe.js';
+
+const AGENTIC_TRAFFIC_CSV_COLUMNS = [
+  'traffic_date',
+  'host',
+  'platform',
+  'agent_type',
+  'user_agent',
+  'http_status',
+  'url_path',
+  'hits',
+  'avg_ttfb_ms',
+  'dimensions',
+  'metrics',
+  'updated_by',
+];
+
+const AGENTIC_CLASSIFICATION_CSV_COLUMNS = [
+  'host',
+  'url_path',
+  'region',
+  'category_name',
+  'page_type',
+  'content_type',
+  'updated_by',
+];
 
 export function getPreviousUtcDate(referenceDate = new Date()) {
   const previous = new Date(referenceDate);
   previous.setUTCDate(previous.getUTCDate() - 1);
   previous.setUTCHours(0, 0, 0, 0);
   return previous;
-}
-
-function escapeCsvValue(value) {
-  if (value === null || value === undefined) {
-    return '';
-  }
-  let normalized;
-  if (typeof value === 'string') {
-    normalized = value;
-  } else if (typeof value === 'object') {
-    normalized = JSON.stringify(value);
-  } else {
-    normalized = String(value);
-  }
-
-  if (/["\n,]/.test(normalized)) {
-    return `"${normalized.replace(/"/g, '""')}"`;
-  }
-
-  return normalized;
-}
-
-function serializeCsv(rows, columns) {
-  const header = columns.join(',');
-  const body = rows.map((row) => columns.map((column) => escapeCsvValue(row[column])).join(','));
-  return [header, ...body].join('\r\n');
 }
 
 function getAgenticBundleKeyPrefix(siteId, trafficDate, batchId) {
@@ -81,34 +81,13 @@ async function uploadBundleToS3({
     s3Client.send(new PutObjectCommand({
       Bucket: bucket,
       Key: uploadedFiles.trafficKey,
-      Body: serializeCsv(trafficRows, [
-        'traffic_date',
-        'host',
-        'platform',
-        'agent_type',
-        'user_agent',
-        'http_status',
-        'url_path',
-        'hits',
-        'avg_ttfb_ms',
-        'dimensions',
-        'metrics',
-        'updated_by',
-      ]),
+      Body: serializeCsv(trafficRows, AGENTIC_TRAFFIC_CSV_COLUMNS),
       ContentType: 'text/csv',
     })),
     s3Client.send(new PutObjectCommand({
       Bucket: bucket,
       Key: uploadedFiles.classificationsKey,
-      Body: serializeCsv(classificationRows, [
-        'host',
-        'url_path',
-        'region',
-        'category_name',
-        'page_type',
-        'content_type',
-        'updated_by',
-      ]),
+      Body: serializeCsv(classificationRows, AGENTIC_CLASSIFICATION_CSV_COLUMNS),
       ContentType: 'text/csv',
     })),
   ]);
@@ -195,7 +174,6 @@ export const testHelpers = {
   cleanupBundleFromS3,
   createBundleId,
   dispatchAnalyticsEvent,
-  escapeCsvValue,
 };
 
 export async function runDailyAgenticExport({

--- a/src/cdn-logs-report/referral-daily-export.js
+++ b/src/cdn-logs-report/referral-daily-export.js
@@ -17,31 +17,13 @@ import { classifyTrafficSource } from '@adobe/spacecat-shared-rum-api-client/src
 import { joinBaseAndPath } from '../utils/url-utils.js';
 import { loadSql, getImporterS3Client } from './utils/report-utils.js';
 import { weeklyBreakdownQueries } from './utils/query-builder.js';
+import { serializeCsv } from '../common/spreadsheet-safe.js';
 
 const CDN_REFERRAL_CSV_COLUMNS = [
   'traffic_date', 'host', 'url_path', 'trf_platform', 'device', 'region',
   'pageviews', 'referrer', 'utm_source', 'utm_medium', 'tracking_param',
   'trf_type', 'trf_channel', 'updated_by',
 ];
-
-function escapeCsvValue(value) {
-  if (value === null || value === undefined) {
-    return '';
-  }
-  const normalized = String(value);
-  if (/["\r\n,]/.test(normalized)) {
-    return `"${normalized.replace(/"/g, '""')}"`;
-  }
-  return normalized;
-}
-
-function serializeCsv(rows) {
-  const header = CDN_REFERRAL_CSV_COLUMNS.join(',');
-  const body = rows.map(
-    (row) => CDN_REFERRAL_CSV_COLUMNS.map((col) => escapeCsvValue(row[col])).join(','),
-  );
-  return [header, ...body].join('\r\n');
-}
 
 export function getPreviousUtcDate(referenceDate = new Date()) {
   const previous = new Date(referenceDate);
@@ -137,7 +119,6 @@ async function getAnalyticsQueueUrl(context) {
 
 export const testHelpers = {
   cleanupCsvFromS3,
-  escapeCsvValue,
 };
 
 export async function runDailyReferralExport({
@@ -221,7 +202,7 @@ export async function runDailyReferralExport({
     await s3Client.send(new PutObjectCommand({
       Bucket: bucket,
       Key: csvKey,
-      Body: serializeCsv(rows),
+      Body: serializeCsv(rows, CDN_REFERRAL_CSV_COLUMNS),
       ContentType: 'text/csv',
     }));
 

--- a/src/cdn-logs-report/utils/query-builder.js
+++ b/src/cdn-logs-report/utils/query-builder.js
@@ -34,7 +34,10 @@ function buildWhereClause(conditions = [], siteFilters = []) {
 }
 
 // Page Type Classification
-function generatePageTypeClassification(remotePatterns = null) {
+// Exported for the JS-twin parity test (test/common/agentic-url-classification.test.js):
+// the mechanical parity check parses this builder's output and the JS classifier
+// must agree, so SQL edits cannot drift from the JS twin silently.
+export function generatePageTypeClassification(remotePatterns = null) {
   const patterns = remotePatterns?.pagePatterns || [];
 
   if (patterns.length === 0) {
@@ -58,7 +61,8 @@ function buildCountryExtractionSQL() {
 }
 
 // Topic Classification
-function buildTopicExtractionSQL(remotePatterns = null) {
+// Exported for the JS-twin parity test (see generatePageTypeClassification).
+export function buildTopicExtractionSQL(remotePatterns = null) {
   const patterns = remotePatterns?.topicPatterns || [];
 
   if (Array.isArray(patterns) && patterns.length > 0) {

--- a/src/common/agentic-url-classification.js
+++ b/src/common/agentic-url-classification.js
@@ -160,6 +160,11 @@ function toRegExp(pattern) {
   // ReDoS guard: reject oversized sources, and refuse known catastrophic shapes
   // up front (exponential shapes that the input cap cannot bound). This is a
   // coarse, incomplete screen — see REDOS_HEURISTICS — not a safety proof.
+  // The rule source is authored for RE2J (Trino/Athena), whose grammar has no
+  // backreferences or lookaround — the features most associated with
+  // catastrophic backtracking — so legitimately-authored rules cannot express
+  // the worst exponential shapes. This guard therefore mainly defends against a
+  // corrupted or hostile rules table, not against normal authored input.
   if (src.length > MAX_PATTERN_LENGTH || REDOS_HEURISTICS.some((re) => re.test(src))) {
     return null;
   }

--- a/src/common/agentic-url-classification.js
+++ b/src/common/agentic-url-classification.js
@@ -374,6 +374,12 @@ export function createClassifier(rules, { log } = {}) {
   return {
     classify(urlPath) {
       const cappedPath = capUrlPath(urlPath);
+      // Output key names are intentionally the inverse of the source-rule
+      // names (see module header): `topic` carries the agentic *category*
+      // rules (agentic_url_category_rules) and `category` carries the agentic
+      // *page-type* rules (agentic_url_page_type_rules). Kept for backward
+      // compatibility with existing report columns — renaming would break
+      // downstream consumers, so the legacy convention is preserved here.
       return {
         topic: applyTopic(cappedPath, topicCompiled),
         category: applyPageType(cappedPath, pageCompiled),

--- a/src/common/agentic-url-classification.js
+++ b/src/common/agentic-url-classification.js
@@ -1,0 +1,378 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * JS application of agentic URL classification rules.
+ *
+ * This is the in-process twin of the Athena SQL emitted by
+ * `src/cdn-logs-report/utils/query-builder.js`
+ * (`buildTopicExtractionSQL` / `generatePageTypeClassification`). Audits that
+ * classify URLs in JavaScript — rather than via an Athena `CASE` expression —
+ * use this module so that the topic/category assigned to a URL matches what the
+ * agentic CDN-logs report would assign for the same site. The authoritative
+ * check that the two stay in lockstep is the mechanical "SQL twin parity" block
+ * in `test/common/agentic-url-classification.test.js`, which parses the actual
+ * emitted SQL and asserts it agrees with this module over a probe set.
+ *
+ * The rules are produced by `fetchAgenticUrlClassificationRules`
+ * (`src/common/agentic-url-classification-rules.js`):
+ *   - `topicPatterns` ← `agentic_url_category_rules`  → topic
+ *   - `pagePatterns`  ← `agentic_url_page_type_rules`  → category (page type)
+ *
+ * NOTE: the agentic SQL applies these regexes against the full `url` column.
+ * Callers here typically only have a URL path, so matches are evaluated against
+ * the path. Patterns that depend on host/scheme will not match.
+ *
+ * DIALECT DIVERGENCE (JS vs Trino):
+ * The stored regex source is authored for Trino/Athena, whose regex engine is
+ * RE2J (Java / re2 syntax). This module compiles the same source with V8's
+ * Irregexp engine (ECMAScript `RegExp`). The two dialects are NOT identical.
+ * Constructs that are valid in Trino but throw or behave differently in JS
+ * include:
+ *   - POSIX character classes, e.g. `[[:alpha:]]`, `[[:digit:]]`
+ *   - possessive quantifiers, e.g. `a++`, `\d*+`
+ *   - mid-pattern / scoped inline flags, e.g. `(?s)`, `(?m)`, `(?i:...)`
+ * Patterns using these either throw at `new RegExp(...)` (→ dropped, see
+ * `toRegExp`) or compile to a different match set than Trino. A dropped rule is
+ * silently skipped here while it still matches in the SQL report, so the JS
+ * label can drift from the report label for that URL. `createClassifier`
+ * surfaces the *count* of dropped/rejected patterns via an aggregated
+ * `log.warn` so the divergence is observable. Only a leading `(?i)` is
+ * normalised to the JS `i` flag; all other inline flags are left to throw.
+ */
+
+/**
+ * Hard cap on the URL length we ever feed to a regex.
+ *
+ * IMPORTANT — what this does and does NOT bound. Capping the input length only
+ * bounds runtime for regexes whose backtracking cost grows *polynomially* with
+ * input size (e.g. `(a+)b` scanned over a long string). It does NOT bound the
+ * *exponential* blow-up shapes (nested/overlapping unbounded quantifiers such as
+ * `(a+)+`, `(a|a)+`): for those, cost explodes with the number of repetitions in
+ * a SHORT input and is effectively input-length-independent — a ~30-char string
+ * can already hang. Exponential shapes must therefore be rejected at compile
+ * time by `REDOS_HEURISTICS`; this cap is only the polynomial-case backstop.
+ */
+const MAX_URL_LENGTH = 2048;
+
+/** Reject regex sources longer than this (ReDoS magnitude guard). */
+const MAX_PATTERN_LENGTH = 1000;
+
+/**
+ * Compile-time screen for catastrophic-backtracking regex shapes.
+ *
+ * These are the exponential-blow-up shapes that `MAX_URL_LENGTH` canNOT mitigate
+ * (see the note there), so they must be refused before `new RegExp`. The screen
+ * rejects:
+ *   1. a group whose body contains an unbounded quantifier, itself repeated —
+ *      `(a+)+`, `(a*)*`, `(.*)*`, `(a+)*`, and the bounded-repeat variant
+ *      `(.*a){20}`;
+ *   2. an alternation-overlap group that is repeated — `(a|a)+`, `(a|aa)+`,
+ *      `(foo|foo)*` — where the alternatives can match the same input;
+ *   3. a doubly-nested quantified group where the OUTER group is repeated, in
+ *      BOTH of its catastrophic forms:
+ *        a. the inner group is itself quantified — `(([a-z])+)+` (quantifier
+ *           sits AFTER the inner `)`);
+ *        b. the inner group merely CONTAINS an unbounded quantifier —
+ *           `((a+))+`, `((a*))*`, `(([a-z]+))+` (quantifier sits INSIDE the
+ *           inner group, before its `)`). The two need separate heuristics
+ *           because `[^()]` stops at the first `)`, so the form-(a) screen does
+ *           not see the form-(b) inner `+`/`*`.
+ *   4. a bounded-range `{m,n}` group that is itself repeated by an outer
+ *      `+`/`*`/`{` — `(a{1,3})+`, `(a{1,2})*`, `([a-z]{1,2})+`, `(\w{1,2})+`.
+ *      The inner `{m,n}` makes each repetition match a VARIABLE span, so the
+ *      outer repeat backtracks exponentially over how that span is partitioned
+ *      — a SHORT input already hangs, so the `MAX_URL_LENGTH` cap cannot bound
+ *      it. Forms (1)–(3) miss this because the inner quantifier is `{m,n}`, not
+ *      a bare `+`/`*`.
+ *
+ * This is a COARSE, KNOWN-INCOMPLETE and intentionally OVER-BROAD screen, NOT a
+ * decision procedure:
+ *   - INCOMPLETE: it does not parse the regex grammar, so it misses shapes it
+ *     does not pattern-match (nesting deeper than one level, overlap split
+ *     across constructs, backreference-driven blow-up). A pattern passing this
+ *     screen is NOT proven safe. There is also no per-match wall-clock timeout:
+ *     a JS `RegExp` runs synchronously and cannot be interrupted in-process
+ *     without offloading to a worker thread or a linear-time engine (RE2) — a
+ *     new dependency that is deliberately NOT taken here. So a catastrophic
+ *     shape that slips this screen hangs the whole invocation; the screen is
+ *     the only line of defence and is sized to over-reject rather than miss.
+ *   - OVER-BROAD: shape (2)/(3)/(4) match on surface syntax, so a benign repeated
+ *     group that merely *contains* a `|`, a nested group, or a `{m,n}` range can
+ *     be rejected even when it is safe — e.g. shape (4) also rejects a
+ *     FIXED-width repeated group like `(a{2})+`, which is linear, not just the
+ *     variable-span `(a{1,3})+`. Rejected rules are skipped (and counted),
+ *     trading a little recall on exotic-but-safe rules for refusing the
+ *     dangerous ones. Single bounded groups like `([^/]+)` and a standalone
+ *     range like `([a-z]{2,4})` (no outer repeat) are NOT flagged.
+ *
+ * Note the trailing class is `[+*{]` (not just `[+*]`) so a `{n,m}` repeat of a
+ * dangerous group — e.g. `(.*a){20}` — is caught as well as `+`/`*`.
+ */
+const REDOS_HEURISTICS = [
+  /\([^)]*[+*][^)]*\)[+*{]/,
+  /\([^)]*\|[^)]*\)[+*{]/,
+  /\([^()]*\([^()]*\)[+*][^()]*\)[+*{]/,
+  /\([^()]*\([^()]*[+*][^()]*\)[^()]*\)[+*{]/,
+  /\([^()]*\{[^}]*\}[^()]*\)[+*{]/,
+];
+
+/**
+ * Compiles a stored rule regex into a `RegExp`, honouring a leading `(?i)`
+ * inline flag (Trino/Athena style) by converting it to the JS `i` flag.
+ *
+ * Returns `null` (a "failure") for patterns that:
+ *   - are not strings (guards `new RegExp(undefined)` compiling to `/undefined/`
+ *     and matching the literal text `undefined`);
+ *   - exceed `MAX_PATTERN_LENGTH`, or trip one of `REDOS_HEURISTICS` (a coarse,
+ *     incomplete, over-broad catastrophic-backtracking screen — see its note;
+ *     it refuses known dangerous shapes but does NOT prove the rest safe);
+ *   - fail to compile under V8/Irregexp (e.g. Trino-only syntax — see the
+ *     dialect-divergence note at the top of the file).
+ * Returning `null` lets a single bad rule be skipped instead of breaking
+ * classification of an entire site; callers count these to report drift.
+ *
+ * @param {string} pattern - stored POSIX/Trino regex source
+ * @returns {RegExp|null}
+ */
+function toRegExp(pattern) {
+  // `new RegExp(undefined)` yields `/undefined/`; reject non-strings outright.
+  if (typeof pattern !== 'string') {
+    return null;
+  }
+
+  let flags = '';
+  let src = pattern;
+  if (src.startsWith('(?i)')) {
+    flags = 'i';
+    src = src.slice(4);
+  }
+
+  // ReDoS guard: reject oversized sources, and refuse known catastrophic shapes
+  // up front (exponential shapes that the input cap cannot bound). This is a
+  // coarse, incomplete screen — see REDOS_HEURISTICS — not a safety proof.
+  if (src.length > MAX_PATTERN_LENGTH || REDOS_HEURISTICS.some((re) => re.test(src))) {
+    return null;
+  }
+
+  try {
+    return new RegExp(src, flags);
+  } catch {
+    return null;
+  }
+}
+
+/** Caps an input to `MAX_URL_LENGTH` characters (ReDoS magnitude guard). */
+function capUrlPath(urlPath) {
+  return String(urlPath).slice(0, MAX_URL_LENGTH);
+}
+
+/**
+ * Sorts rule rows by numeric `sort_order` ascending, mirroring the SQL
+ * `ORDER BY sort_order` used when the rules are fetched. Rows without an
+ * integer `sort_order` keep their relative array order (stable sort), so an
+ * already-ordered or order-less list is left untouched.
+ *
+ * @param {Array<object>} patterns
+ * @returns {Array<object>}
+ */
+function sortByOrder(patterns) {
+  return patterns
+    .map((pattern, index) => ({ pattern, index }))
+    .sort((a, b) => {
+      const ao = Number.isInteger(a.pattern?.sort_order)
+        ? a.pattern.sort_order
+        : a.index;
+      const bo = Number.isInteger(b.pattern?.sort_order)
+        ? b.pattern.sort_order
+        : b.index;
+      return ao - bo || a.index - b.index;
+    })
+    .map(({ pattern }) => pattern);
+}
+
+/**
+ * Compiles a list of rule rows once into `{ name, re }` entries, dropping rows
+ * whose regex fails to compile or is rejected by the guards. Reports the number
+ * of dropped rows via `failures` so the caller can surface drift.
+ *
+ * For topic rules, `splitNamed` separates named (`CASE`) from unnamed
+ * (`REGEXP_EXTRACT`) entries. Page rules pass `splitNamed = false`: every page
+ * rule is treated as a named `CASE` arm even when its name is empty — see the
+ * empty-name note on `classifyPageType`.
+ *
+ * @param {Array<{name?: string, regex: string, sort_order?: number}>} patterns
+ * @param {boolean} splitNamed
+ * @returns {{named: Array, extract: Array, failures: number}}
+ */
+function compilePatterns(patterns, splitNamed) {
+  const named = [];
+  const extract = [];
+  let failures = 0;
+
+  for (const pattern of sortByOrder(patterns)) {
+    const re = toRegExp(pattern.regex);
+    if (!re) {
+      failures += 1;
+    } else if (splitNamed && !pattern.name) {
+      extract.push({ re });
+    } else {
+      named.push({ re, name: pattern.name });
+    }
+  }
+
+  return { named, extract, failures };
+}
+
+/**
+ * Applies compiled topic patterns. Mirrors `buildTopicExtractionSQL`:
+ *   1. Named patterns act as a `CASE` — first matching rule wins, in order.
+ *   2. Unnamed patterns act as `REGEXP_EXTRACT(url, rx, 1)` inside a `COALESCE`
+ *      — first non-empty capture group 1 wins, in order.
+ *   3. Falls back to `'Other'`.
+ *
+ * @param {string} cappedPath
+ * @param {{named: Array, extract: Array}} compiled
+ * @returns {string}
+ */
+function applyTopic(cappedPath, { named, extract }) {
+  for (const { re, name } of named) {
+    if (re.test(cappedPath)) {
+      return name;
+    }
+  }
+
+  for (const { re } of extract) {
+    const match = re.exec(cappedPath);
+    if (match && match[1]) {
+      return match[1];
+    }
+  }
+
+  return 'Other';
+}
+
+/**
+ * Applies compiled page-type patterns. Mirrors `generatePageTypeClassification`:
+ * a `CASE` over the rules where the first matching rule wins, falling back to
+ * `'Other'`.
+ *
+ * @param {string} cappedPath
+ * @param {{named: Array}} compiled
+ * @returns {string}
+ */
+function applyPageType(cappedPath, { named }) {
+  for (const { re, name } of named) {
+    if (re.test(cappedPath)) {
+      return name ?? '';
+    }
+  }
+
+  return 'Other';
+}
+
+/**
+ * Classifies a URL path into a topic, mirroring `buildTopicExtractionSQL`.
+ * See `applyTopic` for the matching semantics.
+ *
+ * @param {string} urlPath
+ * @param {Array<{name?: string, regex: string}>} [topicPatterns=[]]
+ * @returns {string}
+ */
+export function classifyTopic(urlPath, topicPatterns = []) {
+  const compiled = compilePatterns(topicPatterns, true);
+  return applyTopic(capUrlPath(urlPath), compiled);
+}
+
+/**
+ * Classifies a URL path into a page-type category, mirroring
+ * `generatePageTypeClassification`.
+ *
+ * EMPTY-NAME HANDLING — KNOWN DIVERGENCE from the SQL twin. The SQL builder
+ * emits a `WHEN <rx> THEN '<name>'` arm for *every* page rule, interpolating the
+ * name via `sqlEscape(pattern.name)`. For a missing/empty name that means:
+ *   - `name === undefined` → `sqlEscape(undefined)` is `String(undefined)` →
+ *     the SQL emits the literal string `'undefined'`;
+ *   - `name === null` → likewise the literal string `'null'`;
+ *   - `name === ''` → the empty string `''`.
+ * This JS twin deliberately does NOT reproduce the `'undefined'`/`'null'`
+ * literals: a matching page rule with a missing name returns `''` (`name ?? ''`)
+ * rather than the string `"undefined"`/`"null"`, because surfacing those literal
+ * tokens as a category label is a bug, not a value we want to match. So for a
+ * matched rule whose name is `undefined` or `null` the JS label is `''` while
+ * the SQL report label is `'undefined'`/`'null'` — an intentional divergence.
+ * (An explicitly empty `''` name agrees in both.) Only when no rule matches do
+ * both fall back to `'Other'`.
+ *
+ * @param {string} urlPath
+ * @param {Array<{name?: string, regex: string}>} [pagePatterns=[]]
+ * @returns {string}
+ */
+export function classifyPageType(urlPath, pagePatterns = []) {
+  const compiled = compilePatterns(pagePatterns, false);
+  return applyPageType(capUrlPath(urlPath), compiled);
+}
+
+/**
+ * Whether a fetched rule set is usable for classification. Used as the
+ * "rules present" gate: when no rules exist (or the fetch errored), callers
+ * skip enrichment rather than tagging every row as `'Other'`.
+ *
+ * @param {object|null} rules - result of `fetchAgenticUrlClassificationRules`
+ * @returns {boolean}
+ */
+export function hasClassificationRules(rules) {
+  return Boolean(
+    rules
+    && !rules.error
+    && ((rules.topicPatterns && rules.topicPatterns.length > 0)
+      || (rules.pagePatterns && rules.pagePatterns.length > 0)),
+  );
+}
+
+/**
+ * Builds a reusable classifier that compiles all patterns ONCE and applies the
+ * ReDoS guards up front. Returns `null` when the rule set is not usable (see
+ * `hasClassificationRules`), so callers can use the return value as their
+ * "rules present" gate.
+ *
+ * When one or more patterns are dropped (failed to compile or rejected by a
+ * guard) and a `log` is supplied, a single aggregated `log.warn` is emitted at
+ * construction time — see the dialect-divergence note at the top of the file.
+ *
+ * @param {{topicPatterns?: Array, pagePatterns?: Array}} rules
+ * @param {{log?: object}} [options]
+ * @returns {{classify: (urlPath: string) => {topic: string, category: string}}|null}
+ */
+export function createClassifier(rules, { log } = {}) {
+  if (!hasClassificationRules(rules)) {
+    return null;
+  }
+
+  const topicCompiled = compilePatterns(rules.topicPatterns ?? [], true);
+  const pageCompiled = compilePatterns(rules.pagePatterns ?? [], false);
+  const failures = topicCompiled.failures + pageCompiled.failures;
+
+  if (failures > 0 && log?.warn) {
+    log.warn(`agentic-url-classification: ${failures} rule pattern(s) skipped (failed to compile or rejected)`);
+  }
+
+  return {
+    classify(urlPath) {
+      const cappedPath = capUrlPath(urlPath);
+      return {
+        topic: applyTopic(cappedPath, topicCompiled),
+        category: applyPageType(cappedPath, pageCompiled),
+      };
+    },
+  };
+}

--- a/src/common/spreadsheet-safe.js
+++ b/src/common/spreadsheet-safe.js
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Shared spreadsheet/CSV safety helpers.
+ *
+ * Several reports (weekly Excel + multiple daily CSV exports) write
+ * visitor-influenceable RUM values into spreadsheets. A cell whose value begins
+ * with a formula trigger (`= + - @`, tab, CR, or LF) is interpreted as a formula
+ * by Excel/Sheets — a CSV/formula-injection vector. Leading whitespace does not
+ * defang the operator: `' =1+1'` is still evaluated. These helpers neutralize
+ * that by prefixing a single quote, and (for CSV) apply RFC-4180 quoting.
+ *
+ * Consolidated here so every report shares one definition; previously each site
+ * carried its own near-duplicate copy that could drift.
+ */
+
+/**
+ * Leading characters that turn a spreadsheet cell into a formula.
+ */
+export const FORMULA_TRIGGERS = ['=', '+', '-', '@', '\t', '\r', '\n'];
+
+/**
+ * A value needs formula neutralization when it either begins with a bare control
+ * character (tab/CR/LF, dangerous on their own) or has optional leading
+ * whitespace followed by a formula operator (`= + - @`). Leading whitespace is
+ * NOT a safe guard — Excel/Sheets trim it before evaluating — so `' =x'`,
+ * `'\t=x'`, and `'\n=x'` are all treated as formulas. Plain leading-whitespace
+ * text without an operator (`' foo'`, `'   '`) is left alone.
+ */
+const NEUTRALIZE_PATTERN = /^[\t\r\n]|^\s*[=+\-@]/;
+
+/**
+ * Prefixes a single quote when the (already-stringified) value would be
+ * interpreted as a formula. The original text is preserved verbatim — only the
+ * leading quote is added; no trimming or rewriting.
+ *
+ * @param {string} str
+ * @returns {string}
+ */
+function neutralizeFormula(str) {
+  return NEUTRALIZE_PATTERN.test(str) ? `'${str}` : str;
+}
+
+/**
+ * Excel-cell sanitizer (for values handed to a spreadsheet library, e.g. ExcelJS
+ * `addRow`, where RFC-4180 quoting is the library's job — only formula
+ * neutralization is needed here). String values starting with a formula trigger
+ * are prefixed with a single quote; all other values pass through unchanged
+ * (numbers, booleans, null, etc. are not formula vectors).
+ *
+ * @param {*} value
+ * @returns {*}
+ */
+export function sanitizeSpreadsheetValue(value) {
+  if (typeof value === 'string') {
+    return neutralizeFormula(value);
+  }
+  return value;
+}
+
+/**
+ * CSV field escaper. Normalizes the value to a string, neutralizes a leading
+ * formula trigger, then applies RFC-4180 quoting when the field contains a
+ * quote, CR, LF, or comma.
+ *
+ *   - `null`/`undefined` → `''` (empty field).
+ *   - objects → `JSON.stringify` (so structured cells serialize deterministically).
+ *   - everything else → `String(value)`.
+ *
+ * @param {*} value
+ * @returns {string}
+ */
+export function escapeCsvValue(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  const normalized = neutralizeFormula(
+    typeof value === 'object' ? JSON.stringify(value) : String(value),
+  );
+
+  if (/["\r\n,]/.test(normalized)) {
+    return `"${normalized.replace(/"/g, '""')}"`;
+  }
+  return normalized;
+}
+
+/**
+ * Serializes rows to a CSV string. `columns` is REQUIRED (no default): each
+ * caller passes its own explicit column list so the projected schema is always
+ * stated at the call site and cannot silently fall back to a wrong default.
+ * Rows are joined with CRLF (`\r\n`), matching the existing exports.
+ *
+ * @param {Array<object>} rows
+ * @param {Array<string>} columns - explicit, ordered column keys
+ * @returns {string}
+ */
+export function serializeCsv(rows, columns) {
+  const header = columns.join(',');
+  const body = rows.map((row) => columns.map((col) => escapeCsvValue(row[col])).join(','));
+  return [header, ...body].join('\r\n');
+}

--- a/src/common/spreadsheet-safe.js
+++ b/src/common/spreadsheet-safe.js
@@ -36,6 +36,12 @@ export const FORMULA_TRIGGERS = ['=', '+', '-', '@', '\t', '\r', '\n'];
  * NOT a safe guard — Excel/Sheets trim it before evaluating — so `' =x'`,
  * `'\t=x'`, and `'\n=x'` are all treated as formulas. Plain leading-whitespace
  * text without an operator (`' foo'`, `'   '`) is left alone.
+ *
+ * Note on `-`: a leading `-` is a formula trigger, so a value like `-5` would
+ * be prefixed (`'-5`). No column in these reports holds a negative number
+ * today, so this is not hit in practice; quoting is the deliberate safe default
+ * because `-2+cmd(...)` is a valid formula. If a future column can carry a
+ * genuine negative numeric, add a numeric-skip guard (e.g. `!Number.isNaN`).
  */
 const NEUTRALIZE_PATTERN = /^[\t\r\n]|^\s*[=+\-@]/;
 

--- a/src/llmo-referral-traffic-daily/handler.js
+++ b/src/llmo-referral-traffic-daily/handler.js
@@ -17,6 +17,9 @@ import { Audit } from '@adobe/spacecat-shared-data-access';
 import { AuditBuilder } from '../common/audit-builder.js';
 import { wwwUrlResolver } from '../common/index.js';
 import { DEFAULT_COUNTRY_PATTERNS } from '../common/country-patterns.js';
+import { fetchAgenticUrlClassificationRules } from '../common/agentic-url-classification-rules.js';
+import { createClassifier } from '../common/agentic-url-classification.js';
+import { serializeCsv } from '../common/spreadsheet-safe.js';
 
 const { AUDIT_STEP_DESTINATIONS } = Audit;
 
@@ -53,26 +56,16 @@ function validateDate(date) {
   }
 }
 
+// Stable 14-column daily schema (I5). topic + category are always present,
+// positioned after region (mirroring the agentic CDN-logs report layout); their
+// cells are empty when no classification rules exist for the site — never 'Other'.
 const CSV_COLUMNS = [
   'traffic_date', 'host', 'url_path', 'trf_platform', 'device', 'region',
+  'topic', 'category',
   'pageviews', 'consent', 'trf_type', 'trf_channel', 'bounced', 'updated_by',
 ];
 
-function escapeCsvValue(value) {
-  const normalized = String(value ?? '');
-  if (/["\r\n,]/.test(normalized)) {
-    return `"${normalized.replace(/"/g, '""')}"`;
-  }
-  return normalized;
-}
-
-export function serializeCsv(rows) {
-  const header = CSV_COLUMNS.join(',');
-  const body = rows.map((row) => CSV_COLUMNS.map((col) => escapeCsvValue(row[col])).join(','));
-  return [header, ...body].join('\r\n');
-}
-
-function buildCsvRows(records, host) {
+function buildCsvRows(records, host, classifier = null) {
   const grouped = new Map();
 
   for (const row of records) {
@@ -93,6 +86,10 @@ function buildCsvRows(records, host) {
       if (grouped.has(key)) {
         grouped.get(key).pageviews += pageviews;
       } else {
+        // topic/category always present; empty when no classifier (I5)
+        const { topic, category } = classifier
+          ? classifier.classify(urlPath)
+          : { topic: '', category: '' };
         grouped.set(key, {
           traffic_date: trafficDate,
           host,
@@ -100,6 +97,8 @@ function buildCsvRows(records, host) {
           trf_platform: trfPlatform,
           device,
           region,
+          topic,
+          category,
           pageviews,
           consent: consentBool ? 'true' : 'false',
           trf_type: 'earned',
@@ -226,7 +225,21 @@ export async function referralTrafficDailyRunner(context) {
     throw err;
   }
 
-  const rows = buildCsvRows(records, host);
+  // fetch agentic URL classification rules (topic + category); gate enrichment
+  // on rules being present so cells stay empty rather than blanket-tagged 'Other'
+  const classificationRules = await fetchAgenticUrlClassificationRules(site, context);
+  const classifier = createClassifier(classificationRules, { log });
+  // M5: distinguish a failed fetch from a site with no rules. Both yield a null
+  // classifier; the error shape on the fetch result disambiguates the log line.
+  if (classifier) {
+    log.info(`[llmo-referral-traffic-daily] Agentic classification rules found for site ${siteId}`);
+  } else if (classificationRules?.error) {
+    log.warn(`[llmo-referral-traffic-daily] Failed to fetch agentic classification rules for site ${siteId}; topic/category left empty`);
+  } else {
+    log.info(`[llmo-referral-traffic-daily] No agentic classification rules for site ${siteId}; topic/category left empty`);
+  }
+
+  const rows = buildCsvRows(records, host, classifier);
 
   if (rows.length === 0) {
     log.info(`[llmo-referral-traffic-daily] No LLM referral rows after filter for site ${siteId} on ${date}`);
@@ -236,7 +249,7 @@ export async function referralTrafficDailyRunner(context) {
     };
   }
 
-  const csvBody = serializeCsv(rows);
+  const csvBody = serializeCsv(rows, CSV_COLUMNS);
 
   await s3Client.send(new PutObjectCommand({
     Bucket: bucket,

--- a/src/llmo-referral-traffic-daily/handler.js
+++ b/src/llmo-referral-traffic-daily/handler.js
@@ -226,8 +226,12 @@ export async function referralTrafficDailyRunner(context) {
   }
 
   // fetch agentic URL classification rules (topic + category); gate enrichment
-  // on rules being present so cells stay empty rather than blanket-tagged 'Other'
+  // on rules being present so cells stay empty rather than blanket-tagged 'Other'.
+  // Timed: the Postgres fetch latency adds to Lambda runtime and is the first
+  // thing to check during latency investigations.
+  const rulesFetchStart = Date.now();
   const classificationRules = await fetchAgenticUrlClassificationRules(site, context);
+  log.info(`[llmo-referral-traffic-daily] Fetched agentic classification rules for site ${siteId} in ${Date.now() - rulesFetchStart}ms`);
   const classifier = createClassifier(classificationRules, { log });
   // M5: distinguish a failed fetch from a site with no rules. Both yield a null
   // classifier; the error shape on the fetch result disambiguates the log line.

--- a/src/llmo-referral-traffic/handler.js
+++ b/src/llmo-referral-traffic/handler.js
@@ -11,7 +11,6 @@
  */
 
 /* eslint-disable no-param-reassign */
-/* c8 ignore start */
 
 import {
   getStaticContent, getWeekInfo, isoCalendarWeek,
@@ -23,8 +22,20 @@ import { AuditBuilder } from '../common/audit-builder.js';
 import { wwwUrlResolver } from '../common/index.js';
 import { createLLMOSharepointClient, saveExcelReport } from '../utils/report-uploader.js';
 import { DEFAULT_COUNTRY_PATTERNS } from '../common/country-patterns.js';
+import { fetchAgenticUrlClassificationRules } from '../common/agentic-url-classification-rules.js';
+import { createClassifier } from '../common/agentic-url-classification.js';
+import { sanitizeSpreadsheetValue } from '../common/spreadsheet-safe.js';
 
 const { AUDIT_STEP_DESTINATIONS } = Audit;
+
+// Explicit weekly column order. topic/category always present (empty when not
+// classifying) so the Excel schema is stable regardless of rule availability.
+// Headers are NOT inferred from the data so layout cannot drift when the SQL
+// projection or enrichment changes.
+const WEEKLY_COLUMNS = [
+  'path', 'trf_type', 'trf_channel', 'trf_platform', 'device', 'date',
+  'pageviews', 'consent', 'bounced', 'page_intent', 'region', 'topic', 'category',
+];
 
 const COMPILED_COUNTRY_PATTERNS = DEFAULT_COUNTRY_PATTERNS.map(({ name, regex }) => {
   let flags = '';
@@ -51,20 +62,21 @@ async function createWorkbook(results) {
   const workbook = new ExcelJS.Workbook();
   const worksheet = workbook.addWorksheet('Sheet1');
 
-  if (results.length === 0) {
-    return workbook;
-  }
-
-  // set headers from first object
-  const headers = Object.keys(results[0]);
-  worksheet.columns = headers.map((header) => ({
+  // explicit headers (I6): never inferred from the data, so topic/category are
+  // always present and the column order is stable
+  worksheet.columns = WEEKLY_COLUMNS.map((header) => ({
     header,
     key: header,
     width: 20,
   }));
 
   for (const item of results) {
-    worksheet.addRow(item);
+    const row = {};
+    for (const col of WEEKLY_COLUMNS) {
+      // sanitize against spreadsheet formula injection on visitor-influenced cells
+      row[col] = sanitizeSpreadsheetValue(item[col] ?? '');
+    }
+    worksheet.addRow(row);
   }
 
   return workbook;
@@ -118,7 +130,7 @@ export async function referralTrafficRunner(context) {
   const auditResult = audit.getAuditResult();
   const { week, year } = auditResult;
   const { temporalCondition } = getWeekInfo(week, year);
-  const siteId = site.getSiteId();
+  const siteId = site.getId();
   const baseURL = site.getBaseURL();
 
   log.info(
@@ -163,10 +175,29 @@ export async function referralTrafficRunner(context) {
     return acc;
   }, {});
 
-  // enrich with extra fields
+  // fetch agentic URL classification rules (topic + category); gate enrichment
+  // on rules being present so rows are not blanket-tagged as 'Other'
+  const classificationRules = await fetchAgenticUrlClassificationRules(site, context);
+  const classifier = createClassifier(classificationRules, { log });
+  // M5: distinguish a failed fetch from a site that simply has no rules. The
+  // classifier is null in both cases, so the fetch error shape disambiguates.
+  if (classifier) {
+    log.info('[llmo-referral-traffic] Agentic classification rules found; enriching with topic and category');
+  } else if (classificationRules?.error) {
+    log.warn('[llmo-referral-traffic] Failed to fetch agentic classification rules; leaving topic/category empty');
+  } else {
+    log.info('[llmo-referral-traffic] No agentic classification rules for site; skipping topic/category enrichment');
+  }
+
+  // enrich with extra fields. topic/category default to '' when not classifying.
   results.forEach((result) => {
     result.page_intent = pageIntentMap[result.path] || '';
     result.region = extractCountryCode(result.path);
+    const { topic, category } = classifier
+      ? classifier.classify(result.path)
+      : { topic: '', category: '' };
+    result.topic = topic;
+    result.category = category;
   });
   log.info(`[llmo-referral-traffic] Data enrichment completed for ${results.length} rows`);
 
@@ -208,4 +239,3 @@ export default new AuditBuilder()
     referralTrafficRunner,
   )
   .build();
-/* c8 ignore end */

--- a/src/llmo-referral-traffic/handler.js
+++ b/src/llmo-referral-traffic/handler.js
@@ -176,8 +176,12 @@ export async function referralTrafficRunner(context) {
   }, {});
 
   // fetch agentic URL classification rules (topic + category); gate enrichment
-  // on rules being present so rows are not blanket-tagged as 'Other'
+  // on rules being present so rows are not blanket-tagged as 'Other'.
+  // Timed: the Postgres fetch latency adds to Lambda runtime and is the first
+  // thing to check during latency investigations.
+  const rulesFetchStart = Date.now();
   const classificationRules = await fetchAgenticUrlClassificationRules(site, context);
+  log.info(`[llmo-referral-traffic] Fetched agentic classification rules in ${Date.now() - rulesFetchStart}ms`);
   const classifier = createClassifier(classificationRules, { log });
   // M5: distinguish a failed fetch from a site that simply has no rules. The
   // classifier is null in both cases, so the fetch error shape disambiguates.

--- a/test/audits/cdn-logs-report/agentic-daily-export.test.js
+++ b/test/audits/cdn-logs-report/agentic-daily-export.test.js
@@ -22,13 +22,25 @@ use(sinonChai);
 
 describe('agentic daily export', () => {
   let sandbox;
+  let mockedModules;
+
+  // Wrap esmock so every mocked module is tracked and purged after each test.
+  // Without purging, esmock's global registrations leak across spec files and
+  // cause nondeterministic cross-file pollution in the full suite.
+  async function loadMocked(...args) {
+    const module = await esmock(...args);
+    mockedModules.push(module);
+    return module;
+  }
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
+    mockedModules = [];
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     sandbox.restore();
+    await Promise.all(mockedModules.map((module) => esmock.purge(module)));
   });
 
   function createConfiguration(queueUrl = 'https://sqs.us-east-1.amazonaws.com/123/analytics-queue') {
@@ -75,7 +87,7 @@ describe('agentic daily export', () => {
       send: sandbox.stub().resolves({}),
     };
 
-    const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js', {
+    const module = await loadMocked('../../../src/cdn-logs-report/agentic-daily-export.js', {
       '../../../src/cdn-logs-report/utils/report-utils.js': {
         loadSql: sandbox.stub().resolves('CREATE DATABASE IF NOT EXISTS test_db'),
         getImporterS3Client: () => s3Client,
@@ -206,9 +218,12 @@ describe('agentic daily export', () => {
       }),
     };
 
-    const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js', {
+    const s3Client = { send: sandbox.stub().resolves({}) };
+
+    const module = await loadMocked('../../../src/cdn-logs-report/agentic-daily-export.js', {
       '../../../src/cdn-logs-report/utils/report-utils.js': {
         loadSql: sandbox.stub().resolves('CREATE DATABASE'),
+        getImporterS3Client: () => s3Client,
       },
       '../../../src/cdn-logs-report/utils/query-builder.js': {
         weeklyBreakdownQueries: queryBuilder,
@@ -218,8 +233,6 @@ describe('agentic daily export', () => {
         v4: () => 'batch-123',
       },
     });
-
-    const s3Client = { send: sandbox.stub().resolves({}) };
 
     await module.runDailyAgenticExport({
       athenaClient: {
@@ -258,7 +271,7 @@ describe('agentic daily export', () => {
   });
 
   it('logs a warning when cleanup after failure also fails', async () => {
-    const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js');
+    const module = await loadMocked('../../../src/cdn-logs-report/agentic-daily-export.js');
     const log = {
       warn: sandbox.spy(),
     };
@@ -283,7 +296,7 @@ describe('agentic daily export', () => {
   });
 
   it('guards against dispatch without a queue URL', async () => {
-    const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js');
+    const module = await loadMocked('../../../src/cdn-logs-report/agentic-daily-export.js');
 
     await expect(module.testHelpers.dispatchAnalyticsEvent({
       context: {
@@ -303,7 +316,7 @@ describe('agentic daily export', () => {
   });
 
   it('dispatches with FIFO MessageGroupId and MessageDeduplicationId', async () => {
-    const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js');
+    const module = await loadMocked('../../../src/cdn-logs-report/agentic-daily-export.js');
     const sendMessage = sandbox.stub().resolves();
 
     const result = await module.testHelpers.dispatchAnalyticsEvent({
@@ -333,7 +346,7 @@ describe('agentic daily export', () => {
   });
 
   it('requires an importer bucket before running the daily export', async () => {
-    const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js');
+    const module = await loadMocked('../../../src/cdn-logs-report/agentic-daily-export.js');
 
     await expect(module.runDailyAgenticExport({
       athenaClient: {
@@ -377,7 +390,7 @@ describe('agentic daily export', () => {
   });
 
   it('skips upload and dispatch when there are no traffic rows', async () => {
-    const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js', {
+    const module = await loadMocked('../../../src/cdn-logs-report/agentic-daily-export.js', {
       '../../../src/cdn-logs-report/utils/report-utils.js': {
         loadSql: sandbox.stub().resolves('CREATE DATABASE'),
       },
@@ -451,7 +464,7 @@ describe('agentic daily export', () => {
 
   it('fails before Athena or S3 work when the analytics queue is missing', async () => {
     const getImporterS3ClientStub = sandbox.stub().returns({ send: sandbox.stub().resolves({}) });
-    const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js', {
+    const module = await loadMocked('../../../src/cdn-logs-report/agentic-daily-export.js', {
       '../../../src/cdn-logs-report/utils/report-utils.js': {
         loadSql: sandbox.stub().resolves('CREATE DATABASE'),
         getImporterS3Client: getImporterS3ClientStub,
@@ -522,7 +535,7 @@ describe('agentic daily export', () => {
       send: sandbox.stub().resolves({}),
     };
 
-    const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js', {
+    const module = await loadMocked('../../../src/cdn-logs-report/agentic-daily-export.js', {
       '../../../src/cdn-logs-report/utils/report-utils.js': {
         loadSql: sandbox.stub().resolves('CREATE DATABASE'),
         getImporterS3Client: () => s3Client,
@@ -616,7 +629,7 @@ describe('agentic daily export', () => {
     s3Client.send.onCall(1).resolves({});
     s3Client.send.onCall(2).resolves({});
 
-    const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js', {
+    const module = await loadMocked('../../../src/cdn-logs-report/agentic-daily-export.js', {
       '../../../src/cdn-logs-report/utils/report-utils.js': {
         loadSql: sandbox.stub().resolves('CREATE DATABASE'),
         getImporterS3Client: () => s3Client,
@@ -704,7 +717,7 @@ describe('agentic daily export', () => {
 
   it('propagates Athena database setup failures without touching S3', async () => {
     const getImporterS3ClientStub = sandbox.stub().returns({ send: sandbox.stub().resolves({}) });
-    const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js', {
+    const module = await loadMocked('../../../src/cdn-logs-report/agentic-daily-export.js', {
       '../../../src/cdn-logs-report/utils/report-utils.js': {
         loadSql: sandbox.stub().resolves('CREATE DATABASE'),
         getImporterS3Client: getImporterS3ClientStub,

--- a/test/audits/cdn-logs-report/agentic-daily-export.test.js
+++ b/test/audits/cdn-logs-report/agentic-daily-export.test.js
@@ -180,6 +180,83 @@ describe('agentic daily export', () => {
     );
   });
 
+  it('neutralizes formula-leading cells and RFC-quotes CR-containing cells in the uploaded CSV', async () => {
+    const queryBuilder = {
+      createAgenticDailyReportQuery: sandbox.stub().resolves('SELECT * FROM daily_agentic'),
+    };
+    const mapper = {
+      mapToAgenticTrafficBundle: sandbox.stub().resolves({
+        trafficRows: [{
+          traffic_date: '2026-03-31',
+          host: 'docs.example.com',
+          // Formula trigger: cell value STARTS with '='
+          platform: '=cmd|/c calc',
+          agent_type: 'Chatbots',
+          // CR-containing field must be RFC-4180 quoted
+          user_agent: 'ChatGPT\rUser',
+          http_status: 200,
+          url_path: '/docs/page',
+          hits: 12,
+          avg_ttfb_ms: 123.45,
+          dimensions: {},
+          metrics: {},
+          updated_by: 'audit-worker:agentic-daily-export',
+        }],
+        classificationRows: [],
+      }),
+    };
+
+    const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js', {
+      '../../../src/cdn-logs-report/utils/report-utils.js': {
+        loadSql: sandbox.stub().resolves('CREATE DATABASE'),
+      },
+      '../../../src/cdn-logs-report/utils/query-builder.js': {
+        weeklyBreakdownQueries: queryBuilder,
+      },
+      '../../../src/cdn-logs-report/utils/agentic-traffic-mapper.js': mapper,
+      uuid: {
+        v4: () => 'batch-123',
+      },
+    });
+
+    const s3Client = { send: sandbox.stub().resolves({}) };
+
+    await module.runDailyAgenticExport({
+      athenaClient: {
+        execute: sandbox.stub().resolves(),
+        query: sandbox.stub().resolves([{ raw: true }]),
+      },
+      s3Client,
+      s3Config: { bucket: 'cdn-bucket', databaseName: 'db' },
+      site: {
+        getId: () => 'site-1',
+        getOrganizationId: () => 'org-1',
+        getBaseURL: () => 'https://example.com',
+        getConfig: () => ({ getLlmoCdnlogsFilter: () => [] }),
+      },
+      context: {
+        env: { S3_IMPORTER_BUCKET_NAME: 'spacecat-dev-importer' },
+        dataAccess: {
+          Configuration: { findLatest: sandbox.stub().resolves(createConfiguration()) },
+        },
+        log: { info: sandbox.spy() },
+        sqs: { sendMessage: sandbox.stub().resolves() },
+      },
+      reportConfig: { tableName: 'aggregated_logs_example_consolidated' },
+      referenceDate: new Date('2026-04-01T10:00:00Z'),
+    });
+
+    // Locate the traffic CSV upload by its Key, not call order — robust to any
+    // reordering of the two PutObject uploads (traffic vs classifications).
+    const trafficCall = s3Client.send.getCalls()
+      .find((c) => c.args[0].input.Key.endsWith('agentic_traffic.csv'));
+    const trafficBody = trafficCall.args[0].input.Body;
+    // Formula-leading cell is neutralized with a single-quote prefix.
+    expect(trafficBody).to.include("'=cmd|/c calc");
+    // CR-containing cell is RFC-4180 quoted (wrapped in double quotes).
+    expect(trafficBody).to.include('"ChatGPT\rUser"');
+  });
+
   it('logs a warning when cleanup after failure also fails', async () => {
     const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js');
     const log = {
@@ -297,13 +374,6 @@ describe('agentic daily export', () => {
       },
       referenceDate: new Date('2026-04-01T10:00:00Z'),
     })).to.be.rejectedWith('S3_IMPORTER_BUCKET_NAME must be provided for agentic daily export');
-  });
-
-  it('serializes null and undefined CSV values as empty strings', async () => {
-    const module = await esmock('../../../src/cdn-logs-report/agentic-daily-export.js');
-
-    expect(module.testHelpers.escapeCsvValue(null)).to.equal('');
-    expect(module.testHelpers.escapeCsvValue(undefined)).to.equal('');
   });
 
   it('skips upload and dispatch when there are no traffic rows', async () => {

--- a/test/audits/cdn-logs-report/referral-daily-export.test.js
+++ b/test/audits/cdn-logs-report/referral-daily-export.test.js
@@ -530,21 +530,6 @@ describe('referral daily export', function referralDailyExportTests() {
     );
   });
 
-  it('serializes null and undefined CSV field values as empty strings', async () => {
-    const module = await esmock('../../../src/cdn-logs-report/referral-daily-export.js');
-
-    expect(module.testHelpers.escapeCsvValue(null)).to.equal('');
-    expect(module.testHelpers.escapeCsvValue(undefined)).to.equal('');
-  });
-
-  it('wraps CSV values containing commas or quotes in double-quotes', async () => {
-    const module = await esmock('../../../src/cdn-logs-report/referral-daily-export.js');
-
-    expect(module.testHelpers.escapeCsvValue('hello, world')).to.equal('"hello, world"');
-    expect(module.testHelpers.escapeCsvValue('say "hi"')).to.equal('"say ""hi"""');
-    expect(module.testHelpers.escapeCsvValue('line\r\nbreak')).to.equal('"line\r\nbreak"');
-  });
-
   it('handles null/missing optional row fields gracefully', async () => {
     const classifyStub = sandbox.stub().returns({ type: 'earned', category: 'llm', vendor: null });
     const module = await loadModule(classifyStub);
@@ -766,6 +751,41 @@ describe('referral daily export', function referralDailyExportTests() {
     expect(context.log.info).to.have.been.calledWith(
       sinon.match('Athena returned 1 rows, 0 matched classification'),
     );
+  });
+
+  it('neutralizes a formula-leading host value in the uploaded CSV', async () => {
+    const classifyStub = sandbox.stub().returns({ type: 'earned', category: 'llm', vendor: 'chatgpt' });
+    const module = await loadModule(classifyStub);
+    const s3Client = { send: sandbox.stub().resolves({}) };
+
+    await module.runDailyReferralExport({
+      athenaClient: {
+        execute: sandbox.stub().resolves(),
+        query: sandbox.stub().resolves([{
+          path: '/page',
+          // Formula trigger: host value STARTS with '='
+          host: '=evil.example.com',
+          referrer: 'chatgpt.com',
+          utm_source: null,
+          utm_medium: null,
+          tracking_param: null,
+          device: 'desktop',
+          date: '2026-03-31',
+          region: 'US',
+          pageviews: 1,
+        }]),
+      },
+      s3Client,
+      s3Config: { bucket: 'cdn-bucket', databaseName: 'cdn_db' },
+      site: makeSite(),
+      context: makeContext(),
+      reportConfig: { tableName: 'referral_table' },
+      referenceDate: new Date('2026-04-01T00:00:00Z'),
+    });
+
+    const csvBody = s3Client.send.firstCall.args[0].input.Body;
+    // Formula-leading host cell is neutralized with a single-quote prefix.
+    expect(csvBody).to.include("'=evil.example.com");
   });
 
   it('handles path without leading slash in url construction', async () => {

--- a/test/audits/cdn-logs-report/referral-daily-export.test.js
+++ b/test/audits/cdn-logs-report/referral-daily-export.test.js
@@ -25,14 +25,17 @@ describe('referral daily export', function referralDailyExportTests() {
   this.timeout(10000);
   let sandbox;
   let s3ClientMock;
+  let mockedModules;
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
     s3ClientMock = { send: sandbox.stub().resolves({}) };
+    mockedModules = [];
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     sandbox.restore();
+    await Promise.all(mockedModules.map((module) => esmock.purge(module)));
   });
 
   function createConfiguration(queueUrl = 'https://sqs.us-east-1.amazonaws.com/123/analytics-queue') {
@@ -70,7 +73,7 @@ describe('referral daily export', function referralDailyExportTests() {
   }
 
   async function loadModule(classifyStub, reportUtilsOverrides = {}, queryBuilderOverrides = {}) {
-    return esmock('../../../src/cdn-logs-report/referral-daily-export.js', {
+    const module = await esmock('../../../src/cdn-logs-report/referral-daily-export.js', {
       '@adobe/spacecat-shared-rum-api-client/src/common/traffic.js': {
         classifyTrafficSource: classifyStub,
       },
@@ -86,6 +89,8 @@ describe('referral daily export', function referralDailyExportTests() {
         },
       },
     });
+    mockedModules.push(module);
+    return module;
   }
 
   it('uploads CSV and dispatches the analytics event', async () => {
@@ -756,7 +761,7 @@ describe('referral daily export', function referralDailyExportTests() {
   it('neutralizes a formula-leading host value in the uploaded CSV', async () => {
     const classifyStub = sandbox.stub().returns({ type: 'earned', category: 'llm', vendor: 'chatgpt' });
     const module = await loadModule(classifyStub);
-    const s3Client = { send: sandbox.stub().resolves({}) };
+    const s3Client = s3ClientMock;
 
     await module.runDailyReferralExport({
       athenaClient: {

--- a/test/audits/llmo-referral-traffic-daily/handler.test.js
+++ b/test/audits/llmo-referral-traffic-daily/handler.test.js
@@ -16,7 +16,6 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import chaiAsPromised from 'chai-as-promised';
 import esmock from 'esmock';
-import { serializeCsv } from '../../../src/llmo-referral-traffic-daily/handler.js';
 import { MockContextBuilder } from '../../shared.js';
 
 use(sinonChai);
@@ -37,46 +36,6 @@ const PARQUET_ROW = {
   engaged: 1,
 };
 
-describe('serializeCsv', () => {
-  it('should render null field values as empty string', () => {
-    const rows = [{
-      traffic_date: '2026-04-29',
-      host: 'example.com',
-      url_path: '/page',
-      trf_platform: null,
-      device: 'desktop',
-      region: 'GLOBAL',
-      pageviews: 1,
-      consent: 'true',
-      trf_type: 'earned',
-      trf_channel: 'llm',
-      bounced: 0,
-      updated_by: 'spacecat:optel',
-    }];
-    const csv = serializeCsv(rows);
-    expect(csv).to.include('2026-04-29,example.com,/page,,desktop');
-  });
-
-  it('should quote CSV values that contain carriage return', () => {
-    const rows = [{
-      traffic_date: '2026-04-29',
-      host: 'example.com',
-      url_path: '/page',
-      trf_platform: 'platform\rwith\rcr',
-      device: 'desktop',
-      region: 'GLOBAL',
-      pageviews: 1,
-      consent: 'true',
-      trf_type: 'earned',
-      trf_channel: 'llm',
-      bounced: 0,
-      updated_by: 'spacecat:optel',
-    }];
-    const csv = serializeCsv(rows);
-    expect(csv).to.include('"platform\rwith\rcr"');
-  });
-});
-
 describe('LLMO Referral Traffic Daily Handler', function () {
   this.timeout(10000);
 
@@ -87,16 +46,25 @@ describe('LLMO Referral Traffic Daily Handler', function () {
   let s3ClientStub;
   let sqsSendMessageStub;
   let parquetReadObjectsStub;
+  let fetchRulesStub;
+  let createClassifierStub;
   let handlerModule;
 
   before(() => {
     sandbox = sinon.createSandbox();
   });
 
+  // classifier stub matching the frozen contract:
+  // createClassifier(rules, { log }) → { classify(path) } | null
+  const classifierFor = (fn) => ({ classify: (path) => fn(path) });
+
   beforeEach(async () => {
     s3ClientStub = { send: sandbox.stub() };
     sqsSendMessageStub = sandbox.stub().resolves();
     parquetReadObjectsStub = sandbox.stub().resolves([PARQUET_ROW]);
+    // default: no rules → classifier null, topic/category stay empty
+    fetchRulesStub = sandbox.stub().resolves({ topicPatterns: [], pagePatterns: [] });
+    createClassifierStub = sandbox.stub().returns(null);
 
     site = {
       getId: sandbox.stub().returns('site-123'),
@@ -139,6 +107,12 @@ describe('LLMO Referral Traffic Daily Handler', function () {
         GetObjectCommand: sinon.stub().callsFake((args) => ({ ...args, _type: 'GetObjectCommand' })),
         PutObjectCommand: sinon.stub().callsFake((args) => ({ ...args, _type: 'PutObjectCommand' })),
         DeleteObjectCommand: sinon.stub().callsFake((args) => ({ ...args, _type: 'DeleteObjectCommand' })),
+      },
+      '../../../src/common/agentic-url-classification-rules.js': {
+        fetchAgenticUrlClassificationRules: fetchRulesStub,
+      },
+      '../../../src/common/agentic-url-classification.js': {
+        createClassifier: createClassifierStub,
       },
     });
   });
@@ -529,6 +503,161 @@ describe('LLMO Referral Traffic Daily Handler', function () {
       const putCall = s3ClientStub.send.secondCall.args[0];
       expect(putCall.Body).to.include('"platform,with,commas"');
       expect(putCall.Body).to.include('"device""with""quotes"');
+    });
+
+    // ───────────── classification + stable schema (I5/I9) ─────────────
+
+    const EXPECTED_HEADER = 'traffic_date,host,url_path,trf_platform,device,region,'
+      + 'topic,category,pageviews,consent,trf_type,trf_channel,bounced,updated_by';
+
+    it('should populate topic/category when a classifier is present', async () => {
+      createClassifierStub.returns(
+        classifierFor(() => ({ topic: 'Acrobat', category: 'Product' })),
+      );
+      parquetReadObjectsStub.resolves([{ ...PARQUET_ROW, path: '/us/acrobat' }]);
+      s3ClientStub.send
+        .onFirstCall().resolves({
+          Body: { transformToByteArray: sandbox.stub().resolves(new Uint8Array([0])) },
+        })
+        .onSecondCall().resolves({});
+
+      await handlerModule.referralTrafficDailyRunner(context);
+
+      expect(createClassifierStub).to.have.been.calledOnce;
+      const putCall = s3ClientStub.send.secondCall.args[0];
+      const lines = putCall.Body.split('\r\n');
+      // I9: assert EXACT field ordering, not substring matches
+      expect(lines[0]).to.equal(EXPECTED_HEADER);
+      expect(lines[1]).to.equal(
+        '2026-04-29,example.com,/us/acrobat,chatgpt,desktop,US,'
+        + 'Acrobat,Product,100,true,earned,llm,0,spacecat:optel',
+      );
+      expect(context.log.info).to.have.been.calledWithMatch(
+        /Agentic classification rules found/,
+      );
+    });
+
+    it('classifies once per unique group key and applies it to the merged row', async () => {
+      // Two rows with an identical group key must merge: classify() runs once
+      // (on the first-seen key, NOT per raw row), pageviews aggregate, and the
+      // merged row carries the classified topic/category. Guards against a
+      // regression that classifies every row or drops the label on aggregation.
+      const classifySpy = sandbox.stub().returns({ topic: 'Acrobat', category: 'Product' });
+      createClassifierStub.returns(classifierFor(classifySpy));
+      parquetReadObjectsStub.resolves([
+        { ...PARQUET_ROW, path: '/us/acrobat', pageviews: 40 },
+        { ...PARQUET_ROW, path: '/us/acrobat', pageviews: 60 },
+      ]);
+      s3ClientStub.send
+        .onFirstCall().resolves({
+          Body: { transformToByteArray: sandbox.stub().resolves(new Uint8Array([0])) },
+        })
+        .onSecondCall().resolves({});
+
+      const result = await handlerModule.referralTrafficDailyRunner(context);
+
+      expect(result.auditResult.rowCount).to.equal(1);
+      expect(classifySpy).to.have.been.calledOnce;
+      expect(classifySpy).to.have.been.calledWith('/us/acrobat');
+      const putCall = s3ClientStub.send.secondCall.args[0];
+      const lines = putCall.Body.split('\r\n');
+      expect(lines[1]).to.equal(
+        '2026-04-29,example.com,/us/acrobat,chatgpt,desktop,US,'
+        + 'Acrobat,Product,100,true,earned,llm,0,spacecat:optel',
+      );
+    });
+
+    it('should emit 14 columns with empty topic/category when no rules (I5)', async () => {
+      createClassifierStub.returns(null);
+      parquetReadObjectsStub.resolves([{ ...PARQUET_ROW, path: '/us/acrobat' }]);
+      s3ClientStub.send
+        .onFirstCall().resolves({
+          Body: { transformToByteArray: sandbox.stub().resolves(new Uint8Array([0])) },
+        })
+        .onSecondCall().resolves({});
+
+      await handlerModule.referralTrafficDailyRunner(context);
+
+      const putCall = s3ClientStub.send.secondCall.args[0];
+      const lines = putCall.Body.split('\r\n');
+      expect(lines[0]).to.equal(EXPECTED_HEADER);
+      expect(lines[0].split(',')).to.have.lengthOf(14);
+      // topic/category cells empty (NOT 'Other'), exact ordering
+      expect(lines[1]).to.equal(
+        '2026-04-29,example.com,/us/acrobat,chatgpt,desktop,US,'
+        + ',,100,true,earned,llm,0,spacecat:optel',
+      );
+      expect(lines[1].split(',')).to.have.lengthOf(14);
+      expect(context.log.info).to.have.been.calledWithMatch(
+        /No agentic classification rules/,
+      );
+    });
+
+    it('should warn and leave topic/category empty when rule fetch errored (M5)', async () => {
+      fetchRulesStub.resolves({ error: true, source: 'postgres' });
+      createClassifierStub.returns(null);
+      parquetReadObjectsStub.resolves([{ ...PARQUET_ROW, path: '/us/acrobat' }]);
+      s3ClientStub.send
+        .onFirstCall().resolves({
+          Body: { transformToByteArray: sandbox.stub().resolves(new Uint8Array([0])) },
+        })
+        .onSecondCall().resolves({});
+
+      await handlerModule.referralTrafficDailyRunner(context);
+
+      const putCall = s3ClientStub.send.secondCall.args[0];
+      const lines = putCall.Body.split('\r\n');
+      expect(lines[1]).to.equal(
+        '2026-04-29,example.com,/us/acrobat,chatgpt,desktop,US,'
+        + ',,100,true,earned,llm,0,spacecat:optel',
+      );
+      expect(context.log.warn).to.have.been.calledWithMatch(
+        /Failed to fetch agentic classification rules/,
+      );
+    });
+
+    it('should classify the full url path even when it confounds region detection (I9)', async () => {
+      // /us/acrobat → region US; classifier still receives and matches full path
+      createClassifierStub.returns(
+        classifierFor((path) => (path === '/us/acrobat'
+          ? { topic: 'Acrobat', category: 'Product' }
+          : { topic: 'Other', category: 'Other' })),
+      );
+      parquetReadObjectsStub.resolves([{ ...PARQUET_ROW, path: '/us/acrobat' }]);
+      s3ClientStub.send
+        .onFirstCall().resolves({
+          Body: { transformToByteArray: sandbox.stub().resolves(new Uint8Array([0])) },
+        })
+        .onSecondCall().resolves({});
+
+      await handlerModule.referralTrafficDailyRunner(context);
+
+      const putCall = s3ClientStub.send.secondCall.args[0];
+      const lines = putCall.Body.split('\r\n');
+      expect(lines[1]).to.equal(
+        '2026-04-29,example.com,/us/acrobat,chatgpt,desktop,US,'
+        + 'Acrobat,Product,100,true,earned,llm,0,spacecat:optel',
+      );
+    });
+
+    // ───────────── formula injection (I4) ─────────────
+
+    it('should neutralize formula-injection in a classifier-derived topic cell', async () => {
+      createClassifierStub.returns(
+        classifierFor(() => ({ topic: '=2+5', category: '@SUM(A1)' })),
+      );
+      parquetReadObjectsStub.resolves([{ ...PARQUET_ROW, path: '/x' }]);
+      s3ClientStub.send
+        .onFirstCall().resolves({
+          Body: { transformToByteArray: sandbox.stub().resolves(new Uint8Array([0])) },
+        })
+        .onSecondCall().resolves({});
+
+      await handlerModule.referralTrafficDailyRunner(context);
+
+      const putCall = s3ClientStub.send.secondCall.args[0];
+      // leading-quote prefix neutralizes the formula trigger
+      expect(putCall.Body).to.include(",'=2+5,'@SUM(A1),");
     });
   });
 });

--- a/test/audits/llmo-referral-traffic.test.js
+++ b/test/audits/llmo-referral-traffic.test.js
@@ -20,7 +20,9 @@ import { MockContextBuilder } from '../shared.js';
 use(sinonChai);
 use(chaiAsPromised);
 
-describe('LLMO Referral Traffic Handler', () => {
+describe('LLMO Referral Traffic Handler', function () {
+  this.timeout(10000);
+
   let sandbox;
   let context;
   let site;
@@ -30,11 +32,35 @@ describe('LLMO Referral Traffic Handler', () => {
   let getStaticContentStub;
   let createLLMOSharepointClientStub;
   let saveExcelReportStub;
+  let fetchRulesStub;
+  let createClassifierStub;
+  let isoCalendarWeekStub;
+  let savedWorkbook;
   let handlerModule;
 
   before('setup', () => {
     sandbox = sinon.createSandbox();
   });
+
+  // Builds a classifier stub matching the frozen contract:
+  // createClassifier(rules, { log }) → { classify(path) } | null
+  const classifierFor = (fn) => ({ classify: (path) => fn(path) });
+
+  // Reads the row objects written into the workbook captured by saveExcelReport.
+  const capturedRows = () => {
+    const ws = savedWorkbook.getWorksheet('Sheet1');
+    const headers = ws.columns.map((c) => c.key);
+    const rows = [];
+    ws.eachRow({ includeEmpty: false }, (row, rowNumber) => {
+      if (rowNumber === 1) return; // header row
+      const obj = {};
+      headers.forEach((key, idx) => {
+        obj[key] = row.getCell(idx + 1).value;
+      });
+      rows.push(obj);
+    });
+    return { headers, rows };
+  };
 
   beforeEach(async () => {
     mockAthenaClient = {
@@ -47,7 +73,15 @@ describe('LLMO Referral Traffic Handler', () => {
 
     getStaticContentStub = sandbox.stub().resolves('SELECT * FROM table');
     createLLMOSharepointClientStub = sandbox.stub().resolves(mockSharepointClient);
-    saveExcelReportStub = sandbox.stub().resolves();
+    savedWorkbook = undefined;
+    saveExcelReportStub = sandbox.stub().callsFake(({ workbook }) => {
+      savedWorkbook = workbook;
+      return Promise.resolve();
+    });
+    // default: no rules → fetch returns empty patterns, classifier null
+    fetchRulesStub = sandbox.stub().resolves({ topicPatterns: [], pagePatterns: [] });
+    createClassifierStub = sandbox.stub().returns(null);
+    isoCalendarWeekStub = sandbox.stub().returns({ week: 10, year: 2025 });
 
     site = {
       getId: sandbox.stub().returns('site-123'),
@@ -77,12 +111,16 @@ describe('LLMO Referral Traffic Handler', () => {
       })
       .build();
 
-    // Mock the handler module with esmock
+    // Mock the handler module with esmock. The classifier module is stubbed to
+    // the frozen contract (createClassifier) so these tests do not depend on the
+    // module's on-disk shape.
     handlerModule = await esmock('../../src/llmo-referral-traffic/handler.js', {
       '@adobe/spacecat-shared-utils': {
         getStaticContent: getStaticContentStub,
-        getWeekInfo: () => ({ temporalCondition: 'year = 2025 AND week = 10' }),
-        isoCalendarWeek: () => ({ week: 10, year: 2025 }),
+        getWeekInfo: (week = 10, year = 2025) => ({
+          week, year, temporalCondition: 'year = 2025 AND week = 10',
+        }),
+        isoCalendarWeek: isoCalendarWeekStub,
       },
       '@adobe/spacecat-shared-athena-client': {
         AWSAthenaClient: {
@@ -92,6 +130,12 @@ describe('LLMO Referral Traffic Handler', () => {
       '../../src/utils/report-uploader.js': {
         createLLMOSharepointClient: createLLMOSharepointClientStub,
         saveExcelReport: saveExcelReportStub,
+      },
+      '../../src/common/agentic-url-classification-rules.js': {
+        fetchAgenticUrlClassificationRules: fetchRulesStub,
+      },
+      '../../src/common/agentic-url-classification.js': {
+        createClassifier: createClassifierStub,
       },
     });
   });
@@ -170,6 +214,151 @@ describe('LLMO Referral Traffic Handler', () => {
       await handlerModule.referralTrafficRunner(context);
 
       expect(mockTrafficData[0].region).to.equal('CZ');
+    });
+
+    // ───────────── classification enrichment (C1) ─────────────
+
+    it('should add topic/category when classification rules are present', async () => {
+      createClassifierStub.returns(classifierFor(() => ({ topic: 'Acrobat', category: 'Product' })));
+      mockAthenaClient.query.resolves([{ path: '/us/acrobat', trf_type: 'earned' }]);
+
+      await handlerModule.referralTrafficRunner(context);
+
+      expect(createClassifierStub).to.have.been.calledOnce;
+      const { rows } = capturedRows();
+      expect(rows[0].topic).to.equal('Acrobat');
+      expect(rows[0].category).to.equal('Product');
+      expect(context.log.info).to.have.been.calledWithMatch(
+        /Agentic classification rules found/,
+      );
+    });
+
+    it('should classify the full path even when it confounds region detection (I9)', async () => {
+      // /us/acrobat → region US; the classifier must still receive the FULL path,
+      // not a region-stripped one. A path-aware stub returns a hit only for the
+      // exact full path, so a stripped arg would fall through to Other/Other.
+      // Mirrors the daily-export region-confound test.
+      createClassifierStub.returns(
+        classifierFor((path) => (path === '/us/acrobat'
+          ? { topic: 'Acrobat', category: 'Product' }
+          : { topic: 'Other', category: 'Other' })),
+      );
+      mockAthenaClient.query.resolves([{ path: '/us/acrobat', trf_type: 'earned' }]);
+
+      await handlerModule.referralTrafficRunner(context);
+
+      const { rows } = capturedRows();
+      expect(rows[0].region).to.equal('US');
+      expect(rows[0].topic).to.equal('Acrobat');
+      expect(rows[0].category).to.equal('Product');
+    });
+
+    it('should leave topic/category empty when no classification rules exist', async () => {
+      createClassifierStub.returns(null);
+      mockAthenaClient.query.resolves([{ path: '/us/acrobat', trf_type: 'earned' }]);
+
+      await handlerModule.referralTrafficRunner(context);
+
+      const { headers, rows } = capturedRows();
+      expect(headers).to.include('topic');
+      expect(headers).to.include('category');
+      expect(rows[0].topic).to.equal('');
+      expect(rows[0].category).to.equal('');
+      expect(context.log.info).to.have.been.calledWithMatch(
+        /No agentic classification rules/,
+      );
+    });
+
+    it('should leave topic/category empty and warn when rule fetch errored (M5)', async () => {
+      fetchRulesStub.resolves({ error: true, source: 'postgres' });
+      createClassifierStub.returns(null);
+      mockAthenaClient.query.resolves([{ path: '/us/acrobat', trf_type: 'earned' }]);
+
+      await handlerModule.referralTrafficRunner(context);
+
+      const { rows } = capturedRows();
+      expect(rows[0].topic).to.equal('');
+      expect(rows[0].category).to.equal('');
+      expect(context.log.warn).to.have.been.calledWithMatch(
+        /Failed to fetch agentic classification rules/,
+      );
+    });
+
+    // ───────────── explicit schema (I6) ─────────────
+
+    it('should emit explicit stable columns regardless of data keys', async () => {
+      createClassifierStub.returns(null);
+      mockAthenaClient.query.resolves([{
+        path: '/p', trf_type: 'earned', trf_channel: 'llm', trf_platform: 'chatgpt',
+        device: 'desktop', date: '2025-03-10', pageviews: 100, consent: 1, bounced: 0,
+      }]);
+
+      await handlerModule.referralTrafficRunner(context);
+
+      const { headers } = capturedRows();
+      expect(headers).to.deep.equal([
+        'path', 'trf_type', 'trf_channel', 'trf_platform', 'device', 'date',
+        'pageviews', 'consent', 'bounced', 'page_intent', 'region', 'topic', 'category',
+      ]);
+    });
+
+    // ───────────── formula injection (I4) ─────────────
+
+    it('should neutralize formula-injection topic/category in Excel cells', async () => {
+      createClassifierStub.returns(
+        classifierFor(() => ({ topic: '=cmd|calc', category: '@evil' })),
+      );
+      mockAthenaClient.query.resolves([{ path: '/x', trf_type: 'earned' }]);
+
+      await handlerModule.referralTrafficRunner(context);
+
+      const { rows } = capturedRows();
+      expect(rows[0].topic).to.equal("'=cmd|calc");
+      expect(rows[0].category).to.equal("'@evil");
+    });
+
+    it('should neutralize formula-injection in visitor-influenced path cell', async () => {
+      createClassifierStub.returns(null);
+      mockAthenaClient.query.resolves([{ path: '+1+1', trf_type: 'earned' }]);
+
+      await handlerModule.referralTrafficRunner(context);
+
+      const { rows } = capturedRows();
+      expect(rows[0].path).to.equal("'+1+1");
+    });
+  });
+
+  describe('triggerTrafficAnalysisImport', () => {
+    it('should derive week/year from auditContext when provided', async () => {
+      context.auditContext = { week: 12, year: 2024 };
+      context.finalUrl = 'https://example.com';
+
+      const result = await handlerModule.triggerTrafficAnalysisImport(context);
+
+      expect(result.type).to.equal('traffic-analysis');
+      expect(result.siteId).to.equal('site-123');
+      expect(result.auditResult.week).to.equal(12);
+      expect(result.auditResult.year).to.equal(2024);
+      expect(result.allowCache).to.equal(false);
+      expect(result.fullAuditRef).to.equal('https://example.com');
+    });
+
+    it('should default to yesterday when auditContext is absent', async () => {
+      delete context.auditContext;
+      context.finalUrl = 'https://example.com';
+
+      const result = await handlerModule.triggerTrafficAnalysisImport(context);
+
+      expect(result.auditResult.week).to.equal(10);
+      expect(result.auditResult.year).to.equal(2025);
+      // Pin the actual yesterday = (now − 1 day, UTC) math handed to isoCalendarWeek,
+      // not merely the stubbed week/year return.
+      expect(isoCalendarWeekStub).to.have.been.calledOnce;
+      const passedDate = isoCalendarWeekStub.firstCall.args[0];
+      expect(passedDate).to.be.an.instanceof(Date);
+      const expectedYesterday = new Date();
+      expectedYesterday.setUTCDate(expectedYesterday.getUTCDate() - 1);
+      expect(Math.abs(passedDate.getTime() - expectedYesterday.getTime())).to.be.lessThan(5000);
     });
   });
 });

--- a/test/common/agentic-url-classification.test.js
+++ b/test/common/agentic-url-classification.test.js
@@ -1,0 +1,597 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import {
+  classifyTopic,
+  classifyPageType,
+  hasClassificationRules,
+  createClassifier,
+} from '../../src/common/agentic-url-classification.js';
+import {
+  buildTopicExtractionSQL,
+  generatePageTypeClassification,
+} from '../../src/cdn-logs-report/utils/query-builder.js';
+
+use(sinonChai);
+
+describe('agentic-url-classification', () => {
+  describe('classifyTopic', () => {
+    it('returns the first matching named pattern, in order', () => {
+      const patterns = [
+        { name: 'Acrobat', regex: '/acrobat' },
+        { name: 'Photoshop', regex: '/photoshop' },
+      ];
+      expect(classifyTopic('/acrobat/free', patterns)).to.equal('Acrobat');
+      expect(classifyTopic('/photoshop/learn', patterns)).to.equal('Photoshop');
+    });
+
+    it('honours a leading (?i) inline flag as case-insensitive', () => {
+      const patterns = [{ name: 'Acrobat', regex: '(?i)/acrobat' }];
+      expect(classifyTopic('/ACROBAT/free', patterns)).to.equal('Acrobat');
+    });
+
+    it('falls back to extract patterns (capture group 1) when no named match', () => {
+      const patterns = [{ regex: '/products/([^/]+)' }];
+      expect(classifyTopic('/products/lightroom', patterns)).to.equal('lightroom');
+    });
+
+    it('prefers a named match over an extract pattern', () => {
+      const patterns = [
+        { name: 'Acrobat', regex: '/acrobat' },
+        { regex: '/([^/]+)' },
+      ];
+      expect(classifyTopic('/acrobat/x', patterns)).to.equal('Acrobat');
+    });
+
+    it("returns 'Other' when no pattern matches", () => {
+      const patterns = [{ name: 'Acrobat', regex: '/acrobat' }, { regex: '/products/([^/]+)' }];
+      expect(classifyTopic('/blog', patterns)).to.equal('Other');
+    });
+
+    it("returns 'Other' when extract match has an empty capture group", () => {
+      const patterns = [{ regex: '/page(\\d*)' }];
+      expect(classifyTopic('/page', patterns)).to.equal('Other');
+    });
+
+    it('skips named patterns whose regex fails to compile', () => {
+      const patterns = [{ name: 'Bad', regex: '(' }, { name: 'Acrobat', regex: '/acrobat' }];
+      expect(classifyTopic('/acrobat', patterns)).to.equal('Acrobat');
+    });
+
+    it('skips extract patterns whose regex fails to compile', () => {
+      const patterns = [{ regex: '(' }];
+      expect(classifyTopic('/anything', patterns)).to.equal('Other');
+    });
+
+    it("defaults to 'Other' with no patterns", () => {
+      expect(classifyTopic('/x')).to.equal('Other');
+    });
+  });
+
+  describe('classifyPageType', () => {
+    it('returns the first matching named pattern', () => {
+      const patterns = [
+        { name: 'Product', regex: '/products/' },
+        { name: 'Blog', regex: '/blog/' },
+      ];
+      expect(classifyPageType('/blog/post-1', patterns)).to.equal('Blog');
+    });
+
+    it('honours a leading (?i) inline flag', () => {
+      const patterns = [{ name: 'Blog', regex: '(?i)/blog/' }];
+      expect(classifyPageType('/BLOG/x', patterns)).to.equal('Blog');
+    });
+
+    it('skips patterns whose regex fails to compile', () => {
+      const patterns = [{ name: 'Bad', regex: '(' }, { name: 'Blog', regex: '/blog/' }];
+      expect(classifyPageType('/blog/x', patterns)).to.equal('Blog');
+    });
+
+    it("returns 'Other' when no pattern matches", () => {
+      expect(classifyPageType('/x', [{ name: 'Blog', regex: '/blog/' }])).to.equal('Other');
+    });
+
+    it("defaults to 'Other' with no patterns", () => {
+      expect(classifyPageType('/x')).to.equal('Other');
+    });
+
+    // KNOWN DIVERGENCE from the SQL twin (see classifyPageType doc). For an
+    // explicitly empty name ('') both JS and SQL emit '' — they agree. For a
+    // missing (undefined) or null name they DIVERGE: SQL interpolates
+    // sqlEscape(undefined)/sqlEscape(null) → the literal tokens 'undefined'/
+    // 'null', whereas JS returns '' via `name ?? ''`. The JS behavior is
+    // deliberate (the literal tokens are a bug, not a label worth matching), so
+    // the mechanical SQL-twin parity block below uses non-empty page names to
+    // avoid asserting against this intentional divergence.
+    it("returns '' (agrees with SQL) when a matching page rule has an explicitly empty name", () => {
+      expect(classifyPageType('/x', [{ name: '', regex: '/x' }])).to.equal('');
+    });
+
+    it("returns '' (DIVERGES from SQL 'undefined') when a matching page rule has a missing name", () => {
+      expect(classifyPageType('/x', [{ regex: '/x' }])).to.equal('');
+    });
+
+    it("returns '' (DIVERGES from SQL 'null') when a matching page rule has a null name", () => {
+      expect(classifyPageType('/x', [{ name: null, regex: '/x' }])).to.equal('');
+    });
+  });
+
+  describe('hasClassificationRules', () => {
+    it('returns false for null', () => {
+      expect(hasClassificationRules(null)).to.equal(false);
+    });
+
+    it('returns false for an error result', () => {
+      expect(hasClassificationRules({ error: true, source: 'postgres' })).to.equal(false);
+    });
+
+    it('returns false when both pattern lists are empty', () => {
+      expect(hasClassificationRules({ topicPatterns: [], pagePatterns: [] })).to.equal(false);
+    });
+
+    it('returns true when topic patterns are present', () => {
+      expect(hasClassificationRules({ topicPatterns: [{ regex: '/x' }], pagePatterns: [] }))
+        .to.equal(true);
+    });
+
+    it('returns true when page patterns are present', () => {
+      expect(hasClassificationRules({ topicPatterns: [], pagePatterns: [{ regex: '/x' }] }))
+        .to.equal(true);
+    });
+  });
+
+  // I10: edge inputs for toRegExp guards, exercised via the public API.
+  describe('regex compile guards (I10)', () => {
+    it('drops a null regex source instead of matching literal text', () => {
+      // `new RegExp(null)` would compile to /null/ and match 'null' — must drop.
+      expect(classifyTopic('null', [{ name: 'X', regex: null }])).to.equal('Other');
+    });
+
+    it('drops an undefined regex source instead of matching literal "undefined"', () => {
+      expect(classifyTopic('undefined', [{ name: 'X', regex: undefined }])).to.equal('Other');
+    });
+
+    it('drops a non-string (number) regex source', () => {
+      expect(classifyTopic('123', [{ name: 'X', regex: 123 }])).to.equal('Other');
+    });
+
+    it('compiles an empty-string regex (matches everything) for a named topic', () => {
+      // Empty source is a valid regex that matches any input.
+      expect(classifyTopic('/anything', [{ name: 'Empty', regex: '' }])).to.equal('Empty');
+    });
+  });
+
+  // I3: ReDoS magnitude guards.
+  describe('ReDoS guards (I3)', () => {
+    it('caps the input length before matching (oversized URL)', () => {
+      // End-anchored pattern: it matches the FULL string but NOT the capped
+      // 2048-char prefix (whose tail '/blog' is sliced off). So the cap is what
+      // produces 'Other' — removing the cap would match and flip to 'Blog'.
+      const longPath = `${'a'.repeat(3000)}/blog`;
+      expect(/\/blog$/.test(longPath)).to.equal(true); // full string matches
+      expect(classifyPageType(longPath, [{ name: 'Blog', regex: '/blog$' }]))
+        .to.equal('Other');
+    });
+
+    it('still matches within the capped prefix', () => {
+      const longPath = `/blog/${'a'.repeat(3000)}`;
+      expect(classifyPageType(longPath, [{ name: 'Blog', regex: '^/blog' }]))
+        .to.equal('Blog');
+    });
+
+    it('rejects a pattern source exceeding the max length', () => {
+      // Pattern len 1002 (> MAX_PATTERN_LENGTH 1000). The input SATISFIES the
+      // pattern, so if the length rejection were removed the rule would compile,
+      // match, and label 'Huge' — the rejection is what yields 'Other'.
+      const huge = `/${'a'.repeat(1001)}`;
+      const input = `/${'a'.repeat(1001)}`;
+      expect(huge.length).to.equal(1002);
+      expect(classifyTopic(input, [{ name: 'Huge', regex: huge }])).to.equal('Other');
+    });
+
+    it('rejects a nested unbounded quantifier (catastrophic shape)', () => {
+      expect(classifyTopic('aaaa', [{ name: 'Evil', regex: '(a+)+' }])).to.equal('Other');
+    });
+
+    // Exponential blow-up is input-length-INDEPENDENT, so the input cap does NOT
+    // bound it — these shapes must be rejected at compile time by the heuristic.
+    it('rejects a single-char alternation overlap (a|a)+', () => {
+      expect(classifyTopic('aaaa', [{ name: 'Evil', regex: '(a|a)+' }])).to.equal('Other');
+    });
+
+    it('rejects a multi-char alternation overlap (a|aa)+', () => {
+      expect(classifyTopic('aaaa', [{ name: 'Evil', regex: '(a|aa)+' }])).to.equal('Other');
+    });
+
+    it('rejects a doubly-nested group (([a-z])+)+', () => {
+      expect(classifyTopic('abcd', [{ name: 'Evil', regex: '(([a-z])+)+' }])).to.equal('Other');
+    });
+
+    // Form (b): the inner group CONTAINS the unbounded quantifier (`+`/`*` before
+    // the inner `)`) rather than wrapping it. Distinct from `(([a-z])+)+` above;
+    // `((a+))+` hangs V8 on a ~30-char input, so it must be screened at compile.
+    it('rejects a doubly-nested inner-quantifier group ((a+))+', () => {
+      expect(classifyTopic('aaaa', [{ name: 'Evil', regex: '((a+))+' }])).to.equal('Other');
+    });
+
+    it('rejects a doubly-nested inner-quantifier class (([a-z]+))+', () => {
+      expect(classifyTopic('abcd', [{ name: 'Evil', regex: '(([a-z]+))+' }])).to.equal('Other');
+    });
+
+    it('rejects a doubly-nested inner-star group ((a*))*', () => {
+      expect(classifyTopic('aaaa', [{ name: 'Evil', regex: '((a*))*' }])).to.equal('Other');
+    });
+
+    it('rejects a bounded repeat of a greedy group (.*a){20}', () => {
+      // The compiled regex DOES match this input (>=20 'a'), so removing the
+      // guard would flip the label to 'Evil' — the guard is what yields 'Other'.
+      expect(classifyTopic('a'.repeat(20), [{ name: 'Evil', regex: '(.*a){20}' }]))
+        .to.equal('Other');
+    });
+
+    // A bounded-range {m,n} group repeated by an outer +/*/{ is exponential and
+    // input-length-INDEPENDENT (a ~30-char input already hangs V8), so the input
+    // cap cannot bound it — these must be rejected at compile time. The compiled
+    // regex WOULD match the input below, so guard-removal flips the label.
+    it('rejects a bounded-range group repeated by + (a{1,3})+', () => {
+      expect(classifyTopic('aaaa', [{ name: 'Evil', regex: '(a{1,3})+' }])).to.equal('Other');
+    });
+
+    it('rejects a bounded-range group repeated by * (a{1,2})*', () => {
+      expect(classifyTopic('aaaa', [{ name: 'Evil', regex: '(a{1,2})*' }])).to.equal('Other');
+    });
+
+    it('rejects a bounded-range class repeated by + ([a-z]{1,2})+', () => {
+      expect(classifyTopic('abcd', [{ name: 'Evil', regex: '([a-z]{1,2})+' }])).to.equal('Other');
+    });
+
+    it('rejects a bounded-range \\w class repeated by + (\\w{1,2})+', () => {
+      expect(classifyTopic('abcd', [{ name: 'Evil', regex: '(\\w{1,2})+' }])).to.equal('Other');
+    });
+
+    it('does NOT reject a standalone bounded range ([a-z]{2,4})', () => {
+      // No outer repeat → linear → must compile and match normally.
+      expect(classifyTopic('/product/ab', [{ regex: '/product/([a-z]{2,4})' }])).to.equal('ab');
+    });
+
+    it('does NOT reject a single bounded capture group', () => {
+      expect(classifyTopic('/products/x', [{ regex: '/products/([^/]+)' }])).to.equal('x');
+    });
+
+    it('does NOT count safe bounded-range / single-group patterns as ReDoS rejections', () => {
+      // Pins the over-broad-screen boundary: these safe shapes must COMPILE
+      // (zero failures → no warn), proving the heuristic did not fire on them.
+      // Without this, the "does NOT reject" tests above only prove a match, not
+      // that the heuristic abstained.
+      const log = { warn: sinon.spy() };
+      createClassifier({
+        topicPatterns: [
+          { name: 'Range', regex: '/product/([a-z]{2,4})' },
+          { name: 'Group', regex: '/products/([^/]+)' },
+        ],
+      }, { log });
+      expect(log.warn).to.not.have.been.called;
+    });
+  });
+
+  // I2: parity with the SQL twin in query-builder.js.
+  describe('SQL twin parity (I2)', () => {
+    it('named topic CASE: first matching rule wins in order', () => {
+      // Mirrors buildTopicExtractionSQL named-only CASE ... ELSE 'Other'.
+      const patterns = [
+        { name: 'First', regex: '/shared' },
+        { name: 'Second', regex: '/shared' },
+      ];
+      expect(classifyTopic('/shared/x', patterns)).to.equal('First');
+    });
+
+    it('unnamed topic extract: COALESCE first non-empty group-1 wins', () => {
+      // Mirrors COALESCE(NULLIF(REGEXP_EXTRACT(...,1),''), ..., 'Other').
+      const patterns = [
+        { regex: '/empty(x*)' },
+        { regex: '/cat/([^/]+)' },
+      ];
+      expect(classifyTopic('/empty/cat/shoes', patterns)).to.equal('shoes');
+    });
+
+    it('combined topic: named CASE evaluated before extract COALESCE', () => {
+      const patterns = [
+        { name: 'Named', regex: '/named' },
+        { regex: '/([^/]+)' },
+      ];
+      expect(classifyTopic('/named/y', patterns)).to.equal('Named');
+      expect(classifyTopic('/other/y', patterns)).to.equal('other');
+    });
+
+    it("empty-name ('') topic rule routes to extract (group 1), not a named CASE arm", () => {
+      // !pattern.name is falsy for '' → treated as an unnamed extract rule,
+      // mirroring buildTopicExtractionSQL which emits a named CASE arm only for
+      // a truthy name. Group-1 capture supplies the label; a named-CASE misroute
+      // would instead yield the empty name.
+      expect(classifyTopic('/cat/shoes', [{ name: '', regex: '/cat/([^/]+)' }])).to.equal('shoes');
+    });
+
+    it("topic falls back to 'Other' (mirrors ELSE/COALESCE tail)", () => {
+      expect(classifyTopic('/none', [{ name: 'X', regex: '/zzz' }, { regex: '/yyy/([^/]+)' }]))
+        .to.equal('Other');
+    });
+
+    it("page type falls back to 'Other' (mirrors CASE ELSE 'Other')", () => {
+      expect(classifyPageType('/none', [{ name: 'Blog', regex: '/blog' }])).to.equal('Other');
+    });
+
+    // M7: alternation branch with no capture → group 1 undefined → COALESCE skips it.
+    it('M7: extract pattern whose matched branch has no capture skips to next', () => {
+      const patterns = [
+        { regex: '(?:/skip)|/take/([^/]+)' },
+        { regex: '/fallback/([^/]+)' },
+      ];
+      // First pattern matches the '/skip' branch (group 1 undefined) on this URL...
+      expect(classifyTopic('/skip/fallback/here', patterns)).to.equal('here');
+    });
+
+    it('M7: extract pattern uses the captured branch when it matches', () => {
+      const patterns = [{ regex: '(?:/skip)|/take/([^/]+)' }];
+      expect(classifyTopic('/take/value', patterns)).to.equal('value');
+    });
+  });
+
+  // I2 (mechanical): rather than hand-mirroring individual SQL shapes, parse the
+  // ACTUAL strings emitted by buildTopicExtractionSQL / generatePageTypeClassification
+  // and interpret them with the same matching semantics the JS classifier uses,
+  // then assert the two agree over a probe set. This fails loudly if a SQL edit
+  // drifts from the JS twin (arm order, named-vs-extract split, COALESCE/CASE form,
+  // or the 'Other' tail).
+  describe('SQL twin parity — mechanical (I2)', () => {
+    // SQL single-quote un-escape: sqlEscape doubles `'`; reverse it.
+    const sqlUnescape = (s) => s.replace(/''/g, "'");
+
+    // Interpret generated topic SQL: named WHEN arms first (CASE), then extract
+    // REGEXP_EXTRACT group-1 (COALESCE), then 'Other'. Mirrors applyTopic.
+    const interpretTopicSql = (sql, url) => {
+      const named = [...sql.matchAll(/WHEN REGEXP_LIKE\(url, '((?:[^']|'')*)'\) THEN '((?:[^']|'')*)'/g)]
+        .map((m) => ({ re: new RegExp(sqlUnescape(m[1])), name: sqlUnescape(m[2]) }));
+      for (const { re, name } of named) {
+        if (re.test(url)) {
+          return name;
+        }
+      }
+      const extracts = [...sql.matchAll(/REGEXP_EXTRACT\(url, '((?:[^']|'')*)', 1\)/g)]
+        .map((m) => new RegExp(sqlUnescape(m[1])));
+      for (const re of extracts) {
+        const match = re.exec(url);
+        if (match && match[1]) {
+          return match[1];
+        }
+      }
+      return 'Other';
+    };
+
+    // Interpret generated page-type SQL: first matching WHEN arm wins, else 'Other'.
+    // Mirrors applyPageType. Fixture uses non-empty names to avoid the documented
+    // empty/missing-name KNOWN DIVERGENCE.
+    const interpretPageSql = (sql, url) => {
+      const arms = [...sql.matchAll(/WHEN REGEXP_LIKE\(url, '((?:[^']|'')*)'\) THEN '((?:[^']|'')*)'/g)]
+        .map((m) => ({ re: new RegExp(sqlUnescape(m[1])), name: sqlUnescape(m[2]) }));
+      for (const { re, name } of arms) {
+        if (re.test(url)) {
+          return name;
+        }
+      }
+      return 'Other';
+    };
+
+    // Fixture: NO sort_order (JS sorts by it, SQL builder emits array order — so
+    // equal array order keeps both aligned). Dialect-agnostic regexes only.
+    // NOTE: a leading `(?i)` inline flag is EXCLUDED here by necessity, not
+    // oversight — the SQL interpreter compiles the raw rule source with
+    // `new RegExp`, and V8 throws on `(?i)` (an invalid group), so it cannot
+    // cross-check the one construct where the JS classifier and Trino RE2J
+    // genuinely diverge. `(?i)` handling is covered JS-side in isolation by the
+    // "honours a leading (?i) inline flag" cases above.
+    const rules = {
+      topicPatterns: [
+        { name: 'Acrobat', regex: '/acrobat' },
+        { name: 'Photoshop', regex: '/photoshop' },
+        { regex: '/products/([^/]+)' },
+      ],
+      pagePatterns: [
+        { name: 'Product', regex: '/products/' },
+        { name: 'Blog', regex: '/blog/' },
+      ],
+    };
+    const probes = [
+      '/acrobat/free',
+      '/photoshop/x',
+      '/products/lightroom',
+      '/products/',
+      '/blog',
+      '/blog/post',
+      '/about',
+    ];
+
+    it('topic: JS classifyTopic agrees with interpreted buildTopicExtractionSQL on every probe', () => {
+      const sql = buildTopicExtractionSQL(rules);
+      for (const url of probes) {
+        expect(classifyTopic(url, rules.topicPatterns), `topic mismatch for ${url}`)
+          .to.equal(interpretTopicSql(sql, url));
+      }
+    });
+
+    it('page: JS classifyPageType agrees with interpreted generatePageTypeClassification on every probe', () => {
+      const sql = generatePageTypeClassification(rules);
+      for (const url of probes) {
+        expect(classifyPageType(url, rules.pagePatterns), `page mismatch for ${url}`)
+          .to.equal(interpretPageSql(sql, url));
+      }
+    });
+
+    it('empty rule set: both builders fall back to Other-only, agreeing with JS', () => {
+      const topicSql = buildTopicExtractionSQL(null);
+      const pageSql = generatePageTypeClassification(null);
+      // The SQL-side 'Other' assertion is otherwise vacuous (the interpreter
+      // returns 'Other' for ANY input given an Other-only CASE), so first assert
+      // the generated SQL really IS Other-only: no WHEN arms and no
+      // REGEXP_EXTRACT — i.e. there is nothing for a probe to match against.
+      expect(topicSql).to.not.match(/WHEN REGEXP_LIKE/);
+      expect(topicSql).to.not.match(/REGEXP_EXTRACT/);
+      expect(pageSql).to.not.match(/WHEN REGEXP_LIKE/);
+      for (const url of probes) {
+        expect(interpretTopicSql(topicSql, url)).to.equal('Other');
+        expect(classifyTopic(url, [])).to.equal('Other');
+        expect(interpretPageSql(pageSql, url)).to.equal('Other');
+        expect(classifyPageType(url, [])).to.equal('Other');
+      }
+    });
+  });
+
+  // M2: sort_order ordering.
+  describe('sort_order honoured (M2)', () => {
+    it('applies named topic rules in sort_order ascending, not array order', () => {
+      const patterns = [
+        { name: 'Second', regex: '/shared', sort_order: 2 },
+        { name: 'First', regex: '/shared', sort_order: 1 },
+      ];
+      expect(classifyTopic('/shared/x', patterns)).to.equal('First');
+    });
+
+    it('falls back to array order when sort_order is absent (stable)', () => {
+      const patterns = [
+        { name: 'First', regex: '/shared' },
+        { name: 'Second', regex: '/shared' },
+      ];
+      expect(classifyTopic('/shared/x', patterns)).to.equal('First');
+    });
+
+    it('falls back to array order when sort_order is non-integer', () => {
+      const patterns = [
+        { name: 'First', regex: '/shared', sort_order: 'x' },
+        { name: 'Second', regex: '/shared', sort_order: null },
+      ];
+      expect(classifyTopic('/shared/x', patterns)).to.equal('First');
+    });
+
+    it('breaks ties on equal sort_order by stable array order', () => {
+      const patterns = [
+        { name: 'First', regex: '/shared', sort_order: 1 },
+        { name: 'Second', regex: '/shared', sort_order: 1 },
+      ];
+      expect(classifyTopic('/shared/x', patterns)).to.equal('First');
+    });
+
+    it('orders page rules by sort_order ascending', () => {
+      const patterns = [
+        { name: 'B', regex: '/p', sort_order: 5 },
+        { name: 'A', regex: '/p', sort_order: 1 },
+      ];
+      expect(classifyPageType('/p/x', patterns)).to.equal('A');
+    });
+  });
+
+  describe('createClassifier (M1)', () => {
+    it('returns null when no rules are present', () => {
+      expect(createClassifier(null)).to.equal(null);
+      expect(createClassifier({ topicPatterns: [], pagePatterns: [] })).to.equal(null);
+      expect(createClassifier({ error: true })).to.equal(null);
+    });
+
+    it('classifies topic and category from a compiled rule set', () => {
+      const classifier = createClassifier({
+        topicPatterns: [{ name: 'Acrobat', regex: '/acrobat' }],
+        pagePatterns: [{ name: 'Product', regex: '/acrobat' }],
+      });
+      expect(classifier.classify('/acrobat/free'))
+        .to.deep.equal({ topic: 'Acrobat', category: 'Product' });
+    });
+
+    it('reuses the compiled patterns across multiple classify calls', () => {
+      const classifier = createClassifier({
+        topicPatterns: [{ name: 'A', regex: '/a' }, { regex: '/x/([^/]+)' }],
+      });
+      expect(classifier.classify('/a/1')).to.deep.equal({ topic: 'A', category: 'Other' });
+      expect(classifier.classify('/x/y')).to.deep.equal({ topic: 'y', category: 'Other' });
+      expect(classifier.classify('/none')).to.deep.equal({ topic: 'Other', category: 'Other' });
+    });
+
+    it('caps the input length on classify', () => {
+      const classifier = createClassifier({
+        topicPatterns: [{ name: 'Tail', regex: 'a{2500}' }],
+      });
+      expect(classifier.classify('a'.repeat(3000)).topic).to.equal('Other');
+    });
+
+    it('emits ONE aggregated log.warn for dropped patterns at construction', () => {
+      const log = { warn: sinon.spy() };
+      createClassifier({
+        topicPatterns: [{ name: 'Bad', regex: '(' }],
+        pagePatterns: [{ name: 'AlsoBad', regex: '[' }, { name: 'Good', regex: '/g' }],
+      }, { log });
+      expect(log.warn).to.have.been.calledOnce;
+      expect(log.warn.firstCall.args[0]).to.match(
+        /agentic-url-classification: 2 rule pattern\(s\) skipped/,
+      );
+    });
+
+    it('does not warn when no patterns are dropped', () => {
+      const log = { warn: sinon.spy() };
+      createClassifier({ topicPatterns: [{ name: 'Good', regex: '/g' }] }, { log });
+      expect(log.warn).to.not.have.been.called;
+    });
+
+    it('counts null / undefined / non-string regex sources as dropped patterns', () => {
+      // toRegExp rejects non-string sources (typeof !== 'string') → each must
+      // increment the failure tally, not be silently ignored. Pins that the
+      // aggregated warn reflects all three drops.
+      const log = { warn: sinon.spy() };
+      createClassifier({
+        topicPatterns: [
+          { name: 'NullSrc', regex: null },
+          { name: 'UndefSrc', regex: undefined },
+          { name: 'NumSrc', regex: 123 },
+        ],
+      }, { log });
+      expect(log.warn).to.have.been.calledOnce;
+      expect(log.warn.firstCall.args[0]).to.match(
+        /agentic-url-classification: 3 rule pattern\(s\) skipped/,
+      );
+    });
+
+    it('does not throw when patterns are dropped without a log', () => {
+      const classifier = createClassifier({ topicPatterns: [{ name: 'Bad', regex: '(' }, { name: 'G', regex: '/g' }] });
+      expect(classifier.classify('/g')).to.deep.equal({ topic: 'G', category: 'Other' });
+    });
+
+    it('does not throw when patterns are dropped and log has no warn fn', () => {
+      // log present but log.warn undefined → the `log?.warn` guard must hold
+      // (log truthy, .warn falsy). Distinct branch from the no-log case above.
+      const classifier = createClassifier(
+        { topicPatterns: [{ name: 'Bad', regex: '(' }, { name: 'G', regex: '/g' }] },
+        { log: {} },
+      );
+      expect(classifier.classify('/g')).to.deep.equal({ topic: 'G', category: 'Other' });
+    });
+
+    // M6: asymmetric rule sets.
+    it('M6: topic-only rule set (no page patterns) → category always Other', () => {
+      const classifier = createClassifier({ topicPatterns: [{ name: 'T', regex: '/t' }] });
+      expect(classifier.classify('/t/x')).to.deep.equal({ topic: 'T', category: 'Other' });
+    });
+
+    it('M6: page-only rule set (no topic patterns) → topic always Other', () => {
+      const classifier = createClassifier({ pagePatterns: [{ name: 'P', regex: '/p' }] });
+      expect(classifier.classify('/p/x')).to.deep.equal({ topic: 'Other', category: 'P' });
+    });
+  });
+});

--- a/test/common/spreadsheet-safe.test.js
+++ b/test/common/spreadsheet-safe.test.js
@@ -1,0 +1,171 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import { expect } from 'chai';
+import {
+  FORMULA_TRIGGERS,
+  sanitizeSpreadsheetValue,
+  escapeCsvValue,
+  serializeCsv,
+} from '../../src/common/spreadsheet-safe.js';
+
+describe('spreadsheet-safe', () => {
+  describe('FORMULA_TRIGGERS', () => {
+    it('lists the seven formula-injection trigger characters', () => {
+      expect(FORMULA_TRIGGERS).to.deep.equal(['=', '+', '-', '@', '\t', '\r', '\n']);
+    });
+  });
+
+  describe('sanitizeSpreadsheetValue', () => {
+    it('prefixes a single quote to a string starting with each formula trigger', () => {
+      expect(sanitizeSpreadsheetValue('=1+1')).to.equal("'=1+1");
+      expect(sanitizeSpreadsheetValue('+1')).to.equal("'+1");
+      expect(sanitizeSpreadsheetValue('-1')).to.equal("'-1");
+      expect(sanitizeSpreadsheetValue('@x')).to.equal("'@x");
+      expect(sanitizeSpreadsheetValue('\tx')).to.equal("'\tx");
+      expect(sanitizeSpreadsheetValue('\rx')).to.equal("'\rx");
+      expect(sanitizeSpreadsheetValue('\nx')).to.equal("'\nx");
+    });
+
+    it('neutralizes a formula operator after leading whitespace (bypass guard)', () => {
+      // leading space does not defang the operator — Excel/Sheets trim it.
+      expect(sanitizeSpreadsheetValue(' =1+1')).to.equal("' =1+1");
+      expect(sanitizeSpreadsheetValue('  +cmd')).to.equal("'  +cmd");
+      expect(sanitizeSpreadsheetValue('\t=x')).to.equal("'\t=x");
+      expect(sanitizeSpreadsheetValue('\n=x')).to.equal("'\n=x");
+    });
+
+    it('passes through a string that does not start with a trigger', () => {
+      expect(sanitizeSpreadsheetValue('Acrobat')).to.equal('Acrobat');
+    });
+
+    it('passes through leading-whitespace text without a formula operator', () => {
+      expect(sanitizeSpreadsheetValue(' foo')).to.equal(' foo');
+      expect(sanitizeSpreadsheetValue('  hello')).to.equal('  hello');
+      expect(sanitizeSpreadsheetValue('   ')).to.equal('   ');
+    });
+
+    it('passes through an empty string (no leading trigger)', () => {
+      expect(sanitizeSpreadsheetValue('')).to.equal('');
+    });
+
+    it('passes through non-string values unchanged (number, boolean, null)', () => {
+      expect(sanitizeSpreadsheetValue(5)).to.equal(5);
+      expect(sanitizeSpreadsheetValue(true)).to.equal(true);
+      expect(sanitizeSpreadsheetValue(null)).to.equal(null);
+      expect(sanitizeSpreadsheetValue(undefined)).to.equal(undefined);
+    });
+  });
+
+  describe('escapeCsvValue', () => {
+    it('renders null as an empty field', () => {
+      expect(escapeCsvValue(null)).to.equal('');
+    });
+
+    it('renders undefined as an empty field', () => {
+      expect(escapeCsvValue(undefined)).to.equal('');
+    });
+
+    it('renders an empty string as an empty field (no prefix, no quoting)', () => {
+      expect(escapeCsvValue('')).to.equal('');
+    });
+
+    it('stringifies an object as JSON and RFC-4180-quotes the embedded quotes', () => {
+      expect(escapeCsvValue({ a: 1 })).to.equal('"{""a"":1}"');
+    });
+
+    it('coerces a number to its string form', () => {
+      expect(escapeCsvValue(5)).to.equal('5');
+    });
+
+    it('neutralizes each formula-trigger prefix (= + - @ tab CR)', () => {
+      expect(escapeCsvValue('=1')).to.equal("'=1");
+      expect(escapeCsvValue('+1')).to.equal("'+1");
+      expect(escapeCsvValue('-1')).to.equal("'-1");
+      expect(escapeCsvValue('@x')).to.equal("'@x");
+      // tab-triggered value is prefixed; tab is not in the RFC-4180 quote set.
+      expect(escapeCsvValue('\tx')).to.equal("'\tx");
+      // CR-triggered value is prefixed AND quoted (CR is in the quote set).
+      expect(escapeCsvValue('\rx')).to.equal('"\'\rx"');
+    });
+
+    it('neutralizes a formula operator after leading whitespace', () => {
+      expect(escapeCsvValue(' =1+1')).to.equal("' =1+1");
+      expect(escapeCsvValue('  +cmd')).to.equal("'  +cmd");
+      expect(escapeCsvValue('\t=x')).to.equal("'\t=x");
+    });
+
+    it('neutralizes AND RFC-quotes an LF-triggered formula', () => {
+      // LF triggers neutralization (prefix) and is in the RFC-4180 quote set.
+      expect(escapeCsvValue('\n=evil')).to.equal('"\'\n=evil"');
+    });
+
+    it('does not prefix a value that does not start with a trigger', () => {
+      expect(escapeCsvValue('Acrobat')).to.equal('Acrobat');
+    });
+
+    it('does not prefix leading-whitespace text without a formula operator', () => {
+      expect(escapeCsvValue(' foo')).to.equal(' foo');
+      expect(escapeCsvValue('  hello')).to.equal('  hello');
+    });
+
+    it('quotes a value containing a comma', () => {
+      expect(escapeCsvValue('a,b')).to.equal('"a,b"');
+    });
+
+    it('quotes a value containing a double quote and doubles the quote', () => {
+      expect(escapeCsvValue('a"b')).to.equal('"a""b"');
+    });
+
+    it('quotes a value containing a newline', () => {
+      expect(escapeCsvValue('a\nb')).to.equal('"a\nb"');
+    });
+
+    it('quotes a value containing a carriage return', () => {
+      // value does not start with the CR, so only quoting applies (no prefix).
+      expect(escapeCsvValue('a\rb')).to.equal('"a\rb"');
+    });
+  });
+
+  describe('serializeCsv', () => {
+    const COLUMNS = ['traffic_date', 'host', 'url_path', 'trf_platform', 'device'];
+
+    it('emits a header-only string when there are no rows', () => {
+      expect(serializeCsv([], ['a', 'b'])).to.equal('a,b');
+    });
+
+    it('joins multiple rows with CRLF and projects only the listed columns in order', () => {
+      const rows = [
+        { a: 1, b: 2, ignored: 'x' },
+        { a: 3, b: 4 },
+      ];
+      expect(serializeCsv(rows, ['a', 'b'])).to.equal('a,b\r\n1,2\r\n3,4');
+    });
+
+    it('renders a missing column value as an empty field', () => {
+      const rows = [{
+        traffic_date: '2026-04-29',
+        host: 'example.com',
+        url_path: '/page',
+        device: 'desktop',
+      }];
+      // trf_platform absent → empty field between url_path and device.
+      expect(serializeCsv(rows, COLUMNS)).to.include('2026-04-29,example.com,/page,,desktop');
+    });
+
+    it('applies field escaping to each cell', () => {
+      const rows = [{ a: '=1', b: 'a,b' }];
+      expect(serializeCsv(rows, ['a', 'b'])).to.equal('a,b\r\n\'=1,"a,b"');
+    });
+  });
+});


### PR DESCRIPTION
## What

Reuse the agentic (CDN-logs) URL classification rules to enrich **referral-traffic** reports with `topic` + `category` columns — both the **weekly** (`llmo-referral-traffic`) and **daily** (`llmo-referral-traffic-daily`) audits. No page-intent replacement; no new per-URL LLM calls.

## How

- **Shared JS classifier** `src/common/agentic-url-classification.js` — JS twin of the existing SQL `CASE WHEN REGEXP_LIKE(...)` logic. `createClassifier(rules, { log })` compiles all patterns once and returns `{ classify(urlPath) }`, or `null` when no rules are present.
- **Rules-present gate** — `hasClassificationRules()` false (null/error/empty) ⇒ enrichment skipped entirely (rows are *not* tagged `'Other'`).
- **Cost model** — LLM authors regex rules once per site (Tier A, cached in Postgres); every run reuses them with zero LLM (Tier B). Same lever that replaced the deleted per-URL page-intent path.
- **Spreadsheet safety** — shared `src/common/spreadsheet-safe.js` neutralizes formula-injection cells for both the weekly Excel and daily CSV paths.
- **Columns are explicit & stable** — weekly `WEEKLY_COLUMNS`, daily 14-col `CSV_COLUMNS`; topic/category always present, empty `''` when not classifying.

## Hardening (from prior review rounds)

- **ReDoS guard** — `toRegExp` rejects non-string / >1000-char / catastrophic-backtracking patterns (5 heuristics); `classify` caps input to 2048 chars. Guards are a screen, not a proof (see ADR caveats).
- **Dialect drift** — V8 Irregexp vs Trino RE2J: POSIX classes / possessive quantifiers / mid-pattern inline flags silently skipped; covered by SQL-twin parity tests.

## Docs

- ADR: `docs/decisions/001-reuse-agentic-url-classification-for-referral-traffic.md`
- Spec: `docs/specs/referral-traffic-topic-category-enrichment.md`

## Caveats

- **P1:** referral sites without agentic rules get no topic/category (by design).
- **P2:** agentic regex is authored against the full CDN-log `url`; referral classifies on `path` only — host/scheme-dependent patterns won't match.

## Testing

- New: `test/common/agentic-url-classification.test.js`, `test/common/spreadsheet-safe.test.js`.
- Full suite green: 100% lines/branches/statements; 103 targeted tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Review notes

- **Incidental API migration:** `src/llmo-referral-traffic/handler.js` switches `site.getSiteId()` → `site.getId()` (the current data-access accessor). Unrelated to the topic/category feature but included here; called out for reviewability per PR feedback.
- **Review nits addressed** (commit `afc04d06`, all non-blocking): timing logs around the agentic rule fetch in both referral handlers; doc note on the deliberate CSV `-` neutralization; doc note that the RE2J/Trino rule dialect excludes backreferences/lookaround (explicit ReDoS-safety rationale).
