### PR TITLE
feat(reddit-youtube): Slack summary reports UI visibility + hallucina…

### DIFF
--- a/src/reddit-analysis/guidance-handler.js
+++ b/src/reddit-analysis/guidance-handler.js
@@ -142,13 +142,31 @@ export default async function handler(message, context) {
       const slackContext = auditRecord?.getAuditResult()?.slackContext;
       if (slackContext) {
         const { channelId, threadTs } = slackContext;
-        await postMessageOptional(
-          context,
-          channelId,
-          `:white_check_mark: *reddit-analysis* audit finished for *${site.getBaseURL()}*\n`
-          + `• ${suggestions.length} suggestion${suggestions.length === 1 ? '' : 's'} processed`,
-          { threadTs },
-        );
+
+        // Visibility is the QA gate's decision, carried on the opportunity status
+        // (NEW = customer-visible, IGNORED = suppressed). rateDetermined === false
+        // means there was real analysis but the rate couldn't be computed (gate
+        // failed open → visible); show "n/a" rather than a misleading 0%.
+        const isVisible = status !== 'IGNORED';
+        const verdict = opportunityData.qaVerdict;
+        let hallucinationNote = '';
+        if (verdict) {
+          if (verdict.rateDetermined === false) {
+            hallucinationNote = ' — hallucination rate n/a';
+          } else if (typeof verdict.rate === 'number') {
+            hallucinationNote = ` — hallucination ${Math.round(verdict.rate * 100)}%`;
+          }
+        }
+        const suggestionsLine = `• ${suggestions.length} suggestion${suggestions.length === 1 ? '' : 's'} processed`;
+        const slackMessage = isVisible
+          ? `:white_check_mark: *reddit-analysis* audit finished for *${baseUrl}*\n`
+            + `${suggestionsLine}\n`
+            + `• :eye: Visible in the UI${hallucinationNote}`
+          : `:warning: *reddit-analysis* audit finished for *${baseUrl}*\n`
+            + `${suggestionsLine}\n`
+            + `• :see_no_evil: Not visible in the UI${hallucinationNote}`;
+
+        await postMessageOptional(context, channelId, slackMessage, { threadTs });
       }
     }
 

--- a/src/youtube-analysis/guidance-handler.js
+++ b/src/youtube-analysis/guidance-handler.js
@@ -140,13 +140,31 @@ export default async function handler(message, context) {
       const slackContext = audit?.getAuditResult()?.slackContext;
       if (slackContext) {
         const { channelId, threadTs } = slackContext;
-        await postMessageOptional(
-          context,
-          channelId,
-          `:white_check_mark: *youtube-analysis* audit finished for *${site.getBaseURL()}*\n`
-          + `• ${suggestions.length} suggestion${suggestions.length === 1 ? '' : 's'} processed`,
-          { threadTs },
-        );
+
+        // Visibility is the QA gate's decision, carried on the opportunity status
+        // (NEW = customer-visible, IGNORED = suppressed). rateDetermined === false
+        // means there was real analysis but the rate couldn't be computed (gate
+        // failed open → visible); show "n/a" rather than a misleading 0%.
+        const isVisible = status !== 'IGNORED';
+        const verdict = opportunityData.qaVerdict;
+        let hallucinationNote = '';
+        if (verdict) {
+          if (verdict.rateDetermined === false) {
+            hallucinationNote = ' — hallucination rate n/a';
+          } else if (typeof verdict.rate === 'number') {
+            hallucinationNote = ` — hallucination ${Math.round(verdict.rate * 100)}%`;
+          }
+        }
+        const suggestionsLine = `• ${suggestions.length} suggestion${suggestions.length === 1 ? '' : 's'} processed`;
+        const slackMessage = isVisible
+          ? `:white_check_mark: *youtube-analysis* audit finished for *${baseUrl}*\n`
+            + `${suggestionsLine}\n`
+            + `• :eye: Visible in the UI${hallucinationNote}`
+          : `:warning: *youtube-analysis* audit finished for *${baseUrl}*\n`
+            + `${suggestionsLine}\n`
+            + `• :see_no_evil: Not visible in the UI${hallucinationNote}`;
+
+        await postMessageOptional(context, channelId, slackMessage, { threadTs });
       }
     }
 

--- a/test/audits/reddit-analysis/guidance-handler.test.js
+++ b/test/audits/reddit-analysis/guidance-handler.test.js
@@ -492,6 +492,105 @@ describe('Reddit Analysis Guidance Handler', () => {
       const callText = mockPostMessageOptional.firstCall.args[2];
       expect(callText).to.include('2 suggestions processed');
     });
