### PR TITLE
refactor(prerender): extract ai-only handling and Mystique dispatch into focused modules

### DIFF
--- a/src/prerender/ai-only-handler.js
+++ b/src/prerender/ai-only-handler.js
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * AI-only mode handling.
+ *
+ * `handleAiOnlyMode` is the entry point for `audit:prerender mode:ai-only[-current|-missing]`
+ * runs — it resolves the opportunity, scopes suggestions for the mode, and dispatches a
+ * `guidance:prerender` request to Mystique (via guidance-request.js), bypassing the normal
+ * import/scrape/process steps.
+ */
+
+import { Audit } from '@adobe/spacecat-shared-data-access';
+import { fetchLatestScrapeJobId, getS3Path } from './utils/utils.js';
+import { MODE_AI_ONLY } from './utils/constants.js';
+import { buildUrlScopeForMode, getModeFromData } from './mode-selector.js';
+import { sendPrerenderGuidanceRequestToMystique } from './guidance-request.js';
+
+const LOG_PREFIX = 'Prerender -';
+const AUDIT_TYPE = Audit.AUDIT_TYPES.PRERENDER;
+
+/**
+ * Builds the Mystique candidate list for ai-only mode from the in-scope DB suggestions.
+ *
+ * Per-mode eligibility (e.g. excluding FIXED for ai-only, including FIXED-without-summary for
+ * ai-only-missing) is already decided by buildUrlScopeForMode — or by the explicit CSV set — so
+ * this only narrows to urlScope, skips domain-wide / URL-less suggestions, resolves each
+ * suggestion's scrapeJobId (from data.scrapeJobId, else derived from data.originalHtmlKey), and
+ * builds the S3 markdown keys.
+ *
+ * @param {Array} suggestions - The opportunity's DB suggestions
+ * @param {Set<string>} urlScope - URLs eligible for this run (mode-derived or explicit CSV)
+ * @param {Object} log - Logger
+ * @param {string} siteId - Site ID (log context)
+ * @param {string} baseUrl - Site base URL (log context)
+ * @returns {Array} - Candidate objects to send to Mystique
+ */
+function buildAiOnlyCandidates(suggestions, urlScope, log, siteId, baseUrl) {
+  const candidates = [];
+
+  (suggestions || []).forEach((s) => {
+    const data = s.getData();
+
+    // Skip domain-wide aggregate, URL-less, and out-of-scope suggestions.
+    if (!data?.url || data.isDomainWide || !urlScope.has(data.url)) {
+      return;
+    }
+
+    const suggestionId = s.getId?.();
+
+    // Resolve the scrapeJobId in priority order:
+    //   1. data.scrapeJobId — stamped at suggestion-creation time (most reliable)
+    //   2. data.originalHtmlKey — extract the job segment from the stored S3 path
+    //      (format: prerender/scrapes/{scrapeJobId}/...)
+    //   3. Neither available → skip; we cannot build valid S3 keys without a job id
+    let effectiveScrapeJobId = data.scrapeJobId;
+    if (!effectiveScrapeJobId && data.originalHtmlKey) {
+      // prerender/scrapes/{scrapeJobId}/...
+      const parts = data.originalHtmlKey.split('/');
+      effectiveScrapeJobId = parts[2] || null;
+      if (effectiveScrapeJobId) {
+        log.debug(`${LOG_PREFIX} Suggestion ${suggestionId} missing scrapeJobId; `
+          + `derived from originalHtmlKey: ${effectiveScrapeJobId}. `
+          + `baseUrl=${baseUrl}, siteId=${siteId}`);
+      }
+    }
+    if (!effectiveScrapeJobId) {
+      log.warn(`${LOG_PREFIX} Suggestion ${suggestionId} skipped: no scrapeJobId and no `
+        + `originalHtmlKey to derive one from. baseUrl=${baseUrl}, siteId=${siteId}`);
+      return;
+    }
+
+    candidates.push({
+      suggestionId,
+      url: data.url,
+      originalHtmlMarkdownKey: getS3Path(data.url, effectiveScrapeJobId, 'server-side-html.md'),
+      markdownDiffKey: getS3Path(data.url, effectiveScrapeJobId, 'markdown-diff.md'),
+      // Signal whether this suggestion already has prompts so Mystique can skip re-generation
+      hasPrompts: Array.isArray(data.prompts) && data.prompts.length > 0,
+    });
+  });
+
+  return candidates;
+}
+
+/**
+ * Parses the optional ai-only params (opportunityId, scrapeJobId, generatePrompts) from the
+ * audit `data` field. Non-JSON data degrades gracefully to defaults with a warning.
+ * @param {string|Object|null} data - The audit data field
+ * @param {Object} log - Logger
+ * @returns {{opportunityId: string|null, scrapeJobId: string|null, generatePrompts: boolean}}
+ */
+function parseAiOnlyParams(data, log) {
+  try {
+    const parsed = typeof data === 'string' ? JSON.parse(data) : data;
+    if (parsed) {
+      return {
+        opportunityId: parsed.opportunityId ?? null,
+        scrapeJobId: parsed.scrapeJobId ?? null,
+        generatePrompts: !!parsed.generatePrompts,
+      };
+    }
+  } catch (e) {
+    // Non-JSON data — graceful degradation, values stay at defaults
+    log.warn(`${LOG_PREFIX} Failed to parse context.data for opportunityId, scrapeJobId, generatePrompts, defaulting to null, null, false: ${e.message}`);
+  }
+  return { opportunityId: null, scrapeJobId: null, generatePrompts: false };
+}
+
+/**
+ * Resolves the target opportunity for an ai-only run: by explicit id when provided,
+ * otherwise the latest NEW prerender opportunity for the site.
+ * @returns {Promise<Object|null>} - The opportunity, or null when none is found
+ */
+async function resolveAiOnlyOpportunity(Opportunity, opportunityId, siteId, baseUrl, log) {
+  if (opportunityId) {
+    return Opportunity.findById(opportunityId);
+  }
+  const opportunities = await Opportunity.allBySiteIdAndStatus(siteId, 'NEW');
+  const opportunity = opportunities.find((o) => o.getType() === AUDIT_TYPE);
+  if (opportunity) {
+    log.info(`${LOG_PREFIX} ai-only: Found latest NEW opportunity: ${opportunity.getId()} for baseUrl=${baseUrl}, siteId=${siteId}`);
+  }
+  return opportunity ?? null;
+}
+
+/**
+ * Handles AI-summary-only mode: sends existing suggestions to Mystique without running audit.
+ * Called early in step 1 to bypass import/scraping/processing steps.
+ * @param {Object} context - Audit context
+ * @returns {Promise<Object>} - Result indicating success/failure
+ */
+export async function handleAiOnlyMode(context) {
+  const {
+    site, log, dataAccess, data, auditContext,
+  } = context;
+  const { Opportunity } = dataAccess;
+  const siteId = site.getId();
+  const baseUrl = site.getBaseURL();
+  // Default to MODE_AI_ONLY when data is malformed — we already know we're in ai-only
+  // because the caller (importTopPages) verified isAiOnlyMode before dispatching here.
+  const mode = getModeFromData(data) || MODE_AI_ONLY;
+
+  // Shared failure result: log + the standard failed envelope.
+  const failAiOnly = (error) => {
+    log.error(`${LOG_PREFIX} ai-only: ${error} baseUrl=${baseUrl}, siteId=${siteId}`);
+    return {
+      error,
+      status: 'failed',
+      fullAuditRef: `${mode}/failed-${siteId}`,
+      auditResult: { error },
+    };
+  };
+
+  const {
+    opportunityId, scrapeJobId: providedScrapeJobId, generatePrompts,
+  } = parseAiOnlyParams(data, log);
+
+  log.info(`${LOG_PREFIX} ai-only: Processing AI summary request for baseUrl=${baseUrl}, siteId=${siteId}, opportunityId=${opportunityId || 'latest'}, generatePrompts=${generatePrompts}`);
+
+  // Resolve scrapeJobId: from data, else from status.json.
+  let scrapeJobId = providedScrapeJobId;
+  if (!scrapeJobId) {
+    log.info(`${LOG_PREFIX} ai-only: scrapeJobId not provided, fetching from status.json for baseUrl=${baseUrl}, siteId=${siteId}`);
+    scrapeJobId = await fetchLatestScrapeJobId(siteId, context);
+    if (!scrapeJobId) {
+      return failAiOnly('scrapeJobId not found. Either provide it in data or ensure a prerender audit has run recently.');
+    }
+  }
+
+  // Resolve the opportunity (by id, or latest NEW) and verify it belongs to the site.
+  const opportunity = await resolveAiOnlyOpportunity(
+    Opportunity,
+    opportunityId,
+    siteId,
+    baseUrl,
+    log,
+  );
+  if (!opportunity) {
+    return failAiOnly(opportunityId
+      ? `Opportunity not found: ${opportunityId}`
+      : `No NEW prerender opportunity found for site: ${siteId}`);
+  }
+  if (opportunity.getSiteId() !== siteId) {
+    return failAiOnly(`Opportunity ${opportunity.getId()} does not belong to site ${siteId}`);
+  }
+
+  // Build URL scope: explicit URLs (CSV batch) take priority, otherwise derive from the mode.
+  // Fetch suggestions once and reuse them for both the scope and the candidate build.
+  const suggestions = await opportunity.getSuggestions();
+  const explicitUrls = Array.isArray(auditContext?.urls) ? auditContext.urls : [];
+  const urlScope = explicitUrls.length > 0
+    ? new Set(explicitUrls)
+    : buildUrlScopeForMode(mode, suggestions);
+
+  if (urlScope.size === 0) {
+    log.info(`${LOG_PREFIX} ai-only: No suggestions match mode=${mode} for baseUrl=${baseUrl}, siteId=${siteId}`);
+    return {
+      status: 'complete',
+      mode,
+      opportunityId: opportunity.getId(),
+      fullAuditRef: `${mode}/${opportunity.getId()}`,
+      auditResult: { message: 'No suggestions match the requested mode', suggestionCount: 0 },
+    };
+  }
+
+  const scopeSource = explicitUrls.length > 0 ? 'explicit auditContext' : `DB suggestions (mode=${mode})`;
+  log.info(`${LOG_PREFIX} ai-only: Scoping to ${urlScope.size} URLs from ${scopeSource}. baseUrl=${baseUrl}, siteId=${siteId}`);
+
+  const candidates = buildAiOnlyCandidates(suggestions, urlScope, log, siteId, baseUrl);
+
+  // Dispatch the pre-built candidates to Mystique.
+  const auditData = {
+    siteId,
+    // Fallback to custom audit ID for ai-only mode (for old opportunities without auditId)
+    auditId: opportunity.getAuditId() || `prerender-ai-only-${siteId}`,
+    scrapeJobId,
+  };
+
+  const suggestionCount = await sendPrerenderGuidanceRequestToMystique(
+    site.getBaseURL(),
+    auditData,
+    opportunity,
+    context,
+    candidates,
+    generatePrompts,
+  );
+
+  log.info(`${LOG_PREFIX} ai-only: Successfully queued AI summary request for ${suggestionCount} suggestion(s). baseUrl=${baseUrl}, siteId=${siteId}, opportunityId=${opportunity.getId()}`);
+
+  return {
+    status: 'complete',
+    mode,
+    opportunityId: opportunity.getId(),
+    fullAuditRef: `${mode}/${opportunity.getId()}`,
+    auditResult: {
+      message: `AI summary generation queued successfully for ${suggestionCount} suggestion(s)`,
+      suggestionCount,
+    },
+  };
+}

