### PR TITLE
fix(toc): make Impact Engine prompt generation opt-in and add mode:ai-only (LLMO-6167)

### DIFF
--- a/src/toc/eligibility-utils.js
+++ b/src/toc/eligibility-utils.js
@@ -11,17 +11,18 @@
  */
 
 /**
- * True when a TOC suggestion is still open (not FIXED/OUTDATED/SKIPPED) and therefore
- * still eligible to send/receive Impact Engine prompts. Shared by the outbound
- * (sendTocGuidanceRequestToMystique) and inbound (guidance-handler) eligibility checks
- * so the two stay in sync.
+ * True when a TOC suggestion is still open (not FIXED/OUTDATED/SKIPPED), not already
+ * deployed at the CDN edge, and therefore still eligible to send/receive Impact Engine
+ * prompts. Shared by the outbound (sendTocGuidanceRequestToMystique) and inbound
+ * (guidance-handler) eligibility checks so the two stay in sync.
  * @param {Object} suggestion - Suggestion entity
  * @param {Object} Suggestion - The Suggestion data-access collection (for STATUSES)
- * @returns {boolean} True if the suggestion is non-terminal
+ * @returns {boolean} True if the suggestion is non-terminal and not edge-deployed
  */
 export function isEligibleTocSuggestion(suggestion, Suggestion) {
   const status = suggestion.getStatus();
   return status !== Suggestion.STATUSES.FIXED
     && status !== Suggestion.STATUSES.OUTDATED
-    && status !== Suggestion.STATUSES.SKIPPED;
+    && status !== Suggestion.STATUSES.SKIPPED
+    && !suggestion.getData()?.edgeDeployed;
 }

--- a/src/toc/handler.js
+++ b/src/toc/handler.js
@@ -41,9 +41,10 @@ const MODE_AI_ONLY = 'ai-only';
 /**
  * Parses the `mode` value from the audit `data` field.
  * @param {string|Object|null} data - The data field from the message
+ * @param {Object} log - Logger instance
  * @returns {string|null} - The mode value or null
  */
