### PR TITLE
fix(toc): exclude headings inside button elements from TOC suggestions (LLMO-5474)

### DIFF
--- a/src/headings/utils.js
+++ b/src/headings/utils.js
@@ -54,6 +54,10 @@ export const TOC_EXCLUDED_CONTAINER_SELECTORS = [
 
   // Quote/premium calculator form widgets — step labels use <h2> for UI navigation
   '.form-step',
+
+  // Interactive button elements — headings inside buttons are UI labels, not page content
+  'button',
+  '[role="button"]',
 ];
 
 /**

--- a/test/audits/toc.test.js
+++ b/test/audits/toc.test.js
@@ -3062,6 +3062,30 @@ describe('TOC (Table of Contents) Audit', () => {
         expect(result).to.have.lengthOf(2);
         expect(result.map((r) => r.text)).to.deep.equal(['Get Your Quote', 'Why Choose Us']);
       });
+      it('excludes headings inside button elements (e.g. skip-to-main-content widgets)', () => {
+        const $ = cheerioLoad(
+          '<body>'
+          + '<h1 id="title">ICICI Bank</h1>'
+          + '<button class="skip-main-content-btn"><h2>Skip to main content</h2></button>'
+          + '<h2 id="products">Credit Cards</h2>'
+          + '</body>',
+        );
+        const result = extractTocData($, stubGetHeadingSelector);
+        expect(result).to.have.lengthOf(2);
+        expect(result.map((r) => r.text)).to.deep.equal(['ICICI Bank', 'Credit Cards']);
+      });
+      it('excludes headings inside role="button" elements', () => {
+        const $ = cheerioLoad(
+          '<body>'
+          + '<h1 id="title">Home</h1>'
+          + '<div role="button"><h2>Skip to content</h2></div>'
+          + '<h2 id="main">Main Content</h2>'
+          + '</body>',
+        );
+        const result = extractTocData($, stubGetHeadingSelector);
+        expect(result).to.have.lengthOf(2);
+        expect(result.map((r) => r.text)).to.deep.equal(['Home', 'Main Content']);
+      });
       it('deduplicates headings with identical normalised text', () => {
         const $ = cheerioLoad(
           '<body>'


### PR DESCRIPTION
## Summary

- Adds `button` and `[role="button"]` to `TOC_EXCLUDED_CONTAINER_SELECTORS` in `src/headings/utils.js`
- The ICICI Bank site (`icici.bank.in`) places `<h2>Skip to main content</h2>` inside a `<button class="skip-main-content-btn">` element — no existing selector matched this container, causing the heading to appear in every TOC suggestion
- Fix is structural and site-agnostic: any site using an accessible skip-link pattern with a heading inside a button element is covered

## Root Cause

```html
<div class="skip-to-main-content-widget">
  <button class="skip-main-content-btn" aria-label="skip to main content">
    <h2>Skip to main content</h2>
  </button>
</div>
```

`extractTocData()` in `src/headings/utils.js` checks `TOC_EXCLUDED_CONTAINER_SELECTORS` but had no entry for `button` or `[role="button"]`. Headings inside interactive button elements are always UI labels — never page content headings.

## Test Plan

- [x] `excludes headings inside button elements (e.g. skip-to-main-content widgets)` — verifies ICICI-style button/h2 pattern is excluded while real headings are kept
- [x] `excludes headings inside role="button" elements` — verifies ARIA button pattern is also excluded
- [x] All 172 existing `toc.test.js` tests still pass

## Jira

[LLMO-5474](https://jira.corp.adobe.com/browse/LLMO-5474)

---
🤖 Generated with [OrcaFix](https://wiki.corp.adobe.com/spaces/AEMSites/pages/3880474747/OrcaFix+SpaceCat+Jira+Analysis+Status) via [Claude Code](https://claude.ai/claude-code)