### PR TITLE
TOC audit: respect edgeOptimizeStatus = EXPERIMENT_IN_PROGRESS (LLMO-6168)

### DIFF
--- a/src/toc/handler.js
+++ b/src/toc/handler.js
@@ -707,8 +707,10 @@ export async function opportunityAndSuggestions(auditUrl, auditData, context) {
   );
 
   const mergeDataFunction = (existingSuggestion, newSuggestion) => {
-    // Do not overwrite data for suggestions already deployed to the edge CDN
-    if (existingSuggestion.edgeDeployed) {
+    // Do not overwrite data for suggestions already deployed to the edge CDN, or mid-IVE
+    // geo-experiment (edgeOptimizeStatus is set before edgeDeployed) (LLMO-6168)
+    if (existingSuggestion.edgeDeployed
+      || existingSuggestion.edgeOptimizeStatus === 'EXPERIMENT_IN_PROGRESS') {
       return { ...existingSuggestion };
     }
     const converted = { ...newSuggestion };

--- a/src/utils/data-access.js
+++ b/src/utils/data-access.js
@@ -277,6 +277,10 @@ export const handleOutdatedSuggestions = async ({
         || data?.edgeDeployed
         || data?.coveredByDomainWide
         || data?.isDomainWide
+        // Preserve suggestions mid-IVE geo-experiment: edgeOptimizeStatus is set before
+        // edgeDeployed, so without this a suggestion the audit no longer detects an issue
+        // for could flip to OUTDATED while its experiment is still running (LLMO-6168).
+        || data?.edgeOptimizeStatus === 'EXPERIMENT_IN_PROGRESS'
         // Preserve externally / manually-authored suggestions. Records published
         // through the backoffice write path (e.g. cwv-workbench guidance) live on
         // the shared audit-owned opportunity but are NOT part of THIS audit's

--- a/test/audits/toc.test.js
+++ b/test/audits/toc.test.js
@@ -2538,6 +2538,63 @@ describe('TOC (Table of Contents) Audit', () => {
       expect(merged.isEdited).to.equal(true);
     });
 
+    it('returns existing suggestion unchanged when edgeOptimizeStatus is EXPERIMENT_IN_PROGRESS (LLMO-6168)', async () => {
+      const convertToOpportunityStub = sinon.stub().resolves({
+        getId: () => 'test-opportunity-id',
+      });
+
+      let capturedMergeDataFunction;
+      const syncSuggestionsStub = sinon.stub().callsFake((args) => {
+        capturedMergeDataFunction = args.mergeDataFunction;
+        return Promise.resolve();
+      });
+
+      const mockedHandler = await esmock('../../src/toc/handler.js', {
+        '../../src/common/opportunity.js': {
+          convertToOpportunity: convertToOpportunityStub,
+        },
+        '../../src/utils/data-access.js': {
+          syncSuggestions: syncSuggestionsStub,
+        },
+      });
+
+      const auditUrl = 'https://example.com';
+      const auditData = {
+        suggestions: {
+          toc: [{
+            type: 'CODE_CHANGE',
+            checkType: 'toc',
+            url: 'https://example.com/page1',
+          }],
+        },
+      };
+
+      await mockedHandler.opportunityAndSuggestions(auditUrl, auditData, context);
+
+      const existingSuggestion = {
+        url: 'https://example.com/page1',
+        isEdited: true,
+        edgeOptimizeStatus: 'EXPERIMENT_IN_PROGRESS',
+        transformRules: {
+          value: [{ text: 'Experiment Title', level: 1 }],
+        },
+      };
+      const newSuggestion = {
+        url: 'https://example.com/page1',
+        transformRules: {
+          value: [{ text: 'New Audit Title', level: 1 }],
+        },
+      };
+
+      const merged = capturedMergeDataFunction(existingSuggestion, newSuggestion);
+
+      // Must return existing data unchanged — a suggestion mid-IVE-experiment must not be
+      // clobbered by a subsequent audit run, even before edgeDeployed is set
+      expect(merged.edgeOptimizeStatus).to.equal('EXPERIMENT_IN_PROGRESS');
+      expect(merged.transformRules.value).to.deep.equal([{ text: 'Experiment Title', level: 1 }]);
+      expect(merged.isEdited).to.equal(true);
+    });
+
     it('preserves Mystique-persisted prompts across re-audits when the new suggestion has none', async () => {
       const convertToOpportunityStub = sinon.stub().resolves({
         getId: () => 'test-opportunity-id',

--- a/test/utils/data-access.test.js
+++ b/test/utils/data-access.test.js
@@ -1463,6 +1463,56 @@ describe('data-access', () => {
       expect(mockLogger.info).to.have.been.calledWith('[SuggestionSync] Final count of suggestions to mark as OUTDATED: 1');
     });
 
+    it('should not mark suggestions mid-IVE-experiment as OUTDATED (LLMO-6168)', async () => {
+      const buildKeyWithUrl = (data) => `${data.url}|${data.key}`;
+
+      const existingSuggestions = [
+        {
+          id: '1',
+          data: {
+            url: 'https://example.com/page1', key: 'page1', edgeOptimizeStatus: 'EXPERIMENT_IN_PROGRESS',
+          },
+          getId: sinon.stub().returns('1'),
+          getData: sinon.stub().returns({
+            url: 'https://example.com/page1', key: 'page1', edgeOptimizeStatus: 'EXPERIMENT_IN_PROGRESS',
+          }),
+          getStatus: sinon.stub().returns('NEW'),
+        },
+        {
+          id: '2',
+          data: { url: 'https://example.com/page2', key: 'page2' },
+          getId: sinon.stub().returns('2'),
+          getData: sinon.stub().returns({ url: 'https://example.com/page2', key: 'page2' }),
+          getStatus: sinon.stub().returns('NEW'),
+        },
+      ];
+
+      const newData = [{ url: 'https://example.com/page3', key: 'page3' }];
+      const scrapedUrlsSet = new Set([
+        'https://example.com/page1',
+        'https://example.com/page2',
+        'https://example.com/page3',
+      ]);
+
+      mockOpportunity.getSuggestions.resolves(existingSuggestions);
+      mockOpportunity.addSuggestions.resolves({ errorItems: [], createdItems: newData });
+
+      await syncSuggestions({
+        opportunity: mockOpportunity,
+        newData,
+        context,
+        buildKey: buildKeyWithUrl,
+        mapNewSuggestion,
+        scrapedUrlsSet,
+      });
+
+      expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledOnceWith(
+        [existingSuggestions[1]],
+        'OUTDATED',
+      );
+      expect(mockLogger.info).to.have.been.calledWith('[SuggestionSync] Final count of suggestions to mark as OUTDATED: 1');
+    });
+
     it('should not mark prerender domain-wide or covered suggestions as OUTDATED', async () => {
       const buildKeyWithUrl = (data) => `${data.url}|${data.key ?? ''}`;
 


### PR DESCRIPTION
## Summary
- `mergeDataFunction` in the TOC audit now preserves existing suggestion data when `edgeOptimizeStatus === 'EXPERIMENT_IN_PROGRESS'`, same as it already does for `edgeDeployed`, so a suggestion mid-IVE-experiment isn't clobbered by a subsequent audit run.
- The shared `handleOutdatedSuggestions` filter (used by TOC and prerender via `syncSuggestions`) now also excludes `EXPERIMENT_IN_PROGRESS` suggestions from being marked `OUTDATED`.

Jira: https://jira.corp.adobe.com/browse/LLMO-6168

## Test plan
- [x] Added unit test for `mergeDataFunction` returning existing data unchanged when `edgeOptimizeStatus` is `EXPERIMENT_IN_PROGRESS`
- [x] Added unit test for `handleOutdatedSuggestions` preserving a suggestion mid-experiment while still marking an unrelated stale suggestion `OUTDATED`
- [x] `npm run test:spec -- test/audits/toc.test.js test/utils/data-access.test.js` — all passing
- [x] `npx eslint` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)