### PR TITLE
fix: downgrade expected audit-enrollment skip from error to info

### DIFF
--- a/src/common/audit-utils.js
+++ b/src/common/audit-utils.js
@@ -59,7 +59,7 @@ export async function isAuditEnabledForSite(type, site, context) {
       context,
     );
     if (!hasValidEnrollment) {
-      context.log.error(`No valid site enrollment for handler ${type} with product codes ${handler.productCodes} for site ${site.getId()}`);
+      context.log.info(`No valid site enrollment for handler ${type} with product codes ${handler.productCodes} for site ${site.getId()}`);
       return false;
     }
   } else {

--- a/test/common/audit-utils.test.js
+++ b/test/common/audit-utils.test.js
@@ -121,7 +121,7 @@ describe('Audit Utils Tests', () => {
       expect(context.log.error).to.have.been.calledWith('Handler test-handler has no product codes');
     });
 
-    it('returns false when handler has productCodes but no site enrollment', async () => {
+    it('returns false and logs info when handler has productCodes but no site enrollment', async () => {
       configuration.getHandlers = () => ({
         'test-handler': {
           enabledByDefault: true,
@@ -136,6 +136,10 @@ describe('Audit Utils Tests', () => {
 
       const result = await isAuditEnabledForSite('test-handler', site, context);
       expect(result).to.be.false;
+      expect(context.log.info).to.have.been.calledWith(
+        'No valid site enrollment for handler test-handler with product codes ASO,LLMO for site site-123',
+      );
+      expect(context.log.error).to.not.have.been.called;
     });
 
     it('returns true when handler has productCodes and site enrollment', async () => {


### PR DESCRIPTION
## What

In `isAuditEnabledForSite` (`src/common/audit-utils.js`), the "No valid site enrollment for handler ..." log is downgraded from `context.log.error` to `context.log.info`. Message text is unchanged.

## Why

This log fires when a scheduled audit is dispatched for a site that is not enrolled for the handler's required product codes. That is an **expected gating result** - the audit is correctly skipped (`return false`), nothing failed. It is normal steady-state across the scheduled audit sweep: in prod it is the single largest ERROR-noise source (~3,840 occurrences / 5h across hundreds of sites), drowning genuine failures in the ERROR stream.

`info` keeps the line queryable ("why was this audit skipped for this site?") without inflating error metrics. This mirrors the prior auth-service downgrade of an expected entitlement denial from error to a lower level.

## Scope (deliberately narrow)

Only the enrollment-gate line changes. Left at `error` because they are genuine conditions:
- `checkProductCodeEntitlements` catch blocks (`Failed to check entitlement for product code ...`, `Error checking product code entitlements`) - real lookup failures.
- `Handler ${type} has no product codes` - a handler misconfiguration signal.

## Test

The existing test covering this path is renamed and strengthened to lock in the new level: asserts `log.info` is called with the message and `log.error` is not. Full suite green (8611 passing), lint clean, 100% coverage held.