### PR TITLE
feat(cdn-logs-report): generate referral URL categories for sites without CDN logs | LLMO-6257

### DIFF
--- a/docs/specs/2026-07-15-referral-category-generation.md
+++ b/docs/specs/2026-07-15-referral-category-generation.md
@@ -1,0 +1,130 @@
+# Referral Category Generation for Sites Without CDN Logs
+
+| Field | Value |
+|-------|-------|
+| **Status** | Proposed |
+| **Author** | Omair Temurian |
+| **Created** | 2026-07-15 |
+| **Jira** | [LLMO-6257](https://jira.corp.adobe.com/browse/LLMO-6257) (epic LLMO-5440) |
+
+---
+
+## Summary
+
+Extends the `cdn-logs-report` audit so sites whose referral data comes **only** from
+non-CDN sources (optel / GA4 / Adobe Analytics / CJA — stored in the
+`mysticat-data-service` Postgres, not Athena) still get URL **category** classifications.
+It reuses the existing CDN category-generation machinery (`analyzeProducts` → merge →
+`wrpc_replace_agentic_url_classification_rules`), but sources the URL corpus from Postgres
+and materializes the rules onto referral URLs via a new data-service RPC. The
+classification sink (`agentic_url_classifications`) is unchanged, so the shipped Referral
+Traffic category read-filter (LLMO-6025/6/7) works with zero read-side changes.
+
+---
+
+## Problem Statement
+
+The Referral Traffic category filter resolves category by joining referral rows to
+`agentic_url_classifications`. That table is populated **only** by the `cdn-logs-report`
+audit, whose entire URL corpus comes from Athena (CDN access logs). A site with referral
+data only from non-CDN sources therefore has no corpus → `analyzeProducts` never runs →
+no rules → no classifications → the category dropdown shows only "All".
+
+---
+
+## Goals
+
+1. Referral-only sites (no CDN logs) get category rules generated and
+   `agentic_url_classifications` rows materialized.
+2. Reuse the existing category-generation logic; only the URL-corpus source changes.
+3. No read-side changes — the shipped category filter just works once data exists.
+4. Do not double-process CDN-covered sites (their agentic path already generates rules).
+5. Best-effort and non-blocking: a failure never breaks the daily exports.
+
+---
+
+## Technical Design
+
+### Data-service (mysticat-data-service, LLMO-6257 companion)
+
+Two RPCs (migration `20260715150742_referral_category_apply_rpc.sql`):
+
+- `rpc_referral_traffic_top_urls(p_site_id, p_since, p_limit)` — read RPC returning a
+  site's top distinct referral `url_path`s ranked by summed pageviews across all referral
+  sources. The Postgres analogue of the CDN Athena top-URLs query.
+- `wrpc_apply_category_rules_to_referral(p_site_id, p_source, p_since, p_updated_by)` —
+  write RPC that applies the site's active `agentic_url_category_rules` to its referral
+  URLs and upserts `category_name` into `agentic_url_classifications`
+  (`(site_id, host, url_path)`, preserving region/page_type/content_type).
+
+### Audit-worker
+
+New step in `runCdnLogsReport`, gated to no-CDN sites (`hasCdnData` is computed once and
+shared with the agentic step). Flow:
+
+```mermaid
+flowchart TD
+    A[cdn-logs-report audit] --> B{hasCdnData?}
+    B -- yes --> S[skip: agentic path covers it]
+    B -- no --> C[fetchReferralTopUrls → paths]
+    C --> D{paths empty?}
+    D -- yes --> S2[skip: no referral data]
+    D -- no --> E[fetchAgenticUrlClassificationRules]
+    E --> F{existing product rules?}
+    F -- yes --> G[reuse, skip LLM]
+    F -- no --> H[analyzeProducts → regexes]
+    G --> I[mergePatternRules]
+    H --> I
+    I --> J[replaceAgenticUrlClassificationRules\ncategory rules; page-type rules preserved]
+    J --> K[applyCategoryRulesToReferral\n→ agentic_url_classifications]
+```
+
+New functions:
+- `report-utils.js`: `fetchReferralTopUrls`, `applyCategoryRulesToReferral` (thin wrappers
+  over the two RPCs via `context.dataAccess.services.postgrestClient`, siblings of the
+  existing `replaceAgenticUrlClassificationRules`).
+- `patterns-uploader.js`: `generateReferralPatternsWorkbook` — reuses `analyzeProducts` +
+  the module's `mergePatternRules` + `replaceAgenticUrlClassificationRules`, then calls
+  `applyCategoryRulesToReferral`. Only category rules are (re)generated; existing
+  page-type rules are preserved.
+- `handler.js`: `generateReferralPatterns` — best-effort wrapper (own try/catch), gated on
+  `hasCdnData`.
+
+### Decisions
+
+- **Sink reuse** — writes to `agentic_url_classifications` (no new table), so reads are unchanged.
+- **Reuse over regenerate** — existing product rules short-circuit the LLM, so re-runs
+  don't churn customer-tuned categories or re-incur LLM cost.
+- **Region-agnostic MVP** — classifications written with `region=''`; per-region is a follow-up.
+- **`source='ai'`** — auto-derived rules carry the same customer-edit metadata as CDN-derived rules.
+
+---
+
+## Alternatives Considered
+
+- **Loop `rpc_referral_traffic_by_url` per source and merge in JS** — rejected: that RPC is
+  single-source and returns heavy paginated rows; merging across 4 sources is non-trivial
+  new code. A dedicated `rpc_referral_traffic_top_urls` does the ranking/dedup server-side
+  in one call.
+- **New classification table for referral** — rejected: would require read-side changes;
+  reusing `agentic_url_classifications` keeps the read filter untouched.
+
+---
+
+## Success Criteria
+
+1. A referral-only site with configured referral data gets category rules generated and
+   `agentic_url_classifications` rows materialized.
+2. The existing Referral Traffic category dropdown populates for that site with no
+   read-side changes.
+3. CDN-covered sites are not double-processed.
+4. A referral-generation failure is logged and never blocks the daily exports.
+5. 100% test coverage on all new/changed source.
+
+---
+
+## Open Items / Follow-ups
+
+- **Precedence** when a site later gains CDN traffic (human > CDN-derived > referral-derived).
+- **Region fidelity** for multi-region sites (region-agnostic MVP may under-serve them).
+- **LLM cost gating** if the no-CDN cohort grows large.

--- a/src/cdn-logs-report/handler.js
+++ b/src/cdn-logs-report/handler.js
@@ -23,7 +23,7 @@ import {
 } from '../utils/cdn-utils.js';
 import { wwwUrlResolver } from '../common/base-audit.js';
 import { getConfigs } from './constants/report-configs.js';
-import { generatePatternsWorkbook } from './patterns/patterns-uploader.js';
+import { generatePatternsWorkbook, generateReferralPatternsWorkbook } from './patterns/patterns-uploader.js';
 import { runAgenticDbExports } from './utils/agentic-db-export.js';
 import { runDailyReferralExport } from './referral-daily-export.js';
 import { getPreviousUtcDate } from './agentic-daily-export.js';
@@ -53,11 +53,11 @@ function resolvePatternPeriods(auditContext) {
 async function generateAgenticPatterns({
   site,
   context,
-  s3Client,
   athenaClient,
   s3Config,
   agenticReportConfig,
   auditContext,
+  hasCdnData,
 }) {
   const { log } = context;
 
@@ -67,7 +67,7 @@ async function generateAgenticPatterns({
   }
 
   try {
-    if (!(await pathHasData(s3Client, agenticReportConfig.aggregatedLocation))) {
+    if (!hasCdnData) {
       log.info('No agentic report data found - skipping patterns generation');
       return;
     }
@@ -144,6 +144,32 @@ async function runReferralExport({
   }
 }
 
+/**
+ * Generates category classification rules for sites without CDN logs, sourcing the
+ * URL corpus from Postgres referral tables instead of Athena (LLMO-6257). Best-effort:
+ * a failure here must not block the daily exports. Skips sites that have CDN report
+ * data — the agentic path already generates their rules, so re-running the LLM here
+ * would be wasted work.
+ */
+async function generateReferralPatterns({
+  site,
+  context,
+  hasCdnData,
+}) {
+  const { log } = context;
+
+  try {
+    if (hasCdnData) {
+      log.info('CDN report data present - skipping referral pattern generation');
+      return;
+    }
+
+    await generateReferralPatternsWorkbook({ site, context });
+  } catch (error) {
+    log.error(`Referral patterns generation failed for ${site.getId()}: ${error.message}`, error);
+  }
+}
+
 async function runCdnLogsReport(url, context, site, auditContext) {
   const { log } = context;
 
@@ -163,15 +189,22 @@ async function runCdnLogsReport(url, context, site, auditContext) {
   const agenticReportConfig = reportConfigs.find((config) => config.name === 'agentic');
   const referralReportConfig = reportConfigs.find((config) => config.name === 'referral');
 
+  // Whether this site has CDN report data — computed once and shared. The agentic
+  // pattern step needs it (CDN logs are its corpus); the referral step is its inverse
+  // (referral-only sites have no CDN logs, so they generate categories from Postgres).
+  const hasCdnData = agenticReportConfig
+    ? await pathHasData(s3Client, agenticReportConfig.aggregatedLocation)
+    : false;
+
   // 1. Ensure agentic classification rules exist in the DB (generate only if missing).
   await generateAgenticPatterns({
     site,
     context,
-    s3Client,
     athenaClient,
     s3Config,
     agenticReportConfig,
     auditContext,
+    hasCdnData,
   });
 
   // 2. Daily agentic export — feeds PostgreSQL.
@@ -194,7 +227,14 @@ async function runCdnLogsReport(url, context, site, auditContext) {
     auditContext,
   });
 
-  // 4. Assemble the audit result from the DB export outcomes.
+  // 4. Generate referral category rules for sites without CDN logs (best-effort).
+  await generateReferralPatterns({
+    site,
+    context,
+    hasCdnData,
+  });
+
+  // 5. Assemble the audit result from the DB export outcomes.
   const auditResult = [];
   if (agenticDbExportResult.dailyAgenticExport?.batchId) {
     auditResult.push({

--- a/src/cdn-logs-report/patterns/patterns-uploader.js
+++ b/src/cdn-logs-report/patterns/patterns-uploader.js
@@ -12,7 +12,12 @@
 import { analyzeProducts } from './product-analysis.js';
 import { analyzePageTypes } from './page-type-analysis.js';
 import { weeklyBreakdownQueries } from '../utils/query-builder.js';
-import { replaceAgenticUrlClassificationRules } from '../utils/report-utils.js';
+import {
+  replaceAgenticUrlClassificationRules,
+  fetchReferralTopUrls,
+  applyCategoryRulesToReferral,
+} from '../utils/report-utils.js';
+import { fetchAgenticUrlClassificationRules } from '../../common/agentic-url-classification-rules.js';
 
 const SAMPLE_URLS_CAP = 20;
 // sample_urls clamp — a bad element aborts the whole-site replace RPC batch.
@@ -231,4 +236,80 @@ export async function generatePatternsWorkbook(options) {
     log.error(`Failed to generate patterns: ${error.message}`);
     return false;
   }
+}
+
+/**
+ * Generates category classification rules for a site whose URL corpus lives in
+ * Postgres referral tables rather than CDN Athena logs (LLMO-6257). Mirrors
+ * `generatePatternsWorkbook` but sources paths from `fetchReferralTopUrls`, then
+ * reuses the same product LLM analysis + merge + whole-site replace RPC, and
+ * finally materializes the rules onto referral URLs via the apply RPC. Only
+ * category rules are (re)generated; existing page-type rules are preserved.
+ * Throws on data-service failure; the caller runs this best-effort.
+ */
+export async function generateReferralPatternsWorkbook({ site, context }) {
+  const { log } = context;
+
+  const paths = await fetchReferralTopUrls({ site, context });
+  if (paths.length === 0) {
+    log.info('No referral URLs found in DB - skipping referral pattern generation');
+    return false;
+  }
+  log.info(`Fetched ${paths.length} referral URLs for pattern generation`);
+
+  const existingPatterns = await fetchAgenticUrlClassificationRules(site, context);
+  if (existingPatterns?.error) {
+    log.info(`Skipping referral patterns for ${site.getId?.()}; DB rule fetch failed`);
+    return false;
+  }
+
+  const existingTopicPatterns = Array.isArray(existingPatterns?.topicPatterns)
+    ? existingPatterns.topicPatterns
+    : [];
+  const existingPagePatterns = Array.isArray(existingPatterns?.pagePatterns)
+    ? existingPatterns.pagePatterns
+    : [];
+
+  const domain = new URL(site.getBaseURL()).hostname;
+
+  // Reuse existing product rules when present so re-runs don't re-hit the LLM or
+  // churn customer-tuned categories.
+  const reusedExistingRules = existingTopicPatterns.length > 0;
+  let productRegexes = {};
+  if (reusedExistingRules) {
+    log.info('Reusing existing product patterns for referral generation');
+  } else {
+    productRegexes = await analyzeProducts(domain, paths, context);
+  }
+
+  const categoryRules = mergePatternRules(existingTopicPatterns, productRegexes, paths, log);
+  if (categoryRules.length === 0) {
+    log.warn('No referral category rules available after merge');
+    return false;
+  }
+
+  // Only (re)write rules when we generated fresh ones. On the reuse path the rules
+  // are already persisted (that is why existingTopicPatterns is non-empty); calling
+  // the whole-site replace RPC again would DELETE+INSERT daily, resetting
+  // created_by/created_at and hard-purging customer soft-deletes. The apply RPC
+  // reads rules straight from the table, so it does not depend on replace running.
+  if (!reusedExistingRules) {
+    await replaceAgenticUrlClassificationRules({
+      site,
+      context,
+      categoryRules,
+      pageTypeRules: existingPagePatterns,
+      updatedBy: 'audit-worker:referral-patterns',
+    });
+  }
+
+  const applyResult = await applyCategoryRulesToReferral({
+    site,
+    context,
+    updatedBy: 'audit-worker:referral-patterns',
+  });
+
+  log.info(`Synced referral category rules for site ${site.getId()}: ${categoryRules.length} rules, ${applyResult?.classified ?? 0} classifications`);
+
+  return true;
 }

--- a/src/cdn-logs-report/utils/report-utils.js
+++ b/src/cdn-logs-report/utils/report-utils.js
@@ -152,3 +152,72 @@ export async function replaceAgenticUrlClassificationRules({
 
   return Array.isArray(data) ? data[0] : data;
 }
+
+/**
+ * Fetches a site's top distinct referral url_paths (ranked by summed pageviews
+ * across all referral sources) via the read RPC. This is the Postgres analogue of
+ * the CDN Athena top-URLs query — the URL corpus fed to category-rule generation
+ * for referral-only sites (LLMO-6257). Returns a flat array of path strings.
+ */
+export async function fetchReferralTopUrls({ site, context, limit = 200 }) {
+  const siteId = site.getId();
+  const postgrestClient = context?.dataAccess?.services?.postgrestClient;
+
+  if (!postgrestClient?.rpc) {
+    throw new Error('PostgREST client is required to fetch referral top URLs');
+  }
+
+  const { data, error } = await postgrestClient.rpc(
+    'rpc_referral_traffic_top_urls',
+    {
+      p_site_id: siteId,
+      p_limit: limit,
+    },
+  );
+
+  if (error) {
+    context?.log?.error?.(`Failed to fetch referral top URLs for site ${siteId}: ${error.message}`);
+    throw error;
+  }
+
+  return (Array.isArray(data) ? data : [])
+    .map((row) => row?.url_path)
+    .filter((path) => typeof path === 'string' && path.length > 0);
+}
+
+/**
+ * Materializes a site's active category rules onto its referral URLs via the writer
+ * RPC, upserting category_name into agentic_url_classifications (LLMO-6257). Returns
+ * the RPC payload ({ site_id, classified }).
+ */
+export async function applyCategoryRulesToReferral({
+  site,
+  context,
+  source = null,
+  since = null,
+  updatedBy = 'audit-worker:referral-patterns',
+}) {
+  const siteId = site.getId();
+  const postgrestClient = context?.dataAccess?.services?.postgrestClient;
+
+  if (!postgrestClient?.rpc) {
+    throw new Error('PostgREST client is required to apply category rules to referral');
+  }
+
+  const { data, error } = await postgrestClient.rpc(
+    'wrpc_apply_category_rules_to_referral',
+    {
+      p_site_id: siteId,
+      p_source: source,
+      p_since: since,
+      p_updated_by: updatedBy,
+    },
+  );
+
+  if (error) {
+    context?.log?.error?.(`Failed to apply category rules to referral for site ${siteId}: ${error.message}`);
+    throw error;
+  }
+
+  return Array.isArray(data) ? data[0] : data;
+}

--- a/test/audits/cdn-logs-report/handler.test.js
+++ b/test/audits/cdn-logs-report/handler.test.js
@@ -76,6 +76,7 @@ describe('CDN Logs Report Handler', function test() {
       },
       '../../../src/cdn-logs-report/patterns/patterns-uploader.js': {
         generatePatternsWorkbook: (...a) => mocks.generatePatternsWorkbook(...a),
+        generateReferralPatternsWorkbook: (...a) => mocks.generateReferralPatternsWorkbook(...a),
       },
       '../../../src/cdn-logs-report/utils/agentic-db-export.js': {
         runAgenticDbExports: (...a) => mocks.runAgenticDbExports(...a),
@@ -97,6 +98,7 @@ describe('CDN Logs Report Handler', function test() {
     mocks.generateReportingPeriods = sandbox.stub().returns({ weeks: [], periodIdentifier: 'w01-2026' });
     mocks.fetchAgenticUrlClassificationRules = sandbox.stub().resolves(EXISTING_RULES);
     mocks.generatePatternsWorkbook = sandbox.stub().resolves(true);
+    mocks.generateReferralPatternsWorkbook = sandbox.stub().resolves(true);
     mocks.pathHasData = sandbox.stub().resolves(true);
     mocks.getS3Config = sandbox.stub().returns({
       bucket: 'test-bucket',
@@ -190,6 +192,48 @@ describe('CDN Logs Report Handler', function test() {
       const result = await runAudit({});
 
       expect(result.fullAuditRef).to.equal('null');
+    });
+  });
+
+  describe('referral pattern generation (no-CDN sites)', () => {
+    it('skips referral generation when CDN report data is present', async () => {
+      // Default mocks: pathHasData resolves true (CDN data present).
+      await runAudit({});
+
+      expect(mocks.generateReferralPatternsWorkbook).to.not.have.been.called;
+      expect(context.log.info).to.have.been.calledWith(
+        'CDN report data present - skipping referral pattern generation',
+      );
+    });
+
+    it('runs referral generation when the site has no CDN data', async () => {
+      mocks.pathHasData = sandbox.stub().resolves(false);
+
+      await runAudit({});
+
+      expect(mocks.generateReferralPatternsWorkbook).to.have.been.calledOnce;
+      expect(mocks.generateReferralPatternsWorkbook).to.have.been.calledWith(sinon.match({ site, context }));
+    });
+
+    it('runs referral generation when there is no agentic report config', async () => {
+      mocks.getConfigs = sandbox.stub().returns([referralConfig]);
+
+      await runAudit({});
+
+      expect(mocks.generateReferralPatternsWorkbook).to.have.been.calledOnce;
+    });
+
+    it('never lets a referral generation failure block the audit', async () => {
+      mocks.pathHasData = sandbox.stub().resolves(false);
+      mocks.generateReferralPatternsWorkbook = sandbox.stub().rejects(new Error('referral boom'));
+
+      const result = await runAudit({});
+
+      expect(result.auditResult).to.be.an('array');
+      expect(context.log.error).to.have.been.calledWith(
+        'Referral patterns generation failed for test-site: referral boom',
+        sinon.match.instanceOf(Error),
+      );
     });
   });
 

--- a/test/audits/cdn-logs-report/patterns-uploader.test.js
+++ b/test/audits/cdn-logs-report/patterns-uploader.test.js
@@ -482,3 +482,182 @@ describe('Patterns Uploader', () => {
     );
   });
 });
+
+describe('Referral Patterns Uploader', () => {
+  let sandbox;
+  let generateReferralPatternsWorkbook;
+  let mockAnalyzeProducts;
+  let mockFetchReferralTopUrls;
+  let mockApplyCategoryRulesToReferral;
+  let mockReplaceRules;
+  let mockFetchRules;
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+
+    mockAnalyzeProducts = sandbox.stub().resolves({ shoes: '/shoes' });
+    mockFetchReferralTopUrls = sandbox.stub().resolves(['/shoes', '/boots']);
+    mockApplyCategoryRulesToReferral = sandbox.stub().resolves({ site_id: 'test-site', classified: 2 });
+    mockReplaceRules = sandbox.stub().resolves({ category_rules: 1, page_type_rules: 0 });
+    mockFetchRules = sandbox.stub().resolves({ topicPatterns: [], pagePatterns: [] });
+
+    const module = await esmock('../../../src/cdn-logs-report/patterns/patterns-uploader.js', {
+      '../../../src/cdn-logs-report/patterns/product-analysis.js': {
+        analyzeProducts: mockAnalyzeProducts,
+      },
+      '../../../src/cdn-logs-report/utils/report-utils.js': {
+        replaceAgenticUrlClassificationRules: mockReplaceRules,
+        fetchReferralTopUrls: mockFetchReferralTopUrls,
+        applyCategoryRulesToReferral: mockApplyCategoryRulesToReferral,
+      },
+      '../../../src/common/agentic-url-classification-rules.js': {
+        fetchAgenticUrlClassificationRules: mockFetchRules,
+      },
+    });
+
+    generateReferralPatternsWorkbook = module.generateReferralPatternsWorkbook;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  const createMockOptions = () => ({
+    site: {
+      getId: () => 'test-site',
+      getBaseURL: () => 'https://www.example.com',
+    },
+    context: {
+      log: {
+        info: sandbox.spy(),
+        warn: sandbox.spy(),
+        error: sandbox.spy(),
+      },
+    },
+  });
+
+  it('generates rules from referral URLs, persists them, and materializes classifications', async () => {
+    const options = createMockOptions();
+
+    const result = await generateReferralPatternsWorkbook(options);
+
+    expect(result).to.be.true;
+    expect(mockFetchReferralTopUrls).to.have.been.calledWith(sinon.match({ site: options.site }));
+    expect(mockAnalyzeProducts).to.have.been.calledWith('www.example.com', ['/shoes', '/boots']);
+
+    const replaceArgs = mockReplaceRules.getCall(0).args[0];
+    expect(replaceArgs.updatedBy).to.equal('audit-worker:referral-patterns');
+    expect(replaceArgs.categoryRules).to.have.lengthOf(1);
+    expect(replaceArgs.categoryRules[0]).to.include({ name: 'shoes', regex: '/shoes', source: 'ai' });
+    expect(replaceArgs.pageTypeRules).to.deep.equal([]);
+
+    expect(mockApplyCategoryRulesToReferral).to.have.been.calledWith(sinon.match({
+      site: options.site,
+      updatedBy: 'audit-worker:referral-patterns',
+    }));
+    expect(options.context.log.info).to.have.been.calledWith(
+      'Synced referral category rules for site test-site: 1 rules, 2 classifications',
+    );
+  });
+
+  it('skips when the site has no referral URLs in the DB', async () => {
+    mockFetchReferralTopUrls.resolves([]);
+    const options = createMockOptions();
+
+    const result = await generateReferralPatternsWorkbook(options);
+
+    expect(result).to.be.false;
+    expect(mockAnalyzeProducts).to.not.have.been.called;
+    expect(mockReplaceRules).to.not.have.been.called;
+    expect(mockApplyCategoryRulesToReferral).to.not.have.been.called;
+    expect(options.context.log.info).to.have.been.calledWith(
+      'No referral URLs found in DB - skipping referral pattern generation',
+    );
+  });
+
+  it('skips when the existing-rules fetch failed', async () => {
+    mockFetchRules.resolves({ error: true });
+    const options = createMockOptions();
+
+    const result = await generateReferralPatternsWorkbook(options);
+
+    expect(result).to.be.false;
+    expect(mockAnalyzeProducts).to.not.have.been.called;
+    expect(mockReplaceRules).to.not.have.been.called;
+    expect(options.context.log.info).to.have.been.calledWith(
+      'Skipping referral patterns for test-site; DB rule fetch failed',
+    );
+  });
+
+  it('reuses existing product patterns without re-hitting the LLM and preserves page-type rules', async () => {
+    mockFetchRules.resolves({
+      topicPatterns: [{ name: 'apparel', regex: '/apparel' }],
+      pagePatterns: [{ name: 'pdp', regex: '/product' }],
+    });
+    const options = createMockOptions();
+
+    const result = await generateReferralPatternsWorkbook(options);
+
+    expect(result).to.be.true;
+    expect(mockAnalyzeProducts).to.not.have.been.called;
+    expect(options.context.log.info).to.have.been.calledWith(
+      'Reusing existing product patterns for referral generation',
+    );
+    // On the reuse path the rules are already persisted, so the whole-site replace
+    // RPC must NOT run again (it would churn provenance + purge soft-deletes).
+    expect(mockReplaceRules).to.not.have.been.called;
+    expect(mockApplyCategoryRulesToReferral).to.have.been.called;
+  });
+
+  it('propagates a data-service failure to the caller (best-effort catch lives in the handler)', async () => {
+    mockApplyCategoryRulesToReferral.rejects(new Error('apply boom'));
+    const options = createMockOptions();
+
+    let err;
+    try {
+      await generateReferralPatternsWorkbook(options);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).to.be.an('error');
+    expect(err.message).to.equal('apply boom');
+  });
+
+  it('handles a non-array rules payload defensively', async () => {
+    mockFetchRules.resolves({});
+    const options = createMockOptions();
+
+    const result = await generateReferralPatternsWorkbook(options);
+
+    expect(result).to.be.true;
+    // No existing topic patterns -> LLM runs.
+    expect(mockAnalyzeProducts).to.have.been.called;
+    expect(mockReplaceRules.getCall(0).args[0].pageTypeRules).to.deep.equal([]);
+  });
+
+  it('defaults the classified count to 0 when the apply RPC returns no payload', async () => {
+    mockApplyCategoryRulesToReferral.resolves(null);
+    const options = createMockOptions();
+
+    const result = await generateReferralPatternsWorkbook(options);
+
+    expect(result).to.be.true;
+    expect(options.context.log.info).to.have.been.calledWith(
+      'Synced referral category rules for site test-site: 1 rules, 0 classifications',
+    );
+  });
+
+  it('skips when no category rules survive the merge', async () => {
+    mockAnalyzeProducts.resolves({});
+    const options = createMockOptions();
+
+    const result = await generateReferralPatternsWorkbook(options);
+
+    expect(result).to.be.false;
+    expect(mockReplaceRules).to.not.have.been.called;
+    expect(mockApplyCategoryRulesToReferral).to.not.have.been.called;
+    expect(options.context.log.warn).to.have.been.calledWith(
+      'No referral category rules available after merge',
+    );
+  });
+});

--- a/test/audits/cdn-logs-report/report-utils.test.js
+++ b/test/audits/cdn-logs-report/report-utils.test.js
@@ -408,6 +408,155 @@ describe('CDN Logs Report Utils', () => {
     });
   });
 
+  describe('fetchReferralTopUrls', () => {
+    const mockSite = { getId: () => 'test-site-id' };
+
+    it('throws when no PostgREST RPC client is available', async () => {
+      await expect(reportUtils.fetchReferralTopUrls({
+        site: mockSite,
+        context: {},
+      })).to.be.rejectedWith('PostgREST client is required to fetch referral top URLs');
+    });
+
+    it('calls the read RPC and maps rows to a flat path array', async () => {
+      const rpc = sandbox.stub().resolves({
+        data: [{ url_path: '/shoes' }, { url_path: '/boots' }],
+        error: null,
+      });
+
+      const result = await reportUtils.fetchReferralTopUrls({
+        site: mockSite,
+        context: { dataAccess: { services: { postgrestClient: { rpc } } } },
+      });
+
+      expect(result).to.deep.equal(['/shoes', '/boots']);
+      expect(rpc).to.have.been.calledWith(
+        'rpc_referral_traffic_top_urls',
+        { p_site_id: 'test-site-id', p_limit: 200 },
+      );
+    });
+
+    it('honors a custom limit', async () => {
+      const rpc = sandbox.stub().resolves({ data: [], error: null });
+
+      await reportUtils.fetchReferralTopUrls({
+        site: mockSite,
+        context: { dataAccess: { services: { postgrestClient: { rpc } } } },
+        limit: 50,
+      });
+
+      expect(rpc.firstCall.args[1].p_limit).to.equal(50);
+    });
+
+    it('drops empty and non-string paths', async () => {
+      const rpc = sandbox.stub().resolves({
+        data: [{ url_path: '/shoes' }, { url_path: '' }, { url_path: null }, {}],
+        error: null,
+      });
+
+      const result = await reportUtils.fetchReferralTopUrls({
+        site: mockSite,
+        context: { dataAccess: { services: { postgrestClient: { rpc } } } },
+      });
+
+      expect(result).to.deep.equal(['/shoes']);
+    });
+
+    it('returns an empty array when the RPC returns no data', async () => {
+      const rpc = sandbox.stub().resolves({ data: null, error: null });
+
+      const result = await reportUtils.fetchReferralTopUrls({
+        site: mockSite,
+        context: { dataAccess: { services: { postgrestClient: { rpc } } } },
+      });
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('throws and logs RPC errors', async () => {
+      const rpc = sandbox.stub().resolves({ data: null, error: new Error('read boom') });
+      const log = { error: sandbox.stub() };
+
+      await expect(reportUtils.fetchReferralTopUrls({
+        site: mockSite,
+        context: { log, dataAccess: { services: { postgrestClient: { rpc } } } },
+      })).to.be.rejectedWith('read boom');
+      expect(log.error).to.have.been.calledWith(
+        'Failed to fetch referral top URLs for site test-site-id: read boom',
+      );
+    });
+  });
+
+  describe('applyCategoryRulesToReferral', () => {
+    const mockSite = { getId: () => 'test-site-id' };
+
+    it('throws when no PostgREST RPC client is available', async () => {
+      await expect(reportUtils.applyCategoryRulesToReferral({
+        site: mockSite,
+        context: {},
+      })).to.be.rejectedWith('PostgREST client is required to apply category rules to referral');
+    });
+
+    it('calls the apply RPC with defaults and unwraps array responses', async () => {
+      const rpc = sandbox.stub().resolves({
+        data: [{ site_id: 'test-site-id', classified: 3 }],
+        error: null,
+      });
+
+      const result = await reportUtils.applyCategoryRulesToReferral({
+        site: mockSite,
+        context: { dataAccess: { services: { postgrestClient: { rpc } } } },
+      });
+
+      expect(result).to.deep.equal({ site_id: 'test-site-id', classified: 3 });
+      expect(rpc).to.have.been.calledWith(
+        'wrpc_apply_category_rules_to_referral',
+        {
+          p_site_id: 'test-site-id',
+          p_source: null,
+          p_since: null,
+          p_updated_by: 'audit-worker:referral-patterns',
+        },
+      );
+    });
+
+    it('passes source/since/updatedBy overrides and returns object responses as-is', async () => {
+      const rpc = sandbox.stub().resolves({
+        data: { site_id: 'test-site-id', classified: 0 },
+        error: null,
+      });
+
+      const result = await reportUtils.applyCategoryRulesToReferral({
+        site: mockSite,
+        context: { dataAccess: { services: { postgrestClient: { rpc } } } },
+        source: 'ga4',
+        since: '2026-03-01',
+        updatedBy: 'unit-test',
+      });
+
+      expect(result).to.deep.equal({ site_id: 'test-site-id', classified: 0 });
+      expect(rpc.firstCall.args[1]).to.deep.equal({
+        p_site_id: 'test-site-id',
+        p_source: 'ga4',
+        p_since: '2026-03-01',
+        p_updated_by: 'unit-test',
+      });
+    });
+
+    it('throws and logs RPC errors', async () => {
+      const rpc = sandbox.stub().resolves({ data: null, error: new Error('apply boom') });
+      const log = { error: sandbox.stub() };
+
+      await expect(reportUtils.applyCategoryRulesToReferral({
+        site: mockSite,
+        context: { log, dataAccess: { services: { postgrestClient: { rpc } } } },
+      })).to.be.rejectedWith('apply boom');
+      expect(log.error).to.have.been.calledWith(
+        'Failed to apply category rules to referral for site test-site-id: apply boom',
+      );
+    });
+  });
+
   describe('getImporterS3Client', () => {
     it('lazily creates and caches a single importer S3 client', () => {
       const first = reportUtils.getImporterS3Client();


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Extends the `cdn-logs-report` audit so sites with no CDN logs still get URL category classifications, sourcing the corpus from Postgres referral traffic instead of Athena and reusing the existing category-generation machinery.

## 2. Reasoning
Category classifications are only produced by this audit's CDN path, whose URL corpus comes from Athena (CDN access logs). A site whose traffic comes only from non-CDN sources (optel / GA4 / Adobe Analytics / CJA) never gets classifications, so the shipped Referral Traffic "Category" filter shows only "All". This is the producer side of LLMO-6257: generate those categories from referral traffic.

## 3. High-level overview of the changes
A new best-effort step in `runCdnLogsReport`, gated to sites without CDN data:

- `report-utils.js` gains two thin data-service clients: `fetchReferralTopUrls` (calls `rpc_referral_traffic_top_urls`) and `applyCategoryRulesToReferral` (calls `wrpc_apply_category_rules_to_referral`).
- `patterns-uploader.js` gains `generateReferralPatternsWorkbook`: fetch the site's top referral URLs, reuse `analyzeProducts` + the existing rule merge, persist rules via `replaceAgenticUrlClassificationRules`, then materialise them onto referral URLs via the apply RPC. Only category rules are (re)generated; existing page-type rules are preserved.
- `handler.js` gains the `generateReferralPatterns` wrapper. `hasCdnData` is now computed once and shared with the agentic step, so the two paths are mutually exclusive (no double LLM spend) and a CDN site never runs the referral path.

Behaviour delta: before, a referral-only site produced no category classifications; after, the daily audit generates and applies them. The classification sink is unchanged, so the read-path Category filter lights up with no read-side changes. The step is best-effort - a failure (LLM, RPC, PostgREST) is logged and never blocks the daily exports - and on re-runs it reuses existing rules (no LLM re-hit) and skips the whole-site rule replace so it does not churn customer-tuned categories.

## 4. Required information
- Jira / issue: [LLMO-6257](https://jira.corp.adobe.com/browse/LLMO-6257) (epic LLMO-5440)
- Spec: [docs/specs/2026-07-15-referral-category-generation.md](https://github.com/adobe/spacecat-audit-worker/blob/LLMO-6257-referral-category-generation/docs/specs/2026-07-15-referral-category-generation.md)

## 5. Affected / used mysticat-workspace projects
- `mysticat-data-service` - this change calls the two new RPCs (`rpc_referral_traffic_top_urls`, `wrpc_apply_category_rules_to_referral`) at runtime; contract dependency, added in companion PR adobe/mysticat-data-service pull 807.

## 7. Test plan
(a) Local: behavioural verification of the new step via the unit suite (data-service RPCs and the LLM mocked at the module boundary) - confirmed it is gated to non-CDN sites, is best-effort (a thrown RPC/LLM error is caught, logged, and does not block the exports), reuses existing product rules without re-hitting the LLM, and skips the whole-site rule replace on the reuse path. The full end-to-end (real Lambda invocation) has not been run locally.

(b) Per env (dev / stage / prod, after deploy, and only once the data-service companion is deployed): trigger a `cdn-logs-report` run for a referral-only site (no CDN aggregated data, but referral rows present) and confirm it generates `agentic_url_category_rules` and populates `agentic_url_classifications`, and that the site's Referral Traffic Category dropdown then fills. Confirm a CDN-covered site is unaffected (referral path skipped).

## 8. Deployment & merge order
- Depends-on: adobe/mysticat-data-service pull 807 - this audit calls the two RPCs that PR adds, so they must exist in the deployed data-service first.
- Ordered sequence: merge/deploy the data-service PR (807) first, then this PR. Both are drafts under a prod-deploy hold - do not merge until the deploy can be babysat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
