### PR TITLE
feat(llm-error-pages): enrich observation:llm-broken-urls with CDN-log trend facets

### DIFF
--- a/src/llm-error-pages/handler.js
+++ b/src/llm-error-pages/handler.js
@@ -286,7 +286,12 @@ async function publishObservationLlmBrokenUrls({
       // set this `sorted404` was consolidated from, keyed by the raw `url` — so
       // every sorted404 url has a facet row (agentTypes is always an array;
       // avgTtfb/category/product/countryCode may be undefined on sparse rows).
-      const f = facetsByUrl.get(errorPage.url);
+      // The `|| { agentTypes: [] }` is an unreachable-but-defensive default: if
+      // consolidateErrorsByUrl and groupErrorsByUrl ever diverge, a missing
+      // facet row degrades to empty facets instead of throwing a TypeError the
+      // outer try/catch would swallow (silently dropping the whole publish).
+      /* c8 ignore next */
+      const f = facetsByUrl.get(errorPage.url) || { agentTypes: [] };
       const existing = byUrl.get(fullUrl);
       if (existing) {
         existing.hits += entryHits;
@@ -337,7 +342,7 @@ async function publishObservationLlmBrokenUrls({
         agentTypes: Array.from(v.agentTypes)
           .slice(0, OBSERVATION_MAX_USER_AGENTS_PER_URL)
           .map((at) => String(at).slice(0, OBSERVATION_MAX_USER_AGENT_LENGTH)),
-        avgTtfb: v.avgTtfb === null || v.avgTtfb === undefined ? '' : String(v.avgTtfb),
+        avgTtfb: String(v.avgTtfb),
         category: v.category || '',
         product: v.product ?? null,
         countryCode: v.countryCode || 'GLOBAL',

--- a/src/llm-error-pages/handler.js
+++ b/src/llm-error-pages/handler.js
@@ -243,7 +243,8 @@ export async function submitForScraping(context) {
  * @param {object}   args.log            Logger (info/warn/error).
  */
 async function publishObservationLlmBrokenUrls({
-  sorted404, messageBaseUrl, startDate, endDate, site, audit, sqs, env, log,
+  sorted404, facetsByUrl, periodIdentifier, messageBaseUrl, startDate, endDate,
+  site, audit, sqs, env, log,
 }) {
   try {
     if (!messageBaseUrl) {
@@ -281,14 +282,27 @@ async function publishObservationLlmBrokenUrls({
       const fullUrl = new URL(path, messageBaseUrl).toString();
       const entryHits = Number(errorPage.totalRequests) || 0;
       const entryUas = errorPage.rawUserAgents || [];
+      // groupErrorsByUrl produced one facet row per URL from the SAME errors404
+      // set this `sorted404` was consolidated from, keyed by the raw `url` — so
+      // every sorted404 url has a facet row (agentTypes is always an array;
+      // avgTtfb/category/product/countryCode may be undefined on sparse rows).
+      const f = facetsByUrl.get(errorPage.url);
       const existing = byUrl.get(fullUrl);
       if (existing) {
         existing.hits += entryHits;
         entryUas.forEach((ua) => existing.userAgents.add(ua));
+        f.agentTypes.forEach((at) => existing.agentTypes.add(at));
       } else {
         byUrl.set(fullUrl, {
           hits: entryHits,
           userAgents: new Set(entryUas),
+          // Facets are URL-stable across providers/rows; first sighting seeds
+          // them, agentTypes unions across rows mapping to the same full URL.
+          agentTypes: new Set(f.agentTypes),
+          avgTtfb: f.avgTtfb ?? '',
+          category: f.category ?? '',
+          product: f.product ?? null,
+          countryCode: f.countryCode ?? 'GLOBAL',
         });
       }
     });
@@ -315,6 +329,18 @@ async function publishObservationLlmBrokenUrls({
         // any environment. Safe to land unilaterally here because the
         // flag is OFF by default.
         observedThrough: endDate.toISOString(),
+        // CDN-log trend facets the ELMO UI renders (mystique #2490 accepts
+        // these; the projector builds the weekly history[] + filters from them).
+        // periodIdentifier is the same for every URL in this publish (the audit
+        // week). avgTtfb is stringified to match the consumer's string field.
+        periodIdentifier: periodIdentifier || '',
+        agentTypes: Array.from(v.agentTypes)
+          .slice(0, OBSERVATION_MAX_USER_AGENTS_PER_URL)
+          .map((at) => String(at).slice(0, OBSERVATION_MAX_USER_AGENT_LENGTH)),
+        avgTtfb: v.avgTtfb === null || v.avgTtfb === undefined ? '' : String(v.avgTtfb),
+        category: v.category || '',
+        product: v.product ?? null,
+        countryCode: v.countryCode || 'GLOBAL',
       }));
 
     // NOTE: `observationUrls` is guaranteed non-empty here.
@@ -717,8 +743,18 @@ export async function runAuditAndSendToMystique(context) {
             // cutover = delete the legacy publish above AND this flag check;
             // the helper call stays.
             if (env?.OBSERVATION_LLM_BROKEN_URLS_ENABLED === 'true') {
+              // Per-URL CDN-log facets (agentTypes / avgTtfb / category /
+              // product / countryCode) the ELMO UI renders. groupErrorsByUrl
+              // collapses the raw rows to one entry per URL with these facets;
+              // keyed by the raw `url` so the helper can look them up while it
+              // re-groups sorted404 into the observation wire shape.
+              const facetsByUrl = new Map(
+                groupErrorsByUrl(errors404).map((r) => [r.url, r]),
+              );
               await publishObservationLlmBrokenUrls({
                 sorted404,
+                facetsByUrl,
+                periodIdentifier,
                 messageBaseUrl,
                 startDate,
                 endDate,

--- a/test/audits/llm-error-pages/handler.test.js
+++ b/test/audits/llm-error-pages/handler.test.js
@@ -637,11 +637,51 @@ describe('LLM Error Pages Handler', function () {
       // comment in handler.js. Pin to the audit-window end value so a
       // future refactor that swaps in `new Date().toISOString()` would
       // fail this test instead of silently shipping wrong semantics.
-      expect(urlEntry).to.have.all.keys('url', 'hits', 'userAgents', 'observedThrough');
+      expect(urlEntry).to.have.all.keys(
+        'url', 'hits', 'userAgents', 'observedThrough',
+        // CDN-log trend facets (spacecat #2655) the ELMO UI renders.
+        'periodIdentifier', 'agentTypes', 'avgTtfb', 'category', 'product', 'countryCode',
+      );
       expect(urlEntry.url).to.include('/dead');
       expect(urlEntry.hits).to.equal(47);
       expect(urlEntry.userAgents).to.deep.equal(['ChatGPT']);
       expect(urlEntry.observedThrough).to.equal(observationMessage.data.period.end);
+      // This row carries no facet fields → safe defaults (proves the
+      // backwards-compatible path; a facet-rich row is covered separately).
+      expect(urlEntry.periodIdentifier).to.be.a('string');
+      expect(urlEntry.agentTypes).to.deep.equal([]);
+      expect(urlEntry.avgTtfb).to.equal('');
+      expect(urlEntry.category).to.equal('');
+      expect(urlEntry.product).to.equal(null);
+      expect(urlEntry.countryCode).to.equal('GLOBAL');
+    });
+
+    it('observation carries CDN-log trend facets (agentTypes/avgTtfb/category/product/countryCode) when present', async () => {
+      context.env.OBSERVATION_LLM_BROKEN_URLS_ENABLED = 'true';
+      // A raw categorized row carrying the facets groupErrorsByUrl aggregates.
+      mockProcessResults.returns({
+        totalErrors: 1,
+        errorPages: [{
+          ..._consolidatedRow({ url: '/dead', totalRequests: 47, rawUserAgents: ['GPTBot'] }),
+          agent_type: 'Training bots',
+          avg_ttfb_ms: 131,
+          country_code: 'US',
+          product: 'Other',
+          category: 'static asset',
+        }],
+        summary: { uniqueUrls: 1, uniqueUserAgents: 1 },
+      });
+
+      await runAuditAndSendToMystique(context);
+
+      const [, observationMessage] = context.sqs.sendMessage.secondCall.args;
+      const urlEntry = observationMessage.data.urls[0];
+      expect(urlEntry.agentTypes).to.deep.equal(['Training bots']);
+      // avgTtfb stringified to match mystique's string field.
+      expect(urlEntry.avgTtfb).to.equal('131');
+      expect(urlEntry.category).to.equal('static asset');
+      expect(urlEntry.product).to.equal('Other');
+      expect(urlEntry.countryCode).to.equal('US');
     });
 
     it('observation message unions user-agents per URL across providers (one entry per URL)', async () => {

--- a/test/audits/llm-error-pages/handler.test.js
+++ b/test/audits/llm-error-pages/handler.test.js
@@ -684,6 +684,37 @@ describe('LLM Error Pages Handler', function () {
       expect(urlEntry.countryCode).to.equal('US');
     });
 
+    it('observation falls back to safe defaults for empty periodIdentifier and country_code', async () => {
+      context.env.OBSERVATION_LLM_BROKEN_URLS_ENABLED = 'true';
+      // Empty periodIdentifier exercises the `periodIdentifier || ''` fallback;
+      // an explicit empty country_code survives the `?? 'GLOBAL'` build-stage
+      // default and exercises the output-stage `countryCode || 'GLOBAL'` fallback.
+      mockGenerateReportingPeriods.returns({
+        weeks: [{
+          weekNumber: 34,
+          year: 2025,
+          startDate: new Date('2025-08-18T00:00:00Z'),
+          endDate: new Date('2025-08-24T23:59:59Z'),
+          periodIdentifier: '',
+        }],
+      });
+      mockProcessResults.returns({
+        totalErrors: 1,
+        errorPages: [{
+          ..._consolidatedRow({ url: '/dead', totalRequests: 47, rawUserAgents: ['GPTBot'] }),
+          country_code: '',
+        }],
+        summary: { uniqueUrls: 1, uniqueUserAgents: 1 },
+      });
+
+      await runAuditAndSendToMystique(context);
+
+      const [, observationMessage] = context.sqs.sendMessage.secondCall.args;
+      const urlEntry = observationMessage.data.urls[0];
+      expect(urlEntry.periodIdentifier).to.equal('');
+      expect(urlEntry.countryCode).to.equal('GLOBAL');
+    });
+
     it('observation message unions user-agents per URL across providers (one entry per URL)', async () => {
       // Existing consolidateErrorsByUrl keys by (url, provider) — same URL hit
       // by N providers produces N entries. The observation wire format wants


### PR DESCRIPTION
## Summary
Threads the per-URL CDN-log trend facets into the `observation:llm-broken-urls`
SQS payload emitted by the LLM Error Pages audit. The observation message was
previously slim (`url` / `hits` / `userAgents` / `observedThrough`); this adds
`periodIdentifier`, `agentTypes`, `avgTtfb`, `category`, `product`, and
`countryCode` per URL.

## Why

The ELMO UI (project-elmo-ui #1990) renders a weekly-history table plus agent /
country filters that need these per-URL facets. #2655 already computes them for
the legacy DB-sync path; this PR threads the same facets into the observation
message so the new Mysticat blackboard pipeline (mystique ingestion → verifier →
projector → ELMO) can populate the UI with parity to the legacy path.

## Test plan

- [x] `npx eslint src/llm-error-pages/handler.js` — clean
- [x] llm-error-pages handler suite — 87 passing (incl. the two new facet tests)
- [ ] CI green
- [ ] After flag flip in dev: verify the observation payload carries the facets
      and the projector/ELMO render the weekly history + filters