--- a/src/prerender/guidance-request.js
+++ b/src/prerender/guidance-request.js
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Outbound Mystique guidance request (the request half of the prerender↔Mystique
+ * "guidance" protocol; `guidance-handler.js` handles the inbound response).
+ *
+ * `sendPrerenderGuidanceRequestToMystique` is dispatch-only: given a ready list of suggestion
+ * candidates it uploads them to S3 and enqueues a `guidance:prerender` SQS message carrying the
+ * S3 key. Callers build the candidate list (normal flow in handler.js, ai-only in
+ * ai-only-handler.js); this module does not derive or filter candidates.
+ */
+
+import { PutObjectCommand } from '@aws-sdk/client-s3';
+import { MYSTIQUE_SUGGESTIONS_S3_PREFIX } from './utils/constants.js';
+
+const LOG_PREFIX = 'Prerender -';
+
+/**
+ * Uploads the candidate suggestions to S3 and enqueues a guidance:prerender message to Mystique.
+ * @param {string} auditUrl - Audited URL (site base URL)
+ * @param {Object} auditData - Audit data used to build the message (siteId, auditId)
+ * @param {Object} opportunity - The prerender opportunity entity (used for the S3 key + guards)
+ * @param {Object} context - Processing context (log, sqs, env, site, s3Client)
+ * @param {Array} candidates - Pre-built candidate objects to send
+ *   ({ suggestionId, url, originalHtmlMarkdownKey, markdownDiffKey, hasPrompts }).
+ * @param {boolean} [generatePrompts] - Whether to generate RCV prompts for the suggestions.
+ * @returns {Promise<number>} - Number of suggestions sent to Mystique
+ */
+export async function sendPrerenderGuidanceRequestToMystique(
+  auditUrl,
+  auditData,
+  opportunity,
+  context,
+  candidates,
+  generatePrompts = false,
+) {
+  const {
+    log, sqs, env, site,
+  } = context;
+  /* c8 ignore start - Defensive checks and destructuring, tested in ai-only mode tests */
+  const {
+    siteId,
+    auditId,
+  } = auditData || {};
+
+  if (!sqs || !env?.QUEUE_SPACECAT_TO_MYSTIQUE) {
+    log.warn(`${LOG_PREFIX} SQS or Mystique queue not configured, skipping guidance:prerender message. baseUrl=${auditUrl || site?.getBaseURL?.() || ''}, siteId=${siteId}`);
+    return 0;
+  }
+
+  if (!opportunity || !opportunity.getId) {
+    log.warn(`${LOG_PREFIX} Opportunity entity not available, skipping guidance:prerender message. baseUrl=${auditUrl || site?.getBaseURL?.() || ''}, siteId=${siteId}`);
+    return 0;
+  }
+  /* c8 ignore stop */
+
+  const opportunityId = opportunity.getId();
+
+  try {
+    const baseUrl = auditUrl;
+
+    if (!candidates || candidates.length === 0) {
+      log.info(`${LOG_PREFIX} No eligible suggestions to send to Mystique for opportunityId=${opportunityId}. baseUrl=${baseUrl}, siteId=${siteId}`);
+      return 0;
+    }
+
+    const deliveryType = site?.getDeliveryType?.() || 'unknown';
+
+    // Upload all suggestions to S3 and send just the S3 key via SQS.
+    // This avoids the 256 KB SQS message size limit — Mystique downloads from S3.
+    const { s3Client } = context;
+    const suggestionsS3Key = `${MYSTIQUE_SUGGESTIONS_S3_PREFIX}/${opportunityId}.json`;
+
+    await s3Client.send(new PutObjectCommand({
+      Bucket: env.S3_SCRAPER_BUCKET_NAME,
+      Key: suggestionsS3Key,
+      Body: JSON.stringify(candidates),
+      ContentType: 'application/json',
+    }));
+
+    const time = new Date().toISOString();
+    const queue = env.QUEUE_SPACECAT_TO_MYSTIQUE;
+    await sqs.sendMessage(queue, {
+      type: 'guidance:prerender',
+      url: baseUrl,
+      siteId,
+      auditId,
+      deliveryType,
+      time,
+      data: {
+        opportunityId,
+        suggestionsS3Key,
+        suggestionsS3Bucket: env.S3_SCRAPER_BUCKET_NAME,
+        generatePrompts,
+        siteRegion: site.getRegion() ?? '',
+      },
+    });
+
+    log.info(`${LOG_PREFIX} Queued guidance:prerender message to Mystique for baseUrl=${baseUrl}, `
+      + `siteId=${siteId}, opportunityId=${opportunityId}, suggestions=${candidates.length}, `
+      + `suggestionsS3Key=${suggestionsS3Key}`);
+    return candidates.length;
+  /* c8 ignore next 8 - Error handling for SQS failures when sending to Mystique,
+   * difficult to test reliably */
+  } catch (error) {
+    log.error(`${LOG_PREFIX} Failed to send guidance:prerender message to Mystique for opportunityId=${opportunityId}, `
+      + `baseUrl=${auditUrl}, siteId=${siteId}: ${error.message}`, error);
+    return 0;
+  }
+}

--- a/src/prerender/handler.js
+++ b/src/prerender/handler.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { Audit, Suggestion } from '@adobe/spacecat-shared-data-access';
 import { detectBotBlocker } from '@adobe/spacecat-shared-utils';
 import { subDays } from 'date-fns';
