### PR TITLE
feat(toc): wire TOC opportunity into Impact Engine prompt generation (LLMO-5611)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,6 +91,7 @@ import llmoCustomerAnalysis from './llmo-customer-analysis/handler.js';
 import llmoOnboardingPublish from './llmo-onboarding-publish/handler.js';
 import headings from './headings/handler.js';
 import toc from './toc/handler.js';
+import tocGuidance from './toc/guidance-handler.js';
 import vulnerabilities from './vulnerabilities/handler.js';
 import vulnerabilitiesCodeFix from './vulnerabilities-code-fix/handler.js';
 import prerender from './prerender/handler.js';
@@ -198,6 +199,7 @@ const HANDLERS = {
   hreflang,
   headings,
   toc,
+  'guidance:table-of-contents': tocGuidance,
   prerender,
   'guidance:prerender': prerenderGuidance,
   'product-metatags': productMetatags,

--- a/src/toc/eligibility-utils.js
+++ b/src/toc/eligibility-utils.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * True when a TOC suggestion is still open (not FIXED/OUTDATED/SKIPPED) and therefore
+ * still eligible to send/receive Impact Engine prompts. Shared by the outbound
+ * (sendTocGuidanceRequestToMystique) and inbound (guidance-handler) eligibility checks
+ * so the two stay in sync.
+ * @param {Object} suggestion - Suggestion entity
+ * @param {Object} Suggestion - The Suggestion data-access collection (for STATUSES)
+ * @returns {boolean} True if the suggestion is non-terminal
+ */
+export function isEligibleTocSuggestion(suggestion, Suggestion) {
+  const status = suggestion.getStatus();
+  return status !== Suggestion.STATUSES.FIXED
+    && status !== Suggestion.STATUSES.OUTDATED
+    && status !== Suggestion.STATUSES.SKIPPED;
+}

--- a/src/toc/guidance-handler.js
+++ b/src/toc/guidance-handler.js
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { badRequest, notFound, ok } from '@adobe/spacecat-shared-http-utils';
+
+/**
+ * Mystique's guidance:table-of-contents reply carries prompts keyed by page URL, not by
+ * suggestionId (the outbound TocSuggestionData/TocOpportunityData models on the Mystique side
+ * don't round-trip an id). A single URL can have more than one TOC suggestion (one per
+ * checkType, e.g. "missing-toc" and "single-heading" on the same page) — since the generated
+ * prompts are grounded in the page's headings rather than the checkType, it's correct to apply
+ * the same prompt set to every non-terminal suggestion for that URL.
+ * @param {Array<Object>} suggestions - Existing Suggestion entities for the opportunity
+ * @param {Object} Suggestion - The Suggestion data-access collection (for STATUSES)
+ * @returns {Map<string, Array<Object>>} URL -> matching, non-terminal suggestion entities
+ */
+function groupEligibleSuggestionsByUrl(suggestions, Suggestion) {
+  const byUrl = new Map();
+  suggestions.forEach((suggestion) => {
+    const status = suggestion.getStatus();
+    if (
+      status === Suggestion.STATUSES.FIXED
+      || status === Suggestion.STATUSES.OUTDATED
+      || status === Suggestion.STATUSES.SKIPPED
+    ) {
+      return;
+    }
+    const { url } = suggestion.getData() || {};
+    if (!url) {
+      return;
+    }
+    if (!byUrl.has(url)) {
+      byUrl.set(url, []);
+    }
+    byUrl.get(url).push(suggestion);
+  });
+  return byUrl;
+}
+
+/**
+ * Handles the Mystique guidance:table-of-contents callback and persists the generated
+ * Impact Engine prompts back onto their matching TOC suggestions.
+ * @param {Object} message - Message from Mystique with generated prompts
+ * @param {Object} context - Context object with data access and logger
+ * @returns {Promise<Object>} - HTTP response
+ */
+export default async function handler(message, context) {
+  const { log, dataAccess } = context;
+  const {
+    Site, Audit, Opportunity, Suggestion,
+  } = dataAccess;
+  const { siteId, auditId, data } = message;
+  const { opportunityId, suggestions } = data || {};
+
+  log.debug(`[TOC Guidance] Message received in TOC guidance handler: ${JSON.stringify(message, null, 2)}`);
+
+  const site = await Site.findById(siteId);
+  if (!site) {
+    log.error(`[TOC Guidance] Site not found for siteId: ${siteId}`);
+    return notFound('Site not found');
+  }
+
+  const audit = await Audit.findById(auditId);
+  if (!audit) {
+    log.warn(`[TOC Guidance] No audit found for auditId: ${auditId}`);
+    return notFound();
+  }
+
+  const opportunity = await Opportunity.findById(opportunityId);
+  if (!opportunity) {
+    log.error(`[TOC Guidance] Opportunity not found for ID: ${opportunityId}`);
+    return notFound('Opportunity not found');
+  }
+
+  if (opportunity.getSiteId() !== siteId) {
+    log.error(`[TOC Guidance] Site ID mismatch. Expected: ${siteId}, Found: ${opportunity.getSiteId()}`);
+    return badRequest('Site ID mismatch');
+  }
+
+  if (!suggestions || !Array.isArray(suggestions)) {
+    log.error(`[TOC Guidance] Invalid suggestions format. Expected array, got: ${typeof suggestions}. Message: ${JSON.stringify(message)}`);
+    return badRequest('Invalid suggestions format');
+  }
+
+  if (suggestions.length === 0) {
+    log.info('[TOC Guidance] No suggestions provided in Mystique response');
+    return ok();
+  }
+
+  const existingSuggestions = await opportunity.getSuggestions();
+  const eligibleByUrl = groupEligibleSuggestionsByUrl(existingSuggestions || [], Suggestion);
+
+  const toSave = [];
+  suggestions.forEach((promptResult) => {
+    const { url, prompts, hasPrompts } = promptResult;
+    const matches = eligibleByUrl.get(url);
+
+    if (!matches || matches.length === 0) {
+      log.warn(`[TOC Guidance] No matching suggestion found for URL: ${url}`);
+      return;
+    }
+
+    const promptsArray = Array.isArray(prompts) ? prompts : [];
+
+    matches.forEach((suggestion) => {
+      const updatedData = {
+        ...suggestion.getData(),
+        prompts: promptsArray,
+        hasPrompts: !!hasPrompts || promptsArray.length > 0,
+      };
+      suggestion.setData(updatedData);
+      toSave.push(suggestion);
+    });
+  });
+
+  if (toSave.length > 0) {
+    await Suggestion.saveMany(toSave);
+  }
+
+  log.info(`[TOC Guidance] Successfully updated ${toSave.length} suggestion(s) with Mystique prompts for opportunityId=${opportunityId}`);
+  return ok();
+}

--- a/src/toc/guidance-handler.js
+++ b/src/toc/guidance-handler.js
@@ -11,6 +11,7 @@
  */
 
 import { badRequest, notFound, ok } from '@adobe/spacecat-shared-http-utils';
+import { isEligibleTocSuggestion } from './eligibility-utils.js';
 
 /**
  * Mystique's guidance:table-of-contents reply carries prompts keyed by page URL, not by
@@ -26,12 +27,7 @@ import { badRequest, notFound, ok } from '@adobe/spacecat-shared-http-utils';
 function groupEligibleSuggestionsByUrl(suggestions, Suggestion) {
   const byUrl = new Map();
   suggestions.forEach((suggestion) => {
-    const status = suggestion.getStatus();
-    if (
-      status === Suggestion.STATUSES.FIXED
-      || status === Suggestion.STATUSES.OUTDATED
-      || status === Suggestion.STATUSES.SKIPPED
-    ) {
+    if (!isEligibleTocSuggestion(suggestion, Suggestion)) {
       return;
     }
     const { url } = suggestion.getData() || {};

--- a/src/toc/handler.js
+++ b/src/toc/handler.js
@@ -448,7 +448,7 @@ function extractHeadingTextsFromHast(node) {
  */
 async function sendTocGuidanceRequestToMystique(auditUrl, opportunity, context) {
   const {
-    log, sqs, env, site,
+    log, sqs, env, site, audit,
   } = context;
 
   if (!sqs || !env?.QUEUE_SPACECAT_TO_MYSTIQUE) {
@@ -512,6 +512,8 @@ async function sendTocGuidanceRequestToMystique(auditUrl, opportunity, context) 
     await sqs.sendMessage(queue, {
       type: 'guidance:table-of-contents',
       url: auditUrl,
+      siteId: site.getId(),
+      auditId: audit.getId(),
       time,
       data: {
         opportunityId,

--- a/src/toc/handler.js
+++ b/src/toc/handler.js
@@ -19,6 +19,7 @@ import { noopUrlResolver } from '../common/index.js';
 import { syncSuggestions } from '../utils/data-access.js';
 import { convertToOpportunity } from '../common/opportunity.js';
 import { createOpportunityDataForTOC } from './opportunity-data-mapper.js';
+import { isEligibleTocSuggestion } from './eligibility-utils.js';
 import {
   extractTocData,
   tocArrayToHast,
@@ -408,9 +409,13 @@ export function generateSuggestions(auditUrl, auditData, context) {
 }
 
 /**
- * Recursively collect text node values from a HAST node tree.
+ * Recursively collect heading text from a HAST node tree. TOC transformRules render each
+ * heading as `li > a[data-selector] > text` (see tocArrayToHast) — walking every text node
+ * indiscriminately would also pick up insignificant whitespace text nodes and non-heading
+ * content from HTML-round-tripped (isEdited) trees, so this targets anchors carrying a
+ * `data-selector` (the heading link) specifically.
  * @param {Object|Array} node - HAST node or array of nodes
- * @returns {string[]} Array of text strings found in the tree
+ * @returns {string[]} Array of heading text strings found in the tree
  */
 function extractHeadingTextsFromHast(node) {
   if (!node) {
@@ -419,8 +424,13 @@ function extractHeadingTextsFromHast(node) {
   if (Array.isArray(node)) {
     return node.flatMap((child) => extractHeadingTextsFromHast(child));
   }
-  if (node.type === 'text' && typeof node.value === 'string') {
-    return [node.value];
+  if (node.type === 'element' && node.tagName === 'a' && node.properties?.['data-selector']) {
+    const text = (node.children || [])
+      .filter((child) => child.type === 'text' && typeof child.value === 'string')
+      .map((child) => child.value)
+      .join('')
+      .trim();
+    return text ? [text] : [];
   }
   if (node.children && Array.isArray(node.children)) {
     return node.children.flatMap((child) => extractHeadingTextsFromHast(child));
@@ -465,14 +475,9 @@ async function sendTocGuidanceRequestToMystique(auditUrl, opportunity, context) 
 
     existingSuggestions.forEach((s) => {
       const data = s.getData();
-      const status = s.getStatus();
 
       // Skip FIXED, OUTDATED, SKIPPED suggestions
-      if (
-        status === Suggestion.STATUSES.FIXED
-        || status === Suggestion.STATUSES.OUTDATED
-        || status === Suggestion.STATUSES.SKIPPED
-      ) {
+      if (!isEligibleTocSuggestion(s, Suggestion)) {
         return;
       }
 
@@ -484,7 +489,7 @@ async function sendTocGuidanceRequestToMystique(auditUrl, opportunity, context) 
       const suggestionId = s.getId();
       const hastNodes = data?.transformRules?.value;
       const headings = Array.isArray(hastNodes)
-        ? extractHeadingTextsFromHast(hastNodes)
+        ? [...new Set(extractHeadingTextsFromHast(hastNodes))]
         : [];
 
       candidates.push({
@@ -558,6 +563,14 @@ export async function opportunityAndSuggestions(auditUrl, auditData, context) {
       ...existingSuggestion,
       ...converted,
     };
+    // Preserve Mystique-persisted prompts across re-audits. mapNewSuggestion always seeds
+    // new items with prompts:[]/hasPrompts:false — without this, every re-audit would
+    // overwrite already-generated prompts and force sendTocGuidanceRequestToMystique to
+    // re-request them from Mystique.
+    if (!converted.prompts?.length && existingSuggestion.prompts?.length) {
+      mergedSuggestion.prompts = existingSuggestion.prompts;
+      mergedSuggestion.hasPrompts = existingSuggestion.hasPrompts;
+    }
     if (existingSuggestion.isEdited && existingSuggestion.transformRules?.value !== undefined) {
       const existingValue = existingSuggestion.transformRules.value;
       mergedSuggestion.transformRules.value = Array.isArray(existingValue)

--- a/src/toc/handler.js
+++ b/src/toc/handler.js
@@ -11,7 +11,7 @@
  */
 
 import { getPrompt } from '@adobe/spacecat-shared-utils';
-import { Audit } from '@adobe/spacecat-shared-data-access';
+import { Audit, Suggestion } from '@adobe/spacecat-shared-data-access';
 import { AzureOpenAIClient } from '@adobe/spacecat-shared-gpt-client';
 
 import { AuditBuilder } from '../common/audit-builder.js';
@@ -407,6 +407,123 @@ export function generateSuggestions(auditUrl, auditData, context) {
   return { ...auditData, suggestions };
 }
 
+/**
+ * Recursively collect text node values from a HAST node tree.
+ * @param {Object|Array} node - HAST node or array of nodes
+ * @returns {string[]} Array of text strings found in the tree
+ */
+function extractHeadingTextsFromHast(node) {
+  if (!node) {
+    return [];
+  }
+  if (Array.isArray(node)) {
+    return node.flatMap((child) => extractHeadingTextsFromHast(child));
+  }
+  if (node.type === 'text' && typeof node.value === 'string') {
+    return [node.value];
+  }
+  if (node.children && Array.isArray(node.children)) {
+    return node.children.flatMap((child) => extractHeadingTextsFromHast(child));
+  }
+  return [];
+}
+
+/**
+ * Sends a guidance:table-of-contents message to Mystique so that prompts can be
+ * generated for each TOC suggestion (required for the Impact Engine geo-experiment flow).
+ * @param {string} auditUrl - Audited base URL
+ * @param {Object} opportunity - The TOC opportunity entity
+ * @param {Object} context - Audit context
+ * @returns {Promise<number>} Number of suggestions sent to Mystique
+ */
+async function sendTocGuidanceRequestToMystique(auditUrl, opportunity, context) {
+  const {
+    log, sqs, env, site,
+  } = context;
+
+  if (!sqs || !env?.QUEUE_SPACECAT_TO_MYSTIQUE) {
+    log.warn(`[TOC] SQS or Mystique queue not configured, skipping guidance:table-of-contents message. baseUrl=${auditUrl || site?.getBaseURL?.() || ''}`);
+    return 0;
+  }
+
+  if (!opportunity || !opportunity.getId) {
+    log.warn(`[TOC] Opportunity entity not available, skipping guidance:table-of-contents message. baseUrl=${auditUrl || site?.getBaseURL?.() || ''}`);
+    return 0;
+  }
+
+  const opportunityId = opportunity.getId();
+
+  try {
+    const existingSuggestions = await opportunity.getSuggestions();
+
+    if (!existingSuggestions || existingSuggestions.length === 0) {
+      log.debug(`[TOC] No existing suggestions found for opportunityId=${opportunityId}, skipping Mystique message. baseUrl=${auditUrl}`);
+      return 0;
+    }
+
+    const candidates = [];
+
+    existingSuggestions.forEach((s) => {
+      const data = s.getData();
+      const status = s.getStatus();
+
+      // Skip FIXED, OUTDATED, SKIPPED suggestions
+      if (
+        status === Suggestion.STATUSES.FIXED
+        || status === Suggestion.STATUSES.OUTDATED
+        || status === Suggestion.STATUSES.SKIPPED
+      ) {
+        return;
+      }
+
+      // Skip suggestions that already have prompts
+      if (data?.hasPrompts === true && data?.prompts?.length > 0) {
+        return;
+      }
+
+      const suggestionId = s.getId();
+      const hastNodes = data?.transformRules?.value;
+      const headings = Array.isArray(hastNodes)
+        ? extractHeadingTextsFromHast(hastNodes)
+        : [];
+
+      candidates.push({
+        suggestionId,
+        url: data?.url || '',
+        title: data?.title || '',
+        headings,
+        hasPrompts: !!(data?.hasPrompts || (data?.prompts?.length > 0)),
+      });
+    });
+
+    if (candidates.length === 0) {
+      log.info(`[TOC] No eligible suggestions to send to Mystique for opportunityId=${opportunityId}. baseUrl=${auditUrl}`);
+      return 0;
+    }
+
+    const queue = env.QUEUE_SPACECAT_TO_MYSTIQUE;
+    const time = new Date().toISOString();
+
+    await sqs.sendMessage(queue, {
+      type: 'guidance:table-of-contents',
+      url: auditUrl,
+      time,
+      data: {
+        opportunityId,
+        suggestions: candidates,
+        generatePrompts: true,
+        siteRegion: site.getRegion?.() ?? '',
+      },
+    });
+
+    log.info(`[TOC] Queued guidance:table-of-contents message to Mystique for baseUrl=${auditUrl}, opportunityId=${opportunityId}, suggestions=${candidates.length}`);
+    return candidates.length;
+  } catch (error) {
+    log.error(`[TOC] Failed to send guidance:table-of-contents message to Mystique for opportunityId=${opportunityId}, baseUrl=${auditUrl}: ${error.message}`, error);
+    return 0;
+  }
+}
+
 export async function opportunityAndSuggestions(auditUrl, auditData, context) {
   const { log } = context;
   const tocSuggestions = auditData.suggestions?.toc || [];
@@ -469,6 +586,8 @@ export async function opportunityAndSuggestions(auditUrl, auditData, context) {
         recommendedAction: suggestion.recommendedAction,
         checkTitle: suggestion.checkTitle,
         isAISuggested: suggestion.isAISuggested,
+        prompts: [],
+        hasPrompts: false,
         ...(suggestion.transformRules && {
           transformRules: {
             ...suggestion.transformRules,
@@ -481,6 +600,8 @@ export async function opportunityAndSuggestions(auditUrl, auditData, context) {
     mergeDataFunction,
     log,
   });
+
+  await sendTocGuidanceRequestToMystique(auditUrl, opportunity, context);
 
   log.info(`TOC opportunity created for Site Optimizer and ${tocSuggestions.length} suggestions synced for ${auditUrl}`);
   return { ...auditData };

--- a/test/audits/toc.test.js
+++ b/test/audits/toc.test.js
@@ -55,7 +55,9 @@ describe('TOC (Table of Contents) Audit', () => {
   let s3Client;
 
   beforeEach(() => {
-    log = { info: console.log, error: console.error, debug: console.debug };
+    log = {
+      info: console.log, error: console.error, debug: console.debug, warn: console.warn,
+    };
     context = {
       log,
       env: {
@@ -2243,7 +2245,9 @@ describe('TOC (Table of Contents) Audit', () => {
     it('covers line 73: fallback to empty string when pageTags.title is falsy', async () => {
       const baseURL = 'https://example.com';
       const url = 'https://example.com/page';
-      const logSpy = { info: sinon.spy(), error: sinon.spy(), debug: sinon.spy() };
+      const logSpy = {
+        info: sinon.spy(), error: sinon.spy(), debug: sinon.spy(), warn: sinon.spy(),
+      };
       context.log = logSpy;
 
       const mockClient = {

--- a/test/audits/toc.test.js
+++ b/test/audits/toc.test.js
@@ -1065,6 +1065,304 @@ describe('TOC (Table of Contents) Audit', () => {
 
       expect(context.sqs.sendMessage).not.to.have.been.called;
     });
+
+    it('swallows errors from sqs.sendMessage and logs them without failing the audit', async () => {
+      const logSpy = {
+        info: sinon.spy(), error: sinon.spy(), debug: sinon.spy(), warn: sinon.spy(),
+      };
+      context.log = logSpy;
+
+      const convertToOpportunityStub = setupMystiqueContext([
+        makeExistingSuggestion({ url: 'https://example.com/page1', title: 'Page 1' }),
+      ]);
+      context.sqs.sendMessage = sinon.stub().rejects(new Error('SQS unavailable'));
+
+      const mockedHandler = await esmock('../../src/toc/handler.js', {
+        '../../src/common/opportunity.js': { convertToOpportunity: convertToOpportunityStub },
+        '../../src/utils/data-access.js': { syncSuggestions: sinon.stub().resolves() },
+      });
+
+      const auditUrl = 'https://example.com';
+      const auditData = {
+        suggestions: {
+          toc: [{
+            type: 'CODE_CHANGE', checkType: 'toc', url: 'https://example.com/page1', explanation: 'x', recommendedAction: 'x',
+          }],
+        },
+      };
+
+      await expect(mockedHandler.opportunityAndSuggestions(auditUrl, auditData, context)).to.be.fulfilled;
+
+      expect(logSpy.error).to.have.been.calledWith(
+        sinon.match(/Failed to send guidance:table-of-contents message to Mystique/),
+      );
+    });
+
+    it('skips the Mystique message when the opportunity entity has no getId', async () => {
+      const logSpy = {
+        info: sinon.spy(), error: sinon.spy(), debug: sinon.spy(), warn: sinon.spy(),
+      };
+      context.log = logSpy;
+      context.sqs = { sendMessage: sinon.stub().resolves() };
+      context.env.QUEUE_SPACECAT_TO_MYSTIQUE = 'test-mystique-queue';
+
+      const convertToOpportunityStub = sinon.stub().resolves({
+        getSuggestions: sinon.stub().resolves([]),
+      });
+
+      const mockedHandler = await esmock('../../src/toc/handler.js', {
+        '../../src/common/opportunity.js': { convertToOpportunity: convertToOpportunityStub },
+        '../../src/utils/data-access.js': { syncSuggestions: sinon.stub().resolves() },
+      });
+
+      const auditUrl = 'https://example.com';
+      const auditData = {
+        suggestions: {
+          toc: [{
+            type: 'CODE_CHANGE', checkType: 'toc', url: 'https://example.com/page1', explanation: 'x', recommendedAction: 'x',
+          }],
+        },
+      };
+
+      await mockedHandler.opportunityAndSuggestions(auditUrl, auditData, context);
+
+      expect(context.sqs.sendMessage).not.to.have.been.called;
+      expect(logSpy.warn).to.have.been.calledWith(
+        sinon.match(/Opportunity entity not available/),
+      );
+    });
+
+    it('skips the Mystique message when there are no existing suggestions to send', async () => {
+      const convertToOpportunityStub = setupMystiqueContext([]);
+
+      const mockedHandler = await esmock('../../src/toc/handler.js', {
+        '../../src/common/opportunity.js': { convertToOpportunity: convertToOpportunityStub },
+        '../../src/utils/data-access.js': { syncSuggestions: sinon.stub().resolves() },
+      });
+
+      const auditUrl = 'https://example.com';
+      const auditData = {
+        suggestions: {
+          toc: [{
+            type: 'CODE_CHANGE', checkType: 'toc', url: 'https://example.com/page1', explanation: 'x', recommendedAction: 'x',
+          }],
+        },
+      };
+
+      await mockedHandler.opportunityAndSuggestions(auditUrl, auditData, context);
+
+      expect(context.sqs.sendMessage).not.to.have.been.called;
+    });
+
+    it('walks nested HAST wrappers and tolerates null children and childless anchors when extracting headings', async () => {
+      const convertToOpportunityStub = setupMystiqueContext([
+        makeExistingSuggestion({
+          url: 'https://example.com/page1',
+          title: 'Page 1',
+          transformRules: {
+            value: [
+              { type: 'text', value: '\n' },
+              {
+                type: 'element',
+                tagName: 'ul',
+                children: [
+                  null,
+                  {
+                    type: 'element',
+                    tagName: 'li',
+                    children: [
+                      {
+                        type: 'element',
+                        tagName: 'a',
+                        properties: { 'data-selector': 'h2#one' },
+                        children: [{ type: 'text', value: 'First Heading' }],
+                      },
+                    ],
+                  },
+                  {
+                    type: 'element',
+                    tagName: 'a',
+                    properties: { 'data-selector': 'h2#two' },
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+      ]);
+
+      const mockedHandler = await esmock('../../src/toc/handler.js', {
+        '../../src/common/opportunity.js': { convertToOpportunity: convertToOpportunityStub },
+        '../../src/utils/data-access.js': { syncSuggestions: sinon.stub().resolves() },
+      });
+
+      const auditUrl = 'https://example.com';
+      const auditData = {
+        suggestions: {
+          toc: [{
+            type: 'CODE_CHANGE', checkType: 'toc', url: 'https://example.com/page1', explanation: 'x', recommendedAction: 'x',
+          }],
+        },
+      };
+
+      await mockedHandler.opportunityAndSuggestions(auditUrl, auditData, context);
+
+      expect(context.sqs.sendMessage).to.have.been.calledOnce;
+      const [, message] = context.sqs.sendMessage.getCall(0).args;
+      expect(message.data.suggestions[0].headings).to.deep.equal(['First Heading']);
+    });
+
+    it('falls back through site?.getBaseURL?.() in the skip-warning when auditUrl is empty and SQS/queue is unconfigured', async () => {
+      const logSpy = {
+        info: sinon.spy(), error: sinon.spy(), debug: sinon.spy(), warn: sinon.spy(),
+      };
+      context.log = logSpy;
+      // No context.sqs / QUEUE_SPACECAT_TO_MYSTIQUE configured on purpose.
+
+      const convertToOpportunityStub = sinon.stub().resolves({
+        getId: () => 'test-toc-opportunity-id',
+        getSuggestions: sinon.stub().resolves([]),
+      });
+
+      const mockedHandler = await esmock('../../src/toc/handler.js', {
+        '../../src/common/opportunity.js': { convertToOpportunity: convertToOpportunityStub },
+        '../../src/utils/data-access.js': { syncSuggestions: sinon.stub().resolves() },
+      });
+
+      const auditData = {
+        suggestions: {
+          toc: [{
+            type: 'CODE_CHANGE', checkType: 'toc', url: 'https://example.com/page1', explanation: 'x', recommendedAction: 'x',
+          }],
+        },
+      };
+
+      // No site at all: `site?.` short-circuits, falls through to the final `|| ''`.
+      delete context.site;
+      await mockedHandler.opportunityAndSuggestions('', auditData, context);
+      expect(logSpy.warn).to.have.been.calledWith(
+        sinon.match(/SQS or Mystique queue not configured.*baseUrl=$/),
+      );
+
+      // Site present but with no getBaseURL method: `?.()` short-circuits instead.
+      context.site = {};
+      await mockedHandler.opportunityAndSuggestions('', auditData, context);
+      expect(logSpy.warn).to.have.been.calledWith(
+        sinon.match(/SQS or Mystique queue not configured.*baseUrl=$/),
+      );
+
+      // Site present with a real getBaseURL(): the call actually resolves.
+      context.site = { getBaseURL: () => 'https://fallback.example.com' };
+      await mockedHandler.opportunityAndSuggestions('', auditData, context);
+      expect(logSpy.warn).to.have.been.calledWith(
+        sinon.match(/SQS or Mystique queue not configured.*baseUrl=https:\/\/fallback\.example\.com/),
+      );
+    });
+
+    it('falls back through site?.getBaseURL?.() in the skip-warning when auditUrl is empty and the opportunity has no getId', async () => {
+      const logSpy = {
+        info: sinon.spy(), error: sinon.spy(), debug: sinon.spy(), warn: sinon.spy(),
+      };
+      context.log = logSpy;
+      context.sqs = { sendMessage: sinon.stub().resolves() };
+      context.env.QUEUE_SPACECAT_TO_MYSTIQUE = 'test-mystique-queue';
+
+      const convertToOpportunityStub = sinon.stub().resolves({
+        getSuggestions: sinon.stub().resolves([]),
+      });
+
+      const mockedHandler = await esmock('../../src/toc/handler.js', {
+        '../../src/common/opportunity.js': { convertToOpportunity: convertToOpportunityStub },
+        '../../src/utils/data-access.js': { syncSuggestions: sinon.stub().resolves() },
+      });
+
+      const auditData = {
+        suggestions: {
+          toc: [{
+            type: 'CODE_CHANGE', checkType: 'toc', url: 'https://example.com/page1', explanation: 'x', recommendedAction: 'x',
+          }],
+        },
+      };
+
+      // No site at all: `site?.` short-circuits, falls through to the final `|| ''`.
+      delete context.site;
+      await mockedHandler.opportunityAndSuggestions('', auditData, context);
+      expect(context.sqs.sendMessage).not.to.have.been.called;
+      expect(logSpy.warn).to.have.been.calledWith(
+        sinon.match(/Opportunity entity not available.*baseUrl=$/),
+      );
+
+      // Site present but with no getBaseURL method: `?.()` short-circuits instead.
+      context.site = {};
+      await mockedHandler.opportunityAndSuggestions('', auditData, context);
+      expect(logSpy.warn).to.have.been.calledWith(
+        sinon.match(/Opportunity entity not available.*baseUrl=$/),
+      );
+
+      // Site present with a real getBaseURL(): the call actually resolves.
+      context.site = { getBaseURL: () => 'https://fallback.example.com' };
+      await mockedHandler.opportunityAndSuggestions('', auditData, context);
+      expect(logSpy.warn).to.have.been.calledWith(
+        sinon.match(/Opportunity entity not available.*baseUrl=https:\/\/fallback\.example\.com/),
+      );
+    });
+
+    it('defaults siteRegion to an empty string when the site has no getRegion method', async () => {
+      const convertToOpportunityStub = setupMystiqueContext([
+        makeExistingSuggestion({ url: 'https://example.com/page1', title: 'Page 1' }),
+      ]);
+      delete context.site.getRegion;
+
+      const mockedHandler = await esmock('../../src/toc/handler.js', {
+        '../../src/common/opportunity.js': { convertToOpportunity: convertToOpportunityStub },
+        '../../src/utils/data-access.js': { syncSuggestions: sinon.stub().resolves() },
+      });
+
+      const auditUrl = 'https://example.com';
+      const auditData = {
+        suggestions: {
+          toc: [{
+            type: 'CODE_CHANGE', checkType: 'toc', url: 'https://example.com/page1', explanation: 'x', recommendedAction: 'x',
+          }],
+        },
+      };
+
+      await mockedHandler.opportunityAndSuggestions(auditUrl, auditData, context);
+
+      const [, message] = context.sqs.sendMessage.getCall(0).args;
+      expect(message.data.siteRegion).to.equal('');
+    });
+
+    it('derives per-candidate url/title defaults and hasPrompts across edge-case suggestion shapes', async () => {
+      const convertToOpportunityStub = setupMystiqueContext([
+        makeExistingSuggestion({}),
+        makeExistingSuggestion({ url: 'https://example.com/u2', hasPrompts: true, prompts: [] }),
+        makeExistingSuggestion({ url: 'https://example.com/u3', prompts: [{ id: 'p1' }] }),
+      ]);
+
+      const mockedHandler = await esmock('../../src/toc/handler.js', {
+        '../../src/common/opportunity.js': { convertToOpportunity: convertToOpportunityStub },
+        '../../src/utils/data-access.js': { syncSuggestions: sinon.stub().resolves() },
+      });
+
+      const auditUrl = 'https://example.com';
+      const auditData = {
+        suggestions: {
+          toc: [{
+            type: 'CODE_CHANGE', checkType: 'toc', url: 'https://example.com/page1', explanation: 'x', recommendedAction: 'x',
+          }],
+        },
+      };
+
+      await mockedHandler.opportunityAndSuggestions(auditUrl, auditData, context);
+
+      const [, message] = context.sqs.sendMessage.getCall(0).args;
+      const [candidate1, candidate2, candidate3] = message.data.suggestions;
+
+      expect(candidate1).to.include({ url: '', title: '', hasPrompts: false });
+      expect(candidate2.hasPrompts).to.equal(true);
+      expect(candidate3.hasPrompts).to.equal(true);
+    });
   });
 
   describe('TOC custom persister (slimmed audit vs full post-processor data)', () => {
@@ -2138,6 +2436,110 @@ describe('TOC (Table of Contents) Audit', () => {
       expect(merged.edgeDeployed).to.equal(true);
       expect(merged.transformRules.value).to.deep.equal([{ text: 'Deployed Title', level: 1 }]);
       expect(merged.isEdited).to.equal(true);
+    });
+
+    it('preserves Mystique-persisted prompts across re-audits when the new suggestion has none', async () => {
+      const convertToOpportunityStub = sinon.stub().resolves({
+        getId: () => 'test-opportunity-id',
+      });
+
+      let capturedMergeDataFunction;
+      const syncSuggestionsStub = sinon.stub().callsFake((args) => {
+        capturedMergeDataFunction = args.mergeDataFunction;
+        return Promise.resolve();
+      });
+
+      const mockedHandler = await esmock('../../src/toc/handler.js', {
+        '../../src/common/opportunity.js': {
+          convertToOpportunity: convertToOpportunityStub,
+        },
+        '../../src/utils/data-access.js': {
+          syncSuggestions: syncSuggestionsStub,
+        },
+      });
+
+      const auditUrl = 'https://example.com';
+      const auditData = {
+        suggestions: {
+          toc: [{
+            type: 'CODE_CHANGE',
+            checkType: 'toc',
+            url: 'https://example.com/page1',
+          }],
+        },
+      };
+
+      await mockedHandler.opportunityAndSuggestions(auditUrl, auditData, context);
+
+      const existingSuggestion = {
+        url: 'https://example.com/page1',
+        explanation: 'Old explanation',
+        prompts: [{ id: 'p1', prompt: 'What is X?' }],
+        hasPrompts: true,
+      };
+      // Re-audits never re-derive prompts, so the raw new suggestion carries empty defaults
+      const newSuggestion = {
+        url: 'https://example.com/page1',
+        explanation: 'New explanation',
+        prompts: [],
+        hasPrompts: false,
+      };
+
+      const merged = capturedMergeDataFunction(existingSuggestion, newSuggestion);
+
+      expect(merged.explanation).to.equal('New explanation');
+      expect(merged.prompts).to.deep.equal([{ id: 'p1', prompt: 'What is X?' }]);
+      expect(merged.hasPrompts).to.equal(true);
+    });
+
+    it('does not touch prompts on merge when the new suggestion already carries its own', async () => {
+      const convertToOpportunityStub = sinon.stub().resolves({
+        getId: () => 'test-opportunity-id',
+      });
+
+      let capturedMergeDataFunction;
+      const syncSuggestionsStub = sinon.stub().callsFake((args) => {
+        capturedMergeDataFunction = args.mergeDataFunction;
+        return Promise.resolve();
+      });
+
+      const mockedHandler = await esmock('../../src/toc/handler.js', {
+        '../../src/common/opportunity.js': {
+          convertToOpportunity: convertToOpportunityStub,
+        },
+        '../../src/utils/data-access.js': {
+          syncSuggestions: syncSuggestionsStub,
+        },
+      });
+
+      const auditUrl = 'https://example.com';
+      const auditData = {
+        suggestions: {
+          toc: [{
+            type: 'CODE_CHANGE',
+            checkType: 'toc',
+            url: 'https://example.com/page1',
+          }],
+        },
+      };
+
+      await mockedHandler.opportunityAndSuggestions(auditUrl, auditData, context);
+
+      const existingSuggestion = {
+        url: 'https://example.com/page1',
+        prompts: [{ id: 'p1', prompt: 'Old prompt' }],
+        hasPrompts: true,
+      };
+      const newSuggestion = {
+        url: 'https://example.com/page1',
+        prompts: [{ id: 'p2', prompt: 'New prompt' }],
+        hasPrompts: true,
+      };
+
+      const merged = capturedMergeDataFunction(existingSuggestion, newSuggestion);
+
+      expect(merged.prompts).to.deep.equal([{ id: 'p2', prompt: 'New prompt' }]);
+      expect(merged.hasPrompts).to.equal(true);
     });
   });
 

--- a/test/audits/toc.test.js
+++ b/test/audits/toc.test.js
@@ -952,6 +952,121 @@ describe('TOC (Table of Contents) Audit', () => {
     });
   });
 
+  describe('sendTocGuidanceRequestToMystique (outbound guidance:table-of-contents message)', () => {
+    const makeExistingSuggestion = (data, status = 'NEW') => ({
+      getId: () => 'suggestion-1',
+      getStatus: () => status,
+      getData: () => data,
+    });
+
+    const setupMystiqueContext = (existingSuggestions) => {
+      context.sqs = { sendMessage: sinon.stub().resolves() };
+      context.env.QUEUE_SPACECAT_TO_MYSTIQUE = 'test-mystique-queue';
+      context.audit = { getId: () => 'audit-1' };
+      context.site = {
+        getId: () => 'site-1',
+        getBaseURL: () => 'https://example.com',
+        getRegion: () => 'US',
+      };
+      return sinon.stub().resolves({
+        getId: () => 'test-toc-opportunity-id',
+        getSuggestions: sinon.stub().resolves(existingSuggestions),
+      });
+    };
+
+    it('includes siteId and auditId at the top level, matching the guidance:prerender/summarization contract', async () => {
+      const convertToOpportunityStub = setupMystiqueContext([
+        makeExistingSuggestion({
+          url: 'https://example.com/page1',
+          title: 'Page 1',
+          transformRules: {
+            value: [{
+              type: 'element',
+              tagName: 'a',
+              properties: { 'data-selector': 'h1#intro' },
+              children: [{ type: 'text', value: 'Introduction' }],
+            }],
+          },
+        }),
+      ]);
+
+      const mockedHandler = await esmock('../../src/toc/handler.js', {
+        '../../src/common/opportunity.js': { convertToOpportunity: convertToOpportunityStub },
+        '../../src/utils/data-access.js': { syncSuggestions: sinon.stub().resolves() },
+      });
+
+      const auditUrl = 'https://example.com';
+      const auditData = {
+        suggestions: {
+          toc: [{
+            type: 'CODE_CHANGE',
+            checkType: 'toc',
+            url: 'https://example.com/page1',
+            explanation: 'TOC missing',
+            recommendedAction: 'Add TOC',
+            transformRules: {
+              action: 'insertAfter', selector: 'h1', value: [{ text: 'Title', level: 1 }], valueFormat: 'html',
+            },
+          }],
+        },
+      };
+
+      await mockedHandler.opportunityAndSuggestions(auditUrl, auditData, context);
+
+      expect(context.sqs.sendMessage).to.have.been.calledOnce;
+      const [queue, message] = context.sqs.sendMessage.getCall(0).args;
+      expect(queue).to.equal('test-mystique-queue');
+      expect(message).to.include({
+        type: 'guidance:table-of-contents',
+        url: auditUrl,
+        siteId: 'site-1',
+        auditId: 'audit-1',
+      });
+      expect(message.data).to.include({
+        opportunityId: 'test-toc-opportunity-id',
+        generatePrompts: true,
+        siteRegion: 'US',
+      });
+      expect(message.data.suggestions).to.have.length(1);
+      expect(message.data.suggestions[0]).to.include({
+        url: 'https://example.com/page1',
+        title: 'Page 1',
+      });
+      expect(message.data.suggestions[0].headings).to.deep.equal(['Introduction']);
+    });
+
+    it('skips FIXED/OUTDATED/SKIPPED suggestions and ones that already have prompts', async () => {
+      const convertToOpportunityStub = setupMystiqueContext([
+        makeExistingSuggestion({ url: 'https://example.com/fixed' }, 'FIXED'),
+        makeExistingSuggestion({ url: 'https://example.com/outdated' }, 'OUTDATED'),
+        makeExistingSuggestion({ url: 'https://example.com/skipped' }, 'SKIPPED'),
+        makeExistingSuggestion({
+          url: 'https://example.com/already-has-prompts',
+          hasPrompts: true,
+          prompts: [{ id: 'p1' }],
+        }),
+      ]);
+
+      const mockedHandler = await esmock('../../src/toc/handler.js', {
+        '../../src/common/opportunity.js': { convertToOpportunity: convertToOpportunityStub },
+        '../../src/utils/data-access.js': { syncSuggestions: sinon.stub().resolves() },
+      });
+
+      const auditUrl = 'https://example.com';
+      const auditData = {
+        suggestions: {
+          toc: [{
+            type: 'CODE_CHANGE', checkType: 'toc', url: 'https://example.com/fixed', explanation: 'x', recommendedAction: 'x',
+          }],
+        },
+      };
+
+      await mockedHandler.opportunityAndSuggestions(auditUrl, auditData, context);
+
+      expect(context.sqs.sendMessage).not.to.have.been.called;
+    });
+  });
+
   describe('TOC custom persister (slimmed audit vs full post-processor data)', () => {
     it('slimTocAuditResult strips transformRules from urls for persistence', () => {
       const auditResult = {

--- a/test/audits/toc/guidance-handler.test.js
+++ b/test/audits/toc/guidance-handler.test.js
@@ -225,4 +225,35 @@ describe('TOC Guidance Handler', () => {
     expect(dataAccessStub.Suggestion.saveMany).to.not.have.been.called;
     expect(logStub.warn).to.have.been.calledWith(sinon.match(/No matching suggestion found for URL/));
   });
+
+  it('should treat a falsy getData() return value from an existing suggestion as no data', async () => {
+    opportunityStub.getSuggestions.resolves([
+      makeSuggestion(undefined),
+    ]);
+
+    const result = await handler(message, context);
+
+    expect(result.status).to.equal(ok().status);
+    expect(dataAccessStub.Suggestion.saveMany).to.not.have.been.called;
+    expect(logStub.warn).to.have.been.calledWith(sinon.match(/No matching suggestion found for URL/));
+  });
+
+  it('should return badRequest when message.data is missing entirely', async () => {
+    delete message.data;
+
+    const result = await handler(message, context);
+
+    expect(result.status).to.equal(badRequest().status);
+    expect(logStub.error).to.have.been.calledWith(sinon.match(/Invalid suggestions format/));
+  });
+
+  it('should treat a falsy getSuggestions() resolution as no existing suggestions', async () => {
+    opportunityStub.getSuggestions.resolves(null);
+
+    const result = await handler(message, context);
+
+    expect(result.status).to.equal(ok().status);
+    expect(dataAccessStub.Suggestion.saveMany).to.not.have.been.called;
+    expect(logStub.warn).to.have.been.calledWith(sinon.match(/No matching suggestion found for URL/));
+  });
 });

--- a/test/audits/toc/guidance-handler.test.js
+++ b/test/audits/toc/guidance-handler.test.js
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { ok, notFound, badRequest } from '@adobe/spacecat-shared-http-utils';
+import { Suggestion as SuggestionDataAccess } from '@adobe/spacecat-shared-data-access';
+import handler from '../../../src/toc/guidance-handler.js';
+
+use(sinonChai);
+
+describe('TOC Guidance Handler', () => {
+  let context;
+  let message;
+  let logStub;
+  let dataAccessStub;
+  let siteStub;
+  let auditStub;
+  let opportunityStub;
+
+  const makeSuggestion = (data, status = SuggestionDataAccess.STATUSES.NEW) => ({
+    getData: sinon.stub().returns(data),
+    setData: sinon.stub(),
+    getStatus: sinon.stub().returns(status),
+  });
+
+  beforeEach(() => {
+    logStub = {
+      debug: sinon.stub(),
+      info: sinon.stub(),
+      warn: sinon.stub(),
+      error: sinon.stub(),
+    };
+
+    opportunityStub = {
+      getSiteId: sinon.stub().returns('site-123'),
+      getSuggestions: sinon.stub().resolves([
+        makeSuggestion({ url: 'https://example.com/page1', checkType: 'missing-toc' }),
+        makeSuggestion({ url: 'https://example.com/page2', checkType: 'single-heading' }),
+      ]),
+    };
+
+    siteStub = { getId: sinon.stub().returns('site-123') };
+    auditStub = { getId: sinon.stub().returns('audit-123') };
+
+    dataAccessStub = {
+      Site: { findById: sinon.stub().resolves(siteStub) },
+      Audit: { findById: sinon.stub().resolves(auditStub) },
+      Opportunity: { findById: sinon.stub().resolves(opportunityStub) },
+      Suggestion: {
+        STATUSES: SuggestionDataAccess.STATUSES,
+        saveMany: sinon.stub().resolves(),
+      },
+    };
+
+    context = { log: logStub, dataAccess: dataAccessStub };
+
+    message = {
+      auditId: 'audit-123',
+      siteId: 'site-123',
+      data: {
+        opportunityId: 'opp-123',
+        suggestions: [
+          {
+            url: 'https://example.com/page1',
+            title: 'Page 1',
+            headings: ['Intro', 'Details'],
+            prompts: [{ id: 'p1', prompt: 'What is X?', type: 'Non-Branded' }],
+            hasPrompts: true,
+          },
+        ],
+      },
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should persist prompts onto the matching suggestion by URL', async () => {
+    const result = await handler(message, context);
+
+    expect(result.status).to.equal(ok().status);
+    expect(dataAccessStub.Site.findById).to.have.been.calledWith('site-123');
+    expect(dataAccessStub.Audit.findById).to.have.been.calledWith('audit-123');
+    expect(dataAccessStub.Opportunity.findById).to.have.been.calledWith('opp-123');
+    expect(dataAccessStub.Suggestion.saveMany).to.have.been.calledOnce;
+    const [saved] = dataAccessStub.Suggestion.saveMany.getCall(0).args[0];
+    expect(saved.setData).to.have.been.calledWith(sinon.match({
+      url: 'https://example.com/page1',
+      checkType: 'missing-toc',
+      prompts: [{ id: 'p1', prompt: 'What is X?', type: 'Non-Branded' }],
+      hasPrompts: true,
+    }));
+    expect(logStub.info).to.have.been.calledWith(sinon.match(/Successfully updated 1 suggestion/));
+  });
+
+  it('should apply the same prompts to every non-terminal suggestion sharing a URL', async () => {
+    const shared = 'https://example.com/shared';
+    opportunityStub.getSuggestions.resolves([
+      makeSuggestion({ url: shared, checkType: 'missing-toc' }),
+      makeSuggestion({ url: shared, checkType: 'single-heading' }),
+    ]);
+    message.data.suggestions = [
+      { url: shared, prompts: [{ id: 'p1' }], hasPrompts: true },
+    ];
+
+    const result = await handler(message, context);
+
+    expect(result.status).to.equal(ok().status);
+    expect(dataAccessStub.Suggestion.saveMany).to.have.been.calledOnce;
+    expect(dataAccessStub.Suggestion.saveMany.getCall(0).args[0]).to.have.length(2);
+  });
+
+  it('should skip FIXED, OUTDATED and SKIPPED suggestions when matching by URL', async () => {
+    const url = 'https://example.com/page1';
+    opportunityStub.getSuggestions.resolves([
+      makeSuggestion({ url }, SuggestionDataAccess.STATUSES.FIXED),
+      makeSuggestion({ url }, SuggestionDataAccess.STATUSES.OUTDATED),
+      makeSuggestion({ url }, SuggestionDataAccess.STATUSES.SKIPPED),
+    ]);
+
+    const result = await handler(message, context);
+
+    expect(result.status).to.equal(ok().status);
+    expect(dataAccessStub.Suggestion.saveMany).to.not.have.been.called;
+    expect(logStub.warn).to.have.been.calledWith(sinon.match(/No matching suggestion found for URL/));
+  });
+
+  it('should default prompts to an empty array and hasPrompts to false when Mystique omits them', async () => {
+    message.data.suggestions = [{ url: 'https://example.com/page1' }];
+
+    const result = await handler(message, context);
+
+    expect(result.status).to.equal(ok().status);
+    const [saved] = dataAccessStub.Suggestion.saveMany.getCall(0).args[0];
+    expect(saved.setData).to.have.been.calledWith(sinon.match({
+      prompts: [],
+      hasPrompts: false,
+    }));
+  });
+
+  it('should return notFound when site is not found', async () => {
+    dataAccessStub.Site.findById.resolves(null);
+
+    const result = await handler(message, context);
+
+    expect(result.status).to.equal(notFound().status);
+    expect(logStub.error).to.have.been.calledWith(sinon.match(/Site not found for siteId: site-123/));
+  });
+
+  it('should return notFound when audit is not found', async () => {
+    dataAccessStub.Audit.findById.resolves(null);
+
+    const result = await handler(message, context);
+
+    expect(result.status).to.equal(notFound().status);
+    expect(logStub.warn).to.have.been.calledWith(sinon.match(/No audit found for auditId: audit-123/));
+  });
+
+  it('should return notFound when opportunity is not found', async () => {
+    dataAccessStub.Opportunity.findById.resolves(null);
+
+    const result = await handler(message, context);
+
+    expect(result.status).to.equal(notFound().status);
+    expect(logStub.error).to.have.been.calledWith(sinon.match(/Opportunity not found for ID: opp-123/));
+  });
+
+  it('should return badRequest when site ID does not match opportunity', async () => {
+    opportunityStub.getSiteId.returns('different-site-id');
+
+    const result = await handler(message, context);
+
+    expect(result.status).to.equal(badRequest().status);
+    expect(logStub.error).to.have.been.calledWith(sinon.match(/Site ID mismatch/));
+  });
+
+  it('should return badRequest when suggestions is not an array', async () => {
+    message.data.suggestions = 'not an array';
+
+    const result = await handler(message, context);
+
+    expect(result.status).to.equal(badRequest().status);
+    expect(logStub.error).to.have.been.calledWith(sinon.match(/Invalid suggestions format/));
+  });
+
+  it('should return badRequest when suggestions is null', async () => {
+    message.data.suggestions = null;
+
+    const result = await handler(message, context);
+
+    expect(result.status).to.equal(badRequest().status);
+    expect(logStub.error).to.have.been.calledWith(sinon.match(/Invalid suggestions format/));
+  });
+
+  it('should return ok when suggestions array is empty', async () => {
+    message.data.suggestions = [];
+
+    const result = await handler(message, context);
+
+    expect(result.status).to.equal(ok().status);
+    expect(logStub.info).to.have.been.calledWith(sinon.match(/No suggestions provided/));
+    expect(dataAccessStub.Suggestion.saveMany).to.not.have.been.called;
+  });
+
+  it('should ignore existing suggestions with no url in their data', async () => {
+    opportunityStub.getSuggestions.resolves([
+      makeSuggestion({ checkType: 'missing-toc' }),
+    ]);
+
+    const result = await handler(message, context);
+
+    expect(result.status).to.equal(ok().status);
+    expect(dataAccessStub.Suggestion.saveMany).to.not.have.been.called;
+    expect(logStub.warn).to.have.been.calledWith(sinon.match(/No matching suggestion found for URL/));
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `sendTocGuidanceRequestToMystique()` which fires a `guidance:table-of-contents` SQS message to Mystique after `syncSuggestions` runs
- Each suggestion payload carries `url`, `title`, `headings` (extracted from HAST via new `extractHeadingTextsFromHast()`), and `hasPrompts` flag so Mystique can generate LLMO impact-engine prompts
- New suggestions are initialised with `prompts: []` and `hasPrompts: false`; already-prompted and FIXED/OUTDATED/SKIPPED suggestions are skipped to avoid redundant work

Relates to LLMO-5611 / Epic LLMO-28 — TOC in Impact Engine.

## Test plan

- [ ] Run existing TOC handler tests (`npm run test:spec -- test/audits/toc/handler.test.js`) — all green
- [ ] Verify SQS message shape matches `TocOpportunityRequestMessageData` in Mystique
- [ ] Deploy to stage; trigger a TOC audit; confirm a `guidance:table-of-contents` message lands on the Mystique queue with correct suggestion payloads
- [ ] Confirm Mystique task processes the message and writes `prompts` back to suggestion data

🤖 Generated with [Claude Code](https://claude.com/claude-code)