### PR TITLE
refactor(rum-config-refresh): use shared resolveRumDomainKey helper

### DIFF
--- a/src/rum-config-refresh/handler.js
+++ b/src/rum-config-refresh/handler.js
@@ -10,13 +10,12 @@
  * governing permissions and limitations under the License.
  */
 
-import RUMAPIClient from '@adobe/spacecat-shared-rum-api-client';
+import { resolveRumDomainKey } from '@adobe/spacecat-shared-rum-api-client';
 import { ok, internalServerError } from '@adobe/spacecat-shared-http-utils';
 import { Config } from '@adobe/spacecat-shared-data-access/src/models/site/config.js';
 
 const STALENESS_DAYS = 7;
 const STALENESS_MS = STALENESS_DAYS * 24 * 60 * 60 * 1000;
-const RUM_CHECK_TIMEOUT_MS = 3000;
 
 /**
  * Periodic refresh handler for site RUM domain key availability.
@@ -52,83 +51,10 @@ export default async function rumConfigRefresh(message, context) {
     }
   }
 
-  const overrideBaseURL = siteConfig.getFetchConfig()?.overrideBaseURL;
-  let overrideHostname = null;
-  if (overrideBaseURL) {
-    try {
-      overrideHostname = new URL(overrideBaseURL).hostname;
-    } catch {
-      log.warn(`[rum-config-refresh] Malformed overrideBaseURL for site ${siteId}: ${overrideBaseURL}, falling back to baseURL`);
-    }
-  }
+  const { hasDomainKey, timedOut } = await resolveRumDomainKey(site, context);
 
-  let baseHostname;
-  try {
-    baseHostname = new URL(site.getBaseURL()).hostname;
-  } catch {
-    log.error(`[rum-config-refresh] Malformed baseURL for site ${siteId}: ${site.getBaseURL()}, skipping`);
-    return ok({ skipped: true, reason: 'malformed baseURL' });
-  }
-
-  // override-first: overrideBaseURL is the site's canonical RUM domain when set.
-  // For each candidate, also try the www. variant as a fallback — domain keys are
-  // frequently registered under www.{domain} even when the site's base URL is bare.
-  const withWwwFallback = (d) => (d && !d.startsWith('www.') ? `www.${d}` : null);
-
-  const domains = [...new Set([
-    overrideHostname,
-    withWwwFallback(overrideHostname),
-    baseHostname,
-    withWwwFallback(baseHostname),
-  ].filter(Boolean))];
-
-  let hasDomainKey = false;
-  let timeoutId;
-  let timedOut = false;
-  let cancelled = false;
-
-  const rumApiClient = RUMAPIClient.createFrom(context);
-
-  // RUM_CHECK_TIMEOUT_MS is a shared budget for the full candidate loop,
-  // not a per-domain limit, so total RUM check time stays bounded.
-  try {
-    await Promise.race([
-      (async () => {
-        for (const domain of domains) {
-          if (cancelled) {
-            break;
-          }
-          try {
-            // eslint-disable-next-line no-await-in-loop
-            await rumApiClient.retrieveDomainkey(domain);
-            hasDomainKey = true;
-            return;
-          } catch (e) {
-            log.info(`[rum-config-refresh] RUM check failed for ${domain}: ${e.message}`);
-          }
-        }
-      })(),
-      new Promise((_, reject) => {
-        timeoutId = setTimeout(() => {
-          timedOut = true;
-          cancelled = true;
-          reject(new Error('RUM check timed out'));
-        }, RUM_CHECK_TIMEOUT_MS);
-      }),
-    ]);
-    if (!hasDomainKey) {
-      log.warn(`[rum-config-refresh] No domain key found for site ${siteId} across all candidates: ${domains.join(', ')}`);
-    }
-  } catch (e) {
-    if (timedOut) {
-      log.error(`[rum-config-refresh] RUM check timed out for ${domains.join(', ')}, skipping config update`);
-      return ok({ skipped: true, reason: 'timeout' });
-    /* c8 ignore next 3 */
-    } else {
-      log.warn(`[rum-config-refresh] Unexpected error during RUM check for site ${siteId}: ${e.message}`);
-    }
-  } finally {
-    clearTimeout(timeoutId);
+  if (timedOut) {
+    return ok({ skipped: true, reason: 'timeout' });
   }
 
   try {

--- a/src/rum-config-refresh/handler.js
+++ b/src/rum-config-refresh/handler.js
@@ -51,9 +51,17 @@ export default async function rumConfigRefresh(message, context) {
     }
   }
 
-  const { hasDomainKey, timedOut } = await resolveRumDomainKey(site, context);
+  let hasDomainKey;
+  let timedOut;
+  try {
+    ({ hasDomainKey, timedOut } = await resolveRumDomainKey(site, context));
+  } catch (e) {
+    log.error(`[rum-config-refresh] resolveRumDomainKey failed for site ${siteId}: ${e.message}`);
+    return internalServerError(`RUM domain key check failed: ${e.message}`);
+  }
 
   if (timedOut) {
+    log.warn(`[rum-config-refresh] RUM domain key check timed out for site ${siteId}, skipping config update`);
     return ok({ skipped: true, reason: 'timeout' });
   }
 

--- a/test/audits/rum-config-refresh.test.js
+++ b/test/audits/rum-config-refresh.test.js
@@ -26,25 +26,24 @@ const sandbox = sinon.createSandbox();
 const SITE_ID = 'test-site-id';
 const BASE_URL = 'https://www.example.com';
 
-describe('rum-config-refresh handler', () => {
+describe('rum-config-refresh handler', function () {
+  this.timeout(10000);
   let context;
   let mockSite;
   let mockConfig;
-  let retrieveDomainkeyStub;
+  let resolveRumDomainKeyStub;
   let toDynamoItemStub;
   let handler;
 
   beforeEach(async () => {
-    retrieveDomainkeyStub = sandbox.stub();
+    resolveRumDomainKeyStub = sandbox.stub().resolves({ hasDomainKey: false, timedOut: false });
     toDynamoItemStub = sandbox.stub().returns({});
 
     handler = await esmock(
       '../../src/rum-config-refresh/handler.js',
       {
         '@adobe/spacecat-shared-rum-api-client': {
-          default: {
-            createFrom: () => ({ retrieveDomainkey: retrieveDomainkeyStub }),
-          },
+          resolveRumDomainKey: resolveRumDomainKeyStub,
         },
         '@adobe/spacecat-shared-data-access/src/models/site/config.js': {
           Config: { toDynamoItem: toDynamoItemStub },
@@ -111,13 +110,13 @@ describe('rum-config-refresh handler', () => {
       expect(result.status).to.equal(200);
       const body = await result.json();
       expect(body).to.deep.equal({ skipped: true, reason: 'recently checked' });
-      expect(retrieveDomainkeyStub).not.to.have.been.called;
+      expect(resolveRumDomainKeyStub).not.to.have.been.called;
       expect(mockSite.save).not.to.have.been.called;
     });
 
     it('proceeds when rumConfig has no lastCheckedAt', async () => {
       mockConfig.getRumConfig.returns(undefined);
-      retrieveDomainkeyStub.resolves('domainkey-value');
+      resolveRumDomainKeyStub.resolves({ hasDomainKey: true, timedOut: false });
 
       const result = await handler.default({ siteId: SITE_ID }, context);
 
@@ -129,7 +128,7 @@ describe('rum-config-refresh handler', () => {
     it('proceeds when lastCheckedAt is older than 7 days', async () => {
       const staleDate = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
       mockConfig.getRumConfig.returns({ hasDomainKey: false, lastCheckedAt: staleDate });
-      retrieveDomainkeyStub.resolves('domainkey-value');
+      resolveRumDomainKeyStub.resolves({ hasDomainKey: true, timedOut: false });
 
       const result = await handler.default({ siteId: SITE_ID }, context);
 
@@ -140,21 +139,22 @@ describe('rum-config-refresh handler', () => {
   });
 
   describe('RUM domain key check', () => {
-    it('sets hasDomainKey=true when retrieveDomainkey resolves', async () => {
-      retrieveDomainkeyStub.resolves('domainkey-abc');
+    it('sets hasDomainKey=true and saves when resolveRumDomainKey resolves with a key', async () => {
+      resolveRumDomainKeyStub.resolves({ hasDomainKey: true, timedOut: false });
 
       const result = await handler.default({ siteId: SITE_ID }, context);
 
       expect(result.status).to.equal(200);
       const body = await result.json();
       expect(body).to.deep.equal({ hasDomainKey: true, updated: true });
+      expect(resolveRumDomainKeyStub).to.have.been.calledOnceWith(mockSite, context);
       expect(mockConfig.updateRumConfig).to.have.been.calledWith(true);
       expect(toDynamoItemStub).to.have.been.calledWith(mockConfig);
       expect(mockSite.save).to.have.been.calledOnce;
     });
 
-    it('sets hasDomainKey=false when retrieveDomainkey rejects', async () => {
-      retrieveDomainkeyStub.rejects(new Error('no domain key found'));
+    it('sets hasDomainKey=false and saves when no domain key is found', async () => {
+      resolveRumDomainKeyStub.resolves({ hasDomainKey: false, timedOut: false });
 
       const result = await handler.default({ siteId: SITE_ID }, context);
 
@@ -162,223 +162,25 @@ describe('rum-config-refresh handler', () => {
       const body = await result.json();
       expect(body).to.deep.equal({ hasDomainKey: false, updated: true });
       expect(mockConfig.updateRumConfig).to.have.been.calledWith(false);
-      expect(toDynamoItemStub).to.have.been.calledWith(mockConfig);
       expect(mockSite.save).to.have.been.calledOnce;
-      expect(context.log.info).to.have.been.calledWithMatch('RUM check failed');
     });
 
-    it('skips config update and does not write lastCheckedAt when RUM check times out', async () => {
-      const clock = sinon.useFakeTimers();
-      retrieveDomainkeyStub.returns(new Promise(() => {})); // never resolves
+    it('skips config update and save when RUM check times out', async () => {
+      resolveRumDomainKeyStub.resolves({ hasDomainKey: false, timedOut: true });
 
-      const resultPromise = handler.default({ siteId: SITE_ID }, context);
-      await clock.tickAsync(4000); // advance past the 3 s timeout
-      const result = await resultPromise;
-      clock.restore();
+      const result = await handler.default({ siteId: SITE_ID }, context);
 
       expect(result.status).to.equal(200);
       const body = await result.json();
       expect(body).to.deep.equal({ skipped: true, reason: 'timeout' });
       expect(mockConfig.updateRumConfig).not.to.have.been.called;
       expect(mockSite.save).not.to.have.been.called;
-      expect(context.log.error).to.have.been.calledWithMatch('timed out');
-    });
-
-    it('extracts hostname from baseURL before calling retrieveDomainkey', async () => {
-      retrieveDomainkeyStub.resolves('domainkey-abc');
-
-      await handler.default({ siteId: SITE_ID }, context);
-
-      expect(retrieveDomainkeyStub).to.have.been.calledWith('www.example.com');
-    });
-
-    it('tries overrideBaseURL first when fetchConfig.overrideBaseURL is set', async () => {
-      mockConfig.getFetchConfig.returns({ overrideBaseURL: 'https://www.override.com' });
-      retrieveDomainkeyStub.resolves('domainkey-abc');
-
-      const result = await handler.default({ siteId: SITE_ID }, context);
-
-      const body = await result.json();
-      expect(body).to.deep.equal({ hasDomainKey: true, updated: true });
-      expect(retrieveDomainkeyStub).to.have.been.calledWith('www.override.com');
-      expect(retrieveDomainkeyStub).not.to.have.been.calledWith('www.example.com');
-    });
-
-    it('falls back to baseURL when overrideBaseURL domain key lookup fails', async () => {
-      mockConfig.getFetchConfig.returns({ overrideBaseURL: 'https://www.override.com' });
-      retrieveDomainkeyStub
-        .withArgs('www.override.com').rejects(new Error('404'))
-        .withArgs('www.example.com').resolves('domainkey-abc');
-
-      const result = await handler.default({ siteId: SITE_ID }, context);
-
-      const body = await result.json();
-      expect(body).to.deep.equal({ hasDomainKey: true, updated: true });
-      sinon.assert.callOrder(
-        retrieveDomainkeyStub.withArgs('www.override.com'),
-        retrieveDomainkeyStub.withArgs('www.example.com'),
-      );
-      expect(context.log.info).to.have.been.calledWithMatch('RUM check failed for www.override.com');
-    });
-
-    it('falls back to baseURL only when overrideBaseURL is malformed', async () => {
-      mockConfig.getFetchConfig.returns({ overrideBaseURL: 'not-a-valid-url' });
-      retrieveDomainkeyStub.resolves('domainkey-abc');
-
-      const result = await handler.default({ siteId: SITE_ID }, context);
-
-      const body = await result.json();
-      expect(body).to.deep.equal({ hasDomainKey: true, updated: true });
-      expect(retrieveDomainkeyStub).to.have.been.calledOnce;
-      expect(retrieveDomainkeyStub).to.have.been.calledWith('www.example.com');
-      expect(context.log.warn).to.have.been.calledWithMatch('Malformed overrideBaseURL');
-    });
-
-    it('skips when baseURL is malformed', async () => {
-      mockSite.getBaseURL.returns('not-a-valid-url');
-
-      const result = await handler.default({ siteId: SITE_ID }, context);
-
-      expect(result.status).to.equal(200);
-      const body = await result.json();
-      expect(body).to.deep.equal({ skipped: true, reason: 'malformed baseURL' });
-      expect(retrieveDomainkeyStub).not.to.have.been.called;
-      expect(mockSite.save).not.to.have.been.called;
-      expect(context.log.error).to.have.been.calledWithMatch('Malformed baseURL');
-    });
-
-    it('uses baseURL when fetchConfig is set but overrideBaseURL is absent', async () => {
-      mockConfig.getFetchConfig.returns({ someOtherProp: 'value' });
-      retrieveDomainkeyStub.resolves('domainkey-abc');
-
-      const result = await handler.default({ siteId: SITE_ID }, context);
-
-      const body = await result.json();
-      expect(body).to.deep.equal({ hasDomainKey: true, updated: true });
-      expect(retrieveDomainkeyStub).to.have.been.calledOnce;
-      expect(retrieveDomainkeyStub).to.have.been.calledWith('www.example.com');
-    });
-
-    it('deduplicates when overrideBaseURL hostname matches baseURL hostname', async () => {
-      mockConfig.getFetchConfig.returns({ overrideBaseURL: 'https://www.example.com' });
-      retrieveDomainkeyStub.resolves('domainkey-abc');
-
-      await handler.default({ siteId: SITE_ID }, context);
-
-      expect(retrieveDomainkeyStub).to.have.been.calledOnce;
-      expect(retrieveDomainkeyStub).to.have.been.calledWith('www.example.com');
-    });
-
-    it('cancellation flag stops the loop when first domain finishes after timeout', async () => {
-      mockConfig.getFetchConfig.returns({ overrideBaseURL: 'https://www.override.com' });
-      const clock = sinon.useFakeTimers();
-      // first domain rejects after 5 s — past the 3 s timeout
-      retrieveDomainkeyStub.withArgs('www.override.com').returns(
-        new Promise((_, reject) => { setTimeout(() => reject(new Error('slow error')), 5000); }),
-      );
-      retrieveDomainkeyStub.withArgs('www.example.com').resolves('domainkey-abc');
-
-      const resultPromise = handler.default({ siteId: SITE_ID }, context);
-      await clock.tickAsync(3001); // fires 3 s timeout → cancelled = true, handler returns
-      const result = await resultPromise;
-      await clock.tickAsync(5000); // fires 5 s timer → first domain rejects, loop hits cancelled check
-      clock.restore();
-
-      const body = await result.json();
-      expect(body).to.deep.equal({ skipped: true, reason: 'timeout' });
-      expect(retrieveDomainkeyStub).not.to.have.been.calledWith('www.example.com');
-    });
-
-    it('times out before reaching baseURL when override domain hangs', async () => {
-      mockConfig.getFetchConfig.returns({ overrideBaseURL: 'https://www.override.com' });
-      const clock = sinon.useFakeTimers();
-      retrieveDomainkeyStub.withArgs('www.override.com').returns(new Promise(() => {}));
-      retrieveDomainkeyStub.withArgs('www.example.com').resolves('domainkey-abc');
-
-      const resultPromise = handler.default({ siteId: SITE_ID }, context);
-      await clock.tickAsync(4000);
-      const result = await resultPromise;
-      clock.restore();
-
-      const body = await result.json();
-      expect(body).to.deep.equal({ skipped: true, reason: 'timeout' });
-      expect(retrieveDomainkeyStub).not.to.have.been.calledWith('www.example.com');
-      expect(mockSite.save).not.to.have.been.called;
-    });
-
-    it('sets hasDomainKey=false when all domain candidates fail', async () => {
-      mockConfig.getFetchConfig.returns({ overrideBaseURL: 'https://www.override.com' });
-      retrieveDomainkeyStub.rejects(new Error('404'));
-
-      const result = await handler.default({ siteId: SITE_ID }, context);
-
-      const body = await result.json();
-      expect(body).to.deep.equal({ hasDomainKey: false, updated: true });
-      expect(mockConfig.updateRumConfig).to.have.been.calledWith(false);
-      expect(context.log.warn).to.have.been.calledWithMatch('No domain key found');
-    });
-
-    it('falls back to www.{domain} and sets hasDomainKey=true when bare domain has no key', async () => {
-      mockSite.getBaseURL.returns('https://example.com');
-      retrieveDomainkeyStub
-        .withArgs('example.com').rejects(new Error('404'))
-        .withArgs('www.example.com').resolves('domainkey-abc');
-
-      const result = await handler.default({ siteId: SITE_ID }, context);
-
-      const body = await result.json();
-      expect(body).to.deep.equal({ hasDomainKey: true, updated: true });
-      sinon.assert.callOrder(
-        retrieveDomainkeyStub.withArgs('example.com'),
-        retrieveDomainkeyStub.withArgs('www.example.com'),
-      );
-      expect(mockConfig.updateRumConfig).to.have.been.calledWith(true);
-    });
-
-    it('does not try www.www.{domain} when baseURL already has www. prefix', async () => {
-      retrieveDomainkeyStub.resolves('domainkey-abc');
-
-      await handler.default({ siteId: SITE_ID }, context);
-
-      const calledDomains = retrieveDomainkeyStub.args.map(([d]) => d);
-      expect(calledDomains).not.to.include('www.www.example.com');
-      expect(calledDomains).to.include('www.example.com');
-      expect(retrieveDomainkeyStub).to.have.been.calledOnce;
-    });
-
-    it('sets hasDomainKey=false when both bare and www. domain fail', async () => {
-      mockSite.getBaseURL.returns('https://example.com');
-      retrieveDomainkeyStub.rejects(new Error('404'));
-
-      const result = await handler.default({ siteId: SITE_ID }, context);
-
-      const body = await result.json();
-      expect(body).to.deep.equal({ hasDomainKey: false, updated: true });
-      expect(retrieveDomainkeyStub).to.have.been.calledWith('example.com');
-      expect(retrieveDomainkeyStub).to.have.been.calledWith('www.example.com');
-      expect(mockConfig.updateRumConfig).to.have.been.calledWith(false);
-    });
-
-    it('includes www. fallback for overrideBaseURL when it has no www. prefix', async () => {
-      mockConfig.getFetchConfig.returns({ overrideBaseURL: 'https://override.com' });
-      retrieveDomainkeyStub
-        .withArgs('override.com').rejects(new Error('404'))
-        .withArgs('www.override.com').resolves('domainkey-abc');
-
-      const result = await handler.default({ siteId: SITE_ID }, context);
-
-      const body = await result.json();
-      expect(body).to.deep.equal({ hasDomainKey: true, updated: true });
-      sinon.assert.callOrder(
-        retrieveDomainkeyStub.withArgs('override.com'),
-        retrieveDomainkeyStub.withArgs('www.override.com'),
-      );
     });
   });
 
   describe('save failure', () => {
     it('returns 500 when site.save() throws', async () => {
-      retrieveDomainkeyStub.resolves('domainkey-abc');
+      resolveRumDomainKeyStub.resolves({ hasDomainKey: true, timedOut: false });
       mockSite.save.rejects(new Error('DynamoDB write failed'));
 
       const result = await handler.default({ siteId: SITE_ID }, context);

--- a/test/audits/rum-config-refresh.test.js
+++ b/test/audits/rum-config-refresh.test.js
@@ -175,6 +175,18 @@ describe('rum-config-refresh handler', function () {
       expect(body).to.deep.equal({ skipped: true, reason: 'timeout' });
       expect(mockConfig.updateRumConfig).not.to.have.been.called;
       expect(mockSite.save).not.to.have.been.called;
+      expect(context.log.warn).to.have.been.calledWithMatch('timed out');
+    });
+
+    it('returns 500 when resolveRumDomainKey rejects unexpectedly', async () => {
+      resolveRumDomainKeyStub.rejects(new Error('network timeout'));
+
+      const result = await handler.default({ siteId: SITE_ID }, context);
+
+      expect(result.status).to.equal(500);
+      expect(mockConfig.updateRumConfig).not.to.have.been.called;
+      expect(mockSite.save).not.to.have.been.called;
+      expect(context.log.error).to.have.been.calledWithMatch('resolveRumDomainKey failed');
     });
   });
 


### PR DESCRIPTION
Replace the inline 4-candidate waterfall loop (URL parsing, www fallback, Promise.race timeout) with the resolveRumDomainKey() function exported by @adobe/spacecat-shared-rum-api-client@2.43.1.

The handler now just calls resolveRumDomainKey(site, context) and reacts to { hasDomainKey, timedOut }. All candidate-ordering logic lives in the shared package, preventing the drift between audit-worker and api-service described in SITES-46321.

Tests are updated to mock resolveRumDomainKey directly. Candidate-level tests (overrideBaseURL priority, www fallback, deduplication, timeout wiring) are removed here — they belong to the shared package's own test suite.

Resolves SITES-46321

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
