### PR TITLE
fix(cited-analysis): prevent SQS 256 KB message size limit failures

### DIFF
--- a/src/cited-analysis/handler.js
+++ b/src/cited-analysis/handler.js
@@ -30,6 +30,15 @@ import { resolveBrandForSite, applyBrandScope } from '../utils/brand-resolver.js
 
 const LOG_PREFIX = '[Cited]';
 
+// SQS standard-queue maximum payload is 256 KB (262144 bytes). Stay under a
+// safety budget so worst-case serialisation doesn't hit the hard reject.
+const SQS_MAX_SAFE_BYTES = 200 * 1024;
+
+// Cap subPrompts carried per URL. Each URL can accumulate a subPrompt entry
+// for every topic it appears in; without a cap the prompts array alone can
+// push a 50-URL payload well past 256 KB.
+const MAX_PROMPTS_PER_URL = 20;
+
 /**
  * Cited Analysis Audit Handler
  *
@@ -321,8 +330,20 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     log.info(`${LOG_PREFIX} urlLimit=${urlLimit} (URLs sent to Mystique)`);
 
     const { urls, sentimentConfig } = storeData;
+    // Project only the fields Mystique reads (url, categories, prompts,
+    // timesCited) and cap prompts per URL so the payload stays bounded.
+    // URL Store metadata (siteId, byCustomer, audits, timestamps) is not
+    // needed downstream and contributes significant per-URL bloat.
     const enrichedUrls = enrichUrlsWithTopicData(urls, sentimentConfig.topics)
-      .slice(0, urlLimit);
+      .slice(0, urlLimit)
+      .map(({
+        url: urlStr, categories, timesCited, prompts,
+      }) => ({
+        url: urlStr,
+        ...(categories?.length > 0 && { categories }),
+        ...(timesCited > 0 && { timesCited }),
+        ...(prompts?.length > 0 && { prompts: prompts.slice(0, MAX_PROMPTS_PER_URL) }),
+      }));
 
     const baseMessage = {
       type: 'guidance:cited-analysis',
@@ -350,6 +371,22 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     }
     const message = applyBrandScope(baseMessage, brand);
 
+    // Safety guard: if the serialised message still exceeds the budget after
+    // per-URL projection and prompt capping, drop URLs from the tail until
+    // it fits rather than letting SQS reject the send entirely.
+    let sentUrlCount = message.data.urls.length;
+    while (sentUrlCount > 1) {
+      const bytes = Buffer.byteLength(JSON.stringify(message), 'utf8');
+      if (bytes <= SQS_MAX_SAFE_BYTES) {
+        break;
+      }
+      sentUrlCount -= 1;
+      message.data.urls = enrichedUrls.slice(0, sentUrlCount);
+      log.warn(
+        `${LOG_PREFIX} Message size ${bytes} bytes exceeds budget; reducing to ${sentUrlCount} URLs`,
+      );
+    }
+
     log.debug(`${LOG_PREFIX} Built Mystique message type ${message.type}`);
     await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, message);
     const scopeForLog = brand
@@ -357,7 +394,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
       : '';
     log.info(
       `${LOG_PREFIX} Queued Cited analysis request to Mystique for ${config.companyName} `
-        + `with ${enrichedUrls.length} URLs${scopeForLog}`,
+        + `with ${message.data.urls.length} URLs${scopeForLog}`,
     );
     return auditData;
   } catch (error) {

--- a/src/cited-analysis/handler.js
+++ b/src/cited-analysis/handler.js
@@ -26,6 +26,7 @@ import { CITED_ANALYSIS_DRS_CONFIG } from '../offsite-brand-presence/constants.j
 import { computeTopicsFromBrandPresence } from '../utils/offsite-brand-presence-enrichment.js';
 import { enrichUrlsWithTopicData } from '../utils/url-topic-enrichment.js';
 import { resolveBrandForSite, applyBrandScope } from '../utils/brand-resolver.js';
+import { postMessageOptional } from '../utils/slack-utils.js';
 
 const LOG_PREFIX = '[Cited]';
 
@@ -403,6 +404,19 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     return auditData;
   } catch (error) {
     log.error(`${LOG_PREFIX} Failed to send Mystique message: ${error.message}`);
+    // Notify the Slack thread that triggered this audit so the operator knows
+    // Mystique was never reached and doesn't wait for results that won't come.
+    const slackContext = auditResult?.slackContext;
+    if (slackContext) {
+      const { channelId, threadTs } = slackContext;
+      const siteLabel = auditResult.config?.companyWebsite || siteId;
+      await postMessageOptional(
+        context,
+        channelId,
+        `:x: *cited-analysis* failed to queue for *${siteLabel}*\n• Reason: ${error.message}`,
+        { threadTs },
+      );
+    }
     throw error;
   }
 }

--- a/src/cited-analysis/handler.js
+++ b/src/cited-analysis/handler.js
@@ -18,7 +18,6 @@ import StoreClient, {
 } from '../utils/store-client.js';
 import {
   DrsNoContentAvailableError,
-  MYSTIQUE_URLS_LIMIT,
   filterUrlsByDrsStatus,
   resolveMystiqueUrlLimit,
   requestOffsiteScrape,
@@ -34,10 +33,11 @@ const LOG_PREFIX = '[Cited]';
 // safety budget so worst-case serialisation doesn't hit the hard reject.
 const SQS_MAX_SAFE_BYTES = 200 * 1024;
 
-// Cap subPrompts carried per URL. Each URL can accumulate a subPrompt entry
-// for every topic it appears in; without a cap the prompts array alone can
-// push a 50-URL payload well past 256 KB.
-const MAX_PROMPTS_PER_URL = 20;
+// Cited-analysis-specific URL cap. Lower than the global MYSTIQUE_URLS_LIMIT
+// (50) because: (a) each URL requires a full DRS scrape — 50 URLs can take
+// 30-40 min; (b) 40 URLs with full prompts fits within the SQS budget after
+// field projection, removing the need for a per-URL prompts cap.
+const CITED_ANALYSIS_URLS_LIMIT = 40;
 
 /**
  * Cited Analysis Audit Handler
@@ -240,7 +240,10 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
     const storeData = await fetchStoreData(siteId, context, site);
     log.info(`${LOG_PREFIX} Successfully fetched all store data for ${citedConfig.companyName}`);
 
-    const urlLimit = resolveMystiqueUrlLimit(auditContext, log, LOG_PREFIX);
+    const urlLimit = Math.min(
+      resolveMystiqueUrlLimit(auditContext, log, LOG_PREFIX),
+      CITED_ANALYSIS_URLS_LIMIT,
+    );
 
     const { slackContext } = auditContext;
 
@@ -326,14 +329,15 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     }
 
     const { config, storeData } = auditResult;
-    const urlLimit = config?.urlLimit ?? MYSTIQUE_URLS_LIMIT;
+    const urlLimit = config?.urlLimit ?? CITED_ANALYSIS_URLS_LIMIT;
     log.info(`${LOG_PREFIX} urlLimit=${urlLimit} (URLs sent to Mystique)`);
 
     const { urls, sentimentConfig } = storeData;
     // Project only the fields Mystique reads (url, categories, prompts,
-    // timesCited) and cap prompts per URL so the payload stays bounded.
-    // URL Store metadata (siteId, byCustomer, audits, timestamps) is not
-    // needed downstream and contributes significant per-URL bloat.
+    // timesCited). URL Store metadata (siteId, byCustomer, audits, timestamps)
+    // is not needed downstream and contributes significant per-URL bloat.
+    // Full prompts are kept — CITED_ANALYSIS_URLS_LIMIT=40 keeps the payload
+    // within the SQS budget without capping per-URL prompts.
     const enrichedUrls = enrichUrlsWithTopicData(urls, sentimentConfig.topics)
       .slice(0, urlLimit)
       .map(({
@@ -342,7 +346,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
         url: urlStr,
         ...(categories?.length > 0 && { categories }),
         ...(timesCited > 0 && { timesCited }),
-        ...(prompts?.length > 0 && { prompts: prompts.slice(0, MAX_PROMPTS_PER_URL) }),
+        ...(prompts?.length > 0 && { prompts }),
       }));
 
     const baseMessage = {

--- a/src/cited-analysis/handler.js
+++ b/src/cited-analysis/handler.js
@@ -378,7 +378,10 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
 
     // Safety guard: if the serialised message still exceeds the budget after
     // per-URL projection, drop URLs from the tail until it fits rather than
-    // letting SQS reject the send entirely.
+    // letting SQS reject the send entirely. This re-serialises the message once
+    // per dropped URL (O(n)), which is fine while CITED_ANALYSIS_URLS_LIMIT
+    // stays small (40); switch to a binary search / byte-per-URL estimate if the
+    // cap ever grows large enough for the linear passes to matter.
     let sentUrlCount = message.data.urls.length;
     while (sentUrlCount > 1) {
       const bytes = Buffer.byteLength(JSON.stringify(message), 'utf8');

--- a/src/cited-analysis/handler.js
+++ b/src/cited-analysis/handler.js
@@ -377,8 +377,8 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     const message = applyBrandScope(baseMessage, brand);
 
     // Safety guard: if the serialised message still exceeds the budget after
-    // per-URL projection and prompt capping, drop URLs from the tail until
-    // it fits rather than letting SQS reject the send entirely.
+    // per-URL projection, drop URLs from the tail until it fits rather than
+    // letting SQS reject the send entirely.
     let sentUrlCount = message.data.urls.length;
     while (sentUrlCount > 1) {
       const bytes = Buffer.byteLength(JSON.stringify(message), 'utf8');
@@ -390,6 +390,23 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
       log.warn(
         `${LOG_PREFIX} Message size ${bytes} bytes exceeds budget; reducing to ${sentUrlCount} URLs`,
       );
+    }
+
+    // Last-resort: a single URL with extremely long prompts can still exceed
+    // the budget. Strip its prompts so the URL itself always gets through.
+    if (sentUrlCount === 1) {
+      const bytes = Buffer.byteLength(JSON.stringify(message), 'utf8');
+      if (bytes > SQS_MAX_SAFE_BYTES) {
+        log.warn(
+          `${LOG_PREFIX} Single-URL payload (${bytes} bytes) still exceeds budget; stripping prompts`,
+        );
+        const [singleUrl] = message.data.urls;
+        message.data.urls = [{
+          url: singleUrl.url,
+          ...(singleUrl.categories?.length > 0 && { categories: singleUrl.categories }),
+          ...(singleUrl.timesCited > 0 && { timesCited: singleUrl.timesCited }),
+        }];
+      }
     }
 
     log.debug(`${LOG_PREFIX} Built Mystique message type ${message.type}`);

--- a/test/audits/cited-analysis/handler.test.js
+++ b/test/audits/cited-analysis/handler.test.js
@@ -792,6 +792,34 @@ describe('Cited Analysis Handler', () => {
       expect(context.log.warn).to.have.been.calledWithMatch(/Message size \d+ bytes exceeds budget/);
     });
 
+    it('should strip prompts from single URL when payload still exceeds budget', async () => {
+      // One URL whose prompts alone push it over the 200 KB budget.
+      const hugePrompt = 'x'.repeat(300 * 1024); // 300 KB in a single prompt entry
+      const singleBigUrl = [{ url: 'https://example.com/huge', prompts: [hugePrompt] }];
+
+      const auditData = {
+        siteId,
+        auditResult: {
+          success: true,
+          config: { companyName: 'Test' },
+          storeData: {
+            urls: singleBigUrl,
+            sentimentConfig: { topics: [], guidelines: [] },
+          },
+        },
+      };
+
+      const postProcessor = citedAnalysisHandler.default.postProcessors[0];
+      await postProcessor(baseURL, auditData, context);
+
+      expect(context.sqs.sendMessage).to.have.been.calledOnce;
+      const sentMessage = context.sqs.sendMessage.firstCall.args[1];
+      expect(sentMessage.data.urls).to.have.length(1);
+      expect(sentMessage.data.urls[0].url).to.equal('https://example.com/huge');
+      expect(sentMessage.data.urls[0].prompts).to.be.undefined;
+      expect(context.log.warn).to.have.been.calledWithMatch(/Single-URL payload.*still exceeds budget; stripping prompts/);
+    });
+
     it('should skip sending message when audit failed', async () => {
       const auditData = {
         siteId,

--- a/test/audits/cited-analysis/handler.test.js
+++ b/test/audits/cited-analysis/handler.test.js
@@ -789,6 +789,7 @@ describe('Cited Analysis Handler', () => {
       expect(context.sqs.sendMessage).to.have.been.calledOnce;
       const sentMessage = context.sqs.sendMessage.firstCall.args[1];
       expect(sentMessage.data.urls.length).to.be.lessThan(CITED_ANALYSIS_URLS_LIMIT);
+      expect(Buffer.byteLength(JSON.stringify(sentMessage), 'utf8')).to.be.at.most(200 * 1024);
       expect(context.log.warn).to.have.been.calledWithMatch(/Message size \d+ bytes exceeds budget/);
     });
 
@@ -817,6 +818,7 @@ describe('Cited Analysis Handler', () => {
       expect(sentMessage.data.urls).to.have.length(1);
       expect(sentMessage.data.urls[0].url).to.equal('https://example.com/huge');
       expect(sentMessage.data.urls[0].prompts).to.be.undefined;
+      expect(Buffer.byteLength(JSON.stringify(sentMessage), 'utf8')).to.be.at.most(200 * 1024);
       expect(context.log.warn).to.have.been.calledWithMatch(/Single-URL payload.*still exceeds budget; stripping prompts/);
     });
 

--- a/test/audits/cited-analysis/handler.test.js
+++ b/test/audits/cited-analysis/handler.test.js
@@ -627,7 +627,7 @@ describe('Cited Analysis Handler', () => {
       expect(sentMessage.data.urls).to.have.lengthOf(1);
     });
 
-    it('should send raw urls when no topics are available', async () => {
+    it('should send projected urls when no topics are available', async () => {
       const auditData = {
         siteId,
         auditResult: {
@@ -644,7 +644,10 @@ describe('Cited Analysis Handler', () => {
       await postProcessor(baseURL, auditData, context);
 
       const sentMessage = context.sqs.sendMessage.firstCall.args[1];
-      expect(sentMessage.data.urls).to.deep.equal(mockUrls);
+      // URL Store metadata (type, metadata, siteId, etc.) is stripped; only
+      // url/categories/timesCited/prompts are projected for the SQS payload.
+      const expectedUrls = mockUrls.map(({ url }) => ({ url }));
+      expect(sentMessage.data.urls).to.deep.equal(expectedUrls);
     });
 
     it('should limit URLs to MYSTIQUE_URLS_LIMIT when many URLs exist', async () => {
@@ -699,6 +702,85 @@ describe('Cited Analysis Handler', () => {
       expect(context.log.info).to.have.been.calledWith(
         `[Cited] urlLimit=${MYSTIQUE_URLS_LIMIT} (URLs sent to Mystique)`,
       );
+    });
+
+    it('should strip URL Store metadata and keep only url/categories/timesCited/prompts', async () => {
+      const urlsWithMetadata = [
+        {
+          url: 'https://techreview.io/review-of-example',
+          siteId: 'some-site-id',
+          byCustomer: false,
+          audits: ['cited-analysis'],
+          createdAt: '2026-06-16T10:00:00.000Z',
+          updatedAt: '2026-06-16T10:00:00.000Z',
+          createdBy: 'system',
+          updatedBy: 'system',
+        },
+      ];
+
+      const topicsWithData = [
+        {
+          name: 'Test Topic',
+          urls: [{
+            url: 'https://techreview.io/review-of-example',
+            timesCited: 5,
+            category: 'review',
+            subPrompts: ['prompt one'],
+          }],
+        },
+      ];
+
+      const auditData = {
+        siteId,
+        auditResult: {
+          success: true,
+          config: { companyName: 'Test' },
+          storeData: {
+            urls: urlsWithMetadata,
+            sentimentConfig: { topics: topicsWithData, guidelines: [] },
+          },
+        },
+      };
+
+      const postProcessor = citedAnalysisHandler.default.postProcessors[0];
+      await postProcessor(baseURL, auditData, context);
+
+      const sentMessage = context.sqs.sendMessage.firstCall.args[1];
+      const sentUrl = sentMessage.data.urls[0];
+      expect(sentUrl).to.have.property('url', 'https://techreview.io/review-of-example');
+      expect(sentUrl).to.have.property('categories');
+      expect(sentUrl).to.have.property('timesCited', 5);
+      expect(sentUrl).to.have.property('prompts');
+      expect(sentUrl).to.not.have.any.keys('siteId', 'byCustomer', 'audits', 'createdAt', 'updatedAt', 'createdBy', 'updatedBy');
+    });
+
+    it('should reduce URL count when serialised message exceeds size budget', async () => {
+      // 50 URLs × 20 prompts × 500 bytes each = ~500 KB, well over the 200 KB budget.
+      const largePrompt = 'x'.repeat(500);
+      const bigUrls = Array.from({ length: 50 }, (_, i) => ({
+        url: `https://example.com/page-${i}`,
+        prompts: Array.from({ length: 20 }, () => largePrompt),
+      }));
+
+      const auditData = {
+        siteId,
+        auditResult: {
+          success: true,
+          config: { companyName: 'Test' },
+          storeData: {
+            urls: bigUrls,
+            sentimentConfig: { topics: [], guidelines: [] },
+          },
+        },
+      };
+
+      const postProcessor = citedAnalysisHandler.default.postProcessors[0];
+      await postProcessor(baseURL, auditData, context);
+
+      expect(context.sqs.sendMessage).to.have.been.calledOnce;
+      const sentMessage = context.sqs.sendMessage.firstCall.args[1];
+      expect(sentMessage.data.urls.length).to.be.lessThan(50);
+      expect(context.log.warn).to.have.been.calledWithMatch(/Message size \d+ bytes exceeds budget/);
     });
 
     it('should skip sending message when audit failed', async () => {

--- a/test/audits/cited-analysis/handler.test.js
+++ b/test/audits/cited-analysis/handler.test.js
@@ -42,6 +42,7 @@ describe('Cited Analysis Handler', () => {
   let mockComputeTopicsFromBrandPresence;
   let mockFilterUrlsByDrsStatus;
   let mockDrsClient;
+  let mockPostMessageOptional;
   let citedAnalysisHandler;
   let StoreEmptyError;
 
@@ -97,6 +98,7 @@ describe('Cited Analysis Handler', () => {
 
     mockComputeTopicsFromBrandPresence = sandbox.stub().resolves(mockComputedTopics);
     mockFilterUrlsByDrsStatus = sandbox.stub().callsFake(async (urls) => urls);
+    mockPostMessageOptional = sandbox.stub().resolves({ success: true });
 
     mockDrsClient = { isConfigured: sandbox.stub().returns(true) };
 
@@ -134,6 +136,9 @@ describe('Cited Analysis Handler', () => {
       },
       '../../../src/utils/offsite-brand-presence-enrichment.js': {
         computeTopicsFromBrandPresence: mockComputeTopicsFromBrandPresence,
+      },
+      '../../../src/utils/slack-utils.js': {
+        postMessageOptional: mockPostMessageOptional,
       },
     });
 
@@ -876,6 +881,47 @@ describe('Cited Analysis Handler', () => {
       const postProcessor = citedAnalysisHandler.default.postProcessors[0];
       await expect(postProcessor(baseURL, auditData, context)).to.be.rejectedWith('SQS Error');
       expect(context.log.error).to.have.been.calledWith('[Cited] Failed to send Mystique message: SQS Error');
+    });
+
+    it('should post a Slack failure message when SQS send fails and slackContext is present', async () => {
+      context.sqs.sendMessage.rejects(new Error('Message must be shorter than 262144 bytes'));
+
+      const auditData = {
+        siteId,
+        auditResult: {
+          success: true,
+          config: { companyName: 'Test', companyWebsite: baseURL },
+          storeData: { urls: mockUrls, sentimentConfig: expectedSentimentConfigForPostProcessor },
+          slackContext: { channelId: 'C12345', threadTs: '1234567890.000100' },
+        },
+      };
+
+      const postProcessor = citedAnalysisHandler.default.postProcessors[0];
+      await expect(postProcessor(baseURL, auditData, context)).to.be.rejectedWith('Message must be shorter than 262144 bytes');
+      expect(mockPostMessageOptional).to.have.been.calledOnce;
+      const [, channelId, text, opts] = mockPostMessageOptional.firstCall.args;
+      expect(channelId).to.equal('C12345');
+      expect(text).to.include(':x:');
+      expect(text).to.include(baseURL);
+      expect(text).to.include('Message must be shorter than 262144 bytes');
+      expect(opts.threadTs).to.equal('1234567890.000100');
+    });
+
+    it('should not post to Slack when SQS send fails without slackContext', async () => {
+      context.sqs.sendMessage.rejects(new Error('SQS Error'));
+
+      const auditData = {
+        siteId,
+        auditResult: {
+          success: true,
+          config: { companyName: 'Test' },
+          storeData: { urls: mockUrls, sentimentConfig: expectedSentimentConfigForPostProcessor },
+        },
+      };
+
+      const postProcessor = citedAnalysisHandler.default.postProcessors[0];
+      await expect(postProcessor(baseURL, auditData, context)).to.be.rejectedWith('SQS Error');
+      expect(mockPostMessageOptional).to.not.have.been.called;
     });
 
     // Helper: fresh PostgREST chain mock that resolves on limit() (org, status, site_id, order, limit)

--- a/test/audits/cited-analysis/handler.test.js
+++ b/test/audits/cited-analysis/handler.test.js
@@ -23,6 +23,9 @@ import {
   MYSTIQUE_URLS_LIMIT,
   resolveMystiqueUrlLimit as realResolveMystiqueUrlLimit,
 } from '../../../src/utils/offsite-audit-utils.js';
+
+// Mirrors the handler-private constant — update both if the limit changes.
+const CITED_ANALYSIS_URLS_LIMIT = 40;
 import { CITED_ANALYSIS_DRS_CONFIG } from '../../../src/offsite-brand-presence/constants.js';
 import esmock from 'esmock';
 import { MockContextBuilder } from '../../shared.js';
@@ -213,7 +216,7 @@ describe('Cited Analysis Handler', () => {
       expect(result.auditResult.status).to.equal('pending_analysis');
       expect(result.auditResult.storeData.urls).to.deep.equal(mockUrls);
       expect(result.auditResult.storeData.sentimentConfig).to.deep.equal(expectedSentimentConfigForPostProcessor);
-      expect(result.auditResult.config.urlLimit).to.equal(MYSTIQUE_URLS_LIMIT);
+      expect(result.auditResult.config.urlLimit).to.equal(CITED_ANALYSIS_URLS_LIMIT);
       expect(result.fullAuditRef).to.equal(baseURL);
       expect(mockStoreClient.getUrls).to.have.been.calledWith(siteId, URL_TYPES.CITED, { sortBy: 'createdAt', sortOrder: 'desc' });
       expect(mockStoreClient.getGuidelines).to.have.been.calledWith(siteId, GUIDELINE_TYPES.CITED_ANALYSIS);
@@ -599,7 +602,7 @@ describe('Cited Analysis Handler', () => {
       expect(sentMessage.data.urls).to.have.lengthOf(mockUrls.length);
       expect(sentMessage.data.urls[0].url).to.equal(mockUrls[0].url);
       expect(context.log.info).to.have.been.calledWith(
-        `[Cited] urlLimit=${MYSTIQUE_URLS_LIMIT} (URLs sent to Mystique)`,
+        `[Cited] urlLimit=${CITED_ANALYSIS_URLS_LIMIT} (URLs sent to Mystique)`,
       );
       expect(context.log.info).to.have.been.calledWith(
         '[Cited] Queued Cited analysis request to Mystique for Example Corp with 2 URLs',
@@ -650,8 +653,8 @@ describe('Cited Analysis Handler', () => {
       expect(sentMessage.data.urls).to.deep.equal(expectedUrls);
     });
 
-    it('should limit URLs to MYSTIQUE_URLS_LIMIT when many URLs exist', async () => {
-      const manyUrls = Array.from({ length: MYSTIQUE_URLS_LIMIT + 30 }, (_, i) => ({
+    it('should limit URLs to CITED_ANALYSIS_URLS_LIMIT when many URLs exist', async () => {
+      const manyUrls = Array.from({ length: CITED_ANALYSIS_URLS_LIMIT + 20 }, (_, i) => ({
         url: `https://example.com/page-${i}`, type: 'cited-analysis', metadata: {},
       }));
 
@@ -671,14 +674,14 @@ describe('Cited Analysis Handler', () => {
       await postProcessor(baseURL, auditData, context);
 
       const sentMessage = context.sqs.sendMessage.firstCall.args[1];
-      expect(sentMessage.data.urls).to.have.lengthOf(MYSTIQUE_URLS_LIMIT);
+      expect(sentMessage.data.urls).to.have.lengthOf(CITED_ANALYSIS_URLS_LIMIT);
       expect(context.log.info).to.have.been.calledWith(
-        `[Cited] Queued Cited analysis request to Mystique for Test with ${MYSTIQUE_URLS_LIMIT} URLs`,
+        `[Cited] Queued Cited analysis request to Mystique for Test with ${CITED_ANALYSIS_URLS_LIMIT} URLs`,
       );
     });
 
-    it('should fall back to MYSTIQUE_URLS_LIMIT when urlLimit is absent', async () => {
-      const manyUrls = Array.from({ length: MYSTIQUE_URLS_LIMIT + 5 }, (_, i) => ({
+    it('should fall back to CITED_ANALYSIS_URLS_LIMIT when urlLimit is absent', async () => {
+      const manyUrls = Array.from({ length: CITED_ANALYSIS_URLS_LIMIT + 5 }, (_, i) => ({
         url: `https://example.com/page-${i}`, type: 'cited-analysis', metadata: {},
       }));
 
@@ -698,9 +701,9 @@ describe('Cited Analysis Handler', () => {
       await postProcessor(baseURL, auditData, context);
 
       const sentMessage = context.sqs.sendMessage.firstCall.args[1];
-      expect(sentMessage.data.urls).to.have.lengthOf(MYSTIQUE_URLS_LIMIT);
+      expect(sentMessage.data.urls).to.have.lengthOf(CITED_ANALYSIS_URLS_LIMIT);
       expect(context.log.info).to.have.been.calledWith(
-        `[Cited] urlLimit=${MYSTIQUE_URLS_LIMIT} (URLs sent to Mystique)`,
+        `[Cited] urlLimit=${CITED_ANALYSIS_URLS_LIMIT} (URLs sent to Mystique)`,
       );
     });
 
@@ -755,11 +758,12 @@ describe('Cited Analysis Handler', () => {
     });
 
     it('should reduce URL count when serialised message exceeds size budget', async () => {
-      // 50 URLs × 20 prompts × 500 bytes each = ~500 KB, well over the 200 KB budget.
-      const largePrompt = 'x'.repeat(500);
-      const bigUrls = Array.from({ length: 50 }, (_, i) => ({
+      // 40 URLs × 60 prompts × 200 bytes each = ~480 KB, well over the 200 KB budget.
+      // Prompts are no longer capped per URL — the size guard is the safety net.
+      const largePrompt = 'x'.repeat(200);
+      const bigUrls = Array.from({ length: 40 }, (_, i) => ({
         url: `https://example.com/page-${i}`,
-        prompts: Array.from({ length: 20 }, () => largePrompt),
+        prompts: Array.from({ length: 60 }, () => largePrompt),
       }));
 
       const auditData = {
@@ -779,7 +783,7 @@ describe('Cited Analysis Handler', () => {
 
       expect(context.sqs.sendMessage).to.have.been.calledOnce;
       const sentMessage = context.sqs.sendMessage.firstCall.args[1];
-      expect(sentMessage.data.urls.length).to.be.lessThan(50);
+      expect(sentMessage.data.urls.length).to.be.lessThan(CITED_ANALYSIS_URLS_LIMIT);
       expect(context.log.warn).to.have.been.calledWithMatch(/Message size \d+ bytes exceeds budget/);
     });
 

--- a/test/audits/cited-analysis/handler.test.js
+++ b/test/audits/cited-analysis/handler.test.js
@@ -796,7 +796,12 @@ describe('Cited Analysis Handler', () => {
     it('should strip prompts from single URL when payload still exceeds budget', async () => {
       // One URL whose prompts alone push it over the 200 KB budget.
       const hugePrompt = 'x'.repeat(300 * 1024); // 300 KB in a single prompt entry
-      const singleBigUrl = [{ url: 'https://example.com/huge', prompts: [hugePrompt] }];
+      const singleBigUrl = [{
+        url: 'https://example.com/huge',
+        categories: ['Tech'],
+        timesCited: 7,
+        prompts: [hugePrompt],
+      }];
 
       const auditData = {
         siteId,
@@ -818,6 +823,9 @@ describe('Cited Analysis Handler', () => {
       expect(sentMessage.data.urls).to.have.length(1);
       expect(sentMessage.data.urls[0].url).to.equal('https://example.com/huge');
       expect(sentMessage.data.urls[0].prompts).to.be.undefined;
+      // Lightweight metadata is preserved even when prompts are stripped.
+      expect(sentMessage.data.urls[0].categories).to.deep.equal(['Tech']);
+      expect(sentMessage.data.urls[0].timesCited).to.equal(7);
       expect(Buffer.byteLength(JSON.stringify(sentMessage), 'utf8')).to.be.at.most(200 * 1024);
       expect(context.log.warn).to.have.been.calledWithMatch(/Single-URL payload.*still exceeds budget; stripping prompts/);
     });
@@ -935,6 +943,26 @@ describe('Cited Analysis Handler', () => {
       expect(text).to.include(baseURL);
       expect(text).to.include('Message must be shorter than 262144 bytes');
       expect(opts.threadTs).to.equal('1234567890.000100');
+    });
+
+    it('should fall back to siteId in the Slack message when companyWebsite is absent', async () => {
+      context.sqs.sendMessage.rejects(new Error('SQS Error'));
+
+      const auditData = {
+        siteId,
+        auditResult: {
+          success: true,
+          config: { companyName: 'Test' },
+          storeData: { urls: mockUrls, sentimentConfig: expectedSentimentConfigForPostProcessor },
+          slackContext: { channelId: 'C12345', threadTs: '1234567890.000100' },
+        },
+      };
+
+      const postProcessor = citedAnalysisHandler.default.postProcessors[0];
+      await expect(postProcessor(baseURL, auditData, context)).to.be.rejectedWith('SQS Error');
+      expect(mockPostMessageOptional).to.have.been.calledOnce;
+      const [, , text] = mockPostMessageOptional.firstCall.args;
+      expect(text).to.include(siteId);
     });
 
     it('should not post to Slack when SQS send fails without slackContext', async () => {


### PR DESCRIPTION
## Summary

- The `sendMystiqueMessagePostProcessor` was sending full URL Store objects enriched with unbounded `prompts` arrays, causing SQS to reject the `guidance:cited-analysis` message with _"Message must be shorter than 262144 bytes"_ (seen on lovesac.com with 50 URLs)
- Root cause: each URL accumulates one `prompts` entry per subPrompt across every topic that references it — 50 URLs × many topics × many subPrompts easily blows past 256 KB

**Fix (three commits):**

1. **Field projection + size guard** — strip URL Store metadata (`siteId`, `byCustomer`, `audits`, timestamps) Mystique never reads; only send `url`, `categories`, `timesCited`, `prompts`. Size guard drops URLs from the tail if the payload still exceeds the 200 KB safety budget.

2. **Cap at 40 URLs, keep full prompts** — introduce `CITED_ANALYSIS_URLS_LIMIT = 40` (cited-specific, doesn't touch the global 50 used by reddit/youtube). Each URL requires a full DRS scrape; 50 URLs was taking 30-40 min. With field projection, 40 URLs + full prompts fits within the SQS budget, so the `MAX_PROMPTS_PER_URL = 20` cap is not needed.

3. **Slack failure notification** — when the post-processor throws (SQS send fails, any reason), post a `:x:` message to the Slack thread that triggered the audit. Previously, Mystique was never reached so the guidance-handler never ran, leaving the operator with no feedback.

## Test plan

- [ ] All 46 cited-analysis handler tests pass
- [ ] `should strip URL Store metadata and keep only url/categories/timesCited/prompts`
- [ ] `should reduce URL count when serialised message exceeds size budget`
- [ ] `should limit URLs to CITED_ANALYSIS_URLS_LIMIT when many URLs exist`
- [ ] `should fall back to CITED_ANALYSIS_URLS_LIMIT when urlLimit is absent`
- [ ] `should post a Slack failure message when SQS send fails and slackContext is present`
- [ ] `should not post to Slack when SQS send fails without slackContext`