### PR TITLE
feat(prerender): sequential Mystique batch processing with Slack notifications

### DIFF
--- a/src/prerender/guidance-handler.js
+++ b/src/prerender/guidance-handler.js
@@ -10,10 +10,12 @@
  * governing permissions and limitations under the License.
  */
 
+import { DeleteObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
 import { badRequest, notFound, ok } from '@adobe/spacecat-shared-http-utils';
 import { isPaidLLMOCustomer, normalizePathnameWithQuery } from './utils/utils.js';
 import { warnOnInvalidSuggestionData } from '../utils/data-access.js';
 import { fetchAnalysisFromPresignedUrl } from '../utils/analysis-fetch.js';
+import { postMessageOptional } from '../utils/slack-utils.js';
 
 const LOG_PREFIX = 'Prerender -';
 
@@ -40,6 +42,148 @@ async function downloadFromPresignedUrl(presignedUrl, log) {
   }
 
   return data;
+}
+
+/**
+ * Reads the full batch list from S3 for a multi-batch Mystique run.
+ *
+ * @param {Object} s3Client - AWS S3 client
+ * @param {string} bucketName - S3 bucket name
+ * @param {string} key - S3 object key for the batch file
+ * @param {Object} log - Logger instance
+ * @returns {Promise<Array[]>} - Array of batches (each batch is an array of suggestion payloads)
+ */
+async function readBatchesFromS3(s3Client, bucketName, key, log) {
+  const response = await s3Client.send(new GetObjectCommand({ Bucket: bucketName, Key: key }));
+  const body = await response.Body.transformToString();
+  const batches = JSON.parse(body);
+  log.info(`${LOG_PREFIX} Read ${batches.length} batches from S3 key=${key}`);
+  return batches;
+}
+
+/**
+ * Deletes the batch list file from S3 after all batches are complete.
+ *
+ * @param {Object} s3Client - AWS S3 client
+ * @param {string} bucketName - S3 bucket name
+ * @param {string} key - S3 object key to delete
+ * @param {Object} log - Logger instance
+ */
+async function deleteBatchesFromS3(s3Client, bucketName, key, log) {
+  try {
+    await s3Client.send(new DeleteObjectCommand({ Bucket: bucketName, Key: key }));
+    log.info(`${LOG_PREFIX} Deleted S3 batch file key=${key}`);
+  } catch (error) {
+    log.warn(`${LOG_PREFIX} Failed to delete S3 batch file key=${key}: ${error.message}`);
+  }
+}
+
+/**
+ * Chains the next Mystique batch after the current one completes.
+ * Reads session state from the opportunity, sends the next SQS message,
+ * updates the session cursor, and posts Slack notifications.
+ * Cleans up S3 + session when the last batch finishes.
+ *
+ * @param {Object} opportunity - The Opportunity model instance
+ * @param {string} siteId - Site ID
+ * @param {string} auditId - Audit ID
+ * @param {string} baseUrl - Site base URL
+ * @param {string} deliveryType - Site delivery type
+ * @param {Object} context - Lambda context with sqs, env, s3Client, log
+ */
+async function chainNextMystiqueBatch(
+  opportunity,
+  siteId,
+  auditId,
+  baseUrl,
+  deliveryType,
+  context,
+) {
+  const {
+    sqs, env, s3Client, log,
+  } = context;
+
+  const oppData = opportunity.getData() ?? {};
+  const session = oppData.mystiqueSession;
+
+  if (!session) {
+    return; // Single-batch run — nothing to chain
+  }
+
+  const {
+    totalBatches,
+    currentBatchIndex,
+    batchesS3Key,
+    slackChannelId,
+    slackThreadTs,
+  } = session;
+
+  const completedBatch = currentBatchIndex + 1;
+
+  await postMessageOptional(
+    context,
+    slackChannelId,
+    `:white_check_mark: Batch ${completedBatch}/${totalBatches} complete`,
+    { threadTs: slackThreadTs },
+  );
+
+  if (currentBatchIndex < totalBatches - 1) {
+    const nextIndex = currentBatchIndex + 1;
+    const allBatches = await readBatchesFromS3(
+      s3Client,
+      env.S3_SCRAPER_BUCKET_NAME,
+      batchesS3Key,
+      log,
+    );
+    const nextBatch = allBatches[nextIndex];
+
+    await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, {
+      type: 'guidance:prerender',
+      url: baseUrl,
+      siteId,
+      auditId,
+      deliveryType,
+      time: new Date().toISOString(),
+      data: {
+        opportunityId: opportunity.getId(),
+        suggestions: nextBatch,
+        batchIndex: nextIndex,
+        totalBatches,
+      },
+    });
+
+    opportunity.setData({
+      ...oppData,
+      mystiqueSession: { ...session, currentBatchIndex: nextIndex },
+    });
+    await opportunity.save();
+
+    await postMessageOptional(
+      context,
+      slackChannelId,
+      `:adobe-run: Sending batch ${nextIndex + 1}/${totalBatches} to Mystique (${nextBatch.length} URLs)`,
+      { threadTs: slackThreadTs },
+    );
+
+    log.info(`${LOG_PREFIX} Chained batch ${nextIndex + 1}/${totalBatches} to Mystique for `
+      + `opportunityId=${opportunity.getId()}, siteId=${siteId}, suggestions=${nextBatch.length}`);
+  } else {
+    // All batches done — clean up
+    await deleteBatchesFromS3(s3Client, env.S3_SCRAPER_BUCKET_NAME, batchesS3Key, log);
+
+    opportunity.setData({ ...oppData, mystiqueSession: undefined });
+    await opportunity.save();
+
+    await postMessageOptional(
+      context,
+      slackChannelId,
+      `:white_check_mark: All ${totalBatches} batches complete for *${baseUrl}*`,
+      { threadTs: slackThreadTs },
+    );
+
+    log.info(`${LOG_PREFIX} All ${totalBatches} Mystique batches complete for `
+      + `opportunityId=${opportunity.getId()}, siteId=${siteId}`);
+  }
 }
 
 export default async function handler(message, context) {
@@ -209,7 +353,6 @@ export default async function handler(message, context) {
       return true;
     });
 
