### PR TITLE
fix: remove dormant data-access-v2 fallback (drops electrodb/jsonschema, fixes DEP0169 log noise)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Output message body format sent to `AUDIT_RESULTS_QUEUE` is:
 Everyone working on Spacecat should have access to the development environments via [KLAM](https://klam.corp.adobe.com/). 
 If you don’t have access, please refer to the engineering onboarding guide or contact your Spacecat team representative.
 
-After logging into KLAM, you’ll receive the following credentials required to access AWS resources such as DynamoDB and S3 for local development:
+After logging into KLAM, you’ll receive the following credentials required to access AWS resources such as S3 for local development:
 
 - `AWS_ACCESS_KEY_ID`
 - `AWS_SECRET_ACCESS_KEY`
@@ -90,7 +90,7 @@ Both development scripts (`npm start` and `npm run start:unpacked`) require envi
 
 The `.env` file should contain:
 
-1. **AWS Credentials** (from KLAM) for accessing DynamoDB, S3, and other AWS services
+1. **AWS Credentials** (from KLAM) for accessing S3 and other AWS services
 2. **Application Secrets** required by various audits (API keys, service endpoints, etc.)
 
 **Creating your `.env` file:**
@@ -105,7 +105,7 @@ AWS_SECRET_ACCESS_KEY=<your-secret-key-from-klam>
 AWS_SESSION_TOKEN=<your-session-token-from-klam>
 
 # Core Spacecat Configuration
-DYNAMO_TABLE_NAME_DATA=spacecat-services-data
+POSTGREST_URL=<your-postgrest-endpoint>
 S3_SCRAPER_BUCKET_NAME=spacecat-scraper-results
 
 # Add additional secrets as needed for specific audits
@@ -234,9 +234,9 @@ curl -X POST http://localhost:3000 \
      -d '{ "type": "apex", "siteId": "9ab0575a-c238-4470-ae82-9d37fb2d0e78" }'
 ```
 
-#### 4. Inspect the Audit Result in DynamoDB
+#### 4. Inspect the Audit Result
 
-Once the audit completes, the results are saved to DynamoDB by default (unless configured otherwise).
+Once the audit completes, the results are saved to the Postgres data store.
 
 To retrieve the audit result, use the [Spacecat API](https://opensource.adobe.com/spacecat-api-service/#tag/audit/operation/getLatestAuditForSite).
 
@@ -284,7 +284,7 @@ A Spacecat audit is an operation designed for various purposes, including inspec
 
 2. **Step-based Audits**: Multi-step workflows where each step can be processed by different specialized workers. Ideal for complex scenarios requiring different processing capabilities or coordination between multiple services.
 
-Spacecat audits run periodically: weekly, daily, and even hourly. By default, the results of these audits are automatically stored in DynamoDB and sent to the `audit-results-queue`. The results can then be queried by type via [the Spacecat API](https://opensource.adobe.com/spacecat-api-service/#tag/audit).
+Spacecat audits run periodically: weekly, daily, and even hourly. By default, the results of these audits are automatically stored in the Postgres data store and sent to the `audit-results-queue`. The results can then be queried by type via [the Spacecat API](https://opensource.adobe.com/spacecat-api-service/#tag/audit).
 
 ## Audit Steps
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
         "@adobe/spacecat-shared-athena-client": "1.11.0",
         "@adobe/spacecat-shared-data-access": "3.75.3",
-        "@adobe/spacecat-shared-data-access-v2": "npm:@adobe/spacecat-shared-data-access@2.109.0",
         "@adobe/spacecat-shared-drs-client": "1.12.1",
         "@adobe/spacecat-shared-google-client": "1.6.3",
         "@adobe/spacecat-shared-gpt-client": "1.7.1",
@@ -1438,294 +1437,6 @@
       "engines": {
         "node": ">=22.0.0 <25.0.0",
         "npm": ">=10.9.0 <12.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-data-access-v2": {
-      "name": "@adobe/spacecat-shared-data-access",
-      "version": "2.109.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-2.109.0.tgz",
-      "integrity": "sha512-LW+Jic7h1GpBorCKhQvc6EoRyzJGvx0JQRL8lU91PU3dA3B7U+zT8t2kd+ADaR6HbIG8PhZlk80EtEX0A06WNw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@adobe/spacecat-shared-utils": "1.81.1",
-        "@aws-sdk/client-dynamodb": "3.940.0",
-        "@aws-sdk/client-s3": "^3.940.0",
-        "@aws-sdk/lib-dynamodb": "3.940.0",
-        "@types/joi": "17.2.3",
-        "aws-xray-sdk": "3.12.0",
-        "electrodb": "3.5.0",
-        "joi": "18.0.2",
-        "pluralize": "8.0.0"
-      },
-      "engines": {
-        "node": ">=22.0.0 <25.0.0",
-        "npm": ">=10.9.0 <12.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-data-access-v2/node_modules/@adobe/spacecat-shared-utils": {
-      "version": "1.81.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-utils/-/spacecat-shared-utils-1.81.1.tgz",
-      "integrity": "sha512-GSQuLJsPsT6SDJNydhozgRNHl5qat4f+W7/IwyAvNfAqgPrF6Eb7+h4ZUz8Nb01Rm13Z18f6NY/u/wW12sdxtQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@adobe/fetch": "4.2.3",
-        "@aws-sdk/client-s3": "3.940.0",
-        "@aws-sdk/client-sqs": "3.940.0",
-        "@json2csv/plainjs": "7.0.6",
-        "aws-xray-sdk": "3.12.0",
-        "cheerio": "1.1.2",
-        "date-fns": "4.1.0",
-        "franc-min": "6.2.0",
-        "iso-639-3": "3.0.1",
-        "validator": "^13.15.15",
-        "world-countries": "5.1.0",
-        "zod": "^4.1.11"
-      },
-      "engines": {
-        "node": ">=22.0.0 <25.0.0",
-        "npm": ">=10.9.0 <12.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-data-access-v2/node_modules/@aws-sdk/client-s3": {
-      "version": "3.940.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.940.0.tgz",
-      "integrity": "sha512-Wi4qnBT6shRRMXuuTgjMFTU5mu2KFWisgcigEMPptjPGUtJvBVi4PTGgS64qsLoUk/obqDAyOBOfEtRZ2ddC2w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha1-browser": "5.2.0",
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.940.0",
-        "@aws-sdk/credential-provider-node": "3.940.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.936.0",
-        "@aws-sdk/middleware-expect-continue": "3.936.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.940.0",
-        "@aws-sdk/middleware-host-header": "3.936.0",
-        "@aws-sdk/middleware-location-constraint": "3.936.0",
-        "@aws-sdk/middleware-logger": "3.936.0",
-        "@aws-sdk/middleware-recursion-detection": "3.936.0",
-        "@aws-sdk/middleware-sdk-s3": "3.940.0",
-        "@aws-sdk/middleware-ssec": "3.936.0",
-        "@aws-sdk/middleware-user-agent": "3.940.0",
-        "@aws-sdk/region-config-resolver": "3.936.0",
-        "@aws-sdk/signature-v4-multi-region": "3.940.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-endpoints": "3.936.0",
-        "@aws-sdk/util-user-agent-browser": "3.936.0",
-        "@aws-sdk/util-user-agent-node": "3.940.0",
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/core": "^3.18.5",
-        "@smithy/eventstream-serde-browser": "^4.2.5",
-        "@smithy/eventstream-serde-config-resolver": "^4.3.5",
-        "@smithy/eventstream-serde-node": "^4.2.5",
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/hash-blob-browser": "^4.2.6",
-        "@smithy/hash-node": "^4.2.5",
-        "@smithy/hash-stream-node": "^4.2.5",
-        "@smithy/invalid-dependency": "^4.2.5",
-        "@smithy/md5-js": "^4.2.5",
-        "@smithy/middleware-content-length": "^4.2.5",
-        "@smithy/middleware-endpoint": "^4.3.12",
-        "@smithy/middleware-retry": "^4.4.12",
-        "@smithy/middleware-serde": "^4.2.6",
-        "@smithy/middleware-stack": "^4.2.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.8",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.11",
-        "@smithy/util-defaults-mode-node": "^4.2.14",
-        "@smithy/util-endpoints": "^3.2.5",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-retry": "^4.2.5",
-        "@smithy/util-stream": "^4.5.6",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/util-waiter": "^4.2.5",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-data-access-v2/node_modules/@aws-sdk/client-sqs": {
-      "version": "3.940.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.940.0.tgz",
-      "integrity": "sha512-tXPi9OlELbiewGDb9maXDMhdYW617I9osGo/C1GAR6eLYwj40/TfOBeOQf3tX9EcH8NpDBuMksxoAvkpvqYIKw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.940.0",
-        "@aws-sdk/credential-provider-node": "3.940.0",
-        "@aws-sdk/middleware-host-header": "3.936.0",
-        "@aws-sdk/middleware-logger": "3.936.0",
-        "@aws-sdk/middleware-recursion-detection": "3.936.0",
-        "@aws-sdk/middleware-sdk-sqs": "3.936.0",
-        "@aws-sdk/middleware-user-agent": "3.940.0",
-        "@aws-sdk/region-config-resolver": "3.936.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-endpoints": "3.936.0",
-        "@aws-sdk/util-user-agent-browser": "3.936.0",
-        "@aws-sdk/util-user-agent-node": "3.940.0",
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/core": "^3.18.5",
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/hash-node": "^4.2.5",
-        "@smithy/invalid-dependency": "^4.2.5",
-        "@smithy/md5-js": "^4.2.5",
-        "@smithy/middleware-content-length": "^4.2.5",
-        "@smithy/middleware-endpoint": "^4.3.12",
-        "@smithy/middleware-retry": "^4.4.12",
-        "@smithy/middleware-serde": "^4.2.6",
-        "@smithy/middleware-stack": "^4.2.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.8",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.11",
-        "@smithy/util-defaults-mode-node": "^4.2.14",
-        "@smithy/util-endpoints": "^3.2.5",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-retry": "^4.2.5",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-data-access-v2/node_modules/@aws-sdk/core": {
-      "version": "3.940.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.940.0.tgz",
-      "integrity": "sha512-KsGD2FLaX5ngJao1mHxodIVU9VYd1E8810fcYiGwO1PFHDzf5BEkp6D9IdMeQwT8Q6JLYtiiT1Y/o3UCScnGoA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/xml-builder": "3.930.0",
-        "@smithy/core": "^3.18.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/signature-v4": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.8",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-data-access-v2/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.940.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.940.0.tgz",
-      "integrity": "sha512-M8NFAvgvO6xZjiti5kztFiAYmSmSlG3eUfr4ZHSfXYZUA/KUdZU/D6xJyaLnU8cYRWBludb6K9XPKKVwKfqm4g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.940.0",
-        "@aws-sdk/credential-provider-http": "3.940.0",
-        "@aws-sdk/credential-provider-ini": "3.940.0",
-        "@aws-sdk/credential-provider-process": "3.940.0",
-        "@aws-sdk/credential-provider-sso": "3.940.0",
-        "@aws-sdk/credential-provider-web-identity": "3.940.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/credential-provider-imds": "^4.2.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-data-access-v2/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.940.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.940.0.tgz",
-      "integrity": "sha512-nJbLrUj6fY+l2W2rIB9P4Qvpiy0tnTdg/dmixRxrU1z3e8wBdspJlyE+AZN4fuVbeL6rrRrO/zxQC1bB3cw5IA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.940.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-endpoints": "3.936.0",
-        "@smithy/core": "^3.18.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-data-access-v2/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.940.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.940.0.tgz",
-      "integrity": "sha512-dlD/F+L/jN26I8Zg5x0oDGJiA+/WEQmnSE27fi5ydvYnpfQLwThtQo9SsNS47XSR/SOULaaoC9qx929rZuo74A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.940.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-data-access-v2/node_modules/cheerio": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
-      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
-      "license": "MIT",
-      "dependencies": {
-        "cheerio-select": "^2.1.0",
-        "dom-serializer": "^2.0.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.2.2",
-        "encoding-sniffer": "^0.2.1",
-        "htmlparser2": "^10.0.0",
-        "parse5": "^7.3.0",
-        "parse5-htmlparser2-tree-adapter": "^7.1.0",
-        "parse5-parser-stream": "^7.1.2",
-        "undici": "^7.12.0",
-        "whatwg-mimetype": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=20.18.1"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
-      }
-    },
-    "node_modules/@adobe/spacecat-shared-data-access-v2/node_modules/date-fns": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "license": "MIT",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access/node_modules/@adobe/spacecat-shared-utils": {
@@ -6611,147 +6322,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.940.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.940.0.tgz",
-      "integrity": "sha512-u2sXsNJazJbuHeWICvsj6RvNyJh3isedEfPvB21jK/kxcriK+dE/izlKC2cyxUjERCmku0zTFNzY9FhrLbYHjQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.940.0",
-        "@aws-sdk/credential-provider-node": "3.940.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.936.0",
-        "@aws-sdk/middleware-host-header": "3.936.0",
-        "@aws-sdk/middleware-logger": "3.936.0",
-        "@aws-sdk/middleware-recursion-detection": "3.936.0",
-        "@aws-sdk/middleware-user-agent": "3.940.0",
-        "@aws-sdk/region-config-resolver": "3.936.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-endpoints": "3.936.0",
-        "@aws-sdk/util-user-agent-browser": "3.936.0",
-        "@aws-sdk/util-user-agent-node": "3.940.0",
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/core": "^3.18.5",
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/hash-node": "^4.2.5",
-        "@smithy/invalid-dependency": "^4.2.5",
-        "@smithy/middleware-content-length": "^4.2.5",
-        "@smithy/middleware-endpoint": "^4.3.12",
-        "@smithy/middleware-retry": "^4.4.12",
-        "@smithy/middleware-serde": "^4.2.6",
-        "@smithy/middleware-stack": "^4.2.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.8",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-body-length-node": "^4.2.1",
-        "@smithy/util-defaults-mode-browser": "^4.3.11",
-        "@smithy/util-defaults-mode-node": "^4.2.14",
-        "@smithy/util-endpoints": "^3.2.5",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-retry": "^4.2.5",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/util-waiter": "^4.2.5",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/core": {
-      "version": "3.940.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.940.0.tgz",
-      "integrity": "sha512-KsGD2FLaX5ngJao1mHxodIVU9VYd1E8810fcYiGwO1PFHDzf5BEkp6D9IdMeQwT8Q6JLYtiiT1Y/o3UCScnGoA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/xml-builder": "3.930.0",
-        "@smithy/core": "^3.18.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/signature-v4": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.8",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.940.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.940.0.tgz",
-      "integrity": "sha512-M8NFAvgvO6xZjiti5kztFiAYmSmSlG3eUfr4ZHSfXYZUA/KUdZU/D6xJyaLnU8cYRWBludb6K9XPKKVwKfqm4g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.940.0",
-        "@aws-sdk/credential-provider-http": "3.940.0",
-        "@aws-sdk/credential-provider-ini": "3.940.0",
-        "@aws-sdk/credential-provider-process": "3.940.0",
-        "@aws-sdk/credential-provider-sso": "3.940.0",
-        "@aws-sdk/credential-provider-web-identity": "3.940.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/credential-provider-imds": "^4.2.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.940.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.940.0.tgz",
-      "integrity": "sha512-nJbLrUj6fY+l2W2rIB9P4Qvpiy0tnTdg/dmixRxrU1z3e8wBdspJlyE+AZN4fuVbeL6rrRrO/zxQC1bB3cw5IA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.940.0",
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/util-endpoints": "3.936.0",
-        "@smithy/core": "^3.18.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.940.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.940.0.tgz",
-      "integrity": "sha512-dlD/F+L/jN26I8Zg5x0oDGJiA+/WEQmnSE27fi5ydvYnpfQLwThtQo9SsNS47XSR/SOULaaoC9qx929rZuo74A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.940.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@aws-sdk/client-lambda": {
       "version": "3.1068.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1068.0.tgz",
@@ -7895,63 +7465,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@aws-sdk/endpoint-cache": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.893.0.tgz",
-      "integrity": "sha512-KSwTfyLZyNLszz5f/yoLC+LC+CRKpeJii/+zVAy7JUOQsKhSykiRUPYUx7o2Sdc4oJfqqUl26A/jSttKYnYtAA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "mnemonist": "0.38.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/lib-dynamodb": {
-      "version": "3.940.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.940.0.tgz",
-      "integrity": "sha512-5ApYAix2wvJuMszj1lrpg8lm4ipoZMFO8crxtzsdAvxM8TV5bKSRQQ2GA3CMIODrBuSzpXvWueHHrfkx05ZAQw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "3.940.0",
-        "@aws-sdk/util-dynamodb": "3.940.0",
-        "@smithy/core": "^3.18.5",
-        "@smithy/smithy-client": "^4.9.8",
-        "@smithy/types": "^4.9.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.940.0"
-      }
-    },
-    "node_modules/@aws-sdk/lib-dynamodb/node_modules/@aws-sdk/core": {
-      "version": "3.940.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.940.0.tgz",
-      "integrity": "sha512-KsGD2FLaX5ngJao1mHxodIVU9VYd1E8810fcYiGwO1PFHDzf5BEkp6D9IdMeQwT8Q6JLYtiiT1Y/o3UCScnGoA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "3.936.0",
-        "@aws-sdk/xml-builder": "3.930.0",
-        "@smithy/core": "^3.18.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/signature-v4": "^5.3.5",
-        "@smithy/smithy-client": "^4.9.8",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
       "version": "3.936.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.936.0.tgz",
@@ -7964,23 +7477,6 @@
         "@smithy/protocol-http": "^5.3.5",
         "@smithy/types": "^4.9.0",
         "@smithy/util-config-provider": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.936.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.936.0.tgz",
-      "integrity": "sha512-wNJZ8PDw0eQK2x4z1q8JqiDvw9l9xd36EoklVT2CIBt8FnqGdrMGjAx93RRbH3G6Fmvwoe+D3VJXbWHBlhD0Bw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/endpoint-cache": "3.893.0",
-        "@aws-sdk/types": "3.936.0",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -8495,21 +7991,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-dynamodb": {
-      "version": "3.940.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.940.0.tgz",
-      "integrity": "sha512-T8UTYtCYSPxktnk68fKBdWztnqdTQItJwi/8N9lsvp20alJ15wCQsvQR+GKB5p4TCKxOPyNEirkcrNlf5TKppA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-dynamodb": "^3.940.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
@@ -15871,17 +15352,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/electrodb": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/electrodb/-/electrodb-3.5.0.tgz",
-      "integrity": "sha512-msJyMTQmx6AC/otRKSre0rktE3E0RUw7ez9u2F25ZU4iXEqzxeu/OyRJcR53hh+jv4Fefi/3F9R+JopgIUZJHQ==",
-      "license": "ISC",
-      "dependencies": {
-        "@aws-sdk/lib-dynamodb": "^3.654.0",
-        "@aws-sdk/util-dynamodb": "^3.654.0",
-        "jsonschema": "1.2.7"
-      }
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.262",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.262.tgz",
@@ -19977,15 +19447,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/jsonschema": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.7.tgz",
-      "integrity": "sha512-3dFMg9hmI9LdHag/BRIhMefCfbq1hicvYMy8YhZQorAdzOzWz7NjniSpn39yjpzUAMIWtGyyZuH2KNBloH7ZLw==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
@@ -21833,15 +21294,6 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/mnemonist": {
-      "version": "0.38.3",
-      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
-      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
-      "license": "MIT",
-      "dependencies": {
-        "obliterator": "^1.6.1"
       }
     },
     "node_modules/mobx": {
@@ -25097,12 +24549,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/obliterator": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
-      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
-      "license": "MIT"
     },
     "node_modules/on-finished": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "@adobe/spacecat-helix-content-sdk": "1.4.33",
     "@adobe/spacecat-shared-athena-client": "1.11.0",
     "@adobe/spacecat-shared-data-access": "3.75.3",
-    "@adobe/spacecat-shared-data-access-v2": "npm:@adobe/spacecat-shared-data-access@2.109.0",
     "@adobe/spacecat-shared-drs-client": "1.12.1",
     "@adobe/spacecat-shared-google-client": "1.6.3",
     "@adobe/spacecat-shared-gpt-client": "1.7.1",

--- a/src/support/data-access.js
+++ b/src/support/data-access.js
@@ -10,22 +10,14 @@
  * governing permissions and limitations under the License.
  */
 
-import dataAccessV2 from '@adobe/spacecat-shared-data-access-v2';
 import dataAccessV3 from '@adobe/spacecat-shared-data-access';
 
-/* c8 ignore start */
 export default function dataAccess(fn) {
   return async (request, context) => {
     const { env = {} } = context;
-    if (env.DATA_SERVICE_PROVIDER === 'postgres') {
-      if (!env.POSTGREST_URL) {
-        throw new Error(
-          'DATA_SERVICE_PROVIDER is set to "postgres" but POSTGREST_URL is not configured',
-        );
-      }
-      return dataAccessV3(fn)(request, context);
+    if (!env.POSTGREST_URL) {
+      throw new Error('POSTGREST_URL is not configured');
     }
-    return dataAccessV2(fn)(request, context);
+    return dataAccessV3(fn)(request, context);
   };
 }
-/* c8 ignore stop */

--- a/src/support/postgrest-sam-template-override.js
+++ b/src/support/postgrest-sam-template-override.js
@@ -15,7 +15,6 @@
  * overwrites process.env on the first request.
  */
 const SAM_TEMPLATE_POSTGREST = {
-  DATA_SERVICE_PROVIDER: process.env.DATA_SERVICE_PROVIDER,
   POSTGREST_URL: process.env.POSTGREST_URL,
   POSTGREST_SCHEMA: process.env.POSTGREST_SCHEMA,
   POSTGREST_API_KEY: process.env.POSTGREST_API_KEY,

--- a/test/common/index-drs-normalization.test.js
+++ b/test/common/index-drs-normalization.test.js
@@ -37,7 +37,9 @@ describe('Index DRS message normalization', () => {
           }),
         },
       },
-      env: {},
+      env: {
+        POSTGREST_URL: 'https://data-svc.test',
+      },
       log: {
         debug: sandbox.spy(),
         info: sandbox.spy(),

--- a/test/common/index-site-validation.test.js
+++ b/test/common/index-site-validation.test.js
@@ -38,7 +38,9 @@ describe('Index siteId handling and validation flag', () => {
           }),
         },
       },
-      env: {},
+      env: {
+        POSTGREST_URL: 'https://data-svc.test',
+      },
       log: {
         debug: sandbox.spy(),
         info: sandbox.spy(),

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -37,7 +37,9 @@ describe('Index Tests', () => {
     };
     context = {
       dataAccess: {},
-      env: {},
+      env: {
+        POSTGREST_URL: 'https://data-svc.test',
+      },
       log: console,
       runtime: {
         region: 'us-east-1',

--- a/test/support/data-access.test.js
+++ b/test/support/data-access.test.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import esmock from 'esmock';
+
+use(sinonChai);
+use(chaiAsPromised);
+
+describe('dataAccess middleware', () => {
+  let mockFn;
+  let request;
+  let innerMiddleware;
+  let dataAccessV3;
+  let dataAccess;
+
+  beforeEach(async () => {
+    mockFn = sinon.stub().resolves('handler-result');
+    request = { some: 'request' };
+    // dataAccessV3(fn) returns a middleware (request, context) => ...
+    innerMiddleware = sinon.stub().resolves('v3-result');
+    dataAccessV3 = sinon.stub().returns(innerMiddleware);
+
+    dataAccess = await esmock('../../src/support/data-access.js', {
+      '@adobe/spacecat-shared-data-access': { default: dataAccessV3 },
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('throws when POSTGREST_URL is not configured', async () => {
+    const context = { env: {} };
+    await expect(dataAccess(mockFn)(request, context))
+      .to.be.rejectedWith('POSTGREST_URL is not configured');
+    expect(dataAccessV3).to.not.have.been.called;
+    expect(mockFn).to.not.have.been.called;
+  });
+
+  it('throws when context has no env at all', async () => {
+    const context = {};
+    await expect(dataAccess(mockFn)(request, context))
+      .to.be.rejectedWith('POSTGREST_URL is not configured');
+    expect(dataAccessV3).to.not.have.been.called;
+  });
+
+  it('delegates to the V3 data-access when POSTGREST_URL is present', async () => {
+    const context = { env: { POSTGREST_URL: 'https://data-svc.example.com' } };
+    const result = await dataAccess(mockFn)(request, context);
+
+    expect(result).to.equal('v3-result');
+    expect(dataAccessV3).to.have.been.calledOnceWithExactly(mockFn);
+    expect(innerMiddleware).to.have.been.calledOnceWithExactly(request, context);
+  });
+});

--- a/test/support/postgrest-sam-template-override.test.js
+++ b/test/support/postgrest-sam-template-override.test.js
@@ -25,7 +25,6 @@ const MODULE_PATH = pathToFileURL(
 ).href;
 
 const TRACKED_ENV_KEYS = [
-  'DATA_SERVICE_PROVIDER',
   'POSTGREST_URL',
   'POSTGREST_SCHEMA',
   'POSTGREST_API_KEY',
@@ -94,7 +93,6 @@ describe('postgrest-sam-template-override', () => {
 
   it('merges snapshot values into context.env and process.env when POSTGREST_USE_SAM_TEMPLATE is true', async () => {
     const postgrestSamTemplateOverride = await loadPostgrestOverride({
-      DATA_SERVICE_PROVIDER: 'pg',
       POSTGREST_URL: 'https://snap.example.com',
       POSTGREST_SCHEMA: 'public',
       POSTGREST_API_KEY: 'secret',
@@ -105,7 +103,6 @@ describe('postgrest-sam-template-override', () => {
 
     await postgrestSamTemplateOverride(next)(request, context);
 
-    expect(context.env.DATA_SERVICE_PROVIDER).to.equal('pg');
     expect(context.env.POSTGREST_URL).to.equal('https://snap.example.com');
     expect(context.env.POSTGREST_SCHEMA).to.equal('public');
     expect(context.env.POSTGREST_API_KEY).to.equal('secret');


### PR DESCRIPTION
## What

Removes the dormant `@adobe/spacecat-shared-data-access-v2` (legacy electrodb/DynamoDB) fallback. `src/support/data-access.js` now uses the V3 PostgREST layer unconditionally; the `DATA_SERVICE_PROVIDER` switch and the V2 import/branch are gone. This drops `electrodb@3.5.0` and `jsonschema@1.2.7` from the dependency tree entirely (24 packages removed).

## Why

`jsonschema@1.2.7` calls the legacy `url.resolve()`/`url.parse()` at module-load (during electrodb's `Validator` init), which emits Node's **DEP0169** deprecation warning to stderr - once per Lambda process. The Lambda log pipeline maps stderr to ERROR severity, so this benign warning had become the single largest audit-worker ERROR-severity line in prod (and is org-wide across every service that ships this fallback). electrodb/jsonschema only entered the tree via the v2 alias; the V3 package does not use electrodb. Removing the dead fallback removes the warning at the source.

V2 has been a dormant switch-back fallback since the Postgres migration; prod runs V3 unconditionally (this worker's PostgREST writes are live in prod today). Restoring V2 would be a code + dep revert if ever needed - deliberately a point of no return per the team decision to fully retire the DynamoDB path.

## Behavioral change (note for reviewers)

Previously, when `DATA_SERVICE_PROVIDER !== 'postgres'`, the wrapper silently fell through to V2. Now the wrapper requires `POSTGREST_URL` and **throws** `POSTGREST_URL is not configured` if it is absent (fail-loud rather than silent legacy fallback). Prod always sets `POSTGREST_URL`. Ten index tests that previously ran with `env: {}` now set `POSTGREST_URL` to mirror prod.

## Scope

Also removed a stale `DATA_SERVICE_PROVIDER` capture in `src/support/postgrest-sam-template-override.js` (a SAM-local env snapshot; no logic depended on it). This is the **pilot** for a 13-repo sweep - all spacecat services carry the identical `src/support/data-access.js` fallback. The other repos follow once this validates in prod.

## Validation

- `npm ls electrodb` and `npm ls jsonschema`: empty.
- No `spacecat-shared-data-access-v2` references remain (source + lockfile).
- `npm test`: 8621 passing, 100% lines/branches/statements coverage; new `test/support/data-access.test.js` covers the V3 delegation + the missing-`POSTGREST_URL` throw.
- `npm run lint`: clean. `npm run build`: bundle builds and healthchecks 200.