### PR TITLE
fix(prerender): propagate tri-state valuable (true/false/null) from mystique

### DIFF
--- a/src/prerender/guidance-handler.js
+++ b/src/prerender/guidance-handler.js
@@ -199,7 +199,9 @@ export default async function handler(message, context) {
 
       // Track if AI summary is meaningful
       const hasValidAiSummary = aiSummary && aiSummary.toLowerCase() !== 'not available';
-      const isValuable = typeof valuable === 'boolean' ? valuable : true;
+      // Preserve tri-state: true/false = confirmed verdict, null/undefined = indeterminate.
+      // Never coerce null to true — an analysis error is not a confirmed content gain.
+      const isValuable = typeof valuable === 'boolean' ? valuable : null;
 
       if (hasValidAiSummary) {
         validAiSummaryCount += 1;
@@ -220,8 +222,9 @@ export default async function handler(message, context) {
         aiSummary: hasValidAiSummary ? aiSummary : (currentData.aiSummary ?? ''),
         // Use new prompts if provided; otherwise preserve existing
         prompts: hasNewPrompts ? prompts : (currentData.prompts ?? []),
-        // Keep valuable in sync with aiSummary — only update when new AI response is valid
-        valuable: hasValidAiSummary ? isValuable : (currentData.valuable ?? true),
+        // Keep valuable in sync with aiSummary — only update when new AI response is valid.
+        // Preserve tri-state: fall back to existing value (which may be null) not true.
+        valuable: hasValidAiSummary ? isValuable : (currentData.valuable ?? null),
       };
 
       warnOnInvalidSuggestionData(updatedData, opportunity.getType(), log);

--- a/test/audits/prerender/behaviour/mystique-round-trip.test.js
+++ b/test/audits/prerender/behaviour/mystique-round-trip.test.js
@@ -699,6 +699,105 @@ describe('Prerender behaviour — Mystique round-trip (inbound: guidance-handler
     expect(updatedData).to.have.property('valuable', true);
   });
 
+  it('valuable=null (analysis failed) → stored as null, not coerced to true', async () => {
+    // Mystique signals an analysis error by sending valuable=null (indeterminate).
+    // The handler must persist null — not coerce to true — so downstream consumers
+    // can distinguish "confirmed valuable" from "analysis failed".
+    const siteId = 'site-inbound-null-verdict';
+    const oppId = 'opp-null-1';
+    const url = 'https://example.com/page-null';
+
+    const suggestion = buildSuggestion(sandbox, {
+      id: 'sug-null',
+      status: 'NEW',
+      data: { url, aiSummary: '', valuable: null },
+    });
+    suggestion.setData = sandbox.stub();
+
+    const opportunity = buildOpportunity(sandbox, {
+      id: oppId,
+      siteId,
+      suggestions: [suggestion],
+    });
+
+    fetchAnalysisStub.resolves({
+      suggestions: [{ url, aiSummary: 'Some content found.', valuable: null }],
+    });
+
+    const ctx = buildGuidanceCtx({ siteId, opportunity });
+    await guidanceHandler(buildMessage(siteId, oppId), ctx);
+
+    const [updatedData] = suggestion.setData.firstCall.args;
+    expect(updatedData).to.have.property('aiSummary', 'Some content found.');
+    expect(updatedData).to.have.property('valuable', null);
+  });
+
+  it('valuable missing from response → stored as null (indeterminate), not coerced to true', async () => {
+    // Mystique may omit the valuable field entirely (older payload or partial failure).
+    // The handler must treat absence as null, not default to true.
+    const siteId = 'site-inbound-missing-verdict';
+    const oppId = 'opp-missing-1';
+    const url = 'https://example.com/page-missing-verdict';
+
+    const suggestion = buildSuggestion(sandbox, {
+      id: 'sug-missing',
+      status: 'NEW',
+      data: { url, aiSummary: '', valuable: null },
+    });
+    suggestion.setData = sandbox.stub();
+
+    const opportunity = buildOpportunity(sandbox, {
+      id: oppId,
+      siteId,
+      suggestions: [suggestion],
+    });
+
+    fetchAnalysisStub.resolves({
+      // valuable field intentionally absent
+      suggestions: [{ url, aiSummary: 'Content added by JS.' }],
+    });
+
+    const ctx = buildGuidanceCtx({ siteId, opportunity });
+    await guidanceHandler(buildMessage(siteId, oppId), ctx);
+
+    const [updatedData] = suggestion.setData.firstCall.args;
+    expect(updatedData).to.have.property('aiSummary', 'Content added by JS.');
+    expect(updatedData).to.have.property('valuable', null);
+  });
+
+  it('aiSummary invalid + existing valuable=null → null preserved (not overwritten)', async () => {
+    // When aiSummary is invalid and the stored valuable is null, the fallback
+    // must keep null — not default to true via the ?? operator.
+    const siteId = 'site-inbound-preserve-null';
+    const oppId = 'opp-preserve-null-1';
+    const url = 'https://example.com/page-preserve-null';
+
+    const suggestion = buildSuggestion(sandbox, {
+      id: 'sug-preserve-null',
+      status: 'NEW',
+      data: { url, aiSummary: 'Previous summary', valuable: null },
+    });
+    suggestion.setData = sandbox.stub();
+
+    const opportunity = buildOpportunity(sandbox, {
+      id: oppId,
+      siteId,
+      suggestions: [suggestion],
+    });
+
+    fetchAnalysisStub.resolves({
+      suggestions: [{ url, aiSummary: 'Not Available', valuable: true }],
+    });
+
+    const ctx = buildGuidanceCtx({ siteId, opportunity });
+    await guidanceHandler(buildMessage(siteId, oppId), ctx);
+
+    const [updatedData] = suggestion.setData.firstCall.args;
+    // aiSummary preserved (invalid response); valuable stays null (not overwritten)
+    expect(updatedData).to.have.property('aiSummary', 'Previous summary');
+    expect(updatedData).to.have.property('valuable', null);
+  });
+
   // ─── Filtering ────────────────────────────────────────────────────────────
 
   it('OUTDATED suggestion is excluded from update even when URL matches', async () => {

--- a/test/audits/prerender/guidance-handler.test.js
+++ b/test/audits/prerender/guidance-handler.test.js
@@ -220,7 +220,7 @@ describe('Prerender Guidance Handler (Presigned URL)', () => {
       expect(savedSuggestions).to.have.lengthOf(2); // Only 2 non-OUTDATED suggestions
     });
 
-    it('should handle valuable flag correctly (defaults to true if not provided)', async () => {
+    it('should set valuable to null when not provided (indeterminate — not a confirmed verdict)', async () => {
       const s3Data = {
         opportunityId: 'opportunity-123',
         siteId: 'site-123',
@@ -231,7 +231,7 @@ describe('Prerender Guidance Handler (Presigned URL)', () => {
             suggestionId: 'suggestion-1',
             url: 'https://example.com/page1',
             aiSummary: 'Summary without valuable flag',
-            // valuable: undefined (not provided)
+            // valuable: undefined — mystique did not provide a verdict (e.g. analysis error)
           },
         ],
       };
@@ -251,7 +251,42 @@ describe('Prerender Guidance Handler (Presigned URL)', () => {
 
       expect(mockSuggestions[0].setData).to.have.been.called;
       const updatedData = mockSuggestions[0].setData.getCall(0).args[0];
-      expect(updatedData.valuable).to.equal(true); // Default to true
+      // null = indeterminate: analysis error/failure, not a confirmed content gain
+      expect(updatedData.valuable).to.equal(null);
+    });
+
+    it('should set valuable to null when explicitly null (indeterminate)', async () => {
+      const s3Data = {
+        opportunityId: 'opportunity-123',
+        siteId: 'site-123',
+        auditId: 'audit-123',
+        timestamp: '2025-01-15T12:00:00Z',
+        suggestions: [
+          {
+            suggestionId: 'suggestion-1',
+            url: 'https://example.com/page1',
+            aiSummary: '',
+            valuable: null, // explicit indeterminate from mystique (analysis failed)
+          },
+        ],
+      };
+
+      mockFetchSuccess(s3Data);
+
+      const message = {
+        siteId: 'site-123',
+        auditId: 'audit-123',
+        data: {
+          presignedUrl: 'https://s3.amazonaws.com/bucket/path?X-Amz-Signature=...',
+          opportunityId: 'opportunity-123',
+        },
+      };
+
+      await handler.default(message, context);
+
+      expect(mockSuggestions[0].setData).to.have.been.called;
+      const updatedData = mockSuggestions[0].setData.getCall(0).args[0];
+      expect(updatedData.valuable).to.equal(null);
     });
 
     it('should respect explicit false for valuable flag', async () => {
@@ -839,8 +874,8 @@ describe('Prerender Guidance Handler (Presigned URL)', () => {
       );
     });
 
-    it('should default valuable to true when field is missing and track paid customer status', async () => {
-      // Test with missing 'valuable' field - should default to true
+    it('should set valuable to null when field is missing and track paid customer status', async () => {
+      // Test with missing 'valuable' field - should be null (indeterminate), not true
       mockFetchSuccess({
         opportunityId: 'opportunity-123',
         suggestions: [
@@ -870,11 +905,11 @@ describe('Prerender Guidance Handler (Presigned URL)', () => {
       const savedSuggestions = Suggestion.saveMany.getCall(0).args[0];
       expect(savedSuggestions).to.have.lengthOf(2);
       
-      // First suggestion should have valuable=true (defaulted)
+      // First suggestion should have valuable=null (indeterminate — not a confirmed verdict)
       expect(savedSuggestions[0].setData).to.have.been.calledWith(
-        sinon.match({ 
+        sinon.match({
           aiSummary: 'Valid summary without valuable field',
-          valuable: true,
+          valuable: null,
         }),
       );
       
@@ -886,12 +921,14 @@ describe('Prerender Guidance Handler (Presigned URL)', () => {
         }),
       );
 
-      // Verify log includes paid customer flag and correct counts
+      // Verify log includes paid customer flag and correct counts.
+      // valuableSuggestions=0: neither suggestion has a confirmed true verdict
+      // (first is null/indeterminate, second is false).
       expect(log.info).to.have.been.calledWith(
         sinon.match(/prerender_ai_summary_metrics/)
           .and(sinon.match(/isPaidLLMOCustomer=true/))
           .and(sinon.match(/totalSuggestions=2/))
-          .and(sinon.match(/valuableSuggestions=1/))
+          .and(sinon.match(/valuableSuggestions=0/))
           .and(sinon.match(/validAiSummaryCount=2/)),
       );
     });


### PR DESCRIPTION
## Summary
Aligns the audit worker with the mystique tri-state `valuable` contract (SITES definition):
- `true` — confirmed valuable
- `false` — confirmed not valuable
- `null` — indeterminate (analysis error / failure)

Previously the guidance handler coerced a missing or `null` `valuable` field to `true`, reporting "confirmed valuable" when mystique had no verdict. This caused false positives in downstream consumers.

## Changes
- **`isValuable`** — `undefined`/`null` → `null` (was `true`)
- **`updatedData.valuable` fallback** — `currentData.valuable ?? null` (was `?? true`)

## Test plan
- [x] Updated existing unit tests: missing/null `valuable` → `null`; `valuableSuggestions` count updated (null is not a confirmed true verdict)
- [x] Three new behaviour tests in `mystique-round-trip.test.js`:
  - `valuable=null` from mystique → stored as `null`, not coerced to `true`
  - `valuable` missing from response → stored as `null`
  - `aiSummary` invalid + existing `valuable=null` → `null` preserved, not overwritten
- [x] All 23 behaviour tests pass; all 45 unit tests pass
- [x] Existing `true`/`false` round-trips unchanged (regression-free)

## Related
- mystique PR: https://git.corp.adobe.com/experience-platform/mystique/pull/3109

🤖 Generated with [Claude Code](https://claude.com/claude-code)