### PR TITLE
feat(summarization): persist Mystique prompts on suggestions

### DIFF
--- a/src/summarization/utils.js
+++ b/src/summarization/utils.js
@@ -53,6 +53,12 @@ export function getJsonSummarySuggestion(suggestions, urlToContentHash = {}) {
     const pageTransformRules = getPageSummaryTransformRules(suggestion.pageSummary);
     const contentHash = urlToContentHash[suggestion.pageUrl] ?? null;
 
+    // Mystique returns a prompt set per surface; each attaches to its own suggestion.
+    const summaryPrompts = Array.isArray(suggestion.summaryPrompts)
+      ? suggestion.summaryPrompts : [];
+    const keyPointsPrompts = Array.isArray(suggestion.keyPointsPrompts)
+      ? suggestion.keyPointsPrompts : [];
+
     // handle page level summary - only add if summary text is present and not already on page
     const pageSummaryText = suggestion.pageSummary?.formatted_summary;
     const pageSummaryAlreadyPresent = suggestion.page_summary_present === true
@@ -68,6 +74,7 @@ export function getJsonSummarySuggestion(suggestions, urlToContentHash = {}) {
         transformRules: pageTransformRules,
         scrapedAt,
         contentHash,
+        prompts: summaryPrompts,
       });
     }
 
@@ -86,6 +93,7 @@ export function getJsonSummarySuggestion(suggestions, urlToContentHash = {}) {
         transformRules: pageTransformRules,
         scrapedAt,
         contentHash,
+        prompts: keyPointsPrompts,
       });
     }
   });

--- a/test/audits/summarization/utils.test.js
+++ b/test/audits/summarization/utils.test.js
@@ -536,6 +536,86 @@ describe('summarization utils', () => {
       expect(result[1].contentHash).to.equal(hash);
     });
 
+    describe('prompts (Impact Engine opt-in)', () => {
+      it('should route summaryPrompts to the page-summary record and keyPointsPrompts to the key-points record', () => {
+        const summaryPrompts = [
+          { id: 's1', prompt: 'What is X?', type: 'Non-Branded' },
+          { id: 's2', prompt: 'How does Brand do X?', type: 'Branded' },
+        ];
+        const keyPointsPrompts = [
+          { id: 'k1', prompt: 'What are the key benefits of X?', type: 'Non-Branded' },
+        ];
+        const suggestions = [
+          {
+            pageUrl: 'https://example.com/page1',
+            summaryPrompts,
+            keyPointsPrompts,
+            pageSummary: {
+              title: 'Test Page',
+              formatted_summary: 'Test summary',
+              heading_selector: 'h1',
+              insertion_method: 'insertAfter',
+            },
+            keyPoints: { formatted_items: ['Key 1', 'Key 2'] },
+          },
+        ];
+
+        const result = getJsonSummarySuggestion(suggestions);
+
+        expect(result).to.have.length(2);
+        // page-summary record gets summaryPrompts
+        expect(result[0].keyPoints).to.be.false;
+        expect(result[0].prompts).to.deep.equal(summaryPrompts);
+        // key-points record gets keyPointsPrompts
+        expect(result[1].keyPoints).to.be.true;
+        expect(result[1].prompts).to.deep.equal(keyPointsPrompts);
+      });
+
+      it('should default each record\'s prompts to an empty array when Mystique omits them', () => {
+        const suggestions = [
+          {
+            pageUrl: 'https://example.com/page1',
+            pageSummary: {
+              title: 'Test Page',
+              formatted_summary: 'Test summary',
+              heading_selector: 'h1',
+              insertion_method: 'insertAfter',
+            },
+            keyPoints: { formatted_items: ['Key 1'] },
+          },
+        ];
+
+        const result = getJsonSummarySuggestion(suggestions);
+
+        expect(result).to.have.length(2);
+        expect(result[0].prompts).to.deep.equal([]);
+        expect(result[1].prompts).to.deep.equal([]);
+      });
+
+      it('should default to empty arrays when the prompt fields are not arrays', () => {
+        const suggestions = [
+          {
+            pageUrl: 'https://example.com/page1',
+            summaryPrompts: 'not-an-array',
+            keyPointsPrompts: { bogus: true },
+            pageSummary: {
+              title: 'Test Page',
+              formatted_summary: 'Test summary',
+              heading_selector: 'h1',
+              insertion_method: 'insertAfter',
+            },
+            keyPoints: { formatted_items: ['Key 1'] },
+          },
+        ];
+
+        const result = getJsonSummarySuggestion(suggestions);
+
+        expect(result).to.have.length(2);
+        expect(result[0].prompts).to.deep.equal([]);
+        expect(result[1].prompts).to.deep.equal([]);
+      });
+    });
+
     it('should set contentHash to null when url not in urlToContentHash (LLMO-4454)', () => {
       const suggestions = [
         {


### PR DESCRIPTION
## Summary

Mystique now returns **per-surface prompt sets** on the `guidance:summarization` callback — `summaryPrompts` (grounded in the page summary) and `keyPointsPrompts` (grounded in the key points). Persist each on its matching suggestion so the Impact Engine prompts land on the right record.

Pairs with the Mystique PR that produces the two arrays: https://git.corp.adobe.com/experience-platform/mystique/pull/3133

## What changed

`src/summarization/utils.js` — `getJsonSummarySuggestion` reads the two arrays off each Mystique page suggestion and routes them:

| Mystique field | Suggestion record |
|----------------|-------------------|
| `summaryPrompts` | page-summary (`keyPoints = false`) |
| `keyPointsPrompts` | key-points (`keyPoints = true`) |

Each is stored as `data.prompts` on its record, defaulting to `[]` when the field is absent or not an array.

## Context

Previously the outbound path already forwarded `generatePrompts` to Mystique (PR #2732), but the callback path dropped the returned prompts entirely — they were never persisted. This closes that gap. The split (two arrays, one per suggestion) mirrors the Mystique-side design where the summary and key-points suggestions deploy independently and each needs its own prompt set.

## Test plan

- [x] `test/audits/summarization/utils.test.js` — routing (summaryPrompts → summary record, keyPointsPrompts → key-points record), empty-default when omitted, empty-default when non-array
- [x] `src/summarization/utils.js` at **100% lines / branches / functions / statements**
- [x] `npm run lint` clean
- [ ] Manual: run a summarization audit with `generatePrompts: true` and confirm each suggestion's `data.prompts` carries its surface's set

🤖 Generated with [Claude Code](https://claude.com/claude-code)