### PR TITLE
fix(preflight): only report DNS failures as broken external links (SITES-47125)

### DIFF
--- a/src/preflight/links-checks.js
+++ b/src/preflight/links-checks.js
@@ -131,11 +131,17 @@ function isBrokenStatus(status) {
  * connection level (e.g. ups.com resets the HTTP/2 stream with NGHTTP2_INTERNAL_ERROR), so these
  * must NOT be reported as broken (SITES-47125).
  *
+ * Node's DNS resolver reliably sets `err.code === 'ENOTFOUND'`, which is the primary signal. The
+ * message check is a narrow fallback for wrappers that strip `.code`: it only fires when no code
+ * is present and matches the canonical `getaddrinfo ENOTFOUND` format — not any message that
+ * merely contains the substring, which would re-introduce false positives (PR #2727 review).
+ *
  * @param {Error} err
  * @returns {boolean}
  */
 function isDnsResolutionFailure(err) {
-  return err.code === 'ENOTFOUND' || /ENOTFOUND/.test(err.message);
+  return err.code === 'ENOTFOUND'
+    || (err.code == null && /getaddrinfo ENOTFOUND/.test(err.message));
 }
 
 /**

--- a/src/preflight/links-checks.js
+++ b/src/preflight/links-checks.js
@@ -118,6 +118,27 @@ function isBrokenStatus(status) {
 }
 
 /**
+ * Returns true only for a DNS-resolution failure — the one network-level error that
+ * definitively indicates a broken link.
+ *
+ * A DNS-resolution failure (`ENOTFOUND` — getaddrinfo cannot resolve the hostname) means the
+ * domain does not exist, so the link is unambiguously broken (SITES-40919: nonexistent domains
+ * and intranet hosts that fail DNS must surface as status 0).
+ *
+ * Every other thrown error — connection reset, HTTP/2 stream errors, TLS failures, connection
+ * refused, request timeouts — means the host resolves and is reachable but did not return a
+ * usable HTTP response. That is indistinguishable from a valid page that blocks crawlers at the
+ * connection level (e.g. ups.com resets the HTTP/2 stream with NGHTTP2_INTERNAL_ERROR), so these
+ * must NOT be reported as broken (SITES-47125).
+ *
+ * @param {Error} err
+ * @returns {boolean}
+ */
+function isDnsResolutionFailure(err) {
+  return err.code === 'ENOTFOUND' || /ENOTFOUND/.test(err.message);
+}
+
+/**
  * Helper function to check if a link is broken
  * @param {string} href - The URL to check
  * @param {string} pageUrl - The source page URL
@@ -203,16 +224,24 @@ async function checkLinkStatus(href, pageUrl, context, options = {
 
     return null;
   } catch (finalErr) {
-    // Network-level failure (DNS, timeout, unsupported protocol) — the link is
-    // unreachable, which is a broken-link condition. status: 0 is the sentinel
-    // for "no HTTP response received".
-    log.info(`[preflight-audit] ${linkType} link ${href} unreachable (${finalErr.message}) — reporting as broken`);
-    return {
-      urlTo: href,
-      href: pageUrl,
-      status: 0,
-      ...toElementTargets(selectors),
-    };
+    // Only a DNS-resolution failure (ENOTFOUND) is a definitive broken-link condition: the
+    // domain does not exist. status: 0 is the sentinel for "no HTTP response received".
+    if (isDnsResolutionFailure(finalErr)) {
+      log.info(`[preflight-audit] ${linkType} link ${href} unreachable — DNS does not resolve (${finalErr.message}) — reporting as broken`);
+      return {
+        urlTo: href,
+        href: pageUrl,
+        status: 0,
+        ...toElementTargets(selectors),
+      };
+    }
+
+    // Any other network-level failure (connection reset, HTTP/2 stream error, TLS, timeout)
+    // means the host is reachable but did not return a usable response — indistinguishable
+    // from a valid page that blocks bots at the connection level. Do NOT report as broken
+    // (SITES-47125: ups.com and similar bot-protected sites were false-flagged as Status 0).
+    log.info(`[preflight-audit] ${linkType} link ${href} probe inconclusive (${finalErr.message}) — not reporting as broken`);
+    return null;
   }
 }
 

--- a/src/preflight/links-checks.js
+++ b/src/preflight/links-checks.js
@@ -199,7 +199,11 @@ async function checkLinkStatus(href, pageUrl, context, options = {
       return null;
     }
   } catch (err) {
-    log.warn(`[preflight-audit] HEAD request failed (${err.message}), retrying with GET: ${href}`);
+    // DEBUG, not WARN: a thrown HEAD is expected and self-correcting here — we always retry with
+    // GET, and on bot-protected hosts (which reset the connection) every probe throws HEAD first
+    // yet ends up correctly not-broken. Logging that at WARN produced high-volume, non-actionable
+    // noise that also looked like a failure for links we then skip (SITES-47125 review).
+    log.debug(`[preflight-audit] HEAD request failed (${err.message}), retrying with GET: ${href}`);
   }
 
   // GET fallback — HEAD was inconclusive (broken status, fallback status, or network error).
@@ -246,7 +250,10 @@ async function checkLinkStatus(href, pageUrl, context, options = {
     // means the host is reachable but did not return a usable response — indistinguishable
     // from a valid page that blocks bots at the connection level. Do NOT report as broken
     // (SITES-47125: ups.com and similar bot-protected sites were false-flagged as Status 0).
-    log.info(`[preflight-audit] ${linkType} link ${href} probe inconclusive (${finalErr.message}) — not reporting as broken`);
+    // DEBUG, not INFO: on a page with many bot-blocked external links this is the common,
+    // non-actionable path and at INFO it floods the logs. The DNS-failure branch above stays at
+    // INFO because that is the actionable "reporting as broken" case (SITES-47125 review).
+    log.debug(`[preflight-audit] ${linkType} link ${href} probe inconclusive (${finalErr.message}) — not reporting as broken`);
     return null;
   }
 }

--- a/test/audits/preflight.test.js
+++ b/test/audits/preflight.test.js
@@ -145,7 +145,7 @@ describe('Preflight Audit', () => {
 
       const result = await runLinksChecks(urls, scrapedObjects, context);
       expect(result.auditResult.brokenInternalLinks).to.have.lengthOf(0);
-      expect(context.log.info).to.have.been.calledWithMatch(/internal link https:\/\/main--example--page\.aem\.page\/blocked probe inconclusive/);
+      expect(context.log.debug).to.have.been.calledWithMatch(/internal link https:\/\/main--example--page\.aem\.page\/blocked probe inconclusive/);
     });
 
     it('handles HEAD failure with GET fallback success', async () => {
@@ -165,7 +165,7 @@ describe('Preflight Audit', () => {
 
       const result = await runLinksChecks(urls, scrapedObjects, context);
       expect(result.auditResult.brokenInternalLinks).to.deep.equal([]);
-      expect(context.log.warn).to.have.been.calledWithMatch('[preflight-audit] HEAD request failed (HEAD request failed), retrying with GET: https://main--example--page.aem.page/head-fails-get-works');
+      expect(context.log.debug).to.have.been.calledWithMatch('[preflight-audit] HEAD request failed (HEAD request failed), retrying with GET: https://main--example--page.aem.page/head-fails-get-works');
     });
 
     it('handles HEAD failure with GET fallback returning 404', async () => {
@@ -192,7 +192,7 @@ describe('Preflight Audit', () => {
           elements: [{ selector: 'body > a' }],
         },
       ]);
-      expect(context.log.warn).to.have.been.calledWithMatch('[preflight-audit] HEAD request failed (HEAD request failed), retrying with GET: https://main--example--page.aem.page/head-fails-get-404');
+      expect(context.log.debug).to.have.been.calledWithMatch('[preflight-audit] HEAD request failed (HEAD request failed), retrying with GET: https://main--example--page.aem.page/head-fails-get-404');
     });
 
     it('filters out scrapedObjects not in the urls list', async () => {
@@ -398,7 +398,7 @@ describe('Preflight Audit', () => {
 
       const result = await runLinksChecks(urls, scrapedObjects, context);
       expect(result.auditResult.brokenExternalLinks).to.have.lengthOf(0);
-      expect(context.log.info).to.have.been.calledWithMatch(/external link https:\/\/external-site\.com\/blocked probe inconclusive/);
+      expect(context.log.debug).to.have.been.calledWithMatch(/external link https:\/\/external-site\.com\/blocked probe inconclusive/);
     });
 
     it('handles external HEAD failure with GET fallback success', async () => {
@@ -418,7 +418,7 @@ describe('Preflight Audit', () => {
 
       const result = await runLinksChecks(urls, scrapedObjects, context);
       expect(result.auditResult.brokenExternalLinks).to.deep.equal([]);
-      expect(context.log.warn).to.have.been.calledWithMatch('[preflight-audit] HEAD request failed (HEAD request failed), retrying with GET: https://external-site.com/head-fails-get-works');
+      expect(context.log.debug).to.have.been.calledWithMatch('[preflight-audit] HEAD request failed (HEAD request failed), retrying with GET: https://external-site.com/head-fails-get-works');
     });
 
     it('handles external HEAD failure with GET fallback returning 404', async () => {
@@ -445,7 +445,7 @@ describe('Preflight Audit', () => {
           elements: [{ selector: 'body > a' }],
         },
       ]);
-      expect(context.log.warn).to.have.been.calledWithMatch('[preflight-audit] HEAD request failed (HEAD request failed), retrying with GET: https://external-site.com/head-fails-get-404');
+      expect(context.log.debug).to.have.been.calledWithMatch('[preflight-audit] HEAD request failed (HEAD request failed), retrying with GET: https://external-site.com/head-fails-get-404');
     });
 
     it('processes both internal and external links correctly', async () => {

--- a/test/audits/preflight.test.js
+++ b/test/audits/preflight.test.js
@@ -106,13 +106,14 @@ describe('Preflight Audit', () => {
       ]);
     });
 
-    it('handles fetch errors', async () => {
+    it('reports a DNS-resolution failure (ENOTFOUND) as a broken internal link', async () => {
       const urls = ['https://main--example--page.aem.page/page1'];
+      const dnsError = () => Object.assign(new Error('getaddrinfo ENOTFOUND main--example--page.aem.page'), { code: 'ENOTFOUND' });
       nock('https://main--example--page.aem.page')
         .head('/fail')
-        .replyWithError('network fail')
+        .replyWithError(dnsError())
         .get('/fail')
-        .replyWithError('network fail');
+        .replyWithError(dnsError());
 
       const scrapedObjects = [{
         data: {
@@ -125,6 +126,26 @@ describe('Preflight Audit', () => {
       expect(result.auditResult.brokenInternalLinks).to.have.lengthOf(1);
       expect(result.auditResult.brokenInternalLinks[0].status).to.equal(0);
       expect(context.log.info).to.have.been.calledWithMatch(/internal link https:\/\/main--example--page\.aem\.page\/fail unreachable/);
+    });
+
+    it('does NOT report a connection-level (non-DNS) failure as a broken internal link (SITES-47125)', async () => {
+      const urls = ['https://main--example--page.aem.page/page1'];
+      nock('https://main--example--page.aem.page')
+        .head('/blocked')
+        .replyWithError('socket hang up')
+        .get('/blocked')
+        .replyWithError('socket hang up');
+
+      const scrapedObjects = [{
+        data: {
+          scrapeResult: { rawBody: '<a href="/blocked">blocked</a>' },
+          finalUrl: urls[0],
+        },
+      }];
+
+      const result = await runLinksChecks(urls, scrapedObjects, context);
+      expect(result.auditResult.brokenInternalLinks).to.have.lengthOf(0);
+      expect(context.log.info).to.have.been.calledWithMatch(/internal link https:\/\/main--example--page\.aem\.page\/blocked probe inconclusive/);
     });
 
     it('handles HEAD failure with GET fallback success', async () => {
@@ -335,13 +356,14 @@ describe('Preflight Audit', () => {
       ]);
     });
 
-    it('handles external link fetch errors', async () => {
+    it('reports a DNS-resolution failure (ENOTFOUND) as a broken external link', async () => {
       const urls = ['https://main--example--page.aem.page/page1'];
+      const dnsError = () => Object.assign(new Error('getaddrinfo ENOTFOUND external-site.com'), { code: 'ENOTFOUND' });
       nock('https://external-site.com')
         .head('/fail')
-        .replyWithError('network fail')
+        .replyWithError(dnsError())
         .get('/fail')
-        .replyWithError('network fail');
+        .replyWithError(dnsError());
 
       const scrapedObjects = [{
         data: {
@@ -355,6 +377,28 @@ describe('Preflight Audit', () => {
       expect(result.auditResult.brokenExternalLinks[0].status).to.equal(0);
       expect(result.auditResult.brokenExternalLinks[0].urlTo).to.equal('https://external-site.com/fail');
       expect(context.log.info).to.have.been.calledWithMatch(/external link https:\/\/external-site\.com\/fail unreachable/);
+    });
+
+    it('does NOT report a bot-blocking connection-level failure as a broken external link (SITES-47125)', async () => {
+      // ups.com pattern: DNS resolves, but the server resets the HTTP/2 stream to block bots.
+      const urls = ['https://main--example--page.aem.page/page1'];
+      const http2Error = () => Object.assign(new Error('Stream closed with error code NGHTTP2_INTERNAL_ERROR'), { code: 'ERR_HTTP2_STREAM_ERROR' });
+      nock('https://external-site.com')
+        .head('/blocked')
+        .replyWithError(http2Error())
+        .get('/blocked')
+        .replyWithError(http2Error());
+
+      const scrapedObjects = [{
+        data: {
+          scrapeResult: { rawBody: '<a href="https://external-site.com/blocked">external blocked</a>' },
+          finalUrl: urls[0],
+        },
+      }];
+
+      const result = await runLinksChecks(urls, scrapedObjects, context);
+      expect(result.auditResult.brokenExternalLinks).to.have.lengthOf(0);
+      expect(context.log.info).to.have.been.calledWithMatch(/external link https:\/\/external-site\.com\/blocked probe inconclusive/);
     });
 
     it('handles external HEAD failure with GET fallback success', async () => {

--- a/test/preflight/links-checks.test.js
+++ b/test/preflight/links-checks.test.js
@@ -356,7 +356,27 @@ describe('preflight/links-checks - runLinksChecks', () => {
     expect(context.log.error).to.not.have.been.called;
   });
 
-  it('flags internal link as broken (status 0) on a DNS-resolution error (ENOTFOUND)', async () => {
+  it('does NOT flag as broken when a non-DNS error message merely contains the substring "ENOTFOUND"', async () => {
+    // The message-fallback must only match the canonical Node format ("getaddrinfo ENOTFOUND"),
+    // not any message that happens to contain the substring — otherwise a wrapper error like this
+    // would re-introduce the false positives this fix removes (MysticatBot review on PR #2727).
+    const wrappedError = new Error('Retry after ENOTFOUND was cached'); // no .code, non-canonical
+    fetchStub.onFirstCall().rejects(wrappedError);
+    fetchStub.onSecondCall().rejects(wrappedError);
+
+    const result = await runLinksChecks(
+      [pageUrl],
+      makeScrapedObjects('<a href="https://other.com/page">link</a>'),
+      context,
+    );
+
+    expect(result.auditResult.brokenExternalLinks).to.have.lengthOf(0);
+    expect(context.log.error).to.not.have.been.called;
+  });
+
+  // Message-fallback branch: error carries the canonical "getaddrinfo ENOTFOUND" message but no
+  // .code (e.g. a fetch wrapper that strips the code). Still a definitive DNS failure → broken.
+  it('flags internal link as broken (status 0) on a DNS-resolution error message without a code', async () => {
     fetchStub.onFirstCall().rejects(new Error('getaddrinfo ENOTFOUND internal.example.com'));
     fetchStub.onSecondCall().rejects(new Error('getaddrinfo ENOTFOUND internal.example.com'));
 

--- a/test/preflight/links-checks.test.js
+++ b/test/preflight/links-checks.test.js
@@ -297,7 +297,7 @@ describe('preflight/links-checks - runLinksChecks', () => {
     );
 
     expect(fetchStub.callCount).to.equal(2);
-    expect(context.log.warn).to.have.been.calledWith(sinon.match(/HEAD request failed/));
+    expect(context.log.debug).to.have.been.calledWith(sinon.match(/HEAD request failed/));
     expect(result.auditResult.brokenExternalLinks).to.have.lengthOf(0);
   });
 
@@ -340,6 +340,9 @@ describe('preflight/links-checks - runLinksChecks', () => {
 
     expect(result.auditResult.brokenExternalLinks).to.have.lengthOf(0);
     expect(context.log.error).to.not.have.been.called;
+    // Assert the inconclusive branch actually ran, not just that nothing was flagged — a refactor
+    // that exited before reaching isDnsResolutionFailure would still pass the two checks above.
+    expect(context.log.debug).to.have.been.calledWith(sinon.match(/probe inconclusive/));
   });
 
   it('does NOT flag as broken when both HEAD and GET fail with a generic (non-DNS) network error', async () => {
@@ -354,6 +357,7 @@ describe('preflight/links-checks - runLinksChecks', () => {
 
     expect(result.auditResult.brokenExternalLinks).to.have.lengthOf(0);
     expect(context.log.error).to.not.have.been.called;
+    expect(context.log.debug).to.have.been.calledWith(sinon.match(/probe inconclusive/));
   });
 
   it('does NOT flag as broken when a non-DNS error message merely contains the substring "ENOTFOUND"', async () => {
@@ -372,6 +376,7 @@ describe('preflight/links-checks - runLinksChecks', () => {
 
     expect(result.auditResult.brokenExternalLinks).to.have.lengthOf(0);
     expect(context.log.error).to.not.have.been.called;
+    expect(context.log.debug).to.have.been.calledWith(sinon.match(/probe inconclusive/));
   });
 
   // Message-fallback branch: error carries the canonical "getaddrinfo ENOTFOUND" message but no

--- a/test/preflight/links-checks.test.js
+++ b/test/preflight/links-checks.test.js
@@ -301,13 +301,19 @@ describe('preflight/links-checks - runLinksChecks', () => {
     expect(result.auditResult.brokenExternalLinks).to.have.lengthOf(0);
   });
 
-  it('flags as broken (status 0) when both HEAD and GET throw network errors', async () => {
-    fetchStub.onFirstCall().rejects(new Error('network error'));
-    fetchStub.onSecondCall().rejects(new Error('still failing'));
+  // SITES-47125: only DNS-resolution failures (ENOTFOUND) are definitively broken.
+  // Other network-level failures (connection reset, HTTP/2 stream errors, TLS, timeout)
+  // mean the host exists but won't talk to our bot — these are indistinguishable from a
+  // valid page that blocks crawlers, so they must NOT be reported as broken.
+
+  it('flags as broken (status 0) when both HEAD and GET fail with a DNS-resolution error (ENOTFOUND)', async () => {
+    const dnsError = Object.assign(new Error('getaddrinfo ENOTFOUND www.brokenlinkbrokenlink.za'), { code: 'ENOTFOUND' });
+    fetchStub.onFirstCall().rejects(dnsError);
+    fetchStub.onSecondCall().rejects(dnsError);
 
     const result = await runLinksChecks(
       [pageUrl],
-      makeScrapedObjects('<a href="https://other.com/page">link</a>'),
+      makeScrapedObjects('<a href="https://www.brokenlinkbrokenlink.za/page">link</a>'),
       context,
     );
 
@@ -317,7 +323,40 @@ describe('preflight/links-checks - runLinksChecks', () => {
     expect(context.log.error).to.not.have.been.called;
   });
 
-  it('flags internal link as broken (status 0) when both HEAD and GET throw network errors', async () => {
+  it('does NOT flag as broken when a connection-level error blocks the bot (HTTP/2 reset — SITES-47125)', async () => {
+    // ups.com resolves fine but resets the HTTP/2 stream to block bots. Valid in a browser.
+    const http2Error = Object.assign(
+      new Error('Stream closed with error code NGHTTP2_INTERNAL_ERROR'),
+      { code: 'ERR_HTTP2_STREAM_ERROR' },
+    );
+    fetchStub.onFirstCall().rejects(http2Error);
+    fetchStub.onSecondCall().rejects(http2Error);
+
+    const result = await runLinksChecks(
+      [pageUrl],
+      makeScrapedObjects('<a href="https://www.ups.com/ppwa/doWork?loc=en_US">link</a>'),
+      context,
+    );
+
+    expect(result.auditResult.brokenExternalLinks).to.have.lengthOf(0);
+    expect(context.log.error).to.not.have.been.called;
+  });
+
+  it('does NOT flag as broken when both HEAD and GET fail with a generic (non-DNS) network error', async () => {
+    fetchStub.onFirstCall().rejects(new Error('network error'));
+    fetchStub.onSecondCall().rejects(new Error('still failing'));
+
+    const result = await runLinksChecks(
+      [pageUrl],
+      makeScrapedObjects('<a href="https://other.com/page">link</a>'),
+      context,
+    );
+
+    expect(result.auditResult.brokenExternalLinks).to.have.lengthOf(0);
+    expect(context.log.error).to.not.have.been.called;
+  });
+
+  it('flags internal link as broken (status 0) on a DNS-resolution error (ENOTFOUND)', async () => {
     fetchStub.onFirstCall().rejects(new Error('getaddrinfo ENOTFOUND internal.example.com'));
     fetchStub.onSecondCall().rejects(new Error('getaddrinfo ENOTFOUND internal.example.com'));
 


### PR DESCRIPTION
## Problem

Valid external links on bot-protected sites were being false-flagged as **"Status 0 / Broken External Links"** in the preflight links audit. Confirmed against a customer (ups.com): both `https://www.ups.com/us/en/support/shipping-support/legal-terms-conditions/california-privacy-rights` and `https://www.ups.com/ppwa/doWork?loc=en_US` load fine in a browser but were reported as broken.

Jira: [SITES-47125](https://jira.corp.adobe.com/browse/SITES-47125)

## Root cause

The fix for [SITES-40919](https://jira.corp.adobe.com/browse/SITES-40919) (#2476, commit `d83ffb19`) changed the GET-fallback catch block in `src/preflight/links-checks.js` to return `{ status: 0 }` for **any** thrown fetch error — correct for genuinely unreachable hosts (DNS `ENOTFOUND`).

ups.com resolves DNS fine but **resets the HTTP/2 stream** (`ERR_HTTP2_STREAM_ERROR` / "NGHTTP2_INTERNAL_ERROR") to block bots. That throws, bypasses `isBrokenStatus()` (where 403/429 are already excluded), and lands in the catch block that reported it as broken. The existing bot-block protection only covered HTTP responses, not connection-level refusals.

## Fix

Discriminate by error type. Only a **DNS-resolution failure (`ENOTFOUND`)** — the domain does not exist — is a definitive broken link (`status: 0`). All other network-level failures (connection reset, HTTP/2 stream errors, TLS, timeout) mean the host is reachable but returned no usable response — indistinguishable from a valid page that blocks bots — so they are logged as "probe inconclusive" and not reported.

This **preserves the SITES-40919 case** (nonexistent domains / intranet hosts that fail DNS still surface as `status: 0`) while fixing the SITES-47125 false positives. Both behaviors verified end-to-end against the real network.

## Tests

- `test/preflight/links-checks.test.js` — added the HTTP/2 bot-block case (not broken) and the explicit `ENOTFOUND`-with-`code` case (broken); updated the old "any error → status 0" tests.
- `test/audits/preflight.test.js` — added integration coverage (via nock) for both the DNS-failure → broken and connection-level → not-broken paths, internal and external.

## Verification

- ✅ Full suite: 8752 passing
- ✅ 100% line/branch/statement coverage (100% on `links-checks.js`)
- ✅ Lint clean
- ✅ Real-network e2e: ups.com URLs skipped ("probe inconclusive"); dead domain still reported (status 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)