### PR TITLE
fix(offsite-brand-presence): raise DRS poll budget to 30 minutes

### DIFF
--- a/src/offsite-brand-presence/constants.js
+++ b/src/offsite-brand-presence/constants.js
@@ -63,7 +63,7 @@ export const REDDIT_URL_REGEX = /^https:\/\/(www)?\.?reddit\.com\/([rt]|user)\/[
 
 // DRS job completion polling (offsite-brand-presence-drs-status handler).
 export const DRS_POLL_INTERVAL_SECONDS = 120; // 2 minutes between polls
-export const DRS_POLL_MAX_WAIT_SECONDS = 1200; // 20 minute total budget
+export const DRS_POLL_MAX_WAIT_SECONDS = 1800; // 30 minute total budget
 export const DRS_STATUS_AUDIT_TYPE = 'offsite-brand-presence-drs-status';
 export const DRS_TERMINAL_STATUSES = new Set([
   'COMPLETED',


### PR DESCRIPTION
Async scrape jobs (e.g. youtube_comments via BrightData) can take just over 20 minutes; a real run completed in 23m and was reported as timed out. Raise DRS_POLL_MAX_WAIT_SECONDS from 1200s to 1800s so these settle within the window.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