@@ -23,9 +23,11 @@ import { createOpportunityData } from './opportunity-data-mapper.js';
 import { analyzeHtmlForPrerender } from './utils/html-comparator.js';
 import {
   buildSuggestionKey,
+  getS3Path,
   isPaidLLMOCustomer,
   mergeAndGetUniqueHtmlUrls,
   normalizePathnameWithQuery,
+  readSiteStatusJson,
   toPathname,
 } from './utils/utils.js';
 import {
@@ -35,10 +37,10 @@ import {
   TOP_AGENTIC_URLS_LIMIT,
   TOP_ORGANIC_URLS_LIMIT,
   PRERENDER_RECENT_PROCESSING_TIME_DAYS,
-  MODE_AI_ONLY,
-  MYSTIQUE_SUGGESTIONS_S3_PREFIX,
 } from './utils/constants.js';
-import { isAiOnlyMode, buildUrlScopeForMode } from './mode-selector.js';
+import { isAiOnlyMode, getModeFromData } from './mode-selector.js';
+import { handleAiOnlyMode } from './ai-only-handler.js';
+import { sendPrerenderGuidanceRequestToMystique } from './guidance-request.js';
 
 function rebaseUrl(url, preferredBase, log) {
   try {
@@ -57,33 +59,6 @@ const AUDIT_ERROR_MESSAGE = 'Audit failed';
 
 // Domain-wide suggestion URL format (sync scrapedUrlsSet + prepareDomainWideAggregateSuggestion)
 const getDomainWideSuggestionUrl = (baseUrl) => `${baseUrl}/* (All Domain URLs)`;
-
-/**
- * Reads and parses the site's status.json from S3.
- * Returns {} when S3 is not configured, the file does not exist, or any read error occurs.
- * Logs a warning for unexpected errors (non-NoSuchKey).
- * @param {string} siteId
- * @param {Object} context
- * @returns {Promise<Object>}
- */
-async function readSiteStatusJson(siteId, context) {
-  const { s3Client, env, log } = context;
-  if (!env?.S3_SCRAPER_BUCKET_NAME || !s3Client) {
-    return {};
-  }
-  const statusKey = `${AUDIT_TYPE}/scrapes/${siteId}/status.json`;
-  try {
-    const response = await s3Client.send(
-      new GetObjectCommand({ Bucket: env.S3_SCRAPER_BUCKET_NAME, Key: statusKey }),
-    );
-    return JSON.parse(await response.Body.transformToString());
-  } catch (e) {
-    if (e.name !== 'NoSuchKey') {
-      log?.warn?.(`${LOG_PREFIX} Could not read status.json: ${e.message}. siteId=${siteId}`);
-    }
-    return {};
-  }
-}
 
 /** Skip re-scraping when status.json records a confirmed sticky block within this window. */
 const DOMAIN_STICKY_BOT_SKIP_MS = 3 * 24 * 60 * 60 * 1000;
@@ -392,35 +367,6 @@ function isNotRecentUrl(url, recentPathnames) {
 }
 
 /**
- * Sanitizes the import path by replacing special characters with hyphens
- * @param {string} importPath - The path to sanitize
- * @returns {string} The sanitized path
- */
-function sanitizeImportPath(importPath) {
-  return importPath
-    .replace(/^\/+|\/+$/g, '')
-    .replace(/[/._?=&]/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '');
-}
-
-/**
-* Transforms a URL into an S3 path for a given identifier and file type.
-* The identifier can be either a scrape job id or a site id.
-* @param {string} url - The URL to transform
-* @param {string} id - The identifier - scrapeJobId
-* @param {string} fileName - The file name (e.g., 'scrape.json', 'server-side.html',
-* 'client-side.html')
-* @returns {string} The S3 path to the file
-*/
-function getS3Path(url, id, fileName) {
-  const { pathname, search } = new URL(url);
-  const sanitizedImportPath = sanitizeImportPath(pathname + search);
-  const pathSegment = sanitizedImportPath ? `/${sanitizedImportPath}` : '';
-  return `${AUDIT_TYPE}/scrapes/${id}${pathSegment}/${fileName}`;
-}
-
-/**
  * Gets scraped HTML content and metadata from S3 for a specific URL
  * @param {string} url - Full URL
  * @param {Object} context - Audit context (must contain log, s3Client, env;
@@ -525,414 +471,6 @@ async function compareHtmlContent(url, context) {
     log.debug(`${LOG_PREFIX} HTML analysis failed for ${url}: ${error.message}`);
     return { ...scrapeContext, error: true, needsPrerender: false };
   }
-}
-
-/**
- * Parses the mode from the data field
- * @param {string|Object} data - The data field from the message
- * @returns {string|null} - The mode value or null
- */
-function getModeFromData(data) {
-  if (!data) {
-    return null;
-  }
-
-  try {
-    const parsedData = typeof data === 'string' ? JSON.parse(data) : data;
-    return parsedData.mode || null;
-  } catch (e) {
-    // Ignore parse errors
-    return null;
-  }
-}
-
-/**
- * Fetches the latest scrapeJobId from the status.json file in S3
- * @param {string} siteId - The site ID
- * @param {Object} context - Audit context with s3Client and env
- * @returns {Promise<string|null>} - The scrapeJobId or null if not found
- */
-async function fetchLatestScrapeJobId(siteId, context) {
-  const { log } = context;
-  log.info(`${LOG_PREFIX} ai-only: Fetching status.json for siteId=${siteId}`);
-  const statusData = await readSiteStatusJson(siteId, context);
-  if (statusData.scrapeJobId) {
-    log.info(`${LOG_PREFIX} ai-only: Found scrapeJobId: ${statusData.scrapeJobId}`);
-    return statusData.scrapeJobId;
-  }
-  log.warn(`${LOG_PREFIX} ai-only: No scrapeJobId found in status.json`);
-  return null;
-}
-
-/**
- * Sends a guidance:prerender message to Mystique with AI summary generation request
- * @param {string} auditUrl - Audited URL (site base URL)
- * @param {Object} auditData - Audit data used to build the message
- * @param {Object} opportunity - The prerender opportunity entity
- * @param {Object} context - Processing context
- * @param {Array|null} [preBuiltCandidates] - Pre-built candidate objects for normal audit runs.
- *   Each entry is { suggestionId, url, originalHtmlMarkdownKey, markdownDiffKey }.
- *   When null/omitted, candidates are derived from all DB suggestions (ai-only mode).
- * @param {boolean} [generatePrompts] - Whether to generate RCV prompts for the suggestions.
- * @returns {Promise<number>} - Number of suggestions sent to Mystique
- */
-async function sendPrerenderGuidanceRequestToMystique(
-  auditUrl,
-  auditData,
-  opportunity,
-  context,
-  preBuiltCandidates,
-  generatePrompts = false,
-  urlScope = null,
-) {
-  const {
-    log, sqs, env, site,
-  } = context;
-  /* c8 ignore start - Defensive checks and destructuring, tested in ai-only mode tests */
-  const {
-    siteId,
-    auditId,
-  } = auditData || {};
-
-  if (!sqs || !env?.QUEUE_SPACECAT_TO_MYSTIQUE) {
-    log.warn(`${LOG_PREFIX} SQS or Mystique queue not configured, skipping guidance:prerender message. baseUrl=${auditUrl || site?.getBaseURL?.() || ''}, siteId=${siteId}`);
-    return 0;
-  }
-
-  if (!opportunity || !opportunity.getId) {
-    log.warn(`${LOG_PREFIX} Opportunity entity not available, skipping guidance:prerender message. baseUrl=${auditUrl || site?.getBaseURL?.() || ''}, siteId=${siteId}`);
-    return 0;
-  }
-  /* c8 ignore stop */
-
-  const opportunityId = opportunity.getId();
-
-  try {
-    const baseUrl = auditUrl;
-
-    let suggestionsPayload;
-
-    /* c8 ignore next 4 - Normal run path exercised via processContentAndGenerateOpportunities */
-    if (preBuiltCandidates) {
-      suggestionsPayload = preBuiltCandidates;
-    } else {
-      // ai-only mode: no URL list available, derive candidates from all DB suggestions.
-      const existingSuggestions = await opportunity.getSuggestions();
-
-      /* c8 ignore next 4 - Defensive: empty suggestions
-       * filtered by buildUrlScopeForMode before here */
-      if (!existingSuggestions || existingSuggestions.length === 0) {
-        log.debug(`${LOG_PREFIX} No existing suggestions found for opportunityId=${opportunityId}, skipping Mystique message. baseUrl=${baseUrl}, siteId=${siteId}`);
-        return 0;
-      }
-
-      const candidates = [];
-
-      existingSuggestions.forEach((s) => {
-        const data = s.getData();
-
-        // Skip domain-wide aggregate suggestion and anything without URL
-        if (!data?.url || data?.isDomainWide) {
-          return;
-        }
-
-        // Skip OUTDATED and SKIPPED suggestions (stale or user-dismissed)
-        const status = s.getStatus();
-        const isDeployedOrFixed = status === Suggestion.STATUSES.FIXED || !!data?.edgeDeployed;
-        if (
-          status === Suggestion.STATUSES.OUTDATED
-          || status === Suggestion.STATUSES.SKIPPED
-          || isDeployedOrFixed
-        ) {
-          return;
-        }
-
-        const suggestionId = s.getId();
-
-        // Resolve the scrapeJobId in priority order:
-        //   1. data.scrapeJobId — stamped at suggestion-creation time (most reliable)
-        //   2. data.originalHtmlKey — extract the job segment from the stored S3 path
-        //      (format: prerender/scrapes/{scrapeJobId}/...)
-        //   3. Neither available → skip; we cannot build valid S3 keys without a job id
-        let effectiveScrapeJobId = data.scrapeJobId;
-        if (!effectiveScrapeJobId && data.originalHtmlKey) {
-          // prerender/scrapes/{scrapeJobId}/...
-          const parts = data.originalHtmlKey.split('/');
-          effectiveScrapeJobId = parts[2] || null;
-          if (effectiveScrapeJobId) {
-            log.debug(`${LOG_PREFIX} Suggestion ${suggestionId} missing scrapeJobId; `
-              + `derived from originalHtmlKey: ${effectiveScrapeJobId}. `
-              + `baseUrl=${baseUrl}, siteId=${siteId}`);
-          }
-        }
-        if (!effectiveScrapeJobId) {
-          log.warn(`${LOG_PREFIX} Suggestion ${suggestionId} skipped: no scrapeJobId and no `
-            + `originalHtmlKey to derive one from. baseUrl=${baseUrl}, siteId=${siteId}`);
-          return;
-        }
-
-        candidates.push({
-          suggestionId,
-          url: data.url,
-          originalHtmlMarkdownKey: getS3Path(data.url, effectiveScrapeJobId, 'server-side-html.md'),
-          markdownDiffKey: getS3Path(data.url, effectiveScrapeJobId, 'markdown-diff.md'),
-          // Signal whether this suggestion already has prompts so Mystique can skip re-generation
-          hasPrompts: Array.isArray(data.prompts) && data.prompts.length > 0,
-        });
-      });
-
-      suggestionsPayload = candidates;
-    }
-
-    // When a URL scope is provided (CSV batch), filter to only matching URLs
-    if (urlScope && suggestionsPayload.length > 0) {
-      suggestionsPayload = suggestionsPayload.filter((s) => urlScope.has(s.url));
-    }
-
-    if (suggestionsPayload.length === 0) {
-      log.info(`${LOG_PREFIX} No eligible suggestions to send to Mystique for opportunityId=${opportunityId}. baseUrl=${baseUrl}, siteId=${siteId}`);
-      return 0;
-    }
-
-    const deliveryType = site?.getDeliveryType?.() || 'unknown';
-
-    // Upload all suggestions to S3 and send just the S3 key via SQS.
-    // This avoids the 256 KB SQS message size limit — Mystique downloads from S3.
-    const { s3Client } = context;
-    const suggestionsS3Key = `${MYSTIQUE_SUGGESTIONS_S3_PREFIX}/${opportunityId}.json`;
-
-    await s3Client.send(new PutObjectCommand({
-      Bucket: env.S3_SCRAPER_BUCKET_NAME,
-      Key: suggestionsS3Key,
-      Body: JSON.stringify(suggestionsPayload),
-      ContentType: 'application/json',
-    }));
-
-    const time = new Date().toISOString();
-    const queue = env.QUEUE_SPACECAT_TO_MYSTIQUE;
-    await sqs.sendMessage(queue, {
-      type: 'guidance:prerender',
-      url: baseUrl,
-      siteId,
-      auditId,
-      deliveryType,
-      time,
-      data: {
-        opportunityId,
-        suggestionsS3Key,
-        suggestionsS3Bucket: env.S3_SCRAPER_BUCKET_NAME,
-        generatePrompts,
-        siteRegion: site.getRegion() ?? '',
-      },
-    });
-
-    log.info(`${LOG_PREFIX} Queued guidance:prerender message to Mystique for baseUrl=${baseUrl}, `
-      + `siteId=${siteId}, opportunityId=${opportunityId}, suggestions=${suggestionsPayload.length}, `
-      + `suggestionsS3Key=${suggestionsS3Key}`);
-    return suggestionsPayload.length;
-  /* c8 ignore next 8 - Error handling for SQS failures when sending to Mystique,
-   * difficult to test reliably */
-  } catch (error) {
-    log.error(`${LOG_PREFIX} Failed to send guidance:prerender message to Mystique for opportunityId=${opportunityId}, `
-      + `baseUrl=${auditUrl}, siteId=${siteId}: ${error.message}`, error);
-    return 0;
-  }
-}
-
-/**
- * Handles AI-summary-only mode: sends existing suggestions to Mystique without running audit.
- * Called early in step 1 to bypass import/scraping/processing steps.
- * @param {Object} context - Audit context
- * @returns {Promise<Object>} - Result indicating success/failure
- */
-export async function handleAiOnlyMode(context) {
-  const {
-    site, log, dataAccess, data, auditContext,
-  } = context;
-  const { Opportunity } = dataAccess;
-  const siteId = site.getId();
-  const baseUrl = site.getBaseURL();
-
-  // Resolve mode early so error returns use the correct value in fullAuditRef.
-  // Default to MODE_AI_ONLY when data is malformed — the caller (importTopPages)
-  // already verified isAiOnlyMode before dispatching here.
-  const mode = getModeFromData(data) || MODE_AI_ONLY;
-
-  // Parse optional params from data field (opportunityId, scrapeJobId, generatePrompts)
-  let opportunityId = null;
-  let scrapeJobId = null;
-  let generatePrompts = false;
-  try {
-    const parsedData = typeof data === 'string' ? JSON.parse(data) : data;
-    if (parsedData) {
-      opportunityId = parsedData.opportunityId;
-      scrapeJobId = parsedData.scrapeJobId;
-      generatePrompts = !!parsedData.generatePrompts;
-    }
-  } catch (e) {
-    // Ignore parse errors
-    // Non-JSON data — graceful degradation, values stay at defaults
-    log.warn(`${LOG_PREFIX} Failed to parse context.data for opportunityId, scrapeJobId, generatePrompts, defaulting to null, null, false: ${e.message}`);
-  }
-
-  log.info(`${LOG_PREFIX} ai-only: Processing AI summary request for baseUrl=${baseUrl}, siteId=${siteId}, opportunityId=${opportunityId || 'latest'}, generatePrompts=${generatePrompts}`);
-
-  // Fetch scrapeJobId from status.json if not provided
-  if (!scrapeJobId) {
-    log.info(`${LOG_PREFIX} ai-only: scrapeJobId not provided, fetching from status.json for baseUrl=${baseUrl}, siteId=${siteId}`);
-    scrapeJobId = await fetchLatestScrapeJobId(siteId, context);
-
-    if (!scrapeJobId) {
-      const error = 'scrapeJobId not found. Either provide it in data or ensure a prerender audit has run recently.';
-      log.error(`${LOG_PREFIX} ai-only: ${error} baseUrl=${baseUrl}, siteId=${siteId}`);
-      return {
-        error,
-        status: 'failed',
-        fullAuditRef: `${mode}/failed-${siteId}`,
-        auditResult: { error },
-      };
-    }
-  }
-
-  // Find the opportunity
-  let opportunity;
-  if (opportunityId) {
-    opportunity = await Opportunity.findById(opportunityId);
-    if (!opportunity) {
-      const error = `Opportunity not found: ${opportunityId}`;
-      log.error(`${LOG_PREFIX} ai-only: ${error} baseUrl=${baseUrl}, siteId=${siteId}`);
-      return {
-        error,
-        status: 'failed',
-        fullAuditRef: `${mode}/failed-${siteId}`,
-        auditResult: { error },
-      };
-    }
-  } else {
-    // Find latest NEW prerender opportunity for this site
-    const opportunities = await Opportunity.allBySiteIdAndStatus(siteId, 'NEW');
-    opportunity = opportunities.find((o) => o.getType() === AUDIT_TYPE);
-
-    if (!opportunity) {
-      const error = `No NEW prerender opportunity found for site: ${siteId}`;
-      log.error(`${LOG_PREFIX} ai-only: ${error} baseUrl=${baseUrl}, siteId=${siteId}`);
-      return {
-        error,
-        status: 'failed',
-        fullAuditRef: `${mode}/failed-${siteId}`,
-        auditResult: { error },
-      };
-    }
-
-    log.info(`${LOG_PREFIX} ai-only: Found latest NEW opportunity: ${opportunity.getId()} for baseUrl=${baseUrl}, siteId=${siteId}`);
-  }
-
-  // Verify opportunity belongs to the site
-  if (opportunity.getSiteId() !== siteId) {
-    const error = `Opportunity ${opportunity.getId()} does not belong to site ${siteId}`;
-    log.error(`${LOG_PREFIX} ai-only: ${error} baseUrl=${baseUrl}, siteId=${siteId}`);
-    return {
-      error,
-      status: 'failed',
-      fullAuditRef: `${MODE_AI_ONLY}/failed-${siteId}`,
-      auditResult: { error },
-    };
-  }
-
-  // Fetch suggestions once and build candidates directly — avoids a redundant
-  // DB fetch inside sendPrerenderGuidanceRequestToMystique and ensures mode-specific
-  // filtering (e.g. including FIXED suggestions for ai-only-missing) is respected.
-  const allSuggestions = await opportunity.getSuggestions();
-
-  // Determine which URLs are in scope via explicit CSV or mode-based filter.
-  let urlScope = null;
-  if (Array.isArray(auditContext?.urls) && auditContext.urls.length > 0) {
-    urlScope = new Set(auditContext.urls);
-    log.info(`${LOG_PREFIX} ai-only: Scoping to ${urlScope.size} explicit URLs from auditContext. baseUrl=${baseUrl}, siteId=${siteId}`);
-  } else {
-    urlScope = buildUrlScopeForMode(mode, allSuggestions);
-    if (urlScope.size === 0) {
-      log.info(`${LOG_PREFIX} ai-only: No suggestions match mode=${mode} for baseUrl=${baseUrl}, siteId=${siteId}`);
-      return {
-        status: 'complete',
-        mode,
-        opportunityId: opportunity.getId(),
-        fullAuditRef: `${mode}/${opportunity.getId()}`,
-        auditResult: { message: 'No suggestions match the requested mode', suggestionCount: 0 },
-      };
-    }
-    log.info(`${LOG_PREFIX} ai-only: Scoping to ${urlScope.size} URLs from DB suggestions (mode=${mode}). baseUrl=${baseUrl}, siteId=${siteId}`);
-  }
-
-  // Build candidates from the already-fetched suggestions so the downstream
-  // function receives them as preBuiltCandidates and skips its own filter.
-  const candidates = [];
-  for (const s of (allSuggestions || [])) {
-    const d = s.getData();
-    if (!d?.url || d.isDomainWide || !urlScope.has(d.url)) {
-      // eslint-disable-next-line no-continue
-      continue;
-    }
-
-    const suggestionId = s.getId?.();
-
-    // Resolve the scrapeJobId in priority order:
-    //   1. data.scrapeJobId — stamped at suggestion-creation time
-    //   2. data.originalHtmlKey — extract the job segment from the S3 path
-    //   3. Neither available → skip
-    let effectiveScrapeJobId = d.scrapeJobId;
-    if (!effectiveScrapeJobId && d.originalHtmlKey) {
-      const parts = d.originalHtmlKey.split('/');
-      effectiveScrapeJobId = parts[2] || null;
-      if (effectiveScrapeJobId) {
-        log.debug(`${LOG_PREFIX} Suggestion ${suggestionId} missing scrapeJobId; `
-          + `derived from originalHtmlKey: ${effectiveScrapeJobId}. `
-          + `baseUrl=${baseUrl}, siteId=${siteId}`);
-      }
-    }
-    if (!effectiveScrapeJobId) {
-      log.warn(`${LOG_PREFIX} Suggestion ${suggestionId} skipped: no scrapeJobId and no `
-        + `originalHtmlKey to derive one from. baseUrl=${baseUrl}, siteId=${siteId}`);
-      // eslint-disable-next-line no-continue
-      continue;
-    }
-
-    candidates.push({
-      suggestionId,
-      url: d.url,
-      originalHtmlMarkdownKey: getS3Path(d.url, effectiveScrapeJobId, 'server-side-html.md'),
-      markdownDiffKey: getS3Path(d.url, effectiveScrapeJobId, 'markdown-diff.md'),
-      hasPrompts: Array.isArray(d.prompts) && d.prompts.length > 0,
-    });
-  }
-
-  const auditData = {
-    siteId,
-    auditId: opportunity.getAuditId() || `prerender-ai-only-${siteId}`,
-    scrapeJobId,
-  };
-
-  const suggestionCount = await sendPrerenderGuidanceRequestToMystique(
-    site.getBaseURL(),
-    auditData,
-    opportunity,
-    context,
-    candidates,
-    generatePrompts,
-  );
-
-  log.info(`${LOG_PREFIX} ai-only: Successfully queued AI summary request for ${suggestionCount} suggestion(s). baseUrl=${baseUrl}, siteId=${siteId}, opportunityId=${opportunity.getId()}`);
-
-  return {
-    status: 'complete',
-    mode,
-    opportunityId: opportunity.getId(),
-    fullAuditRef: `${mode}/${opportunity.getId()}`,
-    auditResult: {
-      message: `AI summary generation queued successfully for ${suggestionCount} suggestion(s)`,
-      suggestionCount,
-    },
-  };
 }
 
 /**

--- a/src/prerender/mode-selector.js
+++ b/src/prerender/mode-selector.js
@@ -27,6 +27,27 @@ export function isAiOnlyMode(mode) {
   return AI_ONLY_MODES.has(mode);
 }
 
+/**
+ * Extracts the `mode` value from the audit `data` field.
+ * Accepts either a JSON string or an already-parsed object and returns the
+ * `mode` property, or null when absent or unparseable.
+ * @param {string|Object|null} data - The audit data field
+ * @returns {string|null}
+ */
+export function getModeFromData(data) {
+  if (!data) {
+    return null;
+  }
+
+  try {
+    const parsedData = typeof data === 'string' ? JSON.parse(data) : data;
+    return parsedData.mode || null;
+  } catch (e) {
+    // Ignore parse errors
+    return null;
+  }
+}
+
 const EXCLUDED_STATUSES = new Set(['OUTDATED', 'SKIPPED', 'FIXED']);
 
 /**

--- a/src/prerender/utils/utils.js
+++ b/src/prerender/utils/utils.js
@@ -14,9 +14,13 @@
  * General utilities for the Prerender audit.
  */
 
-import { Entitlement } from '@adobe/spacecat-shared-data-access';
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+import { Audit, Entitlement } from '@adobe/spacecat-shared-data-access';
 import { TierClient } from '@adobe/spacecat-shared-tier-client';
 import { DOMAIN_WIDE_SUGGESTION_KEY } from './constants.js';
+
+const LOG_PREFIX = 'Prerender -';
+const AUDIT_TYPE = Audit.AUDIT_TYPES.PRERENDER;
 
 /**
  * Common non-HTML file extensions that should be filtered out
@@ -182,4 +186,78 @@ export async function isPaidLLMOCustomer(context) {
     log.warn(`Prerender - Failed to check paid LLMO customer status for siteId=${site.getId()}: ${e.message}`);
     return false;
   }
+}
+
+/**
+ * Sanitizes the import path by replacing special characters with hyphens
+ * @param {string} importPath - The path to sanitize
+ * @returns {string} The sanitized path
+ */
+function sanitizeImportPath(importPath) {
+  return importPath
+    .replace(/^\/+|\/+$/g, '')
+    .replace(/[/._?=&]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+/**
+* Transforms a URL into an S3 path for a given identifier and file type.
+* The identifier can be either a scrape job id or a site id.
+* @param {string} url - The URL to transform
+* @param {string} id - The identifier - scrapeJobId
+* @param {string} fileName - The file name (e.g., 'scrape.json', 'server-side.html',
+* 'client-side.html')
+* @returns {string} The S3 path to the file
+*/
+export function getS3Path(url, id, fileName) {
+  const { pathname, search } = new URL(url);
+  const sanitizedImportPath = sanitizeImportPath(pathname + search);
+  const pathSegment = sanitizedImportPath ? `/${sanitizedImportPath}` : '';
+  return `${AUDIT_TYPE}/scrapes/${id}${pathSegment}/${fileName}`;
+}
+
+/**
+ * Reads and parses the site's status.json from S3.
+ * Returns {} when S3 is not configured, the file does not exist, or any read error occurs.
+ * Logs a warning for unexpected errors (non-NoSuchKey).
+ * @param {string} siteId
+ * @param {Object} context
+ * @returns {Promise<Object>}
+ */
+export async function readSiteStatusJson(siteId, context) {
+  const { s3Client, env, log } = context;
+  if (!env?.S3_SCRAPER_BUCKET_NAME || !s3Client) {
+    return {};
+  }
+  const statusKey = `${AUDIT_TYPE}/scrapes/${siteId}/status.json`;
+  try {
+    const response = await s3Client.send(
+      new GetObjectCommand({ Bucket: env.S3_SCRAPER_BUCKET_NAME, Key: statusKey }),
+    );
+    return JSON.parse(await response.Body.transformToString());
+  } catch (e) {
+    if (e.name !== 'NoSuchKey') {
+      log?.warn?.(`${LOG_PREFIX} Could not read status.json: ${e.message}. siteId=${siteId}`);
+    }
+    return {};
+  }
+}
+
+/**
+ * Fetches the latest scrapeJobId from the status.json file in S3
+ * @param {string} siteId - The site ID
+ * @param {Object} context - Audit context with s3Client and env
+ * @returns {Promise<string|null>} - The scrapeJobId or null if not found
+ */
+export async function fetchLatestScrapeJobId(siteId, context) {
+  const { log } = context;
+  log.info(`${LOG_PREFIX} ai-only: Fetching status.json for siteId=${siteId}`);
+  const statusData = await readSiteStatusJson(siteId, context);
+  if (statusData.scrapeJobId) {
+    log.info(`${LOG_PREFIX} ai-only: Found scrapeJobId: ${statusData.scrapeJobId}`);
+    return statusData.scrapeJobId;
+  }
+  log.warn(`${LOG_PREFIX} ai-only: No scrapeJobId found in status.json`);
+  return null;
 }

--- a/test/audits/prerender/ai-only-mode.test.js
+++ b/test/audits/prerender/ai-only-mode.test.js
@@ -17,8 +17,8 @@ import {
   importTopPages,
   submitForScraping,
   processContentAndGenerateOpportunities,
-  handleAiOnlyMode,
 } from '../../../src/prerender/handler.js';
+import { handleAiOnlyMode } from '../../../src/prerender/ai-only-handler.js';
 
 use(sinonChai);
 

--- a/test/audits/prerender/behaviour/ai-only-mode.test.js
+++ b/test/audits/prerender/behaviour/ai-only-mode.test.js
@@ -1,0 +1,401 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Behavioural contracts: AI-only mode
+ *
+ * AI-only mode is triggered by context.data = { mode: 'ai-only' }.
+ * It bypasses scraping entirely — step 1 dispatches directly to Mystique,
+ * steps 2 and 3 return immediately with { status: 'skipped' }.
+ *
+ * Covers:
+ *   - Step 2 + Step 3 skip: no S3/DB reads, immediate return
+ *   - Step 1 happy path: scrapeJobId + NEW opportunity → complete
+ *   - Step 1 no scrapeJobId: status.json has no job → failed
+ *   - Step 1 no NEW opportunity: no matching opportunity in DB → failed
+ */
+
+/* eslint-env mocha */
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import {
+  importTopPages,
+  submitForScraping,
+  processContentAndGenerateOpportunities,
+} from '../../../../src/prerender/handler.js';
+import {
+  buildContext,
+  buildSite,
+  buildS3Client,
+  buildDataAccess,
+  buildOpportunity,
+  buildSuggestion,
+  statusKey,
+  buildStatus,
+} from './helpers.js';
+
+use(sinonChai);
+
+describe('Prerender behaviour — AI-only mode', () => {
+  let sandbox;
+
+  beforeEach(() => { sandbox = sinon.createSandbox(); });
+  afterEach(() => { sandbox.restore(); });
+
+  // ─── Step 2 + 3 skip ──────────────────────────────────────────────────────────
+
+  it('Step 2: data.mode=ai-only → returns skipped immediately, S3 never read', async () => {
+    const s3Client = buildS3Client(sandbox); // no keys — any read would NoSuchKey
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: 'site-ai-step2', baseUrl: 'https://example.com' }),
+      s3Client,
+      data: { mode: 'ai-only' },
+    });
+
+    const result = await submitForScraping(ctx);
+
+    expect(result).to.deep.include({ status: 'skipped', mode: 'ai-only' });
+    // S3 must never be touched — the step exits before any I/O
+    expect(s3Client.send).to.not.have.been.called;
+  });
+
+  it('Step 3: data.mode=ai-only → returns skipped immediately, no opportunity lookup', async () => {
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: 'site-ai-step3', baseUrl: 'https://example.com' }),
+      data: { mode: 'ai-only' },
+    });
+
+    const result = await processContentAndGenerateOpportunities(ctx);
+
+    expect(result).to.deep.include({ status: 'skipped', mode: 'ai-only' });
+    expect(ctx.dataAccess.Opportunity.allBySiteIdAndStatus).to.not.have.been.called;
+  });
+
+  // ─── Step 1 happy path ────────────────────────────────────────────────────────
+
+  it('Step 1: scrapeJobId in data + NEW opportunity found → status=complete, mode=ai-only', async () => {
+    const siteId = 'site-ai-happy';
+    const scrapeJobId = 'job-ai-123';
+
+    // Opportunity with two non-domain-wide suggestions for Mystique to process
+    const suggestion = buildSuggestion(sandbox, {
+      id: 'sug-ai-1',
+      status: 'NEW',
+      data: { url: 'https://example.com/page-1', scrapeJobId },
+    });
+    const opportunity = buildOpportunity(sandbox, {
+      id: 'opp-ai-1',
+      siteId,
+      suggestions: [suggestion],
+    });
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox),
+      dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+      data: { mode: 'ai-only', scrapeJobId },
+    });
+
+    const result = await importTopPages(ctx);
+
+    expect(result).to.have.property('status', 'complete');
+    expect(result).to.have.property('mode', 'ai-only');
+    expect(result).to.have.property('fullAuditRef').that.includes('ai-only/opp-ai-1');
+    // SQS message sent to Mystique queue
+    expect(ctx.sqs.sendMessage).to.have.been.called;
+  });
+
+  // ─── Step 1 failure paths ─────────────────────────────────────────────────────
+
+  it('Step 1: no scrapeJobId in data or status.json → status=failed', async () => {
+    const siteId = 'site-ai-no-job';
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      // status.json has no scrapeJobId field → fetchLatestScrapeJobId returns null
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(), // no scrapeJobId in status
+      }),
+      data: { mode: 'ai-only' }, // no scrapeJobId in data either
+    });
+
+    const result = await importTopPages(ctx);
+
+    expect(result).to.have.property('status', 'failed');
+    expect(result).to.have.property('fullAuditRef').that.includes(`failed-${siteId}`);
+    expect(ctx.log.error).to.have.been.called;
+  });
+
+  it('Step 1: scrapeJobId found but no NEW prerender opportunity exists → status=failed', async () => {
+    const siteId = 'site-ai-no-opp';
+    const scrapeJobId = 'job-ai-456';
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox),
+      // No NEW opportunities in DB
+      dataAccess: buildDataAccess(sandbox, { opportunities: [] }),
+      data: { mode: 'ai-only', scrapeJobId },
+    });
+
+    const result = await importTopPages(ctx);
+
+    expect(result).to.have.property('status', 'failed');
+    expect(result).to.have.property('fullAuditRef').that.includes(`failed-${siteId}`);
+    expect(ctx.log.error).to.have.been.called;
+  });
+
+  // ─── Step 1 opportunity resolution ──────────────────────────────────────────
+
+  it('Step 1: opportunityId in data → resolved via findById (not latest-NEW lookup) → complete', async () => {
+    const siteId = 'site-ai-byid';
+    const scrapeJobId = 'job-ai-byid';
+
+    const suggestion = buildSuggestion(sandbox, {
+      id: 'sug-byid',
+      status: 'NEW',
+      data: { url: 'https://example.com/by-id', scrapeJobId },
+    });
+    const opportunity = buildOpportunity(sandbox, {
+      id: 'opp-explicit',
+      siteId,
+      suggestions: [suggestion],
+    });
+    const dataAccess = buildDataAccess(sandbox, { opportunities: [opportunity] });
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox),
+      dataAccess,
+      data: { mode: 'ai-only', opportunityId: 'opp-explicit', scrapeJobId },
+    });
+
+    const result = await importTopPages(ctx);
+
+    expect(result).to.have.property('status', 'complete');
+    expect(result).to.have.property('fullAuditRef').that.includes('opp-explicit');
+    expect(dataAccess.Opportunity.findById).to.have.been.calledWith('opp-explicit');
+    // The explicit-id path must bypass the latest-NEW lookup entirely
+    expect(dataAccess.Opportunity.allBySiteIdAndStatus).to.not.have.been.called;
+  });
+
+  it('Step 1: opportunityId in data but not found in DB → status=failed', async () => {
+    const siteId = 'site-ai-byid-missing';
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox),
+      dataAccess: buildDataAccess(sandbox, { opportunities: [] }), // findById → null
+      data: { mode: 'ai-only', opportunityId: 'missing-opp', scrapeJobId: 'job-x' },
+    });
+
+    const result = await importTopPages(ctx);
+
+    expect(result).to.have.property('status', 'failed');
+    expect(result).to.have.property('fullAuditRef').that.includes(`failed-${siteId}`);
+    expect(ctx.log.error).to.have.been.calledWithMatch(/Opportunity not found: missing-opp/);
+  });
+
+  it('Step 1: resolved opportunity belongs to a different site → status=failed', async () => {
+    const siteId = 'site-requester';
+
+    // findById returns an opportunity owned by a DIFFERENT site
+    const opportunity = buildOpportunity(sandbox, {
+      id: 'opp-other-site',
+      siteId: 'site-other',
+      suggestions: [],
+    });
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox),
+      dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+      data: { mode: 'ai-only', opportunityId: 'opp-other-site', scrapeJobId: 'job-c' },
+    });
+
+    const result = await importTopPages(ctx);
+
+    expect(result).to.have.property('status', 'failed');
+    expect(result).to.have.property('fullAuditRef').that.includes(`failed-${siteId}`);
+    expect(ctx.log.error).to.have.been.calledWithMatch(/does not belong to site/);
+  });
+
+  // ─── Step 1 scope resolution ────────────────────────────────────────────────
+
+  it('Step 1: no suggestion matches the mode → status=complete, suggestionCount 0, Mystique NOT called', async () => {
+    const siteId = 'site-ai-empty-scope';
+    const scrapeJobId = 'job-ai-empty';
+
+    // The only suggestion is FIXED → excluded by the ai-only filter → empty scope
+    const fixed = buildSuggestion(sandbox, {
+      id: 'sug-fixed',
+      status: 'FIXED',
+      data: { url: 'https://example.com/fixed', scrapeJobId },
+    });
+    const opportunity = buildOpportunity(sandbox, {
+      id: 'opp-ai-empty',
+      siteId,
+      suggestions: [fixed],
+    });
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox),
+      dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+      data: { mode: 'ai-only', scrapeJobId },
+    });
+
+    const result = await importTopPages(ctx);
+
+    expect(result).to.have.property('status', 'complete');
+    expect(result.auditResult).to.have.property('suggestionCount', 0);
+    // Early-return before dispatch: no S3 upload, no SQS message
+    expect(ctx.sqs.sendMessage).to.not.have.been.called;
+  });
+
+  it('Step 1: scrapeJobId absent in data but present in status.json → complete + SQS sent', async () => {
+    const siteId = 'site-ai-statusjob';
+    const jobFromStatus = 'job-from-status-json';
+
+    const suggestion = buildSuggestion(sandbox, {
+      id: 'sug-statusjob',
+      status: 'NEW',
+      data: { url: 'https://example.com/needs-ai', scrapeJobId: jobFromStatus },
+    });
+    const opportunity = buildOpportunity(sandbox, {
+      id: 'opp-statusjob',
+      siteId,
+      suggestions: [suggestion],
+    });
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus({ scrapeJobId: jobFromStatus }),
+      }),
+      dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+      data: { mode: 'ai-only' }, // no scrapeJobId — must be resolved from status.json
+    });
+
+    const result = await importTopPages(ctx);
+
+    expect(result).to.have.property('status', 'complete');
+    expect(ctx.sqs.sendMessage).to.have.been.called;
+  });
+
+  // ─── New ai-only mode variants ──────────────────────────────────────────────
+
+  it('Step 1: mode=ai-only-current routes through ai-only handling → complete, mode echoed', async () => {
+    const siteId = 'site-ai-current';
+    const scrapeJobId = 'job-current';
+
+    // NEW, not covered/deployed/pattern-matched → eligible for ai-only-current
+    const suggestion = buildSuggestion(sandbox, {
+      id: 'sug-current',
+      status: 'NEW',
+      data: { url: 'https://example.com/current', scrapeJobId },
+    });
+    const opportunity = buildOpportunity(sandbox, {
+      id: 'opp-current',
+      siteId,
+      suggestions: [suggestion],
+    });
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox),
+      dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+      data: { mode: 'ai-only-current', scrapeJobId },
+    });
+
+    const result = await importTopPages(ctx);
+
+    expect(result).to.have.property('status', 'complete');
+    expect(result).to.have.property('mode', 'ai-only-current');
+    expect(ctx.sqs.sendMessage).to.have.been.called;
+  });
+
+  it('Steps 2 & 3: ai-only-current and ai-only-missing also skip immediately', async () => {
+    for (const mode of ['ai-only-current', 'ai-only-missing']) {
+      // eslint-disable-next-line no-await-in-loop
+      const step2 = await submitForScraping(buildContext(sandbox, {
+        site: buildSite({ id: `s2-${mode}`, baseUrl: 'https://example.com' }),
+        data: { mode },
+      }));
+      expect(step2).to.deep.include({ status: 'skipped', mode });
+
+      // eslint-disable-next-line no-await-in-loop
+      const step3 = await processContentAndGenerateOpportunities(buildContext(sandbox, {
+        site: buildSite({ id: `s3-${mode}`, baseUrl: 'https://example.com' }),
+        data: { mode },
+      }));
+      expect(step3).to.deep.include({ status: 'skipped', mode });
+    }
+  });
+
+  // ─── Explicit URL scope (CSV batch) ─────────────────────────────────────────
+
+  it('Step 1: explicit auditContext.urls scopes to those URLs and dispatches to Mystique', async () => {
+    const siteId = 'site-ai-csv';
+    const scrapeJobId = 'job-csv';
+    const inCsv = 'https://example.com/listed-in-csv';
+    const notInCsv = 'https://example.com/not-listed';
+
+    const listed = buildSuggestion(sandbox, {
+      id: 'sug-listed', status: 'NEW', data: { url: inCsv, scrapeJobId },
+    });
+    const unlisted = buildSuggestion(sandbox, {
+      id: 'sug-unlisted', status: 'NEW', data: { url: notInCsv, scrapeJobId },
+    });
+    const opportunity = buildOpportunity(sandbox, {
+      id: 'opp-csv', siteId, suggestions: [listed, unlisted],
+    });
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox),
+      dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+      auditContext: { urls: [inCsv] },
+      data: { mode: 'ai-only', scrapeJobId },
+    });
+
+    const result = await importTopPages(ctx);
+
+    expect(result).to.have.property('status', 'complete');
+    expect(ctx.sqs.sendMessage).to.have.been.called;
+    const putCall = ctx.s3Client.send.getCalls()
+      .find((c) => c.args[0]?.input?.Key?.includes('mystique-suggestions'));
+    const urls = JSON.parse(putCall.args[0].input.Body).map((s) => s.url);
+    expect(urls).to.deep.equal([inCsv]); // only the CSV-listed URL
+  });
+
+  it('Step 1: explicit auditContext.urls with no DB suggestions → complete, nothing dispatched', async () => {
+    const siteId = 'site-ai-csv-empty';
+    const opportunity = buildOpportunity(sandbox, { id: 'opp-csv-empty', siteId, suggestions: [] });
+    // getSuggestions resolves null → exercises the (suggestions || []) guard during candidate build
+    opportunity.getSuggestions = sandbox.stub().resolves(null);
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox),
+      dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+      auditContext: { urls: ['https://example.com/from-csv'] },
+      data: { mode: 'ai-only', scrapeJobId: 'job-csv-empty' },
+    });
+
+    const result = await importTopPages(ctx);
+
+    expect(result).to.have.property('status', 'complete');
+    expect(ctx.sqs.sendMessage).to.not.have.been.called;
+  });
+});

