### PR TITLE
feat(AGENTCOM-775): send auditId in catalog enrichment payload

### DIFF
--- a/src/commerce-product-enrichments/handler.js
+++ b/src/commerce-product-enrichments/handler.js
@@ -189,6 +189,7 @@ export async function submitForScraping(context) {
 
 async function sendEnrichment(productPages, commerceConfig, site, env, log, {
   imsOrgId = null,
+  auditId = null,
 } = {}) {
   const allScrapes = productPages.map((page) => ({ sku: page.sku, key: page.location }));
 
@@ -200,6 +201,7 @@ async function sendEnrichment(productPages, commerceConfig, site, env, log, {
 
   const enrichmentPayload = {
     siteId: site.getId(),
+    auditId,
     storeViewUrl: commerceConfig.storeViewUrl,
     imsOrgId,
     scrapes: allScrapes,
@@ -413,7 +415,7 @@ export async function runAuditAndProcessResults(context) {
     site,
     env,
     log,
-    { imsOrgId },
+    { imsOrgId, auditId: audit.getId() },
   ));
   const settledResults = await Promise.allSettled(enrichmentPromises);
   const enrichmentResponses = settledResults.map((result) => {

--- a/test/audits/commerce-product-enrichments/handler.test.js
+++ b/test/audits/commerce-product-enrichments/handler.test.js
@@ -1871,6 +1871,7 @@ describe('Commerce Product Enrichments - CAS IMS Authentication', () => {
     const payload = JSON.parse(enrichmentCall.args[1].body);
     expect(payload).to.deep.include({
       siteId: 'site-1',
+      auditId: 'audit-13',
       imsOrgId: 'ims-org-1@AdobeOrg',
       storeViewUrl: 'https://example.com',
     });


### PR DESCRIPTION
Sends the `auditId` to the catalog enrichment endpoint (`/catalog-enrichment`) so downstream consumers can correlate enrichment requests back to the originating audit.

### Changes
- `sendEnrichment()` now accepts an `auditId` option and includes it in the enrichment payload (alongside `siteId`, `storeViewUrl`, `imsOrgId`, `scrapes`).
- `runAuditAndProcessResults()` passes `audit.getId()` into each per-group enrichment call.
- Updated test assertion in `commerce-product-enrichments/handler.test.js` to verify `auditId` is present in the payload.

Tests: all 66 tests pass, `src/commerce-product-enrichments/handler.js` at 100% coverage.

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues
[AGENTCOM-775](https://jira.corp.adobe.com/browse/AGENTCOM-775)

Thanks for contributing!
