### PR TITLE
fix: Sitemap buildKey function enabled for "error" suggestions

### DIFF
--- a/src/sitemap/common.js
+++ b/src/sitemap/common.js
@@ -51,6 +51,8 @@ export const SLOW_PAGE_URL_BATCH_SIZE = 4; // must stay under 1000 per SpaceCat 
 export const SLOW_PAGE_URL_BATCH_DELAY_MS = 100; // 0.1 of a second delay between batches
 
 // ----- internal constants ----------------------------------------------------
+
+// Warning: Keep any updates or changes in sync with the corresponding BackOffice UI list.
 export const ERROR_CODES = Object.freeze({
   // ... codes applicable for a specific sitemap.xml URL ...
   SITEMAP_NOT_FOUND: 'sitemap-not-found', // was 'NO SITEMAP FOUND'
@@ -1014,7 +1016,9 @@ export async function checkRobotsForSitemap(protocol, domain) {
   //       sitemap URLs, such as the root-level sitemap.xml file.
   return {
     paths: sitemapPaths,
-    reasons: sitemapPaths.length ? [] : [ERROR_CODES.NO_SITEMAP_IN_ROBOTS],
+    reasons: sitemapPaths.length
+      ? []
+      : [{ value: robotsUrl, error: ERROR_CODES.NO_SITEMAP_IN_ROBOTS }],
   };
 }
 
@@ -1042,7 +1046,7 @@ export async function checkSitemap(sitemapUrl, log) {
     if (!isValidFormat) {
       return {
         existsAndIsValid: false,
-        reasons: [ERROR_CODES.INVALID_SITEMAP_FORMAT],
+        reasons: [{ value: sitemapUrl, error: ERROR_CODES.INVALID_SITEMAP_FORMAT }],
       };
     }
 
@@ -1055,9 +1059,10 @@ export async function checkSitemap(sitemapUrl, log) {
     /* c8 ignore next */
     log?.error(`Sitemap: Error fetching sitemap URL ${sitemapUrl}: ${error.message}`);
     const isNotFound = error.message.includes('404');
+    const errorCode = isNotFound ? ERROR_CODES.SITEMAP_NOT_FOUND : ERROR_CODES.CANNOT_READ_SITEMAP;
     return {
       existsAndIsValid: false,
-      reasons: [isNotFound ? ERROR_CODES.SITEMAP_NOT_FOUND : ERROR_CODES.CANNOT_READ_SITEMAP],
+      reasons: [{ value: sitemapUrl, error: errorCode }],
     };
   }
 }
@@ -1136,7 +1141,7 @@ export async function getSitemapUrls(inputUrl, log) {
     log?.error(`Sitemap: Invalid URL provided: ${inputUrl}`);
     return {
       success: false,
-      reasons: [{ value: inputUrl, error: ERROR_CODES.GENERAL_ERROR }],
+      reasons: [{ value: `Invalid URL provided: ${inputUrl}`, error: ERROR_CODES.GENERAL_ERROR }],
     };
   }
 

--- a/src/sitemap/handler.js
+++ b/src/sitemap/handler.js
@@ -65,6 +65,96 @@ const SLOW_PAGE_URL_BATCH_OPTIONS = Object.freeze({
   pageUrlHttpRequestIntervalMs: SLOW_PAGE_URL_BATCH_DELAY_MS,
 });
 
+/** Error codes where neither sitemapUrl nor recommendedAction apply (BackOffice-aligned). */
+const ERROR_CODES_WITHOUT_DETAIL = Object.freeze([
+  ERROR_CODES.CANNOT_READ_ROBOTS,
+  ERROR_CODES.NO_SITEMAP_IN_ROBOTS,
+]);
+
+/**
+ * Normalizes a string for error-type suggestion fields and buildKey segments.
+ * Missing, null, and non-string values become an empty string; strings are trimmed.
+ *
+ * @param {unknown} value
+ * @returns {string}
+ */
+export const normalizeString = (value) => (typeof value === 'string' ? value.trim() : '');
+
+/**
+ * Builds a sync key for error-type sitemap suggestions. Examples:
+ *  * cannot-read-robots||
+ *  * sitemap-not-found|https://www.example.com/sitemap.xml|
+ *  * general-error||Something horrible happened
+ *
+ * @param {Object} data
+ * @returns {string}
+ */
+export const buildSitemapErrorSuggestionKey = (data) => [
+  normalizeString(data?.error),
+  normalizeString(data?.sitemapUrl),
+  normalizeString(data?.recommendedAction),
+].join('|');
+
+/**
+ * Builds a sync key for sitemap suggestions (url or error type).
+ *
+ * @param {Object} data
+ * @returns {string}
+ */
+export const buildSitemapSuggestionKey = (data) => (
+  data?.type === 'url'
+    ? `${data.sitemapUrl}|${data.pageUrl}`
+    : buildSitemapErrorSuggestionKey(data)
+);
+
+/**
+ * @param {string} value
+ * @returns {boolean}
+ */
+function isAbsoluteHttpUrlWithPath(value) {
+  if (typeof value !== 'string' || !value.trim()) {
+    return false;
+  }
+  try {
+    const url = new URL(value.trim());
+    return (url.protocol === 'http:' || url.protocol === 'https:') && url.pathname.length > 1;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Maps an audit failure reason to an error-type suggestion payload aligned with BackOffice.
+ *
+ * @param {{ error?: string, value?: string }} reason
+ * @returns {{ type: 'error', error: string, sitemapUrl: string, recommendedAction: string }}
+ */
+export function buildErrorSuggestionFromReason({ error, value }) {
+  const errorCode = normalizeString(error);
+  const suggestion = {
+    type: 'error',
+    error: errorCode,
+    sitemapUrl: '',
+    recommendedAction: '',
+  };
+
+  if (ERROR_CODES_WITHOUT_DETAIL.includes(errorCode)) {
+    return suggestion; // '/robots.txt' type of errors
+  }
+
+  if (errorCode === ERROR_CODES.GENERAL_ERROR) {
+    return {
+      ...suggestion,
+      recommendedAction: normalizeString(value), // since it has free-form text
+    };
+  }
+
+  return { // otherwise, the set of errors involving sitemap URLs
+    ...suggestion,
+    sitemapUrl: isAbsoluteHttpUrlWithPath(value) ? normalizeString(value) : '',
+  };
+}
+
 /**
  * Only return the statistics if they justify slowing down our current rate of probing.
  * Otherwise, return null.
@@ -244,7 +334,7 @@ export async function findSitemap(inputUrl, log) {
   return {
     success: false,
     reasons: [{
-      value: filteredSitemapUrls[0],
+      value: filteredSitemapUrls[0], // a sitemap URL ... granted, the 1st if there is a list
       error: ERROR_CODES.NO_VALID_PATHS_EXTRACTED,
     }],
     url: inputUrl,
@@ -312,19 +402,26 @@ export function generateSuggestions(auditUrl, auditData, context) {
 
   const response = success
     ? []
-    : reasons.map(({ error }) => ({ type: 'error', error }));
+    : reasons
+      .filter((reason) => reason?.error)
+      .map((reason) => buildErrorSuggestionFromReason(reason));
 
   const pagesWithIssues = getPagesWithIssues(auditData);
   /* c8 ignore next */
   log.info(`Sitemap: Found ${pagesWithIssues.length} pages with issues in sitemaps for ${auditUrl}`);
   const suggestions = [...response, ...pagesWithIssues]
     .filter(Boolean)
-    .map((issue) => ({
-      ...issue,
-      recommendedAction: issue.urlsSuggested
-        ? `use this URL instead: ${issue.urlsSuggested}`
-        : 'Make sure your sitemaps only include URLs that return the 200 (OK) response code.',
-    }));
+    .map((issue) => {
+      if (issue.type === 'error') {
+        return issue;
+      }
+      return { // issue.type === 'url'
+        ...issue,
+        recommendedAction: issue.urlsSuggested
+          ? `use this URL instead: ${issue.urlsSuggested}`
+          : 'Make sure your sitemaps only include URLs that return the 200 (OK) response code.',
+      };
+    });
 
   /* c8 ignore next */
   log.info(`Sitemap audit generated ${suggestions.length} suggestions for ${auditUrl}`);
@@ -381,7 +478,7 @@ export async function opportunityAndSuggestions(auditUrl, auditData, context) {
     auditType,
   );
 
-  const buildKey = (data) => (data.type === 'url' ? `${data.sitemapUrl}|${data.pageUrl}` : data.error);
+  const buildKey = buildSitemapSuggestionKey;
 
   await syncSuggestions({
     opportunity,

--- a/test/audits/sitemap.test.js
+++ b/test/audits/sitemap.test.js
@@ -23,6 +23,10 @@ import {
   getPagesWithIssues,
   getSitemapsWithIssues,
   mergeSitemapSuggestionData,
+  buildSitemapSuggestionKey,
+  buildSitemapErrorSuggestionKey,
+  buildErrorSuggestionFromReason,
+  normalizeString,
 } from '../../src/sitemap/handler.js';
 import {
   ERROR_CODES,
@@ -331,7 +335,10 @@ describe('Sitemap Audit', () => {
 
       const { paths, reasons } = await checkRobotsForSitemap(protocol, domain);
       expect(paths).to.eql([]);
-      expect(reasons).to.deep.equal([ERROR_CODES.NO_SITEMAP_IN_ROBOTS]);
+      expect(reasons).to.deep.equal([{
+        value: `${protocol}://${domain}/robots.txt`,
+        error: ERROR_CODES.NO_SITEMAP_IN_ROBOTS,
+      }]);
     });
 
     it('should return error when unable to fetch robots.txt', async () => {
@@ -408,17 +415,24 @@ describe('Sitemap Audit', () => {
     it('should return SITEMAP_NOT_FOUND when the sitemap does not exist', async () => {
       nock(url).get('/sitemap.xml').reply(404);
 
-      const resp = await checkSitemap(`${url}/sitemap.xml`);
+      const sitemapUrl = `${url}/sitemap.xml`;
+      const resp = await checkSitemap(sitemapUrl);
       expect(resp.existsAndIsValid).to.equal(false);
-      expect(resp.reasons).to.include(ERROR_CODES.SITEMAP_NOT_FOUND);
+      expect(resp.reasons).to.deep.equal([{
+        value: sitemapUrl,
+        error: ERROR_CODES.SITEMAP_NOT_FOUND,
+      }]);
     });
 
     it('should return CANNOT_READ_SITEMAP when there is a network error', async () => {
       nock(url).get('/sitemap.xml').replyWithError('Network error');
 
-      const resp = await checkSitemap();
+      const resp = await checkSitemap(`${url}/sitemap.xml`);
       expect(resp.existsAndIsValid).to.equal(false);
-      expect(resp.reasons).to.include(ERROR_CODES.CANNOT_READ_SITEMAP);
+      expect(resp.reasons).to.deep.equal([{
+        value: `${url}/sitemap.xml`,
+        error: ERROR_CODES.CANNOT_READ_SITEMAP,
+      }]);
     });
 
     it('checkSitemap returns INVALID_SITEMAP_FORMAT when sitemap is not valid xml', async () => {
@@ -426,17 +440,25 @@ describe('Sitemap Audit', () => {
         .get('/sitemap.xml')
         .reply(200, 'Not valid XML', { 'content-type': 'invalid' });
 
-      const resp = await checkSitemap(`${url}/sitemap.xml`);
+      const sitemapUrl = `${url}/sitemap.xml`;
+      const resp = await checkSitemap(sitemapUrl);
       expect(resp.existsAndIsValid).to.equal(false);
-      expect(resp.reasons).to.include(ERROR_CODES.INVALID_SITEMAP_FORMAT);
+      expect(resp.reasons).to.deep.equal([{
+        value: sitemapUrl,
+        error: ERROR_CODES.INVALID_SITEMAP_FORMAT,
+      }]);
     });
 
     it('checkSitemap returns invalid result for non-existing sitemap', async () => {
       nock(url).get('/non-existent-sitemap.xml').reply(404);
 
-      const result = await checkSitemap(`${url}/non-existent-sitemap.xml`);
+      const sitemapUrl = `${url}/non-existent-sitemap.xml`;
+      const result = await checkSitemap(sitemapUrl);
       expect(result.existsAndIsValid).to.equal(false);
-      expect(result.reasons).to.deep.equal([ERROR_CODES.SITEMAP_NOT_FOUND]);
+      expect(result.reasons).to.deep.equal([{
+        value: sitemapUrl,
+        error: ERROR_CODES.SITEMAP_NOT_FOUND,
+      }]);
     });
   });
 
@@ -572,7 +594,7 @@ describe('Sitemap Audit', () => {
       expect(result.reasons).to.deep.equal([
         {
           error: ERROR_CODES.GENERAL_ERROR,
-          value: 'not a valid url',
+          value: 'Invalid URL provided: not a valid url',
         },
       ]);
     });
@@ -1307,8 +1329,8 @@ describe('Sitemap Audit', () => {
           {
             type: 'error',
             error: ERROR_CODES.NO_VALID_PATHS_EXTRACTED,
-            recommendedAction:
-              'Make sure your sitemaps only include URLs that return the 200 (OK) response code.',
+            sitemapUrl: 'https://some-domain.adobe/sitemap.xml',
+            recommendedAction: '',
           },
         ],
       });
@@ -1331,8 +1353,8 @@ describe('Sitemap Audit', () => {
           {
             type: 'error',
             error: ERROR_CODES.NO_VALID_PATHS_EXTRACTED,
-            recommendedAction:
-              'Make sure your sitemaps only include URLs that return the 200 (OK) response code.',
+            sitemapUrl: '',
+            recommendedAction: '',
           },
         ],
       });
@@ -1351,8 +1373,8 @@ describe('Sitemap Audit', () => {
           {
             type: 'error',
             error: ERROR_CODES.NO_SITEMAP_IN_ROBOTS,
-            recommendedAction:
-              'Make sure your sitemaps only include URLs that return the 200 (OK) response code.',
+            sitemapUrl: '',
+            recommendedAction: '',
           },
         ],
       });
@@ -1427,6 +1449,123 @@ describe('Sitemap Audit', () => {
         statusCode: 301,
         urlsSuggested: 'https://example.com/new-page',
         recommendedAction: 'use this URL instead: https://example.com/new-page',
+      });
+    });
+  });
+
+  describe('buildSitemapSuggestionKey', () => {
+    it('builds url-type keys from sitemapUrl and pageUrl', () => {
+      expect(buildSitemapSuggestionKey({
+        type: 'url',
+        sitemapUrl: 'https://example.com/sitemap.xml',
+        pageUrl: 'https://example.com/page',
+      })).to.equal('https://example.com/sitemap.xml|https://example.com/page');
+    });
+
+    it('builds error-type keys with three normalized segments', () => {
+      expect(buildSitemapErrorSuggestionKey({
+        type: 'error',
+        error: ERROR_CODES.SITEMAP_NOT_FOUND,
+        sitemapUrl: 'https://example.com/sitemap.xml',
+        recommendedAction: '',
+      })).to.equal(`${ERROR_CODES.SITEMAP_NOT_FOUND}|https://example.com/sitemap.xml|`);
+    });
+
+    it('normalizes missing optional error fields to empty strings', () => {
+      expect(buildSitemapErrorSuggestionKey({
+        error: ERROR_CODES.CANNOT_READ_ROBOTS,
+      })).to.equal(`${ERROR_CODES.CANNOT_READ_ROBOTS}||`);
+
+      expect(buildSitemapErrorSuggestionKey({
+        error: ERROR_CODES.CANNOT_READ_ROBOTS,
+        sitemapUrl: null,
+        recommendedAction: undefined,
+      })).to.equal(`${ERROR_CODES.CANNOT_READ_ROBOTS}||`);
+    });
+
+    it('normalizeString ignores non-string values and trims strings', () => {
+      expect(normalizeString(null)).to.equal('');
+      expect(normalizeString(undefined)).to.equal('');
+      expect(normalizeString(0)).to.equal('');
+      expect(normalizeString(`  ${ERROR_CODES.CANNOT_READ_ROBOTS}  `)).to.equal(ERROR_CODES.CANNOT_READ_ROBOTS);
+      expect(normalizeString('  https://example.com/sitemap.xml  ')).to.equal('https://example.com/sitemap.xml');
+    });
+
+    it('buildSitemapErrorSuggestionKey trims all segments', () => {
+      expect(buildSitemapErrorSuggestionKey({
+        error: `  ${ERROR_CODES.GENERAL_ERROR}  `,
+        sitemapUrl: '  https://example.com/sitemap.xml  ',
+        recommendedAction: '  details  ',
+      })).to.equal(`${ERROR_CODES.GENERAL_ERROR}|https://example.com/sitemap.xml|details`);
+    });
+  });
+
+  describe('buildErrorSuggestionFromReason', () => {
+    it('maps robots-only error codes to empty detail fields', () => {
+      expect(buildErrorSuggestionFromReason({
+        error: ERROR_CODES.CANNOT_READ_ROBOTS,
+        value: 'network failure',
+      })).to.deep.equal({
+        type: 'error',
+        error: ERROR_CODES.CANNOT_READ_ROBOTS,
+        sitemapUrl: '',
+        recommendedAction: '',
+      });
+
+      expect(buildErrorSuggestionFromReason({
+        error: ERROR_CODES.NO_SITEMAP_IN_ROBOTS,
+        value: 'https://example.com/robots.txt',
+      })).to.deep.equal({
+        type: 'error',
+        error: ERROR_CODES.NO_SITEMAP_IN_ROBOTS,
+        sitemapUrl: '',
+        recommendedAction: '',
+      });
+    });
+
+    it('maps general-error to trimmed recommendedAction from reason value', () => {
+      expect(buildErrorSuggestionFromReason({
+        error: ERROR_CODES.GENERAL_ERROR,
+        value: '  not-a-valid-url  ',
+      })).to.deep.equal({
+        type: 'error',
+        error: ERROR_CODES.GENERAL_ERROR,
+        sitemapUrl: '',
+        recommendedAction: 'not-a-valid-url',
+      });
+    });
+
+    it('maps sitemap URL error codes when value is an absolute URL with a path', () => {
+      expect(buildErrorSuggestionFromReason({
+        error: ERROR_CODES.NO_VALID_PATHS_EXTRACTED,
+        value: '  https://example.com/sitemap.xml  ',
+      })).to.deep.equal({
+        type: 'error',
+        error: ERROR_CODES.NO_VALID_PATHS_EXTRACTED,
+        sitemapUrl: 'https://example.com/sitemap.xml',
+        recommendedAction: '',
+      });
+    });
+
+    it('leaves sitemapUrl empty when reason value is not an absolute URL with a path', () => {
+      expect(buildErrorSuggestionFromReason({
+        error: ERROR_CODES.NO_VALID_PATHS_EXTRACTED,
+        value: 'Fetch error for https://example.com/robots.txt Status: 403',
+      })).to.deep.equal({
+        type: 'error',
+        error: ERROR_CODES.NO_VALID_PATHS_EXTRACTED,
+        sitemapUrl: '',
+        recommendedAction: '',
+      });
+
+      expect(buildErrorSuggestionFromReason({
+        error: ERROR_CODES.NO_VALID_PATHS_EXTRACTED,
+        value: '   ',
+      })).to.deep.equal({
+        type: 'error',
+        error: ERROR_CODES.NO_VALID_PATHS_EXTRACTED,
+        sitemapUrl: '',
+        recommendedAction: '',
       });
     });
   });


### PR DESCRIPTION
 * create "error" suggestions with proper data fields
 * use these data fields when computing the `key` for "error" suggestions

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
