### PR TITLE
fix: Sitemap uses kebab-case token for its error codes

### DIFF
--- a/src/sitemap/common.js
+++ b/src/sitemap/common.js
@@ -22,7 +22,7 @@ import {
 } from '../support/utils.js';
 
 // ----- version ----------------------------------------------------------------
-export const COMMON_VERSION = 101; // manually update as needed
+export const COMMON_VERSION = 102; // manually update as needed
 
 // ----- performance tuning constants ------------------------------------------
 
@@ -52,16 +52,16 @@ export const SLOW_PAGE_URL_BATCH_DELAY_MS = 100; // 0.1 of a second delay betwee
 
 // ----- internal constants ----------------------------------------------------
 export const ERROR_CODES = Object.freeze({
-  // ... codes applicable for the /robots.txt file ...
-  CANNOT_READ_ROBOTS: 'CANNOT READ ROBOTS',
-  NO_SITEMAP_IN_ROBOTS: 'NO SITEMAP FOUND IN ROBOTS',
   // ... codes applicable for a specific sitemap.xml URL ...
-  SITEMAP_NOT_FOUND: 'NO SITEMAP FOUND',
-  CANNOT_READ_SITEMAP: 'ERROR FETCHING DATA',
-  INVALID_SITEMAP_FORMAT: 'INVALID SITEMAP FORMAT',
-  NO_VALID_PATHS_EXTRACTED: 'NO VALID URLs FOUND IN SITEMAP',
+  SITEMAP_NOT_FOUND: 'sitemap-not-found', // was 'NO SITEMAP FOUND'
+  CANNOT_READ_SITEMAP: 'cannot-read-sitemap', // was 'ERROR FETCHING DATA'
+  INVALID_SITEMAP_FORMAT: 'invalid-sitemap-format', // was 'INVALID SITEMAP FORMAT'
+  NO_VALID_PATHS_EXTRACTED: 'no-valid-urls-in-sitemap', // was 'NO VALID URLs FOUND IN SITEMAP'
+  // ... codes applicable for the /robots.txt file ...
+  CANNOT_READ_ROBOTS: 'cannot-read-robots', // was 'CANNOT READ ROBOTS'
+  NO_SITEMAP_IN_ROBOTS: 'robots-missing-sitemap', // wsa 'NO SITEMAP FOUND IN ROBOTS'
   // ... audit-level codes ...
-  GENERAL_ERROR: 'INVALID URL', // the customer's URL provided for the audit is not valid
+  GENERAL_ERROR: 'general-error', // was 'INVALID URL'
 });
 
 const VALID_MIME_TYPES = Object.freeze([

--- a/test/audits/sitemap.test.js
+++ b/test/audits/sitemap.test.js
@@ -1207,7 +1207,7 @@ describe('Sitemap Audit', () => {
           {
             value:
               'Fetch error for https://maidenform.com/robots.txt Status: 403',
-            error: 'NO VALID URLs FOUND IN SITEMAP',
+            error: ERROR_CODES.NO_VALID_PATHS_EXTRACTED,
           },
         ],
         scores: {},
@@ -1222,7 +1222,7 @@ describe('Sitemap Audit', () => {
         reasons: [
           {
             value: 'https://some-domain.adobe/sitemap.xml',
-            error: 'NO VALID URLs FOUND IN SITEMAP',
+            error: ERROR_CODES.NO_VALID_PATHS_EXTRACTED,
           },
         ],
         url: 'https://some-domain.adobe',
@@ -1240,7 +1240,7 @@ describe('Sitemap Audit', () => {
         reasons: [
           {
             value: 'https://some-domain.adobe/robots.txt',
-            error: 'NO SITEMAP FOUND IN ROBOTS',
+            error: ERROR_CODES.NO_SITEMAP_IN_ROBOTS,
           },
         ],
         details: {
@@ -1658,7 +1658,7 @@ describe('Sitemap Audit', () => {
           reasons: [
             {
               value: 'https://some-domain.adobe/sitemap.xml',
-              error: 'NO VALID URLs FOUND IN SITEMAP',
+              error: ERROR_CODES.NO_VALID_PATHS_EXTRACTED,
             },
           ],
           url: 'https://some-domain.adobe',
@@ -1680,7 +1680,7 @@ describe('Sitemap Audit', () => {
         suggestions: [
           {
             type: 'error',
-            error: 'NO VALID URLs FOUND IN SITEMAP',
+            error: ERROR_CODES.NO_VALID_PATHS_EXTRACTED,
             recommendedAction:
               'remove_page_from_sitemap_or_fix_page_redirect_or_make_it_accessible',
           },


### PR DESCRIPTION
 * when the Sitemap audit will create an "error" suggestion, it will be coded using kebab-case style
   * note that "error" suggestions will be enabled in a later PR

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
