### PR TITLE
Revert "fix(cdn-logs-report): stop emitting citability score + deployed-at-edge (LLMO-5646)"

### DIFF
--- a/src/cdn-logs-report/utils/agentic-traffic-mapper.js
+++ b/src/cdn-logs-report/utils/agentic-traffic-mapper.js
@@ -79,6 +79,43 @@ function inferContentType(urlPath = '') {
   return 'other';
 }
 
+function buildCitabilityMap(citabilityScores, log) {
+  return (citabilityScores || []).reduce((acc, score) => {
+    let pathname;
+    try {
+      ({ pathname } = new URL(score.getUrl()));
+    } catch (error) {
+      log?.warn?.(`Skipping malformed citability URL during agentic mapping: ${error.message}`);
+      return acc;
+    }
+    const existingScore = acc[pathname];
+
+    if (!existingScore || new Date(score.getUpdatedAt()) > new Date(existingScore.updatedAt)) {
+      acc[pathname] = {
+        score: score.getCitabilityScore(),
+        isDeployedAtEdge: score.getIsDeployedAtEdge(),
+        updatedAt: score.getUpdatedAt(),
+      };
+    }
+
+    return acc;
+  }, {});
+}
+
+async function getCitabilityScores(site, context) {
+  const pageCitability = context?.dataAccess?.PageCitability;
+  if (!pageCitability?.allBySiteId) {
+    return [];
+  }
+
+  try {
+    return await pageCitability.allBySiteId(site.getId());
+  } catch (error) {
+    context?.log?.warn?.(`Failed to fetch citability scores for agentic mapping: ${error.message}`);
+    return [];
+  }
+}
+
 function canonicalizeAgenticUrlPath(rawUrl, baseURL, log) {
   const normalizedUrl = rawUrl === '-' ? '/' : normalizeText(rawUrl, '/');
   const pseudoUrlCandidate = normalizedUrl.replace(/^\/+/, '').toLowerCase();
@@ -104,6 +141,8 @@ export async function mapToAgenticTrafficBundle(rows, site, context, trafficDate
   }
 
   const siteIgnoreList = site.getConfig?.()?.getLlmoCountryCodeIgnoreList?.() || [];
+  const citabilityScores = await getCitabilityScores(site, context);
+  const citabilityMap = buildCitabilityMap(citabilityScores, context?.log);
   const baseURL = site.getConfig?.()?.getFetchConfig?.()?.overrideBaseURL || site.getBaseURL();
   const defaultHost = new URL(baseURL).host;
   const classificationMap = new Map();
@@ -124,7 +163,16 @@ export async function mapToAgenticTrafficBundle(rows, site, context, trafficDate
       }
 
       const host = normalizeText(row.host, defaultHost) || defaultHost;
+      const citability = citabilityMap[urlPath];
       const dimensions = {};
+
+      if (citability?.score !== undefined && citability?.score !== null) {
+        dimensions.citability_score = citability.score;
+      }
+
+      if (citability?.isDeployedAtEdge !== undefined) {
+        dimensions.deployed_at_edge = citability.isDeployedAtEdge;
+      }
 
       const classificationKey = `${host}|${urlPath}`;
       if (!classificationMap.has(classificationKey)) {

--- a/src/cdn-logs-report/utils/agentic-traffic-mapper.js
+++ b/src/cdn-logs-report/utils/agentic-traffic-mapper.js
@@ -170,7 +170,7 @@ export async function mapToAgenticTrafficBundle(rows, site, context, trafficDate
         dimensions.citability_score = citability.score;
       }
 
-      if (citability?.isDeployedAtEdge !== undefined) {
+      if (citability?.isDeployedAtEdge !== undefined && citability?.isDeployedAtEdge !== null) {
         dimensions.deployed_at_edge = citability.isDeployedAtEdge;
       }
 

--- a/test/audits/cdn-logs-report/agentic-daily-export.test.js
+++ b/test/audits/cdn-logs-report/agentic-daily-export.test.js
@@ -304,6 +304,7 @@ describe('agentic daily export', () => {
 
     expect(module.testHelpers.escapeCsvValue(null)).to.equal('');
     expect(module.testHelpers.escapeCsvValue(undefined)).to.equal('');
+    expect(module.testHelpers.escapeCsvValue('a,"b"')).to.equal('"a,""b"""');
   });
 
   it('skips upload and dispatch when there are no traffic rows', async () => {

--- a/test/audits/cdn-logs-report/agentic-daily-export.test.js
+++ b/test/audits/cdn-logs-report/agentic-daily-export.test.js
@@ -55,7 +55,7 @@ describe('agentic daily export', () => {
           url_path: '/docs/page',
           hits: 12,
           avg_ttfb_ms: 123.45,
-          dimensions: {},
+          dimensions: { citability_score: 82 },
           metrics: {},
           updated_by: 'audit-worker:agentic-daily-export',
         }],
@@ -304,7 +304,6 @@ describe('agentic daily export', () => {
 
     expect(module.testHelpers.escapeCsvValue(null)).to.equal('');
     expect(module.testHelpers.escapeCsvValue(undefined)).to.equal('');
-    expect(module.testHelpers.escapeCsvValue('a,"b"')).to.equal('"a,""b"""');
   });
 
   it('skips upload and dispatch when there are no traffic rows', async () => {

--- a/test/audits/cdn-logs-report/agentic-traffic-mapper.test.js
+++ b/test/audits/cdn-logs-report/agentic-traffic-mapper.test.js
@@ -14,49 +14,93 @@
 import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import {
-  mapToAgenticTrafficBundle,
-} from '../../../src/cdn-logs-report/utils/agentic-traffic-mapper.js';
+import { mapToAgenticTrafficBundle } from '../../../src/cdn-logs-report/utils/agentic-traffic-mapper.js';
 
 use(sinonChai);
 
-const baseSite = (overrides = {}) => ({
-  getId: () => 'site-1',
-  getBaseURL: () => 'https://www.example.com',
-  getConfig: () => ({
-    getLlmoCountryCodeIgnoreList: () => [],
-  }),
-  ...overrides,
-});
-
-const chatbotRow = (url, overrides = {}) => ({
-  agent_type: 'Chatbots',
-  user_agent_display: 'ChatGPT-User',
-  status: 200,
-  number_of_hits: 4,
-  avg_ttfb_ms: 50,
-  country_code: 'US',
-  url,
-  host: 'www.example.com',
-  product: 'Docs',
-  category: 'Documentation',
-  ...overrides,
-});
-
 describe('agentic traffic mapper', () => {
   it('maps Athena rows into traffic and classification bundle rows', async () => {
+    const site = {
+      getId: () => 'site-1',
+      getBaseURL: () => 'https://www.example.com',
+      getConfig: () => ({
+        getLlmoCountryCodeIgnoreList: () => ['AA'],
+      }),
+    };
+    const context = {
+      log: {
+        warn: sinon.spy(),
+      },
+      dataAccess: {
+        PageCitability: {
+          allBySiteId: sinon.stub().resolves([
+            {
+              getUrl: () => 'https://www.example.com/docs/page',
+              getCitabilityScore: () => 82,
+              getIsDeployedAtEdge: () => true,
+              getUpdatedAt: () => '2026-03-31T00:00:00.000Z',
+            },
+            {
+              getUrl: () => '/bad-url',
+              getCitabilityScore: () => 12,
+              getIsDeployedAtEdge: () => false,
+              getUpdatedAt: () => '2026-03-30T00:00:00.000Z',
+            },
+          ]),
+        },
+      },
+    };
+
     const result = await mapToAgenticTrafficBundle([
-      chatbotRow('/docs/page', {
-        number_of_hits: 12, avg_ttfb_ms: 123.45, host: 'docs.example.com',
-      }),
-      chatbotRow('/docs/page', {
-        number_of_hits: 5, avg_ttfb_ms: 110, country_code: 'AA', host: 'docs.example.com',
-      }),
-      chatbotRow('/skip-me', { agent_type: 'Other', host: 'docs.example.com' }),
-      chatbotRow('/skip-me', { number_of_hits: 0, host: 'docs.example.com' }),
-    ], baseSite({
-      getConfig: () => ({ getLlmoCountryCodeIgnoreList: () => ['AA'] }),
-    }), { log: { warn: sinon.spy() } }, '2026-03-31');
+      {
+        agent_type: 'Chatbots',
+        user_agent_display: 'ChatGPT-User',
+        status: 200,
+        number_of_hits: 12,
+        avg_ttfb_ms: 123.45,
+        country_code: 'US',
+        url: '/docs/page',
+        host: 'docs.example.com',
+        product: 'Docs',
+        category: 'Documentation',
+      },
+      {
+        agent_type: 'Chatbots',
+        user_agent_display: 'ChatGPT-User',
+        status: 200,
+        number_of_hits: 5,
+        avg_ttfb_ms: 110,
+        country_code: 'AA',
+        url: '/docs/page',
+        host: 'docs.example.com',
+        product: 'Docs',
+        category: 'Documentation',
+      },
+      {
+        agent_type: 'Other',
+        user_agent_display: 'Mozilla/5.0',
+        status: 200,
+        number_of_hits: 8,
+        avg_ttfb_ms: 80,
+        country_code: 'DE',
+        url: '/skip-me',
+        host: 'docs.example.com',
+        product: 'Docs',
+        category: 'Documentation',
+      },
+      {
+        agent_type: 'Chatbots',
+        user_agent_display: 'ChatGPT-User',
+        status: 200,
+        number_of_hits: 0,
+        avg_ttfb_ms: 99,
+        country_code: 'US',
+        url: '/skip-me',
+        host: 'docs.example.com',
+        product: 'Docs',
+        category: 'Documentation',
+      },
+    ], site, context, '2026-03-31');
 
     expect(result.trafficRows).to.have.length(2);
     expect(result.classificationRows).to.have.length(1);
@@ -72,8 +116,10 @@ describe('agentic traffic mapper', () => {
       hits: 12,
       updated_by: 'audit-worker:agentic-daily-export',
     });
-    // Citability is computed UI-side now; the mapper emits an empty dimensions object.
-    expect(result.trafficRows[0].dimensions).to.deep.equal({});
+    expect(result.trafficRows[0].dimensions).to.deep.equal({
+      citability_score: 82,
+      deployed_at_edge: true,
+    });
 
     expect(result.classificationRows[0]).to.deep.equal({
       host: 'docs.example.com',
@@ -84,6 +130,7 @@ describe('agentic traffic mapper', () => {
       content_type: 'html',
       updated_by: 'audit-worker:agentic-daily-export',
     });
+    expect(context.log.warn).to.have.been.calledOnce;
   });
 
   it('returns empty bundle arrays when required inputs are missing', async () => {
@@ -95,15 +142,40 @@ describe('agentic traffic mapper', () => {
   });
 
   it('classifies common image and icon asset content types', async () => {
-    const result = await mapToAgenticTrafficBundle([
-      chatbotRow('/assets/hero.png', { number_of_hits: 12, category: 'Asset' }),
-      chatbotRow('/favicon.ico', { number_of_hits: 6, category: 'Asset' }),
-      chatbotRow('/photo.jpg', { number_of_hits: 3, category: 'Asset' }),
-      chatbotRow('/brochure.gif', { number_of_hits: 2, category: 'Asset' }),
-    ], baseSite(), { log: { warn: sinon.spy() } }, '2026-03-31');
+    const site = {
+      getId: () => 'site-1',
+      getBaseURL: () => 'https://www.example.com',
+      getConfig: () => ({
+        getLlmoCountryCodeIgnoreList: () => [],
+      }),
+    };
 
-    expect(result.classificationRows.map((r) => r.content_type)).to.include('jpg');
-    expect(result.classificationRows.map((r) => r.content_type)).to.include('gif');
+    const result = await mapToAgenticTrafficBundle([
+      {
+        agent_type: 'Chatbots',
+        user_agent_display: 'ChatGPT-User',
+        status: 200,
+        number_of_hits: 12,
+        avg_ttfb_ms: 50,
+        country_code: 'US',
+        url: '/assets/hero.png',
+        host: 'www.example.com',
+        product: 'Docs',
+        category: 'Asset',
+      },
+      {
+        agent_type: 'Chatbots',
+        user_agent_display: 'ChatGPT-User',
+        status: 200,
+        number_of_hits: 6,
+        avg_ttfb_ms: 40,
+        country_code: 'US',
+        url: '/favicon.ico',
+        host: 'www.example.com',
+        product: 'Docs',
+        category: 'Asset',
+      },
+    ], site, { log: { warn: sinon.spy() } }, '2026-03-31');
 
     expect(result.classificationRows).to.deep.include({
       host: 'www.example.com',
@@ -125,21 +197,131 @@ describe('agentic traffic mapper', () => {
     });
   });
 
-  it('always emits an empty dimensions object', async () => {
-    const result = await mapToAgenticTrafficBundle(
-      [chatbotRow('/guide')],
-      baseSite(),
-      { log: { warn: sinon.spy() } },
-      '2026-03-31',
-    );
+  it('uses the newest citability record for a path and supports missing PageCitability access', async () => {
+    const site = {
+      getId: () => 'site-1',
+      getBaseURL: () => 'https://www.example.com',
+      getConfig: () => ({
+        getLlmoCountryCodeIgnoreList: () => [],
+      }),
+    };
+    const context = {
+      log: {
+        warn: sinon.spy(),
+      },
+      dataAccess: {
+        PageCitability: {
+          allBySiteId: sinon.stub().resolves([
+            {
+              getUrl: () => 'https://www.example.com/image.jpg',
+              getCitabilityScore: () => 10,
+              getIsDeployedAtEdge: () => false,
+              getUpdatedAt: () => '2026-03-30T00:00:00.000Z',
+            },
+            {
+              getUrl: () => 'https://www.example.com/image.jpg',
+              getCitabilityScore: () => 55,
+              getIsDeployedAtEdge: () => true,
+              getUpdatedAt: () => '2026-03-31T00:00:00.000Z',
+            },
+          ]),
+        },
+      },
+    };
+
+    const result = await mapToAgenticTrafficBundle([
+      {
+        agent_type: 'Chatbots',
+        user_agent_display: 'ChatGPT-User',
+        status: 200,
+        number_of_hits: 4,
+        avg_ttfb_ms: 50,
+        country_code: 'US',
+        url: '/image.jpg',
+        host: 'www.example.com',
+        product: 'Docs',
+        category: 'Asset',
+      },
+    ], site, context, '2026-03-31');
+
+    expect(result.trafficRows[0].dimensions).to.deep.equal({
+      citability_score: 55,
+      deployed_at_edge: true,
+    });
+    expect(result.classificationRows[0].content_type).to.equal('jpg');
+
+    const noCitabilityResult = await mapToAgenticTrafficBundle([
+      {
+        agent_type: 'Chatbots',
+        user_agent_display: 'ChatGPT-User',
+        status: 200,
+        number_of_hits: 4,
+        avg_ttfb_ms: 50,
+        country_code: 'US',
+        url: '/brochure.gif',
+        host: 'www.example.com',
+        product: 'Docs',
+        category: 'Asset',
+      },
+    ], site, { log: { warn: sinon.spy() } }, '2026-03-31');
+
+    expect(noCitabilityResult.trafficRows[0].dimensions).to.deep.equal({});
+    expect(noCitabilityResult.classificationRows[0].content_type).to.equal('gif');
+  });
+
+  it('returns other for unknown file extensions and logs citability fetch failures', async () => {
+    const warn = sinon.spy();
+    const site = {
+      getId: () => 'site-1',
+      getBaseURL: () => 'https://www.example.com',
+      getConfig: () => ({
+        getLlmoCountryCodeIgnoreList: () => [],
+      }),
+    };
+
+    const result = await mapToAgenticTrafficBundle([
+      {
+        agent_type: 'Chatbots',
+        user_agent_display: 'ChatGPT-User',
+        status: 200,
+        number_of_hits: 4,
+        avg_ttfb_ms: 50,
+        country_code: 'US',
+        url: '/download/file.bin',
+        host: 'www.example.com',
+        product: 'Docs',
+        category: 'Asset',
+      },
+    ], site, {
+      log: { warn },
+      dataAccess: {
+        PageCitability: {
+          allBySiteId: sinon.stub().rejects(new Error('citability unavailable')),
+        },
+      },
+    }, '2026-03-31');
+
     expect(result.trafficRows[0].dimensions).to.deep.equal({});
+    expect(result.classificationRows[0].content_type).to.equal('other');
+    expect(warn).to.have.been.calledWith(
+      'Failed to fetch citability scores for agentic mapping: citability unavailable',
+    );
   });
 
   it('uses site and row fallbacks for host, base URL, status, and timing fields', async () => {
     const resultWithoutConfig = await mapToAgenticTrafficBundle([
-      chatbotRow('-', {
-        status: 'bad-status', number_of_hits: 7, avg_ttfb_ms: 'not-a-number', host: '', category: 'Landing',
-      }),
+      {
+        agent_type: 'Chatbots',
+        user_agent_display: 'ChatGPT-User',
+        status: 'bad-status',
+        number_of_hits: 7,
+        avg_ttfb_ms: 'not-a-number',
+        country_code: 'US',
+        url: '-',
+        host: '',
+        product: 'Docs',
+        category: 'Landing',
+      },
     ], {
       getId: () => 'site-1',
       getBaseURL: () => 'https://fallback.example.com/base',
@@ -155,9 +337,18 @@ describe('agentic traffic mapper', () => {
     expect(resultWithoutConfig.classificationRows[0].host).to.equal('fallback.example.com');
 
     const resultWithOverride = await mapToAgenticTrafficBundle([
-      chatbotRow('/docs/start', {
-        status: 201, number_of_hits: 3, avg_ttfb_ms: 15, host: '',
-      }),
+      {
+        agent_type: 'Chatbots',
+        user_agent_display: 'ChatGPT-User',
+        status: 201,
+        number_of_hits: 3,
+        avg_ttfb_ms: 15,
+        country_code: 'US',
+        url: '/docs/start',
+        host: '',
+        product: 'Docs',
+        category: 'Documentation',
+      },
     ], {
       getId: () => 'site-1',
       getBaseURL: () => 'https://ignored.example.com',
@@ -180,18 +371,32 @@ describe('agentic traffic mapper', () => {
     });
   });
 
-  it('classifies the remaining known file extensions', async () => {
+  it('classifies the remaining known file extensions and tolerates null citability payloads', async () => {
+    const site = {
+      getId: () => 'site-1',
+      getBaseURL: () => 'https://www.example.com',
+      getConfig: () => ({
+        getLlmoCountryCodeIgnoreList: () => [],
+      }),
+    };
+
     const result = await mapToAgenticTrafficBundle([
-      chatbotRow('/a.webp', { number_of_hits: 1, avg_ttfb_ms: 10, category: 'Asset' }),
-      chatbotRow('/a.svg', { number_of_hits: 1, avg_ttfb_ms: 10, category: 'Asset' }),
-      chatbotRow('/a.bmp', { number_of_hits: 1, avg_ttfb_ms: 10, category: 'Asset' }),
-      chatbotRow('/a.avif', { number_of_hits: 1, avg_ttfb_ms: 10, category: 'Asset' }),
-      chatbotRow('/feed.xml', { number_of_hits: 1, avg_ttfb_ms: 10, category: 'Asset' }),
-      chatbotRow('/guide.pdf', { number_of_hits: 1, avg_ttfb_ms: 10, category: 'Asset' }),
-      chatbotRow('/index.htm', { number_of_hits: 1, avg_ttfb_ms: 10, category: 'Asset' }),
-      chatbotRow('/notes.txt', { number_of_hits: 1, avg_ttfb_ms: 10, category: 'Asset' }),
-      chatbotRow('/download/file.bin', { number_of_hits: 1, avg_ttfb_ms: 10, category: 'Asset' }),
-    ], baseSite(), { log: { warn: sinon.spy() } }, '2026-03-31');
+      { agent_type: 'Chatbots', user_agent_display: 'ChatGPT-User', status: 200, number_of_hits: 1, avg_ttfb_ms: 10, country_code: 'US', url: '/a.webp', host: 'www.example.com', product: 'Docs', category: 'Asset' },
+      { agent_type: 'Chatbots', user_agent_display: 'ChatGPT-User', status: 200, number_of_hits: 1, avg_ttfb_ms: 10, country_code: 'US', url: '/a.svg', host: 'www.example.com', product: 'Docs', category: 'Asset' },
+      { agent_type: 'Chatbots', user_agent_display: 'ChatGPT-User', status: 200, number_of_hits: 1, avg_ttfb_ms: 10, country_code: 'US', url: '/a.bmp', host: 'www.example.com', product: 'Docs', category: 'Asset' },
+      { agent_type: 'Chatbots', user_agent_display: 'ChatGPT-User', status: 200, number_of_hits: 1, avg_ttfb_ms: 10, country_code: 'US', url: '/a.avif', host: 'www.example.com', product: 'Docs', category: 'Asset' },
+      { agent_type: 'Chatbots', user_agent_display: 'ChatGPT-User', status: 200, number_of_hits: 1, avg_ttfb_ms: 10, country_code: 'US', url: '/feed.xml', host: 'www.example.com', product: 'Docs', category: 'Asset' },
+      { agent_type: 'Chatbots', user_agent_display: 'ChatGPT-User', status: 200, number_of_hits: 1, avg_ttfb_ms: 10, country_code: 'US', url: '/guide.pdf', host: 'www.example.com', product: 'Docs', category: 'Asset' },
+      { agent_type: 'Chatbots', user_agent_display: 'ChatGPT-User', status: 200, number_of_hits: 1, avg_ttfb_ms: 10, country_code: 'US', url: '/index.htm', host: 'www.example.com', product: 'Docs', category: 'Asset' },
+      { agent_type: 'Chatbots', user_agent_display: 'ChatGPT-User', status: 200, number_of_hits: 1, avg_ttfb_ms: 10, country_code: 'US', url: '/notes.txt', host: 'www.example.com', product: 'Docs', category: 'Asset' },
+    ], site, {
+      log: { warn: sinon.spy() },
+      dataAccess: {
+        PageCitability: {
+          allBySiteId: sinon.stub().resolves(null),
+        },
+      },
+    }, '2026-03-31');
 
     expect(result.classificationRows.map((row) => row.content_type)).to.deep.equal([
       'webp',
@@ -202,18 +407,35 @@ describe('agentic traffic mapper', () => {
       'pdf',
       'html',
       'txt',
-      'other',
     ]);
   });
 
   it('normalizes empty and non-string values when building bundle rows', async () => {
     const result = await mapToAgenticTrafficBundle([
-      chatbotRow('', {
-        status: 202, number_of_hits: 2, avg_ttfb_ms: 5, host: null, product: {}, category: null,
-      }),
-      chatbotRow('/trimmed', {
-        status: 202, number_of_hits: 2, avg_ttfb_ms: 5, host: null, product: '   ', category: 'Category',
-      }),
+      {
+        agent_type: 'Chatbots',
+        user_agent_display: 'ChatGPT-User',
+        status: 202,
+        number_of_hits: 2,
+        avg_ttfb_ms: 5,
+        country_code: 'US',
+        url: '',
+        host: null,
+        product: {},
+        category: null,
+      },
+      {
+        agent_type: 'Chatbots',
+        user_agent_display: 'ChatGPT-User',
+        status: 202,
+        number_of_hits: 2,
+        avg_ttfb_ms: 5,
+        country_code: 'US',
+        url: '/trimmed',
+        host: null,
+        product: '   ',
+        category: 'Category',
+      },
     ], {
       getId: () => 'site-1',
       getBaseURL: () => 'https://fallback.example.com',
@@ -237,13 +459,37 @@ describe('agentic traffic mapper', () => {
 
   it('skips pseudo-urls while preserving normal path-only URLs', async () => {
     const result = await mapToAgenticTrafficBundle([
-      chatbotRow('/data:image/x-icon;base64,abcd', {
-        number_of_hits: 5, avg_ttfb_ms: 15, country_code: 'DE', category: 'Asset',
+      {
+        agent_type: 'Chatbots',
+        user_agent_display: 'ChatGPT-User',
+        status: 200,
+        number_of_hits: 5,
+        avg_ttfb_ms: 15,
+        country_code: 'DE',
+        url: '/data:image/x-icon;base64,abcd',
+        host: 'www.example.com',
+        product: 'Docs',
+        category: 'Asset',
+      },
+      {
+        agent_type: 'Chatbots',
+        user_agent_display: 'ChatGPT-User',
+        status: 200,
+        number_of_hits: 3,
+        avg_ttfb_ms: 10,
+        country_code: 'DE',
+        url: 'de/docs/start',
+        host: 'www.example.com',
+        product: 'Docs',
+        category: 'Documentation',
+      },
+    ], {
+      getId: () => 'site-1',
+      getBaseURL: () => 'https://www.example.com',
+      getConfig: () => ({
+        getLlmoCountryCodeIgnoreList: () => [],
       }),
-      chatbotRow('de/docs/start', {
-        number_of_hits: 3, avg_ttfb_ms: 10, country_code: 'DE',
-      }),
-    ], baseSite(), { log: { warn: sinon.spy() } }, '2026-03-31');
+    }, { log: { warn: sinon.spy() } }, '2026-03-31');
 
     expect(result.trafficRows).to.have.length(1);
     expect(result.classificationRows).to.have.length(1);
@@ -253,9 +499,18 @@ describe('agentic traffic mapper', () => {
 
   it('strips null bytes from host and url path values', async () => {
     const result = await mapToAgenticTrafficBundle([
-      chatbotRow('/unsafe\0path/index.htm', {
-        number_of_hits: 2, avg_ttfb_ms: 20, host: 'WWW.EXAMPLE.COM\0',
-      }),
+      {
+        agent_type: 'Chatbots',
+        user_agent_display: 'ChatGPT-User',
+        status: 200,
+        number_of_hits: 2,
+        avg_ttfb_ms: 20,
+        country_code: 'US',
+        url: '/unsafe\0path/index.htm',
+        host: 'WWW.EXAMPLE.COM\0',
+        product: 'Docs',
+        category: 'Documentation',
+      },
     ], {
       getId: () => 'site-1',
       getBaseURL: () => 'https://fallback.example.com',
@@ -276,9 +531,18 @@ describe('agentic traffic mapper', () => {
 
   it('canonicalizes traversal-style paths after stripping null bytes', async () => {
     const result = await mapToAgenticTrafficBundle([
-      chatbotRow('/wlmdeu/../../../../../../../../../../../etc/passwd\0index.htm', {
-        number_of_hits: 1, avg_ttfb_ms: 10, host: 'corporate.walmart.com\0',
-      }),
+      {
+        agent_type: 'Chatbots',
+        user_agent_display: 'ChatGPT-User',
+        status: 200,
+        number_of_hits: 1,
+        avg_ttfb_ms: 10,
+        country_code: 'US',
+        url: '/wlmdeu/../../../../../../../../../../../etc/passwd\0index.htm',
+        host: 'corporate.walmart.com\0',
+        product: 'Docs',
+        category: 'Documentation',
+      },
     ], {
       getId: () => 'site-1',
       getBaseURL: () => 'https://corporate.walmart.com',
@@ -312,8 +576,25 @@ describe('agentic traffic mapper', () => {
 
     try {
       const result = await mapToAgenticTrafficBundle([
-        chatbotRow('/will-throw', { number_of_hits: 1, avg_ttfb_ms: 10 }),
-      ], baseSite(), { log: { warn } }, '2026-03-31');
+        {
+          agent_type: 'Chatbots',
+          user_agent_display: 'ChatGPT-User',
+          status: 200,
+          number_of_hits: 1,
+          avg_ttfb_ms: 10,
+          country_code: 'US',
+          url: '/will-throw',
+          host: 'www.example.com',
+          product: 'Docs',
+          category: 'Documentation',
+        },
+      ], {
+        getId: () => 'site-1',
+        getBaseURL: () => 'https://www.example.com',
+        getConfig: () => ({
+          getLlmoCountryCodeIgnoreList: () => [],
+        }),
+      }, { log: { warn } }, '2026-03-31');
 
       expect(result).to.deep.equal({
         trafficRows: [],
@@ -329,7 +610,18 @@ describe('agentic traffic mapper', () => {
 
   it('nulls impossible avg_ttfb_ms values instead of exporting them', async () => {
     const result = await mapToAgenticTrafficBundle([
-      chatbotRow('/normal/path', { number_of_hits: 2, avg_ttfb_ms: 24412667 }),
+      {
+        agent_type: 'Chatbots',
+        user_agent_display: 'ChatGPT-User',
+        status: 200,
+        number_of_hits: 2,
+        avg_ttfb_ms: 24412667,
+        country_code: 'US',
+        url: '/normal/path',
+        host: 'www.example.com',
+        product: 'Docs',
+        category: 'Documentation',
+      },
     ], {
       getId: () => 'site-1',
       getBaseURL: () => 'https://fallback.example.com',

--- a/test/audits/cdn-logs-report/agentic-traffic-mapper.test.js
+++ b/test/audits/cdn-logs-report/agentic-traffic-mapper.test.js
@@ -269,6 +269,48 @@ describe('agentic traffic mapper', () => {
     expect(noCitabilityResult.classificationRows[0].content_type).to.equal('gif');
   });
 
+  it('omits citability dimensions when the record has null score and null deployed-at-edge', async () => {
+    const site = {
+      getId: () => 'site-1',
+      getBaseURL: () => 'https://www.example.com',
+      getConfig: () => ({
+        getLlmoCountryCodeIgnoreList: () => [],
+      }),
+    };
+    const context = {
+      log: { warn: sinon.spy() },
+      dataAccess: {
+        PageCitability: {
+          allBySiteId: sinon.stub().resolves([
+            {
+              getUrl: () => 'https://www.example.com/image.jpg',
+              getCitabilityScore: () => null,
+              getIsDeployedAtEdge: () => null,
+              getUpdatedAt: () => '2026-03-31T00:00:00.000Z',
+            },
+          ]),
+        },
+      },
+    };
+
+    const result = await mapToAgenticTrafficBundle([
+      {
+        agent_type: 'Chatbots',
+        user_agent_display: 'ChatGPT-User',
+        status: 200,
+        number_of_hits: 4,
+        avg_ttfb_ms: 50,
+        country_code: 'US',
+        url: '/image.jpg',
+        host: 'www.example.com',
+        product: 'Docs',
+        category: 'Asset',
+      },
+    ], site, context, '2026-03-31');
+
+    expect(result.trafficRows[0].dimensions).to.deep.equal({});
+  });
+
   it('returns other for unknown file extensions and logs citability fetch failures', async () => {
     const warn = sinon.spy();
     const site = {


### PR DESCRIPTION
## What

Reverts #2633 (merge commit `910ad1a`), which removed server-side citability derivation from `agentic-traffic-mapper.js`.

## Why

Restores emission of `citability_score` and `deployed_at_edge` into the agentic-traffic `dimensions` JSONB from the daily export.

## Restored behavior

In `src/cdn-logs-report/utils/agentic-traffic-mapper.js`:
- `buildCitabilityMap()` and `getCitabilityScores()` helpers
- Per-URL citability lookup in `mapToAgenticTrafficBundle`, re-populating `dimensions.citability_score` and `dimensions.deployed_at_edge`

The restored code sources scores from `context.dataAccess.PageCitability` and is fully self-contained — no dangling references to any file removed in #2633.

## Validation

- `test/audits/cdn-logs-report/**` — 184 passing
- `eslint` — clean on the changed source file

🤖 Generated with [Claude Code](https://claude.com/claude-code)