### PR TITLE
fix: downgrade product-metatags empty-extraction log to warn + re-pin data-access 3.75.2 (pageCitability url-upsert)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@adobe/mysticat-shared-seo-client": "1.6.0",
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
         "@adobe/spacecat-shared-athena-client": "1.11.0",
-        "@adobe/spacecat-shared-data-access": "3.75.1",
+        "@adobe/spacecat-shared-data-access": "3.75.2",
         "@adobe/spacecat-shared-data-access-v2": "npm:@adobe/spacecat-shared-data-access@2.109.0",
         "@adobe/spacecat-shared-drs-client": "1.12.1",
         "@adobe/spacecat-shared-google-client": "1.6.3",
@@ -1420,9 +1420,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "3.75.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-3.75.1.tgz",
-      "integrity": "sha512-iQEOhbNOLpl0LdAEyZAzxtOAI+FkTd8hfoCfFCLkSS1z6yJoIjdO1TzfaE13K8UOAKaI0oHqHLFzeR08gTPoTQ==",
+      "version": "3.75.2",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-3.75.2.tgz",
+      "integrity": "sha512-5bSFBiafEQ6Q6lfKgoNTwKDWZY7V6Kz2Usf4UP4NW0gW1RScMJskPVCjp2YZMJifNweh3LCJusM3Ow6bwPSIbw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@adobe/mysticat-shared-seo-client": "1.6.0",
     "@adobe/spacecat-helix-content-sdk": "1.4.33",
     "@adobe/spacecat-shared-athena-client": "1.11.0",
-    "@adobe/spacecat-shared-data-access": "3.75.1",
+    "@adobe/spacecat-shared-data-access": "3.75.2",
     "@adobe/spacecat-shared-data-access-v2": "npm:@adobe/spacecat-shared-data-access@2.109.0",
     "@adobe/spacecat-shared-drs-client": "1.12.1",
     "@adobe/spacecat-shared-google-client": "1.6.3",

--- a/src/product-metatags/handler.js
+++ b/src/product-metatags/handler.js
@@ -618,7 +618,7 @@ export async function productMetatagsAutoDetect(site, pagesMap, context) {
   log.info(`[PRODUCT-METATAGS] Extracted tags from ${extractedTagsCount} pages`);
 
   if (extractedTagsCount === 0) {
-    log.error(`[PRODUCT-METATAGS] Failed to extract tags from scraped content for bucket ${bucketName} and prefix ${prefix}`);
+    log.warn(`[PRODUCT-METATAGS] Failed to extract tags from scraped content for bucket ${bucketName} and prefix ${prefix}`);
   }
 
   // Perform SEO checks with product filtering

--- a/test/audits/product-metatags.test.js
+++ b/test/audits/product-metatags.test.js
@@ -2832,7 +2832,7 @@ describe('Product MetaTags', () => {
       expect(result).to.have.property('detectedTags');
       expect(result).to.have.property('extractedTags');
       expect(Object.keys(result.extractedTags)).to.have.length(0);
-      expect(logStub.error.getCalls().some((call) => call.args[0].includes('Failed to extract tags from scraped content'))).to.be.true;
+      expect(logStub.warn.getCalls().some((call) => call.args[0].includes('Failed to extract tags from scraped content'))).to.be.true;
     });
 
     it('should filter and process only matching pages', async () => {
@@ -2955,12 +2955,12 @@ describe('Product MetaTags', () => {
       }
     });
 
-    it('should log error when no tags are extracted', async () => {
+    it('should log warn when no tags are extracted', async () => {
       mockS3Client.getObjectKeysUsingPrefix = sinon.stub().resolves([]);
 
       await productMetatagsAutoDetect(mockSite, pagesSet, mockContext);
 
-      expect(logStub.error).to.have.been.calledWith(
+      expect(logStub.warn).to.have.been.calledWith(
         '[PRODUCT-METATAGS] Failed to extract tags from scraped content for bucket test-bucket and prefix scrapes/site123/',
       );
     });
@@ -3438,7 +3438,7 @@ describe('Product MetaTags', () => {
 
         // Verify that null metadata was handled properly
         expect(result.extractedTags).to.deep.equal({});
-        expect(testLogStub.error).to.have.been.calledWith(
+        expect(testLogStub.warn).to.have.been.calledWith(
           '[PRODUCT-METATAGS] Failed to extract tags from scraped content for bucket test-bucket and prefix scrapes/site123/',
         );
       },


### PR DESCRIPTION
Two recoverable-noise fixes - the last items from the prod ERROR-noise review.

## Change A - product-metatags empty-extraction -> warn
`src/product-metatags/handler.js:621` logged at error when `extractedTagsCount === 0`. That is a benign summary for non-product sites / empty scrapes (every non-product site hits it). The genuine per-object failures stay at error (handler.js:407 "No Scraped tags found in S3", :432 "Scrape result is empty"). Downgraded only the count==0 summary to warn (~143/6h of prod ERROR noise).

## Change B - re-pin data-access 3.75.2 (pageCitability url-upsert)
data-access 3.75.2 (adobe/spacecat-shared#1683) makes `PageCitability.create` upsert on the globally-unique `url` column, eliminating the read-then-insert duplicate-key race (Postgres 23505, ~100/hour in prod) between page-citability/handler.js:202 and prerender/handler.js:1401. No call-site change needed - the existing creates become race-safe `ON CONFLICT (url) DO UPDATE`.

## Testing
- `npm test`: 8603 passing, 0 failing, 100% coverage.
- lint clean.
- 3 product-metatags test assertions updated from error -> warn to match Change A (same message/args, no weakened coverage).