### PR TITLE
[Draft] fix(prerender): strip FontFaceObserver/Next.js font-detection noise from scraped HTML (LLMO-6061)

### DIFF
--- a/src/index-local.js
+++ b/src/index-local.js
@@ -10,16 +10,10 @@
  * governing permissions and limitations under the License.
  */
 /* eslint-disable no-console */
-process.env.SPACECAT_SKIP_VAULT_SECRETS = '1';
-
-const { main: universalMain } = await import('./index.js');
+import { main as universalMain } from './index.js';
 
 /**
  * Local testing entry point
- *
- * Vault is skipped (`SPACECAT_SKIP_VAULT_SECRETS` is set before loading `index.js`). Provide
- * secrets via `.env` / shell instead. To run the full stack including Vault, invoke `index.js`
- * with `SPACECAT_SKIP_VAULT_SECRETS` unset.
  *
  * Required environment variables:
  *   SPACECAT_API_BASE_URL - e.g., https://spacecat-services--api-service.aem-dev.hlx.page
@@ -31,8 +25,8 @@ const { main: universalMain } = await import('./index.js');
  */
 export const main = async () => {
   // Change this to test different audit types
-  const AUDIT_TYPE = process.env.AUDIT_TYPE || 'sitemap';
-  const SITE_ID = process.env.SITE_ID || 'cfaa3c1b-58a7-4cc8-bec9-ba9d7e201894';
+  const AUDIT_TYPE = process.env.AUDIT_TYPE || 'wikipedia-analysis';
+  const SITE_ID = process.env.SITE_ID || 'b1555a54-48b4-47ee-97c1-438257bd3839';
 
   const messageBody = {
     type: AUDIT_TYPE,

--- a/src/index-local.js
+++ b/src/index-local.js
@@ -10,10 +10,16 @@
  * governing permissions and limitations under the License.
  */
 /* eslint-disable no-console */
-import { main as universalMain } from './index.js';
+process.env.SPACECAT_SKIP_VAULT_SECRETS = '1';
+
+const { main: universalMain } = await import('./index.js');
 
 /**
  * Local testing entry point
+ *
+ * Vault is skipped (`SPACECAT_SKIP_VAULT_SECRETS` is set before loading `index.js`). Provide
+ * secrets via `.env` / shell instead. To run the full stack including Vault, invoke `index.js`
+ * with `SPACECAT_SKIP_VAULT_SECRETS` unset.
  *
  * Required environment variables:
  *   SPACECAT_API_BASE_URL - e.g., https://spacecat-services--api-service.aem-dev.hlx.page
@@ -25,8 +31,8 @@ import { main as universalMain } from './index.js';
  */
 export const main = async () => {
   // Change this to test different audit types
-  const AUDIT_TYPE = process.env.AUDIT_TYPE || 'wikipedia-analysis';
-  const SITE_ID = process.env.SITE_ID || 'b1555a54-48b4-47ee-97c1-438257bd3839';
+  const AUDIT_TYPE = process.env.AUDIT_TYPE || 'sitemap';
+  const SITE_ID = process.env.SITE_ID || 'cfaa3c1b-58a7-4cc8-bec9-ba9d7e201894';
 
   const messageBody = {
     type: AUDIT_TYPE,

--- a/src/prerender/utils/html-comparator.js
+++ b/src/prerender/utils/html-comparator.js
@@ -10,7 +10,46 @@
  * governing permissions and limitations under the License.
  */
 
+import { load as cheerioLoad } from 'cheerio';
 import { calculateStats } from '@adobe/spacecat-shared-html-analyzer';
+
+const FONT_DETECTION_TEST_STRING = 'mmMwWLliI0fiflO';
+const FONT_DETECTION_WORD_MIN_REPS = 10;
+
+/**
+ * Returns true if the text is entirely composed of font-detection noise injected by
+ * FontFaceObserver / Next.js @next/font: either the font-metrics test string
+ * (startsWith to cover &N suffix variants) or exclusively repeated "word" tokens.
+ * Puppeteer captures these elements before the library removes them; direct-fetch HTML
+ * is unaffected. Filtering them prevents inflated word counts that falsely signal
+ * a prerender need.
+ * @param {string} text
+ * @returns {boolean}
+ */
+export function isFontDetectionLeaf(text) {
+  if (!text) {
+    return false;
+  }
+  if (text.startsWith(FONT_DETECTION_TEST_STRING)) {
+    return true;
+  }
+  const tokens = text.trim().split(/\s+/);
+  return tokens.length >= FONT_DETECTION_WORD_MIN_REPS && tokens.every((t) => t === 'word');
+}
+
+function removeFontDetectionNoise(html) {
+  const $ = cheerioLoad(html);
+  $('*').each((i, el) => {
+    const $el = $(el);
+    if ($el.children().length > 0) {
+      return;
+    }
+    if (isFontDetectionLeaf($el.text().trim())) {
+      $el.remove();
+    }
+  });
+  return $.html();
+}
 
 /**
  * Analyzes HTML content to determine if prerendering is needed
@@ -25,7 +64,7 @@ async function analyzeHtmlForPrerender(directHtml, scrapedHtml, threshold = 1.2)
     throw new Error('Missing HTML content for comparison');
   }
 
-  const stats = await calculateStats(directHtml, scrapedHtml, true);
+  const stats = await calculateStats(directHtml, removeFontDetectionNoise(scrapedHtml), true);
   const needsPrerender = typeof stats.contentIncreaseRatio === 'number' && stats.contentIncreaseRatio >= threshold;
 
   return {

--- a/test/audits/prerender/behaviour/helpers.js
+++ b/test/audits/prerender/behaviour/helpers.js
@@ -30,7 +30,7 @@ export const HTML_SAME = '<html><body><p>identical content for both server and c
 export const HTML_SERVER_SPARSE = '<html><body><p>few words here</p></body></html>';
 
 /** Client-side with many words — ratio vs HTML_SERVER_SPARSE well above 1.1 threshold. */
-export const HTML_CLIENT_NEEDS_PRERENDER = `<html><body><p>${'The quick brown fox jumps over the lazy dog. '.repeat(15).trim()}</p></body></html>`;
+export const HTML_CLIENT_NEEDS_PRERENDER = `<html><body><p>${'text '.repeat(60).trim()}</p></body></html>`;
 
 // ─── S3 key helpers ───────────────────────────────────────────────────────────
 

--- a/test/audits/prerender/behaviour/helpers.js
+++ b/test/audits/prerender/behaviour/helpers.js
@@ -30,7 +30,7 @@ export const HTML_SAME = '<html><body><p>identical content for both server and c
 export const HTML_SERVER_SPARSE = '<html><body><p>few words here</p></body></html>';
 
 /** Client-side with many words — ratio vs HTML_SERVER_SPARSE well above 1.1 threshold. */
-export const HTML_CLIENT_NEEDS_PRERENDER = `<html><body><p>${'word '.repeat(60).trim()}</p></body></html>`;
+export const HTML_CLIENT_NEEDS_PRERENDER = `<html><body><p>${'The quick brown fox jumps over the lazy dog. '.repeat(15).trim()}</p></body></html>`;
 
 // ─── S3 key helpers ───────────────────────────────────────────────────────────
 

--- a/test/audits/prerender/html-comparator.test.js
+++ b/test/audits/prerender/html-comparator.test.js
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import esmock from 'esmock';
+
+use(chaiAsPromised);
+use(sinonChai);
+
+describe('Prerender html-comparator', () => {
+  let sandbox;
+  let analyzeHtmlForPrerender;
+  let isFontDetectionLeaf;
+  let calculateStatsStub;
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    calculateStatsStub = sandbox.stub().resolves({
+      contentIncreaseRatio: 1.5,
+      wordCountBefore: 100,
+      wordCountAfter: 150,
+      citationReadability: 0.8,
+      wordDiff: 50,
+    });
+
+    ({ analyzeHtmlForPrerender, isFontDetectionLeaf } = await esmock(
+      '../../../src/prerender/utils/html-comparator.js',
+      {
+        '@adobe/spacecat-shared-html-analyzer': { calculateStats: calculateStatsStub },
+      },
+    ));
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('isFontDetectionLeaf', () => {
+    it('returns false for empty string', () => {
+      expect(isFontDetectionLeaf('')).to.equal(false);
+    });
+
+    it('returns false for falsy input', () => {
+      expect(isFontDetectionLeaf(null)).to.equal(false);
+      expect(isFontDetectionLeaf(undefined)).to.equal(false);
+    });
+
+    it('returns true for the bare mmMwWLliI0fiflO test string', () => {
+      expect(isFontDetectionLeaf('mmMwWLliI0fiflO')).to.equal(true);
+    });
+
+    it('returns true for mmMwWLliI0fiflO with &N suffix variants', () => {
+      expect(isFontDetectionLeaf('mmMwWLliI0fiflO&1')).to.equal(true);
+      expect(isFontDetectionLeaf('mmMwWLliI0fiflO&2')).to.equal(true);
+    });
+
+    it('returns false when mmMwWLliI0fiflO appears mid-text, not at start', () => {
+      expect(isFontDetectionLeaf('some text mmMwWLliI0fiflO')).to.equal(false);
+    });
+
+    it('returns true for 10+ space-separated "word" tokens', () => {
+      expect(isFontDetectionLeaf(Array(10).fill('word').join(' '))).to.equal(true);
+      expect(isFontDetectionLeaf(Array(20).fill('word').join(' '))).to.equal(true);
+    });
+
+    it('returns false for fewer than 10 "word" tokens', () => {
+      expect(isFontDetectionLeaf('word word word')).to.equal(false);
+      expect(isFontDetectionLeaf(Array(9).fill('word').join(' '))).to.equal(false);
+    });
+
+    it('returns false when tokens include non-"word" words', () => {
+      const mixed = `${Array(10).fill('word').join(' ')} door`;
+      expect(isFontDetectionLeaf(mixed)).to.equal(false);
+    });
+
+    it('returns false for legitimate prose', () => {
+      expect(isFontDetectionLeaf('The right word in the right context matters.')).to.equal(false);
+    });
+  });
+
+  describe('analyzeHtmlForPrerender', () => {
+    it('throws when directHtml is missing', async () => {
+      await expect(analyzeHtmlForPrerender(null, '<html><body>content</body></html>'))
+        .to.be.rejectedWith('Missing HTML content for comparison');
+    });
+
+    it('throws when scrapedHtml is missing', async () => {
+      await expect(analyzeHtmlForPrerender('<html><body>content</body></html>', null))
+        .to.be.rejectedWith('Missing HTML content for comparison');
+    });
+
+    it('returns needsPrerender true when ratio meets threshold', async () => {
+      const result = await analyzeHtmlForPrerender(
+        '<html><body>direct</body></html>',
+        '<html><body>scraped</body></html>',
+      );
+      expect(result.needsPrerender).to.equal(true);
+      expect(result.contentGainRatio).to.equal(1.5);
+    });
+
+    it('returns needsPrerender false when ratio is below threshold', async () => {
+      calculateStatsStub.resolves({ contentIncreaseRatio: 1.1, wordCountBefore: 100, wordCountAfter: 110, citationReadability: 0.9, wordDiff: 10 });
+      const result = await analyzeHtmlForPrerender(
+        '<html><body>direct</body></html>',
+        '<html><body>scraped</body></html>',
+      );
+      expect(result.needsPrerender).to.equal(false);
+    });
+
+    it('strips font-detection noise from scrapedHtml before analysis', async () => {
+      const directHtml = '<html><body><p>Real content</p></body></html>';
+      const noise = Array(15).fill('word').join(' ');
+      const scrapedHtml = `<html><body><p>Real content</p><span>${noise}</span></body></html>`;
+
+      await analyzeHtmlForPrerender(directHtml, scrapedHtml);
+
+      const [, filteredScraped] = calculateStatsStub.firstCall.args;
+      expect(filteredScraped).to.not.include(noise);
+      expect(filteredScraped).to.include('Real content');
+    });
+
+    it('strips mmMwWLliI0fiflO spans from scrapedHtml before analysis', async () => {
+      const directHtml = '<html><body><p>Real content</p></body></html>';
+      const scrapedHtml = '<html><body><p>Real content</p><span style="white-space:nowrap">mmMwWLliI0fiflO&amp;1</span></body></html>';
+
+      await analyzeHtmlForPrerender(directHtml, scrapedHtml);
+
+      const [, filteredScraped] = calculateStatsStub.firstCall.args;
+      expect(filteredScraped).to.not.include('mmMwWLliI0fiflO');
+      expect(filteredScraped).to.include('Real content');
+    });
+
+    it('does not strip legitimate content from scrapedHtml', async () => {
+      const directHtml = '<html><body><p>Content</p></body></html>';
+      const scrapedHtml = '<html><body><p>Content</p><p>Use the right word for each context</p></body></html>';
+
+      await analyzeHtmlForPrerender(directHtml, scrapedHtml);
+
+      const [, filteredScraped] = calculateStatsStub.firstCall.args;
+      expect(filteredScraped).to.include('Use the right word for each context');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- FontFaceObserver and Next.js `@next/font` inject transient test elements into the DOM that Puppeteer captures before the library cleans them up, inflating the scraped word count and causing false `needsPrerender: true` results
- Adds `removeFontDetectionNoise()` in `html-comparator.js` that strips these elements from `scrapedHtml` via cheerio before passing to `calculateStats`
- Strips two patterns: `mmMwWLliI0fiflO` prefix (font-metrics probe, covers `&N` suffix variants) and 10+ repeated `word` tokens (character-width probe)
- Adds `html-comparator.test.js` with 16 tests covering both `isFontDetectionLeaf` unit cases and `analyzeHtmlForPrerender` integration cases

## Test plan
- [x] `npx mocha --require test/setup-env.js test/audits/prerender/html-comparator.test.js` — 16 passing

Closes LLMO-6061

🤖 Generated with [Claude Code](https://claude.com/claude-code)