### PR TITLE
fix: enable Bright Data URL validation by default and fix CDN-block false negatives

### DIFF
--- a/src/backlinks/handler.js
+++ b/src/backlinks/handler.js
@@ -508,7 +508,7 @@ export const generateSuggestionData = async (context) => {
 
   // Bright Data: resolve suggestions first, then fallback to Mystique
   const useBrightData = Boolean(env.BRIGHT_DATA_API_KEY && env.BRIGHT_DATA_ZONE);
-  const validateBrightDataUrls = getEnvBool(env, BRIGHT_DATA_VALIDATE_URLS, false);
+  const validateBrightDataUrls = getEnvBool(env, BRIGHT_DATA_VALIDATE_URLS, true);
   const brightDataMaxResults = getEnvInt(env, BRIGHT_DATA_MAX_RESULTS, 10);
   const brightDataRequestDelayMs = getEnvInt(env, BRIGHT_DATA_REQUEST_DELAY_MS, 500);
 

--- a/src/utils/url-utils.js
+++ b/src/utils/url-utils.js
@@ -173,7 +173,12 @@ export function isPreviewPage(url) {
   return urlObj.hostname.endsWith('.page');
 }
 
-export async function filterBrokenSuggestedUrls(suggestedUrls, baseURL) {
+export async function filterBrokenSuggestedUrls(
+  suggestedUrls,
+  baseURL,
+  timeoutMs = 5000,
+  fetchFn = fetch,
+) {
   // Strip www from both sides for consistent domain comparison
   const baseDomain = stripWWW(new URL(baseURL).hostname);
   const checks = suggestedUrls.map(async (suggestedUrl) => {
@@ -182,9 +187,16 @@ export async function filterBrokenSuggestedUrls(suggestedUrls, baseURL) {
       const suggestedURLObj = new URL(schemaPrependedUrl);
       const suggestedDomain = stripWWW(suggestedURLObj.hostname);
       if (suggestedDomain === baseDomain) {
-        const response = await fetch(schemaPrependedUrl);
-        if (response.ok) {
-          return suggestedUrl;
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+        try {
+          const response = await fetchFn(schemaPrependedUrl, { signal: controller.signal });
+          // Only filter confirmed 404s — CDN blocks (403, 429, 5xx) may be valid pages
+          if (response.status !== 404) {
+            return suggestedUrl;
+          }
+        } finally {
+          clearTimeout(timeoutId);
         }
       }
       return null;

--- a/src/utils/url-utils.js
+++ b/src/utils/url-utils.js
@@ -178,6 +178,7 @@ export async function filterBrokenSuggestedUrls(
   baseURL,
   timeoutMs = 5000,
   fetchFn = fetch,
+  log = null,
 ) {
   // Strip www from both sides for consistent domain comparison
   const baseDomain = stripWWW(new URL(baseURL).hostname);
@@ -200,8 +201,8 @@ export async function filterBrokenSuggestedUrls(
         }
       }
       return null;
-      // eslint-disable-next-line no-unused-vars
     } catch (error) {
+      log?.warn(`Backlinks: failed to validate suggested URL ${suggestedUrl}: ${error.message}`);
       return null;
     }
   });

--- a/test/audits/backlinks.test.js
+++ b/test/audits/backlinks.test.js
@@ -1283,6 +1283,8 @@ describe('Backlinks Tests', function () {
       context.dataAccess.Suggestion.allByOpportunityIdAndStatus.resolves(testSuggestions);
       context.dataAccess.Suggestion.findById = sinon.stub().resolves(mockSuggestion);
 
+      nock('https://example.com').get('/suggested-page').reply(200);
+
       await mockedGenerateSuggestionData(context);
 
       expect(mockSuggestion.setData).to.have.been.calledOnce;
@@ -1618,6 +1620,8 @@ describe('Backlinks Tests', function () {
       // Return null for findById to simulate missing suggestion
       context.dataAccess.Suggestion.findById = sinon.stub().resolves(null);
 
+      nock('https://example.com').get('/suggested-page').reply(200);
+
       await mockedGenerateSuggestionData(context);
 
       expect(context.log.warn).to.have.been.calledWith(sinon.match(/suggestion not found/));
@@ -1750,6 +1754,8 @@ describe('Backlinks Tests', function () {
       context.dataAccess.Suggestion.allByOpportunityIdAndStatus.resolves([mockSuggestion]);
       context.dataAccess.Suggestion.findById = sinon.stub().resolves(mockSuggestion);
       context.dataAccess.SiteTopPage.allBySiteIdAndSourceAndGeo.resolves(topPages);
+
+      nock('https://example.com').get('/suggested-page').reply(200);
 
       const result = await mockedGenerateSuggestionData(context);
 

--- a/test/utils/url-utils.test.js
+++ b/test/utils/url-utils.test.js
@@ -10,7 +10,9 @@
  * governing permissions and limitations under the License.
  */
 
-import { expect } from 'chai';
+import { expect, use } from 'chai';
+import sinonChai from 'sinon-chai';
+import sinon from 'sinon';
 import nock from 'nock';
 import {
   isPreviewPage,
@@ -22,6 +24,8 @@ import {
   resolveParentPathFallback,
 } from '../../src/utils/url-utils.js';
 import * as utils from '../../src/utils/url-utils.js';
+
+use(sinonChai);
 
 describe('isPdfUrl', () => {
   it('should return true for URLs ending with .pdf', () => {
@@ -253,16 +257,20 @@ describe('filterBrokenSuggestedUrls', () => {
     expect(result).to.deep.equal(['https://www.example.com/page2']);
   });
 
-  it('should keep URLs blocked by CDN (403, 429) since they may be valid pages', async () => {
+  it('should keep URLs blocked by CDN (403, 429, 5xx) since they may be valid pages', async () => {
     const suggestedUrls = [
       'https://www.example.com/cdn-blocked',
       'https://www.example.com/rate-limited',
+      'https://www.example.com/server-error',
       'https://www.example.com/missing',
     ];
     nock('https://www.example.com')
-      .get('/cdn-blocked').reply(403)
+      .get('/cdn-blocked')
+      .reply(403)
       .get('/rate-limited')
       .reply(429)
+      .get('/server-error')
+      .reply(503)
       .get('/missing')
       .reply(404);
 
@@ -270,6 +278,7 @@ describe('filterBrokenSuggestedUrls', () => {
     expect(result).to.deep.equal([
       'https://www.example.com/cdn-blocked',
       'https://www.example.com/rate-limited',
+      'https://www.example.com/server-error',
     ]);
   });
 
@@ -288,6 +297,23 @@ describe('filterBrokenSuggestedUrls', () => {
     };
     const result = await utils.filterBrokenSuggestedUrls(suggestedUrls, baseURL, 50, mockFetch);
     expect(result).to.deep.equal(['https://www.example.com/fast']);
+  });
+
+  it('should log a warning when a network error occurs during validation', async () => {
+    const suggestedUrls = ['https://www.example.com/unreachable'];
+    const mockFetch = () => Promise.reject(new Error('ECONNREFUSED'));
+    const mockLog = { warn: sinon.spy() };
+    const result = await utils.filterBrokenSuggestedUrls(
+      suggestedUrls,
+      baseURL,
+      5000,
+      mockFetch,
+      mockLog,
+    );
+    expect(result).to.deep.equal([]);
+    expect(mockLog.warn).to.have.been.calledOnceWith(
+      'Backlinks: failed to validate suggested URL https://www.example.com/unreachable: ECONNREFUSED',
+    );
   });
 });
 

--- a/test/utils/url-utils.test.js
+++ b/test/utils/url-utils.test.js
@@ -252,6 +252,43 @@ describe('filterBrokenSuggestedUrls', () => {
     const result = await utils.filterBrokenSuggestedUrls(suggestedUrls, baseURL);
     expect(result).to.deep.equal(['https://www.example.com/page2']);
   });
+
+  it('should keep URLs blocked by CDN (403, 429) since they may be valid pages', async () => {
+    const suggestedUrls = [
+      'https://www.example.com/cdn-blocked',
+      'https://www.example.com/rate-limited',
+      'https://www.example.com/missing',
+    ];
+    nock('https://www.example.com')
+      .get('/cdn-blocked').reply(403)
+      .get('/rate-limited')
+      .reply(429)
+      .get('/missing')
+      .reply(404);
+
+    const result = await utils.filterBrokenSuggestedUrls(suggestedUrls, baseURL);
+    expect(result).to.deep.equal([
+      'https://www.example.com/cdn-blocked',
+      'https://www.example.com/rate-limited',
+    ]);
+  });
+
+  it('should filter out URLs that exceed the fetch timeout', async () => {
+    const suggestedUrls = [
+      'https://www.example.com/slow',
+      'https://www.example.com/fast',
+    ];
+    const mockFetch = (url, { signal }) => {
+      if (url.includes('slow')) {
+        return new Promise((_, reject) => {
+          signal.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')));
+        });
+      }
+      return Promise.resolve({ status: 200, ok: true });
+    };
+    const result = await utils.filterBrokenSuggestedUrls(suggestedUrls, baseURL, 50, mockFetch);
+    expect(result).to.deep.equal(['https://www.example.com/fast']);
+  });
 });
 
 describe('isUnscrapeable', () => {


### PR DESCRIPTION
 ## Problem
  
  `BRIGHT_DATA_VALIDATE_URLS` defaulted to `false`, meaning Bright Data suggested
  URLs were never validated before being shown to customers. This allowed 404 URLs
  to reach the dashboard as actionable suggestions.

  Two additional bugs existed in `filterBrokenSuggestedUrls`:
  - The filter used `response.ok` (2xx only), which treated CDN blocks (403, 429)
    as broken URLs. Sites like ups.com that block bot HTTP requests had all their
    Bright Data suggestions incorrectly filtered out.
  - `fetch()` had no timeout, leaving requests open indefinitely if a site hung.

  ## Changes

  - **`src/backlinks/handler.js`**: Changed `BRIGHT_DATA_VALIDATE_URLS` default
    from `false` to `true`. The env var can still override this to `false` if needed.

  - **`src/utils/url-utils.js`**:
    - Filter now only removes confirmed 404s (`response.status !== 404`). CDN blocks
      (403, 429, 5xx) are treated as potentially valid pages and kept.
    - Added 5-second fetch timeout via `AbortController`. Timed-out URLs are
      filtered out (treated as unverifiable).
    - `fetchFn` is now injectable as an optional parameter to support unit testing
      of timeout behavior without ESM global stubbing.

  - **Tests**: Added coverage for CDN-block pass-through and fetch timeout behavior.
    Fixed three existing backlinks tests that relied on the old `false` default.

  ## Validation

  The `BRIGHT_DATA_VALIDATE_URLS` path only runs when both `BRIGHT_DATA_API_KEY`
  and `BRIGHT_DATA_ZONE` are present, so sites without Bright Data credentials are
  unaffected. A before/after comparison on a production site with Bright Data
  suggestions will be run after deploy to confirm 404 suggestions are filtered.