+
+    it('reports a visible opportunity with the hallucination rate', async () => {
+      mockAudit.getAuditResult.returns({
+        slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },
+      });
+
+      const message = {
+        siteId,
+        auditId,
+        data: {
+          analysis: {
+            suggestions: [{ id: 's1', type: 'CONTENT_UPDATE', rank: 1, data: {} }],
+            opportunity: { status: 'NEW', qaVerdict: { rate: 0.12, rateDetermined: true } },
+          },
+          companyName: 'Example Corp',
+        },
+      };
+
+      await handler.default(message, context);
+
+      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(callText).to.include(':white_check_mark:');
+      expect(callText).to.include('Visible in the UI');
+      expect(callText).to.include('hallucination 12%');
+    });
+
+    it('reports a hidden opportunity (IGNORED) with the hallucination rate', async () => {
+      mockAudit.getAuditResult.returns({
+        slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },
+      });
+
+      const message = {
+        siteId,
+        auditId,
+        data: {
+          analysis: {
+            suggestions: [{ id: 's1', type: 'CONTENT_UPDATE', rank: 1, data: {} }],
+            opportunity: { status: 'IGNORED', qaVerdict: { rate: 0.42, rateDetermined: true } },
+          },
+          companyName: 'Example Corp',
+        },
+      };
+
+      await handler.default(message, context);
+
+      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(callText).to.include(':warning:');
+      expect(callText).to.include('Not visible in the UI');
+      expect(callText).to.include('hallucination 42%');
+    });
+
+    it('shows "n/a" when the rate is visible but undetermined', async () => {
+      mockAudit.getAuditResult.returns({
+        slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },
+      });
+
+      const message = {
+        siteId,
+        auditId,
+        data: {
+          analysis: {
+            suggestions: [{ id: 's1', type: 'CONTENT_UPDATE', rank: 1, data: {} }],
+            opportunity: { status: 'NEW', qaVerdict: { rate: 0, rateDetermined: false } },
+          },
+          companyName: 'Example Corp',
+        },
+      };
+
+      await handler.default(message, context);
+
+      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(callText).to.include('Visible in the UI');
+      expect(callText).to.include('hallucination rate n/a');
+      expect(callText).to.not.include('hallucination 0%');
+    });
+
+    it('omits the hallucination note when no qaVerdict is present', async () => {
+      mockAudit.getAuditResult.returns({
+        slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },
+      });
+
+      const message = {
+        siteId,
+        auditId,
+        data: {
+          analysis: {
+            suggestions: [{ id: 's1', type: 'CONTENT_UPDATE', rank: 1, data: {} }],
+            opportunity: { status: 'NEW' },
+          },
+          companyName: 'Example Corp',
+        },
+      };
+
+      await handler.default(message, context);
+
+      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(callText).to.include('Visible in the UI');
+      expect(callText).to.not.include('hallucination');
+    });
   });
 
   describe('Suggestion mapping', () => {

--- a/test/audits/youtube-analysis/guidance-handler.test.js
+++ b/test/audits/youtube-analysis/guidance-handler.test.js
@@ -683,6 +683,105 @@ describe('YouTube Analysis Guidance Handler', () => {
       const callText = mockPostMessageOptional.firstCall.args[2];
       expect(callText).to.include('1 suggestion processed');
     });
+
+    it('reports a visible opportunity with the hallucination rate', async () => {
+      mockAudit.getAuditResult.returns({
+        slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },
+      });
+
+      const message = {
+        siteId,
+        auditId,
+        data: {
+          analysis: {
+            suggestions: [{ id: 'sug-1', type: 'CONTENT_UPDATE', rank: 1, data: {} }],
+            opportunity: { status: 'NEW', qaVerdict: { rate: 0.12, rateDetermined: true } },
+          },
+          companyName: 'Example Corp',
+        },
+      };
+
+      await guidanceHandler.default(message, context);
+
+      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(callText).to.include(':white_check_mark:');
+      expect(callText).to.include('Visible in the UI');
+      expect(callText).to.include('hallucination 12%');
+    });
+
+    it('reports a hidden opportunity (IGNORED) with the hallucination rate', async () => {
+      mockAudit.getAuditResult.returns({
+        slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },
+      });
+
+      const message = {
+        siteId,
+        auditId,
+        data: {
+          analysis: {
+            suggestions: [{ id: 'sug-1', type: 'CONTENT_UPDATE', rank: 1, data: {} }],
+            opportunity: { status: 'IGNORED', qaVerdict: { rate: 0.42, rateDetermined: true } },
+          },
+          companyName: 'Example Corp',
+        },
+      };
+
+      await guidanceHandler.default(message, context);
+
+      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(callText).to.include(':warning:');
+      expect(callText).to.include('Not visible in the UI');
+      expect(callText).to.include('hallucination 42%');
+    });
+
+    it('shows "n/a" when the rate is visible but undetermined', async () => {
+      mockAudit.getAuditResult.returns({
+        slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },
+      });
+
+      const message = {
+        siteId,
+        auditId,
+        data: {
+          analysis: {
+            suggestions: [{ id: 'sug-1', type: 'CONTENT_UPDATE', rank: 1, data: {} }],
+            opportunity: { status: 'NEW', qaVerdict: { rate: 0, rateDetermined: false } },
+          },
+          companyName: 'Example Corp',
+        },
+      };
+
+      await guidanceHandler.default(message, context);
+
+      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(callText).to.include('Visible in the UI');
+      expect(callText).to.include('hallucination rate n/a');
+      expect(callText).to.not.include('hallucination 0%');
+    });
+
+    it('omits the hallucination note when no qaVerdict is present', async () => {
+      mockAudit.getAuditResult.returns({
+        slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },
+      });
+
+      const message = {
+        siteId,
+        auditId,
+        data: {
+          analysis: {
+            suggestions: [{ id: 'sug-1', type: 'CONTENT_UPDATE', rank: 1, data: {} }],
+            opportunity: { status: 'NEW' },
+          },
+          companyName: 'Example Corp',
+        },
+      };
+
+      await guidanceHandler.default(message, context);
+
+      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(callText).to.include('Visible in the UI');
+      expect(callText).to.not.include('hallucination');
+    });
   });
 
   describe('Complete Flow', () => {


### PR DESCRIPTION
…tion rate

Mirror the cited-analysis handler: branch the Slack summary on the QA gate decision (opportunity status NEW = visible, IGNORED = suppressed) and append the hallucination rate from opportunity.qaVerdict:
- visible:    :white_check_mark: ... Visible in the UI — hallucination X%
- suppressed: :warning: ... Not visible in the UI — hallucination X%
- rate undetermined (rateDetermined=false, gate failed open): '... — hallucination
  rate n/a' instead of a misleading 0%
- no qaVerdict (older payloads): rate note omitted

Pairs with the mystique change exposing qaVerdict + rateDetermined for both.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
