### PR TITLE
feat(evergreen-offsite-opportunities): Make offsite opportunities a stable, persistent entity that is refreshed in place every week (LLMO-6122)

### DIFF
--- a/src/cited-analysis/guidance-handler.js
+++ b/src/cited-analysis/guidance-handler.js
@@ -17,10 +17,15 @@ import { Audit } from '@adobe/spacecat-shared-data-access';
 
 import { syncSuggestions } from '../utils/data-access.js';
 import { createOpportunityData } from './opportunity-data-mapper.js';
-import { convertToOpportunity } from '../common/opportunity.js';
 import { postMessageOptional, buildAnalysisVisibilityMessage } from '../utils/slack-utils.js';
 import { resolveBrandResultForSite, applyScopeToOpportunity } from '../utils/brand-resolver.js';
 import { fetchAnalysisFromPresignedUrl } from '../utils/analysis-fetch.js';
+import {
+  isValidOffsiteAnalysis,
+  persistOffsiteOpportunity,
+  resolveEvergreenOffsiteOpportunity,
+  isSuppressedRun,
+} from '../common/offsite-refresh.js';
 
 const AUDIT_TYPE = Audit.AUDIT_TYPES.CITED_ANALYSIS;
 const LOG_PREFIX = '[Cited]';
@@ -95,9 +100,22 @@ export default async function handler(message, context) {
 
     log.info(`${LOG_PREFIX} Processing ${suggestions.length} suggestions for ${companyName}`);
 
-    const auditType = opportunityData.type || AUDIT_TYPE;
+    // Use the handler-owned type; the payload may only confirm it.
+    const auditType = AUDIT_TYPE;
+    const incomingStatus = opportunityData.status || 'NEW';
 
-    const opportunity = await convertToOpportunity(
+    // Validate before mutating the evergreen opportunity.
+    if (!isValidOffsiteAnalysis(analysisData, auditType)) {
+      log.error(`${LOG_PREFIX} Malformed analysis payload for siteId: ${siteId}; skipping update`);
+      return badRequest('Malformed analysis payload');
+    }
+
+    const evergreenOpportunity = await resolveEvergreenOffsiteOpportunity({
+      dataAccess, siteId, auditType, log,
+    });
+
+    // Suppressed runs create a hidden record; surfaced runs reuse the evergreen record.
+    const opportunity = await persistOffsiteOpportunity(
       baseUrl,
       {
         siteId,
@@ -107,18 +125,17 @@ export default async function handler(message, context) {
       context,
       createOpportunityData,
       auditType,
-      { opportunityData },
-      (oppty) => oppty.getAuditId() === auditId,
+      {
+        opportunityData,
+        existingOpportunity: isSuppressedRun(incomingStatus)
+          ? null
+          : evergreenOpportunity,
+      },
     );
 
-    // Persist the opportunity (with scope) BEFORE syncing suggestions. Reversed
-    // ordering avoids the partial-write window where syncSuggestions succeeds
-    // but opportunity.save() throws — that previously left suggestions orphaned
-    // against an unsaved opportunity, which re-runs would observe in an
-    // unrecoverable state.
+    // Save the scoped opportunity before syncing its suggestions.
     applyScopeToOpportunity(opportunity, brandResult, log, LOG_PREFIX);
-    const status = opportunityData.status || 'NEW';
-    opportunity.setStatus(status);
+    opportunity.setStatus(incomingStatus);
     opportunity.setData({
       ...opportunity.getData(),
       fullAnalysis: analysisData,
@@ -154,7 +171,7 @@ export default async function handler(message, context) {
           analysisName: 'cited-analysis',
           baseUrl,
           suggestionsCount: suggestions.length,
-          isVisible: status !== 'IGNORED',
+          isVisible: incomingStatus !== 'IGNORED',
           verdict: opportunityData.qaVerdict,
         });
 

--- a/src/cited-analysis/opportunity-data-mapper.js
+++ b/src/cited-analysis/opportunity-data-mapper.js
@@ -17,7 +17,7 @@ import { DATA_SOURCES } from '../common/constants.js';
  * Creates opportunity data for cited URL analysis.
  * When a BO JSON opportunity object is provided (from Mystique), uses its values.
  * Otherwise falls back to defaults.
- * @param {Object} props - The props object from convertToOpportunity
+ * @param {Object} props - The options passed by persistOffsiteOpportunity
  * @param {Object} [props.opportunityData] - The opportunity object from the BO JSON
  * @returns {Object} Opportunity data
  */

--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -10,6 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
+import { Audit } from '@adobe/spacecat-shared-data-access';
+
 /**
  * Data sources for opportunities
  */
@@ -22,3 +24,12 @@ export const DATA_SOURCES = {
 };
 
 export const ELMO_LIVE_HOST = 'https://main--project-elmo-ui-data--adobe.aem.live';
+
+/**
+ * Offsite audit types: opportunities refreshed on a recurring schedule.
+ */
+export const OFFSITE_AUDIT_TYPES = new Set([
+  Audit.AUDIT_TYPES.CITED_ANALYSIS,
+  Audit.AUDIT_TYPES.REDDIT_ANALYSIS,
+  Audit.AUDIT_TYPES.YOUTUBE_ANALYSIS,
+]);

--- a/src/common/offsite-refresh.js
+++ b/src/common/offsite-refresh.js
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { Opportunity as Oppty } from '@adobe/spacecat-shared-data-access';
+import { DATA_SOURCES, OFFSITE_AUDIT_TYPES } from './constants.js';
+import { checkGoogleConnection } from './opportunity-utils.js';
+
+/**
+ * Validates the payload shape and rejects a declared opportunity type that differs from
+ * the handler-owned audit type.
+ *
+ * @param {*} analysisData - The parsed analysis payload (inline or fetched from S3).
+ * @param {string} expectedType - The calling handler's own audit type (e.g. 'cited-analysis').
+ * @returns {boolean} true if the payload is well-formed enough to process.
+ */
+export function isValidOffsiteAnalysis(analysisData, expectedType) {
+  if (!analysisData || typeof analysisData !== 'object' || Array.isArray(analysisData)) {
+    return false;
+  }
+  const { opportunity } = analysisData;
+  if (opportunity !== undefined
+      && (typeof opportunity !== 'object' || opportunity === null || Array.isArray(opportunity))) {
+    return false;
+  }
+  if (opportunity?.type !== undefined && opportunity.type !== expectedType) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Creates or refreshes an offsite opportunity using an explicitly resolved target.
+ *
+ * @param {string} auditUrl - Site URL used for data-source filtering.
+ * @param {Object} auditData - Audit identity containing siteId and id.
+ * @param {Object} context - Audit-worker context containing dataAccess and log.
+ * @param {Function} createOpportunityData - Offsite opportunity mapper.
+ * @param {string} auditType - Handler-owned offsite audit type.
+ * @param {Object} options - Mapper input plus the pre-resolved target.
+ * @param {Object} options.opportunityData - Incoming Mystique opportunity data.
+ * @param {Object|null} options.existingOpportunity - Evergreen target, or null to create.
+ * @returns {Promise<Object>} The created or refreshed opportunity.
+ */
+export async function persistOffsiteOpportunity(
+  auditUrl,
+  auditData,
+  context,
+  createOpportunityData,
+  auditType,
+  options,
+) {
+  if (!OFFSITE_AUDIT_TYPES.has(auditType)) {
+    throw new Error(`Unsupported offsite audit type: ${auditType}`);
+  }
+  if (!options || !Object.prototype.hasOwnProperty.call(options, 'existingOpportunity')) {
+    throw new Error('existingOpportunity must be explicitly provided');
+  }
+  const { existingOpportunity: evergreenOpportunity } = options;
+  if (evergreenOpportunity !== null
+      && (typeof evergreenOpportunity !== 'object' || Array.isArray(evergreenOpportunity))) {
+    throw new Error('existingOpportunity must be an opportunity or null');
+  }
+
+  const mappedOpportunity = createOpportunityData(options);
+  const { dataAccess, log } = context;
+  const { Opportunity } = dataAccess;
+
+  const hasGoogleConnection = await checkGoogleConnection(auditUrl, context);
+  if (!hasGoogleConnection && mappedOpportunity.data?.dataSources) {
+    mappedOpportunity.data.dataSources = mappedOpportunity.data.dataSources
+      .filter((source) => source !== DATA_SOURCES.GSC);
+  }
+
+  try {
+    if (evergreenOpportunity === null) {
+      return await Opportunity.create({
+        siteId: auditData.siteId,
+        auditId: auditData.id,
+        runbook: mappedOpportunity.runbook,
+        type: auditType,
+        origin: mappedOpportunity.origin,
+        title: mappedOpportunity.title,
+        description: mappedOpportunity.description,
+        guidance: mappedOpportunity.guidance,
+        tags: mappedOpportunity.tags,
+        data: mappedOpportunity.data,
+        ...(mappedOpportunity.status ? { status: mappedOpportunity.status } : {}),
+      });
+    }
+
+    evergreenOpportunity.setAuditId(auditData.id);
+    evergreenOpportunity.setData({ ...mappedOpportunity.data });
+    evergreenOpportunity.setUpdatedBy('system');
+    await evergreenOpportunity.save();
+
+    return evergreenOpportunity;
+  } catch (error) {
+    log.error(`[OffsiteRefresh] Failed to persist opportunity for siteId ${auditData.siteId}, auditId ${auditData.id}: ${error.message}`);
+    throw error;
+  }
+}
+
+/**
+ * Resolves the evergreen offsite opportunity (status NEW).
+ *
+ * If duplicates exist, keeps the most recently updated one and retires the rest to IGNORED.
+ *
+ * @param {Object} params
+ * @param {Object} params.dataAccess - The data access object (from audit-worker context).
+ * @param {string} params.siteId - The site ID.
+ * @param {string} params.auditType - The opportunity type to resolve (e.g. 'cited-analysis').
+ * @param {Object} params.log - Logger instance.
+ * @returns {Promise<Object|null>} The evergreen offsite opportunity, or null when none exists.
+ * @throws {Error} When lookup or duplicate retirement fails.
+ */
+export async function resolveEvergreenOffsiteOpportunity({
+  dataAccess, siteId, auditType, log,
+}) {
+  const { Opportunity } = dataAccess;
+  let opportunities;
+  try {
+    opportunities = await Opportunity.allBySiteIdAndStatus(siteId, Oppty.STATUSES.NEW);
+  } catch (e) {
+    log.error(`[OffsiteRefresh] Failed to fetch opportunities for siteId ${siteId}: ${e.message}`);
+    throw e;
+  }
+
+  const matchingOpportunities = (opportunities || [])
+    .filter((opportunity) => opportunity.getType() === auditType);
+  if (matchingOpportunities.length === 0) {
+    return null;
+  }
+  if (matchingOpportunities.length === 1) {
+    return matchingOpportunities[0];
+  }
+
+  const [evergreenOpportunity, ...duplicates] = [...matchingOpportunities].sort(
+    (a, b) => new Date(b.getUpdatedAt()) - new Date(a.getUpdatedAt()),
+  );
+
+  log.info(`[OffsiteRefresh] Found ${matchingOpportunities.length} NEW ${auditType} opportunities for siteId ${siteId}; retiring ${duplicates.length} duplicate(s), keeping ${evergreenOpportunity.getId()} as the evergreen opportunity`);
+
+  duplicates.forEach((duplicate) => {
+    duplicate.setStatus(Oppty.STATUSES.IGNORED);
+    duplicate.setUpdatedBy('system');
+  });
+  // Retirement must finish before the caller updates the chosen evergreen opportunity.
+  await Opportunity.saveMany(duplicates);
+
+  return evergreenOpportunity;
+}
+
+/**
+ * Returns true when a suppressed run must be stored separately from the evergreen opportunity.
+ * Replaying the same suppressed run creates another record; replay idempotency is handled later.
+ *
+ * @param {string} incomingStatus - The status carried by the incoming run
+ *   ('NEW' when surfaced, 'IGNORED' when suppressed).
+ * @returns {boolean} Whether the run requires a new opportunity.
+ */
+export function isSuppressedRun(incomingStatus) {
+  return incomingStatus === Oppty.STATUSES.IGNORED;
+}

--- a/src/reddit-analysis/guidance-handler.js
+++ b/src/reddit-analysis/guidance-handler.js
@@ -17,10 +17,15 @@ import { Audit } from '@adobe/spacecat-shared-data-access';
 
 import { syncSuggestions } from '../utils/data-access.js';
 import { createOpportunityData } from './opportunity-data-mapper.js';
-import { convertToOpportunity } from '../common/opportunity.js';
 import { postMessageOptional, buildAnalysisVisibilityMessage } from '../utils/slack-utils.js';
 import { resolveBrandResultForSite, applyScopeToOpportunity } from '../utils/brand-resolver.js';
 import { fetchAnalysisFromPresignedUrl } from '../utils/analysis-fetch.js';
+import {
+  isValidOffsiteAnalysis,
+  persistOffsiteOpportunity,
+  resolveEvergreenOffsiteOpportunity,
+  isSuppressedRun,
+} from '../common/offsite-refresh.js';
 
 const AUDIT_TYPE = Audit.AUDIT_TYPES.REDDIT_ANALYSIS;
 const LOG_PREFIX = '[Reddit]';
@@ -95,9 +100,22 @@ export default async function handler(message, context) {
 
     log.info(`${LOG_PREFIX} Processing ${suggestions.length} suggestions for ${companyName}`);
 
-    const auditType = opportunityData.type || AUDIT_TYPE;
+    // Use the handler-owned type; the payload may only confirm it.
+    const auditType = AUDIT_TYPE;
+    const incomingStatus = opportunityData.status || 'NEW';
 
-    const opportunity = await convertToOpportunity(
+    // Validate before mutating the evergreen opportunity.
+    if (!isValidOffsiteAnalysis(analysisData, auditType)) {
+      log.error(`${LOG_PREFIX} Malformed analysis payload for siteId: ${siteId}; skipping update`);
+      return badRequest('Malformed analysis payload');
+    }
+
+    const evergreenOpportunity = await resolveEvergreenOffsiteOpportunity({
+      dataAccess, siteId, auditType, log,
+    });
+
+    // Suppressed runs create a hidden record; surfaced runs reuse the evergreen record.
+    const opportunity = await persistOffsiteOpportunity(
       baseUrl,
       {
         siteId,
@@ -107,15 +125,17 @@ export default async function handler(message, context) {
       context,
       createOpportunityData,
       auditType,
-      { opportunityData },
-      (oppty) => oppty.getAuditId() === auditId,
+      {
+        opportunityData,
+        existingOpportunity: isSuppressedRun(incomingStatus)
+          ? null
+          : evergreenOpportunity,
+      },
     );
 
-    // Persist the opportunity (with scope) BEFORE syncing suggestions; see
-    // cited-analysis/guidance-handler.js for the same reordering rationale.
+    // Save the scoped opportunity before syncing its suggestions.
     applyScopeToOpportunity(opportunity, brandResult, log, LOG_PREFIX);
-    const status = opportunityData.status || 'NEW';
-    opportunity.setStatus(status);
+    opportunity.setStatus(incomingStatus);
     opportunity.setData({
       ...opportunity.getData(),
       fullAnalysis: analysisData,
@@ -149,7 +169,7 @@ export default async function handler(message, context) {
           analysisName: 'reddit-analysis',
           baseUrl,
           suggestionsCount: suggestions.length,
-          isVisible: status !== 'IGNORED',
+          isVisible: incomingStatus !== 'IGNORED',
           verdict: opportunityData.qaVerdict,
         });
 

--- a/src/reddit-analysis/opportunity-data-mapper.js
+++ b/src/reddit-analysis/opportunity-data-mapper.js
@@ -17,7 +17,7 @@ import { DATA_SOURCES } from '../common/constants.js';
  * Creates opportunity data for Reddit analysis.
  * When a BO JSON opportunity object is provided (from Mystique), uses its values.
  * Otherwise falls back to defaults.
- * @param {Object} props - The props object from convertToOpportunity
+ * @param {Object} props - The options passed by persistOffsiteOpportunity
  * @param {Object} [props.opportunityData] - The opportunity object from the BO JSON
  * @returns {Object} Opportunity data
  */

--- a/src/youtube-analysis/guidance-handler.js
+++ b/src/youtube-analysis/guidance-handler.js
@@ -15,10 +15,15 @@ import {
 } from '@adobe/spacecat-shared-http-utils';
 import { syncSuggestions } from '../utils/data-access.js';
 import { createOpportunityData } from './opportunity-data-mapper.js';
-import { convertToOpportunity } from '../common/opportunity.js';
 import { postMessageOptional, buildAnalysisVisibilityMessage } from '../utils/slack-utils.js';
 import { resolveBrandResultForSite, applyScopeToOpportunity } from '../utils/brand-resolver.js';
 import { fetchAnalysisFromPresignedUrl } from '../utils/analysis-fetch.js';
+import {
+  isValidOffsiteAnalysis,
+  persistOffsiteOpportunity,
+  resolveEvergreenOffsiteOpportunity,
+  isSuppressedRun,
+} from '../common/offsite-refresh.js';
 
 const AUDIT_TYPE = Audit.AUDIT_TYPES.YOUTUBE_ANALYSIS;
 const LOG_PREFIX = '[YouTube]';
@@ -93,9 +98,22 @@ export default async function handler(message, context) {
 
     log.info(`${LOG_PREFIX} Processing ${suggestions.length} suggestions for ${companyName}`);
 
-    const auditType = opportunityData.type || AUDIT_TYPE;
+    // Use the handler-owned type; the payload may only confirm it.
+    const auditType = AUDIT_TYPE;
+    const incomingStatus = opportunityData.status || 'NEW';
 
-    const opportunity = await convertToOpportunity(
+    // Validate before mutating the evergreen opportunity.
+    if (!isValidOffsiteAnalysis(analysisData, auditType)) {
+      log.error(`${LOG_PREFIX} Malformed analysis payload for siteId: ${siteId}; skipping update`);
+      return badRequest('Malformed analysis payload');
+    }
+
+    const evergreenOpportunity = await resolveEvergreenOffsiteOpportunity({
+      dataAccess, siteId, auditType, log,
+    });
+
+    // Suppressed runs create a hidden record; surfaced runs reuse the evergreen record.
+    const opportunity = await persistOffsiteOpportunity(
       baseUrl,
       {
         siteId,
@@ -105,15 +123,17 @@ export default async function handler(message, context) {
       context,
       createOpportunityData,
       auditType,
-      { opportunityData },
-      (oppty) => oppty.getAuditId() === auditId,
+      {
+        opportunityData,
+        existingOpportunity: isSuppressedRun(incomingStatus)
+          ? null
+          : evergreenOpportunity,
+      },
     );
 
-    // Persist the opportunity (with scope) BEFORE syncing suggestions; see
-    // cited-analysis/guidance-handler.js for the same reordering rationale.
+    // Save the scoped opportunity before syncing its suggestions.
     applyScopeToOpportunity(opportunity, brandResult, log, LOG_PREFIX);
-    const status = opportunityData.status || 'NEW';
-    opportunity.setStatus(status);
+    opportunity.setStatus(incomingStatus);
     opportunity.setData({
       ...opportunity.getData(),
       fullAnalysis: analysisData,
@@ -147,7 +167,7 @@ export default async function handler(message, context) {
           analysisName: 'youtube-analysis',
           baseUrl,
           suggestionsCount: suggestions.length,
-          isVisible: status !== 'IGNORED',
+          isVisible: incomingStatus !== 'IGNORED',
           verdict: opportunityData.qaVerdict,
         });
 

--- a/src/youtube-analysis/opportunity-data-mapper.js
+++ b/src/youtube-analysis/opportunity-data-mapper.js
@@ -15,7 +15,7 @@ import { DATA_SOURCES } from '../common/constants.js';
 
 /**
  * Creates opportunity data for YouTube analysis from the Mystique payload.
- * @param {Object} props - The props object from convertToOpportunity
+ * @param {Object} props - The options passed by persistOffsiteOpportunity
  * @param {Object} [props.opportunityData] - The opportunity object from the analysis payload
  * @returns {Object} Opportunity data
  */

--- a/test/audits/cited-analysis/guidance-handler.test.js
+++ b/test/audits/cited-analysis/guidance-handler.test.js
@@ -75,8 +75,8 @@ describe('Cited Analysis Guidance Handler', () => {
       '../../../src/utils/data-access.js': {
         syncSuggestions: syncSuggestionsStub,
       },
-      '../../../src/common/opportunity.js': {
-        convertToOpportunity: convertToOpportunityStub,
+      '../../../src/common/offsite-refresh.js': {
+        persistOffsiteOpportunity: convertToOpportunityStub,
       },
       '../../../src/utils/analysis-fetch.js': {
         fetchAnalysisFromPresignedUrl: fetchAnalysisStub,
@@ -98,6 +98,13 @@ describe('Cited Analysis Guidance Handler', () => {
           },
           Audit: {
             findById: sandbox.stub().resolves(mockAudit),
+          },
+          // withOverrides() shallow-replaces the whole dataAccess object, so Opportunity
+          // must be provided here too — otherwise resolveEvergreenOpportunity's internal
+          // Opportunity.allBySiteIdAndStatus call throws on `undefined` for every test in
+          // this file that doesn't set its own dataAccess.Opportunity mock below.
+          Opportunity: {
+            allBySiteIdAndStatus: sandbox.stub().resolves([]),
           },
         },
       })
@@ -142,10 +149,11 @@ describe('Cited Analysis Guidance Handler', () => {
       expect(mockOpportunity.setStatus).to.have.been.calledWith('NEW');
       expect(mockOpportunity.setData).to.have.been.called;
       expect(mockOpportunity.save).to.have.been.called;
+      expect(mockOpportunity.save).to.have.been.calledBefore(syncSuggestionsStub);
       expect(context.log.info).to.have.been.calledWith(sinon.match(/Successfully processed cited analysis/));
     });
 
-    it('should pass opportunityData from BO JSON to convertToOpportunity', async () => {
+    it('should pass opportunityData from BO JSON to persistOffsiteOpportunity', async () => {
       const opportunityData = {
         title: 'Cited URL Analysis',
         description: 'Custom description from Mystique',
@@ -174,7 +182,7 @@ describe('Cited Analysis Guidance Handler', () => {
       expect(propsArg.opportunityData).to.deep.equal(opportunityData);
     });
 
-    it('should pass comparisonFn that matches by auditId', async () => {
+    it('should not pass a comparisonFn, relying on default match-by-type for a stable opportunity per (site, type)', async () => {
       const message = {
         siteId,
         auditId,
@@ -192,10 +200,7 @@ describe('Cited Analysis Guidance Handler', () => {
 
       await handler.default(message, context);
 
-      const comparisonFn = convertToOpportunityStub.firstCall.args[6];
-      expect(comparisonFn).to.be.a('function');
-      expect(comparisonFn({ getAuditId: () => auditId })).to.be.true;
-      expect(comparisonFn({ getAuditId: () => 'different-audit-id' })).to.be.false;
+      expect(convertToOpportunityStub.firstCall.args[6]).to.be.undefined;
     });
 
     it('should set status from opportunityData when provided by Mystique', async () => {
@@ -220,7 +225,7 @@ describe('Cited Analysis Guidance Handler', () => {
       expect(mockOpportunity.setStatus).to.have.been.calledWith('IGNORED');
     });
 
-    it('should use auditType from opportunityData.type when provided', async () => {
+    it('should always use the handler-owned AUDIT_TYPE, ignoring opportunityData.type', async () => {
       const message = {
         siteId,
         auditId,
@@ -237,10 +242,35 @@ describe('Cited Analysis Guidance Handler', () => {
         },
       };
 
+      const result = await handler.default(message, context);
+
+      // A mismatched declared type is treated as a malformed payload — never trusted for
+      // matching/creation, and never silently corrected to make the run proceed.
+      expect(result.status).to.equal(400);
+      expect(convertToOpportunityStub).to.not.have.been.called;
+    });
+
+    it('should proceed using AUDIT_TYPE when opportunityData.type agrees with it', async () => {
+      const message = {
+        siteId,
+        auditId,
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: { type: 'cited-analysis' },
+            suggestions: [
+              {
+                id: 'test_1', rank: 1, type: 'CONTENT_UPDATE', data: { title: 'Test' },
+              },
+            ],
+          },
+        },
+      };
+
       await handler.default(message, context);
 
       const auditTypeArg = convertToOpportunityStub.firstCall.args[4];
-      expect(auditTypeArg).to.equal('custom-audit-type');
+      expect(auditTypeArg).to.equal('cited-analysis');
     });
 
     it('should return noContent when no suggestions found', async () => {
@@ -778,6 +808,27 @@ describe('Cited Analysis Guidance Handler', () => {
       );
     });
 
+    it('does not sync suggestions when opportunity persistence fails', async () => {
+      mockOpportunity.save.rejects(new Error('save failed'));
+      const message = {
+        siteId,
+        auditId,
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            suggestions: [
+              { id: 's1', priority: 'HIGH', title: 'Test', description: 'Test' },
+            ],
+          },
+        },
+      };
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(400);
+      expect(syncSuggestionsStub).to.not.have.been.called;
+    });
+
     it('should skip audit lookup when auditId is not provided', async () => {
       const message = {
         siteId,
@@ -1015,6 +1066,209 @@ describe('Cited Analysis Guidance Handler', () => {
       expect(resolveBrandResultForSiteStub).to.have.been.called;
       expect(mockOpportunity.setScopeId).to.have.been.calledWith('current-uuid');
       expect(mockOpportunity.setScopeId).not.to.have.been.calledWith('stale-uuid');
+    });
+  });
+
+  describe('Evergreen opportunity refresh safety', () => {
+    const validMessage = (overrides = {}) => ({
+      siteId,
+      auditId,
+      data: {
+        companyName: 'Example Corp',
+        analysis: {
+          suggestions: [
+            {
+              id: 'test_1', rank: 1, type: 'CONTENT_UPDATE', data: { title: 'Test' },
+            },
+          ],
+        },
+      },
+      ...overrides,
+    });
+
+    it('should return badRequest and skip all mutation when analysis.opportunity is malformed', async () => {
+      const message = {
+        siteId,
+        auditId,
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: ['not', 'an', 'object'],
+            suggestions: [{ id: 'test_1', rank: 1, type: 'CONTENT_UPDATE', data: {} }],
+          },
+        },
+      };
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(400);
+      expect(convertToOpportunityStub).to.not.have.been.called;
+      expect(syncSuggestionsStub).to.not.have.been.called;
+    });
+
+    it('should persist a suppressed run as a new opportunity without touching the visible one', async () => {
+      const visibleOpportunity = {
+        getId: sandbox.stub().returns('existing-opp-1'),
+        getType: sandbox.stub().returns('cited-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
+      };
+
+      const message = validMessage({
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: { status: 'IGNORED' },
+            suggestions: [{ id: 'test_1', rank: 1, type: 'CONTENT_UPDATE', data: {} }],
+          },
+        },
+      });
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(200);
+      expect(convertToOpportunityStub).to.have.been.calledOnce;
+      expect(syncSuggestionsStub).to.have.been.calledOnce;
+      expect(mockOpportunity.setStatus).to.have.been.calledWith('IGNORED');
+      // existingOpportunity is explicitly null so persistOffsiteOpportunity creates a record
+      // a new opportunity, never reusing (or re-querying for) the visible one.
+      const propsArg = convertToOpportunityStub.firstCall.args[5];
+      expect(propsArg).to.have.property('existingOpportunity', null);
+    });
+
+    // Whether nothing exists yet, or the only prior opportunity is already IGNORED, the
+    // NEW-status lookup that feeds resolution returns the same thing (no matches) — so both
+    // states exercise this same "create a new row" path.
+    it('should create a new (hidden) opportunity for a suppressed run when nothing is visible yet', async () => {
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([]),
+      };
+
+      const message = validMessage({
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: { status: 'IGNORED' },
+            suggestions: [{ id: 'test_1', rank: 1, type: 'CONTENT_UPDATE', data: {} }],
+          },
+        },
+      });
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(200);
+      expect(convertToOpportunityStub).to.have.been.calledOnce;
+      expect(mockOpportunity.setStatus).to.have.been.calledWith('IGNORED');
+      const propsArg = convertToOpportunityStub.firstCall.args[5];
+      expect(propsArg).to.have.property('existingOpportunity', null);
+    });
+
+    it('should hand the resolved evergreen to persistOffsiteOpportunity for a surfaced run', async () => {
+      const visibleOpportunity = {
+        getId: sandbox.stub().returns('existing-opp-1'),
+        getType: sandbox.stub().returns('cited-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
+      };
+
+      const message = validMessage();
+
+      await handler.default(message, context);
+
+      // A surfaced (NEW) run must reuse the already-resolved evergreen opportunity directly —
+      // never trigger a second, independent query inside persistOffsiteOpportunity.
+      const propsArg = convertToOpportunityStub.firstCall.args[5];
+      expect(propsArg.existingOpportunity).to.equal(visibleOpportunity);
+      expect(context.dataAccess.Opportunity.allBySiteIdAndStatus).to.have.been.calledOnce;
+    });
+
+    it('should lazily retire duplicate NEW opportunities of the same type via saveMany, keeping the most recent as evergreen', async () => {
+      const older = {
+        getId: sandbox.stub().returns('older-opp'),
+        getType: sandbox.stub().returns('cited-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2025-01-01T00:00:00.000Z'),
+        setStatus: sandbox.stub(),
+        setUpdatedBy: sandbox.stub(),
+      };
+      const newer = {
+        getId: sandbox.stub().returns('newer-opp'),
+        getType: sandbox.stub().returns('cited-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+        setStatus: sandbox.stub(),
+        setUpdatedBy: sandbox.stub(),
+      };
+      const saveManyStub = sandbox.stub().resolves();
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([older, newer]),
+        saveMany: saveManyStub,
+      };
+
+      const message = validMessage();
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(200);
+      expect(older.setStatus).to.have.been.calledWith('IGNORED');
+      expect(newer.setStatus).to.not.have.been.called;
+      expect(saveManyStub).to.have.been.calledOnce;
+      expect(saveManyStub.firstCall.args[0]).to.deep.equal([older]);
+      expect(convertToOpportunityStub).to.have.been.calledOnce;
+      // The de-duplicated evergreen opportunity (newer) is what gets reused, not a fresh re-query.
+      expect(convertToOpportunityStub.firstCall.args[5].existingOpportunity).to.equal(newer);
+    });
+
+    it('should propagate the error (badRequest) when duplicate retirement fails, without proceeding', async () => {
+      const older = {
+        getId: sandbox.stub().returns('older-opp'),
+        getType: sandbox.stub().returns('cited-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2025-01-01T00:00:00.000Z'),
+        setStatus: sandbox.stub(),
+        setUpdatedBy: sandbox.stub(),
+      };
+      const newer = {
+        getId: sandbox.stub().returns('newer-opp'),
+        getType: sandbox.stub().returns('cited-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+        setStatus: sandbox.stub(),
+        setUpdatedBy: sandbox.stub(),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([older, newer]),
+        saveMany: sandbox.stub().rejects(new Error('save failed')),
+      };
+
+      const message = validMessage();
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(400);
+      expect(convertToOpportunityStub).to.not.have.been.called;
+    });
+
+    it('should propagate the error (badRequest) when the initial opportunity lookup fails, without creating a duplicate', async () => {
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().rejects(new Error('DB down')),
+      };
+
+      const message = validMessage();
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(400);
+      // A transient read failure must never be treated as "nothing exists yet" (which
+      // would otherwise create a duplicate NEW opportunity) — conversion is never attempted.
+      expect(convertToOpportunityStub).to.not.have.been.called;
+      expect(syncSuggestionsStub).to.not.have.been.called;
     });
   });
 });

--- a/test/audits/reddit-analysis/guidance-handler.test.js
+++ b/test/audits/reddit-analysis/guidance-handler.test.js
@@ -72,8 +72,8 @@ describe('Reddit Analysis Guidance Handler', () => {
       '../../../src/utils/data-access.js': {
         syncSuggestions: syncSuggestionsStub,
       },
-      '../../../src/common/opportunity.js': {
-        convertToOpportunity: convertToOpportunityStub,
+      '../../../src/common/offsite-refresh.js': {
+        persistOffsiteOpportunity: convertToOpportunityStub,
       },
       '../../../src/utils/slack-utils.js': { postMessageOptional: mockPostMessageOptional },
       '../../../src/utils/analysis-fetch.js': {
@@ -94,6 +94,13 @@ describe('Reddit Analysis Guidance Handler', () => {
           },
           Audit: {
             findById: sandbox.stub().resolves(mockAudit),
+          },
+          // withOverrides() shallow-replaces the whole dataAccess object, so Opportunity
+          // must be provided here too — otherwise resolveEvergreenOpportunity's internal
+          // Opportunity.allBySiteIdAndStatus call throws on `undefined` for every test in
+          // this file that doesn't set its own dataAccess.Opportunity mock below.
+          Opportunity: {
+            allBySiteIdAndStatus: sandbox.stub().resolves([]),
           },
         },
       })
@@ -141,7 +148,7 @@ describe('Reddit Analysis Guidance Handler', () => {
       expect(context.log.info).to.have.been.calledWith(sinon.match(/Successfully processed Reddit analysis/));
     });
 
-    it('should pass opportunityData from BO JSON to convertToOpportunity', async () => {
+    it('should pass opportunityData from BO JSON to persistOffsiteOpportunity', async () => {
       const opportunityData = {
         title: '[ʙᴇᴛᴀ] Reddit Sentiment Analysis - Cited',
         description: 'Custom description from Mystique',
@@ -170,7 +177,7 @@ describe('Reddit Analysis Guidance Handler', () => {
       expect(propsArg.opportunityData).to.deep.equal(opportunityData);
     });
 
-    it('should pass comparisonFn that matches by auditId', async () => {
+    it('should not pass a comparisonFn, relying on default match-by-type for a stable opportunity per (site, type)', async () => {
       const message = {
         siteId,
         auditId,
@@ -186,10 +193,7 @@ describe('Reddit Analysis Guidance Handler', () => {
 
       await handler.default(message, context);
 
-      const comparisonFn = convertToOpportunityStub.firstCall.args[6];
-      expect(comparisonFn).to.be.a('function');
-      expect(comparisonFn({ getAuditId: () => auditId })).to.be.true;
-      expect(comparisonFn({ getAuditId: () => 'different-audit-id' })).to.be.false;
+      expect(convertToOpportunityStub.firstCall.args[6]).to.be.undefined;
     });
 
     it('should set status from opportunityData when provided by Mystique', async () => {
@@ -935,6 +939,204 @@ describe('Reddit Analysis Guidance Handler', () => {
       expect(resolveBrandResultForSiteStub).to.have.been.called;
       expect(mockOpportunity.setScopeId).to.have.been.calledWith('current-uuid');
       expect(mockOpportunity.setScopeId).not.to.have.been.calledWith('stale-uuid');
+    });
+  });
+
+  describe('Evergreen opportunity refresh safety', () => {
+    const validMessage = (overrides = {}) => ({
+      siteId,
+      auditId,
+      data: {
+        companyName: 'Example Corp',
+        analysis: {
+          suggestions: [
+            { id: 'test_1', priority: 'HIGH', title: 'Test', description: 'Test' },
+          ],
+        },
+      },
+      ...overrides,
+    });
+
+    it('should return badRequest and skip all mutation when analysis.opportunity is malformed', async () => {
+      const message = {
+        siteId,
+        auditId,
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: ['not', 'an', 'object'],
+            suggestions: [{ id: 'test_1', priority: 'HIGH', title: 'Test', description: 'Test' }],
+          },
+        },
+      };
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(400);
+      expect(convertToOpportunityStub).to.not.have.been.called;
+      expect(syncSuggestionsStub).to.not.have.been.called;
+    });
+
+    it('should persist a suppressed run as a new opportunity without touching the visible one', async () => {
+      const visibleOpportunity = {
+        getId: sandbox.stub().returns('existing-opp-1'),
+        getType: sandbox.stub().returns('reddit-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
+      };
+
+      const message = validMessage({
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: { status: 'IGNORED' },
+            suggestions: [{ id: 'test_1', priority: 'HIGH', title: 'Test', description: 'Test' }],
+          },
+        },
+      });
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(200);
+      expect(convertToOpportunityStub).to.have.been.calledOnce;
+      expect(syncSuggestionsStub).to.have.been.calledOnce;
+      expect(mockOpportunity.setStatus).to.have.been.calledWith('IGNORED');
+      // existingOpportunity is explicitly null so persistOffsiteOpportunity creates a record
+      // a new opportunity, never reusing (or re-querying for) the visible one.
+      const propsArg = convertToOpportunityStub.firstCall.args[5];
+      expect(propsArg).to.have.property('existingOpportunity', null);
+    });
+
+    // Whether nothing exists yet, or the only prior opportunity is already IGNORED, the
+    // NEW-status lookup that feeds resolution returns the same thing (no matches) — so both
+    // states exercise this same "create a new row" path.
+    it('should create a new (hidden) opportunity for a suppressed run when nothing is visible yet', async () => {
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([]),
+      };
+
+      const message = validMessage({
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: { status: 'IGNORED' },
+            suggestions: [{ id: 'test_1', priority: 'HIGH', title: 'Test', description: 'Test' }],
+          },
+        },
+      });
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(200);
+      expect(convertToOpportunityStub).to.have.been.calledOnce;
+      expect(mockOpportunity.setStatus).to.have.been.calledWith('IGNORED');
+      const propsArg = convertToOpportunityStub.firstCall.args[5];
+      expect(propsArg).to.have.property('existingOpportunity', null);
+    });
+
+    it('should hand the resolved evergreen to persistOffsiteOpportunity for a surfaced run', async () => {
+      const visibleOpportunity = {
+        getId: sandbox.stub().returns('existing-opp-1'),
+        getType: sandbox.stub().returns('reddit-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
+      };
+
+      const message = validMessage();
+
+      await handler.default(message, context);
+
+      const propsArg = convertToOpportunityStub.firstCall.args[5];
+      expect(propsArg.existingOpportunity).to.equal(visibleOpportunity);
+      expect(context.dataAccess.Opportunity.allBySiteIdAndStatus).to.have.been.calledOnce;
+    });
+
+    it('should lazily retire duplicate NEW opportunities of the same type via saveMany, keeping the most recent as evergreen', async () => {
+      const older = {
+        getId: sandbox.stub().returns('older-opp'),
+        getType: sandbox.stub().returns('reddit-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2025-01-01T00:00:00.000Z'),
+        setStatus: sandbox.stub(),
+        setUpdatedBy: sandbox.stub(),
+      };
+      const newer = {
+        getId: sandbox.stub().returns('newer-opp'),
+        getType: sandbox.stub().returns('reddit-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+        setStatus: sandbox.stub(),
+        setUpdatedBy: sandbox.stub(),
+      };
+      const saveManyStub = sandbox.stub().resolves();
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([older, newer]),
+        saveMany: saveManyStub,
+      };
+
+      const message = validMessage();
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(200);
+      expect(older.setStatus).to.have.been.calledWith('IGNORED');
+      expect(newer.setStatus).to.not.have.been.called;
+      expect(saveManyStub).to.have.been.calledOnce;
+      expect(saveManyStub.firstCall.args[0]).to.deep.equal([older]);
+      expect(convertToOpportunityStub).to.have.been.calledOnce;
+      expect(convertToOpportunityStub.firstCall.args[5].existingOpportunity).to.equal(newer);
+    });
+
+    it('should propagate the error (badRequest) when duplicate retirement fails, without proceeding', async () => {
+      const older = {
+        getId: sandbox.stub().returns('older-opp'),
+        getType: sandbox.stub().returns('reddit-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2025-01-01T00:00:00.000Z'),
+        setStatus: sandbox.stub(),
+        setUpdatedBy: sandbox.stub(),
+      };
+      const newer = {
+        getId: sandbox.stub().returns('newer-opp'),
+        getType: sandbox.stub().returns('reddit-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+        setStatus: sandbox.stub(),
+        setUpdatedBy: sandbox.stub(),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([older, newer]),
+        saveMany: sandbox.stub().rejects(new Error('save failed')),
+      };
+
+      const message = validMessage();
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(400);
+      expect(convertToOpportunityStub).to.not.have.been.called;
+    });
+
+    it('should propagate the error (badRequest) when the initial opportunity lookup fails, without creating a duplicate', async () => {
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().rejects(new Error('DB down')),
+      };
+
+      const message = validMessage();
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(400);
+      // A transient read failure must never be treated as "nothing exists yet" (which
+      // would otherwise create a duplicate NEW opportunity) — conversion is never attempted.
+      expect(convertToOpportunityStub).to.not.have.been.called;
+      expect(syncSuggestionsStub).to.not.have.been.called;
     });
   });
 });

--- a/test/audits/youtube-analysis/guidance-handler.test.js
+++ b/test/audits/youtube-analysis/guidance-handler.test.js
@@ -98,8 +98,8 @@ describe('YouTube Analysis Guidance Handler', () => {
       '../../../src/utils/data-access.js': {
         syncSuggestions: mockSyncSuggestions,
       },
-      '../../../src/common/opportunity.js': {
-        convertToOpportunity: mockConvertToOpportunity,
+      '../../../src/common/offsite-refresh.js': {
+        persistOffsiteOpportunity: mockConvertToOpportunity,
       },
       '../../../src/utils/slack-utils.js': {
         postMessageOptional: mockPostMessageOptional,
@@ -119,6 +119,13 @@ describe('YouTube Analysis Guidance Handler', () => {
           },
           Audit: {
             findById: sandbox.stub().resolves(mockAudit),
+          },
+          // withOverrides() shallow-replaces the whole dataAccess object, so Opportunity
+          // must be provided here too — otherwise resolveEvergreenOpportunity's internal
+          // Opportunity.allBySiteIdAndStatus call throws on `undefined` for every test in
+          // this file that doesn't set its own dataAccess.Opportunity mock below.
+          Opportunity: {
+            allBySiteIdAndStatus: sandbox.stub().resolves([]),
           },
         },
       })
@@ -401,7 +408,7 @@ describe('YouTube Analysis Guidance Handler', () => {
         context,
         sinon.match.any,
         sinon.match.any,
-        { opportunityData: {} },
+        { opportunityData: {}, existingOpportunity: null },
       );
     });
 
@@ -444,7 +451,7 @@ describe('YouTube Analysis Guidance Handler', () => {
       expect(mockOpportunity.setStatus).to.have.been.calledWith('IGNORED');
     });
 
-    it('should pass comparisonFn that matches by auditId', async () => {
+    it('should not pass a comparisonFn, relying on default match-by-type for a stable opportunity per (site, type)', async () => {
       const message = {
         siteId,
         auditId,
@@ -460,10 +467,7 @@ describe('YouTube Analysis Guidance Handler', () => {
 
       await guidanceHandler.default(message, context);
 
-      const comparisonFn = mockConvertToOpportunity.firstCall.args[6];
-      expect(comparisonFn).to.be.a('function');
-      expect(comparisonFn({ getAuditId: () => auditId })).to.be.true;
-      expect(comparisonFn({ getAuditId: () => 'different-audit-id' })).to.be.false;
+      expect(mockConvertToOpportunity.firstCall.args[6]).to.be.undefined;
     });
 
     it('should pass rank and data from Mystique suggestion', async () => {
@@ -939,6 +943,204 @@ describe('YouTube Analysis Guidance Handler', () => {
       expect(resolveBrandResultForSiteStub).to.have.been.called;
       expect(mockOpportunity.setScopeId).to.have.been.calledWith('current-uuid');
       expect(mockOpportunity.setScopeId).not.to.have.been.calledWith('stale-uuid');
+    });
+  });
+
+  describe('Evergreen opportunity refresh safety', () => {
+    const validMessage = (overrides = {}) => ({
+      siteId,
+      auditId,
+      data: {
+        companyName: 'Example Corp',
+        analysis: {
+          suggestions: [
+            { id: 'test_1', priority: 'HIGH', title: 'Test', description: 'Test' },
+          ],
+        },
+      },
+      ...overrides,
+    });
+
+    it('should return badRequest and skip all mutation when analysis.opportunity is malformed', async () => {
+      const message = {
+        siteId,
+        auditId,
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: ['not', 'an', 'object'],
+            suggestions: [{ id: 'test_1', priority: 'HIGH', title: 'Test', description: 'Test' }],
+          },
+        },
+      };
+
+      const result = await guidanceHandler.default(message, context);
+
+      expect(result.status).to.equal(400);
+      expect(mockConvertToOpportunity).to.not.have.been.called;
+      expect(mockSyncSuggestions).to.not.have.been.called;
+    });
+
+    it('should persist a suppressed run as a new opportunity without touching the visible one', async () => {
+      const visibleOpportunity = {
+        getId: sandbox.stub().returns('existing-opp-1'),
+        getType: sandbox.stub().returns('youtube-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
+      };
+
+      const message = validMessage({
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: { status: 'IGNORED' },
+            suggestions: [{ id: 'test_1', priority: 'HIGH', title: 'Test', description: 'Test' }],
+          },
+        },
+      });
+
+      const result = await guidanceHandler.default(message, context);
+
+      expect(result.status).to.equal(200);
+      expect(mockConvertToOpportunity).to.have.been.calledOnce;
+      expect(mockSyncSuggestions).to.have.been.calledOnce;
+      expect(mockOpportunity.setStatus).to.have.been.calledWith('IGNORED');
+      // existingOpportunity is explicitly null so persistOffsiteOpportunity creates a record
+      // a new opportunity, never reusing (or re-querying for) the visible one.
+      const propsArg = mockConvertToOpportunity.firstCall.args[5];
+      expect(propsArg).to.have.property('existingOpportunity', null);
+    });
+
+    // Whether nothing exists yet, or the only prior opportunity is already IGNORED, the
+    // NEW-status lookup that feeds resolution returns the same thing (no matches) — so both
+    // states exercise this same "create a new row" path.
+    it('should create a new (hidden) opportunity for a suppressed run when nothing is visible yet', async () => {
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([]),
+      };
+
+      const message = validMessage({
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: { status: 'IGNORED' },
+            suggestions: [{ id: 'test_1', priority: 'HIGH', title: 'Test', description: 'Test' }],
+          },
+        },
+      });
+
+      const result = await guidanceHandler.default(message, context);
+
+      expect(result.status).to.equal(200);
+      expect(mockConvertToOpportunity).to.have.been.calledOnce;
+      expect(mockOpportunity.setStatus).to.have.been.calledWith('IGNORED');
+      const propsArg = mockConvertToOpportunity.firstCall.args[5];
+      expect(propsArg).to.have.property('existingOpportunity', null);
+    });
+
+    it('should hand the resolved evergreen to persistOffsiteOpportunity for a surfaced run', async () => {
+      const visibleOpportunity = {
+        getId: sandbox.stub().returns('existing-opp-1'),
+        getType: sandbox.stub().returns('youtube-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
+      };
+
+      const message = validMessage();
+
+      await guidanceHandler.default(message, context);
+
+      const propsArg = mockConvertToOpportunity.firstCall.args[5];
+      expect(propsArg.existingOpportunity).to.equal(visibleOpportunity);
+      expect(context.dataAccess.Opportunity.allBySiteIdAndStatus).to.have.been.calledOnce;
+    });
+
+    it('should lazily retire duplicate NEW opportunities of the same type via saveMany, keeping the most recent as evergreen', async () => {
+      const older = {
+        getId: sandbox.stub().returns('older-opp'),
+        getType: sandbox.stub().returns('youtube-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2025-01-01T00:00:00.000Z'),
+        setStatus: sandbox.stub(),
+        setUpdatedBy: sandbox.stub(),
+      };
+      const newer = {
+        getId: sandbox.stub().returns('newer-opp'),
+        getType: sandbox.stub().returns('youtube-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+        setStatus: sandbox.stub(),
+        setUpdatedBy: sandbox.stub(),
+      };
+      const saveManyStub = sandbox.stub().resolves();
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([older, newer]),
+        saveMany: saveManyStub,
+      };
+
+      const message = validMessage();
+
+      const result = await guidanceHandler.default(message, context);
+
+      expect(result.status).to.equal(200);
+      expect(older.setStatus).to.have.been.calledWith('IGNORED');
+      expect(newer.setStatus).to.not.have.been.called;
+      expect(saveManyStub).to.have.been.calledOnce;
+      expect(saveManyStub.firstCall.args[0]).to.deep.equal([older]);
+      expect(mockConvertToOpportunity).to.have.been.calledOnce;
+      expect(mockConvertToOpportunity.firstCall.args[5].existingOpportunity).to.equal(newer);
+    });
+
+    it('should propagate the error (badRequest) when duplicate retirement fails, without proceeding', async () => {
+      const older = {
+        getId: sandbox.stub().returns('older-opp'),
+        getType: sandbox.stub().returns('youtube-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2025-01-01T00:00:00.000Z'),
+        setStatus: sandbox.stub(),
+        setUpdatedBy: sandbox.stub(),
+      };
+      const newer = {
+        getId: sandbox.stub().returns('newer-opp'),
+        getType: sandbox.stub().returns('youtube-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+        setStatus: sandbox.stub(),
+        setUpdatedBy: sandbox.stub(),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([older, newer]),
+        saveMany: sandbox.stub().rejects(new Error('save failed')),
+      };
+
+      const message = validMessage();
+
+      const result = await guidanceHandler.default(message, context);
+
+      expect(result.status).to.equal(400);
+      expect(mockConvertToOpportunity).to.not.have.been.called;
+    });
+
+    it('should propagate the error (badRequest) when the initial opportunity lookup fails, without creating a duplicate', async () => {
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().rejects(new Error('DB down')),
+      };
+
+      const message = validMessage();
+
+      const result = await guidanceHandler.default(message, context);
+
+      expect(result.status).to.equal(400);
+      // A transient read failure must never be treated as "nothing exists yet" (which
+      // would otherwise create a duplicate NEW opportunity) — conversion is never attempted.
+      expect(mockConvertToOpportunity).to.not.have.been.called;
+      expect(mockSyncSuggestions).to.not.have.been.called;
     });
   });
 });

--- a/test/common/offsite-refresh-integration.test.js
+++ b/test/common/offsite-refresh-integration.test.js
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import esmock from 'esmock';
+
+use(sinonChai);
+
+describe('offsite refresh handler composition', () => {
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('composes the cited handler, mapper, and persistence helper', async () => {
+    const siteId = 'site-1';
+    const auditId = 'audit-2';
+    const state = {
+      data: {
+        staleField: 'remove-me',
+        dashboard: { score: 1 },
+      },
+      status: 'NEW',
+    };
+    const evergreenOpportunity = {
+      getId: () => 'evergreen-1',
+      getType: () => 'cited-analysis',
+      getData: () => state.data,
+      getUpdatedAt: () => '2026-07-01T00:00:00.000Z',
+      setAuditId: sandbox.stub(),
+      setData: sandbox.stub().callsFake((data) => {
+        state.data = data;
+      }),
+      setUpdatedBy: sandbox.stub(),
+      setStatus: sandbox.stub().callsFake((status) => {
+        state.status = status;
+      }),
+      save: sandbox.stub().resolves(),
+    };
+    const syncSuggestions = sandbox.stub().resolves();
+    const checkGoogleConnection = sandbox.stub().resolves(true);
+    const log = {
+      info: sandbox.spy(),
+      error: sandbox.spy(),
+      warn: sandbox.spy(),
+      debug: sandbox.spy(),
+    };
+    const site = {
+      getBaseURL: () => 'https://example.com',
+    };
+    const audit = {
+      getAuditResult: () => ({}),
+    };
+    const context = {
+      log,
+      dataAccess: {
+        Site: {
+          findById: sandbox.stub().resolves(site),
+        },
+        Audit: {
+          findById: sandbox.stub().resolves(audit),
+        },
+        Opportunity: {
+          allBySiteIdAndStatus: sandbox.stub().resolves([evergreenOpportunity]),
+          saveMany: sandbox.stub().resolves(),
+          create: sandbox.stub(),
+        },
+      },
+    };
+
+    const handler = await esmock('../../src/cited-analysis/guidance-handler.js', {
+      '../../src/common/opportunity-utils.js': {
+        checkGoogleConnection,
+      },
+      '../../src/utils/data-access.js': {
+        syncSuggestions,
+      },
+      '../../src/utils/brand-resolver.js': {
+        resolveBrandResultForSite: sandbox.stub().resolves({ brand: null, resolved: true }),
+        applyScopeToOpportunity: sandbox.stub(),
+      },
+      '../../src/utils/slack-utils.js': {
+        postMessageOptional: sandbox.stub(),
+      },
+    });
+
+    const response = await handler.default({
+      siteId,
+      auditId,
+      data: {
+        companyName: 'Example',
+        analysis: {
+          opportunity: {
+            status: 'NEW',
+            data: {
+              dashboard: { score: 2 },
+            },
+          },
+          suggestions: [
+            {
+              id: 'suggestion-1',
+              type: 'CONTENT_UPDATE',
+              rank: 1,
+              data: { title: 'Update content' },
+            },
+          ],
+        },
+      },
+    }, context);
+
+    expect(response.status).to.equal(200);
+    expect(evergreenOpportunity.setAuditId).to.have.been.calledWith(auditId);
+    expect(evergreenOpportunity.setData.firstCall.args[0]).to.deep.equal({
+      dashboard: { score: 2 },
+      dataSources: ['Site', 'Page'],
+    });
+    expect(evergreenOpportunity.setData.firstCall.args[0]).to.not.have.property('staleField');
+    expect(evergreenOpportunity.save).to.have.been.calledTwice;
+    expect(evergreenOpportunity.save.secondCall.callId)
+      .to.be.lessThan(syncSuggestions.firstCall.callId);
+    expect(syncSuggestions).to.have.been.calledOnce;
+    expect(context.dataAccess.Opportunity.create).to.not.have.been.called;
+  });
+});

--- a/test/common/offsite-refresh.test.js
+++ b/test/common/offsite-refresh.test.js
@@ -1,0 +1,251 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
+import {
+  isValidOffsiteAnalysis,
+  resolveEvergreenOffsiteOpportunity,
+  isSuppressedRun,
+} from '../../src/common/offsite-refresh.js';
+
+use(sinonChai);
+use(chaiAsPromised);
+
+describe('offsite-refresh', () => {
+  let sandbox;
+  let log;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    log = {
+      info: sandbox.spy(), error: sandbox.spy(), warn: sandbox.spy(), debug: sandbox.spy(),
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('isValidOffsiteAnalysis', () => {
+    it('returns true for a well-formed payload without an opportunity field', () => {
+      expect(isValidOffsiteAnalysis({ suggestions: [] }, 'cited-analysis')).to.be.true;
+    });
+
+    it('returns true for a well-formed payload with a plain-object opportunity field', () => {
+      expect(isValidOffsiteAnalysis({
+        suggestions: [],
+        opportunity: { status: 'NEW' },
+      }, 'cited-analysis')).to.be.true;
+    });
+
+    it('returns false for null', () => {
+      expect(isValidOffsiteAnalysis(null, 'cited-analysis')).to.be.false;
+    });
+
+    it('returns false for undefined', () => {
+      expect(isValidOffsiteAnalysis(undefined, 'cited-analysis')).to.be.false;
+    });
+
+    it('returns false for a non-object (string)', () => {
+      expect(isValidOffsiteAnalysis('not an object', 'cited-analysis')).to.be.false;
+    });
+
+    it('returns false for an array', () => {
+      expect(isValidOffsiteAnalysis(['a', 'b'], 'cited-analysis')).to.be.false;
+    });
+
+    it('returns false when opportunity is an array', () => {
+      expect(isValidOffsiteAnalysis({ opportunity: ['bad'] }, 'cited-analysis')).to.be.false;
+    });
+
+    it('returns false when opportunity is a string', () => {
+      expect(isValidOffsiteAnalysis({ opportunity: 'bad' }, 'cited-analysis')).to.be.false;
+    });
+
+    it('returns false when opportunity is null', () => {
+      expect(isValidOffsiteAnalysis({ opportunity: null }, 'cited-analysis')).to.be.false;
+    });
+
+    it('returns true when opportunity.type matches the expected type', () => {
+      expect(isValidOffsiteAnalysis({
+        opportunity: { type: 'cited-analysis' },
+      }, 'cited-analysis')).to.be.true;
+    });
+
+    it('returns true when opportunity.type is absent (defaults to the expected type)', () => {
+      expect(isValidOffsiteAnalysis({ opportunity: { status: 'NEW' } }, 'cited-analysis')).to.be.true;
+    });
+
+    it('returns false when opportunity.type disagrees with the expected type (cross-type hijack)', () => {
+      // A cited-analysis message carrying opportunity.type: 'reddit-analysis' must be
+      // rejected outright, not silently routed against Reddit's evergreen opportunity.
+      expect(isValidOffsiteAnalysis({
+        opportunity: { type: 'reddit-analysis' },
+      }, 'cited-analysis')).to.be.false;
+    });
+  });
+
+  describe('resolveEvergreenOpportunity', () => {
+    it('returns null when no opportunities exist for the site', async () => {
+      const dataAccess = { Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) } };
+
+      const result = await resolveEvergreenOffsiteOpportunity({
+        dataAccess, siteId: 'site-1', auditType: 'cited-analysis', log,
+      });
+
+      expect(result).to.be.null;
+    });
+
+    it('treats a nullish resolved value as no opportunities', async () => {
+      const dataAccess = {
+        Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves(undefined) },
+      };
+
+      const result = await resolveEvergreenOffsiteOpportunity({
+        dataAccess, siteId: 'site-1', auditType: 'cited-analysis', log,
+      });
+
+      expect(result).to.be.null;
+    });
+
+    it('logs and rethrows when the fetch itself fails, rather than returning null', async () => {
+      const dataAccess = {
+        Opportunity: { allBySiteIdAndStatus: sandbox.stub().rejects(new Error('DB down')) },
+      };
+
+      await expect(resolveEvergreenOffsiteOpportunity({
+        dataAccess, siteId: 'site-1', auditType: 'cited-analysis', log,
+      })).to.be.rejectedWith('DB down');
+
+      expect(log.error).to.have.been.calledWith(sinon.match(/DB down/));
+    });
+
+    it('returns the single matching opportunity without touching it', async () => {
+      const only = {
+        getType: () => 'cited-analysis',
+        getId: () => 'only-opp',
+      };
+      const dataAccess = {
+        Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([only]) },
+      };
+
+      const result = await resolveEvergreenOffsiteOpportunity({
+        dataAccess, siteId: 'site-1', auditType: 'cited-analysis', log,
+      });
+
+      expect(result).to.equal(only);
+    });
+
+    it('ignores opportunities of a different type', async () => {
+      const other = { getType: () => 'reddit-analysis', getId: () => 'other-opp' };
+      const dataAccess = {
+        Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([other]) },
+      };
+
+      const result = await resolveEvergreenOffsiteOpportunity({
+        dataAccess, siteId: 'site-1', auditType: 'cited-analysis', log,
+      });
+
+      expect(result).to.be.null;
+    });
+
+    it('retires all but the most-recently-updated duplicate to IGNORED via a single saveMany', async () => {
+      const oldest = {
+        getType: () => 'cited-analysis',
+        getId: () => 'oldest',
+        getUpdatedAt: () => '2024-01-01T00:00:00.000Z',
+        setStatus: sandbox.stub(),
+        setUpdatedBy: sandbox.stub(),
+      };
+      const middle = {
+        getType: () => 'cited-analysis',
+        getId: () => 'middle',
+        getUpdatedAt: () => '2025-01-01T00:00:00.000Z',
+        setStatus: sandbox.stub(),
+        setUpdatedBy: sandbox.stub(),
+      };
+      const newest = {
+        getType: () => 'cited-analysis',
+        getId: () => 'newest',
+        getUpdatedAt: () => '2026-01-01T00:00:00.000Z',
+        setStatus: sandbox.stub(),
+        setUpdatedBy: sandbox.stub(),
+      };
+      const saveManyStub = sandbox.stub().resolves();
+      const dataAccess = {
+        Opportunity: {
+          allBySiteIdAndStatus: sandbox.stub().resolves([oldest, newest, middle]),
+          saveMany: saveManyStub,
+        },
+      };
+
+      const result = await resolveEvergreenOffsiteOpportunity({
+        dataAccess, siteId: 'site-1', auditType: 'cited-analysis', log,
+      });
+
+      expect(result).to.equal(newest);
+      expect(oldest.setStatus).to.have.been.calledWith('IGNORED');
+      expect(middle.setStatus).to.have.been.calledWith('IGNORED');
+      expect(newest.setStatus).to.not.have.been.called;
+      // A single bulk write, never a per-item save() (repo's no-N+1 rule). Order follows
+      // the descending-by-updatedAt sort used to pick the evergreen one (middle, then oldest).
+      expect(saveManyStub).to.have.been.calledOnce;
+      expect(saveManyStub.firstCall.args[0]).to.deep.equal([middle, oldest]);
+    });
+
+    it('propagates the error when saveMany fails, rather than swallowing it', async () => {
+      const older = {
+        getType: () => 'cited-analysis',
+        getId: () => 'older',
+        getUpdatedAt: () => '2024-01-01T00:00:00.000Z',
+        setStatus: sandbox.stub(),
+        setUpdatedBy: sandbox.stub(),
+      };
+      const newer = {
+        getType: () => 'cited-analysis',
+        getId: () => 'newer',
+        getUpdatedAt: () => '2026-01-01T00:00:00.000Z',
+        setStatus: sandbox.stub(),
+        setUpdatedBy: sandbox.stub(),
+      };
+      const dataAccess = {
+        Opportunity: {
+          allBySiteIdAndStatus: sandbox.stub().resolves([older, newer]),
+          saveMany: sandbox.stub().rejects(new Error('save failed')),
+        },
+      };
+
+      // A failed retirement means the "single evergreen opportunity" invariant this
+      // function promises no longer holds — the caller must not proceed as if it did.
+      await expect(resolveEvergreenOffsiteOpportunity({
+        dataAccess, siteId: 'site-1', auditType: 'cited-analysis', log,
+      })).to.be.rejectedWith('save failed');
+    });
+  });
+
+  describe('isSuppressedRun', () => {
+    it('returns true when the incoming run is IGNORED', () => {
+      expect(isSuppressedRun('IGNORED')).to.be.true;
+    });
+
+    it('returns false when the incoming run is NEW', () => {
+      expect(isSuppressedRun('NEW')).to.be.false;
+    });
+
+    it('returns false for any other status', () => {
+      expect(isSuppressedRun('RESOLVED')).to.be.false;
+    });
+  });
+});

--- a/test/common/opportunity.test.js
+++ b/test/common/opportunity.test.js
@@ -1,0 +1,345 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import esmock from 'esmock';
+import chaiAsPromised from 'chai-as-promised';
+
+use(sinonChai);
+use(chaiAsPromised);
+
+describe('persistOffsiteOpportunity', () => {
+  let sandbox;
+  let persistOffsiteOpportunity;
+  let checkGoogleConnectionStub;
+
+  const siteId = 'test-site-id';
+  const auditId = 'test-audit-id-2';
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    checkGoogleConnectionStub = sandbox.stub().resolves(true);
+    ({ persistOffsiteOpportunity } = await esmock('../../src/common/offsite-refresh.js', {
+      '../../src/common/opportunity-utils.js': {
+        checkGoogleConnection: checkGoogleConnectionStub,
+      },
+    }));
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  const buildExistingOpportunity = (existingData) => ({
+    getType: () => 'cited-analysis',
+    getData: sandbox.stub().returns(existingData),
+    setAuditId: sandbox.stub(),
+    setData: sandbox.stub(),
+    setUpdatedBy: sandbox.stub(),
+    save: sandbox.stub().resolves(),
+    getId: () => 'existing-opp-id',
+  });
+
+  it('replaces dashboard/performance data wholesale on refresh, dropping fields absent from the latest run', async () => {
+    const existingData = {
+      dataSources: ['ai-search'],
+      dashboard: { sentiment: 'negative', sov: 0.1 },
+      fullAnalysis: { suggestions: ['old'] },
+    };
+    const existingOpportunity = buildExistingOpportunity(existingData);
+
+    const context = {
+      dataAccess: {
+        Opportunity: {
+          allBySiteIdAndStatus: sandbox.stub().resolves([existingOpportunity]),
+        },
+      },
+      log: { info: sandbox.spy(), error: sandbox.spy(), debug: sandbox.spy() },
+    };
+
+    const createOpportunityData = () => ({
+      data: {
+        dataSources: ['ai-search'],
+        dashboard: { sentiment: 'positive', sov: 0.42 },
+      },
+    });
+
+    const auditUrl = 'https://example.com';
+    const auditData = { siteId, id: auditId };
+
+    const result = await persistOffsiteOpportunity(
+      auditUrl,
+      auditData,
+      context,
+      createOpportunityData,
+      'cited-analysis',
+      { opportunityData: {}, existingOpportunity },
+    );
+
+    expect(result.getId()).to.equal('existing-opp-id');
+    // fullAnalysis is absent from the latest mapped data, so it must disappear — not
+    // linger merged in from the prior run. setData is called with exactly the new data.
+    expect(existingOpportunity.setData).to.have.been.calledWith({
+      dataSources: ['ai-search'],
+      dashboard: { sentiment: 'positive', sov: 0.42 },
+    });
+    expect(existingOpportunity.setData.firstCall.args[0]).to.not.have.property('fullAnalysis');
+  });
+
+  it('applies the same wholesale-replace behavior for reddit-analysis and youtube-analysis', async () => {
+    for (const auditType of ['reddit-analysis', 'youtube-analysis']) {
+      const existingOpportunity = buildExistingOpportunity({
+        dashboard: { sov: 0.1 },
+        staleTopic: { id: 'old-only-field' },
+      });
+      existingOpportunity.getType = () => auditType;
+
+      const context = {
+        dataAccess: {
+          Opportunity: {
+            allBySiteIdAndStatus: sandbox.stub().resolves([existingOpportunity]),
+          },
+        },
+        log: { info: sandbox.spy(), error: sandbox.spy(), debug: sandbox.spy() },
+      };
+
+      const createOpportunityData = () => ({ data: { dashboard: { sov: 0.77 } } });
+
+      // eslint-disable-next-line no-await-in-loop
+      await persistOffsiteOpportunity(
+        'https://example.com',
+        { siteId, id: auditId },
+        context,
+        createOpportunityData,
+        auditType,
+        { existingOpportunity },
+      );
+
+      expect(existingOpportunity.setData).to.have.been.calledWith({
+        dashboard: { sov: 0.77 },
+      });
+      expect(existingOpportunity.setData.firstCall.args[0]).to.not.have.property('staleTopic');
+    }
+  });
+
+  it('rejects non-offsite audit types before mutating an opportunity', async () => {
+    const existingOpportunity = buildExistingOpportunity({ staleField: 'must-survive' });
+    const context = {
+      dataAccess: { Opportunity: { create: sandbox.stub() } },
+      log: { info: sandbox.spy(), error: sandbox.spy(), debug: sandbox.spy() },
+    };
+
+    await expect(persistOffsiteOpportunity(
+      'https://example.com',
+      { siteId, id: auditId },
+      context,
+      () => ({ data: { newField: 'new' } }),
+      'prerender',
+      { existingOpportunity },
+    )).to.be.rejectedWith('Unsupported offsite audit type: prerender');
+
+    expect(existingOpportunity.setAuditId).to.not.have.been.called;
+    expect(existingOpportunity.setData).to.not.have.been.called;
+    expect(existingOpportunity.save).to.not.have.been.called;
+  });
+
+  it('requires callers to provide the pre-resolved target explicitly', async () => {
+    const createOpportunityData = sandbox.stub();
+    const context = {
+      dataAccess: { Opportunity: { create: sandbox.stub() } },
+      log: { info: sandbox.spy(), error: sandbox.spy(), debug: sandbox.spy() },
+    };
+
+    await expect(persistOffsiteOpportunity(
+      'https://example.com',
+      { siteId, id: auditId },
+      context,
+      createOpportunityData,
+      'cited-analysis',
+      { opportunityData: {} },
+    )).to.be.rejectedWith('existingOpportunity must be explicitly provided');
+
+    expect(createOpportunityData).to.not.have.been.called;
+    expect(context.dataAccess.Opportunity.create).to.not.have.been.called;
+  });
+
+  [undefined, false, 0].forEach((invalidTarget) => {
+    it(`rejects invalid explicit target ${String(invalidTarget)}`, async () => {
+      const createOpportunityData = sandbox.stub();
+      const context = {
+        dataAccess: { Opportunity: { create: sandbox.stub() } },
+        log: { info: sandbox.spy(), error: sandbox.spy(), debug: sandbox.spy() },
+      };
+
+      await expect(persistOffsiteOpportunity(
+        'https://example.com',
+        { siteId, id: auditId },
+        context,
+        createOpportunityData,
+        'cited-analysis',
+        { opportunityData: {}, existingOpportunity: invalidTarget },
+      )).to.be.rejectedWith('existingOpportunity must be an opportunity or null');
+
+      expect(createOpportunityData).to.not.have.been.called;
+      expect(context.dataAccess.Opportunity.create).to.not.have.been.called;
+    });
+  });
+
+  it('removes GSC from mapped data when the site has no Google connection', async () => {
+    checkGoogleConnectionStub.resolves(false);
+    const existingOpportunity = buildExistingOpportunity({ staleField: 'old' });
+    const context = {
+      dataAccess: { Opportunity: { create: sandbox.stub() } },
+      log: { info: sandbox.spy(), error: sandbox.spy(), debug: sandbox.spy() },
+    };
+
+    await persistOffsiteOpportunity(
+      'https://example.com',
+      { siteId, id: auditId },
+      context,
+      () => ({ data: { dataSources: ['GSC', 'Site'] } }),
+      'cited-analysis',
+      { existingOpportunity },
+    );
+
+    expect(existingOpportunity.setData).to.have.been.calledWith({
+      dataSources: ['Site'],
+    });
+  });
+
+  describe('pre-resolved existingOpportunity (bypasses the internal query)', () => {
+    it('uses a provided existingOpportunity directly without querying allBySiteIdAndStatus', async () => {
+      const existingOpportunity = buildExistingOpportunity({ dashboard: { sov: 0.1 } });
+      const allBySiteIdAndStatusStub = sandbox.stub().resolves([]);
+      const context = {
+        dataAccess: { Opportunity: { allBySiteIdAndStatus: allBySiteIdAndStatusStub } },
+        log: { info: sandbox.spy(), error: sandbox.spy(), debug: sandbox.spy() },
+      };
+      const createOpportunityData = () => ({ data: { dashboard: { sov: 0.77 } } });
+
+      const result = await persistOffsiteOpportunity(
+        'https://example.com',
+        { siteId, id: auditId },
+        context,
+        createOpportunityData,
+        'cited-analysis',
+        { existingOpportunity },
+      );
+
+      expect(result.getId()).to.equal('existing-opp-id');
+      expect(allBySiteIdAndStatusStub).to.not.have.been.called;
+      expect(existingOpportunity.setData).to.have.been.calledWith({ dashboard: { sov: 0.77 } });
+    });
+
+    it('forces creation when existingOpportunity is explicitly null, without querying', async () => {
+      const allBySiteIdAndStatusStub = sandbox.stub().resolves([]);
+      const createStub = sandbox.stub().resolves({ getId: () => 'new-opp-id' });
+      const context = {
+        dataAccess: {
+          Opportunity: { allBySiteIdAndStatus: allBySiteIdAndStatusStub, create: createStub },
+        },
+        log: { info: sandbox.spy(), error: sandbox.spy(), debug: sandbox.spy() },
+      };
+      const createOpportunityData = () => ({ data: { dashboard: { sov: 0.77 } }, status: 'IGNORED' });
+
+      const result = await persistOffsiteOpportunity(
+        'https://example.com',
+        { siteId, id: auditId },
+        context,
+        createOpportunityData,
+        'cited-analysis',
+        { existingOpportunity: null },
+      );
+
+      expect(result.getId()).to.equal('new-opp-id');
+      expect(allBySiteIdAndStatusStub).to.not.have.been.called;
+      expect(createStub).to.have.been.calledOnce;
+      // Status is baked into the single create write — never a separate, later save().
+      expect(createStub.firstCall.args[0]).to.have.property('status', 'IGNORED');
+    });
+
+    it('logs audit context and rethrows when creation fails', async () => {
+      const createStub = sandbox.stub().rejects(new Error('create failed'));
+      const context = {
+        dataAccess: { Opportunity: { create: createStub } },
+        log: { info: sandbox.spy(), error: sandbox.spy(), debug: sandbox.spy() },
+      };
+
+      await expect(persistOffsiteOpportunity(
+        'https://example.com',
+        { siteId, id: auditId },
+        context,
+        () => ({ data: {}, status: 'IGNORED' }),
+        'cited-analysis',
+        { existingOpportunity: null },
+      )).to.be.rejectedWith('create failed');
+
+      expect(context.log.error).to.have.been.calledWith(
+        sinon.match(new RegExp(`${siteId}.*${auditId}.*create failed`)),
+      );
+    });
+  });
+
+  describe('atomic status on create', () => {
+    it('includes the mapper-provided status in the Opportunity.create() payload', async () => {
+      const createStub = sandbox.stub().resolves({ getId: () => 'new-opp-id' });
+      const context = {
+        dataAccess: {
+          Opportunity: {
+            allBySiteIdAndStatus: sandbox.stub().resolves([]),
+            create: createStub,
+          },
+        },
+        log: { info: sandbox.spy(), error: sandbox.spy(), debug: sandbox.spy() },
+      };
+      const createOpportunityData = () => ({ data: {}, status: 'IGNORED' });
+
+      await persistOffsiteOpportunity(
+        'https://example.com',
+        { siteId, id: auditId },
+        context,
+        createOpportunityData,
+        'cited-analysis',
+        { existingOpportunity: null },
+      );
+
+      expect(createStub.firstCall.args[0]).to.have.property('status', 'IGNORED');
+    });
+
+    it('omits status from the create payload when the mapper does not provide one', async () => {
+      const createStub = sandbox.stub().resolves({ getId: () => 'new-opp-id' });
+      const context = {
+        dataAccess: {
+          Opportunity: {
+            allBySiteIdAndStatus: sandbox.stub().resolves([]),
+            create: createStub,
+          },
+        },
+        log: { info: sandbox.spy(), error: sandbox.spy(), debug: sandbox.spy() },
+      };
+      const createOpportunityData = () => ({ data: {} });
+
+      await persistOffsiteOpportunity(
+        'https://example.com',
+        { siteId, id: auditId },
+        context,
+        createOpportunityData,
+        'cited-analysis',
+        { existingOpportunity: null },
+      );
+
+      expect(createStub.firstCall.args[0]).to.not.have.property('status');
+    });
+  });
+});


### PR DESCRIPTION
## Scope

https://jira.corp.adobe.com/browse/LLMO-6122

Make each cited, Reddit, and YouTube offsite opportunity a stable evergreen entity that refreshes in place every week instead of receiving a new identifier on every run.

This preserves customer decisions, Opportunity Workspace links, and Brand Claims references while keeping dashboard data current.

## Implementation

**Stable evergreen opportunity**

`resolveEvergreenOffsiteOpportunity` selects the existing `NEW` opportunity by site and audit type. If historical duplicates exist, it keeps the most recently updated record and retires the others to `IGNORED` before refresh continues.

**Explicit offsite persistence**

`persistOffsiteOpportunity` creates the first opportunity or refreshes the resolved evergreen record. Refreshes preserve the opportunity ID while replacing audit identity and offsite analysis data, and the implementation is restricted to supported offsite audit types so unrelated opportunities are unaffected.

**Payload and suppression safety**

`isValidOffsiteAnalysis` rejects malformed or mismatched payloads before mutation. `isSuppressedRun` keeps an `IGNORED` incoming run separate, so it cannot overwrite the customer-visible evergreen opportunity or its suggestions.

**Supported handlers**

The cited-analysis, reddit-analysis, and youtube-analysis guidance handlers use the shared refresh workflow. Wikipedia analysis is unchanged.

## Testing

- Full unit and integration suite passes with required coverage.
- Lint and build pass.
- Dedicated tests cover validation, first creation, in-place refresh, duplicate retirement, suppressed runs, and all three supported handlers.
- Local Postgres/PostgREST scenarios verified surfaced, suppressed, duplicate, and repeated-refresh behavior.

## Out of Scope

- Snapshot creation, restore, and retention
- Suggestion retention or deterministic suggestion deduplication
- Migration of suggestions or links from retired duplicate opportunities
- Historical dashboard querying and rollback
- Evidence-binding stability across runs
- Comparative QA gates or phased rollout