### PR TITLE
fix: preserve externally-authored suggestions from stale-page OUTDATE sweep (SITES-47557)

### DIFF
--- a/src/utils/data-access.js
+++ b/src/utils/data-access.js
@@ -277,6 +277,14 @@ export const handleOutdatedSuggestions = async ({
         || data?.edgeDeployed
         || data?.coveredByDomainWide
         || data?.isDomainWide
+        // Preserve externally / manually-authored suggestions. Records published
+        // through the backoffice write path (e.g. cwv-workbench guidance) live on
+        // the shared audit-owned opportunity but are NOT part of THIS audit's
+        // generated set, so keyed stale-page cleanup must not age them out
+        // (SITES-47557 / cwv-workbench ADR-0018). `authoredBy` identifies a
+        // non-audit producer; the audit's own suggestions carry no `provenance`
+        // (or `authoredBy: 'cwv-audit'`), so legitimate self-pruning is unaffected.
+        || (data?.provenance?.authoredBy && data.provenance.authoredBy !== 'cwv-audit')
       );
     })
     .filter((existing) => {

--- a/test/utils/data-access.test.js
+++ b/test/utils/data-access.test.js
@@ -1463,6 +1463,71 @@ describe('data-access', () => {
       expect(mockLogger.info).to.have.been.calledWith('[SuggestionSync] Final count of suggestions to mark as OUTDATED: 1');
     });
 
+    it('should not mark externally-authored (data.provenance) suggestions as OUTDATED', async () => {
+      // SITES-47557 / cwv-workbench ADR-0018: a suggestion published through the
+      // backoffice write path carries data.provenance.authoredBy. It lives on the
+      // shared audit-owned opportunity but is not part of this audit's generated
+      // set, so a keyed stale-page sweep must not age it out. A record carrying the
+      // audit's OWN provenance ('cwv-audit') is still pruned normally.
+      const buildKeyWithUrl = (data) => `${data.url}|${data.key ?? ''}`;
+
+      const workbenchSuggestion = {
+        id: 'workbench',
+        data: {
+          url: 'https://example.com/savings',
+          provenance: { authoredBy: 'cwv-workbench' },
+        },
+        getId: sinon.stub().returns('workbench'),
+        getData: sinon.stub().returns({
+          url: 'https://example.com/savings',
+          provenance: { authoredBy: 'cwv-workbench' },
+        }),
+        getStatus: sinon.stub().returns('NEW'),
+      };
+      const auditOwnedSuggestion = {
+        id: 'audit-owned',
+        data: {
+          url: 'https://example.com/old',
+          provenance: { authoredBy: 'cwv-audit' },
+        },
+        getId: sinon.stub().returns('audit-owned'),
+        getData: sinon.stub().returns({
+          url: 'https://example.com/old',
+          provenance: { authoredBy: 'cwv-audit' },
+        }),
+        getStatus: sinon.stub().returns('NEW'),
+      };
+      const normalSuggestion = {
+        id: 'normal',
+        data: { url: 'https://example.com/page2', key: 'page2' },
+        getId: sinon.stub().returns('normal'),
+        getData: sinon.stub().returns({ url: 'https://example.com/page2', key: 'page2' }),
+        getStatus: sinon.stub().returns('NEW'),
+      };
+
+      mockOpportunity.getSuggestions.resolves([
+        workbenchSuggestion,
+        auditOwnedSuggestion,
+        normalSuggestion,
+      ]);
+
+      await syncSuggestions({
+        opportunity: mockOpportunity,
+        newData: [],
+        context,
+        buildKey: buildKeyWithUrl,
+        mapNewSuggestion,
+      });
+
+      // Only the audit-owned + plain stale records are OUTDATED; the
+      // workbench-authored suggestion is preserved.
+      expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledOnceWith(
+        [auditOwnedSuggestion, normalSuggestion],
+        'OUTDATED',
+      );
+      expect(mockLogger.info).to.have.been.calledWith('[SuggestionSync] Final count of suggestions to mark as OUTDATED: 2');
+    });
+
     it('should update suggestions when they are detected again', async () => {
       const suggestionsData = [
         { key: '1', title: 'old title' },


### PR DESCRIPTION
## Summary

`handleOutdatedSuggestions` marks **every** suggestion on the shared opportunity `OUTDATED` when its `buildKey` is absent from the fresh audit's key set. Suggestions authored through the backoffice write path (e.g. **cwv-workbench** CWV guidance) live on the shared, audit-owned `cwv` opportunity so they group with the audit's own suggestions in the UI — but they are **not** part of the audit's generated set, so they get OUTDATEd on every weekly run.

Confirmed 3× on **zepbound.lilly.com** (cwv opp `db8f5769-…`): a manually-authored `/savings` guidance suggestion (`019eba13-…`) was published 2026-06-11 and OUTDATEd by each subsequent audit (restored 2026-06-23, 2026-07-07 — the last run OUTDATEd the entire 32-suggestion batch). Each manual `PATCH {"status":"NEW"}` restore is undone by the next run — a treadmill.

## Change

Extend the existing `data`-flag preserve branch in `handleOutdatedSuggestions` (the one that already spares prerender `edgeDeployed` / `coveredByDomainWide` / `isDomainWide` records) to also skip any suggestion whose `data.provenance.authoredBy` identifies a **non-audit** producer:

```js
  || (data?.provenance?.authoredBy && data.provenance.authoredBy !== 'cwv-audit')
```

- **CWV-safe / self-pruning unaffected**: the audit's own suggestions carry no `provenance` (or, in future, `authoredBy: 'cwv-audit'`), so they continue to be pruned exactly as today.
- **Minimal blast radius**: one boolean term; no change to opportunity selection, the update/create path, or any schema.

## Test

`test/utils/data-access.test.js` — a new case mirroring the prerender preserve tests: a `cwv-workbench`-authored record is preserved through a stale-key sweep, while a `cwv-audit`-owned record and a plain stale record are still OUTDATEd.

## Producer contract

cwv-workbench stamps every published suggestion with:

```jsonc
"data": { "provenance": { "authoredBy": "cwv-workbench", "tool": "cwv-publish", "adr": "ADR-0018", "authoredAt": "<iso>" }, ... }
```

Follow-up (not in this PR): confirm the CWV suggestion `data` Joi schema in `spacecat-shared-data-access` permits an optional `provenance` object (same place `edgeDeployed`/`isDomainWide` live) so a `mergeCwvData` re-save of a matched record doesn't strip it.

## Links

- JIRA: [SITES-47557](https://jira.corp.adobe.com/browse/SITES-47557)
- Producer half (stamps the marker): cwv-workbench PR https://github.com/adobe-rnd/cwv-workbench/pull/6 (ADR-0018)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
