### PR TITLE
revert(prerender): revert inline suggestions revert (#2716)

### DIFF
--- a/src/prerender/handler.js
+++ b/src/prerender/handler.js
@@ -36,7 +36,7 @@ import {
   TOP_ORGANIC_URLS_LIMIT,
   PRERENDER_RECENT_PROCESSING_TIME_DAYS,
   MODE_AI_ONLY,
-  MYSTIQUE_BATCH_SIZE,
+  MYSTIQUE_SUGGESTIONS_S3_PREFIX,
 } from './utils/constants.js';
 import { isAiOnlyMode, buildUrlScopeForMode } from './mode-selector.js';
 
@@ -671,13 +671,17 @@ async function sendPrerenderGuidanceRequestToMystique(
 
     const deliveryType = site?.getDeliveryType?.() || 'unknown';
 
-    // SQS has a 256 KB message size limit. Chunk suggestions into batches to stay safely under it.
-    // TODO: send all batches once Mystique multi-batch handling is fully deployed.
-    const firstBatch = suggestionsPayload.slice(0, MYSTIQUE_BATCH_SIZE);
+    // Upload all suggestions to S3 and send just the S3 key via SQS.
+    // This avoids the 256 KB SQS message size limit — Mystique downloads from S3.
+    const { s3Client } = context;
+    const suggestionsS3Key = `${MYSTIQUE_SUGGESTIONS_S3_PREFIX}/${opportunityId}.json`;
 
-    if (suggestionsPayload.length > MYSTIQUE_BATCH_SIZE) {
-      log.warn(`${LOG_PREFIX} Truncating suggestions from ${suggestionsPayload.length} to ${MYSTIQUE_BATCH_SIZE} for opportunityId=${opportunityId}, baseUrl=${baseUrl}`);
-    }
+    await s3Client.send(new PutObjectCommand({
+      Bucket: env.S3_SCRAPER_BUCKET_NAME,
+      Key: suggestionsS3Key,
+      Body: JSON.stringify(suggestionsPayload),
+      ContentType: 'application/json',
+    }));
 
     const time = new Date().toISOString();
     const queue = env.QUEUE_SPACECAT_TO_MYSTIQUE;
@@ -690,18 +694,18 @@ async function sendPrerenderGuidanceRequestToMystique(
       time,
       data: {
         opportunityId,
-        suggestions: firstBatch,
-        batchIndex: 0,
-        totalBatches: 1,
+        suggestionsS3Key,
+        suggestionsS3Bucket: env.S3_SCRAPER_BUCKET_NAME,
         generatePrompts,
         siteRegion: site.getRegion() ?? '',
       },
     });
 
     log.info(`${LOG_PREFIX} Queued guidance:prerender message to Mystique for baseUrl=${baseUrl}, `
-      + `siteId=${siteId}, opportunityId=${opportunityId}, suggestions=${firstBatch.length}`);
-    return firstBatch.length;
-  /* c8 ignore next 5 - SQS dispatch failures */
+      + `siteId=${siteId}, opportunityId=${opportunityId}, suggestions=${suggestionsPayload.length}, `
+      + `suggestionsS3Key=${suggestionsS3Key}`);
+    return suggestionsPayload.length;
+  /* c8 ignore next 5 - S3/SQS dispatch failures */
   } catch (error) {
     log.error(`${LOG_PREFIX} Failed to send guidance:prerender message to Mystique for opportunityId=${opportunityId}, `
       + `baseUrl=${auditUrl}, siteId=${siteId}: ${error.message}`, error);

--- a/src/prerender/utils/constants.js
+++ b/src/prerender/utils/constants.js
@@ -22,5 +22,4 @@ export const MODE_AI_ONLY = 'ai-only';
 export const MODE_AI_ONLY_CURRENT = 'ai-only-current';
 export const MODE_AI_ONLY_MISSING = 'ai-only-missing';
 export const DOMAIN_WIDE_SUGGESTION_KEY = 'domain-wide-aggregate|prerender';
-export const MYSTIQUE_BATCH_SIZE = DAILY_BATCH_SIZE;
 export const MYSTIQUE_SUGGESTIONS_S3_PREFIX = 'prerender/mystique-suggestions';

--- a/test/audits/prerender/ai-only-mode.test.js
+++ b/test/audits/prerender/ai-only-mode.test.js
@@ -393,7 +393,7 @@ describe('Prerender AI-Only Mode', () => {
       const result = await importTopPages(context);
 
       expect(result.auditResult.suggestionCount).to.equal(1); // Only 1 non-domain-wide
-      const uploadedSuggestions = mockSqs.sendMessage.firstCall.args[1].data.suggestions;
+      const uploadedSuggestions = JSON.parse(mockS3Client.send.firstCall.args[0].input.Body);
       expect(uploadedSuggestions).to.have.lengthOf(1);
       expect(uploadedSuggestions[0].url).to.equal('https://example.com/page2');
     });
@@ -423,7 +423,7 @@ describe('Prerender AI-Only Mode', () => {
       const result = await importTopPages(context);
 
       expect(result.auditResult.suggestionCount).to.equal(1); // Only 1 non-SKIPPED
-      const uploadedSuggestions = mockSqs.sendMessage.firstCall.args[1].data.suggestions;
+      const uploadedSuggestions = JSON.parse(mockS3Client.send.firstCall.args[0].input.Body);
       expect(uploadedSuggestions).to.have.lengthOf(1);
       expect(uploadedSuggestions[0].url).to.equal('https://example.com/page2');
     });
@@ -493,7 +493,7 @@ describe('Prerender AI-Only Mode', () => {
       const result = await importTopPages(context);
 
       expect(result.status).to.equal('complete');
-      const uploadedSuggestions = mockSqs.sendMessage.firstCall.args[1].data.suggestions;
+      const uploadedSuggestions = JSON.parse(mockS3Client.send.firstCall.args[0].input.Body);
       const suggestion = uploadedSuggestions.find((s) => s.url === 'https://example.com/page1');
       expect(suggestion).to.exist;
       expect(suggestion.markdownDiffKey).to.include(`prerender/scrapes/${perSuggestionJobId}`);
@@ -515,7 +515,7 @@ describe('Prerender AI-Only Mode', () => {
       expect(context.log.debug).to.have.been.calledWith(
         sinon.match(/derived from originalHtmlKey/),
       );
-      const uploadedSuggestions = mockSqs.sendMessage.firstCall.args[1].data.suggestions;
+      const uploadedSuggestions = JSON.parse(mockS3Client.send.firstCall.args[0].input.Body);
       const suggestion = uploadedSuggestions.find((s) => s.url === 'https://example.com/page1');
       expect(suggestion).to.exist;
       expect(suggestion.markdownDiffKey).to.include(`prerender/scrapes/${derivedJobId}`);
@@ -536,7 +536,7 @@ describe('Prerender AI-Only Mode', () => {
         sinon.match(/skipped: no scrapeJobId and no originalHtmlKey/),
       );
       // suggestion-1 is skipped; only suggestion-2 (which has scrapeJobId) is sent
-      const uploadedSuggestions = mockSqs.sendMessage.firstCall.args[1].data.suggestions;
+      const uploadedSuggestions = JSON.parse(mockS3Client.send.firstCall.args[0].input.Body);
       expect(uploadedSuggestions).to.have.lengthOf(1);
       expect(uploadedSuggestions[0].url).to.equal('https://example.com/page2');
     });
@@ -556,7 +556,7 @@ describe('Prerender AI-Only Mode', () => {
         sinon.match(/skipped: no scrapeJobId and no originalHtmlKey/),
       );
       // suggestion-1 is skipped; only suggestion-2 is sent
-      const uploadedSuggestions = mockSqs.sendMessage.firstCall.args[1].data.suggestions;
+      const uploadedSuggestions = JSON.parse(mockS3Client.send.firstCall.args[0].input.Body);
       expect(uploadedSuggestions).to.have.lengthOf(1);
       expect(uploadedSuggestions[0].url).to.equal('https://example.com/page2');
     });
@@ -583,7 +583,7 @@ describe('Prerender AI-Only Mode', () => {
       expect(result.status).to.equal('complete');
       // All 3 suggestions (2 from current run + 1 stale) must be sent
       expect(result.auditResult.suggestionCount).to.equal(3);
-      const uploadedSuggestions = mockSqs.sendMessage.firstCall.args[1].data.suggestions;
+      const uploadedSuggestions = JSON.parse(mockS3Client.send.firstCall.args[0].input.Body);
       const sentUrls = uploadedSuggestions.map((s) => s.url);
       expect(sentUrls).to.include('https://example.com/page1');
       expect(sentUrls).to.include('https://example.com/page2');
@@ -750,7 +750,7 @@ describe('Prerender AI-Only Mode', () => {
       const result = await importTopPages(context);
 
       expect(result.status).to.equal('complete');
-      const uploadedSuggestions = mockSqs.sendMessage.firstCall.args[1].data.suggestions;
+      const uploadedSuggestions = JSON.parse(mockS3Client.send.firstCall.args[0].input.Body);
       expect(uploadedSuggestions).to.have.lengthOf(1);
       expect(uploadedSuggestions[0].url).to.equal('https://example.com/page1');
     });
@@ -763,7 +763,7 @@ describe('Prerender AI-Only Mode', () => {
       const result = await importTopPages(context);
 
       expect(result.status).to.equal('complete');
-      const uploadedSuggestions = mockSqs.sendMessage.firstCall.args[1].data.suggestions;
+      const uploadedSuggestions = JSON.parse(mockS3Client.send.firstCall.args[0].input.Body);
       expect(uploadedSuggestions).to.have.lengthOf(1);
       expect(uploadedSuggestions[0].url).to.equal('https://example.com/page2');
     });
@@ -833,7 +833,7 @@ describe('Prerender AI-Only Mode', () => {
       const result = await importTopPages(context);
 
       expect(result.status).to.equal('complete');
-      const uploadedSuggestions = mockSqs.sendMessage.firstCall.args[1].data.suggestions;
+      const uploadedSuggestions = JSON.parse(mockS3Client.send.firstCall.args[0].input.Body);
       uploadedSuggestions.forEach((s) => {
         expect(s.hasPrompts).to.equal(false);
       });
@@ -854,7 +854,7 @@ describe('Prerender AI-Only Mode', () => {
       const result = await importTopPages(context);
 
       expect(result.status).to.equal('complete');
-      const uploadedSuggestions = mockSqs.sendMessage.firstCall.args[1].data.suggestions;
+      const uploadedSuggestions = JSON.parse(mockS3Client.send.firstCall.args[0].input.Body);
       const s1 = uploadedSuggestions.find((s) => s.url === 'https://example.com/page1');
       const s2 = uploadedSuggestions.find((s) => s.url === 'https://example.com/page2');
       expect(s1.hasPrompts).to.equal(true);
@@ -872,7 +872,7 @@ describe('Prerender AI-Only Mode', () => {
       const result = await importTopPages(context);
 
       expect(result.status).to.equal('complete');
-      const uploadedSuggestions = mockSqs.sendMessage.firstCall.args[1].data.suggestions;
+      const uploadedSuggestions = JSON.parse(mockS3Client.send.firstCall.args[0].input.Body);
       const s1 = uploadedSuggestions.find((s) => s.url === 'https://example.com/page1');
       expect(s1.hasPrompts).to.equal(false);
     });
@@ -909,17 +909,17 @@ describe('Prerender AI-Only Mode', () => {
     });
   });
 
-  describe('inline suggestions in SQS payload', () => {
-    it('should include inline suggestions with batchIndex and totalBatches', async () => {
+  describe('suggestionsS3Key and suggestionsS3Bucket in SQS payload', () => {
+    it('should include suggestionsS3Key and suggestionsS3Bucket instead of inline suggestions', async () => {
       const result = await importTopPages(context);
 
       expect(result.status).to.equal('complete');
       const message = mockSqs.sendMessage.getCall(0).args[1];
-      expect(message.data.suggestions).to.be.an('array');
-      expect(message.data.batchIndex).to.equal(0);
-      expect(message.data.totalBatches).to.equal(1);
-      expect(message.data).to.not.have.property('suggestionsS3Key');
-      expect(message.data).to.not.have.property('suggestionsS3Bucket');
+      expect(message.data.suggestionsS3Key).to.equal('prerender/mystique-suggestions/opportunity-123.json');
+      expect(message.data.suggestionsS3Bucket).to.equal('test-bucket');
+      expect(message.data).to.not.have.property('suggestions');
+      expect(message.data).to.not.have.property('batchIndex');
+      expect(message.data).to.not.have.property('totalBatches');
     });
   });
 
@@ -939,20 +939,24 @@ describe('Prerender AI-Only Mode', () => {
     });
   });
 
-  describe('inline suggestions batch behavior', () => {
-    it('should send inline suggestions in SQS message', async () => {
+  describe('S3 upload and mystiqueSession behavior', () => {
+    it('should always upload suggestions to S3 at the correct key', async () => {
       const result = await importTopPages(context);
 
       expect(result.status).to.equal('complete');
 
-      // No S3 upload for suggestions — they go inline
-      expect(mockS3Client.send).to.not.have.been.called;
+      // S3 PutObjectCommand is always called for the suggestions upload
+      expect(mockS3Client.send).to.have.been.calledOnce;
+      const s3Call = mockS3Client.send.firstCall.args[0];
+      expect(s3Call.input.Key).to.equal('prerender/mystique-suggestions/opportunity-123.json');
+      expect(s3Call.input.Bucket).to.equal('test-bucket');
+      expect(s3Call.input.ContentType).to.equal('application/json');
 
-      const sqsMsg = mockSqs.sendMessage.firstCall.args[1];
-      expect(sqsMsg.data.suggestions).to.be.an('array').with.lengthOf(2);
+      const uploadedSuggestions = JSON.parse(s3Call.input.Body);
+      expect(uploadedSuggestions).to.have.lengthOf(2);
     });
 
-    it('should cap inline suggestions at 320 for large suggestion counts', async () => {
+    it('should upload all suggestions to S3 for large suggestion counts', async () => {
       const manySuggestions = Array.from({ length: 400 }, (_, i) => ({
         getId: sandbox.stub().returns(`suggestion-${i}`),
         getData: sandbox.stub().returns({
@@ -967,20 +971,19 @@ describe('Prerender AI-Only Mode', () => {
       const result = await importTopPages(context);
 
       expect(result.status).to.equal('complete');
-      expect(result.auditResult.suggestionCount).to.equal(320);
+      expect(result.auditResult.suggestionCount).to.equal(400);
 
-      // Single SQS message with inline suggestions capped at 320
+      // S3 upload contains all 400 suggestions in a single call
+      expect(mockS3Client.send).to.have.been.calledOnce;
+      const uploadedSuggestions = JSON.parse(mockS3Client.send.firstCall.args[0].input.Body);
+      expect(uploadedSuggestions).to.have.lengthOf(400);
+
+      // Single SQS message with S3 key reference (no inline suggestions)
       expect(mockSqs.sendMessage).to.have.been.calledOnce;
       const sqsMsg = mockSqs.sendMessage.firstCall.args[1];
-      expect(sqsMsg.data.suggestions).to.be.an('array').with.lengthOf(320);
-      expect(sqsMsg.data.batchIndex).to.equal(0);
-      expect(sqsMsg.data.totalBatches).to.equal(1);
-      expect(sqsMsg.data).to.not.have.property('suggestionsS3Key');
-
-      // Truncation warning should be logged
-      expect(context.log.warn).to.have.been.calledWith(
-        sinon.match(/Truncating suggestions from 400 to 320/),
-      );
+      expect(sqsMsg.data.suggestionsS3Key).to.equal('prerender/mystique-suggestions/opportunity-123.json');
+      expect(sqsMsg.data.suggestionsS3Bucket).to.equal('test-bucket');
+      expect(sqsMsg.data).to.not.have.property('suggestions');
     });
 
   });


### PR DESCRIPTION
## Summary

Reverts #2716 (fix(prerender): revert to inline suggestions in Mystique SQS message).

This restores the S3-based suggestion dispatch path that was introduced in #2709 — uploading suggestions to S3 and sending the S3 key/bucket to Mystique instead of inlining the full suggestions array in the SQS message.

## Changes reverted

- `src/prerender/handler.js`: Re-adds `PutObjectCommand` for S3 suggestions upload; sends `suggestionsS3Key`/`suggestionsS3Bucket` instead of inline `data.suggestions`
- `src/prerender/utils/constants.js`: Removes the `MYSTIQUE_BATCH_SIZE` export that was restored in #2716
- `test/audits/prerender/ai-only-mode.test.js`: Reverts assertions back to S3 body parsing

## Test plan

- [ ] Run `npm run test:spec -- test/audits/prerender/ai-only-mode.test.js`
- [ ] Run `npm run test:spec -- test/audits/prerender/handler.test.js`
- [ ] Lint clean on changed files