### PR TITLE
feat(paid-keyword-optimizer): surface pageRecommendation at the opportunity level

### DIFF
--- a/src/paid-keyword-optimizer/guidance-opportunity-mapper.js
+++ b/src/paid-keyword-optimizer/guidance-opportunity-mapper.js
@@ -88,12 +88,16 @@ export function mapToKeywordOptimizerOpportunity(siteId, audit, message) {
     portfolioMetrics = {},
   } = guidanceBody;
   /**
-   * Page-level context fields emitted by mystique (additive, both optional).
+   * Page-level context fields emitted by mystique (additive, all optional).
    *
    * Distinct from per-cluster
    * `gapAnalysis.{keywordToPageGap,adToPageGap}.relevantExtractedTopics`,
    * which are LLM-filtered subsets of `pageTopics` filtered for cluster-
    * specific intent relevance. `pageTopics` here is the full page-level set.
+   *
+   * `pageRecommendation` is the strategist's reconciled, play-aware page-level
+   * recommendation (inferredPlay, primary + rankedActions with lever/alternatives);
+   * `null` when mystique skips/fails the strategist pass or emits an older payload.
    *
    * Use `??` (nullish coalescing) instead of ES destructure defaults so that
    * a future regression emitting `pageTopics: null` (instead of omitting the
@@ -102,6 +106,7 @@ export function mapToKeywordOptimizerOpportunity(siteId, audit, message) {
    */
   const resolvedPageHeading = guidanceBody.resolvedPageHeading ?? null;
   const pageTopics = guidanceBody.pageTopics ?? [];
+  const pageRecommendation = guidanceBody.pageRecommendation ?? null;
   const { langfuseTraceId, langfuseTraceUrl } = guidanceBody?.observability || {};
 
   const hasConflictingHeadlineRecommendations = clusterResults.filter(
@@ -149,6 +154,7 @@ export function mapToKeywordOptimizerOpportunity(siteId, audit, message) {
       totalMisalignedSpend,
       resolvedPageHeading,
       pageTopics,
+      pageRecommendation,
     },
     status: 'NEW',
     tags: [

--- a/test/audits/paid-keyword-optimizer/opportunity-mapper.test.js
+++ b/test/audits/paid-keyword-optimizer/opportunity-mapper.test.js
@@ -670,6 +670,44 @@ describe('Paid Keyword Optimizer opportunity mapper (cluster format)', () => {
       expect(result.data.pageTopics).to.be.an('array').that.is.empty;
     });
 
+    it('passes pageRecommendation through to opportunity.data', () => {
+      const pageRecommendation = {
+        inferredPlay: 'Branded navigational defense',
+        playConfidence: 'high',
+        primary: {
+          lever: 'on_page',
+          actionType: 'modify_heading',
+          title: 'Broaden the H1 for branded visitors',
+          detail: 'Surface the core IAM promise alongside AI.',
+          affectedClusters: ['okta'],
+          alternatives: [],
+        },
+        rankedActions: [],
+        reasoning: 'Reconciled across all branded clusters.',
+      };
+      const audit = createMockAudit();
+      const message = createClusterMessage({ extraBody: { pageRecommendation } });
+
+      const result = mapToKeywordOptimizerOpportunity(TEST_SITE_ID, audit, message);
+
+      expect(result.data.pageRecommendation).to.deep.equal(pageRecommendation);
+    });
+
+    it('defaults pageRecommendation to null when absent (old mystique) or explicitly null', () => {
+      const audit = createMockAudit();
+      // Absent: no extraBody at all.
+      const absent = mapToKeywordOptimizerOpportunity(TEST_SITE_ID, audit, createClusterMessage());
+      expect(absent.data.pageRecommendation).to.be.null;
+
+      // Explicitly null (strategist skipped/failed): collapses to null, not undefined.
+      const explicitNull = mapToKeywordOptimizerOpportunity(
+        TEST_SITE_ID,
+        audit,
+        createClusterMessage({ extraBody: { pageRecommendation: null } }),
+      );
+      expect(explicitNull.data.pageRecommendation).to.be.null;
+    });
+
     it('collapses explicit null pageTopics to [] (future regression guard)', () => {
       const audit = createMockAudit();
       const message = createClusterMessage({


### PR DESCRIPTION
## Summary

Consumer side of the new ad-intent strategist output. mystique's `ad-intent-gap` crew now emits a strategist-reconciled, play-aware **`pageRecommendation`** block in the guidance SQS body — `inferredPlay`, `playConfidence`, a lever-first `primary` action, `rankedActions`, and `alternatives`. This surfaces it at the **opportunity level**: `mapToKeywordOptimizerOpportunity` now reads `guidanceBody.pageRecommendation` and includes it in the `ad-intent-mismatch` opportunity's `data` (alongside `portfolioMetrics`, `resolvedPageHeading`, `pageTopics`).

## Changes

- `src/paid-keyword-optimizer/guidance-opportunity-mapper.js` — read `pageRecommendation` (nullish-coalesced to `null`) and add it to `opportunity.data`; JSDoc updated.
- `test/audits/paid-keyword-optimizer/opportunity-mapper.test.js` — passthrough test (present) + default-to-null test (absent **and** explicit `null`).

## Backward compatibility

Additive and null-safe: older mystique payloads (no `pageRecommendation` key) and skipped/failed strategist passes (`pageRecommendation: null`) both collapse to `null` via `?? null` — no consumer breakage. The opportunity `data` object is free-form JSON (no per-type schema), so no schema change is needed. `guidance-opportunity-mapper.js` stays at 100% coverage (191 passing in the paid-keyword-optimizer suite).

## Producer side

experience-platform/mystique PR #3111 — `feat(ad-intent-gap): brand context + ad-copy/misaligned-spend signals + SEM-strategist page recommendation` (`https://git.corp.adobe.com/experience-platform/mystique/pull/3111`). That PR adds the `pageRecommendation` field to the emitted guidance body; this PR is what makes it visible on the opportunity. The SQS contract was verified compatible (no schema validation on the consumer path) before this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
