### PR TITLE
fix(preflight): throttle link-probe concurrency to prevent timeout false positives (SITES-46696)

### DIFF
--- a/src/preflight/links-checks.js
+++ b/src/preflight/links-checks.js
@@ -16,6 +16,48 @@ import { getDomElementSelector, toElementTargets } from './utils/dom-selector.js
 import { DEFAULT_USER_AGENT } from '../internal-links/helpers.js';
 
 /**
+ * Default number of link probes performed concurrently. Kept low so the audit
+ * does not overwhelm a slow author environment: firing every link at once makes
+ * authenticated author renders queue past the per-request timeout, which the
+ * audit then records as Status 0 / broken (false positives — see SITES-46696).
+ * Override per run via options.linkCheckConcurrency or env
+ * PREFLIGHT_LINK_CHECK_CONCURRENCY.
+ */
+export const DEFAULT_LINK_CHECK_CONCURRENCY = 5;
+
+/**
+ * Minimal promise concurrency limiter. Returns a scheduler that runs at most
+ * `max` tasks at a time and resolves with each task's result. Falls back to
+ * serial (1) for invalid input.
+ *
+ * @param {number} max - maximum number of concurrently running tasks
+ * @returns {(task: () => Promise<*>) => Promise<*>} scheduler function
+ */
+export function createConcurrencyLimiter(max) {
+  const limit = Number.isFinite(max) && max >= 1 ? Math.floor(max) : 1;
+  let active = 0;
+  const queue = [];
+  const next = () => {
+    if (active >= limit || queue.length === 0) {
+      return;
+    }
+    active += 1;
+    const { task, resolve, reject } = queue.shift();
+    Promise.resolve()
+      .then(task)
+      .then(resolve, reject)
+      .finally(() => {
+        active -= 1;
+        next();
+      });
+  };
+  return (task) => new Promise((resolve, reject) => {
+    queue.push({ task, resolve, reject });
+    next();
+  });
+}
+
+/**
  * Removes subtrees rooted at elements whose `class` contains an excluded token.
  * Deepest nodes are removed first so nested excluded wrappers are safe. Mirrors
  * the broken-internal-links crawl filter introduced in PR #2455 so site authors
@@ -198,6 +240,14 @@ export async function runLinksChecks(urls, scrapedObjects, context, options = {
 
   const urlSet = new Set(urls);
 
+  // Bound how many link probes run at once. Unbounded probing overwhelms slow
+  // author environments, making renders queue past the per-request timeout,
+  // which the audit then reports as broken (false positives — SITES-46696).
+  const concurrency = Number(options.linkCheckConcurrency)
+    || Number(context.env?.PREFLIGHT_LINK_CHECK_CONCURRENCY)
+    || DEFAULT_LINK_CHECK_CONCURRENCY;
+  const limit = createConcurrencyLimiter(concurrency);
+
   await Promise.all(
     scrapedObjects
       .filter(({ data }) => urlSet.has(stripTrailingSlash(data.finalUrl)))
@@ -287,30 +337,34 @@ export async function runLinksChecks(urls, scrapedObjects, context, options = {
 
         // Check internal links
         const internalResults = await Promise.all(
-          Array.from(internalLinks.entries()).map(async ([href, selectorSet]) => checkLinkStatus(
-            href,
-            pageUrl,
-            context,
-            {
-              ...options,
-              selectors: [...selectorSet],
-              isInternal: true,
-            },
-          )),
+          Array.from(internalLinks.entries()).map(
+            ([href, selectorSet]) => limit(() => checkLinkStatus(
+              href,
+              pageUrl,
+              context,
+              {
+                ...options,
+                selectors: [...selectorSet],
+                isInternal: true,
+              },
+            )),
+          ),
         );
 
         // Check external links
         const externalResults = await Promise.all(
-          Array.from(externalLinks.entries()).map(async ([href, selectorSet]) => checkLinkStatus(
-            href,
-            pageUrl,
-            context,
-            {
-              ...options,
-              selectors: [...selectorSet],
-              isInternal: false,
-            },
-          )),
+          Array.from(externalLinks.entries()).map(
+            ([href, selectorSet]) => limit(() => checkLinkStatus(
+              href,
+              pageUrl,
+              context,
+              {
+                ...options,
+                selectors: [...selectorSet],
+                isInternal: false,
+              },
+            )),
+          ),
         );
 
         // Filter out null results and add to respective arrays

--- a/test/preflight/links-checks.test.js
+++ b/test/preflight/links-checks.test.js
@@ -868,3 +868,133 @@ describe('preflight/links-checks - runLinksChecks', () => {
     });
   });
 });
+
+describe('preflight/links-checks - probe concurrency (SITES-46696)', () => {
+  let sandbox;
+  let fetchStub;
+  let runLinksChecks;
+  let createConcurrencyLimiter;
+  let DEFAULT_LINK_CHECK_CONCURRENCY;
+  let context;
+  const pageUrl = 'https://www.example.com/page';
+
+  const makeScrapedObjects = (html, finalUrl = pageUrl) => [{
+    data: { finalUrl, scrapeResult: { rawBody: html } },
+  }];
+
+  const makeResponse = (status) => ({
+    status,
+    statusText: String(status),
+    headers: { get: () => null },
+  });
+
+  const manyExternalLinks = (n) => {
+    let html = '';
+    for (let i = 0; i < n; i += 1) {
+      html += `<a href="https://other-${i}.com/x">l</a>`;
+    }
+    return html;
+  };
+
+  // Tracks the peak number of concurrently in-flight fetches.
+  const makeTracker = () => {
+    let active = 0;
+    let max = 0;
+    const fetchImpl = () => new Promise((resolve) => {
+      active += 1;
+      if (active > max) {
+        max = active;
+      }
+      setTimeout(() => {
+        active -= 1;
+        resolve(makeResponse(200));
+      }, 5);
+    });
+    return { fetchImpl, getMax: () => max };
+  };
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    fetchStub = sandbox.stub();
+    ({
+      runLinksChecks,
+      createConcurrencyLimiter,
+      DEFAULT_LINK_CHECK_CONCURRENCY,
+    } = await esmock('../../src/preflight/links-checks.js', {
+      '@adobe/spacecat-shared-utils': {
+        stripTrailingSlash: (url) => url.replace(/\/$/, ''),
+        tracingFetch: fetchStub,
+      },
+    }));
+    context = {
+      log: {
+        debug: sandbox.stub(),
+        warn: sandbox.stub(),
+        error: sandbox.stub(),
+        info: sandbox.stub(),
+      },
+    };
+  });
+
+  afterEach(() => sandbox.restore());
+
+  it('createConcurrencyLimiter runs all tasks and returns their results', async () => {
+    const limit = createConcurrencyLimiter(2);
+    const results = await Promise.all(
+      [1, 2, 3].map((nVal) => limit(() => Promise.resolve(nVal * 2))),
+    );
+    expect(results).to.deep.equal([2, 4, 6]);
+  });
+
+  it('createConcurrencyLimiter never exceeds the limit', async () => {
+    const limit = createConcurrencyLimiter(2);
+    const tracker = makeTracker();
+    await Promise.all(Array.from({ length: 6 }, () => limit(tracker.fetchImpl)));
+    expect(tracker.getMax()).to.equal(2);
+  });
+
+  it('createConcurrencyLimiter propagates task rejection', async () => {
+    const limit = createConcurrencyLimiter(1);
+    let err;
+    try {
+      await limit(() => Promise.reject(new Error('boom')));
+    } catch (e) {
+      err = e;
+    }
+    expect(err).to.be.an('error').with.property('message', 'boom');
+  });
+
+  it('createConcurrencyLimiter falls back to serial for invalid max', async () => {
+    const limit = createConcurrencyLimiter(0);
+    const tracker = makeTracker();
+    await Promise.all(Array.from({ length: 3 }, () => limit(tracker.fetchImpl)));
+    expect(tracker.getMax()).to.equal(1);
+  });
+
+  it('bounds concurrent probes to options.linkCheckConcurrency', async () => {
+    const tracker = makeTracker();
+    fetchStub.callsFake(tracker.fetchImpl);
+    await runLinksChecks(
+      [pageUrl],
+      makeScrapedObjects(manyExternalLinks(10)),
+      context,
+      { pageAuthToken: null, linkCheckConcurrency: 3 },
+    );
+    expect(tracker.getMax()).to.equal(3);
+  });
+
+  it('reads concurrency from env when the option is absent', async () => {
+    const tracker = makeTracker();
+    fetchStub.callsFake(tracker.fetchImpl);
+    context.env = { PREFLIGHT_LINK_CHECK_CONCURRENCY: '2' };
+    await runLinksChecks([pageUrl], makeScrapedObjects(manyExternalLinks(8)), context);
+    expect(tracker.getMax()).to.equal(2);
+  });
+
+  it('defaults to DEFAULT_LINK_CHECK_CONCURRENCY when no option or env is set', async () => {
+    const tracker = makeTracker();
+    fetchStub.callsFake(tracker.fetchImpl);
+    await runLinksChecks([pageUrl], makeScrapedObjects(manyExternalLinks(12)), context);
+    expect(tracker.getMax()).to.equal(DEFAULT_LINK_CHECK_CONCURRENCY);
+  });
+});


### PR DESCRIPTION
## Problem (SITES-46696)

Preflight's broken-links check probes **every link on a page at once** via an unbounded `Promise.all`. On a slow author environment this overwhelms the author: renders queue past the probe's 10s timeout, `tracingFetch` aborts, and `checkLinkStatus` records the timeout as **Status 0 / broken** — a flood of false "broken link" positives.

Micron hit this: **119 of 150** internal author-host links were reported broken, all working pages, all Status 0 from `Request timeout after 10000ms`.

Status 0 is a race: `(per-probe render time) × (probes hitting the author at once)` exceeding the 10s timeout. Firing all links simultaneously maximizes the left side.

## Fix

Route every probe through a shared concurrency limiter instead of unbounded `Promise.all`.

- `createConcurrencyLimiter(max)` — small queue-based limiter (no new dependency).
- Default **5**, overridable via `options.linkCheckConcurrency` or env `PREFLIGHT_LINK_CHECK_CONCURRENCY`.
- Capping concurrency keeps each probe's effective wait under the 10s window, so working links are no longer falsely flagged.
- Behaviour for genuinely broken links (404/410/5xx) is **unchanged** — only the all-at-once firing changes.

The default is deliberately conservative (correctness first); it's configurable so throughput can be tuned later.

## Validation

- **Unit:** 7 new tests + existing suite — limiter runs all tasks, never exceeds the cap, propagates rejections, falls back to serial on invalid input, and reads the option/env/default. `links-checks.js` at **100%** coverage (lines/branches/funcs/stmts); lint clean.
- **Mechanism (real pipeline):** the timeout→Status 0→false-broken path was reproduced end-to-end via an actual preflight run (95/150 on a slow AEM CS author), independent of this change.
- End-to-end before/after on the patched worker will be confirmed post-deploy by re-running preflight on the slow-author repro page (expect 0 broken where it was 95).

## Note on scope

This is the **interim fix in spacecat-audit-worker** to stop Micron's false positives now. The durable home is the links-audit migration (SITES-44289) — the same throttle should land in the new probe utilities so it isn't lost.