### PR TITLE
feat(summarization): pass generatePrompts to Mystique for Impact Engine

### DIFF
--- a/src/summarization/handler.js
+++ b/src/summarization/handler.js
@@ -107,8 +107,18 @@ async function getSummarizationInputUrls(context) {
 /* c8 ignore next 1 - function declaration line often not attributed when called from tests */
 export async function importTopPages(context) {
   const {
-    site, dataAccess, log,
+    site, dataAccess, log, data,
   } = context;
+
+  // Extract generatePrompts so it can be forwarded to downstream steps via auditContext.
+  let generatePromptsFlag = false;
+  try {
+    const parsedData = typeof data === 'string' ? JSON.parse(data) : data;
+    generatePromptsFlag = !!parsedData?.generatePrompts;
+  } catch (e) {
+    log.warn(`[SUMMARIZATION] Failed to parse context.data for generatePrompts flag, defaulting to false: ${e.message}`);
+  }
+
   try {
     const { urls: allUrls } = await getMergedAuditInputUrls({
       site,
@@ -129,6 +139,7 @@ export async function importTopPages(context) {
           topPages: [],
         },
         fullAuditRef: site.getBaseURL(),
+        auditContext: { generatePrompts: generatePromptsFlag },
       };
     }
 
@@ -142,6 +153,7 @@ export async function importTopPages(context) {
         topPages: allUrls,
       },
       fullAuditRef: site.getBaseURL(),
+      auditContext: { generatePrompts: generatePromptsFlag },
     };
   } catch (error) {
     log.error(`[SUMMARIZATION] Failed to import top pages: ${error.message}`, error);
@@ -154,6 +166,7 @@ export async function importTopPages(context) {
         topPages: [],
       },
       fullAuditRef: site.getBaseURL(),
+      auditContext: { generatePrompts: generatePromptsFlag },
     };
   }
 }
