### PR TITLE
feat(offsite-brand-presence): pass imsOrgId to DRS scrape jobs

### DIFF
--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -573,7 +573,12 @@ async function triggerDrsScraping(
       const scrapeUrls = datasetId === SCRAPE_DATASET_IDS.TOP_CITED
         ? urlList.map((url) => ({ url }))
         : urlList;
-      const params = { datasetId, siteId, urls: scrapeUrls };
+      // imsOrgId is guaranteed truthy here (the guard above returns early when
+      // it is absent). DRS attaches it as parameters.metadata.imsOrgId to scope
+      // the job's S2S token instead of relying on site_id auto-resolution.
+      const params = {
+        datasetId, siteId, urls: scrapeUrls, imsOrgId,
+      };
       if (datasetId === SCRAPE_DATASET_IDS.REDDIT_COMMENTS) {
         Object.assign(params, redditCommentsParams);
       }

--- a/test/audits/offsite-brand-presence.test.js
+++ b/test/audits/offsite-brand-presence.test.js
@@ -1047,6 +1047,18 @@ describe('Offsite Brand Presence Handler', () => {
       expect(videosCall.args[0]).to.not.have.property('daysBack');
     });
 
+    it('forwards the resolved imsOrgId to submitScrapeJob for every dataset', async () => {
+      stubBrandPresenceData(['https://youtube.com/watch?v=x', 'https://reddit.com/r/adobe/']);
+
+      await offsiteBrandPresenceRunner(FINAL_URL, context, site);
+
+      const calls = mockSubmitScrapeJob.getCalls();
+      expect(calls).to.not.be.empty;
+      calls.forEach((c) => {
+        expect(c.args[0].imsOrgId).to.equal('1234567890ABCDEF12345678@AdobeOrg');
+      });
+    });
+
     it('should not attach reddit_comments params by default (DRS client applies defaults)', async () => {
       stubBrandPresenceData(['https://reddit.com/r/adobe/']);
 


### PR DESCRIPTION
## What

Forward the already-resolved `imsOrgId` into `submitScrapeJob` params so DRS receives `parameters.metadata.imsOrgId`.

## Why

The runner already resolves `imsOrgId` from `site.getOrganization()` for the skip-guard. Forwarding it lets DRS scope its S2S token directly instead of relying on `site_id` auto-resolution, which **400s** when the org has no `imsOrgId` (adobe.com / hermes.com). `imsOrgId` is guaranteed truthy here because the guard returns early when it is absent.

## Depends on

- adobe/spacecat-shared#1664 (drs-client must forward `parameters.metadata.imsOrgId`). Until that releases and the dep is bumped here, the forwarded value is a harmless no-op.

## Test

- New test: `imsOrgId` forwarded to `submitScrapeJob` for every dataset.
- 73 passing, `offsite-brand-presence/handler.js` 100% coverage, lint clean.