### PR TITLE
fix(toc): cap scraping submissions at MAX_TOP_PAGES=200 (LLMO-5863)

### DIFF
--- a/src/toc/handler.js
+++ b/src/toc/handler.js
@@ -352,9 +352,10 @@ export async function submitForScraping(context) {
     return { auditResult: terminalResult, fullAuditRef: site.getBaseURL() };
   }
 
-  log.info(`[TOC] Submitting ${topPages.length} URLs for scraping`);
+  const pagesToScrape = topPages.slice(0, MAX_TOP_PAGES);
+  log.info(`[TOC] Submitting ${pagesToScrape.length} URLs for scraping`);
   return {
-    urls: topPages.map((url) => ({ url })),
+    urls: pagesToScrape.map((url) => ({ url })),
     siteId: site.getId(),
     maxScrapeAge: 24,
   };

--- a/test/audits/toc.test.js
+++ b/test/audits/toc.test.js
@@ -3735,6 +3735,22 @@ describe('TOC (Table of Contents) Audit', () => {
       expect(context.dataAccess.Audit.updateByKeys).to.have.been.calledOnce;
       expect(logSpy.warn).to.have.been.calledWith('[TOC] No top pages found, ending audit');
     });
+
+    it('caps submitted URLs at MAX_TOP_PAGES (200) when topPages exceeds the limit', async () => {
+      const logSpy = { info: sinon.spy(), error: sinon.spy(), debug: sinon.spy(), warn: sinon.spy() };
+      context.log = logSpy;
+      context.site = site;
+      const pages = Array.from({ length: 250 }, (_, i) => `https://example.com/page-${i}`);
+      context.audit = { getAuditResult: () => ({ success: true, topPages: pages }) };
+
+      const { submitForScraping } = await import('../../src/toc/handler.js');
+      const result = await submitForScraping(context);
+
+      expect(result.urls).to.have.lengthOf(200);
+      expect(result.urls[0]).to.deep.equal({ url: 'https://example.com/page-0' });
+      expect(result.urls[199]).to.deep.equal({ url: 'https://example.com/page-199' });
+      expect(logSpy.info).to.have.been.calledWith('[TOC] Submitting 200 URLs for scraping');
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

- `submitForScraping` in the TOC audit had no hard ceiling on the number of URLs sent to the scraper
- The merged URL list (`auditTargetUrls → includedURLs → agenticUrls → topPagesUrls`) was submitted as-is; sites with large `includedURLs` or agentic URL lists could exceed the intended 200-URL budget
- Added `topPages.slice(0, MAX_TOP_PAGES)` before building the scrape payload, mirroring the existing pattern in the summarization audit

## Changes

- `src/toc/handler.js` — slice `topPages` to `MAX_TOP_PAGES` (200) in `submitForScraping`
- `test/audits/toc.test.js` — new test: caps at 200 when 250 pages are supplied; 175 tests passing, 100% coverage on `src/toc`

## Test plan

- [x] All existing TOC tests pass (175 passing)
- [x] New test confirms only 200 URLs are returned when 250 are supplied
- [x] `src/toc` coverage remains 100% lines/branches/statements
- [x] `eslint src/toc/handler.js` — clean

Jira: [LLMO-5863](https://jira.corp.adobe.com/browse/LLMO-5863)

🤖 Generated with [Claude Code](https://claude.com/claude-code)