### PR TITLE
fix(prerender): prevent duplicate domain-wide suggestions via buildKey symmetry

### DIFF
--- a/src/prerender/handler.js
+++ b/src/prerender/handler.js
@@ -1260,11 +1260,14 @@ export async function processOpportunityAndSuggestions(
     );
   }
 
-  // Build key function that handles both individual and domain-wide suggestions
+  // Build key function that handles both individual and domain-wide suggestions.
+  // Domain-wide suggestions must produce the same constant key whether they come from
+  // allSuggestions (new items have a .key field) or from existing DB records (stored
+  // data has no .key but has isDomainWide:true). Without this symmetry, syncSuggestions
+  // never matches the existing domain-wide record and creates a duplicate every audit run.
   const buildKey = (data) => {
-    // Domain-wide suggestion has a special key field
-    if (data.key) {
-      return data.key;
+    if (data.key === DOMAIN_WIDE_SUGGESTION_KEY || data.isDomainWide) {
+      return DOMAIN_WIDE_SUGGESTION_KEY;
     }
     // Key on pathname+search so that query-param variants (e.g. /page?filter=a vs /page?filter=b)
     // produce distinct suggestions. Domain shifts only affect hostname, so migration tolerance

--- a/src/prerender/handler.js
+++ b/src/prerender/handler.js
@@ -21,10 +21,17 @@ import { getObjectFromKey } from '../utils/s3-utils.js';
 import { getTopAgenticLiveUrlsFromAthena, getPreferredBaseUrl } from '../utils/agentic-urls.js';
 import { createOpportunityData } from './opportunity-data-mapper.js';
 import { analyzeHtmlForPrerender } from './utils/html-comparator.js';
-import { isPaidLLMOCustomer, mergeAndGetUniqueHtmlUrls, toPathname } from './utils/utils.js';
+import {
+  buildSuggestionKey,
+  isPaidLLMOCustomer,
+  mergeAndGetUniqueHtmlUrls,
+  normalizePathnameWithQuery,
+  toPathname,
+} from './utils/utils.js';
 import {
   CONTENT_GAIN_THRESHOLD,
   DAILY_BATCH_SIZE,
+  DOMAIN_WIDE_SUGGESTION_KEY,
   TOP_AGENTIC_URLS_LIMIT,
   TOP_ORGANIC_URLS_LIMIT,
   PRERENDER_RECENT_PROCESSING_TIME_DAYS,
@@ -49,8 +56,6 @@ const AUDIT_ERROR_MESSAGE = 'Audit failed';
 
 // Domain-wide suggestion URL format (sync scrapedUrlsSet + prepareDomainWideAggregateSuggestion)
 const getDomainWideSuggestionUrl = (baseUrl) => `${baseUrl}/* (All Domain URLs)`;
-
-const DOMAIN_WIDE_SUGGESTION_KEY = 'domain-wide-aggregate|prerender';
 
 /**
  * Reads and parses the site's status.json from S3.
@@ -317,23 +322,6 @@ function normalizePathname(url) {
   try {
     const { pathname } = new URL(url);
     return pathname.length > 1 ? pathname.replace(/\/+$/, '') : pathname;
-  } catch {
-    return url;
-  }
-}
-
-/**
- * Normalizes a URL to its pathname + search string.
- * Trailing slashes on the pathname are removed (except for the root path).
- * Falls back to the raw string when the URL is not parseable.
- * @param {string} url
- * @returns {string} pathname+search, or the original string on parse failure
- */
-function normalizePathnameWithQuery(url) {
-  try {
-    const { pathname, search } = new URL(url);
-    const normalized = pathname.length > 1 ? pathname.replace(/\/+$/, '') : pathname;
-    return search ? `${normalized}${search}` : normalized;
   } catch {
     return url;
   }
@@ -1260,21 +1248,6 @@ export async function processOpportunityAndSuggestions(
     );
   }
 
-  // Build key function that handles both individual and domain-wide suggestions.
-  // Domain-wide suggestions must produce the same constant key whether they come from
-  // allSuggestions (new items have a .key field) or from existing DB records (stored
-  // data has no .key but has isDomainWide:true). Without this symmetry, syncSuggestions
-  // never matches the existing domain-wide record and creates a duplicate every audit run.
-  const buildKey = (data) => {
-    if (data.key === DOMAIN_WIDE_SUGGESTION_KEY || data.isDomainWide) {
-      return DOMAIN_WIDE_SUGGESTION_KEY;
-    }
-    // Key on pathname+search so that query-param variants (e.g. /page?filter=a vs /page?filter=b)
-    // produce distinct suggestions. Domain shifts only affect hostname, so migration tolerance
-    // (e.g. switching from site.getBaseURL() to getPreferredBaseUrl()) is preserved.
-    return normalizePathnameWithQuery(data.url);
-  };
-
   // Helper function to extract only the fields we want in suggestions
   const mapSuggestionData = (suggestion) => ({
     url: suggestion.url,
@@ -1307,7 +1280,7 @@ export async function processOpportunityAndSuggestions(
     opportunity,
     newData: allSuggestions,
     context,
-    buildKey,
+    buildKey: buildSuggestionKey,
     mapNewSuggestion: (suggestion) => ({
       opportunityId: opportunity.getId(),
       type: Suggestion.TYPES.CONFIG_UPDATE,

--- a/src/prerender/utils/constants.js
+++ b/src/prerender/utils/constants.js
@@ -20,3 +20,4 @@ export const TOP_ORGANIC_URLS_LIMIT = 200;
 export const PRERENDER_RECENT_PROCESSING_TIME_DAYS = 7;
 export const MODE_AI_ONLY = 'ai-only';
 export const MYSTIQUE_BATCH_SIZE = DAILY_BATCH_SIZE;
+export const DOMAIN_WIDE_SUGGESTION_KEY = 'domain-wide-aggregate|prerender';

--- a/src/prerender/utils/utils.js
+++ b/src/prerender/utils/utils.js
@@ -16,6 +16,7 @@
 
 import { Entitlement } from '@adobe/spacecat-shared-data-access';
 import { TierClient } from '@adobe/spacecat-shared-tier-client';
+import { DOMAIN_WIDE_SUGGESTION_KEY } from './constants.js';
 
 /**
  * Common non-HTML file extensions that should be filtered out
@@ -59,6 +60,39 @@ export function toPathname(url) {
   } catch {
     return url;
   }
+}
+
+/**
+ * Normalizes a URL to its pathname + search string.
+ * Trailing slashes on the pathname are removed (except for the root path).
+ * Falls back to the raw string when the URL is not parseable.
+ * @param {string} url
+ * @returns {string} pathname+search, or the original string on parse failure
+ */
+export function normalizePathnameWithQuery(url) {
+  try {
+    const { pathname, search } = new URL(url);
+    const normalized = pathname.length > 1 ? pathname.replace(/\/+$/, '') : pathname;
+    return search ? `${normalized}${search}` : normalized;
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Builds a dedup key for a prerender suggestion.
+ * Domain-wide suggestions (incoming items with `.key` or stored records with
+ * `isDomainWide:true`) always return the same constant so that syncSuggestions
+ * matches existing domain-wide records instead of creating duplicates.
+ * Individual suggestions are keyed by pathname+search.
+ * @param {Object} data - Suggestion data or incoming new-data item
+ * @returns {string} dedup key
+ */
+export function buildSuggestionKey(data) {
+  if (data.key === DOMAIN_WIDE_SUGGESTION_KEY || data.isDomainWide) {
+    return DOMAIN_WIDE_SUGGESTION_KEY;
+  }
+  return normalizePathnameWithQuery(data.url);
 }
 
 /**

--- a/test/audits/prerender/handler.test.js
+++ b/test/audits/prerender/handler.test.js
@@ -3443,8 +3443,9 @@ describe('Prerender Audit', () => {
         expect(buildKey({ url: 'https://example.com/some/page?filter=iphone' })).to.equal('/some/page?filter=iphone');
         expect(buildKey({ url: 'https://www.example.com/some/page?filter=mac' })).to.equal('/some/page?filter=mac');
 
-        // Domain-wide suggestions (with a `key` field) pass through unchanged
-        expect(buildKey({ key: 'domain-wide-key' })).to.equal('domain-wide-key');
+        // Domain-wide suggestions return the constant key regardless of how the data is stored
+        expect(buildKey({ key: 'domain-wide-aggregate|prerender' })).to.equal('domain-wide-aggregate|prerender');
+        expect(buildKey({ isDomainWide: true, url: 'https://example.com/* (All Domain URLs)' })).to.equal('domain-wide-aggregate|prerender');
       });
 
       it('should normalize scrapedUrlsSet to pathname so domain-shifted suggestions are correctly outdated', async () => {
@@ -3713,7 +3714,11 @@ describe('Prerender Audit', () => {
         expect(domainWideSuggestion).to.be.undefined;
       });
 
-      it('should create new domain-wide suggestion when existing one is OUTDATED without deployed flags', async () => {
+      it('should pass domain-wide suggestion to syncSuggestions when existing one is OUTDATED — buildKey symmetry prevents duplicate', async () => {
+        // When the existing domain-wide is not preservable (OUTDATED, no edgeDeployed),
+        // the new domain-wide aggregate is always included in newData. The fixed buildKey
+        // returns DOMAIN_WIDE_SUGGESTION_KEY for stored data with isDomainWide:true, so
+        // syncSuggestions matches the existing record and updates it instead of creating a duplicate.
         const existingDomainWideSuggestion = {
           getId: () => 'existing-domain-wide-id',
           getStatus: () => 'OUTDATED',
@@ -3764,6 +3769,12 @@ describe('Prerender Audit', () => {
         const domainWideSuggestion = syncArgs.newData.find((s) => s.key);
         expect(domainWideSuggestion).to.exist;
         expect(domainWideSuggestion.key).to.equal('domain-wide-aggregate|prerender');
+
+        // Verify buildKey treats both new (data.key) and stored (isDomainWide) domain-wide
+        // records as the same key — the core fix preventing duplicates
+        const { buildKey } = syncArgs;
+        expect(buildKey({ key: 'domain-wide-aggregate|prerender' })).to.equal('domain-wide-aggregate|prerender');
+        expect(buildKey({ isDomainWide: true, url: 'https://example.com/* (All Domain URLs)' })).to.equal('domain-wide-aggregate|prerender');
       });
 
       it('should not detect domain-wide suggestion by pathPattern alone (requires isDomainWide flag)', async () => {
@@ -8051,7 +8062,10 @@ describe('Prerender Audit', () => {
       );
     });
 
-    it('should create new domain-wide suggestion when existing ones are not preservable', async () => {
+    it('should pass domain-wide aggregate to syncSuggestions when existing one is not preservable — buildKey match prevents duplicate', async () => {
+      // The domain-wide item is always present in newData when no preservable one exists.
+      // The fixed buildKey returns DOMAIN_WIDE_SUGGESTION_KEY for stored isDomainWide:true data,
+      // so syncSuggestions matches and updates the existing record rather than inserting a new one.
       const existingDomainWideSuggestion = {
         getStatus: () => 'OUTDATED',
         getId: () => 'outdated-domain-wide-id',
@@ -8102,9 +8116,13 @@ describe('Prerender Audit', () => {
       await mockHandler.processOpportunityAndSuggestions('https://example.com', auditData, context);
 
       expect(syncSuggestionsStub).to.have.been.calledOnce;
-      const { newData } = syncSuggestionsStub.getCall(0).args[0];
+      const { newData, buildKey } = syncSuggestionsStub.getCall(0).args[0];
       const domainWide = newData.find((item) => item.key);
       expect(domainWide).to.exist;
+
+      // buildKey must return the same constant for both new and stored domain-wide data
+      expect(buildKey({ key: 'domain-wide-aggregate|prerender' })).to.equal('domain-wide-aggregate|prerender');
+      expect(buildKey({ isDomainWide: true })).to.equal('domain-wide-aggregate|prerender');
     });
 
     it('should include suggestionId in auditRunCandidates from saved suggestions', async () => {
@@ -8990,7 +9008,10 @@ describe('Prerender Audit', () => {
       );
     });
 
-    it('should create new domain-wide suggestion when existing ones are not preservable', async () => {
+    it('should pass domain-wide aggregate to syncSuggestions when existing one is not preservable — buildKey match prevents duplicate', async () => {
+      // The domain-wide item is always present in newData when no preservable one exists.
+      // The fixed buildKey returns DOMAIN_WIDE_SUGGESTION_KEY for stored isDomainWide:true data,
+      // so syncSuggestions matches and updates the existing record rather than inserting a new one.
       const existingDomainWideSuggestion = {
         getStatus: () => 'OUTDATED',
         getId: () => 'outdated-domain-wide-id',
@@ -9041,9 +9062,13 @@ describe('Prerender Audit', () => {
       await mockHandler.processOpportunityAndSuggestions('https://example.com', auditData, context);
 
       expect(syncSuggestionsStub).to.have.been.calledOnce;
-      const { newData } = syncSuggestionsStub.getCall(0).args[0];
+      const { newData, buildKey } = syncSuggestionsStub.getCall(0).args[0];
       const domainWide = newData.find((item) => item.key);
       expect(domainWide).to.exist;
+
+      // buildKey must return the same constant for both new and stored domain-wide data
+      expect(buildKey({ key: 'domain-wide-aggregate|prerender' })).to.equal('domain-wide-aggregate|prerender');
+      expect(buildKey({ isDomainWide: true })).to.equal('domain-wide-aggregate|prerender');
     });
   });
 

--- a/test/audits/prerender/sync-suggestions.test.js
+++ b/test/audits/prerender/sync-suggestions.test.js
@@ -19,9 +19,12 @@ import { toPathname } from '../../../src/prerender/utils/utils.js';
 
 use(sinonChai);
 
-// Mirrors the buildKey in processOpportunityAndSuggestions
+// Mirrors the buildKey in processOpportunityAndSuggestions.
+// Domain-wide suggestions must return the same constant regardless of whether data comes
+// from allSuggestions (has .key) or from an existing DB record (has isDomainWide:true).
+const DOMAIN_WIDE_KEY = 'domain-wide-aggregate|prerender';
 const buildKey = (data) => {
-  if (data.key) return data.key;
+  if (data.key === DOMAIN_WIDE_KEY || data.isDomainWide) return DOMAIN_WIDE_KEY;
   return toPathname(data.url);
 };
 
@@ -217,6 +220,52 @@ describe('Prerender syncSuggestions integration', () => {
     // Nothing outdated or updated
     expect(bulkUpdateStatus).to.not.have.been.called;
     expect(saveMany).to.not.have.been.called;
+  });
+
+  it('Case 6 — existing domain-wide suggestion (isDomainWide:true, no .key) is matched and updated, not duplicated', async () => {
+    // Simulates the stale DB record: stored data has isDomainWide but no .key field.
+    // Before the fix, buildKey returned a pathname-based key for the stored record and
+    // DOMAIN_WIDE_KEY for the incoming item, so they never matched and a duplicate was created.
+    const existingDomainWide = makeSuggestion({
+      isDomainWide: true,
+      url: 'https://example.com/* (All Domain URLs)',
+      pathPattern: '/*',
+      allowedRegexPatterns: ['/*'],
+      wordCountBefore: 10,
+      wordCountAfter: 20,
+      contentGainRatio: 0.5,
+    }, 'OUTDATED');
+
+    // Incoming domain-wide from a new audit run — has .key field
+    const incomingDomainWide = {
+      key: DOMAIN_WIDE_KEY,
+      data: {
+        isDomainWide: true,
+        url: 'https://example.com/* (All Domain URLs)',
+        pathPattern: '/*',
+        allowedRegexPatterns: ['/*'],
+        wordCountBefore: 15,
+        wordCountAfter: 35,
+        contentGainRatio: 1.2,
+      },
+    };
+
+    await syncSuggestions({
+      context,
+      opportunity,
+      newData: [incomingDomainWide],
+      buildKey,
+      mergeDataFunction,
+      mapNewSuggestion: (d) => ({ data: d.data ?? d }),
+      existingSuggestions: [existingDomainWide],
+    });
+
+    // Existing was updated in place — no duplicate created
+    expect(saveMany).to.have.been.calledOnce;
+    expect(addSuggestions).to.not.have.been.called;
+    // Fresh aggregated data was applied
+    expect(existingDomainWide.getData().contentGainRatio).to.equal(1.2);
+    expect(existingDomainWide.getData().wordCountBefore).to.equal(15);
   });
 
   it('pathname normalization — domain shift does not create a duplicate suggestion', async () => {

--- a/test/audits/prerender/sync-suggestions.test.js
+++ b/test/audits/prerender/sync-suggestions.test.js
@@ -260,9 +260,10 @@ describe('Prerender syncSuggestions integration', () => {
     expect(existingDomainWide.getData().wordCountBefore).to.equal(15);
   });
 
-  it('Case 6b — multiple OUTDATED domain-wide duplicates: all are updated, no new one created, none re-outdated', async () => {
-    // Reproduces the production incident where 5 OUTDATED domain-wide suggestions
-    // accumulated for the same opportunity due to the buildKey mismatch bug.
+  it('Case 6b — multiple OUTDATED domain-wide duplicates are all updated via buildKey match, no new one created', async () => {
+    // Tests the buildKey fix path: when existing domain-wide suggestions are not
+    // preservable (OUTDATED, no edgeDeployed), the new domain-wide IS in newData
+    // and buildSuggestionKey matches all existing OUTDATED entries for update.
     const dup1 = makeSuggestion({
       isDomainWide: true,
       url: 'https://example.com/* (All Domain URLs)',
@@ -313,6 +314,35 @@ describe('Prerender syncSuggestions integration', () => {
     // handleOutdatedSuggestions, so bulkUpdateStatus must not be called for them
     const outdatedCall = bulkUpdateStatus.getCalls().find((c) => c.args[1] === 'OUTDATED');
     expect(outdatedCall).to.be.undefined;
+  });
+
+  it('Case 6c — multiple NEW domain-wide duplicates from a race are not outdated or duplicated further', async () => {
+    // Reproduces the exact production incident: concurrent Lambdas created multiple
+    // NEW domain-wide suggestions. On the next single-threaded audit run,
+    // findPreservableDomainWideSuggestion finds one of them (NEW is preservable)
+    // and excludes domain-wide from newData entirely. The isDomainWide guard in
+    // handleOutdatedSuggestions must protect all NEW entries from being marked OUTDATED.
+    const dup1 = makeSuggestion({ isDomainWide: true, url: 'https://example.com/* (All Domain URLs)' }, 'NEW');
+    const dup2 = makeSuggestion({ isDomainWide: true, url: 'https://example.com/* (All Domain URLs)' }, 'NEW');
+    const dup3 = makeSuggestion({ isDomainWide: true, url: 'https://example.com/* (All Domain URLs)' }, 'NEW');
+
+    await syncSuggestions({
+      context,
+      opportunity,
+      newData: [], // domain-wide excluded because findPreservableDomainWideSuggestion found a NEW one
+      buildKey,
+      mergeDataFunction,
+      mapNewSuggestion: (d) => ({ data: d }),
+      existingSuggestions: [dup1, dup2, dup3],
+    });
+
+    // isDomainWide guard in handleOutdatedSuggestions must protect all three NEW entries
+    const outdatedCall = bulkUpdateStatus.getCalls().find((c) => c.args[1] === 'OUTDATED');
+    expect(outdatedCall).to.be.undefined;
+    // No new domain-wide created
+    expect(addSuggestions).to.not.have.been.called;
+    // No spurious data updates (nothing to match against in newData)
+    expect(saveMany).to.not.have.been.called;
   });
 
   it('pathname normalization — domain shift does not create a duplicate suggestion', async () => {

--- a/test/audits/prerender/sync-suggestions.test.js
+++ b/test/audits/prerender/sync-suggestions.test.js
@@ -15,18 +15,10 @@ import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import { syncSuggestions } from '../../../src/utils/data-access.js';
-import { toPathname } from '../../../src/prerender/utils/utils.js';
+import { buildSuggestionKey as buildKey, toPathname } from '../../../src/prerender/utils/utils.js';
+import { DOMAIN_WIDE_SUGGESTION_KEY as DOMAIN_WIDE_KEY } from '../../../src/prerender/utils/constants.js';
 
 use(sinonChai);
-
-// Mirrors the buildKey in processOpportunityAndSuggestions.
-// Domain-wide suggestions must return the same constant regardless of whether data comes
-// from allSuggestions (has .key) or from an existing DB record (has isDomainWide:true).
-const DOMAIN_WIDE_KEY = 'domain-wide-aggregate|prerender';
-const buildKey = (data) => {
-  if (data.key === DOMAIN_WIDE_KEY || data.isDomainWide) return DOMAIN_WIDE_KEY;
-  return toPathname(data.url);
-};
 
 // Mirrors the pathname-normalized scrapedUrlsSet created in processOpportunityAndSuggestions
 const makeScrapedUrlsSet = (urls) => {
@@ -266,6 +258,61 @@ describe('Prerender syncSuggestions integration', () => {
     // Fresh aggregated data was applied
     expect(existingDomainWide.getData().contentGainRatio).to.equal(1.2);
     expect(existingDomainWide.getData().wordCountBefore).to.equal(15);
+  });
+
+  it('Case 6b — multiple OUTDATED domain-wide duplicates: all are updated, no new one created, none re-outdated', async () => {
+    // Reproduces the production incident where 5 OUTDATED domain-wide suggestions
+    // accumulated for the same opportunity due to the buildKey mismatch bug.
+    const dup1 = makeSuggestion({
+      isDomainWide: true,
+      url: 'https://example.com/* (All Domain URLs)',
+      contentGainRatio: 0.5,
+    }, 'OUTDATED');
+    const dup2 = makeSuggestion({
+      isDomainWide: true,
+      url: 'https://example.com/* (All Domain URLs)',
+      contentGainRatio: 0.6,
+    }, 'OUTDATED');
+    const dup3 = makeSuggestion({
+      isDomainWide: true,
+      url: 'https://example.com/* (All Domain URLs)',
+      contentGainRatio: 0.7,
+    }, 'OUTDATED');
+
+    const incomingDomainWide = {
+      key: DOMAIN_WIDE_KEY,
+      data: {
+        isDomainWide: true,
+        url: 'https://example.com/* (All Domain URLs)',
+        contentGainRatio: 2.0,
+      },
+    };
+
+    await syncSuggestions({
+      context,
+      opportunity,
+      newData: [incomingDomainWide],
+      buildKey,
+      mergeDataFunction,
+      mapNewSuggestion: (d) => ({ data: d.data ?? d }),
+      existingSuggestions: [dup1, dup2, dup3],
+    });
+
+    // All three share the same buildKey, so all are matched and data-refreshed
+    expect(saveMany).to.have.been.calledOnce;
+    const savedSuggestions = saveMany.firstCall.args[0];
+    expect(savedSuggestions).to.have.lengthOf(3);
+    savedSuggestions.forEach((s) => {
+      expect(s.getData().contentGainRatio).to.equal(2.0);
+    });
+
+    // No new suggestion created — the key is already present among existing
+    expect(addSuggestions).to.not.have.been.called;
+
+    // Domain-wide suggestions are protected by the isDomainWide guard in
+    // handleOutdatedSuggestions, so bulkUpdateStatus must not be called for them
+    const outdatedCall = bulkUpdateStatus.getCalls().find((c) => c.args[1] === 'OUTDATED');
+    expect(outdatedCall).to.be.undefined;
   });
 
   it('pathname normalization — domain shift does not create a duplicate suggestion', async () => {


### PR DESCRIPTION
## Summary

Fixes a bug where the prerender audit created a new domain-wide aggregate suggestion on every audit run when the existing one was in a non-preservable state (OUTDATED, REJECTED, etc.), resulting in an ever-growing list of duplicate domain-wide suggestions that could never be cleaned up.

## Root Cause

`buildKey` inside `processOpportunityAndSuggestions` was asymmetric:

- **Incoming** domain-wide item (from `allSuggestions`) has a `.key` field → `buildKey` returned `'domain-wide-aggregate|prerender'`
- **Stored** domain-wide suggestion (from `existing.getData()`) has no `.key` — only `isDomainWide: true` → `buildKey` fell through to `normalizePathnameWithQuery(data.url)` → returned `/*%20(All%20Domain%20URLs)`

These two keys never matched, so `syncSuggestions` always treated the incoming domain-wide as a brand-new suggestion and inserted a duplicate. The `isDomainWide` guard in `handleOutdatedSuggestions` then prevented the old copies from ever being cleaned up.

## Fix

Extended `buildKey` to recognise `isDomainWide: true` in stored data and return the same constant key as the incoming item:

```js
// Before
const buildKey = (data) => {
  if (data.key) return data.key;
  return normalizePathnameWithQuery(data.url);
};

// After
const buildKey = (data) => {
  if (data.key === DOMAIN_WIDE_SUGGESTION_KEY || data.isDomainWide) {
    return DOMAIN_WIDE_SUGGESTION_KEY;
  }
  return normalizePathnameWithQuery(data.url);
};
```

Now `syncSuggestions` correctly matches the existing domain-wide record and updates it in place instead of inserting a new one.

## Changes

- **`src/prerender/handler.js`** — fix `buildKey` to return `DOMAIN_WIDE_SUGGESTION_KEY` for both incoming (`.key`) and stored (`isDomainWide:true`) domain-wide data
- **`test/audits/prerender/sync-suggestions.test.js`** — update `buildKey` mirror constant; add Case 6 that proves no duplicate is created when existing stored domain-wide has `isDomainWide:true`
- **`test/audits/prerender/handler.test.js`** — update assertions in "OUTDATED" and "not preservable" tests to verify `buildKey` symmetry; fix hardcoded `'domain-wide-key'` probe to use the real constant

## Testing

- All 386 prerender tests pass (`handler`, `sync-suggestions`, `ai-only-mode`, `guidance-handler`, `utils`)
- New test Case 6 in `sync-suggestions.test.js` directly reproduces the bug scenario (existing `isDomainWide:true` in OUTDATED state) and asserts the suggestion is updated in place with no `addSuggestions` call

## Related Issues

None