### PR TITLE
fix(sync): freeze SKIPPED/REJECTED suggestions in syncSuggestions (SITES-44646)

### DIFF
--- a/src/utils/data-access.js
+++ b/src/utils/data-access.js
@@ -507,9 +507,25 @@ export async function syncSuggestions({
     return newDataKeys.has(existingKey);
   });
 
+  // SKIPPED and REJECTED suggestions are operator decisions that must not be
+  // overwritten by subsequent scans — their updatedAt must reflect the moment
+  // the operator acted. FIXED is intentionally excluded: some audits implement
+  // regression detection by transitioning FIXED → NEW via a custom
+  // mergeStatusFunction (e.g. permissions/suggestion-data-mapper.js).
+  const FROZEN_STATUSES = [
+    SuggestionDataAccess.STATUSES.SKIPPED,
+    SuggestionDataAccess.STATUSES.REJECTED,
+  ];
+
   matchedSuggestions.forEach((existing) => {
     const existingData = existing.getData();
     const existingKey = buildKey(existingData);
+
+    if (FROZEN_STATUSES.includes(existing.getStatus())) {
+      log.debug(`Skipping ${existing.getStatus()} suggestion ${existingKey} - terminal status suggestions are never updated`);
+      return;
+    }
+
     const newDataItem = newDataByKey.get(existingKey);
     // mergeDataFunction must return a new object (not mutate existingData)
     // for deepEqual comparison to work correctly

--- a/src/utils/data-access.js
+++ b/src/utils/data-access.js
@@ -341,13 +341,15 @@ const defaultMergeDataFunction = (existingData, newData) => ({
 /**
  * Default merge function for determining the status of an existing suggestion.
  * This function encapsulates the default behavior for status transitions:
- * - REJECTED suggestions remain REJECTED
  * - OUTDATED suggestions transition to PENDING_VALIDATION or NEW (possible regression)
  * - ERROR suggestions transition back to NEW so a re-audit re-dispatches them.
  *   Recovers any suggestion that errored due to a transient or codefix-side bug
  *   once the underlying fix has shipped; pages that fail every run keep
  *   re-dispatching but the audit cadence (weekly for CWV) bounds the cost.
  * - Other statuses remain unchanged
+ *
+ * Note: SKIPPED and REJECTED suggestions never reach this function — they are
+ * frozen upstream in syncSuggestions before mergeStatusFunction is called.
  *
  * @param {Object} existing - The existing suggestion object.
  * @param {Object} newDataItem - The new data item being merged.
@@ -357,12 +359,6 @@ const defaultMergeDataFunction = (existingData, newData) => ({
 export const defaultMergeStatusFunction = (existing, newDataItem, context) => {
   const { log, site } = context;
   const currentStatus = existing.getStatus();
-
-  if (currentStatus === SuggestionDataAccess.STATUSES.REJECTED) {
-    // Keep REJECTED status when same suggestion appears again in audit
-    log.debug('REJECTED suggestion found in audit. Preserving REJECTED status.');
-    return null; // Keep existing status
-  }
 
   if (currentStatus === SuggestionDataAccess.STATUSES.OUTDATED) {
     log.warn('Outdated suggestion found in audit. Possible regression.');

--- a/test/audits/permissions/permissions.test.js
+++ b/test/audits/permissions/permissions.test.js
@@ -1643,8 +1643,9 @@ describe('Permissions Handler Tests', () => {
 
       const result = mergeSuggestionStatus(mockExistingSuggestion, {}, mockContext);
 
+      // REJECTED is frozen upstream in syncSuggestions before mergeStatusFunction is called;
+      // if somehow reached directly, defaultMergeStatusFunction returns null (keep status).
       expect(result).to.be.null;
-      expect(mockContext.log.debug).to.have.been.calledWith('REJECTED suggestion found in audit. Preserving REJECTED status.');
     });
 
     it('should return null when existing suggestion is PENDING_VALIDATION', () => {
@@ -1856,8 +1857,10 @@ describe('Permissions Handler Tests', () => {
 
       expect(result).to.deep.equal({ status: 'complete' });
       expect(mockRejectedSuggestion.setStatus).to.not.have.been.called;
-      expect(context.dataAccess.Suggestion.saveMany).to.have.been.called;
-      expect(context.log.debug).to.have.been.calledWith('REJECTED suggestion found in audit. Preserving REJECTED status.');
+      expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
+      expect(context.log.debug).to.have.been.calledWith(
+        'Skipping REJECTED suggestion admin1@/content/admin1#7d4700c5 - terminal status suggestions are never updated',
+      );
     });
 
     it('should create unique keys based on permission hash for same principal and path', async () => {

--- a/test/utils/data-access.test.js
+++ b/test/utils/data-access.test.js
@@ -888,19 +888,16 @@ describe('data-access', () => {
         mapNewSuggestion,
       });
 
-      // Verify that REJECTED status is NOT changed (setStatus should not be called)
+      // REJECTED suggestions are frozen before merge functions run
       expect(existingSuggestions[0].setStatus).to.not.have.been.called;
-      // Verify that debug log is called with the correct message
-      expect(mockLogger.debug).to.have.been.calledWith('REJECTED suggestion found in audit. Preserving REJECTED status.');
-      // With no data changes and no status change, save should be skipped
-      expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
-      // Verify that setData is NOT called when data hasn't changed
       expect(existingSuggestions[0].setData).to.not.have.been.called;
-      // Verify that skip log is called
-      expect(mockLogger.debug).to.have.been.calledWith(sinon.match(/Skipping update for suggestion/));
+      expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
+      expect(mockLogger.debug).to.have.been.calledWith(
+        sinon.match(/Skipping REJECTED suggestion .* terminal status/),
+      );
     });
 
-    it('should preserve REJECTED status when data changes', async () => {
+    it('should not save REJECTED suggestion when data changes between scans', async () => {
       const suggestionsData = [
         { key: '1', title: 'old title', description: 'old description' },
       ];
@@ -931,18 +928,16 @@ describe('data-access', () => {
         mapNewSuggestion,
       });
 
-      // Verify that REJECTED status is NOT changed (setStatus should not be called)
+      // REJECTED suggestions must never be saved regardless of data changes
       expect(existingSuggestions[0].setStatus).to.not.have.been.called;
-      // Verify that debug log is called with the correct message
-      expect(mockLogger.debug).to.have.been.calledWith('REJECTED suggestion found in audit. Preserving REJECTED status.');
-      // Verify that saveMany is called with the updated suggestion
-      expect(context.dataAccess.Suggestion.saveMany).to.have.been
-        .calledOnceWith([existingSuggestions[0]]);
-      // Verify that setData is called to update the data
-      expect(existingSuggestions[0].setData).to.have.been.called;
+      expect(existingSuggestions[0].setData).to.not.have.been.called;
+      expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
+      expect(mockLogger.debug).to.have.been.calledWith(
+        sinon.match(/Skipping REJECTED suggestion .* terminal status/),
+      );
     });
 
-    it('should preserve REJECTED status when data changes even if site requires validation', async () => {
+    it('should not save REJECTED suggestion when data changes even if site requires validation', async () => {
       const suggestionsData = [
         { key: '1', title: 'old title', url: 'https://example.com/page1' },
       ];
@@ -958,16 +953,11 @@ describe('data-access', () => {
         setUpdatedBy: sinon.stub().returnsThis(),
       }];
 
-      // Data changed (url changed)
       const newData = [
         { key: '1', title: 'old title', url: 'https://example.com/page2' },
       ];
 
-      // Mock site with requiresValidation
-      context.site = {
-        requiresValidation: true,
-      };
-
+      context.site = { requiresValidation: true };
       mockOpportunity.getSuggestions.resolves(existingSuggestions);
 
       await syncSuggestions({
@@ -978,18 +968,15 @@ describe('data-access', () => {
         mapNewSuggestion,
       });
 
-      // Verify that REJECTED status is NOT changed (setStatus should not be called)
       expect(existingSuggestions[0].setStatus).to.not.have.been.called;
-      // Verify that debug log is called with the correct message
-      expect(mockLogger.debug).to.have.been.calledWith('REJECTED suggestion found in audit. Preserving REJECTED status.');
-      // Verify that saveMany is called with the updated suggestion
-      expect(context.dataAccess.Suggestion.saveMany).to.have.been
-        .calledOnceWith([existingSuggestions[0]]);
-      // Verify that setData is called to update the data
-      expect(existingSuggestions[0].setData).to.have.been.called;
+      expect(existingSuggestions[0].setData).to.not.have.been.called;
+      expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
+      expect(mockLogger.debug).to.have.been.calledWith(
+        sinon.match(/Skipping REJECTED suggestion .* terminal status/),
+      );
     });
 
-    it('should preserve REJECTED status when nested objects and arrays change', async () => {
+    it('should not save REJECTED suggestion when nested objects and arrays change', async () => {
       const suggestionsData = [
         { key: '1', metrics: [{ value: 100 }], issues: [{ type: 'error1' }] },
       ];
@@ -1005,14 +992,48 @@ describe('data-access', () => {
         setUpdatedBy: sinon.stub().returnsThis(),
       }];
 
-      // Nested object/array changed in data
       const newData = [
         { key: '1', metrics: [{ value: 200 }], issues: [{ type: 'error2' }] },
       ];
 
-      context.site = {
-        requiresValidation: false,
-      };
+      context.site = { requiresValidation: false };
+      mockOpportunity.getSuggestions.resolves(existingSuggestions);
+
+      await syncSuggestions({
+        context,
+        opportunity: mockOpportunity,
+        newData,
+        buildKey,
+        mapNewSuggestion,
+      });
+
+      expect(existingSuggestions[0].setStatus).to.not.have.been.called;
+      expect(existingSuggestions[0].setData).to.not.have.been.called;
+      expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
+      expect(mockLogger.debug).to.have.been.calledWith(
+        sinon.match(/Skipping REJECTED suggestion .* terminal status/),
+      );
+    });
+
+    it('should not save SKIPPED suggestion when data changes between scans', async () => {
+      const suggestionsData = [
+        { key: '1', title: 'old title', url: 'https://example.com/page1' },
+      ];
+      const existingSuggestions = [{
+        id: '1',
+        data: suggestionsData[0],
+        getData: sinon.stub().returns(suggestionsData[0]),
+        setData: sinon.stub(),
+        setRank: sinon.stub(),
+        save: sinon.stub().resolves(),
+        getStatus: sinon.stub().returns(SuggestionDataAccess.STATUSES.SKIPPED),
+        setStatus: sinon.stub(),
+        setUpdatedBy: sinon.stub().returnsThis(),
+      }];
+
+      const newData = [
+        { key: '1', title: 'new title', url: 'https://example.com/page1' },
+      ];
 
       mockOpportunity.getSuggestions.resolves(existingSuggestions);
 
@@ -1024,12 +1045,56 @@ describe('data-access', () => {
         mapNewSuggestion,
       });
 
-      // Verify that REJECTED status is NOT changed (setStatus should not be called)
       expect(existingSuggestions[0].setStatus).to.not.have.been.called;
-      expect(mockLogger.debug).to.have.been.calledWith('REJECTED suggestion found in audit. Preserving REJECTED status.');
-      expect(context.dataAccess.Suggestion.saveMany).to.have.been
-        .calledOnceWith([existingSuggestions[0]]);
-      expect(existingSuggestions[0].setData).to.have.been.called;
+      expect(existingSuggestions[0].setData).to.not.have.been.called;
+      expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
+      expect(mockLogger.debug).to.have.been.calledWith(
+        sinon.match(/Skipping SKIPPED suggestion .* terminal status/),
+      );
+    });
+
+    it('should allow FIXED suggestion to be updated when custom mergeStatusFunction detects regression', async () => {
+      const suggestionsData = [
+        { key: '1', title: 'old title', url: 'https://example.com/page1' },
+      ];
+      const existingSuggestions = [{
+        id: '1',
+        data: suggestionsData[0],
+        getData: sinon.stub().returns(suggestionsData[0]),
+        setData: sinon.stub(),
+        setRank: sinon.stub(),
+        save: sinon.stub().resolves(),
+        getStatus: sinon.stub().returns(SuggestionDataAccess.STATUSES.FIXED),
+        setStatus: sinon.stub(),
+        setUpdatedBy: sinon.stub().returnsThis(),
+      }];
+
+      const newData = [
+        { key: '1', title: 'old title', url: 'https://example.com/page1' },
+      ];
+
+      // Custom mergeStatusFunction that detects FIXED regression (e.g. permissions audit)
+      const regressionMergeStatus = (existing) => {
+        if (existing.getStatus() === SuggestionDataAccess.STATUSES.FIXED) {
+          return SuggestionDataAccess.STATUSES.NEW;
+        }
+        return null;
+      };
+
+      mockOpportunity.getSuggestions.resolves(existingSuggestions);
+
+      await syncSuggestions({
+        context,
+        opportunity: mockOpportunity,
+        newData,
+        buildKey,
+        mapNewSuggestion,
+        mergeStatusFunction: regressionMergeStatus,
+      });
+
+      // FIXED is NOT frozen — custom mergeStatusFunction can transition it to NEW
+      expect(existingSuggestions[0].setStatus).to.have.been.calledWith(SuggestionDataAccess.STATUSES.NEW);
+      expect(context.dataAccess.Suggestion.saveMany).to.have.been.calledOnce;
     });
 
     it('should update suggestion when status changes but data does not', async () => {

--- a/test/utils/data-access.test.js
+++ b/test/utils/data-access.test.js
@@ -1093,7 +1093,9 @@ describe('data-access', () => {
       });
 
       // FIXED is NOT frozen — custom mergeStatusFunction can transition it to NEW
-      expect(existingSuggestions[0].setStatus).to.have.been.calledWith(SuggestionDataAccess.STATUSES.NEW);
+      expect(existingSuggestions[0].setStatus).to.have.been.calledWith(
+        SuggestionDataAccess.STATUSES.NEW,
+      );
       expect(context.dataAccess.Suggestion.saveMany).to.have.been.calledOnce;
     });
 


### PR DESCRIPTION
## Summary

- **Root cause**: `syncSuggestions` had no guard for terminal-status suggestions in its matched-suggestions loop. When a merge function produced any difference in data (updated backlink counts, new metrics, etc.), SKIPPED and REJECTED suggestions were still added to `toUpdate` and saved via `saveMany` — bumping `updatedAt` on every scan.
- **PR #2593 was a partial fix**: its `deepEqual` guard prevents spurious bumps only when data is *identical*. Any data delta still triggered a save.
- **This fix**: return early for `SKIPPED` and `REJECTED` suggestions before merge functions run. Their `updatedAt` must reflect the moment the operator acted, not subsequent audit runs.
- **`FIXED` is intentionally excluded**: some audits (e.g. `permissions/suggestion-data-mapper.js`) implement regression detection by transitioning `FIXED → NEW` via a custom `mergeStatusFunction`. That path must remain reachable.

## Changes

- [`src/utils/data-access.js`](src/utils/data-access.js): added `FROZEN_STATUSES` early-return guard in the `matchedSuggestions.forEach` loop of `syncSuggestions`
- [`test/utils/data-access.test.js`](test/utils/data-access.test.js): corrected 3 existing REJECTED tests that were asserting the buggy behavior (saveMany called on data change), added tests for SKIPPED freeze and FIXED regression path

## Test plan

- [ ] `npx mocha test/utils/data-access.test.js` — 138 passing, 0 failing
- [ ] SKIPPED suggestion with changed data → not saved, `updatedAt` unchanged
- [ ] REJECTED suggestion with changed data → not saved, `updatedAt` unchanged
- [ ] FIXED suggestion with custom mergeStatusFunction → still transitions to NEW (regression detection intact)
- [ ] NEW/PENDING_VALIDATION/OUTDATED suggestions still update normally

Fixes: [SITES-44646](https://jira.corp.adobe.com/browse/SITES-44646)

🤖 Generated with [Claude Code](https://claude.com/claude-code)