### PR TITLE
fix(preflight): wait for meta tags so slow-rendering SPAs aren't captured as empty shells

### DIFF
--- a/src/preflight/handler.js
+++ b/src/preflight/handler.js
@@ -36,6 +36,18 @@ export const PREFLIGHT_STEP_IDENTIFY = 'identify';
 export const PREFLIGHT_STEP_SUGGEST = 'suggest';
 
 /**
+ * Per-selector timeout (ms) handed to the content scraper's meta-tags wait via the
+ * scrape `options`. When set, the scraper waits for `title`/`h1`/`description` to
+ * appear (non-throwing `Promise.allSettled`) before capturing, and resolves the
+ * instant they land — so fast pages are unaffected while slow-rendering SPA pages
+ * are captured after hydration instead of as an empty shell.
+ *
+ * Fixes SITES-46324: slow-rendering AEM author SPAs (e.g. Cox) whose `<h1>` paints
+ * after the scraper's fixed ~5s wait, causing a false "h1 not found".
+ */
+export const PREFLIGHT_META_TAGS_WAIT_MS = 5000;
+
+/**
  * List of available checks.
  * Should not be changed as it would break existing clients.
  * @type {string}
@@ -101,6 +113,7 @@ export async function scrapePages(context) {
     options: {
       enableAuthentication,
       screenshotTypes: [],
+      waitTimeoutForMetaTags: PREFLIGHT_META_TAGS_WAIT_MS,
       ...(context.promiseToken ? { promiseToken: context.promiseToken } : {}),
     },
   };

--- a/test/audits/preflight.test.js
+++ b/test/audits/preflight.test.js
@@ -23,6 +23,7 @@ import { TierClient } from '@adobe/spacecat-shared-tier-client';
 import {
   scrapePages, PREFLIGHT_STEP_SUGGEST, PREFLIGHT_STEP_IDENTIFY,
   AUDIT_BODY_SIZE, AUDIT_LOREM_IPSUM, AUDIT_H1_COUNT,
+  PREFLIGHT_META_TAGS_WAIT_MS,
 } from '../../src/preflight/handler.js';
 import { runLinksChecks } from '../../src/preflight/links-checks.js';
 import { MockContextBuilder } from '../shared.js';
@@ -536,6 +537,7 @@ describe('Preflight Audit', () => {
         options: {
           enableAuthentication: true,
           screenshotTypes: [],
+          waitTimeoutForMetaTags: PREFLIGHT_META_TAGS_WAIT_MS,
         },
       });
     });
@@ -568,8 +570,26 @@ describe('Preflight Audit', () => {
         options: {
           enableAuthentication,
           screenshotTypes: [],
+          waitTimeoutForMetaTags: PREFLIGHT_META_TAGS_WAIT_MS,
         },
       });
+    });
+
+    it('sets waitTimeoutForMetaTags so slow-rendering SPA pages are captured after hydration', async () => {
+      const context = {
+        site: { getId: () => 'site-123', getDeliveryType: () => Site.DELIVERY_TYPES.AEM_EDGE },
+        job: {
+          getMetadata: () => ({
+            payload: {
+              step: PREFLIGHT_STEP_IDENTIFY,
+              urls: ['https://main--example--page.aem.page'],
+            },
+          }),
+        },
+      };
+      const result = await scrapePages(context);
+      expect(result.options.waitTimeoutForMetaTags).to.equal(PREFLIGHT_META_TAGS_WAIT_MS);
+      expect(PREFLIGHT_META_TAGS_WAIT_MS).to.equal(5000);
     });
 
     it('includes promiseToken in options if context.promiseToken exists', async () => {


### PR DESCRIPTION
## Problem

Preflight reports a false **"h1 not found"** on slow-rendering AEM author SPAs. The content scraper's default profile captures the page after a fixed ~5s wait; on pages like Cox `business-internet` the `<h1>` paints later (~6–7s), so the scraper captures the ~492-byte empty React shell (`h1=0`) instead of the hydrated page.

Jira: [SITES-46324](https://jira.corp.adobe.com/browse/SITES-46324)

## Fix

Preflight scrapes now pass `waitTimeoutForMetaTags: 5000` in the content-scraper `options`. The scraper ([`abstract-handler.js`](https://github.com/adobe/spacecat-content-scraper/blob/main/src/handlers/abstract-handler.js), shipped in v1.72.7) waits for `title`/`h1`/`description` via a **non-throwing** `Promise.allSettled` before capturing, and resolves the instant they land:

- **Fast pages are unaffected** — resolves immediately once the tags are present.
- **Slow SPA pages are captured after hydration** instead of as an empty shell.
- **Non-throwing** — pages legitimately missing an `<h1>` are not failed; they just hit the cap.

One file of behavior change: [`src/preflight/handler.js`](src/preflight/handler.js).

## Validation

**Unit tests** — green at 100% coverage (lines/branches/statements). New focused test asserts the option is set; two existing `scrapePages` expectations updated.

**Live empirical proof** — ran the *real* merged scraper handler against the live Cox author page. Same page, only the wait strategy changed:

| Case | h1 | bodyLen |
|------|----|---------|
| Control (default 5s) | **0** | 492 (empty shell) |
| **`waitTimeoutForMetaTags: 5000`** (this PR's path) | **1** | 318,693 |

The false "h1 not found" is resolved.

## Known trade-off

The wait short-circuits on the first `<h1>`, so a very-slow page is captured mid-hydration (318KB at first-h1 vs ~421KB fully-settled). This fixes the h1 false-positive; fuller render-readiness detection is a scraping-layer concern (DRS roadmap), not preflight.