--- a/test/audits/prerender/behaviour/helpers.js
+++ b/test/audits/prerender/behaviour/helpers.js
@@ -1,0 +1,344 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Shared factory helpers for prerender behavioural contract tests.
+ *
+ * Rule: helpers mock only EXTERNAL dependencies — S3, SQS, DB entities.
+ * They never stub internal handler functions (convertToOpportunity,
+ * getObjectFromKey, syncSuggestions, etc.). That keeps these tests
+ * green through any internal refactoring or module extraction.
+ */
+
+// ─── HTML fixtures ────────────────────────────────────────────────────────────
+
+/** Identical server/client HTML — ratio = 1.0, needsPrerender = false. */
+export const HTML_SAME = '<html><body><p>identical content for both server and client sides testing</p></body></html>';
+
+/** Server-side with few words; pair with HTML_CLIENT_NEEDS_PRERENDER for ratio >> 1.1. */
+export const HTML_SERVER_SPARSE = '<html><body><p>few words here</p></body></html>';
+
+/** Client-side with many words — ratio vs HTML_SERVER_SPARSE well above 1.1 threshold. */
+export const HTML_CLIENT_NEEDS_PRERENDER = `<html><body><p>${'word '.repeat(60).trim()}</p></body></html>`;
+
+// ─── S3 key helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Mirrors handler.js sanitizeImportPath + getS3Path to compute canonical S3 keys
+ * for a given scrapeJobId + URL triple (server-side.html, client-side.html, scrape.json).
+ *
+ * Used in test keyMaps so there's a single source of truth for the expected key format.
+ */
+export function scrapeKeys(scrapeJobId, url) {
+  const { pathname } = new URL(url);
+  const sanitized = pathname
+    .replace(/^\/+|\/+$/g, '')
+    .replace(/[/._]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  const segment = sanitized ? `/${sanitized}` : '';
+  const base = `prerender/scrapes/${scrapeJobId}${segment}`;
+  return {
+    serverHtml: `${base}/server-side.html`,
+    clientHtml: `${base}/client-side.html`,
+    scrapeJson: `${base}/scrape.json`,
+  };
+}
+
+/**
+ * Builds a partial S3 keyMap for one URL — ready to spread into the full keyMap.
+ *
+ * @param {string} scrapeJobId
+ * @param {string} url
+ * @param {Object} options
+ * @param {string} [options.serverHtml=HTML_SAME]
+ * @param {string} [options.clientHtml=HTML_SAME]
+ * @param {Object} [options.scrapeJson={ isDeployedAtEdge: false }]
+ */
+export function buildUrlS3Content(scrapeJobId, url, {
+  serverHtml = HTML_SAME,
+  clientHtml = HTML_SAME,
+  scrapeJson = { isDeployedAtEdge: false },
+} = {}) {
+  const keys = scrapeKeys(scrapeJobId, url);
+  return {
+    [keys.serverHtml]: serverHtml,
+    [keys.clientHtml]: clientHtml,
+    [keys.scrapeJson]: scrapeJson,
+  };
+}
+
+// ─── Site ─────────────────────────────────────────────────────────────────────
+
+export function buildSite({
+  id = 'test-site-id',
+  baseUrl = 'https://example.com',
+  includedUrls = [],
+  overrideBaseURL = null,
+} = {}) {
+  const fetchConfig = overrideBaseURL ? { getFetchConfig: () => ({ overrideBaseURL }) } : {};
+  return {
+    getId: () => id,
+    getBaseURL: () => baseUrl,
+    getDeliveryType: () => 'aem_edge',
+    getRegion: () => 'us-east-1',
+    getConfig: () => ({
+      getIncludedURLs: () => Promise.resolve(includedUrls),
+      ...fetchConfig,
+    }),
+  };
+}
+
+// ─── Logger ───────────────────────────────────────────────────────────────────
+
+export function buildLog(sandbox) {
+  return {
+    info: sandbox.stub(),
+    warn: sandbox.stub(),
+    error: sandbox.stub(),
+    debug: sandbox.stub(),
+  };
+}
+
+// ─── S3 client ────────────────────────────────────────────────────────────────
+
+/** Convenience: creates the NoSuchKey error S3 SDK throws for missing objects. */
+export function noSuchKeyError() {
+  const err = new Error('The specified key does not exist.');
+  err.name = 'NoSuchKey';
+  return err;
+}
+
+/**
+ * Builds an S3 client stub that dispatches by key.
+ *
+ * keyMap values:
+ *   - string       → raw body (no ContentType) — use for HTML
+ *   - plain object → JSON body with ContentType: application/json
+ *   - Error        → rejected (use noSuchKeyError() for missing keys)
+ *   - absent key   → rejects with NoSuchKey automatically
+ *
+ * PutObjectCommand always resolves; use captureStatusWrite(s3Client) to inspect.
+ */
+export function buildS3Client(sandbox, keyMap = {}) {
+  const send = sandbox.stub().callsFake((cmd) => {
+    if (cmd.constructor.name === 'GetObjectCommand') {
+      const { Key } = cmd.input;
+      if (Object.hasOwn(keyMap, Key)) {
+        const value = keyMap[Key];
+        if (value instanceof Error) {
+          return Promise.reject(value);
+        }
+        const isString = typeof value === 'string';
+        const body = isString ? value : JSON.stringify(value);
+        return Promise.resolve({
+          Body: { transformToString: () => Promise.resolve(body) },
+          ...(isString ? {} : { ContentType: 'application/json' }),
+        });
+      }
+      return Promise.reject(noSuchKeyError());
+    }
+    if (cmd.constructor.name === 'PutObjectCommand') {
+      return Promise.resolve({});
+    }
+    return Promise.reject(new Error(`Unexpected S3 command: ${cmd.constructor.name}`));
+  });
+  return { send };
+}
+
+/** Canonical S3 key for a site's status.json. */
+export function statusKey(siteId) {
+  return `prerender/scrapes/${siteId}/status.json`;
+}
+
+// ─── Status.json shape ────────────────────────────────────────────────────────
+
+/**
+ * Builds a valid status.json object.
+ * pages[] entries follow the shape: { url, pathname, needsPrerender, isDeployedAtEdge }
+ */
+export function buildStatus({
+  scrapeForbidden = false,
+  scrapeForbiddenSince = undefined,
+  scrapeJobId = undefined,
+  pages = [],
+} = {}) {
+  const status = { scrapeForbidden, pages };
+  if (scrapeForbiddenSince !== undefined) {
+    status.scrapeForbiddenSince = scrapeForbiddenSince;
+  }
+  if (scrapeJobId !== undefined) {
+    status.scrapeJobId = scrapeJobId;
+  }
+  return status;
+}
+
+/** Returns a scrapeForbiddenSince timestamp N days in the past. */
+export function daysAgo(n) {
+  return new Date(Date.now() - n * 24 * 60 * 60 * 1000).toISOString();
+}
+
+// ─── Suggestion ───────────────────────────────────────────────────────────────
+
+export function buildSuggestion(sandbox, {
+  id = 'suggestion-id',
+  siteId = 'test-site-id',
+  status = 'NEW',
+  data = {},
+} = {}) {
+  return {
+    getId: () => id,
+    getSiteId: () => siteId,
+    getStatus: () => status,
+    getData: () => data,
+    setData: sandbox.stub(),
+    setStatus: sandbox.stub(),
+    setUpdatedBy: sandbox.stub(),
+    save: sandbox.stub().resolvesThis(),
+  };
+}
+
+// ─── Opportunity ──────────────────────────────────────────────────────────────
+
+export function buildOpportunity(sandbox, {
+  id = 'opportunity-id',
+  siteId = 'test-site-id',
+  type = 'prerender',
+  status = 'NEW',
+  suggestions = [],
+  data = {},
+} = {}) {
+  return {
+    getId: () => id,
+    getSiteId: () => siteId,
+    getType: () => type,
+    getStatus: () => status,
+    getAuditId: () => 'audit-id',
+    getData: () => data,
+    setAuditId: sandbox.stub(),
+    setData: sandbox.stub(),
+    setStatus: sandbox.stub(),
+    setUpdatedBy: sandbox.stub(),
+    getSuggestions: sandbox.stub().resolves(suggestions),
+    // addSuggestions is called by syncSuggestions when new suggestions are created
+    addSuggestions: sandbox.stub().callsFake((newSuggestions) => Promise.resolve(newSuggestions)),
+    save: sandbox.stub().resolvesThis(),
+  };
+}
+
+// ─── DataAccess ───────────────────────────────────────────────────────────────
+
+/**
+ * Builds a dataAccess stub covering all entities the handler touches.
+ *
+ * Pass pre-built entities via overrides to control specific return values:
+ *   buildDataAccess(sandbox, { opportunities: [myOpp], topPages: [{ url, traffic }] })
+ */
+export function buildDataAccess(sandbox, {
+  opportunities = [],
+  topPages = [],
+  citabilityRecords = [],
+  scrapeUrls = [],
+} = {}) {
+  return {
+    Opportunity: {
+      allBySiteIdAndStatus: sandbox.stub().resolves(opportunities),
+      findById: sandbox.stub().resolves(opportunities[0] ?? null),
+      create: sandbox.stub().callsFake((data) => Promise.resolve(
+        buildOpportunity(sandbox, { siteId: data.siteId ?? 'test-site-id' }),
+      )),
+    },
+    SiteTopPage: {
+      allBySiteIdAndSourceAndGeo: sandbox.stub().resolves(
+        topPages.map((p) => ({
+          getUrl: () => (typeof p === 'string' ? p : p.url),
+          getTraffic: () => (typeof p === 'string' ? 100 : (p.traffic ?? 100)),
+        })),
+      ),
+    },
+    PageCitability: {
+      allByIndexKeys: sandbox.stub().resolves(citabilityRecords),
+      findByIndexKeys: sandbox.stub().resolves(null),
+      create: sandbox.stub().resolvesThis(),
+    },
+    ScrapeUrl: {
+      allByScrapeJobId: sandbox.stub().resolves(
+        scrapeUrls.map((u) => ({
+          getUrl: () => u,
+          getStatus: () => 'COMPLETE',
+          getStatusCode: () => 200,
+        })),
+      ),
+    },
+    Suggestion: {
+      saveMany: sandbox.stub().resolves([]),
+      bulkUpdateStatus: sandbox.stub().resolves([]),
+      allByOpportunityIdAndStatus: sandbox.stub().resolves([]),
+    },
+  };
+}
+
+// ─── SQS ──────────────────────────────────────────────────────────────────────
+
+export function buildSqs(sandbox) {
+  return { sendMessage: sandbox.stub().resolves() };
+}
+
+// ─── Full context ─────────────────────────────────────────────────────────────
+
+/**
+ * Assembles a complete handler context.
+ * All dependencies default to safe stubs; pass overrides for the ones your test cares about.
+ *
+ * @example
+ * const ctx = buildContext(sandbox, {
+ *   site: buildSite({ id: 'blocked-site' }),
+ *   s3Client: buildS3Client(sandbox, {
+ *     [statusKey('blocked-site')]: buildStatus({
+ *       scrapeForbidden: true, scrapeForbiddenSince: daysAgo(1),
+ *     }),
+ *   }),
+ * });
+ */
+export function buildContext(sandbox, overrides = {}) {
+  const site = overrides.site ?? buildSite();
+  return {
+    site,
+    log: buildLog(sandbox),
+    s3Client: buildS3Client(sandbox),
+    dataAccess: buildDataAccess(sandbox),
+    sqs: buildSqs(sandbox),
+    env: {
+      S3_SCRAPER_BUCKET_NAME: 'test-bucket',
+      QUEUE_SPACECAT_TO_MYSTIQUE: 'https://sqs.us-east-1.amazonaws.com/test-queue',
+    },
+    finalUrl: site.getBaseURL(),
+    audit: { getId: () => 'audit-id' },
+    auditContext: {},
+    scrapeResultPaths: new Map(),
+    data: null,
+    ...overrides,
+  };
+}
+
+// ─── S3 inspection helpers ────────────────────────────────────────────────────
+
+/** Returns the parsed body of the first PutObjectCommand sent to an s3Client stub. */
+export function captureStatusWrite(s3Client) {
+  const put = s3Client.send.getCalls().find(
+    (c) => c.args[0]?.constructor?.name === 'PutObjectCommand',
+  );
+  if (!put) {
+    return null;
+  }
+  return JSON.parse(put.args[0].input.Body);
+}

--- a/test/audits/prerender/behaviour/mystique-round-trip.test.js
+++ b/test/audits/prerender/behaviour/mystique-round-trip.test.js
@@ -1,0 +1,775 @@
+/*
+ * Copyright 2025 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Behavioural contracts: Mystique round-trip
+ *
+ * OUTBOUND (audit worker → Mystique via SQS):
+ *   - Branch A fires → SQS message sent to QUEUE_SPACECAT_TO_MYSTIQUE
+ *   - Message structure: type=guidance:prerender, data.opportunityId, data.suggestions[].url
+ *   - Branch C (no prerender URLs) → no SQS message sent
+ *
+ * INBOUND (Mystique → guidance-handler.js):
+ *   - Valid aiSummary → aiSummary + valuable both updated
+ *   - aiSummary absent/invalid → existing aiSummary + valuable BOTH preserved
+ *   - OUTDATED suggestion excluded from update
+ *   - URL in Mystique response not in DB → warning logged, skipped
+ *   - Missing presignedUrl or opportunityId → badRequest
+ *   - Opportunity not found → notFound
+ */
+
+/* eslint-env mocha */
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import esmock from 'esmock';
+import {
+  processContentAndGenerateOpportunities,
+} from '../../../../src/prerender/handler.js';
+import { handleAiOnlyMode } from '../../../../src/prerender/ai-only-handler.js';
+import {
+  buildContext,
+  buildSite,
+  buildS3Client,
+  buildDataAccess,
+  buildOpportunity,
+  buildSuggestion,
+  buildUrlS3Content,
+  statusKey,
+  buildStatus,
+  HTML_SERVER_SPARSE,
+  HTML_CLIENT_NEEDS_PRERENDER,
+} from './helpers.js';
+
+use(sinonChai);
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Reads the candidate suggestion payload sent to Mystique.
+ *
+ * Since the presigned-URL change, the candidate array is uploaded to S3 (the
+ * PutObjectCommand body keyed `prerender/mystique-suggestions/{opportunityId}.json`)
+ * and the SQS message carries only `data.suggestionsS3Key` — not the inline array.
+ * This extracts and parses that uploaded payload.
+ */
+function uploadedSuggestions(ctx) {
+  const putCall = ctx.s3Client.send.getCalls()
+    .find((c) => c.args[0]?.input?.Key?.includes('mystique-suggestions'));
+  expect(putCall, 'expected a PutObject upload to mystique-suggestions').to.not.be.undefined;
+  return JSON.parse(putCall.args[0].input.Body);
+}
+
+/**
+ * Builds a context that will trigger Branch A (prerender URLs found) in step 3.
+ * Server HTML is sparse; client HTML is rich → contentGainRatio > 1.1.
+ */
+function buildBranchAStep3Ctx(sandbox, siteId, scrapeJobId, url) {
+  return buildContext(sandbox, {
+    site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+    s3Client: buildS3Client(sandbox, {
+      [statusKey(siteId)]: buildStatus(),
+      ...buildUrlS3Content(scrapeJobId, url, {
+        serverHtml: HTML_SERVER_SPARSE,
+        clientHtml: HTML_CLIENT_NEEDS_PRERENDER,
+      }),
+    }),
+    dataAccess: buildDataAccess(sandbox, {
+      scrapeUrls: [url],
+      opportunities: [],
+    }),
+    scrapeResultPaths: new Map([[url, {}]]),
+    auditContext: { scrapeJobId },
+  });
+}
+
+// ─── OUTBOUND ─────────────────────────────────────────────────────────────────
+
+describe('Prerender behaviour — Mystique round-trip (outbound)', () => {
+  let sandbox;
+
+  beforeEach(() => { sandbox = sinon.createSandbox(); });
+  afterEach(() => { sandbox.restore(); });
+
+  it('Branch A: SQS message sent to Mystique queue with type=guidance:prerender and data.suggestions', async () => {
+    const siteId = 'site-outbound-a';
+    const scrapeJobId = 'job-outbound-a';
+    const url = 'https://example.com/page-1';
+
+    const ctx = buildBranchAStep3Ctx(sandbox, siteId, scrapeJobId, url);
+
+    await processContentAndGenerateOpportunities(ctx);
+
+    expect(ctx.sqs.sendMessage).to.have.been.called;
+    const [queue, message] = ctx.sqs.sendMessage.firstCall.args;
+
+    // Sent to the correct Mystique queue
+    expect(queue).to.equal(ctx.env.QUEUE_SPACECAT_TO_MYSTIQUE);
+
+    // Message structure
+    expect(message).to.have.property('type', 'guidance:prerender');
+    expect(message).to.have.property('siteId', siteId);
+    expect(message.data).to.have.property('opportunityId').that.is.a('string');
+    // Payload is uploaded to S3; the SQS message references it by key.
+    expect(message.data).to.have.property('suggestionsS3Key').that.is.a('string');
+
+    // Each uploaded suggestion carries the URL so Mystique can match it on response
+    const suggestions = uploadedSuggestions(ctx);
+    expect(suggestions).to.be.an('array').with.length.greaterThan(0);
+    expect(suggestions[0]).to.have.property('url', url);
+  });
+
+  it('Branch B (isDomainBlocked=true / scrapeForbidden) → Mystique SQS message NOT sent', async () => {
+    const siteId = 'site-outbound-b';
+
+    // isDomainBlocked=true → scrapeForbidden=true → Branch B fires (createScrapeForbiddenOpportunity).
+    // Branch B never reaches sendPrerenderGuidanceRequestToMystique, so no SQS message is sent.
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+      }),
+      dataAccess: buildDataAccess(sandbox, {
+        opportunities: [],
+      }),
+      scrapeResultPaths: new Map(),
+      auditContext: { domainBlocked: true },
+    });
+
+    await processContentAndGenerateOpportunities(ctx);
+
+    expect(ctx.sqs.sendMessage).to.not.have.been.called;
+  });
+
+  it('Branch C (no prerender URLs): SQS message NOT sent to Mystique', async () => {
+    const siteId = 'site-outbound-c';
+    const scrapeJobId = 'job-outbound-c';
+    const url = 'https://example.com/no-prerender';
+
+    // Identical HTML → ratio = 1.0 < 1.1 → needsPrerender=false → Branch C
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId, baseUrl: 'https://example.com' }),
+      s3Client: buildS3Client(sandbox, {
+        [statusKey(siteId)]: buildStatus(),
+        // HTML_SAME (default) → no prerender needed
+        ...buildUrlS3Content(scrapeJobId, url),
+      }),
+      dataAccess: buildDataAccess(sandbox, {
+        scrapeUrls: [url],
+        opportunities: [],
+      }),
+      scrapeResultPaths: new Map([[url, {}]]),
+      auditContext: { scrapeJobId },
+    });
+
+    await processContentAndGenerateOpportunities(ctx);
+
+    // No SQS send — Branch C does not dispatch to Mystique
+    expect(ctx.sqs.sendMessage).to.not.have.been.called;
+  });
+});
+
+// ─── OUTBOUND: ai-only filtering ─────────────────────────────────────────────
+
+describe('Prerender behaviour — Mystique outbound (ai-only filtering)', () => {
+  let sandbox;
+
+  beforeEach(() => { sandbox = sinon.createSandbox(); });
+  afterEach(() => { sandbox.restore(); });
+
+  it('ai-only: FIXED suggestion excluded from Mystique SQS message', async () => {
+    // In ai-only mode, sendPrerenderGuidanceRequestToMystique derives candidates from DB
+    // suggestions and skips any with status=FIXED (D-07). The NEW suggestion must still appear.
+    const siteId = 'site-ai-fixed';
+    const oppId = 'opp-ai-fixed';
+    const scrapeJobId = 'job-ai-fixed';
+    const fixedUrl = 'https://example.com/fixed-page';
+    const newUrl = 'https://example.com/new-page';
+
+    const fixedSuggestion = buildSuggestion(sandbox, {
+      id: 'sug-fixed',
+      status: 'FIXED',
+      data: { url: fixedUrl, scrapeJobId },
+    });
+    const newSuggestion = buildSuggestion(sandbox, {
+      id: 'sug-new',
+      status: 'NEW',
+      data: { url: newUrl, scrapeJobId },
+    });
+
+    const opportunity = buildOpportunity(sandbox, {
+      id: oppId,
+      siteId,
+      suggestions: [fixedSuggestion, newSuggestion],
+    });
+
+    const dataAccess = buildDataAccess(sandbox, { opportunities: [opportunity] });
+    // handleAiOnlyMode uses findById when opportunityId is provided in data
+    dataAccess.Opportunity.findById = sandbox.stub().resolves(opportunity);
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId }),
+      dataAccess,
+      data: { opportunityId: oppId, scrapeJobId },
+    });
+
+    await handleAiOnlyMode(ctx);
+
+    expect(ctx.sqs.sendMessage).to.have.been.called;
+    const suggestionUrls = uploadedSuggestions(ctx).map((s) => s.url);
+    expect(suggestionUrls).to.not.include(fixedUrl);
+    expect(suggestionUrls).to.include(newUrl);
+  });
+
+  it('ai-only: suggestion with originalHtmlKey but no scrapeJobId → scrapeJobId derived from S3 path (fallback path 2)', async () => {
+    // D-02 fallback chain: data.scrapeJobId → extract from data.originalHtmlKey path[2] → null
+    // Path 2: scrapeJobId absent on data, but originalHtmlKey = 'prerender/scrapes/{jobId}/...'
+    // → effectiveScrapeJobId derived as parts[2], log.debug emitted, suggestion included in SQS.
+    const siteId = 'site-ai-fallback-path2';
+    const oppId = 'opp-ai-fallback-path2';
+    const derivedJobId = 'derived-job-from-html-key';
+    const url = 'https://example.com/needs-ai';
+
+    const suggestion = buildSuggestion(sandbox, {
+      id: 'sug-fallback',
+      status: 'NEW',
+      data: {
+        url,
+        // no scrapeJobId — forces fallback to originalHtmlKey extraction
+        originalHtmlKey: `prerender/scrapes/${derivedJobId}/needs-ai/server-side.html`,
+      },
+    });
+
+    const opportunity = buildOpportunity(sandbox, { id: oppId, siteId, suggestions: [suggestion] });
+    const dataAccess = buildDataAccess(sandbox, { opportunities: [opportunity] });
+    dataAccess.Opportunity.findById = sandbox.stub().resolves(opportunity);
+
+    // Provide an audit-level scrapeJobId so handleAiOnlyMode doesn't fail on the status.json check
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId }),
+      dataAccess,
+      data: { opportunityId: oppId, scrapeJobId: 'audit-level-job' },
+    });
+
+    await handleAiOnlyMode(ctx);
+
+    // Suggestion must be included in SQS despite missing data.scrapeJobId
+    expect(ctx.sqs.sendMessage).to.have.been.called;
+    const suggestionUrls = uploadedSuggestions(ctx).map((s) => s.url);
+    expect(suggestionUrls).to.include(url);
+
+    // The derivation must be logged at debug level
+    expect(ctx.log.debug).to.have.been.calledWithMatch(/derived from originalHtmlKey/);
+  });
+
+  it('ai-only: suggestion with neither scrapeJobId nor originalHtmlKey → skipped with warn (fallback path 3)', async () => {
+    // D-02 fallback chain: when both data.scrapeJobId and data.originalHtmlKey are absent,
+    // the suggestion is skipped and log.warn emitted. Other valid suggestions still go to Mystique.
+    const siteId = 'site-ai-fallback-path3';
+    const oppId = 'opp-ai-fallback-path3';
+    const scrapeJobId = 'job-path3';
+    const skippedUrl = 'https://example.com/no-job-id';
+    const validUrl = 'https://example.com/valid';
+
+    const skippedSuggestion = buildSuggestion(sandbox, {
+      id: 'sug-no-job',
+      status: 'NEW',
+      data: { url: skippedUrl /* no scrapeJobId, no originalHtmlKey */ },
+    });
+    const validSuggestion = buildSuggestion(sandbox, {
+      id: 'sug-valid',
+      status: 'NEW',
+      data: { url: validUrl, scrapeJobId },
+    });
+
+    const opportunity = buildOpportunity(sandbox, {
+      id: oppId, siteId, suggestions: [skippedSuggestion, validSuggestion],
+    });
+    const dataAccess = buildDataAccess(sandbox, { opportunities: [opportunity] });
+    dataAccess.Opportunity.findById = sandbox.stub().resolves(opportunity);
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId }),
+      dataAccess,
+      data: { opportunityId: oppId, scrapeJobId },
+    });
+
+    await handleAiOnlyMode(ctx);
+
+    // Valid suggestion still sent; skipped suggestion absent
+    expect(ctx.sqs.sendMessage).to.have.been.called;
+    const suggestionUrls = uploadedSuggestions(ctx).map((s) => s.url);
+    expect(suggestionUrls).to.include(validUrl);
+    expect(suggestionUrls).to.not.include(skippedUrl);
+
+    // The skip must be observable via warn log
+    expect(ctx.log.warn).to.have.been.calledWithMatch(/no scrapeJobId and no originalHtmlKey/);
+  });
+
+  it('ai-only: edgeDeployed suggestion excluded from Mystique SQS message', async () => {
+    // In ai-only mode, suggestions with data.edgeDeployed set are skipped (D-07).
+    // The plain NEW suggestion without edgeDeployed must still be sent.
+    const siteId = 'site-ai-edge';
+    const oppId = 'opp-ai-edge';
+    const scrapeJobId = 'job-ai-edge';
+    const edgeUrl = 'https://example.com/edge-page';
+    const newUrl = 'https://example.com/new-page';
+
+    const edgeSuggestion = buildSuggestion(sandbox, {
+      id: 'sug-edge',
+      status: 'NEW',
+      data: { url: edgeUrl, scrapeJobId, edgeDeployed: new Date().toISOString() },
+    });
+    const newSuggestion = buildSuggestion(sandbox, {
+      id: 'sug-new',
+      status: 'NEW',
+      data: { url: newUrl, scrapeJobId },
+    });
+
+    const opportunity = buildOpportunity(sandbox, {
+      id: oppId,
+      siteId,
+      suggestions: [edgeSuggestion, newSuggestion],
+    });
+
+    const dataAccess = buildDataAccess(sandbox, { opportunities: [opportunity] });
+    dataAccess.Opportunity.findById = sandbox.stub().resolves(opportunity);
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId }),
+      dataAccess,
+      data: { opportunityId: oppId, scrapeJobId },
+    });
+
+    await handleAiOnlyMode(ctx);
+
+    expect(ctx.sqs.sendMessage).to.have.been.called;
+    const suggestionUrls = uploadedSuggestions(ctx).map((s) => s.url);
+    expect(suggestionUrls).to.not.include(edgeUrl);
+    expect(suggestionUrls).to.include(newUrl);
+  });
+
+  it('ai-only: uploaded candidate carries the S3 markdown keys and hasPrompts flag', async () => {
+    // The Mystique payload contract: each candidate must carry the originalHtmlMarkdownKey
+    // and markdownDiffKey (so Mystique can fetch the diff) plus a hasPrompts hint.
+    const siteId = 'site-ai-shape';
+    const oppId = 'opp-ai-shape';
+    const scrapeJobId = 'job-ai-shape';
+    const url = 'https://example.com/needs-summary';
+
+    const suggestion = buildSuggestion(sandbox, {
+      id: 'sug-shape',
+      status: 'NEW',
+      data: { url, scrapeJobId, prompts: [{ q: 'existing' }] },
+    });
+    const opportunity = buildOpportunity(sandbox, { id: oppId, siteId, suggestions: [suggestion] });
+    const dataAccess = buildDataAccess(sandbox, { opportunities: [opportunity] });
+    dataAccess.Opportunity.findById = sandbox.stub().resolves(opportunity);
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId }),
+      dataAccess,
+      data: { opportunityId: oppId, scrapeJobId },
+    });
+
+    await handleAiOnlyMode(ctx);
+
+    const [candidate] = uploadedSuggestions(ctx);
+    expect(candidate).to.have.property('url', url);
+    expect(candidate).to.have.property('originalHtmlMarkdownKey').that.is.a('string')
+      .and.includes('server-side-html.md');
+    expect(candidate).to.have.property('markdownDiffKey').that.is.a('string')
+      .and.includes('markdown-diff.md');
+    // prompts present on the suggestion → hasPrompts true
+    expect(candidate).to.have.property('hasPrompts', true);
+  });
+
+  it('ai-only: SKIPPED suggestion excluded from Mystique payload', async () => {
+    const siteId = 'site-ai-skipped';
+    const oppId = 'opp-ai-skipped';
+    const scrapeJobId = 'job-ai-skipped';
+    const skippedUrl = 'https://example.com/skipped-page';
+    const newUrl = 'https://example.com/new-page';
+
+    const skipped = buildSuggestion(sandbox, {
+      id: 'sug-skipped',
+      status: 'SKIPPED',
+      data: { url: skippedUrl, scrapeJobId },
+    });
+    const fresh = buildSuggestion(sandbox, {
+      id: 'sug-new',
+      status: 'NEW',
+      data: { url: newUrl, scrapeJobId },
+    });
+    const opportunity = buildOpportunity(sandbox, {
+      id: oppId, siteId, suggestions: [skipped, fresh],
+    });
+    const dataAccess = buildDataAccess(sandbox, { opportunities: [opportunity] });
+    dataAccess.Opportunity.findById = sandbox.stub().resolves(opportunity);
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId }),
+      dataAccess,
+      data: { opportunityId: oppId, scrapeJobId },
+    });
+
+    await handleAiOnlyMode(ctx);
+
+    const suggestionUrls = uploadedSuggestions(ctx).map((s) => s.url);
+    expect(suggestionUrls).to.not.include(skippedUrl);
+    expect(suggestionUrls).to.include(newUrl);
+  });
+
+  it('ai-only: domain-wide aggregate suggestion excluded from Mystique payload', async () => {
+    const siteId = 'site-ai-dw';
+    const oppId = 'opp-ai-dw';
+    const scrapeJobId = 'job-ai-dw';
+    const domainWideUrl = 'https://example.com/* (All Domain URLs)';
+    const newUrl = 'https://example.com/real-page';
+
+    const domainWide = buildSuggestion(sandbox, {
+      id: 'sug-dw',
+      status: 'NEW',
+      data: { url: domainWideUrl, isDomainWide: true, scrapeJobId },
+    });
+    const fresh = buildSuggestion(sandbox, {
+      id: 'sug-new',
+      status: 'NEW',
+      data: { url: newUrl, scrapeJobId },
+    });
+    const opportunity = buildOpportunity(sandbox, {
+      id: oppId, siteId, suggestions: [domainWide, fresh],
+    });
+    const dataAccess = buildDataAccess(sandbox, { opportunities: [opportunity] });
+    dataAccess.Opportunity.findById = sandbox.stub().resolves(opportunity);
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId }),
+      dataAccess,
+      data: { opportunityId: oppId, scrapeJobId },
+    });
+
+    await handleAiOnlyMode(ctx);
+
+    const suggestionUrls = uploadedSuggestions(ctx).map((s) => s.url);
+    expect(suggestionUrls).to.not.include(domainWideUrl);
+    expect(suggestionUrls).to.include(newUrl);
+  });
+
+  it('ai-only: wildcard-URL suggestion excluded from Mystique payload', async () => {
+    const siteId = 'site-ai-wild';
+    const oppId = 'opp-ai-wild';
+    const scrapeJobId = 'job-ai-wild';
+    const wildcardUrl = 'https://example.com/section/*';
+    const newUrl = 'https://example.com/concrete-page';
+
+    const wildcard = buildSuggestion(sandbox, {
+      id: 'sug-wild',
+      status: 'NEW',
+      data: { url: wildcardUrl, scrapeJobId },
+    });
+    const fresh = buildSuggestion(sandbox, {
+      id: 'sug-new',
+      status: 'NEW',
+      data: { url: newUrl, scrapeJobId },
+    });
+    const opportunity = buildOpportunity(sandbox, {
+      id: oppId, siteId, suggestions: [wildcard, fresh],
+    });
+    const dataAccess = buildDataAccess(sandbox, { opportunities: [opportunity] });
+    dataAccess.Opportunity.findById = sandbox.stub().resolves(opportunity);
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId }),
+      dataAccess,
+      data: { opportunityId: oppId, scrapeJobId },
+    });
+
+    await handleAiOnlyMode(ctx);
+
+    const suggestionUrls = uploadedSuggestions(ctx).map((s) => s.url);
+    expect(suggestionUrls).to.not.include(wildcardUrl);
+    expect(suggestionUrls).to.include(newUrl);
+  });
+});
+
+// ─── INBOUND ──────────────────────────────────────────────────────────────────
+
+describe('Prerender behaviour — Mystique round-trip (inbound: guidance-handler)', () => {
+  let sandbox;
+  let guidanceHandler;
+  let fetchAnalysisStub;
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    fetchAnalysisStub = sandbox.stub();
+    ({ default: guidanceHandler } = await esmock(
+      '../../../../src/prerender/guidance-handler.js',
+      {
+        '../../../../src/utils/analysis-fetch.js': {
+          fetchAnalysisFromPresignedUrl: fetchAnalysisStub,
+        },
+      },
+    ));
+  });
+  afterEach(() => { sandbox.restore(); });
+
+  // ─── Context builder for guidance-handler ──────────────────────────────────
+
+  function buildGuidanceCtx(overrides = {}) {
+    const site = buildSite({ id: overrides.siteId ?? 'site-guidance', baseUrl: 'https://example.com' });
+    return {
+      log: {
+        info: sandbox.stub(),
+        warn: sandbox.stub(),
+        error: sandbox.stub(),
+        debug: sandbox.stub(),
+      },
+      dataAccess: {
+        Site: {
+          findById: sandbox.stub().resolves(site),
+        },
+        Opportunity: {
+          findById: sandbox.stub().resolves(overrides.opportunity ?? null),
+        },
+        Suggestion: {
+          saveMany: sandbox.stub().resolves([]),
+        },
+      },
+      env: { QUEUE_SPACECAT_TO_MYSTIQUE: 'https://sqs.us-east-1.amazonaws.com/test' },
+      ...overrides.ctxOverrides,
+    };
+  }
+
+  function buildMessage(siteId, opportunityId, overrides = {}) {
+    return {
+      siteId,
+      data: {
+        presignedUrl: 'https://s3.amazonaws.com/bucket/results.json?X-Amz-Signature=abc',
+        opportunityId,
+        ...overrides,
+      },
+    };
+  }
+
+  // ─── aiSummary / valuable coupling ────────────────────────────────────────
+
+  it('valid aiSummary → aiSummary AND valuable both updated in DB', async () => {
+    const siteId = 'site-inbound-summary';
+    const oppId = 'opp-summary-1';
+    const url = 'https://example.com/page-1';
+
+    const suggestion = buildSuggestion(sandbox, {
+      id: 'sug-1',
+      status: 'NEW',
+      data: { url, wordCountBefore: 10, wordCountAfter: 100 },
+    });
+    suggestion.setData = sandbox.stub();
+
+    const opportunity = buildOpportunity(sandbox, {
+      id: oppId,
+      siteId,
+      suggestions: [suggestion],
+    });
+
+    fetchAnalysisStub.resolves({
+      suggestions: [{ url, aiSummary: 'Great page with rich content.', valuable: true }],
+    });
+
+    const ctx = buildGuidanceCtx({ siteId, opportunity });
+    await guidanceHandler(buildMessage(siteId, oppId), ctx);
+
+    expect(suggestion.setData).to.have.been.called;
+    const [updatedData] = suggestion.setData.firstCall.args;
+    expect(updatedData).to.have.property('aiSummary', 'Great page with rich content.');
+    expect(updatedData).to.have.property('valuable', true);
+    expect(ctx.dataAccess.Suggestion.saveMany).to.have.been.called;
+  });
+
+  it('valid aiSummary with valuable=false → both updated, valuable=false persisted', async () => {
+    const siteId = 'site-inbound-not-valuable';
+    const oppId = 'opp-nv-1';
+    const url = 'https://example.com/page-2';
+
+    const suggestion = buildSuggestion(sandbox, {
+      id: 'sug-nv',
+      status: 'NEW',
+      data: { url, aiSummary: 'old', valuable: true },
+    });
+    suggestion.setData = sandbox.stub();
+
+    const opportunity = buildOpportunity(sandbox, {
+      id: oppId,
+      siteId,
+      suggestions: [suggestion],
+    });
+
+    fetchAnalysisStub.resolves({
+      suggestions: [{ url, aiSummary: 'Thin page, little value.', valuable: false }],
+    });
+
+    const ctx = buildGuidanceCtx({ siteId, opportunity });
+    await guidanceHandler(buildMessage(siteId, oppId), ctx);
+
+    const [updatedData] = suggestion.setData.firstCall.args;
+    expect(updatedData).to.have.property('aiSummary', 'Thin page, little value.');
+    expect(updatedData).to.have.property('valuable', false);
+  });
+
+  it('aiSummary absent in response → existing aiSummary AND valuable both preserved', async () => {
+    // When Mystique sends "Not Available", the handler preserves the previously stored
+    // aiSummary and valuable — it still calls setData/saveMany but with the old values intact.
+    const siteId = 'site-inbound-preserve';
+    const oppId = 'opp-preserve-1';
+    const url = 'https://example.com/page-3';
+
+    const suggestion = buildSuggestion(sandbox, {
+      id: 'sug-preserve',
+      status: 'NEW',
+      data: { url, aiSummary: 'Previously computed summary', valuable: true },
+    });
+    suggestion.setData = sandbox.stub();
+
+    const opportunity = buildOpportunity(sandbox, {
+      id: oppId,
+      siteId,
+      suggestions: [suggestion],
+    });
+
+    // Mystique returns "Not Available" — treated as no summary
+    fetchAnalysisStub.resolves({
+      suggestions: [{ url, aiSummary: 'Not Available', valuable: false }],
+    });
+
+    const ctx = buildGuidanceCtx({ siteId, opportunity });
+    await guidanceHandler(buildMessage(siteId, oppId), ctx);
+
+    // setData IS called but with the preserved (old) values — not the "Not Available" response
+    expect(suggestion.setData).to.have.been.called;
+    const [updatedData] = suggestion.setData.firstCall.args;
+    expect(updatedData).to.have.property('aiSummary', 'Previously computed summary');
+    expect(updatedData).to.have.property('valuable', true);
+  });
+
+  // ─── Filtering ────────────────────────────────────────────────────────────
+
+  it('OUTDATED suggestion is excluded from update even when URL matches', async () => {
+    const siteId = 'site-inbound-outdated';
+    const oppId = 'opp-outdated-1';
+    const url = 'https://example.com/page-outdated';
+
+    const outdatedSuggestion = buildSuggestion(sandbox, {
+      id: 'sug-outdated',
+      status: 'OUTDATED',
+      data: { url },
+    });
+    outdatedSuggestion.setData = sandbox.stub();
+
+    const activeSuggestion = buildSuggestion(sandbox, {
+      id: 'sug-active',
+      status: 'NEW',
+      data: { url: 'https://example.com/page-active' },
+    });
+    activeSuggestion.setData = sandbox.stub();
+
+    const opportunity = buildOpportunity(sandbox, {
+      id: oppId,
+      siteId,
+      suggestions: [outdatedSuggestion, activeSuggestion],
+    });
+
+    fetchAnalysisStub.resolves({
+      suggestions: [
+        { url, aiSummary: 'Summary for outdated page', valuable: true },
+        { url: 'https://example.com/page-active', aiSummary: 'Active summary', valuable: true },
+      ],
+    });
+
+    const ctx = buildGuidanceCtx({ siteId, opportunity });
+    await guidanceHandler(buildMessage(siteId, oppId), ctx);
+
+    // OUTDATED suggestion must not have been updated
+    expect(outdatedSuggestion.setData).to.not.have.been.called;
+    // Active suggestion was updated
+    expect(activeSuggestion.setData).to.have.been.called;
+  });
+
+  it('URL in Mystique response not in DB → warning logged, other suggestions still processed', async () => {
+    const siteId = 'site-inbound-unknown-url';
+    const oppId = 'opp-unknown-1';
+    const knownUrl = 'https://example.com/known';
+    const unknownUrl = 'https://example.com/ghost-page';
+
+    const knownSuggestion = buildSuggestion(sandbox, {
+      id: 'sug-known',
+      status: 'NEW',
+      data: { url: knownUrl },
+    });
+    knownSuggestion.setData = sandbox.stub();
+
+    const opportunity = buildOpportunity(sandbox, {
+      id: oppId,
+      siteId,
+      suggestions: [knownSuggestion],
+    });
+
+    fetchAnalysisStub.resolves({
+      suggestions: [
+        { url: unknownUrl, aiSummary: 'Stale response for deleted page', valuable: true },
+        { url: knownUrl, aiSummary: 'Good summary', valuable: true },
+      ],
+    });
+
+    const ctx = buildGuidanceCtx({ siteId, opportunity });
+    await guidanceHandler(buildMessage(siteId, oppId), ctx);
+
+    // Unknown URL is skipped with a warning
+    expect(ctx.log.warn).to.have.been.calledWithMatch(new RegExp(unknownUrl));
+    // Known URL is still processed
+    expect(knownSuggestion.setData).to.have.been.called;
+  });
+
+  // ─── Early exits ──────────────────────────────────────────────────────────
+
+  it('missing presignedUrl in message → badRequest response', async () => {
+    const ctx = buildGuidanceCtx({ siteId: 'site-bad-req' });
+    const message = buildMessage('site-bad-req', 'opp-1', { presignedUrl: undefined });
+
+    const result = await guidanceHandler(message, ctx);
+
+    expect(result.status).to.equal(400);
+  });
+
+  it('missing opportunityId in message → badRequest response', async () => {
+    const ctx = buildGuidanceCtx({ siteId: 'site-bad-opp' });
+    const message = { siteId: 'site-bad-opp', data: { presignedUrl: 'https://s3.amazonaws.com/x.json' } };
+
+    const result = await guidanceHandler(message, ctx);
+
+    expect(result.status).to.equal(400);
+  });
+
+  it('opportunity not found in DB → notFound response', async () => {
+    const siteId = 'site-no-opp';
+    fetchAnalysisStub.resolves({ suggestions: [] });
+
+    const ctx = buildGuidanceCtx({
+      siteId,
+      opportunity: null, // Opportunity.findById returns null
+    });
+    ctx.dataAccess.Opportunity.findById = sandbox.stub().resolves(null);
+
+    const result = await guidanceHandler(buildMessage(siteId, 'opp-missing'), ctx);
+
+    expect(result.status).to.equal(404);
+  });
+});