-    // 9. Batch save all suggestions using DynamoDB batch write
     if (uniqueSuggestionsToSave.length > 0) {
       try {
         await Suggestion.saveMany(uniqueSuggestionsToSave);
@@ -235,6 +378,19 @@ export default async function handler(message, context) {
     } else {
       log.warn(`${LOG_PREFIX} No valid suggestions to update for opportunityId=${opportunityId}, siteId=${siteId}`);
     }
+
+    // Chain the next Mystique batch if this is a multi-batch run.
+    // Reads session state from the opportunity and sends the next SQS message.
+    const auditId = message.auditId ?? null;
+    const deliveryType = site.getDeliveryType?.() ?? 'unknown';
+    await chainNextMystiqueBatch(
+      opportunity,
+      siteId,
+      auditId,
+      site.getBaseURL(),
+      deliveryType,
+      context,
+    );
 
     return ok();
   } catch (error) {

--- a/src/prerender/handler.js
+++ b/src/prerender/handler.js
@@ -18,6 +18,7 @@ import { AuditBuilder } from '../common/audit-builder.js';
 import { convertToOpportunity } from '../common/opportunity.js';
 import { syncSuggestions } from '../utils/data-access.js';
 import { getObjectFromKey } from '../utils/s3-utils.js';
+import { postMessageOptional } from '../utils/slack-utils.js';
 import { getTopAgenticLiveUrlsFromAthena, getPreferredBaseUrl } from '../utils/agentic-urls.js';
 import { createOpportunityData } from './opportunity-data-mapper.js';
 import { analyzeHtmlForPrerender } from './utils/html-comparator.js';
@@ -696,9 +697,49 @@ async function sendPrerenderGuidanceRequestToMystique(
 
     const deliveryType = site?.getDeliveryType?.() || 'unknown';
 
-    // SQS has a 256 KB message size limit. Chunk suggestions into batches to stay safely under it.
-    // TODO: send all batches once Mystique multi-batch handling is fully deployed.
+    // SQS has a 256 KB message size limit — chunk into MYSTIQUE_BATCH_SIZE batches.
+    // Send only the first batch now; guidance-handler will chain subsequent batches
+    // sequentially after each Mystique response to avoid parallel-processing overload.
+    const totalBatches = Math.ceil(suggestionsPayload.length / MYSTIQUE_BATCH_SIZE);
     const firstBatch = suggestionsPayload.slice(0, MYSTIQUE_BATCH_SIZE);
+
+    if (totalBatches > 1) {
+      const { s3Client } = context;
+      const batchesKey = `prerender/mystique-batches/${opportunityId}.json`;
+
+      const allBatches = Array.from({ length: totalBatches }, (_, i) => suggestionsPayload
+        .slice(i * MYSTIQUE_BATCH_SIZE, (i + 1) * MYSTIQUE_BATCH_SIZE));
+
+      await s3Client.send(new PutObjectCommand({
+        Bucket: env.S3_SCRAPER_BUCKET_NAME,
+        Key: batchesKey,
+        Body: JSON.stringify(allBatches),
+        ContentType: 'application/json',
+      }));
+
+      const slackCtx = context.auditContext?.slackContext;
+      opportunity.setData({
+        ...(opportunity.getData() ?? {}),
+        mystiqueSession: {
+          totalBatches,
+          currentBatchIndex: 0,
+          batchesS3Key: batchesKey,
+          slackChannelId: slackCtx?.channelId ?? null,
+          slackThreadTs: slackCtx?.threadTs ?? null,
+        },
+      });
+      await opportunity.save();
+
+      await postMessageOptional(
+        context,
+        slackCtx?.channelId,
+        `:adobe-run: Sending batch 1/${totalBatches} to Mystique (${firstBatch.length} URLs)`,
+        { threadTs: slackCtx?.threadTs },
+      );
+
+      log.info(`${LOG_PREFIX} Multi-batch Mystique run: stored ${totalBatches} batches to S3 key=${batchesKey}, `
+        + `sending batch 1/${totalBatches}. baseUrl=${baseUrl}, siteId=${siteId}, opportunityId=${opportunityId}`);
+    }
 
     const time = new Date().toISOString();
     const queue = env.QUEUE_SPACECAT_TO_MYSTIQUE;
@@ -713,14 +754,15 @@ async function sendPrerenderGuidanceRequestToMystique(
         opportunityId,
         suggestions: firstBatch,
         batchIndex: 0,
-        totalBatches: 1,
+        totalBatches,
         generatePrompts,
         siteRegion: site.getRegion() ?? '',
       },
     });
 
     log.info(`${LOG_PREFIX} Queued guidance:prerender message to Mystique for baseUrl=${baseUrl}, `
-      + `siteId=${siteId}, opportunityId=${opportunityId}, suggestions=${firstBatch.length} (capped to 1 batch of ${MYSTIQUE_BATCH_SIZE})`);
+      + `siteId=${siteId}, opportunityId=${opportunityId}, suggestions=${firstBatch.length}, `
+      + `batch 1/${totalBatches}`);
     return firstBatch.length;
   /* c8 ignore next 8 - Error handling for SQS failures when sending to Mystique,
    * difficult to test reliably */

