### PR TITLE
fix: add cooldown period for offsite audits

### DIFF
--- a/src/offsite-brand-presence/constants.js
+++ b/src/offsite-brand-presence/constants.js
@@ -80,3 +80,8 @@ export const DRS_SUCCESS_STATUSES = new Set([
   'COMPLETED',
   'COMPLETED_WITH_ERRORS',
 ]);
+
+// Minimum elapsed time before re-triggering the same analysis audit for a site.
+// Prevents duplicate analysis runs caused by SQS at-least-once redelivery of
+// the DRS status poll completion message.
+export const AUDIT_TRIGGER_COOLDOWN_MS = 60 * 60 * 1000; // 1 hour

--- a/src/offsite-brand-presence/drs-status-handler.js
+++ b/src/offsite-brand-presence/drs-status-handler.js
@@ -56,16 +56,12 @@ function resolveAnalysisAuditType(domain) {
  */
 async function hasRecentAudit(siteId, auditType, dataAccess, log) {
   try {
-    const { Audit } = dataAccess;
-    const { data: audits } = await Audit.allBySiteIdAndAuditType(
-      siteId,
-      auditType,
-      { limit: 1, order: 'desc', returnCursor: true },
-    );
-    if (audits.length === 0) {
+    const { LatestAudit } = dataAccess;
+    const latest = await LatestAudit.findBySiteIdAndAuditType(siteId, auditType);
+    if (!latest) {
       return false;
     }
-    const auditedAt = new Date(audits[0].getAuditedAt()).getTime();
+    const auditedAt = new Date(latest.getAuditedAt()).getTime();
     return (Date.now() - auditedAt) < AUDIT_TRIGGER_COOLDOWN_MS;
   } catch (err) {
     log.warn(`${LOG_PREFIX} Failed to check recent ${auditType} audit for site ${siteId}: ${err.message}`);

--- a/src/offsite-brand-presence/drs-status-handler.js
+++ b/src/offsite-brand-presence/drs-status-handler.js
@@ -19,6 +19,7 @@ import {
   DRS_SUCCESS_STATUSES,
   OFFSITE_DOMAINS,
   CITED_ANALYSIS_DRS_CONFIG,
+  AUDIT_TRIGGER_COOLDOWN_MS,
 } from './constants.js';
 
 const LOG_PREFIX = '[offsite-brand-presence][drs-status]';
@@ -42,11 +43,46 @@ function resolveAnalysisAuditType(domain) {
 }
 
 /**
+ * Returns true when a recent audit of the given type already exists for the site,
+ * meaning a new trigger should be suppressed. "Recent" is defined by
+ * AUDIT_TRIGGER_COOLDOWN_MS. Swallows lookup errors so a transient DB failure
+ * never blocks a legitimate trigger.
+ *
+ * @param {string} siteId
+ * @param {string} auditType
+ * @param {object} dataAccess
+ * @param {object} log
+ * @returns {Promise<boolean>}
+ */
+async function hasRecentAudit(siteId, auditType, dataAccess, log) {
+  try {
+    const { Audit } = dataAccess;
+    const { data: audits } = await Audit.allBySiteIdAndAuditType(
+      siteId,
+      auditType,
+      { limit: 1, order: 'desc', returnCursor: true },
+    );
+    if (audits.length === 0) {
+      return false;
+    }
+    const auditedAt = new Date(audits[0].getAuditedAt()).getTime();
+    return (Date.now() - auditedAt) < AUDIT_TRIGGER_COOLDOWN_MS;
+  } catch (err) {
+    log.warn(`${LOG_PREFIX} Failed to check recent ${auditType} audit for site ${siteId}: ${err.message}`);
+    return false;
+  }
+}
+
+/**
  * Triggers the downstream analysis audits for every domain whose scrape jobs produced
  * usable data (a DRS_SUCCESS_STATUSES terminal status). Each audit type is triggered at
  * most once. The originating Slack context is forwarded so each analysis audit posts its
  * results to the same thread. Domains that failed, were cancelled, or are still running
  * at the deadline are skipped — there is no fresh data to analyze.
+ *
+ * An audit type is also skipped when a recent audit of the same type already exists for
+ * the site (within AUDIT_TRIGGER_COOLDOWN_MS). This prevents duplicate analysis runs
+ * caused by SQS at-least-once redelivery of the poll completion message.
  *
  * @param {Array<{domain: string, status: string|undefined}>} statuses - Per-job statuses
  * @param {string} siteId - The site ID
@@ -73,6 +109,12 @@ async function triggerAnalysisAudits(statuses, siteId, slackContext, context) {
   const configuration = await dataAccess.Configuration.findLatest();
   const queueUrl = configuration.getQueues().audits;
   for (const type of auditTypes) {
+    // eslint-disable-next-line no-await-in-loop
+    if (await hasRecentAudit(siteId, type, dataAccess, log)) {
+      log.info(`${LOG_PREFIX} Skipping ${type} for site ${siteId} — recent audit exists`);
+      // eslint-disable-next-line no-continue
+      continue;
+    }
     // eslint-disable-next-line no-await-in-loop
     await sqs.sendMessage(queueUrl, {
       type,

--- a/test/audits/offsite-brand-presence-drs-status.test.js
+++ b/test/audits/offsite-brand-presence-drs-status.test.js
@@ -71,8 +71,8 @@ describe('offsite-brand-presence DRS status handler', () => {
         Configuration: {
           findLatest: sandbox.stub().resolves({ getQueues: () => ({ audits: 'audits-queue-url' }) }),
         },
-        Audit: {
-          allBySiteIdAndAuditType: sandbox.stub().resolves({ data: [], cursor: null }),
+        LatestAudit: {
+          findBySiteIdAndAuditType: sandbox.stub().resolves(null),
         },
       },
     };
@@ -306,8 +306,8 @@ describe('offsite-brand-presence DRS status handler', () => {
       mockGetJob.withArgs('job-2').resolves({ status: 'COMPLETED' });
 
       const recentAudit = { getAuditedAt: () => new Date(Date.now() - AUDIT_TRIGGER_COOLDOWN_MS / 2).toISOString() };
-      context.dataAccess.Audit.allBySiteIdAndAuditType
-        .withArgs(SITE_ID, 'reddit-analysis').resolves({ data: [recentAudit], cursor: null });
+      context.dataAccess.LatestAudit.findBySiteIdAndAuditType
+        .withArgs(SITE_ID, 'reddit-analysis').resolves(recentAudit);
 
       await handler.default(buildMessage(), context);
 
@@ -322,8 +322,8 @@ describe('offsite-brand-presence DRS status handler', () => {
       mockGetJob.withArgs('job-2').resolves({ status: 'COMPLETED' });
 
       const oldAudit = { getAuditedAt: () => new Date(Date.now() - AUDIT_TRIGGER_COOLDOWN_MS * 2).toISOString() };
-      context.dataAccess.Audit.allBySiteIdAndAuditType
-        .withArgs(SITE_ID, 'reddit-analysis').resolves({ data: [oldAudit], cursor: null });
+      context.dataAccess.LatestAudit.findBySiteIdAndAuditType
+        .withArgs(SITE_ID, 'reddit-analysis').resolves(oldAudit);
 
       await handler.default(buildMessage(), context);
 
@@ -336,7 +336,7 @@ describe('offsite-brand-presence DRS status handler', () => {
       mockGetJob.withArgs('job-1').resolves({ status: 'COMPLETED' });
       mockGetJob.withArgs('job-2').resolves({ status: 'COMPLETED' });
 
-      context.dataAccess.Audit.allBySiteIdAndAuditType.rejects(new Error('DB timeout'));
+      context.dataAccess.LatestAudit.findBySiteIdAndAuditType.rejects(new Error('DB timeout'));
 
       await handler.default(buildMessage(), context);
 

--- a/test/audits/offsite-brand-presence-drs-status.test.js
+++ b/test/audits/offsite-brand-presence-drs-status.test.js
@@ -15,6 +15,7 @@ import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import esmock from 'esmock';
+import { AUDIT_TRIGGER_COOLDOWN_MS } from '../../src/offsite-brand-presence/constants.js';
 
 use(sinonChai);
 
@@ -69,6 +70,9 @@ describe('offsite-brand-presence DRS status handler', () => {
       dataAccess: {
         Configuration: {
           findLatest: sandbox.stub().resolves({ getQueues: () => ({ audits: 'audits-queue-url' }) }),
+        },
+        Audit: {
+          allBySiteIdAndAuditType: sandbox.stub().resolves({ data: [], cursor: null }),
         },
       },
     };
@@ -295,6 +299,51 @@ describe('offsite-brand-presence DRS status handler', () => {
       expect(result.status).to.equal(200);
       expect(mockPostMessageOptional).to.have.been.calledOnce;
       expect(log.warn).to.have.been.calledWithMatch(/Failed to trigger analysis audits/);
+    });
+
+    it('skips an audit type when a recent audit exists within the cooldown window', async () => {
+      mockGetJob.withArgs('job-1').resolves({ status: 'COMPLETED' });
+      mockGetJob.withArgs('job-2').resolves({ status: 'COMPLETED' });
+
+      const recentAudit = { getAuditedAt: () => new Date(Date.now() - AUDIT_TRIGGER_COOLDOWN_MS / 2).toISOString() };
+      context.dataAccess.Audit.allBySiteIdAndAuditType
+        .withArgs(SITE_ID, 'reddit-analysis').resolves({ data: [recentAudit], cursor: null });
+
+      await handler.default(buildMessage(), context);
+
+      const types = context.sqs.sendMessage.getCalls().map((c) => c.args[1].type);
+      expect(types).to.include('youtube-analysis');
+      expect(types).to.not.include('reddit-analysis');
+      expect(log.info).to.have.been.calledWithMatch(/Skipping reddit-analysis.*recent audit exists/);
+    });
+
+    it('triggers the audit when the most recent audit is older than the cooldown window', async () => {
+      mockGetJob.withArgs('job-1').resolves({ status: 'COMPLETED' });
+      mockGetJob.withArgs('job-2').resolves({ status: 'COMPLETED' });
+
+      const oldAudit = { getAuditedAt: () => new Date(Date.now() - AUDIT_TRIGGER_COOLDOWN_MS * 2).toISOString() };
+      context.dataAccess.Audit.allBySiteIdAndAuditType
+        .withArgs(SITE_ID, 'reddit-analysis').resolves({ data: [oldAudit], cursor: null });
+
+      await handler.default(buildMessage(), context);
+
+      const types = context.sqs.sendMessage.getCalls().map((c) => c.args[1].type);
+      expect(types).to.include('reddit-analysis');
+      expect(types).to.include('youtube-analysis');
+    });
+
+    it('still triggers when the recent-audit lookup fails', async () => {
+      mockGetJob.withArgs('job-1').resolves({ status: 'COMPLETED' });
+      mockGetJob.withArgs('job-2').resolves({ status: 'COMPLETED' });
+
+      context.dataAccess.Audit.allBySiteIdAndAuditType.rejects(new Error('DB timeout'));
+
+      await handler.default(buildMessage(), context);
+
+      const types = context.sqs.sendMessage.getCalls().map((c) => c.args[1].type);
+      expect(types).to.include('reddit-analysis');
+      expect(types).to.include('youtube-analysis');
+      expect(log.warn).to.have.been.calledWithMatch(/Failed to check recent/);
     });
   });
 });


### PR DESCRIPTION
During the `offsite-brand-presence` audit, check if there exists a recent audit (that was triggered in the past hour) before triggering a new one.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
