### PR TITLE
feat(sqs): propagate organizationId to Mystique-bound messages

### DIFF
--- a/src/support/sqs.js
+++ b/src/support/sqs.js
@@ -34,8 +34,10 @@ class SQS {
   }
 
   /**
-   * Resolves the organization ID for a site, caching the result (including null) per siteId.
-   * Never throws — a failed lookup must not block the message send.
+   * Resolves the organization ID for a site, caching only successful resolutions
+   * (including a genuine null) per siteId. Never throws — a failed lookup must not
+   * block the message send, and a transient failure is left uncached so later
+   * sends for the same site can retry.
    *
    * @param {string} siteId - The site ID carried on the message.
    * @returns {Promise<string|null>} The organization ID, or null if it can't be resolved.
@@ -45,17 +47,19 @@ class SQS {
       return this.#organizationIdCache.get(siteId);
     }
 
-    let organizationId = null;
     try {
       const { Site } = this.context?.dataAccess ?? {};
       const site = await Site?.findById(siteId);
-      organizationId = site?.getOrganizationId?.() ?? null;
+      const organizationId = site?.getOrganizationId?.() ?? null;
+      // Cache only on success. A transient Site.findById failure (timeout/throttle)
+      // must NOT be cached as a permanent null — that would suppress the org ID for
+      // every subsequent message for this site within the invocation.
+      this.#organizationIdCache.set(siteId, organizationId);
+      return organizationId;
     } catch (e) {
       this.log.warn(`Failed to resolve organizationId for Mystique message (siteId: ${siteId}): ${e.message}`);
+      return null;
     }
-
-    this.#organizationIdCache.set(siteId, organizationId);
-    return organizationId;
   }
 
   async sendMessage(queueUrl, message, msgGroupId, delaySeconds = 0, msgDedupId = undefined) {

--- a/src/support/sqs.js
+++ b/src/support/sqs.js
@@ -11,7 +11,6 @@
  */
 import { SendMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
 import { hasText } from '@adobe/spacecat-shared-utils';
-import { getImsOrgId } from '../utils/data-access.js';
 
 /**
  * @class SQS utility to send messages to SQS
@@ -20,9 +19,9 @@ import { getImsOrgId } from '../utils/data-access.js';
  * @param {object} context - context object for trace ID propagation
  */
 class SQS {
-  // Per-invocation cache of resolved IMS org IDs, keyed by siteId, so a handler
+  // Per-invocation cache of resolved organization IDs, keyed by siteId, so a handler
   // that emits many Mystique messages for the same site only pays the DB lookup once.
-  #imsOrgIdCache = new Map();
+  #organizationIdCache = new Map();
 
   constructor(region, log, context) {
     this.sqsClient = new SQSClient({ region });
@@ -35,30 +34,28 @@ class SQS {
   }
 
   /**
-   * Resolves the IMS org ID for a site, caching the result (including null) per siteId.
+   * Resolves the organization ID for a site, caching the result (including null) per siteId.
    * Never throws — a failed lookup must not block the message send.
    *
    * @param {string} siteId - The site ID carried on the message.
-   * @returns {Promise<string|null>} The IMS org ID, or null if it can't be resolved.
+   * @returns {Promise<string|null>} The organization ID, or null if it can't be resolved.
    */
-  async #resolveImsOrgId(siteId) {
-    if (this.#imsOrgIdCache.has(siteId)) {
-      return this.#imsOrgIdCache.get(siteId);
+  async #resolveOrganizationId(siteId) {
+    if (this.#organizationIdCache.has(siteId)) {
+      return this.#organizationIdCache.get(siteId);
     }
 
-    let imsOrgId = null;
+    let organizationId = null;
     try {
       const { Site } = this.context?.dataAccess ?? {};
       const site = await Site?.findById(siteId);
-      if (site) {
-        imsOrgId = await getImsOrgId(site, this.context.dataAccess, this.log);
-      }
+      organizationId = site?.getOrganizationId?.() ?? null;
     } catch (e) {
-      this.log.warn(`Failed to resolve imsOrgId for Mystique message (siteId: ${siteId}): ${e.message}`);
+      this.log.warn(`Failed to resolve organizationId for Mystique message (siteId: ${siteId}): ${e.message}`);
     }
 
-    this.#imsOrgIdCache.set(siteId, imsOrgId);
-    return imsOrgId;
+    this.#organizationIdCache.set(siteId, organizationId);
+    return organizationId;
   }
 
   async sendMessage(queueUrl, message, msgGroupId, delaySeconds = 0, msgDedupId = undefined) {
@@ -73,19 +70,19 @@ class SQS {
       body.traceId = this.context.traceId;
     }
 
-    // Auto-add the IMS org ID to Mystique-bound messages so org identity propagates
+    // Auto-add the organization ID to Mystique-bound messages so org identity propagates
     // across the SpaceCat → Mystique boundary (mirrors the traceId propagation above).
     // Scoped to the Mystique queue only and skipped when already set on the message.
     const mystiqueQueueUrl = this.context?.env?.QUEUE_SPACECAT_TO_MYSTIQUE;
     if (
       hasText(mystiqueQueueUrl)
       && queueUrl === mystiqueQueueUrl
-      && !('imsOrgId' in body)
+      && !('organizationId' in body)
       && hasText(body.siteId)
     ) {
-      const imsOrgId = await this.#resolveImsOrgId(body.siteId);
-      if (imsOrgId) {
-        body.imsOrgId = imsOrgId;
+      const organizationId = await this.#resolveOrganizationId(body.siteId);
+      if (organizationId) {
+        body.organizationId = organizationId;
       }
     }
 

--- a/src/support/sqs.js
+++ b/src/support/sqs.js
@@ -11,6 +11,7 @@
  */
 import { SendMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
 import { hasText } from '@adobe/spacecat-shared-utils';
+import { getImsOrgId } from '../utils/data-access.js';
 
 /**
  * @class SQS utility to send messages to SQS
@@ -19,6 +20,10 @@ import { hasText } from '@adobe/spacecat-shared-utils';
  * @param {object} context - context object for trace ID propagation
  */
 class SQS {
+  // Per-invocation cache of resolved IMS org IDs, keyed by siteId, so a handler
+  // that emits many Mystique messages for the same site only pays the DB lookup once.
+  #imsOrgIdCache = new Map();
+
   constructor(region, log, context) {
     this.sqsClient = new SQSClient({ region });
     this.log = log;
@@ -27,6 +32,33 @@ class SQS {
 
   static #isFifoQueue(queueUrl) {
     return hasText(queueUrl) && queueUrl.toLowerCase().endsWith('.fifo');
+  }
+
+  /**
+   * Resolves the IMS org ID for a site, caching the result (including null) per siteId.
+   * Never throws — a failed lookup must not block the message send.
+   *
+   * @param {string} siteId - The site ID carried on the message.
+   * @returns {Promise<string|null>} The IMS org ID, or null if it can't be resolved.
+   */
+  async #resolveImsOrgId(siteId) {
+    if (this.#imsOrgIdCache.has(siteId)) {
+      return this.#imsOrgIdCache.get(siteId);
+    }
+
+    let imsOrgId = null;
+    try {
+      const { Site } = this.context?.dataAccess ?? {};
+      const site = await Site?.findById(siteId);
+      if (site) {
+        imsOrgId = await getImsOrgId(site, this.context.dataAccess, this.log);
+      }
+    } catch (e) {
+      this.log.warn(`Failed to resolve imsOrgId for Mystique message (siteId: ${siteId}): ${e.message}`);
+    }
+
+    this.#imsOrgIdCache.set(siteId, imsOrgId);
+    return imsOrgId;
   }
 
   async sendMessage(queueUrl, message, msgGroupId, delaySeconds = 0, msgDedupId = undefined) {
@@ -39,6 +71,22 @@ class SQS {
     // This maintains trace continuity across service boundaries (e.g., SpaceCat → Mystique)
     if (!('traceId' in body) && this.context?.traceId) {
       body.traceId = this.context.traceId;
+    }
+
+    // Auto-add the IMS org ID to Mystique-bound messages so org identity propagates
+    // across the SpaceCat → Mystique boundary (mirrors the traceId propagation above).
+    // Scoped to the Mystique queue only and skipped when already set on the message.
+    const mystiqueQueueUrl = this.context?.env?.QUEUE_SPACECAT_TO_MYSTIQUE;
+    if (
+      hasText(mystiqueQueueUrl)
+      && queueUrl === mystiqueQueueUrl
+      && !('imsOrgId' in body)
+      && hasText(body.siteId)
+    ) {
+      const imsOrgId = await this.#resolveImsOrgId(body.siteId);
+      if (imsOrgId) {
+        body.imsOrgId = imsOrgId;
+      }
     }
 
     // Auto-extract MessageGroupId from message for SQS fair queuing.

--- a/test/support/sqs.test.js
+++ b/test/support/sqs.test.js
@@ -615,6 +615,38 @@ describe('sqs', () => {
       );
     });
 
+    it('does not cache a transient resolution failure (retries on the next send)', async () => {
+      setupMystiqueContext();
+      // First lookup throws (transient throttle/timeout); the default stub
+      // resolves the site on the second call.
+      siteFindByIdStub.onFirstCall().rejects(new Error('throttled'));
+      const message = { type: 'guidance:metatags', siteId: 'site-1' };
+
+      const seen = [];
+      nock('https://sqs.us-east-1.amazonaws.com')
+        .post('/')
+        .times(2)
+        .reply(200, (_, body) => {
+          const { MessageBody } = JSON.parse(body);
+          seen.push(JSON.parse(MessageBody).organizationId);
+          return {
+            MessageId: 'message-id',
+            MD5OfMessageBody: crypto.createHash('md5').update(MessageBody, 'utf-8').digest('hex'),
+          };
+        });
+
+      await wrap(async (req, ctx) => {
+        await ctx.sqs.sendMessage(mystiqueQueueUrl, { ...message });
+        await ctx.sqs.sendMessage(mystiqueQueueUrl, { ...message });
+      }).with(sqsWrapper)({}, context);
+
+      // Transient failure → no org id and NOT cached, so the second send retries
+      // the lookup and resolves it (cache wasn't poisoned with a permanent null).
+      expect(seen[0]).to.be.undefined;
+      expect(seen[1]).to.equal('4854e75e-894b-4a74-92bf-d674abad1423');
+      expect(siteFindByIdStub).to.have.been.calledTwice;
+    });
+
     it('sends without organizationId when dataAccess is unavailable on context', async () => {
       setupMystiqueContext({ withDataAccess: false });
       const message = { type: 'guidance:metatags', siteId: 'site-1' };

--- a/test/support/sqs.test.js
+++ b/test/support/sqs.test.js
@@ -434,6 +434,205 @@ describe('sqs', () => {
     expect(logSpy).to.have.been.calledWith('Success, message sent. Queue: unknown, Type: unknown, MessageID: message-id');
   });
 
+  describe('imsOrgId propagation for Mystique-bound messages', () => {
+    const mystiqueQueueUrl = 'https://sqs.us-east-1.amazonaws.com/123456789/spacecat-to-mystique';
+    let siteFindByIdStub;
+
+    const setupMystiqueContext = ({
+      imsOrgId = 'ABC123@AdobeOrg',
+      organizationId = 'org-123',
+      withDataAccess = true,
+    } = {}) => {
+      context.env = { QUEUE_SPACECAT_TO_MYSTIQUE: mystiqueQueueUrl };
+      if (!withDataAccess) {
+        return;
+      }
+      const site = {
+        getOrganizationId: () => organizationId,
+        getBaseURL: () => 'https://example.com',
+      };
+      const organization = { getImsOrgId: () => imsOrgId };
+      siteFindByIdStub = sandbox.stub().resolves(site);
+      context.dataAccess = {
+        Site: { findById: siteFindByIdStub },
+        Organization: { findById: sandbox.stub().resolves(organization) },
+      };
+    };
+
+    const nockSend = (assertFn) => nock('https://sqs.us-east-1.amazonaws.com')
+      .post('/')
+      .reply(200, (_, body) => {
+        const { MessageBody } = JSON.parse(body);
+        if (assertFn) {
+          assertFn(JSON.parse(MessageBody));
+        }
+        return {
+          MessageId: 'message-id',
+          MD5OfMessageBody: crypto.createHash('md5').update(MessageBody, 'utf-8').digest('hex'),
+        };
+      });
+
+    it('adds the resolved imsOrgId to a Mystique-bound message', async () => {
+      setupMystiqueContext();
+      const message = { type: 'guidance:metatags', siteId: 'site-1' };
+
+      nockSend((parsed) => {
+        expect(parsed.imsOrgId).to.equal('ABC123@AdobeOrg');
+        expect(parsed.siteId).to.equal('site-1');
+      });
+
+      await wrap(async (req, ctx) => {
+        await ctx.sqs.sendMessage(mystiqueQueueUrl, message);
+      }).with(sqsWrapper)({}, context);
+    });
+
+    it('omits imsOrgId when it cannot be resolved (organization has none)', async () => {
+      setupMystiqueContext({ imsOrgId: null });
+      const message = { type: 'guidance:metatags', siteId: 'site-1' };
+
+      nockSend((parsed) => {
+        expect(parsed.imsOrgId).to.be.undefined;
+      });
+
+      await wrap(async (req, ctx) => {
+        await ctx.sqs.sendMessage(mystiqueQueueUrl, message);
+      }).with(sqsWrapper)({}, context);
+    });
+
+    it('omits imsOrgId when the site cannot be found', async () => {
+      setupMystiqueContext();
+      siteFindByIdStub.resolves(undefined);
+      const message = { type: 'guidance:metatags', siteId: 'missing-site' };
+
+      nockSend((parsed) => {
+        expect(parsed.imsOrgId).to.be.undefined;
+      });
+
+      await wrap(async (req, ctx) => {
+        await ctx.sqs.sendMessage(mystiqueQueueUrl, message);
+      }).with(sqsWrapper)({}, context);
+    });
+
+    it('does not resolve or add imsOrgId for non-Mystique queues', async () => {
+      setupMystiqueContext();
+      const otherQueue = 'https://sqs.us-east-1.amazonaws.com/123456789/some-other-queue';
+      const message = { type: 'audit', siteId: 'site-1' };
+
+      nockSend((parsed) => {
+        expect(parsed.imsOrgId).to.be.undefined;
+      });
+
+      await wrap(async (req, ctx) => {
+        await ctx.sqs.sendMessage(otherQueue, message);
+      }).with(sqsWrapper)({}, context);
+
+      expect(siteFindByIdStub).to.not.have.been.called;
+    });
+
+    it('skips imsOrgId resolution when QUEUE_SPACECAT_TO_MYSTIQUE is not configured', async () => {
+      setupMystiqueContext();
+      context.env = {};
+      const message = { type: 'guidance:metatags', siteId: 'site-1' };
+
+      nockSend((parsed) => {
+        expect(parsed.imsOrgId).to.be.undefined;
+      });
+
+      await wrap(async (req, ctx) => {
+        await ctx.sqs.sendMessage(mystiqueQueueUrl, message);
+      }).with(sqsWrapper)({}, context);
+
+      expect(siteFindByIdStub).to.not.have.been.called;
+    });
+
+    it('does not overwrite an imsOrgId already present on the message', async () => {
+      setupMystiqueContext();
+      const message = { type: 'guidance:metatags', siteId: 'site-1', imsOrgId: 'EXISTING@AdobeOrg' };
+
+      nockSend((parsed) => {
+        expect(parsed.imsOrgId).to.equal('EXISTING@AdobeOrg');
+      });
+
+      await wrap(async (req, ctx) => {
+        await ctx.sqs.sendMessage(mystiqueQueueUrl, message);
+      }).with(sqsWrapper)({}, context);
+
+      expect(siteFindByIdStub).to.not.have.been.called;
+    });
+
+    it('skips imsOrgId resolution when the message has no siteId', async () => {
+      setupMystiqueContext();
+      const message = { type: 'guidance:metatags' };
+
+      nockSend((parsed) => {
+        expect(parsed.imsOrgId).to.be.undefined;
+      });
+
+      await wrap(async (req, ctx) => {
+        await ctx.sqs.sendMessage(mystiqueQueueUrl, message);
+      }).with(sqsWrapper)({}, context);
+
+      expect(siteFindByIdStub).to.not.have.been.called;
+    });
+
+    it('caches the resolved imsOrgId across sends for the same siteId', async () => {
+      setupMystiqueContext();
+      const message = { type: 'guidance:metatags', siteId: 'site-1' };
+
+      nock('https://sqs.us-east-1.amazonaws.com')
+        .post('/')
+        .times(2)
+        .reply(200, (_, body) => {
+          const { MessageBody } = JSON.parse(body);
+          expect(JSON.parse(MessageBody).imsOrgId).to.equal('ABC123@AdobeOrg');
+          return {
+            MessageId: 'message-id',
+            MD5OfMessageBody: crypto.createHash('md5').update(MessageBody, 'utf-8').digest('hex'),
+          };
+        });
+
+      await wrap(async (req, ctx) => {
+        await ctx.sqs.sendMessage(mystiqueQueueUrl, { ...message });
+        await ctx.sqs.sendMessage(mystiqueQueueUrl, { ...message });
+      }).with(sqsWrapper)({}, context);
+
+      expect(siteFindByIdStub).to.have.been.calledOnce;
+    });
+
+    it('sends without imsOrgId (and logs a warning) when resolution throws', async () => {
+      setupMystiqueContext();
+      siteFindByIdStub.rejects(new Error('db down'));
+      const warnSpy = sandbox.spy(context.log, 'warn');
+      const message = { type: 'guidance:metatags', siteId: 'site-1' };
+
+      nockSend((parsed) => {
+        expect(parsed.imsOrgId).to.be.undefined;
+        expect(parsed.siteId).to.equal('site-1');
+      });
+
+      await wrap(async (req, ctx) => {
+        await ctx.sqs.sendMessage(mystiqueQueueUrl, message);
+      }).with(sqsWrapper)({}, context);
+
+      expect(warnSpy).to.have.been.calledWith(
+        'Failed to resolve imsOrgId for Mystique message (siteId: site-1): db down',
+      );
+    });
+
+    it('sends without imsOrgId when dataAccess is unavailable on context', async () => {
+      setupMystiqueContext({ withDataAccess: false });
+      const message = { type: 'guidance:metatags', siteId: 'site-1' };
+
+      nockSend((parsed) => {
+        expect(parsed.imsOrgId).to.be.undefined;
+      });
+
+      await wrap(async (req, ctx) => {
+        await ctx.sqs.sendMessage(mystiqueQueueUrl, message);
+      }).with(sqsWrapper)({}, context);
+    });
+  });
+
   it('uses unknown as fallback when queueUrl is undefined', async () => {
     const message = { key: 'value' };
     const logSpy = sandbox.spy(context.log, 'info');

--- a/test/support/sqs.test.js
+++ b/test/support/sqs.test.js
@@ -434,13 +434,12 @@ describe('sqs', () => {
     expect(logSpy).to.have.been.calledWith('Success, message sent. Queue: unknown, Type: unknown, MessageID: message-id');
   });
 
-  describe('imsOrgId propagation for Mystique-bound messages', () => {
+  describe('organizationId propagation for Mystique-bound messages', () => {
     const mystiqueQueueUrl = 'https://sqs.us-east-1.amazonaws.com/123456789/spacecat-to-mystique';
     let siteFindByIdStub;
 
     const setupMystiqueContext = ({
-      imsOrgId = 'ABC123@AdobeOrg',
-      organizationId = 'org-123',
+      organizationId = '4854e75e-894b-4a74-92bf-d674abad1423',
       withDataAccess = true,
     } = {}) => {
       context.env = { QUEUE_SPACECAT_TO_MYSTIQUE: mystiqueQueueUrl };
@@ -449,13 +448,10 @@ describe('sqs', () => {
       }
       const site = {
         getOrganizationId: () => organizationId,
-        getBaseURL: () => 'https://example.com',
       };
-      const organization = { getImsOrgId: () => imsOrgId };
       siteFindByIdStub = sandbox.stub().resolves(site);
       context.dataAccess = {
         Site: { findById: siteFindByIdStub },
-        Organization: { findById: sandbox.stub().resolves(organization) },
       };
     };
 
@@ -472,12 +468,12 @@ describe('sqs', () => {
         };
       });
 
-    it('adds the resolved imsOrgId to a Mystique-bound message', async () => {
+    it('adds the resolved organizationId to a Mystique-bound message', async () => {
       setupMystiqueContext();
       const message = { type: 'guidance:metatags', siteId: 'site-1' };
 
       nockSend((parsed) => {
-        expect(parsed.imsOrgId).to.equal('ABC123@AdobeOrg');
+        expect(parsed.organizationId).to.equal('4854e75e-894b-4a74-92bf-d674abad1423');
         expect(parsed.siteId).to.equal('site-1');
       });
 
@@ -486,12 +482,12 @@ describe('sqs', () => {
       }).with(sqsWrapper)({}, context);
     });
 
-    it('omits imsOrgId when it cannot be resolved (organization has none)', async () => {
-      setupMystiqueContext({ imsOrgId: null });
+    it('omits organizationId when it cannot be resolved (site has none)', async () => {
+      setupMystiqueContext({ organizationId: null });
       const message = { type: 'guidance:metatags', siteId: 'site-1' };
 
       nockSend((parsed) => {
-        expect(parsed.imsOrgId).to.be.undefined;
+        expect(parsed.organizationId).to.be.undefined;
       });
 
       await wrap(async (req, ctx) => {
@@ -499,13 +495,13 @@ describe('sqs', () => {
       }).with(sqsWrapper)({}, context);
     });
 
-    it('omits imsOrgId when the site cannot be found', async () => {
+    it('omits organizationId when the site cannot be found', async () => {
       setupMystiqueContext();
       siteFindByIdStub.resolves(undefined);
       const message = { type: 'guidance:metatags', siteId: 'missing-site' };
 
       nockSend((parsed) => {
-        expect(parsed.imsOrgId).to.be.undefined;
+        expect(parsed.organizationId).to.be.undefined;
       });
 
       await wrap(async (req, ctx) => {
@@ -513,13 +509,13 @@ describe('sqs', () => {
       }).with(sqsWrapper)({}, context);
     });
 
-    it('does not resolve or add imsOrgId for non-Mystique queues', async () => {
+    it('does not resolve or add organizationId for non-Mystique queues', async () => {
       setupMystiqueContext();
       const otherQueue = 'https://sqs.us-east-1.amazonaws.com/123456789/some-other-queue';
       const message = { type: 'audit', siteId: 'site-1' };
 
       nockSend((parsed) => {
-        expect(parsed.imsOrgId).to.be.undefined;
+        expect(parsed.organizationId).to.be.undefined;
       });
 
       await wrap(async (req, ctx) => {
@@ -529,13 +525,13 @@ describe('sqs', () => {
       expect(siteFindByIdStub).to.not.have.been.called;
     });
 
-    it('skips imsOrgId resolution when QUEUE_SPACECAT_TO_MYSTIQUE is not configured', async () => {
+    it('skips organizationId resolution when QUEUE_SPACECAT_TO_MYSTIQUE is not configured', async () => {
       setupMystiqueContext();
       context.env = {};
       const message = { type: 'guidance:metatags', siteId: 'site-1' };
 
       nockSend((parsed) => {
-        expect(parsed.imsOrgId).to.be.undefined;
+        expect(parsed.organizationId).to.be.undefined;
       });
 
       await wrap(async (req, ctx) => {
@@ -545,12 +541,12 @@ describe('sqs', () => {
       expect(siteFindByIdStub).to.not.have.been.called;
     });
 
-    it('does not overwrite an imsOrgId already present on the message', async () => {
+    it('does not overwrite an organizationId already present on the message', async () => {
       setupMystiqueContext();
-      const message = { type: 'guidance:metatags', siteId: 'site-1', imsOrgId: 'EXISTING@AdobeOrg' };
+      const message = { type: 'guidance:metatags', siteId: 'site-1', organizationId: 'existing-org-id' };
 
       nockSend((parsed) => {
-        expect(parsed.imsOrgId).to.equal('EXISTING@AdobeOrg');
+        expect(parsed.organizationId).to.equal('existing-org-id');
       });
 
       await wrap(async (req, ctx) => {
@@ -560,12 +556,12 @@ describe('sqs', () => {
       expect(siteFindByIdStub).to.not.have.been.called;
     });
 
-    it('skips imsOrgId resolution when the message has no siteId', async () => {
+    it('skips organizationId resolution when the message has no siteId', async () => {
       setupMystiqueContext();
       const message = { type: 'guidance:metatags' };
 
       nockSend((parsed) => {
-        expect(parsed.imsOrgId).to.be.undefined;
+        expect(parsed.organizationId).to.be.undefined;
       });
 
       await wrap(async (req, ctx) => {
@@ -575,7 +571,7 @@ describe('sqs', () => {
       expect(siteFindByIdStub).to.not.have.been.called;
     });
 
-    it('caches the resolved imsOrgId across sends for the same siteId', async () => {
+    it('caches the resolved organizationId across sends for the same siteId', async () => {
       setupMystiqueContext();
       const message = { type: 'guidance:metatags', siteId: 'site-1' };
 
@@ -584,7 +580,7 @@ describe('sqs', () => {
         .times(2)
         .reply(200, (_, body) => {
           const { MessageBody } = JSON.parse(body);
-          expect(JSON.parse(MessageBody).imsOrgId).to.equal('ABC123@AdobeOrg');
+          expect(JSON.parse(MessageBody).organizationId).to.equal('4854e75e-894b-4a74-92bf-d674abad1423');
           return {
             MessageId: 'message-id',
             MD5OfMessageBody: crypto.createHash('md5').update(MessageBody, 'utf-8').digest('hex'),
@@ -599,14 +595,14 @@ describe('sqs', () => {
       expect(siteFindByIdStub).to.have.been.calledOnce;
     });
 
-    it('sends without imsOrgId (and logs a warning) when resolution throws', async () => {
+    it('sends without organizationId (and logs a warning) when resolution throws', async () => {
       setupMystiqueContext();
       siteFindByIdStub.rejects(new Error('db down'));
       const warnSpy = sandbox.spy(context.log, 'warn');
       const message = { type: 'guidance:metatags', siteId: 'site-1' };
 
       nockSend((parsed) => {
-        expect(parsed.imsOrgId).to.be.undefined;
+        expect(parsed.organizationId).to.be.undefined;
         expect(parsed.siteId).to.equal('site-1');
       });
 
@@ -615,16 +611,16 @@ describe('sqs', () => {
       }).with(sqsWrapper)({}, context);
 
       expect(warnSpy).to.have.been.calledWith(
-        'Failed to resolve imsOrgId for Mystique message (siteId: site-1): db down',
+        'Failed to resolve organizationId for Mystique message (siteId: site-1): db down',
       );
     });
 
-    it('sends without imsOrgId when dataAccess is unavailable on context', async () => {
+    it('sends without organizationId when dataAccess is unavailable on context', async () => {
       setupMystiqueContext({ withDataAccess: false });
       const message = { type: 'guidance:metatags', siteId: 'site-1' };
 
       nockSend((parsed) => {
-        expect(parsed.imsOrgId).to.be.undefined;
+        expect(parsed.organizationId).to.be.undefined;
       });
 
       await wrap(async (req, ctx) => {


### PR DESCRIPTION
**Jira:** [SITES-46272](https://jira.corp.adobe.com/browse/SITES-46272)

## What

Auto-attaches the organization ID (`organizationId`) to every message sent to the Mystique queue (`QUEUE_SPACECAT_TO_MYSTIQUE`), at the SQS transport layer in `src/support/sqs.js`.

Previously, none of the ~32 Mystique-bound `sqs.sendMessage` call sites included an organization ID — payloads only carried `siteId` and `deliveryType`. This change makes the org identity available to Mystique across the SpaceCat → Mystique boundary.

## How

Mirrors the existing `traceId` propagation pattern already in `sendMessage`:

- When the target queue is `QUEUE_SPACECAT_TO_MYSTIQUE`, the message carries a `siteId`, and no `organizationId` is already present, the org ID is resolved (`Site.findById(siteId)` → `site.getOrganizationId()`, a plain getter — no extra `Organization` lookup) and attached as top-level `organizationId` (camelCase, consistent with `siteId`/`deliveryType` and the inbound message convention).
- Resolution is **cached per invocation** (keyed by `siteId`) so a handler emitting many messages for the same site pays the `Site.findById` lookup only once — avoids the N+1 pattern.
- Resolution **never blocks the send**: a failed lookup logs a warning and the message is sent without `organizationId`.
- No-op for non-Mystique queues; generic `sendMessage` behavior is unchanged elsewhere.

### Why the transport layer (vs. per-handler)

There is no single chokepoint at the payload level — the ~32 Mystique payloads are built inline across many handlers. `SQS.sendMessage` is the single transport chokepoint, and the file already establishes this exact pattern for `traceId`. This covers **all current and future** Mystique sends with no per-handler changes and a single, concentrated test surface.

**Tradeoff:** the SQS support client now reaches into `context.dataAccess.Site` at runtime to resolve the org ID (gated to the Mystique queue, best-effort). It does so via the injected `context` — no new module import / no circular-dependency concern. The alternative — resolving once onto `context.organizationId` via middleware — keeps the support client fully decoupled but needs a reliable universal set-point across audit and guidance handlers.

## Testing

- `sqs.js`: **100% lines / branches / statements**
- 10 tests covering: happy path, unresolvable site (no org id), site-not-found, non-Mystique queue, missing queue env, pre-set `organizationId` not overwritten, missing `siteId`, cache reuse, resolution throwing, missing `dataAccess`.
- `npm run lint`: clean

## Related PRs

- **Consumer:** [experience-platform/mystique#2813](https://git.corp.adobe.com/experience-platform/mystique/pull/2813) — consumes this `organizationId` and lands it (plus `siteId`) on the Langfuse trace metadata of the SQS-driven guidance/detection/autofix crews + tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
