### PR TITLE
chore: johnho dev alias for isolated testing (SITES-47125)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "hedy -v --test-bundle",
     "deploy": "hedy -v --deploy --aws-deploy-bucket=spacecat-prod-deploy --pkgVersion=latest --aws-reserved-concurrency=100",
     "deploy-stage": "hedy -v --deploy --aws-deploy-bucket=spacecat-stage-deploy --pkgVersion=latest --aws-reserved-concurrency=10",
-    "deploy-dev": "hedy -v --deploy --pkgVersion=ci$CI_BUILD_NUM -l latest --aws-deploy-bucket=spacecat-dev-deploy --cleanup-ci=24h --aws-reserved-concurrency=10",
+    "deploy-dev": "hedy -v --deploy --pkgVersion=ci$CI_BUILD_NUM -l johnho --aws-deploy-bucket=spacecat-dev-deploy --cleanup-ci=24h --aws-reserved-concurrency=10",
     "deploy-secrets": "hedy --aws-update-secrets --params-file=secrets/secrets.env",
     "prepare": "husky",
     "local-build": "sam build",


### PR DESCRIPTION
Disposable dev-alias deploy for isolated DEV testing of #2727. Sets `deploy-dev` to `-l johnho` so CI deploys the links fix onto my personal Lambda alias instead of the shared `latest`. Do not merge — closed when testing is done.