--- a/test/audits/prerender/behaviour/mystique-round-trip.test.js
+++ b/test/audits/prerender/behaviour/mystique-round-trip.test.js
@@ -500,6 +500,45 @@ describe('Prerender behaviour — Mystique outbound (ai-only filtering)', () => 
     expect(suggestionUrls).to.not.include(wildcardUrl);
     expect(suggestionUrls).to.include(newUrl);
   });
+
+  it('ai-only-missing: FIXED suggestion without aiSummary IS included in the payload', async () => {
+    // Per-mode eligibility lives in buildUrlScopeForMode: ai-only-missing intentionally includes
+    // NEW *and* FIXED suggestions that lack an aiSummary. The candidate builder must not re-exclude
+    // FIXED (it trusts urlScope) — otherwise FIXED-without-summary pages would never get a summary.
+    const siteId = 'site-ai-missing-fixed';
+    const oppId = 'opp-ai-missing-fixed';
+    const scrapeJobId = 'job-ai-missing-fixed';
+    const fixedNoSummary = 'https://example.com/fixed-no-summary';
+    const newWithSummary = 'https://example.com/new-with-summary';
+
+    const fixed = buildSuggestion(sandbox, {
+      id: 'sug-fixed-missing',
+      status: 'FIXED',
+      data: { url: fixedNoSummary, scrapeJobId }, // no aiSummary → eligible for ai-only-missing
+    });
+    const hasSummary = buildSuggestion(sandbox, {
+      id: 'sug-has-summary',
+      status: 'NEW',
+      data: { url: newWithSummary, scrapeJobId, aiSummary: 'already summarised' },
+    });
+    const opportunity = buildOpportunity(sandbox, {
+      id: oppId, siteId, suggestions: [fixed, hasSummary],
+    });
+    const dataAccess = buildDataAccess(sandbox, { opportunities: [opportunity] });
+    dataAccess.Opportunity.findById = sandbox.stub().resolves(opportunity);
+
+    const ctx = buildContext(sandbox, {
+      site: buildSite({ id: siteId }),
+      dataAccess,
+      data: { mode: 'ai-only-missing', opportunityId: oppId, scrapeJobId },
+    });
+
+    await handleAiOnlyMode(ctx);
+
+    const suggestionUrls = uploadedSuggestions(ctx).map((s) => s.url);
+    expect(suggestionUrls).to.include(fixedNoSummary); // FIXED-without-summary IS sent
+    expect(suggestionUrls).to.not.include(newWithSummary); // already summarised → excluded
+  });
 });
 
 // ─── INBOUND ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Structural refactor + behaviour-contract tests layered on top of #2713 (the ai-only-current/ai-only-missing work). Targets that PR's branch so this diff is **only** the refactor.

