### PR TITLE
fix: cancel preflight audit runs when disabled for site, surface errorCode

### DIFF
--- a/src/common/audit-utils.js
+++ b/src/common/audit-utils.js
@@ -20,9 +20,19 @@ import { retrieveAuditById } from '../utils/data-access.js';
  * @param {string[]} productCodes - Array of product codes to check
  * @param {Object} site - Site object
  * @param {Object} context - Lambda context
+ * @param {{ throwOnError?: boolean }} [options] - When `throwOnError` is true, an error
+ * encountered while checking entitlement (e.g. a network blip) is rethrown instead of being
+ * swallowed and treated as "not entitled". Callers that only skip an individual check on failure
+ * should keep the default (`false`); callers that take an irreversible action (e.g. cancelling a
+ * job) on a `false` result should pass `true` so a transient error isn't treated as a real denial.
  * @returns {Promise<boolean>} - True if site has enrollment for any product code
  */
-export async function checkProductCodeEntitlements(productCodes, site, context) {
+export async function checkProductCodeEntitlements(
+  productCodes,
+  site,
+  context,
+  { throwOnError = false } = {},
+) {
   if (!isNonEmptyArray(productCodes)) {
     return false; // No product codes to check, deny by default
   }
@@ -35,6 +45,9 @@ export async function checkProductCodeEntitlements(productCodes, site, context) 
           const tierResult = await tierClient.checkValidEntitlement();
           return tierResult.siteEnrollment || false;
         } catch (error) {
+          if (throwOnError) {
+            throw error;
+          }
           context.log.error(`Failed to check entitlement for product code ${productCode}:`, error);
           return false;
         }
@@ -42,12 +55,15 @@ export async function checkProductCodeEntitlements(productCodes, site, context) 
     );
     return enrollmentChecks.some((hasEnrollment) => hasEnrollment);
   } catch (error) {
+    if (throwOnError) {
+      throw error;
+    }
     context.log.error('Error checking product code entitlements:', error);
     return false; // Fail safe - deny audit if entitlement check fails
   }
 }
 