--- a/src/prerender/handler.js
+++ b/src/prerender/handler.js
@@ -681,9 +681,12 @@ async function sendPrerenderGuidanceRequestToMystique(
       suggestionsPayload = candidates;
     }
 
-    // When a URL scope is provided (CSV batch), filter to only matching URLs
+    // When a URL scope is provided (CSV batch), filter to only matching URLs.
+    // Compare by pathname+query so hostname variants don't cause mismatches.
     if (urlScope && suggestionsPayload.length > 0) {
-      suggestionsPayload = suggestionsPayload.filter((s) => urlScope.has(s.url));
+      suggestionsPayload = suggestionsPayload.filter(
+        (s) => urlScope.has(normalizePathnameWithQuery(s.url)),
+      );
     }
 
     if (suggestionsPayload.length === 0) {
@@ -824,8 +827,9 @@ export async function handleAiOnlyMode(context) {
   }
 
   // When explicit URLs are provided (CSV batch), scope suggestions to that set.
+  // Normalise to pathname+query so hostname variants (casio.com vs www.casio.com) match.
   const urlScope = Array.isArray(auditContext?.urls) && auditContext.urls.length > 0
-    ? new Set(auditContext.urls)
+    ? new Set(auditContext.urls.map((u) => normalizePathnameWithQuery(u)))
     : null;
   if (urlScope) {
     log.info(`${LOG_PREFIX} ai-only: Scoping to ${urlScope.size} explicit URLs from auditContext. baseUrl=${baseUrl}, siteId=${siteId}`);

--- a/test/audits/prerender/ai-only-mode.test.js
+++ b/test/audits/prerender/ai-only-mode.test.js
@@ -65,6 +65,9 @@ describe('Prerender AI-Only Mode', () => {
       getSiteId: sandbox.stub().returns('site-123'),
       getType: sandbox.stub().returns('prerender'),
       getSuggestions: sandbox.stub().resolves(mockSuggestions),
+      getData: sandbox.stub().returns({}),
+      setData: sandbox.stub(),
+      save: sandbox.stub().resolves(),
     };
 
     mockDataAccess = {
@@ -930,6 +933,98 @@ describe('Prerender AI-Only Mode', () => {
       expect(result.auditResult.suggestionCount).to.equal(0);
       expect(context.log.error).to.have.been.calledWith(
         sinon.match(/Failed to send guidance:prerender message/),
+      );
+    });
+  });
+
+  describe('Multi-batch Mystique dispatch (>320 suggestions)', () => {
+    const buildSuggestion = (index) => ({
+      getId: sandbox.stub().returns(`suggestion-${index}`),
+      getData: sandbox.stub().returns({
+        url: `https://example.com/page${index}`,
+        isDomainWide: false,
+        scrapeJobId: 'test-scrape-job',
+      }),
+      getStatus: sandbox.stub().returns('NEW'),
+    });
+
+    it('should store all batches in S3 and save mystiqueSession when suggestions exceed MYSTIQUE_BATCH_SIZE', async () => {
+      // Create 321 suggestions to force a second batch
+      const manySuggestions = Array.from({ length: 321 }, (_, i) => buildSuggestion(i));
+      mockOpportunity.getSuggestions.resolves(manySuggestions);
+      mockS3Client.send.resolves(); // PutObjectCommand for batch file
+
+      const result = await importTopPages(context);
+
+      expect(result.status).to.equal('complete');
+
+      // S3 PutObjectCommand was called to store batch file
+      expect(mockS3Client.send).to.have.been.calledOnce;
+      const [s3Call] = mockS3Client.send.firstCall.args;
+      expect(s3Call.input.Key).to.match(/^prerender\/mystique-batches\/opportunity-123\.json$/);
+
+      const storedBatches = JSON.parse(s3Call.input.Body);
+      expect(storedBatches).to.have.lengthOf(2);
+      expect(storedBatches[0]).to.have.lengthOf(320);
+      expect(storedBatches[1]).to.have.lengthOf(1);
+
+      // mystiqueSession saved to opportunity
+      expect(mockOpportunity.setData).to.have.been.calledWith(
+        sinon.match({
+          mystiqueSession: sinon.match({
+            totalBatches: 2,
+            currentBatchIndex: 0,
+            batchesS3Key: 'prerender/mystique-batches/opportunity-123.json',
+          }),
+        }),
+      );
+      expect(mockOpportunity.save).to.have.been.calledOnce;
+
+      // Only first 320 sent to Mystique
+      expect(mockSqs.sendMessage).to.have.been.calledOnce;
+      const sqsMsg = mockSqs.sendMessage.firstCall.args[1];
+      expect(sqsMsg.data.suggestions).to.have.lengthOf(320);
+      expect(sqsMsg.data.batchIndex).to.equal(0);
+      expect(sqsMsg.data.totalBatches).to.equal(2);
+    });
+
+    it('should send single batch without S3 or session when suggestions fit in one batch', async () => {
+      // Default: only 2 suggestions (< 320)
+      const result = await importTopPages(context);
+
+      expect(result.status).to.equal('complete');
+
+      // No S3 write for batch file
+      expect(mockS3Client.send).to.not.have.been.called;
+
+      // No mystiqueSession saved
+      expect(mockOpportunity.setData).to.not.have.been.called;
+      expect(mockOpportunity.save).to.not.have.been.called;
+
+      // All suggestions in the single SQS message
+      expect(mockSqs.sendMessage).to.have.been.calledOnce;
+      const sqsMsg = mockSqs.sendMessage.firstCall.args[1];
+      expect(sqsMsg.data.totalBatches).to.equal(1);
+    });
+
+    it('should include slackContext in mystiqueSession when triggered from Slack', async () => {
+      const manySuggestions = Array.from({ length: 321 }, (_, i) => buildSuggestion(i));
+      mockOpportunity.getSuggestions.resolves(manySuggestions);
+      mockS3Client.send.resolves();
+
+      context.auditContext = {
+        slackContext: { channelId: 'C999', threadTs: '9999.999' },
+      };
+
+      await importTopPages(context);
+
+      expect(mockOpportunity.setData).to.have.been.calledWith(
+        sinon.match({
+          mystiqueSession: sinon.match({
+            slackChannelId: 'C999',
+            slackThreadTs: '9999.999',
+          }),
+        }),
       );
     });
   });

--- a/test/audits/prerender/guidance-handler.test.js
+++ b/test/audits/prerender/guidance-handler.test.js
@@ -29,6 +29,9 @@ describe('Prerender Guidance Handler (Presigned URL)', () => {
   let fetchStub;
   let handler;
   let mockIsPaidLLMOCustomer;
+  let mockPostMessageOptional;
+  let mockS3Client;
+  let mockSqs;
 
   // Helper to mock successful fetch response (resolves the parsed JSON directly).
   const mockFetchSuccess = (data) => {
@@ -52,6 +55,7 @@ describe('Prerender Guidance Handler (Presigned URL)', () => {
     mockSite = {
       getId: sinon.stub().returns('site-123'),
       getBaseURL: sinon.stub().returns('https://example.com'),
+      getDeliveryType: sinon.stub().returns('aem_edge'),
     };
 
     mockSuggestions = [
@@ -89,6 +93,9 @@ describe('Prerender Guidance Handler (Presigned URL)', () => {
       getSiteId: sinon.stub().returns('site-123'),
       getSuggestions: sinon.stub().resolves(mockSuggestions),
       getType: () => 'prerender',
+      getData: sinon.stub().returns({}), // no mystiqueSession by default
+      setData: sinon.stub(),
+      save: sinon.stub().resolves(),
     };
 
     Site = {
@@ -113,13 +120,17 @@ describe('Prerender Guidance Handler (Presigned URL)', () => {
       },
     };
 
+    mockS3Client = { send: sinon.stub().resolves() };
+    mockSqs = { sendMessage: sinon.stub().resolves() };
+
     // Stub the shared analysis-fetch helper directly (no need to fake a Response).
     fetchStub = sinon.stub();
 
     // Mock isPaidLLMOCustomer utility
     mockIsPaidLLMOCustomer = sinon.stub().resolves(true);
+    mockPostMessageOptional = sinon.stub().resolves({ success: true });
 
-    // Import handler with mocked isPaidLLMOCustomer + shared fetch helper
+    // Import handler with mocked helpers
     handler = await esmock('../../../src/prerender/guidance-handler.js', {
       '../../../src/prerender/utils/utils.js': {
         isPaidLLMOCustomer: mockIsPaidLLMOCustomer,
@@ -127,11 +138,20 @@ describe('Prerender Guidance Handler (Presigned URL)', () => {
       '../../../src/utils/analysis-fetch.js': {
         fetchAnalysisFromPresignedUrl: fetchStub,
       },
+      '../../../src/utils/slack-utils.js': {
+        postMessageOptional: mockPostMessageOptional,
+      },
     });
 
     context = {
       log,
       site: mockSite,
+      s3Client: mockS3Client,
+      sqs: mockSqs,
+      env: {
+        S3_SCRAPER_BUCKET_NAME: 'test-bucket',
+        QUEUE_SPACECAT_TO_MYSTIQUE: 'https://sqs.us-east-1.amazonaws.com/test-mystique-queue',
+      },
       dataAccess: {
         Site,
         Opportunity,
@@ -928,6 +948,9 @@ describe('Prerender Guidance Handler (Presigned URL)', () => {
         getId: () => 'opportunity-123',
         getSiteId: () => 'site-123',
         getType: () => 'prerender',
+        getData: sinon.stub().returns({}),
+        setData: sinon.stub(),
+        save: sinon.stub().resolves(),
         getSuggestions: sinon.stub().resolves([
           {
             getId: () => 's1',
@@ -1501,6 +1524,168 @@ describe('Prerender Guidance Handler (Presigned URL)', () => {
       // Verify no duplicate IDs in the saved array
       const ids = saved.map((s) => s.getId());
       expect(new Set(ids).size).to.equal(ids.length);
+    });
+  });
+
+  describe('Multi-batch chaining', () => {
+    const baseMessage = {
+      siteId: 'site-123',
+      auditId: 'audit-123',
+      data: {
+        presignedUrl: 'https://s3.amazonaws.com/bucket/path?X-Amz-Signature=...',
+        opportunityId: 'opportunity-123',
+      },
+    };
+
+    const successPayload = {
+      opportunityId: 'opportunity-123',
+      suggestions: [
+        { url: 'https://example.com/page1', aiSummary: 'Summary 1', valuable: true },
+      ],
+    };
+
+    it('should not chain or post Slack when no mystiqueSession on opportunity', async () => {
+      mockFetchSuccess(successPayload);
+      mockOpportunity.getData.returns({});
+
+      await handler.default(baseMessage, context);
+
+      expect(mockSqs.sendMessage).to.not.have.been.called;
+      expect(mockPostMessageOptional).to.not.have.been.called;
+    });
+
+    it('should post "batch complete" Slack and send next batch when not on last batch', async () => {
+      const nextBatch = [{ suggestionId: 's-3', url: 'https://example.com/page3' }];
+      const allBatches = [
+        [{ suggestionId: 's-1', url: 'https://example.com/page1' }],
+        nextBatch,
+      ];
+
+      mockOpportunity.getData.returns({
+        mystiqueSession: {
+          totalBatches: 2,
+          currentBatchIndex: 0,
+          batchesS3Key: 'prerender/mystique-batches/opportunity-123.json',
+          slackChannelId: 'C123',
+          slackThreadTs: '1234567890.123456',
+        },
+      });
+
+      mockS3Client.send.resolves({
+        Body: { transformToString: sinon.stub().resolves(JSON.stringify(allBatches)) },
+      });
+
+      mockFetchSuccess(successPayload);
+
+      await handler.default(baseMessage, context);
+
+      // Slack: "Batch 1/2 complete"
+      expect(mockPostMessageOptional).to.have.been.calledWith(
+        sinon.match.any,
+        'C123',
+        sinon.match(/Batch 1\/2 complete/),
+        sinon.match({ threadTs: '1234567890.123456' }),
+      );
+
+      // SQS: next batch sent
+      expect(mockSqs.sendMessage).to.have.been.calledOnce;
+      const sqsCall = mockSqs.sendMessage.getCall(0);
+      expect(sqsCall.args[0]).to.equal('https://sqs.us-east-1.amazonaws.com/test-mystique-queue');
+      expect(sqsCall.args[1].data.suggestions).to.deep.equal(nextBatch);
+      expect(sqsCall.args[1].data.batchIndex).to.equal(1);
+      expect(sqsCall.args[1].data.totalBatches).to.equal(2);
+
+      // Session updated on opportunity
+      expect(mockOpportunity.setData).to.have.been.calledWith(
+        sinon.match({ mystiqueSession: sinon.match({ currentBatchIndex: 1 }) }),
+      );
+      expect(mockOpportunity.save).to.have.been.calledOnce;
+
+      // Slack: "Sending batch 2/2"
+      expect(mockPostMessageOptional).to.have.been.calledWith(
+        sinon.match.any,
+        'C123',
+        sinon.match(/Sending batch 2\/2/),
+        sinon.match({ threadTs: '1234567890.123456' }),
+      );
+    });
+
+    it('should post "all batches complete", clean up S3, and clear session on last batch', async () => {
+      mockOpportunity.getData.returns({
+        mystiqueSession: {
+          totalBatches: 2,
+          currentBatchIndex: 1, // already on last batch
+          batchesS3Key: 'prerender/mystique-batches/opportunity-123.json',
+          slackChannelId: 'C123',
+          slackThreadTs: '1234567890.123456',
+        },
+      });
+
+      mockFetchSuccess(successPayload);
+
+      await handler.default(baseMessage, context);
+
+      // SQS: no next batch
+      expect(mockSqs.sendMessage).to.not.have.been.called;
+
+      // S3 delete called
+      expect(mockS3Client.send).to.have.been.called;
+
+      // Session cleared on opportunity
+      expect(mockOpportunity.setData).to.have.been.calledWith(
+        sinon.match({ mystiqueSession: undefined }),
+      );
+      expect(mockOpportunity.save).to.have.been.calledOnce;
+
+      // Slack: "All 2 batches complete"
+      expect(mockPostMessageOptional).to.have.been.calledWith(
+        sinon.match.any,
+        'C123',
+        sinon.match(/All 2 batches complete/),
+        sinon.match({ threadTs: '1234567890.123456' }),
+      );
+    });
+
+    it('should not post Slack when slackChannelId or slackThreadTs is absent', async () => {
+      mockOpportunity.getData.returns({
+        mystiqueSession: {
+          totalBatches: 2,
+          currentBatchIndex: 1,
+          batchesS3Key: 'prerender/mystique-batches/opportunity-123.json',
+          slackChannelId: null,
+          slackThreadTs: null,
+        },
+      });
+
+      mockFetchSuccess(successPayload);
+
+      await handler.default(baseMessage, context);
+
+      // postMessageOptional is still called but with null channel/thread — it no-ops internally
+      const calls = mockPostMessageOptional.getCalls();
+      calls.forEach((c) => {
+        expect(c.args[1]).to.be.null;
+      });
+    });
+
+    it('should warn but not throw when S3 batch file delete fails on last batch', async () => {
+      mockOpportunity.getData.returns({
+        mystiqueSession: {
+          totalBatches: 1,
+          currentBatchIndex: 0,
+          batchesS3Key: 'prerender/mystique-batches/opportunity-123.json',
+          slackChannelId: null,
+          slackThreadTs: null,
+        },
+      });
+
+      mockS3Client.send.rejects(new Error('S3 delete failed'));
+      mockFetchSuccess(successPayload);
+
+      const result = await handler.default(baseMessage, context);
+
+      expect(result.status).to.equal(200);
+      expect(log.warn).to.have.been.calledWith(sinon.match(/Failed to delete S3 batch file/));
     });
   });
 


### PR DESCRIPTION
## Summary

- When suggestions exceed `MYSTIQUE_BATCH_SIZE` (320), store all batches in S3 and save a `mystiqueSession` on the Opportunity with batch cursor, S3 key, and Slack context
- `guidance-handler` now chains the next batch after each Mystique response completes — fully sequential, no parallel processing
- Posts Slack notifications on each batch completion and sends "all batches complete" when the last batch finishes
- Cleans up S3 batch file and clears session from Opportunity when all batches are done
- Single-batch runs (<= 320 suggestions) are unchanged — no S3 storage, no session, no chaining

## Test plan

- [x] Existing 423 prerender tests pass (0 failures)
- [x] New guidance-handler tests: multi-batch chaining, last-batch cleanup, Slack notifications, S3 delete failure tolerance
- [x] New ai-only-mode tests: >320 suggestions triggers multi-batch S3 storage + session, single-batch skips it, Slack context threading
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)