### PR TITLE
fix(cwv): dispatch guidance for PENDING_VALIDATION suggestions (SITES-47558)

### DIFF
--- a/docs/cwv-autofix-flow.md
+++ b/docs/cwv-autofix-flow.md
@@ -51,10 +51,17 @@ The CWV audit is a 2-step `StepAudit` registered as audit type `cwv` ([`src/cwv/
 ## Eligibility gate
 
 A suggestion is sent to Mystique only when ALL of:
-- Status is `NEW`
-- No guidance has been written yet
+- Status is `NEW` **or** `PENDING_VALIDATION` (guidance must be generated for
+  `PENDING_VALIDATION` so an SME has something to review before approving to `NEW` —
+  gating on `NEW` deadlocked paid-tier sites, SITES-47558)
+- No code patch has run yet (`isCodeChangeAvailable !== true`)
+- For `PENDING_VALIDATION`: guidance is missing or in the legacy aggregated format
+  (issues lack `source_index`) — avoids regenerating granular guidance every weekly audit
 - `type: 'url'` (group-type suggestions are skipped)
 - The site has `cwv-auto-suggest` enabled in `Configuration`
+
+The outbound message carries `data.suggestionStatus` so Mystique gates code-fix
+generation on SME approval (`NEW` → code-fix; `PENDING_VALIDATION` → guidance only).
 
 ## Feature flags (per site, in `Configuration`)
 

--- a/src/cwv/auto-suggest.js
+++ b/src/cwv/auto-suggest.js
@@ -51,7 +51,8 @@ const CWV_AUTO_FIX_FEATURE_TOGGLE = 'cwv-auto-fix';
  *
  * CWV suggestion structure:
  * {
- *   status: 'NEW' | 'APPROVED' | 'SKIPPED' | 'FIXED' | 'ERROR' | 'REJECTED',
+ *   status: 'NEW' | 'PENDING_VALIDATION' | 'APPROVED' | 'SKIPPED' | 'FIXED' | 'ERROR'
+ *     | 'REJECTED',
  *   data: {
  *     type: 'url' | 'group',
  *     url?: string,                  // Present for type: 'url'
@@ -59,16 +60,27 @@ const CWV_AUTO_FIX_FEATURE_TOGGLE = 'cwv-auto-fix';
  *     metrics: [{...}],
  *     isCodeChangeAvailable?: boolean, // Set by autofix-worker when a patch lands
  *     issues?: [                     // Auto-suggest guidance stored here
- *       { type: 'lcp' | 'cls' | 'inp', value: string, patchContent?: string }
+ *       { type: 'lcp' | 'cls' | 'inp', value: string, source_index?: number,
+ *         patchContent?: string }
  *     ]
  *   }
  * }
  *
- * Dispatches when the suggestion is NEW and no code patch has been produced yet
+ * On paid-tier ASO sites, CWV suggestions are created as PENDING_VALIDATION and an
+ * SME reviews the generated guidance before approving them to NEW. Guidance is
+ * therefore dispatched for both statuses — without it for PENDING_VALIDATION there
+ * is nothing for the SME to review and the suggestion can never be approved.
+ *
+ * For NEW, we dispatch whenever no code patch has been produced yet
  * (`data.isCodeChangeAvailable !== true`). We deliberately ignore
  * `issues[*].value` here — text guidance being present is not proof that a code
  * patch ran successfully, and `mergeCwvData` preserves that field across every
  * re-audit, which used to silently block retries forever.
+ *
+ * For PENDING_VALIDATION, re-dispatch is gated on the existing guidance being
+ * missing or in the legacy aggregated format (no per-issue `source_index`), so a
+ * suggestion that already has granular guidance isn't re-sent (and regenerated)
+ * on every weekly audit while it's awaiting SME review.
  *
  * Group filtering and "page is all-green" filtering happen in `processAutoSuggest`.
  *
@@ -76,12 +88,19 @@ const CWV_AUTO_FIX_FEATURE_TOGGLE = 'cwv-auto-fix';
  * @returns {boolean} True if suggestion should receive auto-suggest
  */
 export function shouldSendAutoSuggestForSuggestion(suggestion) {
-  if (suggestion.getStatus() !== 'NEW') {
+  const status = suggestion.getStatus();
+  if (status !== 'NEW' && status !== 'PENDING_VALIDATION') {
     return false;
   }
   const data = suggestion.getData() || {};
   if (data.isCodeChangeAvailable === true) {
     return false;
+  }
+  if (status === 'PENDING_VALIDATION') {
+    const { issues } = data;
+    const hasGranularGuidance = Array.isArray(issues) && issues.length > 0
+      && issues.some((i) => Number.isInteger(i.source_index));
+    return !hasGranularGuidance;
   }
   return true;
 }
@@ -90,7 +109,8 @@ export function shouldSendAutoSuggestForSuggestion(suggestion) {
  * Processes CWV auto-suggest for eligible suggestions.
  * Checks if auto-suggest is enabled, filters suggestions that need guidance,
  * and sends messages to Mystique for AI-powered guidance generation.
- * Sends one message per suggestion that needs auto-suggest (NEW status, no guidance)
+ * Sends one message per suggestion that needs auto-suggest (NEW or PENDING_VALIDATION
+ * status, no guidance yet — see `shouldSendAutoSuggestForSuggestion`)
  * Includes code repository information (codeBucket, codePath) if auto-fix feature is enabled
  *
  * @param {Object} context - Context object containing log, sqs, env, s3Client
@@ -178,6 +198,10 @@ export async function processAutoSuggest(context, opportunity, site) {
           url,
           opportunityId,
           suggestionId,
+          // Current suggestion status so Mystique can gate code-fix generation on
+          // SME approval (PENDING_VALIDATION → guidance only, NEW → approved for
+          // code-fix generation).
+          suggestionStatus: suggestion.getStatus(),
           device_type: firstMetrics.deviceType || 'mobile',
           // Metrics flagged as failing in RUM — Mystique must only generate guidance
           // for these metrics, keeping the identify and suggest steps consistent.

--- a/test/audits/cwv/auto-suggest.test.js
+++ b/test/audits/cwv/auto-suggest.test.js
@@ -708,6 +708,33 @@ describe('CWV Auto-Suggest', () => {
       expect(message.data.suggestionStatus).to.equal('NEW');
     });
 
+    it('does NOT dispatch for PENDING_VALIDATION suggestions that already have granular guidance — no weekly re-spam (SITES-47558)', async () => {
+      // Guards the no-re-dispatch path at the SQS-send boundary (processAutoSuggest),
+      // not just via the shouldSendAutoSuggestForSuggestion helper: a PENDING_VALIDATION
+      // suggestion whose issues already carry source_index (granular guidance) must not
+      // be re-sent to Mystique on every weekly audit while it awaits SME review.
+      const opportunity = {
+        getSiteId: () => 'site-123',
+        getAuditId: () => 'audit-456',
+        getId: () => 'oppty-789',
+        getType: () => 'cwv',
+        getSuggestions: () => Promise.resolve([{
+          getId: () => 'sugg-001',
+          getStatus: () => 'PENDING_VALIDATION',
+          getData: () => ({
+            type: 'url',
+            url: 'https://example.com/page1',
+            metrics: [{ deviceType: 'mobile', lcp: 3500 }],
+            issues: [{ type: 'lcp', value: '# LCP Optimization...', source_index: 0 }],
+          }),
+        }]),
+      };
+
+      await processAutoSuggest(context, opportunity, site);
+
+      expect(sqsStub.called).to.be.false;
+    });
+
     it('should skip suggestions whose metrics are all green (defense-in-depth)', async () => {
       const opportunity = {
         getSiteId: () => 'site-123',

--- a/test/audits/cwv/auto-suggest.test.js
+++ b/test/audits/cwv/auto-suggest.test.js
@@ -658,6 +658,56 @@ describe('CWV Auto-Suggest', () => {
       expect(sqsStub.firstCall.args[1].data.device_type).to.equal('mobile');
     });
 
+    it('dispatches guidance for PENDING_VALIDATION suggestions and stamps suggestionStatus (SITES-47558 regression)', async () => {
+      const opportunity = {
+        getSiteId: () => 'site-123',
+        getAuditId: () => 'audit-456',
+        getId: () => 'oppty-789',
+        getType: () => 'cwv',
+        getSuggestions: () => Promise.resolve([{
+          getId: () => 'sugg-001',
+          getStatus: () => 'PENDING_VALIDATION',
+          getData: () => ({
+            type: 'url',
+            url: 'https://example.com/page1',
+            metrics: [{ deviceType: 'mobile', lcp: 3500 }],
+            issues: [],
+          }),
+        }]),
+      };
+
+      await processAutoSuggest(context, opportunity, site);
+
+      expect(sqsStub.calledOnce).to.be.true;
+      const message = sqsStub.firstCall.args[1];
+      expect(message.data.suggestionStatus).to.equal('PENDING_VALIDATION');
+    });
+
+    it('stamps suggestionStatus as NEW on the outbound message for NEW suggestions', async () => {
+      const opportunity = {
+        getSiteId: () => 'site-123',
+        getAuditId: () => 'audit-456',
+        getId: () => 'oppty-789',
+        getType: () => 'cwv',
+        getSuggestions: () => Promise.resolve([{
+          getId: () => 'sugg-001',
+          getStatus: () => 'NEW',
+          getData: () => ({
+            type: 'url',
+            url: 'https://example.com/page1',
+            metrics: [{ deviceType: 'mobile', lcp: 3500, cls: 0.05, inp: 100 }],
+            issues: [],
+          }),
+        }]),
+      };
+
+      await processAutoSuggest(context, opportunity, site);
+
+      expect(sqsStub.calledOnce).to.be.true;
+      const message = sqsStub.firstCall.args[1];
+      expect(message.data.suggestionStatus).to.equal('NEW');
+    });
+
     it('should skip suggestions whose metrics are all green (defense-in-depth)', async () => {
       const opportunity = {
         getSiteId: () => 'site-123',
@@ -759,6 +809,49 @@ describe('CWV Auto-Suggest', () => {
 
       const result = shouldSendAutoSuggestForSuggestion(suggestion);
       expect(result).to.be.true;
+    });
+
+    it('returns true for PENDING_VALIDATION without guidance (SITES-47558)', () => {
+      const suggestion = {
+        getStatus: () => 'PENDING_VALIDATION',
+        getData: () => ({ issues: [] }),
+      };
+
+      const result = shouldSendAutoSuggestForSuggestion(suggestion);
+      expect(result).to.be.true;
+    });
+
+    it('returns true for PENDING_VALIDATION with legacy aggregated guidance lacking source_index (SITES-47558 upgrade)', () => {
+      const suggestion = {
+        getStatus: () => 'PENDING_VALIDATION',
+        getData: () => ({ issues: [{ type: 'lcp', value: 'x' }] }),
+      };
+
+      const result = shouldSendAutoSuggestForSuggestion(suggestion);
+      expect(result).to.be.true;
+    });
+
+    it('returns false for PENDING_VALIDATION that already has granular guidance (source_index) — no re-spam', () => {
+      const suggestion = {
+        getStatus: () => 'PENDING_VALIDATION',
+        getData: () => ({ issues: [{ type: 'lcp', value: 'x', source_index: 0 }] }),
+      };
+
+      const result = shouldSendAutoSuggestForSuggestion(suggestion);
+      expect(result).to.be.false;
+    });
+
+    it('returns false for PENDING_VALIDATION when isCodeChangeAvailable is true', () => {
+      const suggestion = {
+        getStatus: () => 'PENDING_VALIDATION',
+        getData: () => ({
+          issues: [{ type: 'lcp', value: 'x', source_index: 0 }],
+          isCodeChangeAvailable: true,
+        }),
+      };
+
+      const result = shouldSendAutoSuggestForSuggestion(suggestion);
+      expect(result).to.be.false;
     });
   });
 });


### PR DESCRIPTION
## What

On paid-tier ASO sites, CWV suggestions are created `PENDING_VALIDATION` and an SME reviews the generated guidance before approving them to `NEW`. `processAutoSuggest` gated the `guidance:cwv` dispatch on `status === 'NEW'`, so `PENDING_VALIDATION` suggestions never received guidance — the SME had nothing to review and the suggestion could never be approved (deadlock). Primary defect behind [SITES-47558](https://jira.corp.adobe.com/browse/SITES-47558).

Free/PLG sites (created `NEW`) are unaffected; this fixes paid-tier ASO sites.

## Changes

- `shouldSendAutoSuggestForSuggestion`: dispatch for `NEW` **and** `PENDING_VALIDATION`. For `PENDING_VALIDATION`, only (re)dispatch when guidance is missing or in the legacy aggregated format (issues lack `source_index`), so granular guidance is not regenerated on every weekly audit. `APPROVED`/other statuses stay ineligible; the `isCodeChangeAvailable` skip is unchanged.
- `processAutoSuggest`: stamp `data.suggestionStatus` on the outbound message so Mystique gates code-fix generation on SME approval.
- `docs/cwv-autofix-flow.md`: eligibility gate updated.

## Tests

Red→green regression coverage in `test/audits/cwv/auto-suggest.test.js`: PENDING_VALIDATION dispatch + `suggestionStatus` stamping (integration) and per-branch unit tests (no-guidance → dispatch, legacy-aggregated → dispatch, granular → skip, patch-present → skip). Full file green (31); CWV suite 48.

## Paired change

Requires the Mystique side, which gates code-fix (Task B) on `suggestionStatus === 'NEW'` so `PENDING_VALIDATION` receives guidance only — see SITES-47558. Deploy Mystique first, then this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)