-function getModeFromData(data) {
+function getModeFromData(data, log) {
   if (!data) {
     return null;
   }
@@ -52,7 +53,7 @@ function getModeFromData(data) {
     const parsedData = typeof data === 'string' ? JSON.parse(data) : data;
     return parsedData.mode || null;
   } catch (e) {
-    // Ignore parse errors
+    log.warn(`[TOC] Failed to parse context.data for mode, defaulting to null: ${e.message}`);
     return null;
   }
 }
@@ -527,15 +528,23 @@ export async function handleAiOnlyModeForToc(context) {
     generatePrompts,
   );
 
-  log.info(`[TOC] ai-only: Successfully queued prompt request for ${suggestionCount} suggestion(s). baseUrl=${baseUrl}, siteId=${siteId}, opportunityId=${opportunity.getId()}`);
+  // Distinguish "nothing to do" from "prompts are being generated" — suggestionCount is 0 when
+  // the opportunity has no suggestions or none are eligible, and status: 'complete' would
+  // otherwise misleadingly read as success to an operator running mode:ai-only from Slack.
+  const status = suggestionCount > 0 ? 'complete' : 'no-op';
+  const message = suggestionCount > 0
+    ? `Prompt generation queued successfully for ${suggestionCount} suggestion(s)`
+    : 'No eligible suggestions found to queue prompts for';
+
+  log.info(`[TOC] ai-only: ${message}. baseUrl=${baseUrl}, siteId=${siteId}, opportunityId=${opportunity.getId()}`);
 
   return {
-    status: 'complete',
+    status,
     mode: MODE_AI_ONLY,
     opportunityId: opportunity.getId(),
     fullAuditRef: `${MODE_AI_ONLY}/${opportunity.getId()}`,
     auditResult: {
-      message: `Prompt generation queued successfully for ${suggestionCount} suggestion(s)`,
+      message,
       suggestionCount,
     },
   };
@@ -550,7 +559,7 @@ export async function importTopPages(context) {
   const { site, log, data } = context;
 
   // Check for AI-only mode (from command like: audit:toc mode:ai-only)
-  const mode = getModeFromData(data);
+  const mode = getModeFromData(data, log);
   if (mode === MODE_AI_ONLY) {
     log.info('[TOC] Detected ai-only mode in step 1, skipping import/scraping/processing');
     return handleAiOnlyModeForToc(context);

--- a/src/toc/handler.js
+++ b/src/toc/handler.js
@@ -36,6 +36,26 @@ import { getTopAgenticUrlsFromAthena } from '../utils/agentic-urls.js';
 const auditType = Audit.AUDIT_TYPES.TOC;
 const { AUDIT_STEP_DESTINATIONS } = Audit;
 const MAX_TOP_PAGES = 200;
+const MODE_AI_ONLY = 'ai-only';
+
+/**
+ * Parses the `mode` value from the audit `data` field.
+ * @param {string|Object|null} data - The data field from the message
+ * @returns {string|null} - The mode value or null
+ */
+function getModeFromData(data) {
+  if (!data) {
+    return null;
+  }
+
+  try {
+    const parsedData = typeof data === 'string' ? JSON.parse(data) : data;
+    return parsedData.mode || null;
+  } catch (e) {
+    // Ignore parse errors
+    return null;
+  }
+}
 
 /**
  * Fetches and merges TOC audit input URLs from three sources in priority order:
@@ -295,12 +315,258 @@ export async function validatePageTocFromScrapeJson(
 }
 
 /**
- * Step 1: Import top pages for the TOC audit.
+ * Recursively collect heading text from a HAST node tree. TOC transformRules render each
+ * heading as `li > a[data-selector] > text` (see tocArrayToHast) — walking every text node
+ * indiscriminately would also pick up insignificant whitespace text nodes and non-heading
+ * content from HTML-round-tripped (isEdited) trees, so this targets anchors carrying a
+ * `data-selector` (the heading link) specifically.
+ * @param {Object|Array} node - HAST node or array of nodes
+ * @returns {string[]} Array of heading text strings found in the tree
+ */
+function extractHeadingTextsFromHast(node) {
+  if (!node) {
+    return [];
+  }
+  if (Array.isArray(node)) {
+    return node.flatMap((child) => extractHeadingTextsFromHast(child));
+  }
+  if (node.type === 'element' && node.tagName === 'a' && node.properties?.['data-selector']) {
+    const text = (node.children || [])
+      .filter((child) => child.type === 'text' && typeof child.value === 'string')
+      .map((child) => child.value)
+      .join('')
+      .trim();
+    return text ? [text] : [];
+  }
+  if (node.children && Array.isArray(node.children)) {
+    return node.children.flatMap((child) => extractHeadingTextsFromHast(child));
+  }
+  return [];
+}
+
+/**
+ * Sends a guidance:table-of-contents message to Mystique so that prompts can be
+ * generated for each TOC suggestion (required for the Impact Engine geo-experiment flow).
+ * @param {string} auditUrl - Audited base URL
+ * @param {Object} opportunity - The TOC opportunity entity
  * @param {Object} context - Audit context
- * @returns {Promise<Object>}
+ * @param {boolean} [generatePrompts] - Whether to request prompt generation for the suggestions.
+ * @returns {Promise<number>} Number of suggestions sent to Mystique
+ */
+async function sendTocGuidanceRequestToMystique(
+  auditUrl,
+  opportunity,
+  context,
+  generatePrompts = false,
+) {
+  const {
+    log, sqs, env, site, audit,
+  } = context;
+
+  if (!sqs || !env?.QUEUE_SPACECAT_TO_MYSTIQUE) {
+    log.warn(`[TOC] SQS or Mystique queue not configured, skipping guidance:table-of-contents message. baseUrl=${auditUrl || site?.getBaseURL?.() || ''}`);
+    return 0;
+  }
+
+  if (!opportunity || !opportunity.getId) {
+    log.warn(`[TOC] Opportunity entity not available, skipping guidance:table-of-contents message. baseUrl=${auditUrl || site?.getBaseURL?.() || ''}`);
+    return 0;
+  }
+
+  const opportunityId = opportunity.getId();
+
+  try {
+    const existingSuggestions = await opportunity.getSuggestions();
+
+    if (!existingSuggestions || existingSuggestions.length === 0) {
+      log.debug(`[TOC] No existing suggestions found for opportunityId=${opportunityId}, skipping Mystique message. baseUrl=${auditUrl}`);
+      return 0;
+    }
+
+    const candidates = [];
+
+    existingSuggestions.forEach((s) => {
+      const data = s.getData();
+
+      // Skip FIXED, OUTDATED, SKIPPED, and edge-deployed suggestions. Suggestions that
+      // already have prompts are still included (tagged with hasPrompts below) rather than
+      // silently excluded — Mystique decides whether to regenerate.
+      if (!isEligibleTocSuggestion(s, Suggestion)) {
+        return;
+      }
+
+      const suggestionId = s.getId();
+      const hastNodes = data?.transformRules?.value;
+      const headings = Array.isArray(hastNodes)
+        ? [...new Set(extractHeadingTextsFromHast(hastNodes))]
+        : [];
+
+      candidates.push({
+        suggestionId,
+        url: data?.url || '',
+        title: data?.title || '',
+        headings,
+        hasPrompts: !!(data?.hasPrompts || (data?.prompts?.length > 0)),
+      });
+    });
+
+    if (candidates.length === 0) {
+      log.info(`[TOC] No eligible suggestions to send to Mystique for opportunityId=${opportunityId}. baseUrl=${auditUrl}`);
+      return 0;
+    }
+
+    const queue = env.QUEUE_SPACECAT_TO_MYSTIQUE;
+    const time = new Date().toISOString();
+    // context.audit is undefined when called from ai-only mode (step 1, before any Audit
+    // record exists for this run) — fall back to the opportunity's stored auditId, or a
+    // synthetic one so the outbound message still carries a stable auditId.
+    const auditId = audit?.getId() || opportunity.getAuditId() || `toc-ai-only-${site.getId()}`;
+
+    await sqs.sendMessage(queue, {
+      type: 'guidance:table-of-contents',
+      url: auditUrl,
+      siteId: site.getId(),
+      auditId,
+      time,
+      data: {
+        opportunityId,
+        suggestions: candidates,
+        generatePrompts,
+        siteRegion: site.getRegion?.() ?? '',
+      },
+    });
+
+    log.info(`[TOC] Queued guidance:table-of-contents message to Mystique for baseUrl=${auditUrl}, opportunityId=${opportunityId}, suggestions=${candidates.length}`);
+    return candidates.length;
+  } catch (error) {
+    log.error(`[TOC] Failed to send guidance:table-of-contents message to Mystique for opportunityId=${opportunityId}, baseUrl=${auditUrl}: ${error.message}`, error);
+    return 0;
+  }
+}
+
+/**
+ * Handles TOC's ai-only mode: sends prompts for existing eligible suggestions to Mystique
+ * without re-running the audit (no re-scrape, no TOC-presence re-detection). Called early in
+ * step 1 to bypass import/scraping/processing steps.
+ * @param {Object} context - Audit context
+ * @returns {Promise<Object>} - Result indicating success/failure
+ */
+export async function handleAiOnlyModeForToc(context) {
+  const {
+    site, log, dataAccess, data,
+  } = context;
+  const { Opportunity } = dataAccess;
+  const siteId = site.getId();
+  const baseUrl = site.getBaseURL();
+
+  // Parse optional params from data field (opportunityId, generatePrompts)
+  let opportunityId = null;
+  let generatePrompts = false;
+  try {
+    const parsedData = typeof data === 'string' ? JSON.parse(data) : data;
+    if (parsedData) {
+      opportunityId = parsedData.opportunityId;
+      generatePrompts = !!parsedData.generatePrompts;
+    }
+  } catch (e) {
+    // Non-JSON data — graceful degradation, values stay at defaults
+    log.warn(`[TOC] ai-only: Failed to parse context.data for opportunityId, generatePrompts, defaulting to null, false: ${e.message}`);
+  }
+
+  log.info(`[TOC] ai-only: Processing prompt request for baseUrl=${baseUrl}, siteId=${siteId}, opportunityId=${opportunityId || 'latest'}, generatePrompts=${generatePrompts}`);
+
+  // Find the opportunity
+  let opportunity;
+  if (opportunityId) {
+    opportunity = await Opportunity.findById(opportunityId);
+    if (!opportunity) {
+      const error = `Opportunity not found: ${opportunityId}`;
+      log.error(`[TOC] ai-only: ${error} baseUrl=${baseUrl}, siteId=${siteId}`);
+      return {
+        error,
+        status: 'failed',
+        fullAuditRef: `${MODE_AI_ONLY}/failed-${siteId}`,
+        auditResult: { error },
+      };
+    }
+  } else {
+    // Find latest NEW TOC opportunity for this site
+    const opportunities = await Opportunity.allBySiteIdAndStatus(siteId, 'NEW');
+    opportunity = opportunities.find((o) => o.getType() === auditType);
+
+    if (!opportunity) {
+      const error = `No NEW TOC opportunity found for site: ${siteId}`;
+      log.error(`[TOC] ai-only: ${error} baseUrl=${baseUrl}, siteId=${siteId}`);
+      return {
+        error,
+        status: 'failed',
+        fullAuditRef: `${MODE_AI_ONLY}/failed-${siteId}`,
+        auditResult: { error },
+      };
+    }
+
+    log.info(`[TOC] ai-only: Found latest NEW opportunity: ${opportunity.getId()} for baseUrl=${baseUrl}, siteId=${siteId}`);
+  }
+
+  // Verify opportunity belongs to the site
+  if (opportunity.getSiteId() !== siteId) {
+    const error = `Opportunity ${opportunity.getId()} does not belong to site ${siteId}`;
+    log.error(`[TOC] ai-only: ${error} baseUrl=${baseUrl}, siteId=${siteId}`);
+    return {
+      error,
+      status: 'failed',
+      fullAuditRef: `${MODE_AI_ONLY}/failed-${siteId}`,
+      auditResult: { error },
+    };
+  }
+
+  const suggestionCount = await sendTocGuidanceRequestToMystique(
+    baseUrl,
+    opportunity,
+    context,
+    generatePrompts,
+  );
+
+  log.info(`[TOC] ai-only: Successfully queued prompt request for ${suggestionCount} suggestion(s). baseUrl=${baseUrl}, siteId=${siteId}, opportunityId=${opportunity.getId()}`);
+
+  return {
+    status: 'complete',
+    mode: MODE_AI_ONLY,
+    opportunityId: opportunity.getId(),
+    fullAuditRef: `${MODE_AI_ONLY}/${opportunity.getId()}`,
+    auditResult: {
+      message: `Prompt generation queued successfully for ${suggestionCount} suggestion(s)`,
+      suggestionCount,
+    },
+  };
+}
+
+/**
+ * Step 1: Import top pages for the TOC audit, OR handle ai-only mode.
+ * @param {Object} context - Audit context
+ * @returns {Promise<Object>} - Import job configuration OR ai-only result
  */
 export async function importTopPages(context) {
-  const { site, log } = context;
+  const { site, log, data } = context;
+
+  // Check for AI-only mode (from command like: audit:toc mode:ai-only)
+  const mode = getModeFromData(data);
+  if (mode === MODE_AI_ONLY) {
+    log.info('[TOC] Detected ai-only mode in step 1, skipping import/scraping/processing');
+    return handleAiOnlyModeForToc(context);
+  }
+
+  // Extract generatePrompts so it can be forwarded to downstream steps via auditContext.
+  // context.data is only populated on the SQS message that triggers Step 1 (the original
+  // Slack command payload) — it is NOT automatically forwarded to Steps 2 and 3.
+  let generatePrompts = false;
+  try {
+    const parsedData = typeof data === 'string' ? JSON.parse(data) : data;
+    generatePrompts = !!parsedData?.generatePrompts;
+  } catch (e) {
+    log.warn(`[TOC] Failed to parse context.data for generatePrompts flag, defaulting to false: ${e.message}`);
+  }
+
   try {
     const { urls } = await getTocInputUrls(context, site);
     log.info(`[TOC] Found ${urls.length} URLs for audit`);
@@ -309,6 +575,7 @@ export async function importTopPages(context) {
       siteId: site.getId(),
       auditResult: { success: true, topPages: urls },
       fullAuditRef: site.getBaseURL(),
+      auditContext: { generatePrompts },
     };
   } catch (error) {
     log.error(`[TOC] Failed to import top pages: ${error.message}`, error);
@@ -317,6 +584,7 @@ export async function importTopPages(context) {
       siteId: site.getId(),
       auditResult: { success: false, error: error.message, topPages: [] },
       fullAuditRef: site.getBaseURL(),
+      auditContext: { generatePrompts },
     };
   }
 }
@@ -330,7 +598,9 @@ export async function importTopPages(context) {
  * @returns {Promise<Object>}
  */
 export async function submitForScraping(context) {
-  const { site, audit, log } = context;
+  const {
+    site, audit, log, auditContext,
+  } = context;
   const { Audit: AuditModel } = context.dataAccess;
   const auditResult = audit.getAuditResult();
   const topPages = auditResult?.topPages ?? [];
@@ -359,6 +629,7 @@ export async function submitForScraping(context) {
     urls: pagesToScrape.map((url) => ({ url })),
     siteId: site.getId(),
     maxScrapeAge: 24,
+    auditContext: { ...auditContext, generatePrompts: !!auditContext?.generatePrompts },
   };
 }
 
@@ -407,129 +678,6 @@ export function generateSuggestions(auditUrl, auditData, context) {
 
   log.debug(`Generated ${suggestions.toc.length} TOC suggestions for ${auditUrl}`);
   return { ...auditData, suggestions };
-}
-
-/**
- * Recursively collect heading text from a HAST node tree. TOC transformRules render each
- * heading as `li > a[data-selector] > text` (see tocArrayToHast) — walking every text node
- * indiscriminately would also pick up insignificant whitespace text nodes and non-heading
- * content from HTML-round-tripped (isEdited) trees, so this targets anchors carrying a
- * `data-selector` (the heading link) specifically.
- * @param {Object|Array} node - HAST node or array of nodes
- * @returns {string[]} Array of heading text strings found in the tree
- */
-function extractHeadingTextsFromHast(node) {
-  if (!node) {
-    return [];
-  }
-  if (Array.isArray(node)) {
-    return node.flatMap((child) => extractHeadingTextsFromHast(child));
-  }
-  if (node.type === 'element' && node.tagName === 'a' && node.properties?.['data-selector']) {
-    const text = (node.children || [])
-      .filter((child) => child.type === 'text' && typeof child.value === 'string')
-      .map((child) => child.value)
-      .join('')
-      .trim();
-    return text ? [text] : [];
-  }
-  if (node.children && Array.isArray(node.children)) {
-    return node.children.flatMap((child) => extractHeadingTextsFromHast(child));
-  }
-  return [];
-}
-
-/**
- * Sends a guidance:table-of-contents message to Mystique so that prompts can be
- * generated for each TOC suggestion (required for the Impact Engine geo-experiment flow).
- * @param {string} auditUrl - Audited base URL
- * @param {Object} opportunity - The TOC opportunity entity
- * @param {Object} context - Audit context
- * @returns {Promise<number>} Number of suggestions sent to Mystique
- */
-async function sendTocGuidanceRequestToMystique(auditUrl, opportunity, context) {
-  const {
-    log, sqs, env, site, audit,
-  } = context;
-
-  if (!sqs || !env?.QUEUE_SPACECAT_TO_MYSTIQUE) {
-    log.warn(`[TOC] SQS or Mystique queue not configured, skipping guidance:table-of-contents message. baseUrl=${auditUrl || site?.getBaseURL?.() || ''}`);
-    return 0;
-  }
-
-  if (!opportunity || !opportunity.getId) {
-    log.warn(`[TOC] Opportunity entity not available, skipping guidance:table-of-contents message. baseUrl=${auditUrl || site?.getBaseURL?.() || ''}`);
-    return 0;
-  }
-
-  const opportunityId = opportunity.getId();
-
-  try {
-    const existingSuggestions = await opportunity.getSuggestions();
-
-    if (!existingSuggestions || existingSuggestions.length === 0) {
-      log.debug(`[TOC] No existing suggestions found for opportunityId=${opportunityId}, skipping Mystique message. baseUrl=${auditUrl}`);
-      return 0;
-    }
-
-    const candidates = [];
-
-    existingSuggestions.forEach((s) => {
-      const data = s.getData();
-
-      // Skip FIXED, OUTDATED, SKIPPED suggestions
-      if (!isEligibleTocSuggestion(s, Suggestion)) {
-        return;
-      }
-
-      // Skip suggestions that already have prompts
-      if (data?.hasPrompts === true && data?.prompts?.length > 0) {
-        return;
-      }
-
-      const suggestionId = s.getId();
-      const hastNodes = data?.transformRules?.value;
-      const headings = Array.isArray(hastNodes)
-        ? [...new Set(extractHeadingTextsFromHast(hastNodes))]
-        : [];
-
-      candidates.push({
-        suggestionId,
-        url: data?.url || '',
-        title: data?.title || '',
-        headings,
-        hasPrompts: !!(data?.hasPrompts || (data?.prompts?.length > 0)),
-      });
-    });
-
-    if (candidates.length === 0) {
-      log.info(`[TOC] No eligible suggestions to send to Mystique for opportunityId=${opportunityId}. baseUrl=${auditUrl}`);
-      return 0;
-    }
-
-    const queue = env.QUEUE_SPACECAT_TO_MYSTIQUE;
-    const time = new Date().toISOString();
-
-    await sqs.sendMessage(queue, {
-      type: 'guidance:table-of-contents',
-      url: auditUrl,
-      siteId: site.getId(),
-      auditId: audit.getId(),
-      time,
-      data: {
-        opportunityId,
-        suggestions: candidates,
-        generatePrompts: true,
-        siteRegion: site.getRegion?.() ?? '',
-      },
-    });
-
-    log.info(`[TOC] Queued guidance:table-of-contents message to Mystique for baseUrl=${auditUrl}, opportunityId=${opportunityId}, suggestions=${candidates.length}`);
-    return candidates.length;
-  } catch (error) {
-    log.error(`[TOC] Failed to send guidance:table-of-contents message to Mystique for opportunityId=${opportunityId}, baseUrl=${auditUrl}: ${error.message}`, error);
-    return 0;
-  }
 }
 
 export async function opportunityAndSuggestions(auditUrl, auditData, context) {
@@ -617,7 +765,12 @@ export async function opportunityAndSuggestions(auditUrl, auditData, context) {
     log,
   });
 
-  await sendTocGuidanceRequestToMystique(auditUrl, opportunity, context);
+  await sendTocGuidanceRequestToMystique(
+    auditUrl,
+    opportunity,
+    context,
+    !!context.auditContext?.generatePrompts,
+  );
 
   log.info(`TOC opportunity created for Site Optimizer and ${tocSuggestions.length} suggestions synced for ${auditUrl}`);
   return { ...auditData };

--- a/test/audits/toc.test.js
+++ b/test/audits/toc.test.js
@@ -970,6 +970,7 @@ describe('TOC (Table of Contents) Audit', () => {
       };
       return sinon.stub().resolves({
         getId: () => 'test-toc-opportunity-id',
+        getAuditId: () => null,
         getSuggestions: sinon.stub().resolves(existingSuggestions),
       });
     };
@@ -989,6 +990,8 @@ describe('TOC (Table of Contents) Audit', () => {
           },
         }),
       ]);
+      // Simulates the flag having been parsed in step 1 and forwarded through steps 2/3.
+      context.auditContext = { generatePrompts: true };
 
       const mockedHandler = await esmock('../../src/toc/handler.js', {
         '../../src/common/opportunity.js': { convertToOpportunity: convertToOpportunityStub },
@@ -1035,16 +1038,12 @@ describe('TOC (Table of Contents) Audit', () => {
       expect(message.data.suggestions[0].headings).to.deep.equal(['Introduction']);
     });
 
-    it('skips FIXED/OUTDATED/SKIPPED suggestions and ones that already have prompts', async () => {
+    it('skips FIXED/OUTDATED/SKIPPED/edge-deployed suggestions, and no eligible suggestions remain', async () => {
       const convertToOpportunityStub = setupMystiqueContext([
         makeExistingSuggestion({ url: 'https://example.com/fixed' }, 'FIXED'),
         makeExistingSuggestion({ url: 'https://example.com/outdated' }, 'OUTDATED'),
         makeExistingSuggestion({ url: 'https://example.com/skipped' }, 'SKIPPED'),
-        makeExistingSuggestion({
-          url: 'https://example.com/already-has-prompts',
-          hasPrompts: true,
-          prompts: [{ id: 'p1' }],
-        }),
+        makeExistingSuggestion({ url: 'https://example.com/edge-deployed', edgeDeployed: true }),
       ]);
 
       const mockedHandler = await esmock('../../src/toc/handler.js', {
@@ -1064,6 +1063,107 @@ describe('TOC (Table of Contents) Audit', () => {
       await mockedHandler.opportunityAndSuggestions(auditUrl, auditData, context);
 
       expect(context.sqs.sendMessage).not.to.have.been.called;
+    });
+
+    it('includes already-prompted suggestions tagged with hasPrompts instead of silently excluding them', async () => {
+      const convertToOpportunityStub = setupMystiqueContext([
+        makeExistingSuggestion({
+          url: 'https://example.com/already-has-prompts',
+          hasPrompts: true,
+          prompts: [{ id: 'p1' }],
+        }),
+      ]);
+
+      const mockedHandler = await esmock('../../src/toc/handler.js', {
+        '../../src/common/opportunity.js': { convertToOpportunity: convertToOpportunityStub },
+        '../../src/utils/data-access.js': { syncSuggestions: sinon.stub().resolves() },
+      });
+
+      const auditUrl = 'https://example.com';
+      const auditData = {
+        suggestions: {
+          toc: [{
+            type: 'CODE_CHANGE', checkType: 'toc', url: 'https://example.com/already-has-prompts', explanation: 'x', recommendedAction: 'x',
+          }],
+        },
+      };
+
+      await mockedHandler.opportunityAndSuggestions(auditUrl, auditData, context);
+
+      expect(context.sqs.sendMessage).to.have.been.calledOnce;
+      const [, message] = context.sqs.sendMessage.getCall(0).args;
+      expect(message.data.suggestions).to.have.length(1);
+      expect(message.data.suggestions[0]).to.include({
+        url: 'https://example.com/already-has-prompts',
+        hasPrompts: true,
+      });
+    });
+
+    it('defaults generatePrompts to false in the outbound message when auditContext has no flag', async () => {
+      const convertToOpportunityStub = setupMystiqueContext([
+        makeExistingSuggestion({ url: 'https://example.com/page1' }),
+      ]);
+
+      const mockedHandler = await esmock('../../src/toc/handler.js', {
+        '../../src/common/opportunity.js': { convertToOpportunity: convertToOpportunityStub },
+        '../../src/utils/data-access.js': { syncSuggestions: sinon.stub().resolves() },
+      });
+
+      const auditUrl = 'https://example.com';
+      const auditData = {
+        suggestions: {
+          toc: [{
+            type: 'CODE_CHANGE', checkType: 'toc', url: 'https://example.com/page1', explanation: 'x', recommendedAction: 'x',
+          }],
+        },
+      };
+
+      await mockedHandler.opportunityAndSuggestions(auditUrl, auditData, context);
+
+      const [, message] = context.sqs.sendMessage.getCall(0).args;
+      expect(message.data.generatePrompts).to.equal(false);
+    });
+
+    it('falls back to opportunity.getAuditId() then a synthetic id when context.audit is absent', async () => {
+      const convertToOpportunityStub = setupMystiqueContext([
+        makeExistingSuggestion({ url: 'https://example.com/page1' }),
+      ]);
+      delete context.audit;
+
+      const mockedHandler = await esmock('../../src/toc/handler.js', {
+        '../../src/common/opportunity.js': { convertToOpportunity: convertToOpportunityStub },
+        '../../src/utils/data-access.js': { syncSuggestions: sinon.stub().resolves() },
+      });
+
+      const auditUrl = 'https://example.com';
+      const auditData = {
+        suggestions: {
+          toc: [{
+            type: 'CODE_CHANGE', checkType: 'toc', url: 'https://example.com/page1', explanation: 'x', recommendedAction: 'x',
+          }],
+        },
+      };
+
+      // No opportunity.getAuditId() on the resolved entity → synthetic fallback.
+      await mockedHandler.opportunityAndSuggestions(auditUrl, auditData, context);
+      let [, message] = context.sqs.sendMessage.getCall(0).args;
+      expect(message.auditId).to.equal('toc-ai-only-site-1');
+
+      // opportunity.getAuditId() present → used over the synthetic fallback.
+      const convertToOpportunityStubWithAuditId = sinon.stub().resolves({
+        getId: () => 'test-toc-opportunity-id',
+        getAuditId: () => 'stored-audit-id',
+        getSuggestions: sinon.stub().resolves([
+          makeExistingSuggestion({ url: 'https://example.com/page1' }),
+        ]),
+      });
+      const mockedHandler2 = await esmock('../../src/toc/handler.js', {
+        '../../src/common/opportunity.js': { convertToOpportunity: convertToOpportunityStubWithAuditId },
+        '../../src/utils/data-access.js': { syncSuggestions: sinon.stub().resolves() },
+      });
+      await mockedHandler2.opportunityAndSuggestions(auditUrl, auditData, context);
+      [, message] = context.sqs.sendMessage.getCall(1).args;
+      expect(message.auditId).to.equal('stored-audit-id');
     });
 
     it('swallows errors from sqs.sendMessage and logs them without failing the audit', async () => {
@@ -4186,6 +4286,86 @@ describe('TOC (Table of Contents) Audit', () => {
       expect(result.auditResult.success).to.be.true;
       expect(result.auditResult.topPages).to.deep.equal([]);
     });
+
+    const stubUrlDeps = () => ({
+      '../../src/utils/audit-input-urls.js': {
+        getMergedAuditInputUrls: sinon.stub().resolves({
+          urls: [],
+          topPagesUrls: [],
+          agenticUrls: [],
+          includedURLs: [],
+          filteredCount: 0,
+        }),
+        sortTopPagesByTraffic: sinon.stub().returns([]),
+      },
+      '../../src/utils/agentic-urls.js': {
+        getTopAgenticUrlsFromAthena: sinon.stub().resolves([]),
+      },
+    });
+
+    it('forwards a true generatePrompts flag via auditContext when present in context.data', async () => {
+      context.site = site;
+      context.data = { generatePrompts: true };
+
+      const mockedHandler = await esmock('../../src/toc/handler.js', stubUrlDeps());
+      const result = await mockedHandler.importTopPages(context);
+
+      expect(result.auditContext).to.deep.equal({ generatePrompts: true });
+    });
+
+    it('parses generatePrompts from a JSON-string context.data', async () => {
+      context.site = site;
+      context.data = JSON.stringify({ generatePrompts: true });
+
+      const mockedHandler = await esmock('../../src/toc/handler.js', stubUrlDeps());
+      const result = await mockedHandler.importTopPages(context);
+
+      expect(result.auditContext).to.deep.equal({ generatePrompts: true });
+    });
+
+    it('defaults generatePrompts to false when context.data is absent', async () => {
+      context.site = site;
+      context.data = undefined;
+
+      const mockedHandler = await esmock('../../src/toc/handler.js', stubUrlDeps());
+      const result = await mockedHandler.importTopPages(context);
+
+      expect(result.auditContext).to.deep.equal({ generatePrompts: false });
+    });
+
+    it('defaults generatePrompts to false and logs a warning when context.data is malformed JSON', async () => {
+      const logSpy = { info: sinon.spy(), error: sinon.spy(), debug: sinon.spy(), warn: sinon.spy() };
+      context.log = logSpy;
+      context.site = site;
+      context.data = '{not valid json';
+
+      const mockedHandler = await esmock('../../src/toc/handler.js', stubUrlDeps());
+      const result = await mockedHandler.importTopPages(context);
+
+      expect(result.auditContext).to.deep.equal({ generatePrompts: false });
+      expect(logSpy.warn).to.have.been.calledWith(
+        sinon.match(/Failed to parse context\.data for generatePrompts flag/),
+      );
+    });
+
+    it('still includes auditContext.generatePrompts on the failure path when getTocInputUrls throws', async () => {
+      context.site = site;
+      context.data = { generatePrompts: true };
+
+      const mockedHandler = await esmock('../../src/toc/handler.js', {
+        '../../src/utils/audit-input-urls.js': {
+          getMergedAuditInputUrls: sinon.stub().rejects(new Error('DB error')),
+          sortTopPagesByTraffic: sinon.stub().returns([]),
+        },
+        '../../src/utils/agentic-urls.js': {
+          getTopAgenticUrlsFromAthena: sinon.stub().resolves([]),
+        },
+      });
+      const result = await mockedHandler.importTopPages(context);
+
+      expect(result.auditResult.success).to.be.false;
+      expect(result.auditContext).to.deep.equal({ generatePrompts: true });
+    });
   });
 
   describe('submitForScraping', () => {
@@ -4203,7 +4383,24 @@ describe('TOC (Table of Contents) Audit', () => {
       expect(result.processingType).to.be.undefined;
       expect(result.options).to.be.undefined;
       expect(result.maxScrapeAge).to.equal(24);
+      expect(result.auditContext).to.deep.equal({ generatePrompts: false });
       expect(logSpy.info).to.have.been.calledWith('[TOC] Submitting 1 URLs for scraping');
+    });
+
+    it('forwards auditContext (including generatePrompts) from step 1 through to step 3', async () => {
+      const url = 'https://example.com/page';
+      context.log = { info: sinon.spy(), error: sinon.spy(), debug: sinon.spy(), warn: sinon.spy() };
+      context.site = site;
+      context.audit = { getAuditResult: () => ({ success: true, topPages: [url] }) };
+      context.auditContext = { generatePrompts: true, someOtherKey: 'preserved' };
+
+      const { submitForScraping } = await import('../../src/toc/handler.js');
+      const result = await submitForScraping(context);
+
+      expect(result.auditContext).to.deep.equal({
+        generatePrompts: true,
+        someOtherKey: 'preserved',
+      });
     });
 
     it('persists terminal result and returns when previous audit step failed', async () => {

--- a/test/audits/toc.test.js
+++ b/test/audits/toc.test.js
@@ -4344,6 +4344,9 @@ describe('TOC (Table of Contents) Audit', () => {
 
       expect(result.auditContext).to.deep.equal({ generatePrompts: false });
       expect(logSpy.warn).to.have.been.calledWith(
+        sinon.match(/Failed to parse context\.data for mode/),
+      );
+      expect(logSpy.warn).to.have.been.calledWith(
         sinon.match(/Failed to parse context\.data for generatePrompts flag/),
       );
     });

--- a/test/audits/toc/ai-only-mode.test.js
+++ b/test/audits/toc/ai-only-mode.test.js
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use as chaiUse } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+import { handleAiOnlyModeForToc, importTopPages } from '../../../src/toc/handler.js';
+
+chaiUse(sinonChai);
+
+describe('TOC ai-only mode (handleAiOnlyModeForToc)', () => {
+  let context;
+  let logSpy;
+
+  const makeSuggestion = (data, status = 'NEW') => ({
+    getId: () => 'suggestion-1',
+    getStatus: () => status,
+    getData: () => data,
+  });
+
+  const makeOpportunity = (overrides = {}) => ({
+    getId: () => 'opportunity-1',
+    getSiteId: () => 'site-1',
+    getAuditId: () => null,
+    getSuggestions: sinon.stub().resolves([
+      makeSuggestion({ url: 'https://example.com/page1', title: 'Page 1' }),
+    ]),
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    logSpy = {
+      info: sinon.spy(), error: sinon.spy(), debug: sinon.spy(), warn: sinon.spy(),
+    };
+    context = {
+      log: logSpy,
+      site: {
+        getId: () => 'site-1',
+        getBaseURL: () => 'https://example.com',
+        getRegion: () => 'US',
+      },
+      sqs: { sendMessage: sinon.stub().resolves() },
+      env: { QUEUE_SPACECAT_TO_MYSTIQUE: 'test-mystique-queue' },
+      dataAccess: {
+        Opportunity: {
+          findById: sinon.stub(),
+          allBySiteIdAndStatus: sinon.stub(),
+        },
+      },
+    };
+  });
+
+  it('resolves the opportunity by explicit opportunityId and queues prompts with generatePrompts forwarded', async () => {
+    const opportunity = makeOpportunity();
+    context.dataAccess.Opportunity.findById.resolves(opportunity);
+    context.data = { opportunityId: 'opportunity-1', generatePrompts: true };
+
+    const result = await handleAiOnlyModeForToc(context);
+
+    expect(context.dataAccess.Opportunity.findById).to.have.been.calledWith('opportunity-1');
+    expect(context.sqs.sendMessage).to.have.been.calledOnce;
+    const [, message] = context.sqs.sendMessage.getCall(0).args;
+    expect(message.data.generatePrompts).to.equal(true);
+    expect(result).to.deep.equal({
+      status: 'complete',
+      mode: 'ai-only',
+      opportunityId: 'opportunity-1',
+      fullAuditRef: 'ai-only/opportunity-1',
+      auditResult: {
+        message: 'Prompt generation queued successfully for 1 suggestion(s)',
+        suggestionCount: 1,
+      },
+    });
+  });
+
+  it('defaults generatePrompts to false when omitted from data', async () => {
+    const opportunity = makeOpportunity();
+    context.dataAccess.Opportunity.findById.resolves(opportunity);
+    context.data = { opportunityId: 'opportunity-1' };
+
+    await handleAiOnlyModeForToc(context);
+
+    const [, message] = context.sqs.sendMessage.getCall(0).args;
+    expect(message.data.generatePrompts).to.equal(false);
+  });
+
+  it('falls back to the latest NEW opportunity for the site when opportunityId is not provided', async () => {
+    const opportunity = makeOpportunity({ getType: () => 'toc' });
+    context.dataAccess.Opportunity.allBySiteIdAndStatus.resolves([opportunity]);
+    context.data = { generatePrompts: false };
+
+    const result = await handleAiOnlyModeForToc(context);
+
+    expect(context.dataAccess.Opportunity.allBySiteIdAndStatus).to.have.been.calledWith('site-1', 'NEW');
+    expect(result.status).to.equal('complete');
+    expect(result.opportunityId).to.equal('opportunity-1');
+  });
+
+  it('returns a failed result when the explicit opportunityId is not found', async () => {
+    context.dataAccess.Opportunity.findById.resolves(undefined);
+    context.data = { opportunityId: 'missing-opportunity' };
+
+    const result = await handleAiOnlyModeForToc(context);
+
+    expect(result.status).to.equal('failed');
+    expect(result.error).to.include('Opportunity not found: missing-opportunity');
+    expect(context.sqs.sendMessage).not.to.have.been.called;
+  });
+
+  it('returns a failed result when no NEW TOC opportunity exists for the site', async () => {
+    context.dataAccess.Opportunity.allBySiteIdAndStatus.resolves([]);
+    context.data = {};
+
+    const result = await handleAiOnlyModeForToc(context);
+
+    expect(result.status).to.equal('failed');
+    expect(result.error).to.include('No NEW TOC opportunity found for site: site-1');
+  });
+
+  it('returns a failed result when the resolved opportunity belongs to a different site', async () => {
+    const opportunity = makeOpportunity({ getSiteId: () => 'other-site' });
+    context.dataAccess.Opportunity.findById.resolves(opportunity);
+    context.data = { opportunityId: 'opportunity-1' };
+
+    const result = await handleAiOnlyModeForToc(context);
+
+    expect(result.status).to.equal('failed');
+    expect(result.error).to.include('does not belong to site site-1');
+    expect(context.sqs.sendMessage).not.to.have.been.called;
+  });
+
+  it('gracefully defaults opportunityId/generatePrompts when context.data is malformed JSON', async () => {
+    const opportunity = makeOpportunity({ getType: () => 'toc' });
+    context.dataAccess.Opportunity.allBySiteIdAndStatus.resolves([opportunity]);
+    context.data = '{not valid json';
+
+    const result = await handleAiOnlyModeForToc(context);
+
+    expect(logSpy.warn).to.have.been.calledWith(
+      sinon.match(/Failed to parse context\.data for opportunityId, generatePrompts/),
+    );
+    expect(result.status).to.equal('complete');
+  });
+
+  it('falls back to opportunity.getAuditId() then a synthetic id when context.audit is absent', async () => {
+    const opportunity = makeOpportunity({ getAuditId: () => 'stored-audit-id' });
+    context.dataAccess.Opportunity.findById.resolves(opportunity);
+    context.data = { opportunityId: 'opportunity-1' };
+
+    await handleAiOnlyModeForToc(context);
+
+    const [, message] = context.sqs.sendMessage.getCall(0).args;
+    expect(message.auditId).to.equal('stored-audit-id');
+  });
+
+  it('falls back to a synthetic auditId when neither context.audit nor opportunity.getAuditId() are available', async () => {
+    const opportunity = makeOpportunity({ getAuditId: () => null });
+    context.dataAccess.Opportunity.findById.resolves(opportunity);
+    context.data = { opportunityId: 'opportunity-1' };
+
+    await handleAiOnlyModeForToc(context);
+
+    const [, message] = context.sqs.sendMessage.getCall(0).args;
+    expect(message.auditId).to.equal('toc-ai-only-site-1');
+  });
+
+  describe('importTopPages routing', () => {
+    it('delegates to handleAiOnlyModeForToc when mode:ai-only is present in context.data', async () => {
+      const opportunity = makeOpportunity();
+      context.dataAccess.Opportunity.findById.resolves(opportunity);
+      context.site.getBaseURL = () => 'https://example.com';
+      context.data = { mode: 'ai-only', opportunityId: 'opportunity-1', generatePrompts: true };
+
+      const result = await importTopPages(context);
+
+      expect(result.status).to.equal('complete');
+      expect(result.mode).to.equal('ai-only');
+      expect(context.sqs.sendMessage).to.have.been.calledOnce;
+      expect(logSpy.info).to.have.been.calledWith(
+        '[TOC] Detected ai-only mode in step 1, skipping import/scraping/processing',
+      );
+    });
+  });
+});

--- a/test/audits/toc/ai-only-mode.test.js
+++ b/test/audits/toc/ai-only-mode.test.js
@@ -83,6 +83,30 @@ describe('TOC ai-only mode (handleAiOnlyModeForToc)', () => {
     });
   });
 
+  it('returns status: no-op instead of misleadingly reporting complete when zero suggestions are eligible', async () => {
+    const opportunity = makeOpportunity({
+      getSuggestions: sinon.stub().resolves([
+        makeSuggestion({ url: 'https://example.com/fixed' }, 'FIXED'),
+      ]),
+    });
+    context.dataAccess.Opportunity.findById.resolves(opportunity);
+    context.data = { opportunityId: 'opportunity-1' };
+
+    const result = await handleAiOnlyModeForToc(context);
+
+    expect(context.sqs.sendMessage).not.to.have.been.called;
+    expect(result).to.deep.equal({
+      status: 'no-op',
+      mode: 'ai-only',
+      opportunityId: 'opportunity-1',
+      fullAuditRef: 'ai-only/opportunity-1',
+      auditResult: {
+        message: 'No eligible suggestions found to queue prompts for',
+        suggestionCount: 0,
+      },
+    });
+  });
+
   it('defaults generatePrompts to false when omitted from data', async () => {
     const opportunity = makeOpportunity();
     context.dataAccess.Opportunity.findById.resolves(opportunity);


### PR DESCRIPTION
## Summary
- `sendTocGuidanceRequestToMystique()` hardcoded `generatePrompts: true`, so every `run audit {url} toc` auto-triggered Impact Engine prompt generation as an unrequested side effect. `generatePrompts` now defaults to `false` and must be explicitly opted into (`run audit {url} audit:toc generatePrompts:true`), matching the pattern already established for the prerender audit.
- Added a `mode:ai-only` path (`handleAiOnlyModeForToc`) that resolves the relevant TOC opportunity and requests prompts for existing eligible suggestions without re-running the audit (`run audit {url} audit:toc generatePrompts:true mode:ai-only`).
- `isEligibleTocSuggestion()` now also excludes `edgeDeployed` suggestions — shared by both the outbound Mystique request and the inbound guidance handler, so they stay in sync.
- Already-prompted suggestions are now tagged with `hasPrompts` instead of being silently dropped from the outbound candidate list, letting Mystique (not this code) decide whether to regenerate.

Jira: [LLMO-6167](https://jira.corp.adobe.com/browse/LLMO-6167)

## Test plan
- [x] `test/audits/toc.test.js` updated: `generatePrompts` flag parsing/forwarding through `importTopPages` → `submitForScraping` → `opportunityAndSuggestions`, `edgeDeployed` exclusion, already-prompted suggestions now included/tagged, `auditId` fallback chain
- [x] New `test/audits/toc/ai-only-mode.test.js`: opportunity resolution (explicit id / latest NEW / not-found / site-mismatch), malformed-data handling, `importTopPages` routing to ai-only mode
- [x] `npm run lint` clean on changed files
- [x] `src/toc/handler.js` and `src/toc/eligibility-utils.js` at 100% line/branch/function coverage
- [x] Broader regression pass (8933 tests across the repo, excluding 4 pre-existing files broken by an unrelated missing `@connectrpc/connect` dependency) — no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)