### PR TITLE
fix(cdn-analysis): roll up completed weeks on byocdn-other past-week backfills

### DIFF
--- a/src/cdn-analysis/handler.js
+++ b/src/cdn-analysis/handler.js
@@ -28,6 +28,7 @@ import {
   shouldRecreateTable,
 } from '../utils/cdn-utils.js';
 import { getImsOrgId } from '../utils/data-access.js';
+import { weekClosingSundayKey } from '../utils/date-utils.js';
 import { getConfigCdnProvider } from '../utils/llmo-config-utils.js';
 import { wwwUrlResolver } from '../common/base-audit.js';
 
@@ -203,24 +204,6 @@ export async function findRecentUploads(s3Client, bucketName, pathId, auditDate,
 
   log.info(`Found ${detectedDays.size} byocdn-other day(s) with recent uploads`);
   return detectedDays;
-}
-
-// Key of the Sunday closing a day's ISO week, or null if that week isn't complete yet
-// (Sunday not before the audit day) — the live daily schedule rolls up the current week.
-function weekClosingSundayKey(dayKey, auditDate) {
-  const [year, month, day] = dayKey.split('/').map(Number);
-  const date = new Date(Date.UTC(year, month - 1, day));
-  const dow = date.getUTCDay(); // 0 = Sunday
-  const sunday = new Date(date.getTime() + (dow === 0 ? 0 : 7 - dow) * ONE_DAY_MS);
-  const auditDayStartMs = Date.UTC(
-    auditDate.getUTCFullYear(),
-    auditDate.getUTCMonth(),
-    auditDate.getUTCDate(),
-  );
-  if (sunday.getTime() >= auditDayStartMs) {
-    return null;
-  }
-  return `${sunday.getUTCFullYear()}/${pad2(sunday.getUTCMonth() + 1)}/${pad2(sunday.getUTCDate())}`;
 }
 
 /**

--- a/src/cdn-analysis/handler.js
+++ b/src/cdn-analysis/handler.js
@@ -205,17 +205,31 @@ export async function findRecentUploads(s3Client, bucketName, pathId, auditDate,
   return detectedDays;
 }
 
+// Key of the Sunday closing a day's ISO week, or null if that week isn't complete yet
+// (Sunday not before the audit day) — the live daily schedule rolls up the current week.
+function weekClosingSundayKey(dayKey, auditDate) {
+  const [year, month, day] = dayKey.split('/').map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  const dow = date.getUTCDay(); // 0 = Sunday
+  const sunday = new Date(date.getTime() + (dow === 0 ? 0 : 7 - dow) * ONE_DAY_MS);
+  const auditDayStartMs = Date.UTC(
+    auditDate.getUTCFullYear(),
+    auditDate.getUTCMonth(),
+    auditDate.getUTCDate(),
+  );
+  if (sunday.getTime() >= auditDayStartMs) {
+    return null;
+  }
+  return `${sunday.getUTCFullYear()}/${pad2(sunday.getUTCMonth() + 1)}/${pad2(sunday.getUTCDate())}`;
+}
+
 /**
- * Triggers cdn-logs-analysis sub-audits for each detected day, and one
- * date-based cdn-logs-report per detected day.
- *
- * Sub-audits include isSubAudit: true to prevent recursive scanning,
- * and forceReprocess: true because the same day may already have partial
- * aggregated data from an earlier run.
- *
- * cdn-logs-report messages are delayed by 900s so analysis finishes first.
+ * Triggers cdn-logs-analysis sub-audits per detected day, and a date-based
+ * cdn-logs-report per detected day plus each completed week's closing Sunday
+ * (so past-week backfills roll up to the weekly view even with no Sunday file).
+ * Sub-audits use isSubAudit/forceReprocess; reports are delayed so analysis finishes first.
  */
