### PR TITLE
feat(prerender): support CSV URL scoping for ai-only mode batches

### DIFF
--- a/src/prerender/handler.js
+++ b/src/prerender/handler.js
@@ -527,11 +527,19 @@ async function compareHtmlContent(url, context) {
 }
 
 /**
- * Parses the mode from the data field
+ * Parses the mode from the data field or auditContext.
+ * The mode may arrive in either location:
+ *   - data.mode: set via Slack command keyword arguments (legacy)
+ *   - auditContext.mode: set via run-audit command's mode:ai-only flag
  * @param {string|Object} data - The data field from the message
+ * @param {Object} [auditCtx] - The auditContext from the message
  * @returns {string|null} - The mode value or null
  */
-function getModeFromData(data) {
+function getModeFromData(data, auditCtx) {
+  if (auditCtx?.mode) {
+    return auditCtx.mode;
+  }
+
   if (!data) {
     return null;
   }
@@ -582,6 +590,7 @@ async function sendPrerenderGuidanceRequestToMystique(
   context,
   preBuiltCandidates,
   generatePrompts = false,
+  urlScope = null,
 ) {
   const {
     log, sqs, env, site,
@@ -680,6 +689,11 @@ async function sendPrerenderGuidanceRequestToMystique(
       suggestionsPayload = candidates;
     }
 
+    // When a URL scope is provided (CSV batch), filter to only matching URLs
+    if (urlScope && suggestionsPayload.length > 0) {
+      suggestionsPayload = suggestionsPayload.filter((s) => urlScope.has(s.url));
+    }
+
     if (suggestionsPayload.length === 0) {
       log.info(`${LOG_PREFIX} No eligible suggestions to send to Mystique for opportunityId=${opportunityId}. baseUrl=${baseUrl}, siteId=${siteId}`);
       return 0;
@@ -730,7 +744,7 @@ async function sendPrerenderGuidanceRequestToMystique(
  */
 export async function handleAiOnlyMode(context) {
   const {
-    site, log, dataAccess, data,
+    site, log, dataAccess, data, auditContext,
   } = context;
   const { Opportunity } = dataAccess;
   const siteId = site.getId();
@@ -817,6 +831,14 @@ export async function handleAiOnlyMode(context) {
     };
   }
 
+  // When explicit URLs are provided (CSV batch), scope suggestions to that set.
+  const urlScope = Array.isArray(auditContext?.urls) && auditContext.urls.length > 0
+    ? new Set(auditContext.urls)
+    : null;
+  if (urlScope) {
+    log.info(`${LOG_PREFIX} ai-only: Scoping to ${urlScope.size} explicit URLs from auditContext. baseUrl=${baseUrl}, siteId=${siteId}`);
+  }
+
   // Send to Mystique using the existing function
   const auditData = {
     siteId,
@@ -832,6 +854,7 @@ export async function handleAiOnlyMode(context) {
     context,
     null, // preBuiltCandidates — build from DB suggestions in ai-only mode
     generatePrompts,
+    urlScope,
   );
 
   log.info(`${LOG_PREFIX} ai-only: Successfully queued AI summary request for ${suggestionCount} suggestion(s). baseUrl=${baseUrl}, siteId=${siteId}, opportunityId=${opportunity.getId()}`);
@@ -859,7 +882,7 @@ export async function importTopPages(context) {
   } = context;
 
   // Check for AI-only mode (from command like: audit:prerender mode:ai-only)
-  const mode = getModeFromData(data);
+  const mode = getModeFromData(data, auditContext);
   if (mode === MODE_AI_ONLY) {
     log.info(`${LOG_PREFIX} Detected ai-only mode in step 1, skipping import/scraping/processing`);
     return handleAiOnlyMode(context);
@@ -905,7 +928,7 @@ export async function submitForScraping(context) {
   } = context;
 
   // Check for AI-only mode - skip scraping step (step 1 already triggered Mystique)
-  const mode = getModeFromData(data);
+  const mode = getModeFromData(data, auditContext);
   if (mode === MODE_AI_ONLY) {
     log.info(`${LOG_PREFIX} Detected ai-only mode in step 2, skipping scraping (already handled in step 1)`);
     return { status: 'skipped', mode: MODE_AI_ONLY };
@@ -1641,7 +1664,7 @@ export async function processContentAndGenerateOpportunities(context) {
   } = context;
 
   // Check for AI-only mode - skip processing step (step 1 already triggered Mystique)
-  const mode = getModeFromData(data);
+  const mode = getModeFromData(data, auditContext);
   if (mode === MODE_AI_ONLY) {
     log.info(`${LOG_PREFIX} Detected ai-only mode in step 3, skipping processing (already handled in step 1)`);
     return { status: 'skipped', mode: MODE_AI_ONLY };

--- a/src/prerender/handler.js
+++ b/src/prerender/handler.js
@@ -527,19 +527,11 @@ async function compareHtmlContent(url, context) {
 }
 
 /**
- * Parses the mode from the data field or auditContext.
- * The mode may arrive in either location:
- *   - data.mode: set via Slack command keyword arguments (legacy)
- *   - auditContext.mode: set via run-audit command's mode:ai-only flag
+ * Parses the mode from the data field
  * @param {string|Object} data - The data field from the message
- * @param {Object} [auditCtx] - The auditContext from the message
  * @returns {string|null} - The mode value or null
  */
-function getModeFromData(data, auditCtx) {
-  if (auditCtx?.mode) {
-    return auditCtx.mode;
-  }
-
+function getModeFromData(data) {
   if (!data) {
     return null;
   }
@@ -882,7 +874,7 @@ export async function importTopPages(context) {
   } = context;
 
   // Check for AI-only mode (from command like: audit:prerender mode:ai-only)
-  const mode = getModeFromData(data, auditContext);
+  const mode = getModeFromData(data);
   if (mode === MODE_AI_ONLY) {
     log.info(`${LOG_PREFIX} Detected ai-only mode in step 1, skipping import/scraping/processing`);
     return handleAiOnlyMode(context);
@@ -928,7 +920,7 @@ export async function submitForScraping(context) {
   } = context;
 
   // Check for AI-only mode - skip scraping step (step 1 already triggered Mystique)
-  const mode = getModeFromData(data, auditContext);
+  const mode = getModeFromData(data);
   if (mode === MODE_AI_ONLY) {
     log.info(`${LOG_PREFIX} Detected ai-only mode in step 2, skipping scraping (already handled in step 1)`);
     return { status: 'skipped', mode: MODE_AI_ONLY };
@@ -1664,7 +1656,7 @@ export async function processContentAndGenerateOpportunities(context) {
   } = context;
 
   // Check for AI-only mode - skip processing step (step 1 already triggered Mystique)
-  const mode = getModeFromData(data, auditContext);
+  const mode = getModeFromData(data);
   if (mode === MODE_AI_ONLY) {
     log.info(`${LOG_PREFIX} Detected ai-only mode in step 3, skipping processing (already handled in step 1)`);
     return { status: 'skipped', mode: MODE_AI_ONLY };

--- a/test/audits/prerender/ai-only-mode.test.js
+++ b/test/audits/prerender/ai-only-mode.test.js
@@ -738,39 +738,23 @@ describe('Prerender AI-Only Mode', () => {
     });
   });
 
-  describe('mode detection from auditContext', () => {
-    it('should detect ai-only mode from auditContext.mode', async () => {
-      context.data = JSON.stringify({ scrapeJobId: 'test-scrape-job' });
-      context.auditContext = { mode: 'ai-only' };
-
-      const result = await importTopPages(context);
-
-      expect(result.status).to.equal('complete');
-      expect(result.mode).to.equal('ai-only');
-    });
-
-    it('should detect ai-only mode from auditContext.mode with explicit URLs', async () => {
-      context.data = JSON.stringify({ scrapeJobId: 'test-scrape-job' });
+  describe('CSV URL scoping in ai-only mode', () => {
+    it('should scope suggestions to auditContext.urls when provided', async () => {
       context.auditContext = {
-        mode: 'ai-only',
         urls: ['https://example.com/page1'],
       };
 
       const result = await importTopPages(context);
 
       expect(result.status).to.equal('complete');
-      expect(result.mode).to.equal('ai-only');
-      // Should scope to only the provided URL
       const message = mockSqs.sendMessage.getCall(0).args[1];
       expect(message.data.suggestions).to.have.lengthOf(1);
       expect(message.data.suggestions[0].url).to.equal('https://example.com/page1');
     });
 
-    it('should filter suggestions to auditContext.urls when provided', async () => {
-      context.data = JSON.stringify({ scrapeJobId: 'test-scrape-job' });
+    it('should filter out suggestions not in auditContext.urls', async () => {
       context.auditContext = {
-        mode: 'ai-only',
-        urls: ['https://example.com/page2'], // Only page2
+        urls: ['https://example.com/page2'],
       };
 
       const result = await importTopPages(context);
@@ -781,14 +765,22 @@ describe('Prerender AI-Only Mode', () => {
       expect(message.data.suggestions[0].url).to.equal('https://example.com/page2');
     });
 
-    it('should prefer auditContext.mode over data.mode', async () => {
-      context.data = JSON.stringify({ scrapeJobId: 'test' }); // No mode in data
-      context.auditContext = { mode: 'ai-only' };
-
+    it('should send all suggestions when auditContext.urls is not set', async () => {
+      // Default context has no auditContext.urls
       const result = await importTopPages(context);
 
       expect(result.status).to.equal('complete');
-      expect(result.mode).to.equal('ai-only');
+      expect(result.auditResult.suggestionCount).to.equal(2);
+    });
+
+    it('should return 0 when no suggestions match auditContext.urls', async () => {
+      context.auditContext = {
+        urls: ['https://example.com/no-match'],
+      };
+
+      const result = await importTopPages(context);
+
+      expect(result.auditResult.suggestionCount).to.equal(0);
     });
   });
 

--- a/test/audits/prerender/ai-only-mode.test.js
+++ b/test/audits/prerender/ai-only-mode.test.js
@@ -738,6 +738,60 @@ describe('Prerender AI-Only Mode', () => {
     });
   });
 
+  describe('mode detection from auditContext', () => {
+    it('should detect ai-only mode from auditContext.mode', async () => {
+      context.data = JSON.stringify({ scrapeJobId: 'test-scrape-job' });
+      context.auditContext = { mode: 'ai-only' };
+
+      const result = await importTopPages(context);
+
+      expect(result.status).to.equal('complete');
+      expect(result.mode).to.equal('ai-only');
+    });
+
+    it('should detect ai-only mode from auditContext.mode with explicit URLs', async () => {
+      context.data = JSON.stringify({ scrapeJobId: 'test-scrape-job' });
+      context.auditContext = {
+        mode: 'ai-only',
+        urls: ['https://example.com/page1'],
+      };
+
+      const result = await importTopPages(context);
+
+      expect(result.status).to.equal('complete');
+      expect(result.mode).to.equal('ai-only');
+      // Should scope to only the provided URL
+      const message = mockSqs.sendMessage.getCall(0).args[1];
+      expect(message.data.suggestions).to.have.lengthOf(1);
+      expect(message.data.suggestions[0].url).to.equal('https://example.com/page1');
+    });
+
+    it('should filter suggestions to auditContext.urls when provided', async () => {
+      context.data = JSON.stringify({ scrapeJobId: 'test-scrape-job' });
+      context.auditContext = {
+        mode: 'ai-only',
+        urls: ['https://example.com/page2'], // Only page2
+      };
+
+      const result = await importTopPages(context);
+
+      expect(result.status).to.equal('complete');
+      const message = mockSqs.sendMessage.getCall(0).args[1];
+      expect(message.data.suggestions).to.have.lengthOf(1);
+      expect(message.data.suggestions[0].url).to.equal('https://example.com/page2');
+    });
+
+    it('should prefer auditContext.mode over data.mode', async () => {
+      context.data = JSON.stringify({ scrapeJobId: 'test' }); // No mode in data
+      context.auditContext = { mode: 'ai-only' };
+
+      const result = await importTopPages(context);
+
+      expect(result.status).to.equal('complete');
+      expect(result.mode).to.equal('ai-only');
+    });
+  });
+
   describe('generatePrompts flag in SQS payload', () => {
     it('should include generatePrompts:false in SQS message by default', async () => {
       const result = await importTopPages(context);


### PR DESCRIPTION
## Summary

Adds CSV URL scoping to the ai-only prerender flow so batched audits only process their subset of URLs.

### What changed

- **`sendPrerenderGuidanceRequestToMystique`** — accepts optional `urlScope` (a Set of URLs) to filter candidates before sending to Mystique
- **`handleAiOnlyMode`** — when `auditContext.urls` is present (CSV batch from run-audit command), passes the URL set as a scope filter

Mode detection is unchanged — the worker reads `mode: 'ai-only'` from the SQS `data` field via its existing `getModeFromData(data)`.

### How batch support works

The API service sends one SQS message per batch:
```json
{
  "type": "prerender",
  "data": "{\"mode\":\"ai-only\"}",
  "auditContext": { "urls": ["url1", ..., "url320"] }
}
```

The worker:
1. Detects `ai-only` from `data.mode` (existing logic)
2. Finds the opportunity and loads all its suggestions from DB
3. Filters suggestions to only those matching the batch's `auditContext.urls`
4. Sends the scoped set to Mystique

Without `auditContext.urls`, all eligible suggestions are sent (existing behavior preserved).

## Test plan (56 tests passing)

- [x] Scopes suggestions to `auditContext.urls` when provided
- [x] Filters out suggestions not in `auditContext.urls`
- [x] Sends all suggestions when `auditContext.urls` is not set
- [x] Returns 0 when no suggestions match the URL scope
- [x] All existing tests pass unchanged