### PR TITLE
feat(prerender): filter URLs by excludedPathPrefixes handler config (LLMO-6132)

### DIFF
--- a/src/prerender/handler.js
+++ b/src/prerender/handler.js
@@ -59,6 +59,19 @@ function rebaseUrl(url, preferredBase, log) {
   }
 }
 
+function applyPathPrefixExclusions(urls, excludedPrefixes) {
+  if (!excludedPrefixes || excludedPrefixes.length === 0) {
+    return urls;
+  }
+  return urls.filter((url) => !excludedPrefixes.some((prefix) => {
+    try {
+      return new URL(url).pathname.startsWith(prefix);
+    } catch {
+      return false;
+    }
+  }));
+}
+
 const LOG_PREFIX = 'Prerender -';
 const AUDIT_TYPE = Audit.AUDIT_TYPES.PRERENDER;
 const { AUDIT_STEP_DESTINATIONS } = Audit;
@@ -604,6 +617,8 @@ export async function submitForScraping(context) {
   const rebasedTopPagesUrls = topPagesUrls.map((url) => rebaseUrl(url, preferredBase, log));
   const rebasedIncludedURLs = ((await site?.getConfig?.()?.getIncludedURLs?.(AUDIT_TYPE)) || [])
     .map((url) => rebaseUrl(url, preferredBase, log));
+  const excludedPathPrefixes = site?.getConfig?.()
+    ?.getHandlerConfig?.(AUDIT_TYPE)?.excludedPathPrefixes ?? [];
 
   let finalUrls;
   let filteredCount;
@@ -633,6 +648,7 @@ export async function submitForScraping(context) {
     // Single site-scope filter on the merged candidate set (scoped here, not per-source).
     finalUrls = filterBySiteScope(crossSlackDeduped, siteBaseUrl);
     scopeFilteredCount = crossSlackDeduped.length - finalUrls.length;
+    finalUrls = applyPathPrefixExclusions(finalUrls, excludedPathPrefixes);
     filteredCount = organicSlackFiltered + includedSlackFiltered;
     currentOrganic = organicSlackDeduped.length;
     currentIncludedUrls = includedSlackDeduped.length;
@@ -682,7 +698,8 @@ export async function submitForScraping(context) {
     // slice so out-of-scope URLs don't consume batch slots and starve in-scope ones.
     const scopedUrls = filterBySiteScope(crossDeduped, siteBaseUrl);
     scopeFilteredCount = crossDeduped.length - scopedUrls.length;
-    const batchedUrls = scopedUrls.slice(0, DAILY_BATCH_SIZE);
+    const pathFilteredUrls = applyPathPrefixExclusions(scopedUrls, excludedPathPrefixes);
+    const batchedUrls = pathFilteredUrls.slice(0, DAILY_BATCH_SIZE);
 
     const organicUrlSet = new Set(organicDeduped);
     const includedUrlSet = new Set(includedDeduped);

--- a/test/audits/prerender/handler.test.js
+++ b/test/audits/prerender/handler.test.js
@@ -1806,6 +1806,230 @@ describe('Prerender Audit', () => {
 
       });
 
+      describe('excludedPathPrefixes filtering', () => {
+        it('filters out organic URLs whose pathname starts with an excluded prefix (non-Slack)', async () => {
+          const mockHandler = await esmock('../../../src/prerender/handler.js', {
+            '../../../src/utils/agentic-urls.js': {
+              getTopAgenticLiveUrlsFromAthena: async () => [],
+            },
+          });
+
+          const context = {
+            site: {
+              getId: () => 'site-1',
+              getBaseURL: () => 'https://pwc.com',
+              getConfig: () => ({
+                getIncludedURLs: () => [],
+                getHandlerConfig: () => ({ excludedPathPrefixes: ['/jp/ja'] }),
+              }),
+            },
+            dataAccess: {
+              SiteTopPage: {
+                allBySiteIdAndSourceAndGeo: async () => [
+                  { getUrl: () => 'https://pwc.com/en/page-1' },
+                  { getUrl: () => 'https://pwc.com/jp/ja/page-2' },
+                  { getUrl: () => 'https://pwc.com/jp/ja/page-3' },
+                  { getUrl: () => 'https://pwc.com/en/page-4' },
+                ],
+              },
+              Opportunity: { allBySiteIdAndStatus: sinon.stub().resolves([]) },
+              LatestAudit: { updateByKeys: sinon.stub().resolves() },
+            },
+            log: { info: sinon.stub(), warn: sinon.stub(), debug: sinon.stub() },
+            s3Client: { send: sinon.stub().rejects(Object.assign(new Error('NoSuchKey'), { name: 'NoSuchKey' })) },
+            env: { S3_SCRAPER_BUCKET_NAME: 'test-bucket' },
+          };
+
+          const result = await mockHandler.submitForScraping(context);
+          const submittedUrls = result.urls.map((u) => u.url);
+          expect(submittedUrls).to.include('https://pwc.com/en/page-1');
+          expect(submittedUrls).to.include('https://pwc.com/en/page-4');
+          expect(submittedUrls).to.not.include('https://pwc.com/jp/ja/page-2');
+          expect(submittedUrls).to.not.include('https://pwc.com/jp/ja/page-3');
+        });
+
+        it('applies no filtering when excludedPathPrefixes is an empty array (non-Slack)', async () => {
+          const mockHandler = await esmock('../../../src/prerender/handler.js', {
+            '../../../src/utils/agentic-urls.js': {
+              getTopAgenticLiveUrlsFromAthena: async () => [],
+            },
+          });
+
+          const context = {
+            site: {
+              getId: () => 'site-1',
+              getBaseURL: () => 'https://pwc.com',
+              getConfig: () => ({
+                getIncludedURLs: () => [],
+                getHandlerConfig: () => ({ excludedPathPrefixes: [] }),
+              }),
+            },
+            dataAccess: {
+              SiteTopPage: {
+                allBySiteIdAndSourceAndGeo: async () => [
+                  { getUrl: () => 'https://pwc.com/jp/ja/page-1' },
+                  { getUrl: () => 'https://pwc.com/en/page-2' },
+                ],
+              },
+              Opportunity: { allBySiteIdAndStatus: sinon.stub().resolves([]) },
+              LatestAudit: { updateByKeys: sinon.stub().resolves() },
+            },
+            log: { info: sinon.stub(), warn: sinon.stub(), debug: sinon.stub() },
+            s3Client: { send: sinon.stub().rejects(Object.assign(new Error('NoSuchKey'), { name: 'NoSuchKey' })) },
+            env: { S3_SCRAPER_BUCKET_NAME: 'test-bucket' },
+          };
+
+          const result = await mockHandler.submitForScraping(context);
+          const submittedUrls = result.urls.map((u) => u.url);
+          expect(submittedUrls).to.include('https://pwc.com/jp/ja/page-1');
+          expect(submittedUrls).to.include('https://pwc.com/en/page-2');
+        });
+
+        it('applies no filtering when getHandlerConfig returns undefined (non-Slack)', async () => {
+          const mockHandler = await esmock('../../../src/prerender/handler.js', {
+            '../../../src/utils/agentic-urls.js': {
+              getTopAgenticLiveUrlsFromAthena: async () => [],
+            },
+          });
+
+          const context = {
+            site: {
+              getId: () => 'site-1',
+              getBaseURL: () => 'https://pwc.com',
+              getConfig: () => ({
+                getIncludedURLs: () => [],
+                getHandlerConfig: () => undefined,
+              }),
+            },
+            dataAccess: {
+              SiteTopPage: {
+                allBySiteIdAndSourceAndGeo: async () => [
+                  { getUrl: () => 'https://pwc.com/jp/ja/page-1' },
+                  { getUrl: () => 'https://pwc.com/en/page-2' },
+                ],
+              },
+              Opportunity: { allBySiteIdAndStatus: sinon.stub().resolves([]) },
+              LatestAudit: { updateByKeys: sinon.stub().resolves() },
+            },
+            log: { info: sinon.stub(), warn: sinon.stub(), debug: sinon.stub() },
+            s3Client: { send: sinon.stub().rejects(Object.assign(new Error('NoSuchKey'), { name: 'NoSuchKey' })) },
+            env: { S3_SCRAPER_BUCKET_NAME: 'test-bucket' },
+          };
+
+          const result = await mockHandler.submitForScraping(context);
+          const submittedUrls = result.urls.map((u) => u.url);
+          expect(submittedUrls).to.include('https://pwc.com/jp/ja/page-1');
+          expect(submittedUrls).to.include('https://pwc.com/en/page-2');
+        });
+
+        it('filters out organic URLs whose pathname starts with an excluded prefix (Slack-triggered)', async () => {
+          const mockHandler = await esmock('../../../src/prerender/handler.js', {
+            '../../../src/utils/agentic-urls.js': {
+              getTopAgenticLiveUrlsFromAthena: async () => [],
+            },
+          });
+
+          const context = {
+            site: {
+              getId: () => 'site-1',
+              getBaseURL: () => 'https://pwc.com',
+              getConfig: () => ({
+                getIncludedURLs: () => [],
+                getHandlerConfig: () => ({ excludedPathPrefixes: ['/jp/ja'] }),
+              }),
+            },
+            auditContext: { slackContext: { channelId: 'C123', threadTs: '1.0' } },
+            dataAccess: {
+              SiteTopPage: {
+                allBySiteIdAndSourceAndGeo: async () => [
+                  { getUrl: () => 'https://pwc.com/en/page-1' },
+                  { getUrl: () => 'https://pwc.com/jp/ja/page-2' },
+                  { getUrl: () => 'https://pwc.com/en/page-3' },
+                ],
+              },
+            },
+            log: { info: sinon.stub(), warn: sinon.stub(), debug: sinon.stub() },
+            env: {},
+          };
+
+          const result = await mockHandler.submitForScraping(context);
+          const submittedUrls = result.urls.map((u) => u.url);
+          expect(submittedUrls).to.include('https://pwc.com/en/page-1');
+          expect(submittedUrls).to.include('https://pwc.com/en/page-3');
+          expect(submittedUrls).to.not.include('https://pwc.com/jp/ja/page-2');
+        });
+
+        it('applies no filtering when getHandlerConfig is absent from config (non-Slack)', async () => {
+          const mockHandler = await esmock('../../../src/prerender/handler.js', {
+            '../../../src/utils/agentic-urls.js': {
+              getTopAgenticLiveUrlsFromAthena: async () => [],
+            },
+          });
+
+          const context = {
+            site: {
+              getId: () => 'site-1',
+              getBaseURL: () => 'https://pwc.com',
+              getConfig: () => ({ getIncludedURLs: () => [] }),
+            },
+            dataAccess: {
+              SiteTopPage: {
+                allBySiteIdAndSourceAndGeo: async () => [
+                  { getUrl: () => 'https://pwc.com/jp/ja/page-1' },
+                  { getUrl: () => 'https://pwc.com/en/page-2' },
+                ],
+              },
+              Opportunity: { allBySiteIdAndStatus: sinon.stub().resolves([]) },
+              LatestAudit: { updateByKeys: sinon.stub().resolves() },
+            },
+            log: { info: sinon.stub(), warn: sinon.stub(), debug: sinon.stub() },
+            s3Client: { send: sinon.stub().rejects(Object.assign(new Error('NoSuchKey'), { name: 'NoSuchKey' })) },
+            env: { S3_SCRAPER_BUCKET_NAME: 'test-bucket' },
+          };
+
+          const result = await mockHandler.submitForScraping(context);
+          const submittedUrls = result.urls.map((u) => u.url);
+          expect(submittedUrls).to.include('https://pwc.com/jp/ja/page-1');
+          expect(submittedUrls).to.include('https://pwc.com/en/page-2');
+        });
+
+        it('keeps malformed URLs when excludedPathPrefixes is configured (URL parse error is silently ignored)', async () => {
+          const mockHandler = await esmock('../../../src/prerender/handler.js', {
+            '../../../src/utils/agentic-urls.js': {
+              getTopAgenticLiveUrlsFromAthena: async () => [],
+            },
+          });
+
+          const context = {
+            site: {
+              getId: () => 'site-1',
+              getBaseURL: () => 'https://pwc.com',
+              getConfig: () => ({
+                getIncludedURLs: () => ['not-a-valid-url'],
+                getHandlerConfig: () => ({ excludedPathPrefixes: ['/jp/ja'] }),
+              }),
+            },
+            dataAccess: {
+              SiteTopPage: {
+                allBySiteIdAndSourceAndGeo: async () => [
+                  { getUrl: () => 'https://pwc.com/en/page-1' },
+                ],
+              },
+              Opportunity: { allBySiteIdAndStatus: sinon.stub().resolves([]) },
+              LatestAudit: { updateByKeys: sinon.stub().resolves() },
+            },
+            log: { info: sinon.stub(), warn: sinon.stub(), debug: sinon.stub() },
+            s3Client: { send: sinon.stub().rejects(Object.assign(new Error('NoSuchKey'), { name: 'NoSuchKey' })) },
+            env: { S3_SCRAPER_BUCKET_NAME: 'test-bucket' },
+          };
+
+          const result = await mockHandler.submitForScraping(context);
+          const submittedUrls = result.urls.map((u) => u.url);
+          // The valid URL is present; the malformed URL doesn't crash the filter
+          expect(submittedUrls).to.include('https://pwc.com/en/page-1');
+        });
+      });
+
     });
 
     describe('processContentAndGenerateOpportunities', () => {


### PR DESCRIPTION
## Summary

- Adds `applyPathPrefixExclusions(urls, excludedPrefixes)` helper in `src/prerender/handler.js`
- Reads `excludedPathPrefixes` from `site.getConfig().getHandlerConfig(AUDIT_TYPE)`
- Applies the filter after `filterBySiteScope` in **both** the Slack-triggered and non-Slack branches

Prevents subpath-sibling site URLs (e.g. `/jp/ja/...` for PwC Japan) from appearing in PwC GLSC's audit opportunities. Works today via `getHandlerConfig(type)?.excludedPathPrefixes` (handlers object has `.unknown(true)`); `getExcludedPathPrefixes` accessor lands with the spacecat-shared PR.

**Depends on:** adobe/spacecat-shared#1817
**Jira:** [LLMO-6132](https://jira.corp.adobe.com/browse/LLMO-6132)

## Test plan
- [ ] 9041 unit tests pass
- [ ] Filter applies in both Slack-triggered and non-Slack branches
- [ ] Empty/undefined excludedPathPrefixes → passthrough
- [ ] Malformed URLs silently kept
- [ ] 100% lines/branches/statements coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)