### PR TITLE
feat(offsite): notify Slack when DRS scrape is skipped

### DIFF
--- a/src/cited-analysis/handler.js
+++ b/src/cited-analysis/handler.js
@@ -269,10 +269,25 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
 
     const storeData = await fetchStoreData(siteId, context, site);
     log.info(`${LOG_PREFIX} Successfully fetched all store data for ${citedConfig.companyName}`);
+    log.info(
+      `${LOG_PREFIX} DRS content available for ${storeData.urls.length} URL(s) `
+        + '— no scrape job needed, proceeding to Mystique',
+    );
 
     const urlLimit = resolveMystiqueUrlLimit(auditContext, log, LOG_PREFIX);
 
     const { slackContext } = auditContext;
+
+    // Manual Slack-triggered runs get a notification explaining that no DRS scrape
+    // job was needed (content already available). No-ops on scheduled runs where
+    // slackContext is absent.
+    await postMessageOptional(
+      context,
+      slackContext?.channelId,
+      `:mag: *cited-analysis* for *${site.getBaseURL()}* — DRS content already available `
+        + `(${storeData.urls.length} URL(s)); no scrape job needed, sending to Mystique.`,
+      { threadTs: slackContext?.threadTs },
+    );
 
     return {
       auditResult: {

--- a/src/reddit-analysis/handler.js
+++ b/src/reddit-analysis/handler.js
@@ -27,6 +27,7 @@ import { OFFSITE_DOMAINS } from '../offsite-brand-presence/constants.js';
 import { computeTopicsFromBrandPresence } from '../utils/offsite-brand-presence-enrichment.js';
 import { enrichUrlsWithTopicData } from '../utils/url-topic-enrichment.js';
 import { resolveBrandForSite, applyBrandScope } from '../utils/brand-resolver.js';
+import { postMessageOptional } from '../utils/slack-utils.js';
 
 const LOG_PREFIX = '[Reddit]';
 
@@ -147,10 +148,25 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
 
     const storeData = await fetchStoreData(siteId, context, site);
     log.info(`${LOG_PREFIX} Successfully fetched all store data for ${redditConfig.companyName}`);
+    log.info(
+      `${LOG_PREFIX} DRS content available for ${storeData.urls.length} URL(s) `
+        + '— no scrape job needed, proceeding to Mystique',
+    );
 
     const urlLimit = resolveMystiqueUrlLimit(auditContext, log, LOG_PREFIX);
 
     const { slackContext } = auditContext;
+
+    // Manual Slack-triggered runs get a notification explaining that no DRS scrape
+    // job was needed (content already available). No-ops on scheduled runs where
+    // slackContext is absent.
+    await postMessageOptional(
+      context,
+      slackContext?.channelId,
+      `:mag: *reddit-analysis* for *${site.getBaseURL()}* — DRS content already available `
+        + `(${storeData.urls.length} URL(s)); no scrape job needed, sending to Mystique.`,
+      { threadTs: slackContext?.threadTs },
+    );
 
     return {
       auditResult: {

--- a/src/youtube-analysis/handler.js
+++ b/src/youtube-analysis/handler.js
@@ -27,6 +27,7 @@ import { OFFSITE_DOMAINS } from '../offsite-brand-presence/constants.js';
 import { computeTopicsFromBrandPresence } from '../utils/offsite-brand-presence-enrichment.js';
 import { enrichUrlsWithTopicData } from '../utils/url-topic-enrichment.js';
 import { resolveBrandForSite, applyBrandScope } from '../utils/brand-resolver.js';
+import { postMessageOptional } from '../utils/slack-utils.js';
 
 const LOG_PREFIX = '[YouTube]';
 
@@ -147,10 +148,25 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
 
     const storeData = await fetchStoreData(siteId, context, site);
     log.info(`${LOG_PREFIX} Successfully fetched all store data for ${youtubeConfig.companyName}`);
+    log.info(
+      `${LOG_PREFIX} DRS content available for ${storeData.urls.length} URL(s) `
+        + '— no scrape job needed, proceeding to Mystique',
+    );
 
     const urlLimit = resolveMystiqueUrlLimit(auditContext, log, LOG_PREFIX);
 
     const { slackContext } = auditContext;
+
+    // Manual Slack-triggered runs get a notification explaining that no DRS scrape
+    // job was needed (content already available). No-ops on scheduled runs where
+    // slackContext is absent.
+    await postMessageOptional(
+      context,
+      slackContext?.channelId,
+      `:mag: *youtube-analysis* for *${site.getBaseURL()}* — DRS content already available `
+        + `(${storeData.urls.length} URL(s)); no scrape job needed, sending to Mystique.`,
+      { threadTs: slackContext?.threadTs },
+    );
 
     return {
       auditResult: {

--- a/test/audits/cited-analysis/handler.test.js
+++ b/test/audits/cited-analysis/handler.test.js
@@ -33,7 +33,9 @@ import { MockContextBuilder } from '../../shared.js';
 use(sinonChai);
 use(chaiAsPromised);
 
-describe('Cited Analysis Handler', () => {
+describe('Cited Analysis Handler', function () {
+  this.timeout(10000);
+
   let sandbox;
   let context;
   let mockSite;
@@ -433,6 +435,12 @@ describe('Cited Analysis Handler', () => {
 
       expect(result.auditResult.success).to.be.true;
       expect(result.auditResult.slackContext).to.deep.equal(slackContext);
+      expect(mockPostMessageOptional).to.have.been.calledWithMatch(
+        context,
+        'C-test',
+        /no scrape job needed, sending to Mystique/,
+        { threadTs: '1700000000.123456' },
+      );
     });
 
     it('should not include slackContext in auditResult when not provided', async () => {
@@ -440,6 +448,13 @@ describe('Cited Analysis Handler', () => {
 
       expect(result.auditResult.success).to.be.true;
       expect(result.auditResult.slackContext).to.be.undefined;
+      // postMessageOptional is still invoked but with no channel/thread, so it no-ops.
+      expect(mockPostMessageOptional).to.have.been.calledWithMatch(
+        context,
+        undefined,
+        /no scrape job needed, sending to Mystique/,
+        { threadTs: undefined },
+      );
     });
   });
 

--- a/test/audits/reddit-analysis/handler.test.js
+++ b/test/audits/reddit-analysis/handler.test.js
@@ -30,7 +30,9 @@ import { MockContextBuilder } from '../../shared.js';
 use(sinonChai);
 use(chaiAsPromised);
 
-describe('Reddit Analysis Handler', () => {
+describe('Reddit Analysis Handler', function () {
+  this.timeout(10000);
+
   let sandbox;
   let context;
   let mockSite;
@@ -39,6 +41,7 @@ describe('Reddit Analysis Handler', () => {
   let mockComputeTopicsFromBrandPresence;
   let mockFilterUrlsByDrsStatus;
   let mockDrsClient;
+  let mockPostMessageOptional;
   let redditAnalysisHandler;
   let StoreEmptyError;
 
@@ -93,6 +96,8 @@ describe('Reddit Analysis Handler', () => {
 
     mockDrsClient = { isConfigured: sandbox.stub().returns(true) };
 
+    mockPostMessageOptional = sandbox.stub().resolves({ success: true });
+
     mockStoreClient = {
       getUrls: sandbox.stub().resolves(mockUrls),
       getGuidelines: sandbox.stub().resolves(mockGuidelinesApiResponse),
@@ -127,6 +132,9 @@ describe('Reddit Analysis Handler', () => {
       },
       '../../../src/utils/offsite-brand-presence-enrichment.js': {
         computeTopicsFromBrandPresence: mockComputeTopicsFromBrandPresence,
+      },
+      '../../../src/utils/slack-utils.js': {
+        postMessageOptional: mockPostMessageOptional,
       },
     });
 
@@ -427,6 +435,12 @@ describe('Reddit Analysis Handler', () => {
 
       expect(result.auditResult.success).to.be.true;
       expect(result.auditResult.slackContext).to.deep.equal(slackContext);
+      expect(mockPostMessageOptional).to.have.been.calledWithMatch(
+        context,
+        'C-test',
+        /no scrape job needed, sending to Mystique/,
+        { threadTs: '1700000000.123456' },
+      );
     });
 
     it('should not include slackContext in auditResult when not provided', async () => {
@@ -434,6 +448,13 @@ describe('Reddit Analysis Handler', () => {
 
       expect(result.auditResult.success).to.be.true;
       expect(result.auditResult.slackContext).to.be.undefined;
+      // postMessageOptional is still invoked but with no channel/thread, so it no-ops.
+      expect(mockPostMessageOptional).to.have.been.calledWithMatch(
+        context,
+        undefined,
+        /no scrape job needed, sending to Mystique/,
+        { threadTs: undefined },
+      );
     });
   });
 

--- a/test/audits/youtube-analysis/handler.test.js
+++ b/test/audits/youtube-analysis/handler.test.js
@@ -30,7 +30,9 @@ import { MockContextBuilder } from '../../shared.js';
 use(sinonChai);
 use(chaiAsPromised);
 
-describe('YouTube Analysis Handler', () => {
+describe('YouTube Analysis Handler', function () {
+  this.timeout(10000);
+
   let sandbox;
   let context;
   let mockSite;
@@ -39,6 +41,7 @@ describe('YouTube Analysis Handler', () => {
   let mockComputeTopicsFromBrandPresence;
   let mockFilterUrlsByDrsStatus;
   let mockDrsClient;
+  let mockPostMessageOptional;
   let youtubeAnalysisHandler;
   let StoreEmptyError;
 
@@ -107,6 +110,8 @@ describe('YouTube Analysis Handler', () => {
       createFrom: sandbox.stub().returns(mockDrsClient),
     };
 
+    mockPostMessageOptional = sandbox.stub().resolves({ success: true });
+
     youtubeAnalysisHandler = await esmock('../../../src/youtube-analysis/handler.js', {
       '@adobe/spacecat-shared-drs-client': {
         default: mockDrsClientClass,
@@ -128,6 +133,9 @@ describe('YouTube Analysis Handler', () => {
       },
       '../../../src/utils/offsite-brand-presence-enrichment.js': {
         computeTopicsFromBrandPresence: mockComputeTopicsFromBrandPresence,
+      },
+      '../../../src/utils/slack-utils.js': {
+        postMessageOptional: mockPostMessageOptional,
       },
     });
 
@@ -409,6 +417,12 @@ describe('YouTube Analysis Handler', () => {
 
       expect(result.auditResult.success).to.be.true;
       expect(result.auditResult.slackContext).to.deep.equal(slackContext);
+      expect(mockPostMessageOptional).to.have.been.calledWithMatch(
+        context,
+        'C-test',
+        /no scrape job needed, sending to Mystique/,
+        { threadTs: '1700000000.123456' },
+      );
     });
 
     it('should not include slackContext in auditResult when not provided', async () => {
@@ -416,6 +430,13 @@ describe('YouTube Analysis Handler', () => {
 
       expect(result.auditResult.success).to.be.true;
       expect(result.auditResult.slackContext).to.be.undefined;
+      // postMessageOptional is still invoked but with no channel/thread, so it no-ops.
+      expect(mockPostMessageOptional).to.have.been.calledWithMatch(
+        context,
+        undefined,
+        /no scrape job needed, sending to Mystique/,
+        { threadTs: undefined },
+      );
     });
   });
 


### PR DESCRIPTION
Add a log line and an optional Slack notification to the youtube, reddit, and cited analysis handlers explaining that no DRS scrape job was needed because content was already available, before proceeding to Mystique. The notification posts to the run's slackContext thread and no-ops on scheduled runs via postMessageOptional's internal guards.

Also set this.timeout(10000) on the three handler test suites to avoid intermittent esmock first-load timeouts.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
