### PR TITLE
fix(backlinks): keep broken backlinks whose target uses overrideBaseURL

### DIFF
--- a/src/backlinks/handler.js
+++ b/src/backlinks/handler.js
@@ -281,9 +281,19 @@ export async function brokenBacklinksAuditRunner(auditUrl, context, site) {
 
     // Drop backlinks whose target belongs to a different subdomain than the audited site.
     // www and the bare domain are treated as the same host and are never filtered.
+    // A backlink is kept if it matches either the site's base URL or, when configured, the
+    // override URL the SEMrush query itself was run against (see withUrlResolver /
+    // site.resolveFinalURL()). Without this, every backlink would be rejected for sites with
+    // config.fetchConfig.overrideBaseURL configured, since the query domain and the base URL
+    // domain never match in that case (SITES-47904).
     const siteBaseURL = site.getBaseURL();
+    const overrideBaseURL = site.getConfig()?.getFetchConfig?.()?.overrideBaseURL;
     const filteredBacklinks = excludedFilteredBacklinks?.filter((backlink) => {
-      if (isOnDifferentSubdomain(backlink.url_to, siteBaseURL)) {
+      const differsFromBase = isOnDifferentSubdomain(backlink.url_to, siteBaseURL);
+      const differsFromOverride = overrideBaseURL
+        ? isOnDifferentSubdomain(backlink.url_to, overrideBaseURL)
+        : true;
+      if (differsFromBase && differsFromOverride) {
         log.debug(`Excluding backlink ${backlink.url_to}: different subdomain from ${siteBaseURL}`);
         return false;
       }

--- a/test/audits/backlinks.test.js
+++ b/test/audits/backlinks.test.js
@@ -457,6 +457,76 @@ describe('Backlinks Tests', function () {
       expect(result.auditResult.brokenBacklinks).to.have.length(1);
       expect(result.auditResult.brokenBacklinks[0].url_to).to.equal('https://example.com/page');
     });
+
+    it('should keep backlinks whose url_to is on the configured overrideBaseURL domain (SITES-47904)', async () => {
+      const backlinks = [
+        {
+          title: null,
+          url_from: 'https://applyonline.hdfcbank.com/maintenance.html',
+          url_to: 'https://applyonline.hdfc.bank.in/maintenance.html',
+          traffic_domain: 46,
+        },
+      ];
+
+      nock('https://applyonline.hdfc.bank.in')
+        .get('/maintenance.html')
+        .reply(404);
+
+      const siteWithOverride = {
+        getId: () => 'override-site',
+        getBaseURL: () => 'https://applyonline.hdfcbank.com',
+        getConfig: () => Config({
+          fetchConfig: { overrideBaseURL: 'https://applyonline.hdfc.bank.in' },
+        }),
+      };
+
+      mockSeoClient.getBrokenBacklinks.resolves({
+        result: { backlinks },
+        fullAuditRef: auditUrl,
+      });
+
+      const result = await brokenBacklinksAuditRunner(
+        'applyonline.hdfc.bank.in',
+        context,
+        siteWithOverride,
+      );
+
+      expect(result.auditResult.brokenBacklinks).to.have.length(1);
+      expect(result.auditResult.brokenBacklinks[0].url_to)
+        .to.equal('https://applyonline.hdfc.bank.in/maintenance.html');
+    });
+
+    it('should still exclude backlinks on an unrelated subdomain when overrideBaseURL is configured', async () => {
+      const backlinks = [
+        {
+          title: null,
+          url_from: 'https://ref.com/page',
+          url_to: 'https://unrelated.example.com/page',
+          traffic_domain: 10,
+        },
+      ];
+
+      const siteWithOverride = {
+        getId: () => 'override-site-2',
+        getBaseURL: () => 'https://applyonline.hdfcbank.com',
+        getConfig: () => Config({
+          fetchConfig: { overrideBaseURL: 'https://applyonline.hdfc.bank.in' },
+        }),
+      };
+
+      mockSeoClient.getBrokenBacklinks.resolves({
+        result: { backlinks },
+        fullAuditRef: auditUrl,
+      });
+
+      const result = await brokenBacklinksAuditRunner(
+        'applyonline.hdfc.bank.in',
+        context,
+        siteWithOverride,
+      );
+
+      expect(result.auditResult.brokenBacklinks).to.have.length(0);
+    });
   });
 
   describe('soft-404 detection', () => {


### PR DESCRIPTION
## Summary
- The `broken-backlinks` audit's subdomain filter compared each SEMrush result's target host only against `site.getBaseURL()`, while the SEMrush query itself was run against `site.resolveFinalURL()` (which honors `config.fetchConfig.overrideBaseURL` when set).
- Whenever a site has `overrideBaseURL` configured and it differs from `base_url`, those two domains never match, so **every** real broken backlink was silently rejected as "different subdomain" — no error, no opportunity, no suggestion, ever.
- Found while investigating a real customer report (HDFC Bank, `applyonline.hdfcbank.com` / override `applyonline.hdfc.bank.in`): the audit ran clean twice, SEMrush returned ~19 real live broken backlinks both times (confirmed via Splunk logs), yet the stored result was empty both times. An existing opportunity had also been incorrectly auto-resolved as a side effect.
- Fix: a backlink is now kept if its target matches *either* the site's base URL *or* the configured override URL, so both legitimate query domains are recognized as "the site."

## Test plan
- [x] Reproduced the bug with an isolated unit test against the real (unmodified) `brokenBacklinksAuditRunner` before applying the fix — confirmed it returned `[]` for a real, valid backlink.
- [x] Added two regression tests: one confirming override-domain backlinks are now kept, one confirming genuinely unrelated subdomains are still excluded.
- [x] Full existing `backlinks.test.js` suite passes unchanged (81 tests).
- [x] Full repo test suite (`npm test`) passes with 100% coverage maintained.
- [x] `npm run lint` clean.

Jira: SITES-47904

🤖 Generated with [Claude Code](https://claude.com/claude-code)