### PR TITLE
feat(offsite-brand-presence): stop DRS-scraping wikipedia

### DIFF
--- a/src/offsite-brand-presence/constants.js
+++ b/src/offsite-brand-presence/constants.js
@@ -40,11 +40,11 @@ export const OFFSITE_DOMAINS = Object.freeze({
     auditType: Audit.AUDIT_TYPES.REDDIT_ANALYSIS,
     datasetIds: [SCRAPE_DATASET_IDS.REDDIT_POSTS, SCRAPE_DATASET_IDS.REDDIT_COMMENTS],
   },
-  'wikipedia.org': {
-    auditType: Audit.AUDIT_TYPES.WIKIPEDIA_ANALYSIS,
-    datasetIds: [SCRAPE_DATASET_IDS.WIKIPEDIA],
-  },
 });
+
+// Recognized only to keep their URLs out of the top-cited bucket; not DRS-scraped here.
+// wikipedia-analysis is handled independently by Mystique (fetches Wikipedia directly).
+export const TOP_CITED_EXCLUDED_DOMAINS = Object.freeze(['wikipedia.org']);
 
 export const CITED_ANALYSIS_DRS_CONFIG = Object.freeze({
   auditType: Audit.AUDIT_TYPES.CITED_ANALYSIS,

--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -26,6 +26,7 @@ import {
   CITED_ANALYSIS_DRS_CONFIG,
   YOUTUBE_URL_REGEX,
   REDDIT_URL_REGEX,
+  TOP_CITED_EXCLUDED_DOMAINS,
   DRS_POLL_INTERVAL_SECONDS,
   DRS_POLL_MAX_WAIT_SECONDS,
   DRS_STATUS_AUDIT_TYPE,
@@ -176,6 +177,13 @@ function classifyAndNormalize(rawUrl, siteHostname) {
       if (domain === 'reddit.com' && !REDDIT_URL_REGEX.test(rawUrl)) {
         return null;
       }
+      return { url: normalizeUrl(parsed, domain), domain };
+    }
+  }
+
+  // Tag (but don't scrape) these so selectTopUrls keeps them out of top-cited.
+  for (const domain of TOP_CITED_EXCLUDED_DOMAINS) {
+    if (hostname === domain || hostname.endsWith(`.${domain}`)) {
       return { url: normalizeUrl(parsed, domain), domain };
     }
   }
@@ -800,7 +808,7 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
   }
 
   // Sort once, partition into per-domain + top-cited buckets
-  const excludedFromTopCited = Object.keys(OFFSITE_DOMAINS);
+  const excludedFromTopCited = [...Object.keys(OFFSITE_DOMAINS), ...TOP_CITED_EXCLUDED_DOMAINS];
   const {
     topByDomain, topCited,
   } = selectTopUrls(allUrls, DRS_URLS_LIMIT, excludedFromTopCited);

--- a/test/audits/offsite-brand-presence.test.js
+++ b/test/audits/offsite-brand-presence.test.js
@@ -468,7 +468,8 @@ describe('Offsite Brand Presence Handler', () => {
       expect(result.auditResult.success).to.be.true;
       expect(result.auditResult.urlCounts['youtube.com']).to.equal(0);
       expect(result.auditResult.urlCounts['reddit.com']).to.equal(0);
-      expect(result.auditResult.urlCounts['wikipedia.org']).to.equal(0);
+      // wikipedia is no longer a scraped offsite domain, so it is not counted.
+      expect(result.auditResult.urlCounts).to.not.have.property('wikipedia.org');
       expect(result.fullAuditRef).to.equal(FINAL_URL);
       expect(log.info).to.have.been.calledWith(
         sinon.match(/No offsite URLs found/),
@@ -603,15 +604,23 @@ describe('Offsite Brand Presence Handler', () => {
       expect(auditTypes).to.include('reddit-analysis');
     });
 
-    it('should add wikipedia URLs to URL store with wikipedia-analysis audit type', async () => {
+    it('does not store or scrape wikipedia URLs (analyzed independently by Mystique)', async () => {
       stubBrandPresenceData(['https://en.wikipedia.org/wiki/Adobe']);
 
       await offsiteBrandPresenceRunner(FINAL_URL, context, site);
 
-      const createCalls = dataAccess.AuditUrl.create.getCalls();
-      const wikiCalls = createCalls.filter((c) => c.args[0].audits[0] === 'wikipedia-analysis');
-      expect(wikiCalls).to.have.lengthOf(1);
-      expect(wikiCalls[0].args[0].url).to.include('wikipedia.org');
+      // Recognized for exclusion only: not bucketed, persisted, or scraped.
+      expect(dataAccess.AuditUrl.create).to.not.have.been.called;
+      expect(mockSubmitScrapeJob).to.not.have.been.called;
+    });
+
+    it('excludes a bare wikipedia.org host (exact match, no subdomain)', async () => {
+      stubBrandPresenceData(['https://wikipedia.org/wiki/Adobe']);
+
+      await offsiteBrandPresenceRunner(FINAL_URL, context, site);
+
+      expect(dataAccess.AuditUrl.create).to.not.have.been.called;
+      expect(mockSubmitScrapeJob).to.not.have.been.called;
     });
   });
 
@@ -1204,17 +1213,13 @@ describe('Offsite Brand Presence Handler', () => {
       expect(commentsCall.args[0]).to.not.have.property('sortBy');
     });
 
-    it('should call submitScrapeJob with wikipedia dataset for wikipedia URLs', async () => {
+    it('does not submit a DRS scrape job for wikipedia URLs', async () => {
       stubBrandPresenceData(['https://en.wikipedia.org/wiki/Adobe']);
 
       await offsiteBrandPresenceRunner(FINAL_URL, context, site);
 
-      expect(mockSubmitScrapeJob).to.have.been.calledOnce;
-      expect(mockSubmitScrapeJob.firstCall.args[0]).to.deep.include({
-        datasetId: SCRAPE_DATASET_IDS.WIKIPEDIA,
-        siteId: SITE_ID,
-      });
-      expect(mockSubmitScrapeJob.firstCall.args[0].urls[0]).to.include('wikipedia.org');
+      // Not scraped and excluded from top-cited, so no job for a wikipedia-only run.
+      expect(mockSubmitScrapeJob).to.not.have.been.called;
     });
 
     it('should handle DRS API returning error response', async () => {
@@ -1299,7 +1304,8 @@ describe('Offsite Brand Presence Handler', () => {
       const auditContext = { messageData: { spacecatOrgId: 'org-multi' } };
       const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site, auditContext);
 
-      expect(result.auditResult.drsJobs).to.have.lengthOf(6);
+      // youtube (2) + reddit (2) + top-cited (1); wikipedia is excluded, not scraped.
+      expect(result.auditResult.drsJobs).to.have.lengthOf(5);
       for (const call of mockSubmitScrapeJob.getCalls()) {
         expect(call.args[0].spacecatOrgId).to.equal('org-multi');
       }
@@ -1558,8 +1564,10 @@ describe('Offsite Brand Presence Handler', () => {
       expect(result.auditResult.success).to.be.true;
       expect(result.auditResult.urlCounts['youtube.com']).to.equal(2);
       expect(result.auditResult.urlCounts['reddit.com']).to.equal(1);
-      expect(result.auditResult.urlCounts['wikipedia.org']).to.equal(1);
-      expect(result.auditResult.drsJobs).to.have.lengthOf(6);
+      // wikipedia is not scraped/counted and stays out of top-cited (cited-analysis).
+      expect(result.auditResult.urlCounts).to.not.have.property('wikipedia.org');
+      // youtube (2) + reddit (2) + top-cited (1) = 5 jobs, no wikipedia.
+      expect(result.auditResult.drsJobs).to.have.lengthOf(5);
       expect(result.fullAuditRef).to.equal(FINAL_URL);
 
       const createCalls = dataAccess.AuditUrl.create.getCalls();


### PR DESCRIPTION
## Summary

The wikipedia DRS scrape job that `offsite-brand-presence` fires is **never consumed**, so this removes it — leaving 3 scraped buckets (reddit, youtube, top-cited) instead of 4.

### Why it's safe to remove
- **audit-worker:** `SCRAPE_DATASET_IDS.WIKIPEDIA` was referenced in exactly one place — the `OFFSITE_DOMAINS['wikipedia.org']` config that *creates* the job. Nothing reads it back (reddit/youtube/cited each consume their datasets via `filterUrlsByDrsStatus`; wikipedia had no consumer).
- **wikipedia-analysis audit:** self-contained — derives `companyName`/`wikipediaUrl` from site config and hands off to Mystique. No `DrsClient`, no stored-URL lookup.
- **Mystique:** `WikipediaAnalysisTool` fetches `wikipedia.org` directly (HTTP + Wikipedia/Wikidata APIs, BeautifulSoup parsing). Zero DRS/S3 dependency.

### What changes
- Remove `wikipedia.org` from `OFFSITE_DOMAINS` → no wikipedia scrape job, not bucketed/stored/counted.
- Add `TOP_CITED_EXCLUDED_DOMAINS = ['wikipedia.org']`: wikipedia URLs are still *recognized* and kept **out of the top-cited bucket**, so they don't leak into `cited-analysis`.
- `wikipedia-analysis` remains a fully functional, independently-triggered audit — only its (unused) DRS scraping is removed.

This also means the PR #2667 auto-trigger (which derives audits from DRS jobs) will naturally fire only reddit/youtube/cited.

## Test Plan

- [x] `npm test` — full suite passes, 100% coverage
- [x] `npm run lint` — clean
- [x] Existing "should exclude offsite domain URLs from top-cited bucket" still passes (wikipedia stays out of cited-analysis)
- [ ] Manual: run `offsite-brand-presence`; confirm no wikipedia DRS job is created and wikipedia URLs don't appear in cited-analysis.

> Note: branched off `main`. Once merged, PRs #2668 (30-min budget) and #2667 (auto-trigger) will need a quick rebase (both touch `constants.js`/`handler.js` nearby).