-export async function isAuditEnabledForSite(type, site, context) {
+export async function isAuditEnabledForSite(type, site, context, { throwOnError = false } = {}) {
   const { Configuration } = context.dataAccess;
   const configuration = await Configuration.findLatest();
   const handler = configuration.getHandlers()?.[type];
@@ -57,6 +73,7 @@ export async function isAuditEnabledForSite(type, site, context) {
       handler.productCodes,
       site,
       context,
+      { throwOnError },
     );
     if (!hasValidEnrollment) {
       context.log.info(`No valid site enrollment for handler ${type} with product codes ${handler.productCodes} for site ${site.getId()}`);

--- a/src/preflight/CLAUDE.md
+++ b/src/preflight/CLAUDE.md
@@ -1,0 +1,38 @@
+# Preflight Package
+
+Guidance for changes under `src/preflight/`. This file is loaded automatically
+when an agent works with files in this directory.
+
+## Logging convention — MUST prefix every log with `[preflight-audit]`
+
+Every log statement in this package (`log.info`, `log.warn`, `log.error`,
+`log.debug`) **MUST** begin its message with the literal string
+`[preflight-audit]`. This is a hard requirement: the prefix is what lets us
+grep/filter these lines in Splunk, so an unprefixed log is effectively
+invisible to on-call.
+
+Put the prefix first, before any interpolation, and keep the existing
+`site` / `job` / `step` context that surrounding lines use:
+
+```js
+// GOOD
+log.info(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. Preflight audit started.`);
+log.error(`[preflight-audit] site: ${site.getId()}, job: ${jobId}. Failed to cancel job.`, error);
+
+// BAD — no prefix, will not surface in Splunk searches
+log.info(`Processing preflight audit for ${site.getId()}`);
+log.warn(`job ${jobId} skipped`);
+```
+
+Rules:
+- The prefix is exactly `[preflight-audit]` (lower-case, hyphenated, in square
+  brackets) — do not invent per-file variants like `[preflight]` or
+  `[preflight-canonical]`.
+- Applies to every file in this package, including sub-check handlers
+  (`canonical.js`, `metatags.js`, `links.js`, `headings.js`, etc.).
+- When editing an existing log line that is missing the prefix, add it as part
+  of your change.
+- Do not assert on the exact free-form text of a log message in tests unless
+  the message is a real contract; when you do assert, match on the
+  `[preflight-audit]` prefix plus the stable part so wording tweaks don't break
+  tests.

--- a/src/preflight/CLAUDE.md
+++ b/src/preflight/CLAUDE.md
@@ -36,3 +36,68 @@ Rules:
   the message is a real contract; when you do assert, match on the
   `[preflight-audit]` prefix plus the stable part so wording tweaks don't break
   tests.
+
+## Response errors — use the `PreflightError` catalog
+
+When the audit ends a job for a reason a consumer needs to act on (the MFE
+renders it, an on-call needs to classify it), surface a **stable error code**
+from the catalog in `src/preflight/error-constants.js` — do **not** hand a
+consumer a freeform `reason` string to parse.
+
+Why: the `reason` text is for humans/logs and can be reworded at any time. The
+MFE (and any other consumer) keys off the `code`, maps it to its own localized
+copy, and uses the `classification` to decide whether the state is retryable.
+A freeform string is an implicit, unversioned contract that breaks silently the
+moment someone rewords it.
+
+### The pattern
+
+Each catalog entry is a frozen object with four fields:
+
+| Field | Purpose |
+|-------|---------|
+| `code` | Stable external identifier, `PREFLIGHT-NNN`. Part of the contract with consumers. |
+| `message` | Human-readable default text. Safe to reword; consumers should not parse it. |
+| `description` | Internal explanation of the cause (for developers/logs), not shown to end users. |
+| `classification` | A `PreflightErrorClassification` value telling consumers how to react (e.g. `CONFIG_ERROR` = not transient, retry won't help). |
+
+Surface it on the job's metadata `payload` when setting a terminal status:
+
+```js
+import { PreflightError } from './error-constants.js';
+
+jobEntity.setStatus(AsyncJob.Status.CANCELLED); // or FAILED
+jobEntity.setMetadata({
+  payload: {
+    siteId: site.getId(),
+    reason: PreflightError.PREFLIGHT_DISABLED.message,
+    errorCode: PreflightError.PREFLIGHT_DISABLED.code,
+  },
+});
+```
+
+### Adding a new response error (checklist)
+
+1. Add a new frozen entry to `PreflightError` in `error-constants.js` with the
+   next unused `PREFLIGHT-NNN` code, a `message`, a `description`, and a
+   `classification`. Add a new `PreflightErrorClassification` value if none of
+   the existing ones fit the consumer-reaction semantics.
+2. **Never reword or reuse an existing `code`** — codes are an external
+   contract. Superseding one means adding a new entry, not editing the old.
+3. Reference the entry via `PreflightError.X.code` / `.message` at the point you
+   set the terminal status — never inline a bare string literal for `errorCode`
+   or a bespoke `reason`.
+4. Coordinate the new `code` with the consuming MFE team so they can add the
+   matching localized copy before it ships.
+5. Add a test asserting the job's metadata carries the expected `errorCode`
+   (assert on the code, which is the contract — not the free-form `message`).
+
+### Enforcement / review expectation
+
+This is convention, not yet a mechanical gate. On review of any change that
+ends a preflight job (`setStatus(CANCELLED|FAILED)` + `setMetadata`), confirm
+the payload carries an `errorCode` sourced from the catalog and that no new
+`PREFLIGHT-NNN` reuses an existing code. If this drifts, the natural mechanical
+enforcement is an ESLint `no-restricted-syntax` rule that flags an `errorCode`
+property whose value is a string literal rather than a `PreflightError.*.code`
+reference — add that rule if manual review proves insufficient.

--- a/src/preflight/error-constants.js
+++ b/src/preflight/error-constants.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Classification of preflight error types, used to group codes by how a
+ * consumer should react to them.
+ */
+export const PreflightErrorClassification = Object.freeze({
+  // Site/org configuration prevents the audit from running (e.g. handler disabled,
+  // missing entitlement). Not transient - retrying the job won't help.
+  CONFIG_ERROR: 'CONFIG_ERROR',
+});
+
+/**
+ * Preflight error catalog. Each entry is surfaced via `errorCode` on a cancelled/failed
+ * AsyncJob's metadata payload, so consumers (e.g. the preflight MFE) can look up a
+ * stable code instead of parsing the freeform `reason` string.
+ *
+ * NOTE: `code` values are part of the external contract with consumers (e.g. the MFE).
+ * Do not change or reuse an existing code - add a new entry instead.
+ */
+export const PreflightError = Object.freeze({
+  PREFLIGHT_DISABLED: Object.freeze({
+    code: 'PREFLIGHT-100',
+    message: 'Preflight audits are not enabled for this site.',
+    description: 'The preflight handler is disabled in the site configuration.',
+    classification: PreflightErrorClassification.CONFIG_ERROR,
+  }),
+});

--- a/src/preflight/error-constants.js
+++ b/src/preflight/error-constants.js
@@ -31,7 +31,7 @@ export const PreflightErrorClassification = Object.freeze({
 export const PreflightError = Object.freeze({
   PREFLIGHT_DISABLED: Object.freeze({
     code: 'PREFLIGHT-100',
-    message: 'Preflight audits are not enabled for this site.',
+    message: 'The Preflight audit is not enabled for this site.',
     description: 'The preflight handler is disabled in the site configuration.',
     classification: PreflightErrorClassification.CONFIG_ERROR,
   }),

--- a/src/preflight/handler.js
+++ b/src/preflight/handler.js
@@ -130,11 +130,23 @@ export const preflightAudit = async (context) => {
   const { S3_SCRAPER_BUCKET_NAME } = context.env;
   const jobId = job.getId();
 
-  log.info(`Processing preflight audit for ${site}`);
+  log.info(`Processing preflight audit for ${site.getId()}`);
 
   if (!(await isAuditEnabledForSite('preflight', site, context))) {
-    log.error(`[preflight-audit] site: ${site.getId()}, job: ${jobId}. Preflight is disabled for this site.`);
-    throw new Error(`[preflight-audit] site: ${site.getId()}. Preflight handler is disabled for this site.`);
+    const reason = `preflight audits disabled for site ${site.getId()}`;
+    log.info(`[preflight-audit] site: ${site.getId()}, job: ${jobId}. ${reason}, skipping`);
+
+    const jobEntity = await AsyncJobEntity.findById(jobId);
+    jobEntity.setStatus(AsyncJob.Status.CANCELLED);
+    jobEntity.setMetadata({
+      payload: {
+        siteId: site.getId(),
+        reason,
+      },
+    });
+    jobEntity.setEndedAt(new Date().toISOString());
+    await jobEntity.save();
+    return;
   }
 
   const jobMetadata = job.getMetadata();

--- a/src/preflight/handler.js
+++ b/src/preflight/handler.js
@@ -22,6 +22,7 @@ import {
 } from './utils.js';
 import { getDomElementSelector, toElementTargets } from './utils/dom-selector.js';
 import { AUDIT_ALT_TEXT } from './audit-constants.js';
+import { PreflightError } from './error-constants.js';
 import canonical from './canonical.js';
 import metatags from './metatags.js';
 import links from './links.js';
@@ -142,6 +143,7 @@ export const preflightAudit = async (context) => {
       payload: {
         siteId: site.getId(),
         reason,
+        errorCode: PreflightError.PREFLIGHT_DISABLED.code,
       },
     });
     jobEntity.setEndedAt(new Date().toISOString());

--- a/src/preflight/handler.js
+++ b/src/preflight/handler.js
@@ -389,7 +389,7 @@ export const preflightAudit = async (context) => {
       },
     }));
 
-    log.debug(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. resultWithProfiling: ${JSON.stringify(resultWithProfiling)}`);
+    log.info(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. resultWithProfiling: ${JSON.stringify(resultWithProfiling)}`);
 
     const jobEntity = await AsyncJobEntity.findById(jobId);
     const anyProcessing = handlerResults.some((r) => r && r.processing === true);

--- a/src/preflight/handler.js
+++ b/src/preflight/handler.js
@@ -130,6 +130,11 @@ export const preflightAudit = async (context) => {
   const { S3_SCRAPER_BUCKET_NAME } = context.env;
   const jobId = job.getId();
 
+  if (!(await isAuditEnabledForSite('preflight', site, context))) {
+    log.error(`[preflight-audit] site: ${site.getId()}, job: ${jobId}. Preflight is disabled for this site.`);
+    throw new Error(`[preflight-audit] site: ${site.getId()}. Preflight handler is disabled for this site.`);
+  }
+
   const jobMetadata = job.getMetadata();
   /**
    * @type {{
@@ -151,7 +156,7 @@ export const preflightAudit = async (context) => {
     return stripTrailingSlash(url);
   });
 
-  log.debug(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. Preflight audit started.`);
+  log.info(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. Preflight audit started.`);
 
   if (job.getStatus() !== AsyncJob.Status.IN_PROGRESS) {
     throw new Error(`[preflight-audit] site: ${site.getId()}. Job not in progress for jobId: ${job.getId()}. Status: ${job.getStatus()}`);
@@ -168,7 +173,7 @@ export const preflightAudit = async (context) => {
       }),
     )).filter(Boolean);
 
-    log.debug(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. Enabled checks: ${JSON.stringify(enabledChecks)}`);
+    log.info(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. Enabled checks: ${JSON.stringify(enabledChecks)}`);
 
     const jobEntity = await AsyncJobEntity.findById(jobId);
     const currentMetadata = jobEntity.getMetadata();
@@ -333,7 +338,7 @@ export const preflightAudit = async (context) => {
       const domEndTime = Date.now();
       const domEndTimestamp = new Date().toISOString();
       const domElapsed = ((domEndTime - domStartTime) / 1000).toFixed(2);
-      log.debug(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. DOM-based audit completed in ${domElapsed} seconds`);
+      log.info(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. DOM-based audit completed in ${domElapsed} seconds`);
 
       timeExecutionBreakdown.push({
         name: 'dom',

--- a/src/preflight/handler.js
+++ b/src/preflight/handler.js
@@ -142,7 +142,7 @@ export const preflightAudit = async (context) => {
     jobEntity.setMetadata({
       payload: {
         siteId: site.getId(),
-        reason,
+        reason: PreflightError.PREFLIGHT_DISABLED.message,
         errorCode: PreflightError.PREFLIGHT_DISABLED.code,
       },
     });

--- a/src/preflight/handler.js
+++ b/src/preflight/handler.js
@@ -130,6 +130,8 @@ export const preflightAudit = async (context) => {
   const { S3_SCRAPER_BUCKET_NAME } = context.env;
   const jobId = job.getId();
 
+  log.info(`Processing preflight audit for ${site}`);
+
   if (!(await isAuditEnabledForSite('preflight', site, context))) {
     log.error(`[preflight-audit] site: ${site.getId()}, job: ${jobId}. Preflight is disabled for this site.`);
     throw new Error(`[preflight-audit] site: ${site.getId()}. Preflight handler is disabled for this site.`);

--- a/src/preflight/handler.js
+++ b/src/preflight/handler.js
@@ -131,25 +131,7 @@ export const preflightAudit = async (context) => {
   const { S3_SCRAPER_BUCKET_NAME } = context.env;
   const jobId = job.getId();
 
-  log.info(`Processing preflight audit for ${site.getId()}`);
-
-  if (!(await isAuditEnabledForSite('preflight', site, context))) {
-    const reason = `preflight audits disabled for site ${site.getId()}`;
-    log.info(`[preflight-audit] site: ${site.getId()}, job: ${jobId}. ${reason}, skipping`);
-
-    const jobEntity = await AsyncJobEntity.findById(jobId);
-    jobEntity.setStatus(AsyncJob.Status.CANCELLED);
-    jobEntity.setMetadata({
-      payload: {
-        siteId: site.getId(),
-        reason: PreflightError.PREFLIGHT_DISABLED.message,
-        errorCode: PreflightError.PREFLIGHT_DISABLED.code,
-      },
-    });
-    jobEntity.setEndedAt(new Date().toISOString());
-    await jobEntity.save();
-    return;
-  }
+  log.info(`[preflight-audit] site: ${site.getId()}, job: ${jobId}. Processing preflight audit.`);
 
   const jobMetadata = job.getMetadata();
   /**
@@ -176,6 +158,32 @@ export const preflightAudit = async (context) => {
 
   if (job.getStatus() !== AsyncJob.Status.IN_PROGRESS) {
     throw new Error(`[preflight-audit] site: ${site.getId()}. Job not in progress for jobId: ${job.getId()}. Status: ${job.getStatus()}`);
+  }
+
+  // Only cancel on a genuine "disabled"/"not entitled" result (throwOnError: true), so a
+  // transient entitlement-service error doesn't get treated as a real denial and permanently
+  // cancel the job - it propagates instead, letting the message retry.
+  if (!(await isAuditEnabledForSite('preflight', site, context, { throwOnError: true }))) {
+    const reason = `preflight audits disabled for site ${site.getId()}`;
+    log.info(`[preflight-audit] site: ${site.getId()}, job: ${jobId}. ${reason}, skipping`);
+
+    try {
+      const jobEntity = await AsyncJobEntity.findById(jobId);
+      jobEntity.setStatus(AsyncJob.Status.CANCELLED);
+      jobEntity.setMetadata({
+        payload: {
+          siteId: site.getId(),
+          reason: PreflightError.PREFLIGHT_DISABLED.message,
+          errorCode: PreflightError.PREFLIGHT_DISABLED.code,
+        },
+      });
+      jobEntity.setEndedAt(new Date().toISOString());
+      await jobEntity.save();
+    } catch (e) {
+      log.error(`[preflight-audit] site: ${site.getId()}, job: ${jobId}. Failed to cancel job after determining preflight is disabled for the site.`, e);
+      throw e;
+    }
+    return;
   }
 
   // Enabled checks for this run, resolved from per-site configuration. Persist the resolved
@@ -405,7 +413,7 @@ export const preflightAudit = async (context) => {
       },
     }));
 
-    log.info(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. resultWithProfiling: ${JSON.stringify(resultWithProfiling)}`);
+    log.debug(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. resultWithProfiling: ${JSON.stringify(resultWithProfiling)}`);
 
     const jobEntity = await AsyncJobEntity.findById(jobId);
     const anyProcessing = handlerResults.some((r) => r && r.processing === true);

--- a/test/audits/preflight.test.js
+++ b/test/audits/preflight.test.js
@@ -1469,7 +1469,7 @@ describe('Preflight Audit', () => {
       expect(finalJobEntity.setMetadata).to.have.been.calledWith({
         payload: {
           siteId: 'site-123',
-          reason: 'preflight audits disabled for site site-123',
+          reason: 'The Preflight audit is not enabled for this site.',
           errorCode: 'PREFLIGHT-100',
         },
       });

--- a/test/audits/preflight.test.js
+++ b/test/audits/preflight.test.js
@@ -1477,6 +1477,52 @@ describe('Preflight Audit', () => {
       expect(finalJobEntity.save).to.have.been.called;
     });
 
+    it('does not cancel a job that is no longer in progress, even if preflight is disabled for the site', async () => {
+      job.getStatus.returns('COMPLETED');
+      configuration.isHandlerEnabledForSite.withArgs('preflight', site).returns(false);
+      configuration.isHandlerEnabledForSite.returns(true);
+
+      await expect(preflightAuditFunction(context)).to.be.rejectedWith('[preflight-audit] site: site-123. Job not in progress for jobId: job-123. Status: COMPLETED');
+
+      expect(context.dataAccess.AsyncJob.findById).to.not.have.been.called;
+    });
+
+    it('logs and propagates the error when AsyncJob.findById fails while cancelling a disabled job', async () => {
+      configuration.isHandlerEnabledForSite.withArgs('preflight', site).returns(false);
+      configuration.isHandlerEnabledForSite.returns(true);
+      context.dataAccess.AsyncJob.findById = sinon.stub().rejects(new Error('db unavailable'));
+
+      await expect(preflightAuditFunction(context)).to.be.rejectedWith('db unavailable');
+
+      expect(context.log.error).to.have.been.calledWithMatch(/Failed to cancel job/);
+    });
+
+    it('logs and propagates the error when saving the cancelled job fails', async () => {
+      configuration.isHandlerEnabledForSite.withArgs('preflight', site).returns(false);
+      configuration.isHandlerEnabledForSite.returns(true);
+      context.dataAccess.AsyncJob.findById = sinon.stub().resolves({
+        setStatus: sinon.stub(),
+        setMetadata: sinon.stub(),
+        setEndedAt: sinon.stub(),
+        save: sinon.stub().rejects(new Error('save failed')),
+      });
+
+      await expect(preflightAuditFunction(context)).to.be.rejectedWith('save failed');
+
+      expect(context.log.error).to.have.been.calledWithMatch(/Failed to cancel job/);
+    });
+
+    it('does not cancel the job and lets the error propagate when the entitlement check itself errors', async () => {
+      TierClient.createForSite.restore();
+      sinon.stub(TierClient, 'createForSite').returns({
+        checkValidEntitlement: sinon.stub().rejects(new Error('entitlement service unavailable')),
+      });
+
+      await expect(preflightAuditFunction(context)).to.be.rejectedWith('entitlement service unavailable');
+
+      expect(context.log.info).to.not.have.been.calledWithMatch(/disabled for site/);
+    });
+
     it('throws if the provided urls are invalid', async () => {
       job.getMetadata = () => ({
         payload: {

--- a/test/audits/preflight.test.js
+++ b/test/audits/preflight.test.js
@@ -719,6 +719,7 @@ describe('Preflight Audit', () => {
         setResult: sinon.stub(),
         setStatus: sinon.stub(),
         setResultType: sinon.stub(),
+        setMetadata: sinon.stub(),
         setEndedAt: sinon.stub(),
         setError: sinon.stub(),
         save: sinon.stub().resolves(),
@@ -1410,13 +1411,25 @@ describe('Preflight Audit', () => {
       await expect(preflightAuditFunction(context)).to.be.rejectedWith('[preflight-audit] site: site-123. Job not in progress for jobId: job-123. Status: COMPLETED');
     });
 
-    it('throws and logs if the preflight handler is disabled for the site', async () => {
+    it('cancels the job and logs when the preflight handler is disabled for the site', async () => {
       configuration.isHandlerEnabledForSite.withArgs('preflight', site).returns(false);
       configuration.isHandlerEnabledForSite.returns(true);
 
-      await expect(preflightAuditFunction(context)).to.be.rejectedWith('[preflight-audit] site: site-123. Preflight handler is disabled for this site.');
+      await preflightAuditFunction(context);
 
-      expect(context.log.error).to.have.been.calledWithMatch('[preflight-audit] site: site-123, job: job-123. Preflight is disabled for this site.');
+      expect(context.log.info).to.have.been.calledWithMatch('[preflight-audit] site: site-123, job: job-123. preflight audits disabled for site site-123, skipping');
+
+      const jobEntityCalls = context.dataAccess.AsyncJob.findById.returnValues;
+      const finalJobEntity = await jobEntityCalls[jobEntityCalls.length - 1];
+      expect(finalJobEntity.setStatus).to.have.been.calledWith('CANCELLED');
+      expect(finalJobEntity.setMetadata).to.have.been.calledWith({
+        payload: {
+          siteId: 'site-123',
+          reason: 'preflight audits disabled for site site-123',
+        },
+      });
+      expect(finalJobEntity.setEndedAt).to.have.been.called;
+      expect(finalJobEntity.save).to.have.been.called;
     });
 
     it('throws if the provided urls are invalid', async () => {

--- a/test/audits/preflight.test.js
+++ b/test/audits/preflight.test.js
@@ -1426,6 +1426,7 @@ describe('Preflight Audit', () => {
         payload: {
           siteId: 'site-123',
           reason: 'preflight audits disabled for site site-123',
+          errorCode: 'PREFLIGHT-100',
         },
       });
       expect(finalJobEntity.setEndedAt).to.have.been.called;

--- a/test/audits/preflight.test.js
+++ b/test/audits/preflight.test.js
@@ -726,6 +726,7 @@ describe('Preflight Audit', () => {
       configuration = {
         isHandlerEnabledForSite: sinon.stub(),
         getHandlers: sinon.stub().returns({
+          preflight: { productCodes: ['aem-sites'] },
           'readability-preflight': { productCodes: ['aem-sites'] },
           'accessibility-preflight': { productCodes: ['aem-sites'] },
           'metatags-preflight': { productCodes: ['aem-sites'] },
@@ -739,6 +740,7 @@ describe('Preflight Audit', () => {
           'alt-text-preflight': { productCodes: ['aem-sites'] },
         }),
       };
+      configuration.isHandlerEnabledForSite.withArgs('preflight', site).returns(true);
       context.dataAccess.Configuration.findLatest.resolves(configuration);
 
       // Ensure entitlement checks pass for tests; avoid double-stubbing across tests
@@ -1408,6 +1410,15 @@ describe('Preflight Audit', () => {
       await expect(preflightAuditFunction(context)).to.be.rejectedWith('[preflight-audit] site: site-123. Job not in progress for jobId: job-123. Status: COMPLETED');
     });
 
+    it('throws and logs if the preflight handler is disabled for the site', async () => {
+      configuration.isHandlerEnabledForSite.withArgs('preflight', site).returns(false);
+      configuration.isHandlerEnabledForSite.returns(true);
+
+      await expect(preflightAuditFunction(context)).to.be.rejectedWith('[preflight-audit] site: site-123. Preflight handler is disabled for this site.');
+
+      expect(context.log.error).to.have.been.calledWithMatch('[preflight-audit] site: site-123, job: job-123. Preflight is disabled for this site.');
+    });
+
     it('throws if the provided urls are invalid', async () => {
       job.getMetadata = () => ({
         payload: {
@@ -1787,6 +1798,7 @@ describe('Preflight Audit', () => {
       const mockConfiguration = {
         isHandlerEnabledForSite: sinon.stub().returns(true),
         getHandlers: () => ({
+          preflight: { productCodes: ['aem-sites'] },
           'readability-preflight': { productCodes: ['aem-sites'] },
           'accessibility-preflight': { productCodes: ['aem-sites'] },
         }),
@@ -1865,6 +1877,7 @@ describe('Preflight Audit', () => {
       const mockConfiguration = {
         isHandlerEnabledForSite: sinon.stub().returns(true),
         getHandlers: () => ({
+          preflight: { productCodes: ['aem-sites'] },
           'readability-preflight': { productCodes: ['aem-sites'] },
           'accessibility-preflight': { productCodes: ['aem-sites'] },
           'body-size-preflight': { productCodes: ['aem-sites'] },
@@ -4791,6 +4804,7 @@ describe('Preflight Audit', () => {
       configuration = {
         isHandlerEnabledForSite: sinon.stub(),
         getHandlers: sinon.stub().returns({
+          preflight: { productCodes: ['aem-sites'] },
           'readability-preflight': { productCodes: ['aem-sites'] },
           'accessibility-preflight': { productCodes: ['aem-sites'] },
           'metatags-preflight': { productCodes: ['aem-sites'] },
@@ -4804,6 +4818,7 @@ describe('Preflight Audit', () => {
           'alt-text-preflight': { productCodes: ['aem-sites'] },
         }),
       };
+      configuration.isHandlerEnabledForSite.withArgs('preflight', site).returns(true);
 
       // Ensure entitlement checks pass for enabled checks calculation
       const mockTierClient = {

--- a/test/common/audit-utils.test.js
+++ b/test/common/audit-utils.test.js
@@ -180,6 +180,23 @@ describe('Audit Utils Tests', () => {
       const result = await isAuditEnabledForSite('test-handler', site, context);
       expect(result).to.be.false;
     });
+
+    it('rethrows an entitlement-check error instead of returning false when throwOnError is true', async () => {
+      configuration.getHandlers = () => ({
+        'test-handler': {
+          enabledByDefault: true,
+          productCodes: ['ASO'],
+        },
+      });
+
+      const mockTierClient = {
+        checkValidEntitlement: sandbox.stub().rejects(new Error('entitlement service unavailable')),
+      };
+      sandbox.stub(TierClient, 'createForSite').returns(mockTierClient);
+
+      await expect(isAuditEnabledForSite('test-handler', site, context, { throwOnError: true }))
+        .to.be.rejectedWith('entitlement service unavailable');
+    });
   });
 
   describe('isAuditDisabledForSite', () => {
@@ -343,6 +360,25 @@ describe('Audit Utils Tests', () => {
       const result = await checkProductCodeEntitlements(['ASO', 'LLMO'], site, context);
       expect(result).to.be.false;
       expect(context.log.error).to.have.been.calledWith('Error checking product code entitlements:', sinon.match.instanceOf(Error));
+    });
+
+    it('rethrows a per-product-code error instead of returning false when throwOnError is true', async () => {
+      const mockTierClient = {
+        checkValidEntitlement: sandbox.stub().rejects(new Error('ASO check failed')),
+      };
+      sandbox.stub(TierClient, 'createForSite').returns(mockTierClient);
+
+      await expect(
+        checkProductCodeEntitlements(['ASO'], site, context, { throwOnError: true }),
+      ).to.be.rejectedWith('ASO check failed');
+    });
+
+    it('rethrows a critical error instead of returning false when throwOnError is true', async () => {
+      sandbox.stub(Promise, 'all').throws(new Error('Critical Promise.all error'));
+
+      await expect(
+        checkProductCodeEntitlements(['ASO', 'LLMO'], site, context, { throwOnError: true }),
+      ).to.be.rejectedWith('Critical Promise.all error');
     });
   });
 

--- a/test/preflight/links-selectors.test.js
+++ b/test/preflight/links-selectors.test.js
@@ -104,6 +104,7 @@ describe('Preflight Links - Insecure Links Coverage Tests', () => {
     configuration = {
       isHandlerEnabledForSite: sinon.stub(),
       getHandlers: sinon.stub().returns({
+        preflight: { productCodes: ['aem-sites'] },
         'links-preflight': { productCodes: ['aem-sites'] },
       }),
     };
@@ -117,6 +118,9 @@ describe('Preflight Links - Insecure Links Coverage Tests', () => {
     }
     sinon.stub(TierClient, 'createForSite').resolves(mockTierClient);
 
+    configuration.isHandlerEnabledForSite
+      .withArgs('preflight', site)
+      .returns(true);
     configuration.isHandlerEnabledForSite
       .withArgs('links-preflight', site)
       .returns(true);

--- a/test/preflight/links-unique-selectors.test.js
+++ b/test/preflight/links-unique-selectors.test.js
@@ -120,6 +120,7 @@ describe('Preflight Links - Unique Selector Tests', () => {
     configuration = {
       isHandlerEnabledForSite: sinon.stub().returns(true),
       getHandlers: sinon.stub().returns({
+        preflight: { productCodes: ['aem-sites'] },
         'links-preflight': { productCodes: ['aem-sites'] },
       }),
     };


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues

SITES-47836

## Summary
- Reject/cancel preflight audit runs instead of throwing when the preflight handler is disabled for a site (or the site lacks the required product-code entitlement) — the `AsyncJob` is set to `CANCELLED` with metadata instead of erroring out on every retry.
- Register the preflight handler in the links-selector test configs.
- Add a small `PreflightError` catalog (`src/preflight/error-constants.js`) with `code` / `message` / `description` / `classification` per entry, modeled after Content Backflow's error enum pattern.
- Surface a stable `errorCode` (`PREFLIGHT-100`) plus a static `reason` message on the cancellation job's metadata payload, so downstream consumers (e.g. the preflight MFE) can map the code to a localized message instead of parsing a freeform string.

## Test plan
- [x] `npx mocha test/audits/preflight.test.js` — 143 passing
- [x] `npm run lint` on changed files