- **New `src/prerender/ai-only-handler.js`** — `handleAiOnlyMode` extracted out of the 1900-line `handler.js`.
- **New `src/prerender/guidance-request.js`** — the outbound Mystique guidance dispatch (`sendPrerenderGuidanceRequestToMystique`), paired with the inbound `guidance-handler.js`. Now **dispatch-only**: guards → upload to S3 → enqueue SQS.
- **Shared helpers relocated** out of `handler.js`: `getModeFromData` → `mode-selector.js`; `getS3Path`/`sanitizeImportPath`/`readSiteStatusJson`/`fetchLatestScrapeJobId` → `utils/utils.js`.
- **`buildAiOnlyCandidates`** derives ai-only candidates; suggestions are fetched **once** (removes the double `getSuggestions()`). Per-mode eligibility stays solely in `buildUrlScopeForMode`, so `ai-only-missing` correctly keeps FIXED-without-summary candidates.
- **`handleAiOnlyMode` simplified**: flattened scope branching, DRY failure returns via `failAiOnly`, extracted `parseAiOnlyParams` / `resolveAiOnlyOpportunity`.
- **No import cycles** (`handler.js` → `ai-only-handler.js` → `guidance-request.js`/`mode-selector.js`/`utils.js`, one-directional).

## Behaviour

Behaviour is preserved; the author's decisions from #2713 are kept (`fullAuditRef` uses `${mode}`, `urlScope`-driven filtering, `getId?.()` resilience).

⚠️ **Note for reviewers:** per-mode filtering now lives solely in `buildUrlScopeForMode`, so the **explicit-CSV path trusts the listed URLs** — a `FIXED`/edge-deployed suggestion *will* be dispatched if an operator lists its URL. Deliberate; flagged for a conscious nod.

## Test plan

- [x] New black-box `behaviour/` contracts (ai-only mode + Mystique round-trip): payload-level exclusions (FIXED/SKIPPED/edge/domain-wide/wildcard), candidate shape, scrapeJobId fallback, explicit-CSV scope, opportunity resolution (by-id / latest-NEW / ownership), mode routing
- [x] Payload-level guard that `ai-only-missing` **includes** a FIXED-without-summary suggestion (and excludes already-summarised ones)
- [x] 486 prerender tests passing, stable across runs
- [x] 100% coverage (lines/branches/functions/statements) on all touched src files
- [x] ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)