### PR TITLE
fix: repair TOC guidance:table-of-contents Mystique roundtrip (LLMO-6167)

### DIFF
--- a/src/toc/guidance-handler.js
+++ b/src/toc/guidance-handler.js
@@ -11,6 +11,7 @@
  */
 
 import { badRequest, notFound, ok } from '@adobe/spacecat-shared-http-utils';
+import { Suggestion } from '@adobe/spacecat-shared-data-access';
 import { isEligibleTocSuggestion } from './eligibility-utils.js';
 
 /**
@@ -21,13 +22,14 @@ import { isEligibleTocSuggestion } from './eligibility-utils.js';
  * prompts are grounded in the page's headings rather than the checkType, it's correct to apply
  * the same prompt set to every non-terminal suggestion for that URL.
  * @param {Array<Object>} suggestions - Existing Suggestion entities for the opportunity
- * @param {Object} Suggestion - The Suggestion data-access collection (for STATUSES)
+ * @param {Object} SuggestionClass - The Suggestion class (for STATUSES; not the request-scoped
+ * data-access collection, which doesn't carry it)
  * @returns {Map<string, Array<Object>>} URL -> matching, non-terminal suggestion entities
  */
-function groupEligibleSuggestionsByUrl(suggestions, Suggestion) {
+function groupEligibleSuggestionsByUrl(suggestions, SuggestionClass) {
   const byUrl = new Map();
   suggestions.forEach((suggestion) => {
-    if (!isEligibleTocSuggestion(suggestion, Suggestion)) {
+    if (!isEligibleTocSuggestion(suggestion, SuggestionClass)) {
       return;
     }
     const { url } = suggestion.getData() || {};
@@ -43,6 +45,25 @@ function groupEligibleSuggestionsByUrl(suggestions, Suggestion) {
 }
 
 /**
+ * Normalizes a single Mystique-generated prompt into the legacy, minimal shape used
+ * by existing TOC suggestion data (e.g. CrowdStrike): {id, origin, prompt, source,
+ * regions}. Mystique's current PromptItem schema adds type/topic/category/reasoning/
+ * supporting_evidence and sets its own origin/source values, but TOC intentionally
+ * keeps the older, narrower field set rather than adopting the richer shape.
+ * @param {Object} prompt - Raw prompt object from Mystique
+ * @returns {Object} Normalized prompt: {id, origin: "ai", prompt, source: "config", regions}
+ */
+function normalizeTocPrompt(prompt) {
+  return {
+    id: prompt?.id,
+    origin: 'ai',
+    prompt: prompt?.prompt,
+    source: 'config',
+    regions: Array.isArray(prompt?.regions) ? prompt.regions : [],
+  };
+}
+
+/**
  * Handles the Mystique guidance:table-of-contents callback and persists the generated
  * Impact Engine prompts back onto their matching TOC suggestions.
  * @param {Object} message - Message from Mystique with generated prompts
@@ -51,11 +72,18 @@ function groupEligibleSuggestionsByUrl(suggestions, Suggestion) {
  */
 export default async function handler(message, context) {
   const { log, dataAccess } = context;
+  // Suggestion here is the request-scoped data-access collection (used below for
+  // saveMany persistence) — it does not carry the static STATUSES map, so
+  // groupEligibleSuggestionsByUrl uses the Suggestion class imported above instead.
   const {
-    Site, Audit, Opportunity, Suggestion,
+    Site, Audit, Opportunity, Suggestion: SuggestionCollection,
   } = dataAccess;
   const { siteId, auditId, data } = message;
-  const { opportunityId, suggestions } = data || {};
+  // Mystique's reply serializes `data` without applying its camelCase alias generator
+  // (a bug on Mystique's side), so opportunityId currently arrives as opportunity_id.
+  // Accept either casing so this keeps working regardless of which side ends up fixed.
+  const opportunityId = data?.opportunityId ?? data?.opportunity_id;
+  const { suggestions } = data || {};
 
   log.debug(`[TOC Guidance] Message received in TOC guidance handler: ${JSON.stringify(message, null, 2)}`);
 
@@ -97,7 +125,8 @@ export default async function handler(message, context) {
 
   const toSave = [];
   suggestions.forEach((promptResult) => {
-    const { url, prompts, hasPrompts } = promptResult;
+    const { url, prompts } = promptResult;
+    const hasPrompts = promptResult.hasPrompts ?? promptResult.has_prompts;
     const matches = eligibleByUrl.get(url);
 
     if (!matches || matches.length === 0) {
@@ -105,7 +134,7 @@ export default async function handler(message, context) {
       return;
     }
 
-    const promptsArray = Array.isArray(prompts) ? prompts : [];
+    const promptsArray = (Array.isArray(prompts) ? prompts : []).map(normalizeTocPrompt);
 
     matches.forEach((suggestion) => {
       const updatedData = {
@@ -119,7 +148,7 @@ export default async function handler(message, context) {
   });
 
   if (toSave.length > 0) {
-    await Suggestion.saveMany(toSave);
+    await SuggestionCollection.saveMany(toSave);
   }
 
   log.info(`[TOC Guidance] Successfully updated ${toSave.length} suggestion(s) with Mystique prompts for opportunityId=${opportunityId}`);

--- a/src/toc/guidance-handler.js
+++ b/src/toc/guidance-handler.js
@@ -126,7 +126,6 @@ export default async function handler(message, context) {
   const toSave = [];
   suggestions.forEach((promptResult) => {
     const { url, prompts } = promptResult;
-    const hasPrompts = promptResult.hasPrompts ?? promptResult.has_prompts;
     const matches = eligibleByUrl.get(url);
 
     if (!matches || matches.length === 0) {
@@ -137,10 +136,18 @@ export default async function handler(message, context) {
     const promptsArray = (Array.isArray(prompts) ? prompts : []).map(normalizeTocPrompt);
 
     matches.forEach((suggestion) => {
+      const existingData = suggestion.getData();
+      // Mystique replies with prompts:[] for a suggestion it skipped regenerating
+      // (audit-worker never forwards existing prompt content in the outbound
+      // request, only a hasPrompts flag, so Mystique has no prompts to echo back).
+      // Preserve whatever real prompts the suggestion already has in that case,
+      // instead of wiping them — and derive hasPrompts from the final array only,
+      // never from Mystique's echoed flag, so it can't desync from the data again.
+      const finalPrompts = promptsArray.length > 0 ? promptsArray : (existingData?.prompts ?? []);
       const updatedData = {
-        ...suggestion.getData(),
-        prompts: promptsArray,
-        hasPrompts: !!hasPrompts || promptsArray.length > 0,
+        ...existingData,
+        prompts: finalPrompts,
+        hasPrompts: finalPrompts.length > 0,
       };
       suggestion.setData(updatedData);
       toSave.push(suggestion);

--- a/src/toc/handler.js
+++ b/src/toc/handler.js
@@ -410,7 +410,12 @@ async function sendTocGuidanceRequestToMystique(
         url: data?.url || '',
         title: data?.title || '',
         headings,
-        hasPrompts: !!(data?.hasPrompts || (data?.prompts?.length > 0)),
+        // Derive from the actual prompts array rather than the stored hasPrompts flag,
+        // which can desync from it (e.g. a suggestion left with hasPrompts:true and
+        // prompts:[] after a prior Mystique reply carried no prompts). Checking the
+        // array directly makes that state self-healing: it's re-sent to Mystique for
+        // another attempt instead of being permanently skipped.
+        hasPrompts: (data?.prompts?.length ?? 0) > 0,
       });
     });
 

--- a/src/toc/handler.js
+++ b/src/toc/handler.js
@@ -398,7 +398,10 @@ async function sendTocGuidanceRequestToMystique(
 
       const suggestionId = s.getId();
       const hastNodes = data?.transformRules?.value;
-      const headings = Array.isArray(hastNodes)
+      // hastNodes is normally a HAST root node (`{ type: 'root', children: [...] }`),
+      // not a bare array — extractHeadingTextsFromHast already handles both shapes
+      // (and null), so gate on truthiness rather than Array.isArray.
+      const headings = hastNodes
         ? [...new Set(extractHeadingTextsFromHast(hastNodes))]
         : [];
 

--- a/test/audits/toc.test.js
+++ b/test/audits/toc.test.js
@@ -1485,10 +1485,17 @@ describe('TOC (Table of Contents) Audit', () => {
       expect(message.data.siteRegion).to.equal('');
     });
 
-    it('derives per-candidate url/title defaults and hasPrompts across edge-case suggestion shapes', async () => {
+    it('derives per-candidate url/title defaults and hasPrompts from prompts.length, not the stored flag (LLMO-6167)', async () => {
       const convertToOpportunityStub = setupMystiqueContext([
         makeExistingSuggestion({}),
+        // Corrupted state: hasPrompts:true but prompts:[] (e.g. left behind by a prior
+        // Mystique reply that carried no prompts). hasPrompts must be derived from
+        // prompts.length alone so this suggestion is re-sent to Mystique for another
+        // attempt, rather than being permanently skipped because the stale flag says
+        // "already has prompts".
         makeExistingSuggestion({ url: 'https://example.com/u2', hasPrompts: true, prompts: [] }),
+        // Flag missing/unset but real prompts present — must still resolve to true from
+        // the array alone.
         makeExistingSuggestion({ url: 'https://example.com/u3', prompts: [{ id: 'p1' }] }),
       ]);
 
@@ -1512,7 +1519,7 @@ describe('TOC (Table of Contents) Audit', () => {
       const [candidate1, candidate2, candidate3] = message.data.suggestions;
 
       expect(candidate1).to.include({ url: '', title: '', hasPrompts: false });
-      expect(candidate2.hasPrompts).to.equal(true);
+      expect(candidate2.hasPrompts).to.equal(false);
       expect(candidate3.hasPrompts).to.equal(true);
     });
   });

--- a/test/audits/toc.test.js
+++ b/test/audits/toc.test.js
@@ -1038,6 +1038,58 @@ describe('TOC (Table of Contents) Audit', () => {
       expect(message.data.suggestions[0].headings).to.deep.equal(['Introduction']);
     });
 
+    it('extracts headings when transformRules.value is a HAST root node (real shape stored by the API), not a bare array (LLMO-6167)', async () => {
+      const convertToOpportunityStub = setupMystiqueContext([
+        makeExistingSuggestion({
+          url: 'https://example.com/page1',
+          title: 'Page 1',
+          transformRules: {
+            value: {
+              type: 'root',
+              children: [{
+                type: 'element',
+                tagName: 'nav',
+                children: [{
+                  type: 'element',
+                  tagName: 'ul',
+                  children: [{
+                    type: 'element',
+                    tagName: 'li',
+                    children: [{
+                      type: 'element',
+                      tagName: 'a',
+                      properties: { 'data-selector': 'h1#intro' },
+                      children: [{ type: 'text', value: 'Introduction' }],
+                    }],
+                  }],
+                }],
+              }],
+            },
+          },
+        }),
+      ]);
+
+      const mockedHandler = await esmock('../../src/toc/handler.js', {
+        '../../src/common/opportunity.js': { convertToOpportunity: convertToOpportunityStub },
+        '../../src/utils/data-access.js': { syncSuggestions: sinon.stub().resolves() },
+      });
+
+      const auditUrl = 'https://example.com';
+      const auditData = {
+        suggestions: {
+          toc: [{
+            type: 'CODE_CHANGE', checkType: 'toc', url: 'https://example.com/page1', explanation: 'x', recommendedAction: 'x',
+          }],
+        },
+      };
+
+      await mockedHandler.opportunityAndSuggestions(auditUrl, auditData, context);
+
+      expect(context.sqs.sendMessage).to.have.been.calledOnce;
+      const [, message] = context.sqs.sendMessage.getCall(0).args;
+      expect(message.data.suggestions[0].headings).to.deep.equal(['Introduction']);
+    });
+
     it('skips FIXED/OUTDATED/SKIPPED/edge-deployed suggestions, and no eligible suggestions remain', async () => {
       const convertToOpportunityStub = setupMystiqueContext([
         makeExistingSuggestion({ url: 'https://example.com/fixed' }, 'FIXED'),

--- a/test/audits/toc/guidance-handler.test.js
+++ b/test/audits/toc/guidance-handler.test.js
@@ -57,8 +57,11 @@ describe('TOC Guidance Handler', () => {
       Site: { findById: sinon.stub().resolves(siteStub) },
       Audit: { findById: sinon.stub().resolves(auditStub) },
       Opportunity: { findById: sinon.stub().resolves(opportunityStub) },
+      // Real dataAccess.Suggestion is the request-scoped collection — it does not carry
+      // the static STATUSES map (LLMO-6167), unlike this mock's previous shape. Kept
+      // deliberately minimal so a regression reintroducing a STATUSES read on this
+      // object fails loudly instead of being silently tolerated by an inaccurate mock.
       Suggestion: {
-        STATUSES: SuggestionDataAccess.STATUSES,
         saveMany: sinon.stub().resolves(),
       },
     };
@@ -75,7 +78,21 @@ describe('TOC Guidance Handler', () => {
             url: 'https://example.com/page1',
             title: 'Page 1',
             headings: ['Intro', 'Details'],
-            prompts: [{ id: 'p1', prompt: 'What is X?', type: 'Non-Branded' }],
+            // Realistic shape of a raw Mystique PromptItem: richer fields
+            // (type/topic/category/reasoning/supporting_evidence) plus its own
+            // origin/source values — none of which TOC persists (LLMO-6167).
+            prompts: [{
+              id: 'p1',
+              prompt: 'What is X?',
+              type: 'Non-Branded',
+              topic: 'some topic',
+              category: 'Informational',
+              reasoning: 'because reasons',
+              supporting_evidence: 'quoted heading text',
+              origin: 'TOC-grounded',
+              source: 'TABLE OF CONTENTS',
+              regions: ['US'],
+            }],
             hasPrompts: true,
           },
         ],
@@ -87,7 +104,7 @@ describe('TOC Guidance Handler', () => {
     sinon.restore();
   });
 
-  it('should persist prompts onto the matching suggestion by URL', async () => {
+  it('should persist prompts onto the matching suggestion by URL, normalized to the legacy minimal shape', async () => {
     const result = await handler(message, context);
 
     expect(result.status).to.equal(ok().status);
@@ -99,10 +116,29 @@ describe('TOC Guidance Handler', () => {
     expect(saved.setData).to.have.been.calledWith(sinon.match({
       url: 'https://example.com/page1',
       checkType: 'missing-toc',
-      prompts: [{ id: 'p1', prompt: 'What is X?', type: 'Non-Branded' }],
+      prompts: [{
+        id: 'p1', origin: 'ai', prompt: 'What is X?', source: 'config', regions: ['US'],
+      }],
       hasPrompts: true,
     }));
     expect(logStub.info).to.have.been.calledWith(sinon.match(/Successfully updated 1 suggestion/));
+  });
+
+  it('strips Mystique\'s richer PromptItem fields and normalizes origin/source (LLMO-6167)', async () => {
+    const result = await handler(message, context);
+
+    expect(result.status).to.equal(ok().status);
+    const [saved] = dataAccessStub.Suggestion.saveMany.getCall(0).args[0];
+    const [savedCall] = saved.setData.getCall(0).args;
+    const [savedPrompt] = savedCall.prompts;
+    expect(savedPrompt).to.deep.equal({
+      id: 'p1', origin: 'ai', prompt: 'What is X?', source: 'config', regions: ['US'],
+    });
+    expect(savedPrompt).to.not.have.property('type');
+    expect(savedPrompt).to.not.have.property('topic');
+    expect(savedPrompt).to.not.have.property('category');
+    expect(savedPrompt).to.not.have.property('reasoning');
+    expect(savedPrompt).to.not.have.property('supporting_evidence');
   });
 
   it('should apply the same prompts to every non-terminal suggestion sharing a URL', async () => {
@@ -147,6 +183,36 @@ describe('TOC Guidance Handler', () => {
     expect(saved.setData).to.have.been.calledWith(sinon.match({
       prompts: [],
       hasPrompts: false,
+    }));
+  });
+
+  it('resolves opportunityId and hasPrompts from Mystique\'s actual snake_case reply shape (LLMO-6167)', async () => {
+    message.data = {
+      opportunity_id: 'opp-123',
+      suggestions: [
+        {
+          url: 'https://example.com/page1',
+          title: 'Page 1',
+          headings: ['Intro', 'Details'],
+          prompts: [{
+            id: 'p1', prompt: 'What is X?', type: 'Non-Branded', origin: 'TOC-grounded', source: 'TABLE OF CONTENTS',
+          }],
+          has_prompts: true,
+        },
+      ],
+    };
+
+    const result = await handler(message, context);
+
+    expect(result.status).to.equal(ok().status);
+    expect(dataAccessStub.Opportunity.findById).to.have.been.calledWith('opp-123');
+    expect(dataAccessStub.Suggestion.saveMany).to.have.been.calledOnce;
+    const [saved] = dataAccessStub.Suggestion.saveMany.getCall(0).args[0];
+    expect(saved.setData).to.have.been.calledWith(sinon.match({
+      prompts: [{
+        id: 'p1', origin: 'ai', prompt: 'What is X?', source: 'config', regions: [],
+      }],
+      hasPrompts: true,
     }));
   });
 

--- a/test/audits/toc/guidance-handler.test.js
+++ b/test/audits/toc/guidance-handler.test.js
@@ -186,6 +186,78 @@ describe('TOC Guidance Handler', () => {
     }));
   });
 
+  it('preserves existing real prompts when Mystique skips regeneration and replies with an empty prompts array (LLMO-6167)', async () => {
+    const existingPrompts = [{
+      id: 'existing-1', origin: 'ai', prompt: 'Existing real prompt', source: 'config', regions: ['US'],
+    }];
+    opportunityStub.getSuggestions.resolves([
+      makeSuggestion({
+        url: 'https://example.com/page1', checkType: 'missing-toc', prompts: existingPrompts, hasPrompts: true,
+      }),
+    ]);
+    // Mystique's actual behavior for an already-prompted suggestion: it never received
+    // the real prompt content in the request (audit-worker only forwards a hasPrompts
+    // flag), so when it skips regeneration it can only reply with an empty array.
+    message.data.suggestions = [
+      { url: 'https://example.com/page1', prompts: [], hasPrompts: true },
+    ];
+
+    const result = await handler(message, context);
+
+    expect(result.status).to.equal(ok().status);
+    const [saved] = dataAccessStub.Suggestion.saveMany.getCall(0).args[0];
+    expect(saved.setData).to.have.been.calledWith(sinon.match({
+      prompts: existingPrompts,
+      hasPrompts: true,
+    }));
+  });
+
+  it('replaces existing prompts wholesale when Mystique sends a fresh non-empty prompts array', async () => {
+    const existingPrompts = [{
+      id: 'existing-1', origin: 'ai', prompt: 'Old prompt', source: 'config', regions: ['US'],
+    }];
+    opportunityStub.getSuggestions.resolves([
+      makeSuggestion({
+        url: 'https://example.com/page1', checkType: 'missing-toc', prompts: existingPrompts, hasPrompts: true,
+      }),
+    ]);
+    message.data.suggestions = [
+      { url: 'https://example.com/page1', prompts: [{ id: 'new-1', prompt: 'New prompt' }], hasPrompts: true },
+    ];
+
+    const result = await handler(message, context);
+
+    expect(result.status).to.equal(ok().status);
+    const [saved] = dataAccessStub.Suggestion.saveMany.getCall(0).args[0];
+    expect(saved.setData).to.have.been.calledWith(sinon.match({
+      prompts: [{
+        id: 'new-1', origin: 'ai', prompt: 'New prompt', source: 'config', regions: [],
+      }],
+      hasPrompts: true,
+    }));
+  });
+
+  it('derives hasPrompts from the final prompts array only, ignoring Mystique\'s echoed flag', async () => {
+    opportunityStub.getSuggestions.resolves([
+      makeSuggestion({ url: 'https://example.com/page1', checkType: 'missing-toc' }),
+    ]);
+    // Mystique claims hasPrompts:true but sends no prompts and there's nothing existing
+    // to preserve — the persisted hasPrompts must reflect the real (empty) result, not
+    // the claim, so the suggestion isn't left in a false "has prompts" state.
+    message.data.suggestions = [
+      { url: 'https://example.com/page1', prompts: [], hasPrompts: true },
+    ];
+
+    const result = await handler(message, context);
+
+    expect(result.status).to.equal(ok().status);
+    const [saved] = dataAccessStub.Suggestion.saveMany.getCall(0).args[0];
+    expect(saved.setData).to.have.been.calledWith(sinon.match({
+      prompts: [],
+      hasPrompts: false,
+    }));
+  });
+
   it('resolves opportunityId and hasPrompts from Mystique\'s actual snake_case reply shape (LLMO-6167)', async () => {
     message.data = {
       opportunity_id: 'opp-123',


### PR DESCRIPTION
## Summary

Four independent bugs prevented the TOC `guidance:table-of-contents` pipeline from ever completing successfully end-to-end — each one masked the next until fixed, so no real production TOC audit has ever successfully round-tripped through Mystique and back.

1. **`src/toc/handler.js`** — the headings guard `Array.isArray(hastNodes)` rejected the real HAST root-node shape (`{type: 'root', children: [...]}`) that `transformRules.value` actually stores. Headings sent to Mystique were therefore always empty, so Mystique's crew correctly (per its own instructions) returned empty prompts for every suggestion in every real audit run.
2. **`src/toc/guidance-handler.js`** — destructured `opportunityId`/`hasPrompts` in camelCase, but Mystique's reply nests them in `data` as snake_case (`opportunity_id`/`has_prompts`). `Opportunity.findById(undefined)` threw a validation error on every real Mystique reply.
3. **`src/toc/guidance-handler.js`** — read `Suggestion.STATUSES` off the request-scoped `dataAccess.Suggestion` collection, which doesn't carry that static map (unlike the class imported directly from `@adobe/spacecat-shared-data-access`, which `handler.js` already does correctly for the outbound side). Crashed with `Cannot read properties of undefined (reading 'FIXED')` the first time a real message got past bug #2.
4. **`src/toc/guidance-handler.js`** — persisted Mystique's prompts as-is, including its newer `PromptItem` fields (`type`/`topic`/`category`/`reasoning`/`supporting_evidence`) and non-standard `origin`/`source` values (`"TOC-grounded"`/`"TABLE OF CONTENTS"`). Normalized to the existing suggestion data convention used elsewhere: `{id, origin: "ai", prompt, source: "config", regions}`.

## Test plan

- [x] Each bug reproduced locally first (confirmed failing on unfixed code with a realistic input matching the real message shape), then confirmed fixed.
- [x] Added regression tests for all 4 fixes in `test/audits/toc.test.js` and `test/audits/toc/guidance-handler.test.js`.
- [x] Full `toc.test.js` + `guidance-handler.test.js` suite: 214 passing, 0 failing.
- [x] **Full live end-to-end verification** against a real dev SpaceCat opportunity with real scraped headings and a real `Audit` record: triggered via `mode:ai-only generatePrompts:true` → `spacecat-audit-worker` sent real headings to Mystique → Mystique generated real CrewAI prompts → `guidance-handler.js` wrote them back onto the suggestions with the correct `{id, origin, prompt, source, regions}` shape, `hasPrompts: true`, no errors. Verified directly via the SpaceCat API on the persisted suggestion data.

Related: LLMO-6167 (this closes out the audit-worker side of the same TOC ai-only prompt-generation feature; the companion Mystique-side fix — `TocOpportunityData` missing from the `Opportunity.data` Pydantic union — is in `mystique` PR #3394, already merged).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>