-async function triggerSubAudits(context, site, detectedDays) {
+async function triggerSubAudits(context, site, detectedDays, auditDate) {
   const { sqs, dataAccess, log } = context;
   const { Configuration } = dataAccess;
   const configuration = await Configuration.findLatest();
@@ -242,11 +256,19 @@ async function triggerSubAudits(context, site, detectedDays) {
     log.info(`Triggered cdn-logs-analysis sub-audit for siteId=${siteId} day=${dayKey}`);
   }
 
-  // One date-based cdn-logs-report per detected day. cdn-logs-report exports the
-  // day BEFORE auditContext.date, so send day + 1 as the reference. Delayed by a
-  // base wait (so the analysis sub-audits above have time to finish) plus a per-day
-  // stagger, capped at the SQS max, so the reports don't all fire at once.
-  for (const [index, dayKey] of [...detectedDays].entries()) {
+  // Report per detected day + each completed week's closing Sunday (deduped). Report
+  // exports the day BEFORE auditContext.date, so send day + 1; staggered under the SQS cap.
+  const reportDayKeys = [...detectedDays];
+  const seenReportDays = new Set(detectedDays);
+  for (const dayKey of detectedDays) {
+    const sundayKey = weekClosingSundayKey(dayKey, auditDate);
+    if (sundayKey && !seenReportDays.has(sundayKey)) {
+      seenReportDays.add(sundayKey);
+      reportDayKeys.push(sundayKey);
+    }
+  }
+
+  for (const [index, dayKey] of reportDayKeys.entries()) {
     const [year, month, day] = dayKey.split('/').map(Number);
     const reportDate = new Date(Date.UTC(year, month - 1, day + 1)).toISOString();
     const delaySeconds = Math.min(
@@ -342,7 +364,7 @@ export async function processCdnLogs(auditUrl, context, site, auditContext) {
     try {
       const recentUploads = await findRecentUploads(s3Client, bucketName, pathId, auditDate, log);
       if (recentUploads.size > 0) {
-        await triggerSubAudits(context, site, recentUploads);
+        await triggerSubAudits(context, site, recentUploads, auditDate);
       } else {
         log.info(`No recent byocdn-other files found for siteId=${siteId}, nothing to trigger`);
       }

--- a/src/utils/date-utils.js
+++ b/src/utils/date-utils.js
@@ -88,6 +88,28 @@ export function getPreviousWeekYear(today = new Date()) {
  * Used to map a specific day to the weekOffset parameter expected by cdn-logs-report,
  * so that multiple days in the same week produce a single report trigger.
  */
+/**
+ * Returns the "YYYY/MM/DD" key of the Sunday that closes the ISO week containing
+ * `dayKey`, or null when that week isn't complete yet (its Sunday is not before
+ * `reference`). UTC throughout — CDN log day keys are UTC dates.
+ */
+export function weekClosingSundayKey(dayKey, reference = new Date()) {
+  const [year, month, day] = dayKey.split('/').map(Number);
+  const sunday = new Date(Date.UTC(year, month - 1, day));
+  const dow = sunday.getUTCDay(); // 0 = Sunday
+  sunday.setUTCDate(sunday.getUTCDate() + (dow === 0 ? 0 : 7 - dow));
+  const referenceStartMs = Date.UTC(
+    reference.getUTCFullYear(),
+    reference.getUTCMonth(),
+    reference.getUTCDate(),
+  );
+  if (sunday.getTime() >= referenceStartMs) {
+    return null;
+  }
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${sunday.getUTCFullYear()}/${pad(sunday.getUTCMonth() + 1)}/${pad(sunday.getUTCDate())}`;
+}
+
 export function computeWeekOffset(year, month, day) {
   const targetDate = new Date(Date.UTC(year, month - 1, day));
   const today = new Date();

--- a/test/audits/cdn-analysis/handler.test.js
+++ b/test/audits/cdn-analysis/handler.test.js
@@ -582,6 +582,85 @@ describe('CDN Analysis Handler', () => {
       });
     });
 
+    // S3 fake for byocdn-other: detection prefix returns the given day paths (recently
+    // modified), discovery prefix exposes byocdn-other as a provider.
+    const byocdnOtherS3Fake = (orgId, recentDate, dayPaths) => (command) => {
+      if (command.constructor.name === 'HeadBucketCommand') {
+        return Promise.resolve({});
+      }
+      if (command.constructor.name === 'ListObjectsV2Command') {
+        const { Prefix = '' } = command.input || {};
+        if (Prefix.includes('aggregated')) {
+          return Promise.resolve({ Contents: [] });
+        }
+        if (Prefix.includes('/raw/byocdn-other/')) {
+          return Promise.resolve({
+            Contents: dayPaths.map((dp) => ({
+              Key: `${orgId}/raw/byocdn-other/${dp}/file.log`,
+              LastModified: recentDate,
+            })),
+          });
+        }
+        return Promise.resolve({
+          Contents: [{ Key: `${orgId}/raw/byocdn-other/2025/06/15/file1.log` }],
+          CommonPrefixes: [{ Prefix: `${orgId}/raw/byocdn-other/` }],
+        });
+      }
+      return Promise.resolve({});
+    };
+
+    const reportDatesFor = () => context.sqs.sendMessage.getCalls()
+      .filter((call) => call.args[1].type === 'cdn-logs-report')
+      .map((call) => call.args[1].auditContext.date);
+
+    it('also triggers a report for a completed week\'s closing Sunday when no Sunday file was delivered', async () => {
+      // Past week Mon 06/02 .. Sun 06/08 2025; only Mon–Fri uploaded, audit runs 06/15.
+      context.s3Client.send.callsFake(byocdnOtherS3Fake('test-ims-org-id', new Date(), [
+        '2025/06/02', '2025/06/03', '2025/06/04', '2025/06/05', '2025/06/06',
+      ]));
+
+      await cdnLogsAnalysisRunner('https://example.com', context, site, {
+        year: 2025, month: 6, day: 15, hour: 23,
+      });
+
+      const reportDates = reportDatesFor();
+      // 5 per-day reports (day+1) + the week-closing Sunday 06/08 (sent as 06/09).
+      expect(reportDates).to.have.length(6);
+      expect(reportDates).to.include('2025-06-09T00:00:00.000Z');
+    });
+
+    it('does not duplicate the Sunday report when the Sunday file was delivered', async () => {
+      // Full week Mon 06/02 .. Sun 06/08 uploaded; Sunday already produces its own report.
+      context.s3Client.send.callsFake(byocdnOtherS3Fake('test-ims-org-id', new Date(), [
+        '2025/06/02', '2025/06/03', '2025/06/04', '2025/06/05', '2025/06/06', '2025/06/07', '2025/06/08',
+      ]));
+
+      await cdnLogsAnalysisRunner('https://example.com', context, site, {
+        year: 2025, month: 6, day: 15, hour: 23,
+      });
+
+      const reportDates = reportDatesFor();
+      // 7 detected days → 7 reports; the Sunday-derived 06/09 appears exactly once.
+      expect(reportDates).to.have.length(7);
+      expect(reportDates.filter((d) => d === '2025-06-09T00:00:00.000Z')).to.have.length(1);
+    });
+
+    it('does not add a Sunday report for the in-progress (incomplete) week', async () => {
+      // Mon/Tue of the current week (06/02, 06/03); audit runs mid-week 06/04, week not closed.
+      context.s3Client.send.callsFake(byocdnOtherS3Fake('test-ims-org-id', new Date(), [
+        '2025/06/02', '2025/06/03',
+      ]));
+
+      await cdnLogsAnalysisRunner('https://example.com', context, site, {
+        year: 2025, month: 6, day: 4, hour: 23,
+      });
+
+      const reportDates = reportDatesFor();
+      // Only the two per-day reports; no week-closing Sunday (06/09) added.
+      expect(reportDates).to.have.length(2);
+      expect(reportDates).to.not.include('2025-06-09T00:00:00.000Z');
+    });
+
     it('byocdn-other sub-audit processes logs normally without scanning', async () => {
       const auditContext = {
         year: 2025, month: 6, day: 15, hour: 23,


### PR DESCRIPTION
## What

The weekly agentic rollup (`wrpc_refresh_agentic_traffic_weekly`) only fires when a `cdn-logs-report` runs for a **week-closing Sunday** (normal Sunday import, or the empty-Sunday path added in #2632).

For **byocdn-other**, the dispatcher-scheduled scan triggers a `cdn-logs-report` only **per detected upload day**. So when a customer backfills a *past* week's logs that don't include that week's Sunday (e.g. Mon–Fri only), no report ever runs for the Sunday and the week never rolls up to the weekly view — daily has the data, weekly doesn't.

## Fix

In `triggerSubAudits`, in addition to the per-detected-day reports, also emit a `cdn-logs-report` for the **week-closing Sunday of every completed week** the detected days fall in:
- Deduped against detected days (a delivered Sunday already produces its own report).
- **Completed weeks only** — the in-progress week is left to the live daily schedule.
- An absent Sunday exports zero rows, and the empty-Sunday path then triggers the weekly rollup for the completed week (which reads the already-imported earlier days).

## Testing
- `npm run test:spec -- test/audits/cdn-analysis/handler.test.js` — 52 passing, 100% coverage on `src/cdn-analysis`.
- New cases: past-week backfill with no Sunday file (extra Sunday report emitted), Sunday already delivered (no duplicate), in-progress week (no Sunday report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)