### PR TITLE
feat(cited-analysis): Slack summary reports UI visibility + hallucina…

### DIFF
--- a/src/cited-analysis/guidance-handler.js
+++ b/src/cited-analysis/guidance-handler.js
@@ -151,10 +151,18 @@ export default async function handler(message, context) {
         // than re-deriving the threshold here: the gate may surface a payload after
         // dropping bad items, so its decision is authoritative over the raw rate.
         const isVisible = status !== 'IGNORED';
-        const rate = opportunityData.qaVerdict?.rate;
-        const hallucinationNote = typeof rate === 'number'
-          ? ` — hallucination ${Math.round(rate * 100)}%`
-          : '';
+        const verdict = opportunityData.qaVerdict;
+        // rateDetermined === false means there was real analysis but the rate
+        // couldn't be computed (gate failed open → visible); show "n/a" rather
+        // than a misleading 0%. Older payloads without the flag fall back to the rate.
+        let hallucinationNote = '';
+        if (verdict) {
+          if (verdict.rateDetermined === false) {
+            hallucinationNote = ' — hallucination rate n/a';
+          } else if (typeof verdict.rate === 'number') {
+            hallucinationNote = ` — hallucination ${Math.round(verdict.rate * 100)}%`;
+          }
+        }
         const suggestionsLine = `• ${suggestions.length} suggestion${suggestions.length === 1 ? '' : 's'} processed`;
         const slackMessage = isVisible
           ? `:white_check_mark: *cited-analysis* audit finished for *${baseUrl}*\n`

--- a/src/cited-analysis/guidance-handler.js
+++ b/src/cited-analysis/guidance-handler.js
@@ -145,13 +145,26 @@ export default async function handler(message, context) {
       const slackContext = auditRecord?.getAuditResult()?.slackContext;
       if (slackContext) {
         const { channelId, threadTs } = slackContext;
-        await postMessageOptional(
-          context,
-          channelId,
-          `:white_check_mark: *cited-analysis* audit finished for *${site.getBaseURL()}*\n`
-          + `• ${suggestions.length} suggestion${suggestions.length === 1 ? '' : 's'} processed`,
-          { threadTs },
-        );
+
+        // Visibility is the QA gate's decision, carried on the opportunity status
+        // (NEW = customer-visible, IGNORED = suppressed). Branch on status rather
+        // than re-deriving the threshold here: the gate may surface a payload after
+        // dropping bad items, so its decision is authoritative over the raw rate.
+        const isVisible = status !== 'IGNORED';
+        const rate = opportunityData.qaVerdict?.rate;
+        const hallucinationNote = typeof rate === 'number'
+          ? ` — hallucination ${Math.round(rate * 100)}%`
+          : '';
+        const suggestionsLine = `• ${suggestions.length} suggestion${suggestions.length === 1 ? '' : 's'} processed`;
+        const slackMessage = isVisible
+          ? `:white_check_mark: *cited-analysis* audit finished for *${baseUrl}*\n`
+            + `${suggestionsLine}\n`
+            + `• :eye: Visible in the UI${hallucinationNote}`
+          : `:warning: *cited-analysis* audit finished for *${baseUrl}*\n`
+            + `${suggestionsLine}\n`
+            + `• :see_no_evil: Not visible in the UI${hallucinationNote}`;
+
+        await postMessageOptional(context, channelId, slackMessage, { threadTs });
       }
     }
 

--- a/test/audits/cited-analysis/guidance-handler.test.js
+++ b/test/audits/cited-analysis/guidance-handler.test.js
@@ -672,6 +672,31 @@ describe('Cited Analysis Guidance Handler', () => {
       expect(callText).to.include('hallucination 42%');
     });
 
+    it('shows "n/a" when the rate is visible but undetermined', async () => {
+      mockAudit.getAuditResult.returns({
+        slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },
+      });
+
+      const message = {
+        siteId,
+        auditId,
+        data: {
+          analysis: {
+            suggestions: [{ id: 's1', type: 'CONTENT_UPDATE', rank: 1, data: {} }],
+            opportunity: { status: 'NEW', qaVerdict: { rate: 0, rateDetermined: false } },
+          },
+          companyName: 'Example Corp',
+        },
+      };
+
+      await handler.default(message, context);
+
+      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(callText).to.include('Visible in the UI');
+      expect(callText).to.include('hallucination rate n/a');
+      expect(callText).to.not.include('hallucination 0%');
+    });
+
     it('omits the hallucination note when no qaVerdict is present', async () => {
       mockAudit.getAuditResult.returns({
         slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },

--- a/test/audits/cited-analysis/guidance-handler.test.js
+++ b/test/audits/cited-analysis/guidance-handler.test.js
@@ -620,6 +620,81 @@ describe('Cited Analysis Guidance Handler', () => {
       const callText = mockPostMessageOptional.firstCall.args[2];
       expect(callText).to.include('2 suggestions processed');
     });
+
+    it('reports a visible opportunity with the hallucination rate', async () => {
+      mockAudit.getAuditResult.returns({
+        slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },
+      });
+
+      const message = {
+        siteId,
+        auditId,
+        data: {
+          analysis: {
+            suggestions: [{ id: 's1', type: 'CONTENT_UPDATE', rank: 1, data: {} }],
+            opportunity: { status: 'NEW', qaVerdict: { rate: 0.12 } },
+          },
+          companyName: 'Example Corp',
+        },
+      };
+
+      await handler.default(message, context);
+
+      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(callText).to.include(':white_check_mark:');
+      expect(callText).to.include('Visible in the UI');
+      expect(callText).to.include('hallucination 12%');
+      expect(callText).to.not.include('Not visible');
+    });
+
+    it('reports a hidden opportunity (IGNORED) with the hallucination rate', async () => {
+      mockAudit.getAuditResult.returns({
+        slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },
+      });
+
+      const message = {
+        siteId,
+        auditId,
+        data: {
+          analysis: {
+            suggestions: [{ id: 's1', type: 'CONTENT_UPDATE', rank: 1, data: {} }],
+            opportunity: { status: 'IGNORED', qaVerdict: { rate: 0.42 } },
+          },
+          companyName: 'Example Corp',
+        },
+      };
+
+      await handler.default(message, context);
+
+      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(callText).to.include(':warning:');
+      expect(callText).to.include('Not visible in the UI');
+      expect(callText).to.include('hallucination 42%');
+    });
+
+    it('omits the hallucination note when no qaVerdict is present', async () => {
+      mockAudit.getAuditResult.returns({
+        slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },
+      });
+
+      const message = {
+        siteId,
+        auditId,
+        data: {
+          analysis: {
+            suggestions: [{ id: 's1', type: 'CONTENT_UPDATE', rank: 1, data: {} }],
+            opportunity: { status: 'NEW' },
+          },
+          companyName: 'Example Corp',
+        },
+      };
+
+      await handler.default(message, context);
+
+      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(callText).to.include('Visible in the UI');
+      expect(callText).to.not.include('hallucination');
+    });
   });
 
   describe('Error handling', () => {


### PR DESCRIPTION
…tion rate

The cited guidance handler posted a fixed 'audit finished / N suggestions processed' message regardless of whether the QA gate actually surfaced the opportunity to customers. Operators couldn't tell from Slack whether the result was visible or suppressed for hallucination.

Branch the message on the opportunity status (the QA gate decision: NEW = visible, IGNORED = suppressed) and append the hallucination rate from the newly exposed opportunity.qaVerdict:
- visible:   :white_check_mark: ... Visible in the UI — hallucination X%
- suppressed: :warning: ... Not visible in the UI — hallucination X%
Falls back to no rate when qaVerdict is absent. Pairs with the mystique change
exposing qaVerdict in the BO JSON.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
