### PR TITLE
fix(cdn-analysis): warn when raw logs aggregate to zero rows (wrong format)

### DIFF
--- a/src/cdn-analysis/handler.js
+++ b/src/cdn-analysis/handler.js
@@ -532,6 +532,16 @@ export async function processCdnLogs(auditUrl, context, site, auditContext) {
       // eslint-disable-next-line no-await-in-loop
       await athenaClient.execute(sqlInsertReferral, database, `[Athena Query] Insert aggregated referral data for ${serviceProvider} into ${database}.${aggregatedReferralTable}`);
 
+      // Raw logs were present but the aggregation wrote no rows. The usual cause is a
+      // wrong log format: the JSON SerDe runs with ignore.malformed.json=true, so
+      // unparseable lines become all-NULL rows, the LLM user-agent filter matches
+      // nothing, and the audit "succeeds" empty with no error. Emit one greppable line
+      // so it can be alerted/dashboarded instead of failing silently.
+      // eslint-disable-next-line no-await-in-loop
+      if (!await pathHasData(s3Client, paths.aggregatedOutput)) {
+        log.warn(`[cdn-logs-analysis] empty aggregation despite raw logs - possible wrong log format siteId=${siteId} host=${host} serviceProvider=${serviceProvider} cdnType=${cdnType} rawDataPath=${rawDataPath}`);
+      }
+
       log.info(`${auditType} processed logs for siteId=${siteId} with:
         serviceProvider=${serviceProvider}
         cdnType=${cdnType}

--- a/test/audits/cdn-analysis/handler.test.js
+++ b/test/audits/cdn-analysis/handler.test.js
@@ -320,6 +320,74 @@ describe('CDN Analysis Handler', () => {
       );
     });
 
+    it('warns when raw logs are present but aggregation produced no rows (wrong log format)', async () => {
+      const mockedHandler = await loadMockedHandler('byocdn-akamai');
+      const auditContext = {
+        year: 2025, month: 6, day: 15, hour: 10,
+      };
+
+      // Default mock returns empty Contents for any 'aggregated' prefix, so the output
+      // partition is empty after the inserts -> the wrong-format warning should fire.
+      context.s3Client.send.callsFake(
+        createS3MockForServiceProviders(['byocdn-akamai']),
+      );
+
+      const result = await mockedHandler.cdnLogsAnalysisRunner(
+        'https://example.com',
+        context,
+        site,
+        auditContext,
+      );
+
+      expect(result.auditResult.providers).to.be.an('array').with.length(1);
+      expect(context.log.warn).to.have.been.calledWith(
+        sinon.match(/\[cdn-logs-analysis\] empty aggregation despite raw logs/)
+          .and(sinon.match(/serviceProvider=byocdn-akamai/))
+          .and(sinon.match(/cdnType=akamai/)),
+      );
+    });
+
+    it('does not warn when the aggregation produced rows (output partition has data)', async () => {
+      const mockedHandler = await loadMockedHandler('byocdn-akamai');
+      const auditContext = {
+        year: 2025, month: 6, day: 15, hour: 10, forceReprocess: true,
+      };
+
+      // Output partition has data after the inserts (forceReprocess bypasses the
+      // idempotency skip) -> no wrong-format warning.
+      context.s3Client.send.callsFake((command) => {
+        if (command.constructor.name === 'HeadBucketCommand') {
+          return Promise.resolve({});
+        }
+        if (command.constructor.name === 'ListObjectsV2Command') {
+          const { Prefix = '' } = command.input || {};
+          if (Prefix.includes('aggregated')) {
+            return Promise.resolve({ Contents: [{ Key: `${Prefix}part-0.parquet` }] });
+          }
+          if (Prefix === 'test-ims-org-id/raw/') {
+            return Promise.resolve({
+              Contents: [],
+              CommonPrefixes: [{ Prefix: 'test-ims-org-id/raw/byocdn-akamai/' }],
+            });
+          }
+          return Promise.resolve({ Contents: [{ Key: `${Prefix}file1.log` }] });
+        }
+        return Promise.resolve({});
+      });
+
+      const result = await mockedHandler.cdnLogsAnalysisRunner(
+        'https://example.com',
+        context,
+        site,
+        auditContext,
+      );
+
+      expect(result.auditResult.providers).to.be.an('array').with.length(1);
+      expect(context.log.warn).to.not.have.been.calledWith(
+        sinon.match(/empty aggregation despite raw logs/),
+      );
+    });
+
     it('filters legacy discovered CDN providers using the configured service-provider mapping', async () => {
       const mockedHandler = await loadMockedHandler('byocdn-fastly');
       const auditContext = {


### PR DESCRIPTION
## Problem

A wrong CDN log format (e.g. a non-JSON feed delivered to a JSON-SerDe table) is **silently dropped** today. The raw tables use `org.openx.data.jsonserde.JsonSerDe` with `ignore.malformed.json = true`, so any unparseable line becomes a row of all-NULL columns instead of erroring. The aggregation's LLM user-agent `WHERE` filter then matches nothing, the `INSERT` writes an empty partition, and the audit returns a **normal success** with no error anywhere in the pipeline.

The result: a customer who *is* delivering logs (in the wrong format) looks identical to a customer with genuinely no agentic traffic. The dashboard is empty and there is no signal to act on.


## Fix

After the aggregation inserts, if raw logs were present but the aggregated output partition is empty, emit one greppable warning:

```
[cdn-logs-analysis] empty aggregation despite raw logs - possible wrong log format siteId=... host=... serviceProvider=... cdnType=... rawDataPath=...
```

- **Naming-agnostic:** probes the S3 output partition via the existing `pathHasData` helper rather than per-CDN raw columns (`reqHost` / `"x-host-header"` / `properties.hostname` / …), so it works for every CDN without a column map.
- **No extra Athena query:** `pathHasData` is a single `ListObjectsV2` with `MaxKeys: 1`.
- **Minimal:** 4 functional lines in the per-provider loop.

This turns a silent failure into a dashboardable / alertable signal:

```
index=dx_aem_engineering sourcetype=dx_aem_sites_spacecat_backend_prod service=audit-worker
  "[cdn-logs-analysis] empty aggregation despite raw logs"
| stats count by siteId, host, cdnType, serviceProvider
```

## Testing

- Added two tests: warning fires on empty output; warning suppressed when the output partition has data (via `forceReprocess`).
- `src/cdn-analysis/handler.js` at 100% lines/branches/functions/statements; full cdn-analysis spec green (54 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Notes / limitations

- It is a `warn`, not a definitive wrong-format detector: an hour with genuinely zero agentic traffic also produces empty aggregation, so the message says *"possible"*. A site emitting it **every hour** = wrong format; sporadic = a quiet hour.