@@ -163,7 +176,7 @@ export async function importTopPages(context) {
  */
 export async function submitForScraping(context) {
   const {
-    site, audit, log,
+    site, audit, log, auditContext,
   } = context;
 
   const auditResult = audit.getAuditResult();
@@ -194,6 +207,7 @@ export async function submitForScraping(context) {
   return {
     auditContext: {
       [AUDIT_CONTEXT_URLS_KEY]: topPagesToScrape,
+      generatePrompts: !!auditContext?.generatePrompts,
     },
     urls: topPagesToScrape.map((url) => ({ url })),
     siteId: site.getId(),
@@ -227,6 +241,7 @@ export async function sendToMystique(context) {
     throw new Error('No submitted URLs found');
   }
   const urlsToCheck = submittedUrls;
+  const generatePrompts = !!auditContext?.generatePrompts;
 
   // Verify scrape availability before sending to Mystique
   if (!scrapeResultPaths || scrapeResultPaths.size === 0) {
@@ -322,7 +337,7 @@ export async function sendToMystique(context) {
     auditId: audit.getId(),
     deliveryType: site.getDeliveryType(),
     time: new Date().toISOString(),
-    data: { pages: topPagesPayload },
+    data: { pages: topPagesPayload, generatePrompts },
   };
 
   await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, message);

--- a/src/summarization/handler.js
+++ b/src/summarization/handler.js
@@ -27,6 +27,16 @@ const MAX_PAGES_TO_MYSTIQUE = 100;
 // Summarization opportunities remain in NEW status while active/unresolved.
 const ACTIVE_OPPORTUNITY_STATUS = 'NEW';
 
+function parseGeneratePromptsFlag(data, log) {
+  try {
+    const parsedData = typeof data === 'string' ? JSON.parse(data) : data;
+    return !!parsedData?.generatePrompts;
+  } catch (e) {
+    log.warn(`[SUMMARIZATION] Failed to parse context.data for generatePrompts flag, defaulting to false: ${e.message}`);
+    return false;
+  }
+}
+
 /**
  * Builds a map of URL → stored contentHash from the most recent suggestions
  * for the site's active summarization opportunity.
@@ -110,14 +120,7 @@ export async function importTopPages(context) {
     site, dataAccess, log, data,
   } = context;
 
-  // Extract generatePrompts so it can be forwarded to downstream steps via auditContext.
-  let generatePromptsFlag = false;
-  try {
-    const parsedData = typeof data === 'string' ? JSON.parse(data) : data;
-    generatePromptsFlag = !!parsedData?.generatePrompts;
-  } catch (e) {
-    log.warn(`[SUMMARIZATION] Failed to parse context.data for generatePrompts flag, defaulting to false: ${e.message}`);
-  }
+  const generatePromptsFlag = parseGeneratePromptsFlag(data, log);
 
   try {
     const { urls: allUrls } = await getMergedAuditInputUrls({

--- a/test/audits/summarization/handler.test.js
+++ b/test/audits/summarization/handler.test.js
@@ -131,6 +131,7 @@ describe('Summarization Handler', () => {
           ],
         },
         fullAuditRef: 'https://adobe.com',
+        auditContext: { generatePrompts: false },
       });
       expect(dataAccess.SiteTopPage.allBySiteIdAndSourceAndGeo).to.have.been.calledWith(
         'site-id-123',
@@ -153,6 +154,7 @@ describe('Summarization Handler', () => {
           topPages: [],
         },
         fullAuditRef: 'https://adobe.com',
+        auditContext: { generatePrompts: false },
       });
       expect(log.info).to.have.been.calledWith(
         '[SUMMARIZATION] No top pages found for site; continuing with fallback URL sources',
@@ -174,11 +176,48 @@ describe('Summarization Handler', () => {
           topPages: [],
         },
         fullAuditRef: 'https://adobe.com',
+        auditContext: { generatePrompts: false },
       });
       expect(log.error).to.have.been.calledWith(
         '[SUMMARIZATION] Failed to import top pages: Database error',
         error,
       );
+    });
+
+    it('should forward generatePrompts=true when data is an object', async () => {
+      context.data = { generatePrompts: true };
+
+      const result = await importTopPages(context);
+
+      expect(result.auditContext).to.deep.equal({ generatePrompts: true });
+    });
+
+    it('should forward generatePrompts=true when data is a JSON string', async () => {
+      context.data = JSON.stringify({ generatePrompts: true });
+
+      const result = await importTopPages(context);
+
+      expect(result.auditContext).to.deep.equal({ generatePrompts: true });
+    });
+
+    it('should default generatePrompts to false and warn on invalid JSON in data', async () => {
+      context.data = '{not-json';
+
+      const result = await importTopPages(context);
+
+      expect(result.auditContext).to.deep.equal({ generatePrompts: false });
+      expect(log.warn).to.have.been.calledWithMatch(
+        /\[SUMMARIZATION\] Failed to parse context.data for generatePrompts flag, defaulting to false:/,
+      );
+    });
+
+    it('should forward generatePrompts=false when no SEO pages and data omits the flag', async () => {
+      dataAccess.SiteTopPage.allBySiteIdAndSourceAndGeo.resolves([]);
+      context.data = { somethingElse: true };
+
+      const result = await importTopPages(context);
+
+      expect(result.auditContext).to.deep.equal({ generatePrompts: false });
     });
   });
 
@@ -195,6 +234,7 @@ describe('Summarization Handler', () => {
             'https://adobe.com/page2',
             'https://adobe.com/page3',
           ],
+          generatePrompts: false,
         },
         urls: [
           { url: 'https://adobe.com/page1' },
@@ -205,6 +245,15 @@ describe('Summarization Handler', () => {
         type: 'summarization',
       });
       expect(log.info).to.have.been.calledWith('[SUMMARIZATION] Submitting 3 pages for scraping');
+    });
+
+    it('should forward generatePrompts=true from auditContext when present', async () => {
+      audit.getAuditResult.returns({ success: true });
+      context.auditContext = { generatePrompts: true };
+
+      const result = await submitForScraping(context);
+
+      expect(result.auditContext.generatePrompts).to.equal(true);
     });
 
     it('should limit to 200 pages when submitting for scraping', async () => {
@@ -289,7 +338,7 @@ describe('Summarization Handler', () => {
       const result = await sendToMystique(context);
 
       expect(result).to.deep.equal({ status: 'complete' });
-      
+
       const sentMessage = sqs.sendMessage.getCall(0).args[1];
       expect(sentMessage.type).to.equal('guidance:summarization');
       expect(sentMessage.siteId).to.equal('site-id-123');
@@ -297,7 +346,8 @@ describe('Summarization Handler', () => {
       expect(sentMessage.auditId).to.equal('audit-id-456');
       expect(sentMessage.deliveryType).to.equal('aem');
       expect(sentMessage.data.pages).to.have.lengthOf(3);
-      
+      expect(sentMessage.data.generatePrompts).to.equal(false);
+
       // Check that all pages are from the scraped URLs
       const pageUrls = sentMessage.data.pages.map((p) => p.page_url);
       expect(pageUrls).to.include.members([
@@ -305,10 +355,22 @@ describe('Summarization Handler', () => {
         'https://adobe.com/page2',
         'https://adobe.com/page3',
       ]);
-      
+
       expect(log.info).to.have.been.calledWith(
         '[SUMMARIZATION] Sent 3 pages to Mystique for site site-id-123',
       );
+    });
+
+    it('should propagate generatePrompts=true from auditContext into Mystique payload', async () => {
+      context.auditContext = {
+        ...context.auditContext,
+        generatePrompts: true,
+      };
+
+      await sendToMystique(context);
+
+      const sentMessage = sqs.sendMessage.getCall(0).args[1];
+      expect(sentMessage.data.generatePrompts).to.equal(true);
     });
 
     it('should limit to 100 pages when sending to Mystique', async () => {


### PR DESCRIPTION
## Summary

Forward the `generatePrompts` kwarg from Slack/API producers through the summarization audit chain so it reaches the outbound `guidance:summarization` Mystique payload — unblocking **Impact Engine** prompt generation for summarization suggestions (same hook that prerender already uses).

- Linked mystique PR: https://git.corp.adobe.com/experience-platform/mystique/pull/2578

## What changed

`src/summarization/handler.js`:
- Private helper `parseGeneratePromptsFlag(data, log)` — reads a JSON string or object, warn-and-default-to-false on parse error.
- `importTopPages` (step 1): destructures `data` from context, calls the helper, returns `auditContext: { generatePrompts }` on all three return paths (empty SEO, success, catch).
- `submitForScraping` (step 2): forwards `generatePrompts: !!auditContext?.generatePrompts` alongside the existing `summarizationUrls` in the returned `auditContext`.
- `sendToMystique` (step 3): reads `const generatePrompts = !!auditContext?.generatePrompts;` and includes it in `message.data.generatePrompts` on the outbound Mystique SQS message. Mystique consumes this flag to decide whether to generate Impact Engine prompts alongside the summarization suggestions.

## Test plan

- [x] `src/summarization/handler.js` at **100% lines / branches / functions / statements**
- [x] `test/audits/summarization/handler.test.js`: **51 tests passing**, including 6 new cases covering:
  - parse from object data
  - parse from JSON string data
  - invalid JSON falls back to `false` and emits a warn log
  - `generatePrompts=false` propagated when SEO is empty
  - step-2 forwards `generatePrompts=true` from incoming auditContext
  - step-3 propagates `generatePrompts=true` into the Mystique payload
- [x] `npm run lint` clean
- [ ] Manual: trigger a summarization run from Slack with `generatePrompts: true` and confirm Mystique receives `data.generatePrompts === true` on the `guidance:summarization` message, and that Impact Engine prompts are generated downstream