### PR TITLE
feat(cdn-analysis): count self-referer agentic hits for byocdn-other logs

### DIFF
--- a/src/cdn-analysis/sql/other/insert-aggregated.sql
+++ b/src/cdn-analysis/sql/other/insert-aggregated.sql
@@ -44,9 +44,6 @@ WHERE year  = '{{year}}'
     )
   )
 
-  -- agentic and LLM-attributed traffic never has self-referer 
-  AND NOT REGEXP_LIKE(COALESCE(request_referer, ''), '{{host}}')
-
 GROUP BY
   url_extract_path(url),
   request_user_agent,


### PR DESCRIPTION
## What
Removes the self-referer exclusion from the byocdn-other agentic aggregation (`src/cdn-analysis/sql/other/insert-aggregated.sql`) so agentic hits that carry a same-site ("self") referer are counted. Other CDN providers are unchanged.

## Why
The self-referer exclusion was added when agentic crawlers did not send a referer. That behaviour has since changed — crawlers such as GPTBot and OAI-SearchBot now send the source page as `Referer` when following internal links and redirects, so a meaningful share of genuine agentic hits carry a self-referer and are currently dropped.

Scoping this to the `byocdn-other` provider first lets us:
- observe the data/volume change on a single provider before considering it more broadly; and
- better support customers who upload generic CDN logs and have limited control over their CDN logging configuration, where this exclusion has the largest impact.

## Change
- `other/insert-aggregated.sql`: removed `AND NOT REGEXP_LIKE(COALESCE(request_referer, ''), '{{host}}')`.

## Impact to watch
Counted agentic traffic for byocdn-other sites will increase. Part of the recovered volume is duplicate / locale-variant crawling, so monitor the volume change and downstream load (projector import + daily/weekly refresh, serving tables), and the dashboard change for affected tenants.

## Testing
- cdn-analysis handler tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
