### PR TITLE
fix(SITES-47741): mark suggestions OUTDATED, not FIXED, when no leftover items are found

### DIFF
--- a/src/csp/csp.js
+++ b/src/csp/csp.js
@@ -114,7 +114,7 @@ export async function resolveOpportunity(auditData, context, auditType) {
     return;
   }
 
-  // Mark all suggestions as completed
+  // Mark all suggestions as outdated
   try {
     opportunity.setStatus(Oppty.STATUSES.RESOLVED);
     await opportunity.save();
@@ -130,7 +130,7 @@ export async function resolveOpportunity(auditData, context, auditType) {
     if (isNonEmptyArray(existingOutdatedSuggestions)) {
       await Suggestion.bulkUpdateStatus(
         existingOutdatedSuggestions,
-        SuggestionDataAccess.STATUSES.FIXED,
+        SuggestionDataAccess.STATUSES.OUTDATED,
       );
     }
   } catch (e) {

--- a/src/permissions/common.js
+++ b/src/permissions/common.js
@@ -112,7 +112,7 @@ export async function markOpportunityAsFixed(auditType, opportunity, site, conte
 
   // If there are suggestions, update their status to outdated
   if (isNonEmptyArray(suggestions)) {
-    await Suggestion.bulkUpdateStatus(suggestions, SuggestionDataAccess.STATUSES.FIXED);
+    await Suggestion.bulkUpdateStatus(suggestions, SuggestionDataAccess.STATUSES.OUTDATED);
   }
   opportunity.setUpdatedBy('system');
   await opportunity.save();

--- a/src/vulnerabilities/handler.js
+++ b/src/vulnerabilities/handler.js
@@ -280,7 +280,7 @@ export const opportunityAndSuggestionsStep = async (context) => {
 
       // If there are suggestions, update their status to outdated
       if (isNonEmptyArray(suggestions)) {
-        await Suggestion.bulkUpdateStatus(suggestions, SuggestionDataAccess.STATUSES.FIXED);
+        await Suggestion.bulkUpdateStatus(suggestions, SuggestionDataAccess.STATUSES.OUTDATED);
       }
       opportunity.setUpdatedBy('system');
       await opportunity.save();

--- a/test/audits/csp/csp.test.js
+++ b/test/audits/csp/csp.test.js
@@ -302,7 +302,7 @@ describe('CSP Post-processor', () => {
     expect(suggestionStub.bulkUpdateStatus).to.have.been.calledWith([
       ...[activeSuggestion],
       ...[activeSuggestion],
-    ], Suggestion.STATUSES.FIXED);
+    ], Suggestion.STATUSES.OUTDATED);
   });
 
   it('should resolve existing opportunity if no CSP findings in lighthouse report - error case 1', async () => {

--- a/test/audits/permissions/permissions.test.js
+++ b/test/audits/permissions/permissions.test.js
@@ -770,7 +770,7 @@ describe('Permissions Handler Tests', () => {
       expect(result).to.deep.equal({ status: 'complete' });
       expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledWith(
         mockSuggestions,
-        SuggestionDataAccess.STATUSES.FIXED,
+        SuggestionDataAccess.STATUSES.OUTDATED,
       );
     });
 
@@ -969,7 +969,7 @@ describe('Permissions Handler Tests', () => {
       expect(result).to.deep.equal({ status: 'complete' });
       expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledWith(
         mockSuggestions,
-        SuggestionDataAccess.STATUSES.FIXED,
+        SuggestionDataAccess.STATUSES.OUTDATED,
       );
     });
 

--- a/test/audits/vulnerabilities.test.js
+++ b/test/audits/vulnerabilities.test.js
@@ -395,7 +395,7 @@ describe('Vulnerabilities Handler Integration Tests', () => {
       expect(mockOpportunity.getSuggestions).to.have.been.calledOnce;
       expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledWith(
         suggestions,
-        'FIXED',
+        'OUTDATED',
       );
       expect(mockOpportunity.setUpdatedBy).to.have.been.calledWith('system');
       expect(mockOpportunity.save).to.have.been.calledOnce;
@@ -459,7 +459,7 @@ describe('Vulnerabilities Handler Integration Tests', () => {
 
       expect(result).to.deep.equal({ status: 'complete' });
       expect(staleOpportunity.setStatus).to.have.been.calledWith('RESOLVED');
-      expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledWith(suggestions, 'FIXED');
+      expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledWith(suggestions, 'OUTDATED');
     });
 
     it('should process vulnerabilities and create opportunities with suggestions', async () => {


### PR DESCRIPTION
## Summary
Jira: https://jira.corp.adobe.com/browse/SITES-47741

- `csp`, `vulnerabilities`, and `permissions` audits all resolve their opportunity (status `RESOLVED`) once a subsequent scan finds no remaining issues, and bulk-update the leftover suggestions accordingly.
- They were bulk-updating those suggestions to `FIXED`, which asserts the specific fix was verified as applied/deployed. These code paths only know the issue is no longer *reported* — that's exactly what `OUTDATED` means. Some of the surrounding comments already said "update their status to outdated" while the code set `FIXED`, confirming this was a bug rather than intentional.
- Changed the three call sites:
  - `src/csp/csp.js` (`resolveOpportunity`)
  - `src/vulnerabilities/handler.js` (`opportunityAndSuggestionsStep`, no-vulnerabilities branch)
  - `src/permissions/common.js` (`markOpportunityAsFixed`, shared by both the too-strong and admin/redundant permissions handlers)

## Test plan
- [x] Updated the corresponding test assertions in `test/audits/csp/csp.test.js`, `test/audits/vulnerabilities.test.js`, `test/audits/permissions/permissions.test.js`
- [x] `npx mocha test/audits/csp/csp.test.js test/audits/vulnerabilities.test.js test/audits/permissions/permissions.test.js` — 161 passing
- [x] `src/csp`, `src/vulnerabilities`, `src/permissions` all at 100% line/branch/function coverage
- [x] Lint clean on all touched files