### PR TITLE
fix: drop resolved per-issue entries so UI doesn't show below-threshold issues

### DIFF
--- a/src/cwv/opportunity-sync.js
+++ b/src/cwv/opportunity-sync.js
@@ -17,13 +17,13 @@ import { convertToOpportunity } from '../common/opportunity.js';
 import calculateKpiDeltasForAudit, { THRESHOLDS, METRICS, calculateConfidenceScore } from './kpi-metrics.js';
 
 /**
- * Per-issue statuses that should NOT be overwritten when re-audit detects a metric
- * has resolved. Mirrors the skip list used by `handleOutdatedSuggestions` for
- * suggestion-level statuses — preserves customer/system intent on issues that
- * already moved past NEW.
+ * Per-issue statuses that should NOT be removed when re-audit detects a metric
+ * has resolved. These represent customer/system intent (FIXED, SKIPPED, etc.) or
+ * in-flight work (APPROVED, IN_PROGRESS) — dropping them would lose history. Issues
+ * with any other status (NEW, OUTDATED) get pruned when their metric is no longer
+ * failing, so the UI never shows resolved/below-threshold issues.
  */
 const ISSUE_STATUSES_TO_PRESERVE = new Set([
-  Suggestion.STATUSES.OUTDATED,
   Suggestion.STATUSES.FIXED,
   Suggestion.STATUSES.ERROR,
   Suggestion.STATUSES.SKIPPED,
@@ -80,32 +80,34 @@ export function isMetricFailing(entry, metric) {
 }
 
 /**
- * For each existing issue in `data.issues[]`, if its metric type no longer exceeds
- * threshold in the new audit data, mark it OUTDATED — unless its status is in
- * ISSUE_STATUSES_TO_PRESERVE, in which case it's untouched.
+ * For each existing issue in `data.issues[]`, drop it if its metric type no longer
+ * exceeds threshold in the new audit data — unless its status is in
+ * ISSUE_STATUSES_TO_PRESERVE (FIXED / SKIPPED / APPROVED / IN_PROGRESS / REJECTED /
+ * ERROR), which we keep as customer/system intent.
  *
- * Issues without a `type` field (legacy data) are left untouched: we can't tell
+ * This prevents the UI from showing issue entries for metrics that have improved
+ * back below threshold. Previously these were left in the array with status
+ * OUTDATED, which leaked through to the UI.
+ *
+ * Issues without a `type` field (legacy data) are kept untouched: we can't tell
  * which metric they describe, so the safe behaviour is "no change."
  *
  * @param {Object[]} existingIssues - issues array from existing suggestion.data
  * @param {Object} newDataItem - the new CWV entry for this URL/pattern
- * @returns {Object[]} a new array (does not mutate input) with updated statuses
+ * @returns {Object[]} a new array (does not mutate input) with resolved issues removed
  */
 export function applyPerIssueOutdated(existingIssues, newDataItem) {
   if (!Array.isArray(existingIssues) || existingIssues.length === 0) {
     return existingIssues || [];
   }
-  return existingIssues.map((issue) => {
+  return existingIssues.filter((issue) => {
     if (!issue || !issue.type) {
-      return issue;
+      return true;
     }
     if (issue.status && ISSUE_STATUSES_TO_PRESERVE.has(issue.status)) {
-      return issue;
+      return true;
     }
-    if (isMetricFailing(newDataItem, issue.type)) {
-      return issue;
-    }
-    return { ...issue, status: Suggestion.STATUSES.OUTDATED };
+    return isMetricFailing(newDataItem, issue.type);
   });
 }
 
@@ -113,9 +115,11 @@ export function applyPerIssueOutdated(existingIssues, newDataItem) {
  * Custom mergeDataFunction for CWV suggestions used by syncSuggestions on re-audit.
  *
  * Default behaviour is a shallow `{...existing, ...new}` spread. We extend it with
- * per-issue OUTDATED detection: when a URL still fails some metrics but others
- * resolved between audits, only the resolved metrics' issues flip to OUTDATED.
- * The suggestion itself stays NEW because the URL is still failing overall.
+ * per-issue resolution: when a URL still fails some metrics but others resolved
+ * between audits, the resolved-metric issues are dropped from `data.issues[]` so
+ * the UI no longer surfaces them. Customer/system-touched issues (FIXED, SKIPPED,
+ * APPROVED, IN_PROGRESS, REJECTED, ERROR) are preserved for history. The suggestion
+ * itself stays NEW because the URL is still failing overall.
  *
  * The newDataItem (raw CWV entry) doesn't carry `issues`, so the existing
  * `data.issues[]` is preserved via the spread; we then post-process it.

--- a/test/audits/cwv.test.js
+++ b/test/audits/cwv.test.js
@@ -901,7 +901,7 @@ describe('shouldSendAutoSuggestForSuggestion — codefix dispatch gating', () =>
   });
 });
 
-describe('Per-issue OUTDATED merge helpers', () => {
+describe('Per-issue prune-on-resolve merge helpers', () => {
   // Imported lazily to keep the existing top-level imports unchanged.
   let isMetricFailing;
   let applyPerIssueOutdated;
@@ -945,15 +945,12 @@ describe('Per-issue OUTDATED merge helpers', () => {
   });
 
   describe('applyPerIssueOutdated', () => {
-    it('marks issue OUTDATED when its metric type no longer fails', () => {
+    it('drops an issue when its metric type no longer fails', () => {
       const existing = [
         { id: 'a', type: 'lcp', status: 'NEW', value: 'lcp guidance' },
       ];
       const result = applyPerIssueOutdated(existing, entryAllPassing);
-      expect(result[0].status).to.equal('OUTDATED');
-      // Other fields preserved
-      expect(result[0].id).to.equal('a');
-      expect(result[0].value).to.equal('lcp guidance');
+      expect(result).to.deep.equal([]);
     });
 
     it('keeps issue NEW when its metric type still fails', () => {
@@ -961,10 +958,11 @@ describe('Per-issue OUTDATED merge helpers', () => {
         { id: 'a', type: 'lcp', status: 'NEW', value: 'lcp guidance' },
       ];
       const result = applyPerIssueOutdated(existing, entryFailingLcp);
+      expect(result).to.have.lengthOf(1);
       expect(result[0].status).to.equal('NEW');
     });
 
-    it('marks only the resolved metric OUTDATED; others stay NEW', () => {
+    it('drops only the resolved metric; others stay NEW', () => {
       const existing = [
         { id: 'a', type: 'lcp', status: 'NEW' },
         { id: 'b', type: 'cls', status: 'NEW' },
@@ -972,36 +970,46 @@ describe('Per-issue OUTDATED merge helpers', () => {
       ];
       // Only CLS and INP fail now — LCP resolved
       const result = applyPerIssueOutdated(existing, entryFailingClsAndInp);
-      expect(result[0].status).to.equal('OUTDATED'); // lcp resolved
-      expect(result[1].status).to.equal('NEW'); // cls still failing
-      expect(result[2].status).to.equal('NEW'); // inp still failing
+      expect(result).to.have.lengthOf(2);
+      expect(result.map((i) => i.id)).to.deep.equal(['b', 'c']);
+      expect(result.every((i) => i.status === 'NEW')).to.be.true;
     });
 
     it('preserves APPROVED status when metric resolves (skip list)', () => {
       const existing = [{ id: 'a', type: 'lcp', status: 'APPROVED' }];
       const result = applyPerIssueOutdated(existing, entryAllPassing);
+      expect(result).to.have.lengthOf(1);
       expect(result[0].status).to.equal('APPROVED');
     });
 
-    it('preserves FIXED, REJECTED, SKIPPED, IN_PROGRESS, ERROR, OUTDATED in skip list', () => {
-      const statuses = ['FIXED', 'REJECTED', 'SKIPPED', 'IN_PROGRESS', 'ERROR', 'OUTDATED'];
+    it('preserves FIXED, REJECTED, SKIPPED, IN_PROGRESS, ERROR in skip list', () => {
+      const statuses = ['FIXED', 'REJECTED', 'SKIPPED', 'IN_PROGRESS', 'ERROR'];
       statuses.forEach((status) => {
         const existing = [{ id: 'a', type: 'lcp', status }];
         const result = applyPerIssueOutdated(existing, entryAllPassing);
+        expect(result, `expected ${status} preserved`).to.have.lengthOf(1);
         expect(result[0].status, `expected ${status} preserved`).to.equal(status);
       });
+    });
+
+    it('drops stale OUTDATED issues so they no longer leak to the UI', () => {
+      // OUTDATED is no longer in the preserve set — these are pruned on re-merge.
+      const existing = [{ id: 'a', type: 'lcp', status: 'OUTDATED' }];
+      const result = applyPerIssueOutdated(existing, entryAllPassing);
+      expect(result).to.deep.equal([]);
     });
 
     it('leaves legacy issues without a type field untouched', () => {
       const existing = [{ value: 'markdown only, no type', status: 'NEW' }];
       const result = applyPerIssueOutdated(existing, entryAllPassing);
+      expect(result).to.have.lengthOf(1);
       expect(result[0]).to.deep.equal({ value: 'markdown only, no type', status: 'NEW' });
     });
 
-    it('marks NEW issue OUTDATED even when status field is missing (defaults to OUTDATED on resolve)', () => {
+    it('drops a NEW issue even when status field is missing (no customer intent recorded)', () => {
       const existing = [{ id: 'a', type: 'lcp' }]; // no status field
       const result = applyPerIssueOutdated(existing, entryAllPassing);
-      expect(result[0].status).to.equal('OUTDATED');
+      expect(result).to.deep.equal([]);
     });
 
     it('returns empty array for empty input', () => {
@@ -1076,7 +1084,7 @@ describe('Per-issue OUTDATED merge helpers', () => {
       expect(result.jiraLink).to.equal(null);
     });
 
-    it('marks resolved-metric issues OUTDATED on re-merge', () => {
+    it('drops resolved-metric issues on re-merge so the UI does not surface them', () => {
       const existing = {
         url: 'x',
         metrics: [{ deviceType: 'mobile', lcp: 4500, cls: 0.3 }],
@@ -1090,8 +1098,10 @@ describe('Per-issue OUTDATED merge helpers', () => {
         metrics: [{ deviceType: 'mobile', lcp: 1800, cls: 0.3 }], // lcp resolved, cls still failing
       };
       const result = mergeCwvData(existing, newItem);
-      expect(result.issues[0].status).to.equal('OUTDATED'); // lcp
-      expect(result.issues[1].status).to.equal('NEW'); // cls
+      // LCP issue is dropped entirely; only CLS remains
+      expect(result.issues).to.have.lengthOf(1);
+      expect(result.issues[0].id).to.equal('b');
+      expect(result.issues[0].status).to.equal('NEW');
       // metrics overwritten by new data
       expect(result.metrics[0].lcp).to.equal(1800);
     });


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/SITES-46397

Issue links (LCP / INP / CLS) are appearing under CWV suggestions in the UI even when the metric values were already    below threshold (i.e., the page was passing for that metric and the issue was no longer actionable).                                                    
                                                                                                                                                          
Root cause                                                                                                                                              
                                                                                                                                                          
In spacecat-audit-worker/src/cwv/opportunity-sync.js, the helper applyPerIssueOutdated() handles per-issue lifecycle on re-audit. When a previously-failing metric improved back below threshold, the helper kept the issue in data.issues[] and only flipped its status to OUTDATED. Worse, OUTDATED was itself listed in ISSUE_STATUSES_TO_PRESERVE, so once-OUTDATED issues persisted across every subsequent audit and accumulated forever. Since the UI renders all entries in data.issues[] regardless of status, those resolved/below-threshold issues kept showing up.

Audit thresholds (spacecat-audit-worker/src/cwv/kpi-metrics.js): LCP > 2500ms, CLS > 0.1, INP > 200ms = failing. Anything below is passing and should not appear as an issue.
                                                                                                                                                          
Fix                                                                                                                                                     
  
Changed applyPerIssueOutdated() to drop resolved issues from the array instead of marking them OUTDATED, and removed OUTDATED from ISSUE_STATUSES_TO_PRESERVE so legacy stale entries are also cleaned up on the next re-audit. Customer/system-touched statuses (FIXED, SKIPPED, APPROVED, IN_PROGRESS, REJECTED, ERROR) are still preserved — those carry intent and history we don't want to lose. Legacy issues without a type field are also untouched. 