### PR TITLE
fix(prerender): normalize urlScope filter by pathname so hostname variants match

### DIFF
--- a/src/prerender/handler.js
+++ b/src/prerender/handler.js
@@ -681,9 +681,12 @@ async function sendPrerenderGuidanceRequestToMystique(
       suggestionsPayload = candidates;
     }
 
-    // When a URL scope is provided (CSV batch), filter to only matching URLs
+    // When a URL scope is provided (CSV batch), filter to only matching URLs.
+    // Compare by pathname+query so hostname variants don't cause mismatches.
     if (urlScope && suggestionsPayload.length > 0) {
-      suggestionsPayload = suggestionsPayload.filter((s) => urlScope.has(s.url));
+      suggestionsPayload = suggestionsPayload.filter(
+        (s) => urlScope.has(normalizePathnameWithQuery(s.url)),
+      );
     }
 
     if (suggestionsPayload.length === 0) {
@@ -824,8 +827,9 @@ export async function handleAiOnlyMode(context) {
   }
 
   // When explicit URLs are provided (CSV batch), scope suggestions to that set.
+  // Normalise to pathname+query so hostname variants (casio.com vs www.casio.com) match.
   const urlScope = Array.isArray(auditContext?.urls) && auditContext.urls.length > 0
-    ? new Set(auditContext.urls)
+    ? new Set(auditContext.urls.map((u) => normalizePathnameWithQuery(u)))
     : null;
   if (urlScope) {
     log.info(`${LOG_PREFIX} ai-only: Scoping to ${urlScope.size} explicit URLs from auditContext. baseUrl=${baseUrl}, siteId=${siteId}`);


### PR DESCRIPTION
## Summary

- Normalize both sides of the `urlScope` filter in `sendPrerenderGuidanceRequestToMystique` using `normalizePathnameWithQuery` so hostname variants (`casio.com` vs `www.casio.com`) match correctly

## Problem

When `ai-only-missing` (or any mode with explicit URLs) sends URLs via `auditContext.urls`, the audit-worker builds a `urlScope` Set from those URLs and filters DB suggestion candidates against it using exact string match (`urlScope.has(s.url)`).

If the URLs use `https://casio.com/us/watches/...` but DB suggestions store `https://www.casio.com/us/watches/...`, none match → the filter is a no-op → all eligible candidates pass through → count inflates from 151 to 175+ (capped at 320).

**Observed in prod:** aia.com.hk submitted 151 URLs, audit-worker sent 175. casio.com submitted 297, audit-worker sent 320.

## Fix

Normalize by pathname+query on both sides:
- **Building the Set** (line 835): `auditContext.urls.map(normalizePathnameWithQuery)`
- **Matching** (line 691): `urlScope.has(normalizePathnameWithQuery(s.url))`

`normalizePathnameWithQuery` is already used in the guidance-handler (PR #2703) and preserves query params while stripping the hostname.

## Test plan

- [x] Verified casio.com and aia.com.hk prod logs showing the hostname mismatch
- [x] ESLint passes
- [x] Existing tests pass