### PR TITLE
fix(broken-internal-links): cache inconclusive URLs

### DIFF
--- a/src/internal-links/crawl-batch-orchestration.js
+++ b/src/internal-links/crawl-batch-orchestration.js
@@ -182,7 +182,7 @@ export function createCrawlBatchOrchestration({
   }
 
   async function processOneBatch({
-    auditId, batchNum, batchStartIndex, batchSize, scrapeResultPaths, context, log,
+    auditId, batchNum, batchStartIndex, batchSize, scrapeResultPaths, context, log, lambdaStartTime,
   }) {
     const claimEtag = await tryStartBatchProcessing(auditId, batchNum, { ...context, log });
     /* c8 ignore next 4 - Concurrent worker guard; requires multi-Lambda race to trigger */
@@ -203,7 +203,22 @@ export function createCrawlBatchOrchestration({
         batchSize,
         initialBrokenUrls: brokenUrlsCache,
         initialWorkingUrls: workingUrlsCache,
+        lambdaStartTime,
       }, { ...context, log });
+
+      if (batchResult.earlyExit) {
+        // Batch was interrupted mid-page due to Lambda timeout approaching.
+        // Only persist the cache (broken/working URLs found so far) — do NOT save partial batch
+        // results or mark the batch complete. The next Lambda will re-process this full batch
+        // from batchStartIndex, using the updated cache to skip already-validated URLs quickly.
+        await updateCache(auditId, batchResult.brokenUrlsCache, batchResult.workingUrlsCache, {
+          ...context, log,
+        });
+        /* c8 ignore next 3 - earlyExit claim release; tested via outer loop continuation test */
+        await releaseBatchProcessingClaim(auditId, batchNum, claimEtag, { ...context, log });
+        log.info(`Batch ${batchNum}: early exit after ${batchResult.pagesProcessed} pages (timeout), resuming from index ${batchStartIndex}`);
+        return { ...batchResult, nextBatchStartIndex: batchStartIndex };
+      }
 
       await saveBatchResults(auditId, batchNum, batchResult.results, batchResult.pagesProcessed, {
         ...context, log,
@@ -215,8 +230,8 @@ export function createCrawlBatchOrchestration({
 
       await markBatchCompleted(auditId, batchNum, { ...context, log });
       await releaseBatchProcessingClaim(auditId, batchNum, claimEtag, { ...context, log });
-
       log.info(`Batch ${batchNum}: ${batchResult.results.length} broken links from ${batchResult.pagesProcessed} pages`);
+
       return batchResult;
     /* c8 ignore start - Claim cleanup on unexpected batch failure */
     } catch (error) {
@@ -355,6 +370,7 @@ export function createCrawlBatchOrchestration({
           scrapeResultPaths,
           context,
           log,
+          lambdaStartTime,
         });
       } catch (error) {
         log.error(`Batch ${batchNum} processing failed: ${error.message}`);
@@ -370,6 +386,30 @@ export function createCrawlBatchOrchestration({
 
       batchesProcessedThisLambda += 1;
       currentIndex = batchResult.nextBatchStartIndex;
+
+      if (batchResult.earlyExit) {
+        // Batch was interrupted mid-page due to Lambda timeout — send continuation immediately
+        // without attempting another batch, to ensure the SQS message is sent before Lambda dies.
+        log.info(`Early exit detected, sending continuation from index ${currentIndex}`);
+        // eslint-disable-next-line no-await-in-loop
+        await sendContinuationWithRetry({
+          auditId,
+          nextBatchIndex: currentIndex,
+          continuationCount: continuationCount + 1,
+          site,
+          audit,
+          scrapeJobId,
+          sqs,
+          env,
+          log,
+          context,
+        });
+        return {
+          status: 'batch-continuation',
+          batchesProcessedThisLambda,
+          batchesSkipped,
+        };
+      }
     }
 
     log.info(`All ${estimatedTotalBatches} batches complete (${batchesProcessedThisLambda} processed, ${batchesSkipped} skipped in this Lambda)`);

--- a/src/internal-links/crawl-detection.js
+++ b/src/internal-links/crawl-detection.js
@@ -728,6 +728,7 @@ async function validateLinksWithCache(
         };
       }
       if (validation.inconclusive) {
+        workingUrlsCache.add(cacheKey);
         return { type: 'api-inconclusive' };
       }
       workingUrlsCache.add(cacheKey);

--- a/src/internal-links/crawl-detection.js
+++ b/src/internal-links/crawl-detection.js
@@ -848,7 +848,7 @@ export async function detectBrokenLinksFromCrawlBatch({
   // TEMP LOG - branch: broken-internal-inconclusive-url-cache
   /* c8 ignore next */
   log.info('[TEMP] broken-internal-test-log');
-  log.info(`${formatElapsed()} ====== BATCH PROCESSING STARTT ======`);
+  log.info(`${formatElapsed()} ====== BATCH PROCESSING STARTTT ======`);
   log.info(`${formatElapsed()} Processing pages ${batchStartIndex + 1}-${batchEndIndex} of ${totalPages}`);
   log.info(`${formatElapsed()} Initial cache: ${initialBrokenUrls.length} broken, ${initialWorkingUrls.length} working URLs`);
 

--- a/src/internal-links/crawl-detection.js
+++ b/src/internal-links/crawl-detection.js
@@ -729,9 +729,7 @@ async function validateLinksWithCache(
         };
       }
       if (validation.inconclusive) {
-        // TEMP LOG - branch: broken-internal-inconclusive-url-cache
-        /* c8 ignore next */
-        log.info(`[TEMP] inconclusive URL cached as working: ${link.url}`);
+        log.info(`Inconclusive URL cached as working: ${link.url}`);
         workingUrlsCache.add(cacheKey);
         return { type: 'api-inconclusive' };
       }

--- a/src/internal-links/crawl-detection.js
+++ b/src/internal-links/crawl-detection.js
@@ -847,7 +847,7 @@ export async function detectBrokenLinksFromCrawlBatch({
 
   // TEMP LOG - branch: broken-internal-inconclusive-url-cache
   /* c8 ignore next */
-  log.info('[TEMP] broken-internal-inconclusive-url-cache branch is active');
+  log.info('[TEMP] broken-internal-test');
   log.info(`${formatElapsed()} ====== BATCH PROCESSING START ======`);
   log.info(`${formatElapsed()} Processing pages ${batchStartIndex + 1}-${batchEndIndex} of ${totalPages}`);
   log.info(`${formatElapsed()} Initial cache: ${initialBrokenUrls.length} broken, ${initialWorkingUrls.length} working URLs`);

--- a/src/internal-links/crawl-detection.js
+++ b/src/internal-links/crawl-detection.js
@@ -12,6 +12,7 @@
 
 import { load as cheerioLoad } from 'cheerio';
 import { getObjectFromKey } from '../utils/s3-utils.js';
+import { getTimeoutStatus } from './batch-state.js';
 import { isWithinAuditScope } from './subpath-filter.js';
 import { isLinkInaccessible } from './helpers.js';
 import { limitConcurrency, sleep } from '../support/utils.js';
@@ -787,6 +788,7 @@ function updateValidationStats(stats, validations) {
  * @param {number} params.batchSize - Number of pages to process in this batch
  * @param {Array} params.initialBrokenUrls - Array of known broken URLs from previous batches
  * @param {Array} params.initialWorkingUrls - Array of known working URLs from previous batches
+ * @param {number} [params.lambdaStartTime] - Lambda invocation start timestamp for timeout check
  * @param {Object} context - Context object with s3Client, log, env, site
  * @returns {Promise<Object>} Object containing:
  *   - results: Array of broken links found in this batch
@@ -795,6 +797,7 @@ function updateValidationStats(stats, validations) {
  *   - pagesProcessed: Number of pages processed in this batch
  *   - hasMorePages: Boolean indicating if more pages remain
  *   - nextBatchStartIndex: Index to start the next batch from
+ *   - earlyExit: Boolean, true if processing stopped early due to Lambda timeout
  *   - stats: Object with processing statistics
  */
 export async function detectBrokenLinksFromCrawlBatch({
@@ -803,6 +806,7 @@ export async function detectBrokenLinksFromCrawlBatch({
   batchSize = PAGES_PER_BATCH,
   initialBrokenUrls = [],
   initialWorkingUrls = [],
+  lambdaStartTime = null,
 }, context) {
   const {
     s3Client, env, log: baseLog, site,
@@ -845,10 +849,7 @@ export async function detectBrokenLinksFromCrawlBatch({
   const batchEndIndex = Math.min(batchStartIndex + batchSize, totalPages);
   const batchPaths = allPaths.slice(batchStartIndex, batchEndIndex);
 
-  // TEMP LOG - branch: broken-internal-inconclusive-url-cache
-  /* c8 ignore next */
-  log.info('[TEMP] broken-internal-test-log');
-  log.info(`${formatElapsed()} ====== BATCH PROCESSING STARTTT ======`);
+  log.info(`${formatElapsed()} ====== BATCH PROCESSING START ======`);
   log.info(`${formatElapsed()} Processing pages ${batchStartIndex + 1}-${batchEndIndex} of ${totalPages}`);
   log.info(`${formatElapsed()} Initial cache: ${initialBrokenUrls.length} broken, ${initialWorkingUrls.length} working URLs`);
 
@@ -871,6 +872,12 @@ export async function detectBrokenLinksFromCrawlBatch({
   let pagesSkipped = 0;
 
   for (const [url, s3Key] of batchPaths) {
+    if (lambdaStartTime && getTimeoutStatus(lambdaStartTime, context).isApproachingTimeout) {
+      const nextPageIndex = batchStartIndex + pagesProcessed;
+      log.info(`${formatElapsed()} Approaching Lambda timeout before page ${nextPageIndex + 1}, stopping batch early`);
+      break;
+    }
+
     try {
       pagesProcessed += 1;
       const globalPageNum = batchStartIndex + pagesProcessed;
@@ -970,7 +977,9 @@ export async function detectBrokenLinksFromCrawlBatch({
     : 0;
 
   const totalTime = ((Date.now() - startTime) / 1000).toFixed(1);
-  const hasMorePages = batchEndIndex < totalPages;
+  const actualEndIndex = batchStartIndex + pagesProcessed;
+  const earlyExit = actualEndIndex < batchEndIndex;
+  const hasMorePages = earlyExit || batchEndIndex < totalPages;
 
   log.info(`${formatElapsed()} ====== BATCH SUMMARY ======`);
   log.info(`${formatElapsed()} Time: ${totalTime}s for ${pagesProcessed} pages`);
@@ -978,7 +987,10 @@ export async function detectBrokenLinksFromCrawlBatch({
   log.info(`${formatElapsed()} Cache: ${totalCacheHits} hits (${cacheHitRate}%) - ${cacheHitsBroken} broken, ${cacheHitsWorking} working`);
   log.info(`${formatElapsed()} Results: ${results.length} broken links found in this batch`);
   log.info(`${formatElapsed()} Updated cache: ${brokenUrlsCache.size} broken, ${workingUrlsCache.size} working URLs`);
-  log.info(`${formatElapsed()} Progress: ${hasMorePages ? `${totalPages - batchEndIndex} pages remaining` : 'ALL PAGES COMPLETE'}`);
+  log.info(`${formatElapsed()} Progress: ${hasMorePages ? `${totalPages - actualEndIndex} pages remaining` : 'ALL PAGES COMPLETE'}`);
+  if (earlyExit) {
+    log.info(`${formatElapsed()} Early exit: will resume from page ${actualEndIndex + 1} in next Lambda`);
+  }
   log.info(`${formatElapsed()} ===========================`);
 
   return {
@@ -988,7 +1000,8 @@ export async function detectBrokenLinksFromCrawlBatch({
     pagesProcessed,
     pagesSkipped,
     hasMorePages,
-    nextBatchStartIndex: batchEndIndex,
+    earlyExit,
+    nextBatchStartIndex: actualEndIndex,
     totalPages,
     stats: {
       totalLinksAnalyzed,

--- a/src/internal-links/crawl-detection.js
+++ b/src/internal-links/crawl-detection.js
@@ -870,14 +870,9 @@ export async function detectBrokenLinksFromCrawlBatch({
   const validationStats = createValidationStats();
   let pagesProcessed = 0;
   let pagesSkipped = 0;
+  let timeoutExit = false;
 
   for (const [url, s3Key] of batchPaths) {
-    if (lambdaStartTime && getTimeoutStatus(lambdaStartTime, context).isApproachingTimeout) {
-      const nextPageIndex = batchStartIndex + pagesProcessed;
-      log.info(`${formatElapsed()} Approaching Lambda timeout before page ${nextPageIndex + 1}, stopping batch early`);
-      break;
-    }
-
     try {
       pagesProcessed += 1;
       const globalPageNum = batchStartIndex + pagesProcessed;
@@ -938,10 +933,23 @@ export async function detectBrokenLinksFromCrawlBatch({
         Object.assign(validationStats, updateValidationStats(validationStats, batchResults));
         validations.push(...batchResults);
 
+        // Check Lambda timeout after each link batch; finer granularity than per-page
+        // so a single slow page with many links cannot exhaust the remaining Lambda time.
+        if (lambdaStartTime && getTimeoutStatus(lambdaStartTime, context).isApproachingTimeout) {
+          const linkBatchNum = Math.floor(i / linkCheckBatchSize) + 1;
+          log.info(`${formatElapsed()} Approaching Lambda timeout after link batch ${linkBatchNum}, stopping early`);
+          timeoutExit = true;
+          break;
+        }
+
         if (i + linkCheckBatchSize < allLinks.length) {
           // eslint-disable-next-line no-await-in-loop
           await sleep(linkCheckDelayMs);
         }
+      }
+
+      if (timeoutExit) {
+        break;
       }
 
       const brokenLinks = validations.filter(

--- a/src/internal-links/crawl-detection.js
+++ b/src/internal-links/crawl-detection.js
@@ -847,8 +847,8 @@ export async function detectBrokenLinksFromCrawlBatch({
 
   // TEMP LOG - branch: broken-internal-inconclusive-url-cache
   /* c8 ignore next */
-  log.info('[TEMP] broken-internal-test');
-  log.info(`${formatElapsed()} ====== BATCH PROCESSING START ======`);
+  log.info('[TEMP] broken-internal-test-log');
+  log.info(`${formatElapsed()} ====== BATCH PROCESSING STARTT ======`);
   log.info(`${formatElapsed()} Processing pages ${batchStartIndex + 1}-${batchEndIndex} of ${totalPages}`);
   log.info(`${formatElapsed()} Initial cache: ${initialBrokenUrls.length} broken, ${initialWorkingUrls.length} working URLs`);
 

--- a/src/internal-links/crawl-detection.js
+++ b/src/internal-links/crawl-detection.js
@@ -728,6 +728,9 @@ async function validateLinksWithCache(
         };
       }
       if (validation.inconclusive) {
+        // TEMP LOG - branch: broken-internal-inconclusive-url-cache
+        /* c8 ignore next */
+        log.info(`[TEMP] inconclusive URL cached as working: ${link.url}`);
         workingUrlsCache.add(cacheKey);
         return { type: 'api-inconclusive' };
       }
@@ -842,6 +845,9 @@ export async function detectBrokenLinksFromCrawlBatch({
   const batchEndIndex = Math.min(batchStartIndex + batchSize, totalPages);
   const batchPaths = allPaths.slice(batchStartIndex, batchEndIndex);
 
+  // TEMP LOG - branch: broken-internal-inconclusive-url-cache
+  /* c8 ignore next */
+  log.info('[TEMP] broken-internal-inconclusive-url-cache branch is active');
   log.info(`${formatElapsed()} ====== BATCH PROCESSING START ======`);
   log.info(`${formatElapsed()} Processing pages ${batchStartIndex + 1}-${batchEndIndex} of ${totalPages}`);
   log.info(`${formatElapsed()} Initial cache: ${initialBrokenUrls.length} broken, ${initialWorkingUrls.length} working URLs`);

--- a/test/audits/internal-links/crawl-detection.test.js
+++ b/test/audits/internal-links/crawl-detection.test.js
@@ -332,7 +332,7 @@ describe('Crawl Detection Module', () => {
       expect(result.workingUrlsCache).to.include('https://example.com/working1');
     });
 
-    it('should not report or cache inconclusive transport errors as working', async () => {
+    it('should cache inconclusive transport errors as working to avoid redundant re-checks', async () => {
       const scrapeResultPaths = new Map([
         ['https://example.com/page1', 'scrapes/page1.json'],
       ]);
@@ -364,7 +364,7 @@ describe('Crawl Detection Module', () => {
       }, mockContext);
 
       expect(result.results).to.deep.equal([]);
-      expect(result.workingUrlsCache).to.not.include('https://example.com/timeout-link');
+      expect(result.workingUrlsCache).to.include('https://example.com/timeout-link');
       expect(result.brokenUrlsCache.map((entry) => entry.url)).to.not.include('https://example.com/timeout-link');
       expect(result.stats.linksCheckedViaAPI).to.equal(1);
     });

--- a/test/audits/internal-links/crawl-detection.test.js
+++ b/test/audits/internal-links/crawl-detection.test.js
@@ -29,6 +29,7 @@ describe('Crawl Detection Module', () => {
   let isLinkInaccessibleStub;
   let isWithinAuditScopeStub;
   let isSharedInternalResourceStub;
+  let getTimeoutStatusStub;
 
   const mockSite = {
     getBaseURL: () => 'https://example.com',
@@ -54,6 +55,7 @@ describe('Crawl Detection Module', () => {
     isLinkInaccessibleStub = sandbox.stub();
     isWithinAuditScopeStub = sandbox.stub().returns(true);
     isSharedInternalResourceStub = sandbox.stub().returns(false);
+    getTimeoutStatusStub = sandbox.stub().returns({ isApproachingTimeout: false });
 
     const module = await esmock('../../../src/internal-links/crawl-detection.js', {
       '../../../src/utils/s3-utils.js': {
@@ -67,6 +69,9 @@ describe('Crawl Detection Module', () => {
       },
       '../../../src/internal-links/scope-utils.js': {
         isSharedInternalResource: isSharedInternalResourceStub,
+      },
+      '../../../src/internal-links/batch-state.js': {
+        getTimeoutStatus: getTimeoutStatusStub,
       },
     });
 
@@ -2062,6 +2067,62 @@ describe('Crawl Detection Module', () => {
         'https://example.com/styles/hero-bg.jpg',
         'https://example.com/inline/cta-bg.png',
       ]);
+    });
+
+    it('should stop early and return earlyExit=true when Lambda timeout is approaching before a page', async () => {
+      const scrapeResultPaths = new Map([
+        ['https://example.com/page1', 'scrapes/page1.json'],
+        ['https://example.com/page2', 'scrapes/page2.json'],
+        ['https://example.com/page3', 'scrapes/page3.json'],
+      ]);
+
+      getObjectFromKeyStub.resolves({
+        scrapeResult: { rawBody: '<html><body><a href="/link1">Link</a></body></html>' },
+        finalUrl: 'https://example.com/page1',
+      });
+      isLinkInaccessibleStub.resolves({ isBroken: false, httpStatus: 200, statusBucket: null, contentType: 'text/html' });
+
+      // Timeout approaching immediately — triggers before the first page
+      getTimeoutStatusStub.returns({ isApproachingTimeout: true });
+
+      const result = await detectBrokenLinksFromCrawlBatch({
+        scrapeResultPaths,
+        batchStartIndex: 0,
+        batchSize: 3,
+        initialBrokenUrls: [],
+        initialWorkingUrls: [],
+        lambdaStartTime: Date.now(),
+      }, mockContext);
+
+      expect(result.earlyExit).to.equal(true);
+      expect(result.pagesProcessed).to.equal(0);
+      expect(result.nextBatchStartIndex).to.equal(0);
+      expect(result.hasMorePages).to.equal(true);
+    });
+
+    it('should not check timeout when lambdaStartTime is not provided', async () => {
+      const scrapeResultPaths = new Map([
+        ['https://example.com/page1', 'scrapes/page1.json'],
+      ]);
+
+      getObjectFromKeyStub.resolves({
+        scrapeResult: { rawBody: '<html><body><a href="/link1">Link</a></body></html>' },
+        finalUrl: 'https://example.com/page1',
+      });
+      isLinkInaccessibleStub.resolves({ isBroken: false, httpStatus: 200, statusBucket: null, contentType: 'text/html' });
+
+      const result = await detectBrokenLinksFromCrawlBatch({
+        scrapeResultPaths,
+        batchStartIndex: 0,
+        batchSize: 3,
+        initialBrokenUrls: [],
+        initialWorkingUrls: [],
+        // lambdaStartTime intentionally omitted
+      }, mockContext);
+
+      expect(result.earlyExit).to.equal(false);
+      expect(result.pagesProcessed).to.equal(1);
+      expect(getTimeoutStatusStub).to.not.have.been.called;
     });
   });
 

--- a/test/audits/internal-links/crawl-detection.test.js
+++ b/test/audits/internal-links/crawl-detection.test.js
@@ -2069,7 +2069,7 @@ describe('Crawl Detection Module', () => {
       ]);
     });
 
-    it('should stop early and return earlyExit=true when Lambda timeout is approaching before a page', async () => {
+    it('should stop early and return earlyExit=true when Lambda timeout is approaching after a link batch', async () => {
       const scrapeResultPaths = new Map([
         ['https://example.com/page1', 'scrapes/page1.json'],
         ['https://example.com/page2', 'scrapes/page2.json'],
@@ -2082,7 +2082,7 @@ describe('Crawl Detection Module', () => {
       });
       isLinkInaccessibleStub.resolves({ isBroken: false, httpStatus: 200, statusBucket: null, contentType: 'text/html' });
 
-      // Timeout approaching immediately — triggers before the first page
+      // Timeout approaching — triggers after the first link batch of the first page
       getTimeoutStatusStub.returns({ isApproachingTimeout: true });
 
       const result = await detectBrokenLinksFromCrawlBatch({
@@ -2095,8 +2095,8 @@ describe('Crawl Detection Module', () => {
       }, mockContext);
 
       expect(result.earlyExit).to.equal(true);
-      expect(result.pagesProcessed).to.equal(0);
-      expect(result.nextBatchStartIndex).to.equal(0);
+      expect(result.pagesProcessed).to.equal(1);
+      expect(result.nextBatchStartIndex).to.equal(1);
       expect(result.hasMorePages).to.equal(true);
     });
 

--- a/test/audits/internal-links/handler.test.js
+++ b/test/audits/internal-links/handler.test.js
@@ -4676,4 +4676,94 @@ describe('runCrawlDetectionBatch - Coverage Tests', () => {
     );
     expect(mockLog.error).to.have.been.calledWith(sinon.match(/MANUAL ACTION REQUIRED: Resume audit audit-123/));
   });
+
+  it('should send continuation immediately when detectBrokenLinksFromCrawlBatch returns earlyExit=true', async function () {
+    this.timeout(15000);
+
+    const mockLog = {
+      info: sandbox.stub(),
+      warn: sandbox.stub(),
+      error: sandbox.stub(),
+      debug: sandbox.stub(),
+    };
+
+    const smallScrapeResultPaths = new Map([
+      ['https://example.com/page1', 'scrape/page1.json'],
+      ['https://example.com/page2', 'scrape/page2.json'],
+    ]);
+
+    const noSuchKeyError = Object.assign(new Error('NoSuchKey'), { name: 'NoSuchKey' });
+    const mockS3Send = sandbox.stub().callsFake(async (command) => {
+      const commandName = command.constructor.name;
+      if (commandName === 'GetObjectCommand') {
+        const { Key } = command.input;
+        if (Key.includes('/cache/')) {
+          return {
+            Body: { transformToString: async () => JSON.stringify({ broken: [], working: [] }) },
+            ETag: '"cache-etag"',
+          };
+        }
+        if (Key.includes('/completed.json')) {
+          throw noSuchKeyError;
+        }
+        throw noSuchKeyError;
+      }
+      if (commandName === 'ListObjectsV2Command') {
+        return { Contents: [] };
+      }
+      return { ETag: '"mock-etag"' };
+    });
+
+    const sqsSendStub = sandbox.stub().resolves();
+
+    const mockContext = {
+      log: mockLog,
+      site: {
+        getId: () => 'test-site-early',
+        getBaseURL: () => 'https://example.com',
+      },
+      audit: {
+        getId: () => 'audit-early',
+        getAuditType: () => AUDIT_TYPE,
+        getFullAuditRef: () => 'site/audit-type/audit-early',
+        getAuditResult: () => ({ brokenInternalLinks: [] }),
+        setAuditResult: sandbox.stub(),
+        save: sandbox.stub().resolves(),
+      },
+      auditContext: {},
+      sqs: { sendMessage: sqsSendStub },
+      env: {
+        AUDIT_JOBS_QUEUE_URL: 'https://sqs.test/queue',
+        S3_SCRAPER_BUCKET_NAME: 'test-bucket',
+      },
+      s3Client: { send: mockS3Send },
+      scrapeResultPaths: smallScrapeResultPaths,
+      scrapeJobId: 'scrape-early',
+      dataAccess: {
+        SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([]) },
+      },
+    };
+
+    const module = await esmock('../../../src/internal-links/handler.js', {
+      '../../../src/internal-links/crawl-detection.js': {
+        detectBrokenLinksFromCrawlBatch: async () => ({
+          results: [],
+          brokenUrlsCache: [],
+          workingUrlsCache: [],
+          pagesProcessed: 1,
+          pagesSkipped: 0,
+          hasMorePages: true,
+          earlyExit: true,
+          nextBatchStartIndex: 1,
+          stats: { linksChecked: 0, linksSkipped: 0, brokenLinksFound: 0 },
+        }),
+      },
+    });
+
+    const result = await module.runCrawlDetectionBatch(mockContext);
+
+    expect(result.status).to.equal('batch-continuation');
+    expect(sqsSendStub).to.have.been.called;
+    expect(mockLog.info).to.have.been.calledWith(sinon.match(/Early exit detected, sending continuation from index 0/));
+  });
 });


### PR DESCRIPTION
**Problem**
The Avalara broken-internal-links audit was getting hard-killed by AWS Lambda mid-batch. Inconclusive (ETIMEOUT) URLs were being re-validated on every request, causing cascading slowdowns on rate-limited sites. Combined with a timeout check that only fired between batches (every 10 pages), a single slow page could exhaust the remaining Lambda time before the next batch boundary.

**Solution**
Inconclusive URLs (e.g. ETIMEOUT) are now cached as working so they are not re-validated within the same audit run
Added a timeout check inside the per-link-batch loop (every 10 links within a page). When timeout is detected: cache is saved to S3, batch is released without being marked complete, continuation SQS message is sent, and the next Lambda re-processes the same batch using the warm cache


Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
