### PR TITLE
feat: filter out URLs from non-english speaking regions

### DIFF
--- a/src/offsite-brand-presence/constants.js
+++ b/src/offsite-brand-presence/constants.js
@@ -26,6 +26,9 @@ export const PROVIDERS = Object.freeze([
 export const PROVIDERS_SET = new Set(PROVIDERS);
 export const BRAND_PRESENCE_REGEX = /brandpresence-(.+?)-w(\d{1,2})-(\d{4})(?:-.*)?$/;
 
+// Region codes whose brand-presence rows are processed. Limited to English-speaking markets.
+export const ACCEPTED_REGIONS = Object.freeze(new Set(['US', 'GB', 'CA', 'AU', 'IE', 'NZ']));
+
 export const URL_STORE_STATUS = Object.freeze({
   CREATED: 'created',
   FAILED: 'failed',

--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -22,6 +22,7 @@ import {
   DRS_URLS_LIMIT,
   RETRIABLE_STATUSES,
   RETRY_DELAY_MS,
+  ACCEPTED_REGIONS,
   OFFSITE_DOMAINS,
   CITED_ANALYSIS_DRS_CONFIG,
   YOUTUBE_URL_REGEX,
@@ -227,7 +228,7 @@ function trackTopicUrl(topicMap, topicName, url, category, prompt) {
 /**
  * Extracts URLs and topic associations from brand presence data rows in a single pass.
  * Populates both the global URL map (for URL store) and the topic map (for guideline store).
- * Only processes rows with Region=US.
+ * Only processes rows whose Region is in ACCEPTED_REGIONS.
  *
  * @param {object} data - Brand presence JSON data (expects a "data" array of rows)
  * @param {Map<string, {count: number, domain: string|null}>} allUrls - Global URL map (mutated)
@@ -239,7 +240,7 @@ function extractUrlsAndTopics(data, allUrls, topicMap, log, siteHostname) {
   const rows = data.data;
   for (const row of rows) {
     const sources = row.Sources?.trim();
-    if (!sources) {
+    if (!sources || !ACCEPTED_REGIONS.has(row.Region)) {
       // eslint-disable-next-line no-continue
       continue;
     }

--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -239,7 +239,7 @@ function extractUrlsAndTopics(data, allUrls, topicMap, log, siteHostname) {
   const rows = data.data;
   for (const row of rows) {
     const sources = row.Sources?.trim();
-    if (!sources || row.Region !== 'US') {
+    if (!sources) {
       // eslint-disable-next-line no-continue
       continue;
     }

--- a/src/utils/offsite-brand-presence-enrichment.js
+++ b/src/utils/offsite-brand-presence-enrichment.js
@@ -22,6 +22,7 @@ import { loadBrandPresenceDataFromPostgrest } from './offsite-brand-presence-pos
 import { createLLMOSharepointClient, readFromSharePointWithRetry } from './report-uploader.js';
 import { buildColumnMap, getColumn } from '../faqs/utils.js';
 import {
+  ACCEPTED_REGIONS,
   BRAND_PRESENCE_REGEX,
   OFFSITE_DOMAINS,
   PROVIDERS_SET,
@@ -303,7 +304,7 @@ function trackTopicUrl(topicMap, topicName, url, category, prompt) {
 
 /**
  * Extracts URLs and topic associations from brand presence data rows in a single pass.
- * Only processes rows with Region=US.
+ * Only processes rows whose Region is in ACCEPTED_REGIONS.
  *
  * @param {object} data - Brand presence JSON data (expects a "data" array of rows)
  * @param {Map<string, {count: number, domain: string|null}>} allUrls - Global URL map (mutated)
@@ -315,7 +316,7 @@ function extractUrlsAndTopics(data, allUrls, topicMap, log, siteHostname) {
   const rows = data.data;
   for (const row of rows) {
     const sources = row.Sources?.trim();
-    if (!sources || row.Region !== 'US') {
+    if (!sources || !ACCEPTED_REGIONS.has(row.Region)) {
       // eslint-disable-next-line no-continue
       continue;
     }

--- a/test/audits/offsite-brand-presence.test.js
+++ b/test/audits/offsite-brand-presence.test.js
@@ -259,28 +259,23 @@ describe('Offsite Brand Presence Handler', () => {
       expect(result.auditResult.urlCounts['youtube.com']).to.equal(1);
     });
 
-    it('should extract URLs from all regions', async () => {
+    it('extracts rows from accepted regions and skips others', async () => {
       mockLoadBrandPresenceData.resolves({
         data: [
-          {
-            Sources: 'https://youtube.com/v1', Region: 'EU',
-          },
-          {
-            Sources: 'https://youtube.com/v2', Region: 'US',
-          },
-          {
-            Sources: 'https://youtube.com/ok', Region: 'US',
-          },
-          {
-            Sources: 'https://reddit.com/r/ok/', Region: 'US',
-          },
+          // Not in ACCEPTED_REGIONS -> skipped.
+          { Sources: 'https://youtube.com/v1', Region: 'EU' },
+          // Accepted region.
+          { Sources: 'https://youtube.com/v2', Region: 'US' },
+          // Accepted non-US region.
+          { Sources: 'https://youtube.com/ok', Region: 'GB' },
+          { Sources: 'https://reddit.com/r/ok/', Region: 'US' },
         ],
       });
 
       const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
 
-      // All three YouTube URLs (including the EU one) are counted.
-      expect(result.auditResult.urlCounts['youtube.com']).to.equal(3);
+      // US + GB YouTube URLs counted; the EU row is excluded.
+      expect(result.auditResult.urlCounts['youtube.com']).to.equal(2);
       expect(result.auditResult.urlCounts['reddit.com']).to.equal(1);
     });
 

--- a/test/audits/offsite-brand-presence.test.js
+++ b/test/audits/offsite-brand-presence.test.js
@@ -259,7 +259,7 @@ describe('Offsite Brand Presence Handler', () => {
       expect(result.auditResult.urlCounts['youtube.com']).to.equal(1);
     });
 
-    it('should only extract URLs with Region=US', async () => {
+    it('should extract URLs from all regions', async () => {
       mockLoadBrandPresenceData.resolves({
         data: [
           {
@@ -279,7 +279,8 @@ describe('Offsite Brand Presence Handler', () => {
 
       const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
 
-      expect(result.auditResult.urlCounts['youtube.com']).to.equal(2);
+      // All three YouTube URLs (including the EU one) are counted.
+      expect(result.auditResult.urlCounts['youtube.com']).to.equal(3);
       expect(result.auditResult.urlCounts['reddit.com']).to.equal(1);
     });
 


### PR DESCRIPTION
Currently, our offsite analysis work only on english content. The current filtering strategy is to discard anything outside the `US` region, but there are other english-speaking regions that should be taken into account (`GB`, `AU`, `NZ` etc).

Added `ACCEPTED_REGIONS` which is used to filter out regions when URLs are processed.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
