### PR TITLE
feat(offsite-snapshot-opportunties): Make offsite opportunities snapshots on every refresh (LLMO-6152)

### DIFF
--- a/docs/specs/2026-07-15-offsite-snapshot-preservation.md
+++ b/docs/specs/2026-07-15-offsite-snapshot-preservation.md
@@ -1,0 +1,106 @@
+# Offsite Opportunities — Snapshot Preservation on Every Refresh
+
+- **Status:** Implemented
+- **Date:** 2026-07-15
+- **Jira:** LLMO-6152
+- **Related:** [offsite-structured-logging spec](2026-07-31-offsite-structured-logging.md)
+
+## Problem statement
+
+The offsite audits (cited, reddit, youtube) maintain a single "evergreen" opportunity per site.
+Each refresh from Mystique currently overwrites that record in place — the previous state
+(suggestions, review statuses, QA decisions) is lost with no audit trail. Suppressed runs
+(IGNORED status from the QA gate) are discarded entirely and cannot be inspected later.
+This makes debugging, QA retrospectives, and future restore operations impossible.
+
+## Goals
+
+1. Preserve the previous evergreen state before every surfaced refresh overwrites it.
+2. Persist every suppressed audit run as a separate, inert snapshot.
+3. Enable idempotent redelivery: replaying the same Mystique message must not create duplicate
+   snapshots.
+4. Link suppressed snapshots to the evergreen opportunity when one exists.
+
+Non-goals: snapshot restore (LLMO-6153), automatic snapshot deletion (LLMO-6154), Backoffice
+UI for snapshots, retroactive tagging of existing IGNORED records, Wikipedia analysis.
+
+## Technical design
+
+### Snapshot record shape
+
+Snapshots are stored as regular `Opportunity` records with:
+- `status: IGNORED`
+- `tags: [...existingTags, 'offsite-snapshot']` — the tag distinguishes snapshots from
+  organically retired duplicates
+- `data.snapshot` metadata:
+  - `kind`: `'superseded-refresh'` or `'suppressed-refresh'`
+  - `evergreenOpportunityId`: the live evergreen this snapshot is derived from (when known)
+  - `triggerAuditId`: the incoming audit that triggered the snapshot (when available)
+
+### Two workflows
+
+**Superseded-refresh snapshot (surfaced run):**
+1. Before the evergreen opportunity is mutated, copy its current state — data, title, description,
+   guidance, scope, suggestions (type/rank/data/status/kpiDeltas/skipReason/skipDetail) — into a
+   new IGNORED+tagged record.
+2. Link it to the evergreen via `evergreenOpportunityId`.
+3. Return the original evergreen as the persistence target; the normal refresh path then updates it.
+4. First-ever run (no evergreen exists): no snapshot is created.
+
+**Suppressed-refresh snapshot (suppressed run):**
+1. The incoming suppressed run itself becomes the snapshot — its data is tagged and annotated with
+   snapshot metadata before being written.
+2. The evergreen record is not touched.
+
+### Idempotency
+
+When `triggerAuditId` is available, `findSnapshotByTriggerAuditId` looks up an existing snapshot
+for (siteId, auditType, triggerAuditId) before creating a new one. Redelivery reuses the existing
+record. A suppressed snapshot created before an evergreen existed can receive its
+`evergreenOpportunityId` link on redelivery.
+
+Without `triggerAuditId`, no idempotency check is performed; the snapshot is still created and
+tagged but redelivery will produce a duplicate.
+
+### Orphan protection
+
+If `addSuggestions` throws entirely (not a partial error), the snapshot record already exists
+in the DB but has no suggestions. The catch block deletes the orphan and rethrows so the next
+delivery recreates the snapshot cleanly. If the delete itself fails, the error is logged
+(`snapshot_cleanup outcome=failure`) and the original error is still rethrown.
+
+### Shared orchestration
+
+`prepareSnapshotForRun` in `offsite-refresh.js` combines `resolveEvergreenOffsiteOpportunity`
+and the suppressed/surfaced dispatch into one call, eliminating the duplicate 20-line block
+that previously existed in each of the three guidance handlers.
+
+### Known limitation — in-memory scan
+
+`findSnapshotByTriggerAuditId` fetches all IGNORED opportunities for a site and filters
+in-memory (type, tag, triggerAuditId). Since every refresh creates a snapshot, this working set
+grows over time. For active sites across three audit types this can reach hundreds of records
+within months. Pushing the filter to the PostgREST layer is tracked in a follow-up.
+
+### Structured logging
+
+All snapshot operations emit structured `key=value` logs via `createOffsiteLogger` from
+`offsite-logging.js`, using events `snapshot_lookup`, `snapshot_prepare`,
+`snapshot_copy_suggestions`, and `snapshot_cleanup`.
+
+## Alternatives
+
+- **Soft-delete via a separate snapshot table:** cleaner schema, but requires a data-access
+  migration; deferred to a future iteration.
+- **Store snapshots in S3:** avoids DB growth, but makes them harder to query and link to
+  opportunity records.
+
+## Success criteria
+
+- `npm test` green with 100% coverage gate.
+- Every surfaced refresh that has an existing evergreen creates a `superseded-refresh` snapshot
+  before overwriting it.
+- Every suppressed run is persisted as a `suppressed-refresh` snapshot.
+- Replaying the same Mystique message (same `auditId`) does not create a second snapshot.
+- `snapshot_prepare outcome=success` and `snapshot_copy_suggestions outcome=failure` are
+  queryable in Splunk via `domain=offsite event=snapshot_prepare`.

--- a/docs/specs/2026-07-15-offsite-snapshot-preservation.md
+++ b/docs/specs/2026-07-15-offsite-snapshot-preservation.md
@@ -69,11 +69,14 @@ in the DB but has no suggestions. The catch block deletes the orphan and rethrow
 delivery recreates the snapshot cleanly. If the delete itself fails, the error is logged
 (`snapshot_cleanup outcome=failure`) and the original error is still rethrown.
 
-### Shared orchestration
+### No shared orchestrator
 
-`prepareSnapshotForRun` in `offsite-refresh.js` combines `resolveEvergreenOffsiteOpportunity`
-and the suppressed/surfaced dispatch into one call, eliminating the duplicate 20-line block
-that previously existed in each of the three guidance handlers.
+Each guidance handler calls `resolveEvergreenOffsiteOpportunity` (from `offsite-refresh.js`)
+followed by `prepareSuppressedRunSnapshot` or `prepareSupersededRunSnapshot` (from
+`offsite-snapshot.js`) inline, rather than through a single combining function. A shared
+orchestrator was tried and reverted: it required one of the two modules to import the other,
+and esmock deadlocks when two modules that both partially mock each other are loaded in the
+same test. `offsite-refresh.js` and `offsite-snapshot.js` have no cross-imports as a result.
 
 ### Known limitation — in-memory scan
 

--- a/src/cited-analysis/guidance-handler.js
+++ b/src/cited-analysis/guidance-handler.js
@@ -30,6 +30,10 @@ import {
 import {
   createOffsiteLogger, errorField, AUDIT, PEER,
 } from '../utils/offsite-logging.js';
+import {
+  prepareSuppressedRunSnapshot,
+  prepareSupersededRunSnapshot,
+} from '../common/offsite-snapshot.js';
 
 const AUDIT_TYPE = Audit.AUDIT_TYPES.CITED_ANALYSIS;
 // Human prefix for the two shared, untouched utils that still log via a passed-in prefix
@@ -147,8 +151,27 @@ export default async function handler(message, context) {
     const evergreenOpportunity = await resolveEvergreenOffsiteOpportunity({
       dataAccess, siteId, auditType, log,
     });
+    const suppressedRun = isSuppressedRun(incomingStatus);
+    const preparedOpportunityPersistence = suppressedRun
+      ? await prepareSuppressedRunSnapshot({
+        dataAccess,
+        siteId,
+        auditType,
+        triggerAuditId: auditId,
+        opportunityData,
+        evergreenOpportunity,
+        log,
+      })
+      : await prepareSupersededRunSnapshot({
+        dataAccess,
+        siteId,
+        auditType,
+        triggerAuditId: auditId,
+        opportunityData,
+        evergreenOpportunity,
+        log,
+      });
 
-    // Suppressed runs create a hidden record; surfaced runs reuse the evergreen record.
     const opportunity = await persistOffsiteOpportunity(
       baseUrl,
       {
@@ -159,12 +182,7 @@ export default async function handler(message, context) {
       context,
       createOpportunityData,
       auditType,
-      {
-        opportunityData,
-        existingOpportunity: isSuppressedRun(incomingStatus)
-          ? null
-          : evergreenOpportunity,
-      },
+      preparedOpportunityPersistence,
     );
 
     const ologOpp = olog.with({ opportunityId: opportunity.getId() });

--- a/src/cited-analysis/guidance-handler.js
+++ b/src/cited-analysis/guidance-handler.js
@@ -28,12 +28,12 @@ import {
   isSuppressedRun,
 } from '../common/offsite-refresh.js';
 import {
-  createOffsiteLogger, errorField, AUDIT, PEER,
-} from '../utils/offsite-logging.js';
-import {
   prepareSuppressedRunSnapshot,
   prepareSupersededRunSnapshot,
 } from '../common/offsite-snapshot.js';
+import {
+  createOffsiteLogger, errorField, AUDIT, PEER,
+} from '../utils/offsite-logging.js';
 
 const AUDIT_TYPE = Audit.AUDIT_TYPES.CITED_ANALYSIS;
 // Human prefix for the two shared, untouched utils that still log via a passed-in prefix
@@ -151,8 +151,7 @@ export default async function handler(message, context) {
     const evergreenOpportunity = await resolveEvergreenOffsiteOpportunity({
       dataAccess, siteId, auditType, log,
     });
-    const suppressedRun = isSuppressedRun(incomingStatus);
-    const preparedOpportunityPersistence = suppressedRun
+    const preparedOpportunityPersistence = isSuppressedRun(incomingStatus)
       ? await prepareSuppressedRunSnapshot({
         dataAccess,
         siteId,

--- a/src/common/offsite-refresh.js
+++ b/src/common/offsite-refresh.js
@@ -59,7 +59,7 @@ export function isValidOffsiteAnalysis(analysisData, expectedType) {
  * @param {string} auditType - Handler-owned offsite audit type.
  * @param {Object} options - Mapper input plus the pre-resolved target.
  * @param {Object} options.opportunityData - Incoming Mystique opportunity data.
- * @param {Object|null} options.existingOpportunity - Evergreen target, or null to create.
+ * @param {Object|null} options.opportunityToUpdate - Persistence target, or null to create.
  * @returns {Promise<Object>} The created or refreshed opportunity.
  */
 export async function persistOffsiteOpportunity(
@@ -73,13 +73,13 @@ export async function persistOffsiteOpportunity(
   if (!OFFSITE_AUDIT_TYPES.has(auditType)) {
     throw new Error(`Unsupported offsite audit type: ${auditType}`);
   }
-  if (!options || !Object.prototype.hasOwnProperty.call(options, 'existingOpportunity')) {
-    throw new Error('existingOpportunity must be explicitly provided');
+  if (!options || !Object.prototype.hasOwnProperty.call(options, 'opportunityToUpdate')) {
+    throw new Error('opportunityToUpdate must be explicitly provided');
   }
-  const { existingOpportunity: evergreenOpportunity } = options;
-  if (evergreenOpportunity !== null
-      && (typeof evergreenOpportunity !== 'object' || Array.isArray(evergreenOpportunity))) {
-    throw new Error('existingOpportunity must be an opportunity or null');
+  const { opportunityToUpdate } = options;
+  if (opportunityToUpdate !== null
+      && (typeof opportunityToUpdate !== 'object' || Array.isArray(opportunityToUpdate))) {
+    throw new Error('opportunityToUpdate must be an opportunity or null');
   }
 
   const mappedOpportunity = createOpportunityData(options);
@@ -98,7 +98,7 @@ export async function persistOffsiteOpportunity(
   }
 
   try {
-    if (evergreenOpportunity === null) {
+    if (opportunityToUpdate === null) {
       const created = await Opportunity.create({
         siteId: auditData.siteId,
         auditId: auditData.id,
@@ -121,10 +121,10 @@ export async function persistOffsiteOpportunity(
       return created;
     }
 
-    evergreenOpportunity.setAuditId(auditData.id);
-    evergreenOpportunity.setData({ ...mappedOpportunity.data });
-    evergreenOpportunity.setUpdatedBy('system');
-    await evergreenOpportunity.save();
+    opportunityToUpdate.setAuditId(auditData.id);
+    opportunityToUpdate.setData({ ...mappedOpportunity.data });
+    opportunityToUpdate.setUpdatedBy('system');
+    await opportunityToUpdate.save();
 
     olog.success('opportunity_persist', `Refreshed evergreen ${auditType} opportunity`, {
       peer: PEER.POSTGRES,
@@ -132,7 +132,7 @@ export async function persistOffsiteOpportunity(
       opportunityId: evergreenOpportunity.getId(),
       status: mappedOpportunity.status,
     });
-    return evergreenOpportunity;
+    return opportunityToUpdate;
   } catch (error) {
     // The sharpest edge: a silent DB write failure here strands the run. Log loudly and
     // structured, THEN rethrow unchanged so the caller's error handling is preserved.
@@ -203,7 +203,7 @@ export async function resolveEvergreenOffsiteOpportunity({
 
 /**
  * Returns true when a suppressed run must be stored separately from the evergreen opportunity.
- * Replaying the same suppressed run creates another record; replay idempotency is handled later.
+ * Snapshot lookup makes suppressed-run redelivery idempotent when auditId is available.
  *
  * @param {string} incomingStatus - The status carried by the incoming run
  *   ('NEW' when surfaced, 'IGNORED' when suppressed).

--- a/src/common/offsite-refresh.js
+++ b/src/common/offsite-refresh.js
@@ -129,7 +129,7 @@ export async function persistOffsiteOpportunity(
     olog.success('opportunity_persist', `Refreshed evergreen ${auditType} opportunity`, {
       peer: PEER.POSTGRES,
       direction: 'outbound',
-      opportunityId: evergreenOpportunity.getId(),
+      opportunityId: opportunityToUpdate.getId(),
       status: mappedOpportunity.status,
     });
     return opportunityToUpdate;

--- a/src/common/offsite-snapshot.js
+++ b/src/common/offsite-snapshot.js
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { Opportunity as Oppty } from '@adobe/spacecat-shared-data-access';
+
+export const SNAPSHOT_TAG = 'offsite-snapshot';
+
+export const SNAPSHOT_KINDS = {
+  // Previous evergreen state preserved before a surfaced refresh replaces it.
+  SUPERSEDED_REFRESH: 'superseded-refresh',
+  // Suppressed audit run retained as an inert snapshot.
+  SUPPRESSED_REFRESH: 'suppressed-refresh',
+};
+
+/**
+ * Finds a snapshot by (siteId, auditType, triggerAuditId).
+ * Lookup failures propagate to avoid duplicate creation.
+ */
+export async function findSnapshotByTriggerAuditId({
+  dataAccess, siteId, auditType, triggerAuditId, log,
+}) {
+  const { Opportunity } = dataAccess;
+  let opportunities;
+
+  try {
+    opportunities = await Opportunity.allBySiteIdAndStatus(siteId, Oppty.STATUSES.IGNORED);
+  } catch (e) {
+    log.error(`[Offsite][Snapshot] Failed to look up existing auditType ${auditType} snapshots for siteId ${siteId}: ${e.message}`);
+    throw e;
+  }
+
+  return (opportunities || []).find((opportunity) => {
+    const snapshotMetadata = opportunity.getData()?.snapshot;
+
+    return opportunity.getType() === auditType
+      && (opportunity.getTags() || []).includes(SNAPSHOT_TAG)
+      && snapshotMetadata?.triggerAuditId === triggerAuditId;
+  }) || null;
+}
+
+/**
+ * Adds snapshot metadata to plain opportunity data.
+ */
+export function buildSnapshotData(
+  sourceData,
+  { evergreenOpportunityId, kind, triggerAuditId },
+) {
+  return {
+    ...sourceData,
+    snapshot: {
+      ...(evergreenOpportunityId ? { evergreenOpportunityId } : {}),
+      kind,
+      ...(triggerAuditId ? { triggerAuditId } : {}),
+    },
+  };
+}
+
+/**
+ * Adds snapshot tag to existing tags.
+ */
+function buildSnapshotTags(existingTags) {
+  return [...new Set([...(existingTags || []), SNAPSHOT_TAG])];
+}
+
+/**
+ * Prepares persistence options for a suppressed audit-run snapshot.
+ */
+export async function prepareSuppressedRunSnapshot({
+  dataAccess,
+  siteId,
+  auditType,
+  triggerAuditId,
+  opportunityData,
+  evergreenOpportunity,
+  log,
+}) {
+  // The suppressed run itself becomes the snapshot; the evergreen remains unchanged.
+  const suppressedRunSnapshotData = {
+    ...opportunityData,
+    tags: buildSnapshotTags(opportunityData.tags),
+    data: buildSnapshotData(opportunityData.data || {}, {
+      evergreenOpportunityId: evergreenOpportunity?.getId(),
+      kind: SNAPSHOT_KINDS.SUPPRESSED_REFRESH,
+      triggerAuditId,
+    }),
+  };
+
+  if (!triggerAuditId) {
+    log.warn('[Offsite][Snapshot] Missing auditId; snapshot idempotency and traceability are unavailable');
+  }
+
+  const existingSuppressedRunSnapshot = triggerAuditId
+    ? await findSnapshotByTriggerAuditId({
+      dataAccess, siteId, auditType, triggerAuditId, log,
+    })
+    : null;
+
+  if (existingSuppressedRunSnapshot) {
+    log.info(`[Offsite][Snapshot] Reusing suppressed-refresh snapshot ${existingSuppressedRunSnapshot.getId()} for siteId ${siteId}, auditType ${auditType}, triggerAuditId ${triggerAuditId}`);
+  } else {
+    log.info(`[Offsite][Snapshot] Preparing new suppressed-refresh snapshot for siteId ${siteId}, auditType ${auditType}, triggerAuditId ${triggerAuditId || 'unknown'}`);
+  }
+
+  return {
+    opportunityData: suppressedRunSnapshotData,
+    opportunityToUpdate: existingSuppressedRunSnapshot,
+  };
+}
+
+/**
+ * Preserves the previous evergreen state and prepares its surfaced refresh.
+ */
+export async function prepareSupersededRunSnapshot({
+  dataAccess,
+  siteId,
+  auditType,
+  triggerAuditId,
+  opportunityData,
+  evergreenOpportunity,
+  log,
+}) {
+  if (!evergreenOpportunity) {
+    // First surfaced run: there is no previous evergreen state to preserve.
+    log.debug(`[Offsite][Snapshot] No evergreen opportunity exists; no superseded-refresh snapshot is needed for siteId ${siteId}, auditType ${auditType}`);
+    return { opportunityData, opportunityToUpdate: null };
+  }
+
+  if (!triggerAuditId) {
+    log.warn('[Offsite][Snapshot] Missing auditId; snapshot idempotency and traceability are unavailable');
+  }
+
+  const existingSupersededRunSnapshot = triggerAuditId
+    ? await findSnapshotByTriggerAuditId({
+      dataAccess, siteId, auditType, triggerAuditId, log,
+    })
+    : null;
+
+  if (existingSupersededRunSnapshot) {
+    log.info(`[Offsite][Snapshot] Reusing superseded-refresh snapshot ${existingSupersededRunSnapshot.getId()} for siteId ${siteId}, auditType ${auditType}, triggerAuditId ${triggerAuditId}`);
+  }
+
+  if (!existingSupersededRunSnapshot) {
+    // Preserve the evergreen before its data and suggestions are refreshed.
+    const { Opportunity } = dataAccess;
+
+    const scopeType = evergreenOpportunity.getScopeType();
+    const scopeId = evergreenOpportunity.getScopeId();
+
+    const snapshot = await Opportunity.create({
+      siteId: evergreenOpportunity.getSiteId(),
+      auditId: evergreenOpportunity.getAuditId(),
+      type: evergreenOpportunity.getType(),
+      origin: evergreenOpportunity.getOrigin(),
+      title: evergreenOpportunity.getTitle(),
+      description: evergreenOpportunity.getDescription(),
+      runbook: evergreenOpportunity.getRunbook(),
+      guidance: evergreenOpportunity.getGuidance(),
+      tags: buildSnapshotTags(evergreenOpportunity.getTags()),
+      status: Oppty.STATUSES.IGNORED,
+      ...(scopeType && scopeId ? { scopeType, scopeId } : {}),
+      data: buildSnapshotData(evergreenOpportunity.getData(), {
+        evergreenOpportunityId: evergreenOpportunity.getId(),
+        kind: SNAPSHOT_KINDS.SUPERSEDED_REFRESH,
+        triggerAuditId,
+      }),
+    });
+
+    // Copy suggestion statuses and review metadata exactly as observed.
+    const suggestions = await evergreenOpportunity.getSuggestions();
+
+    if (suggestions.length > 0) {
+      const { errorItems } = await snapshot.addSuggestions(suggestions.map((suggestion) => ({
+        type: suggestion.getType(),
+        rank: suggestion.getRank(),
+        data: suggestion.getData(),
+        status: suggestion.getStatus(),
+        ...(suggestion.getKpiDeltas() ? { kpiDeltas: suggestion.getKpiDeltas() } : {}),
+        ...(suggestion.getSkipReason() ? { skipReason: suggestion.getSkipReason() } : {}),
+        ...(suggestion.getSkipDetail() ? { skipDetail: suggestion.getSkipDetail() } : {}),
+      })));
+      if (errorItems?.length > 0) {
+        log.error(`[Offsite][Snapshot] ${errorItems.length} suggestion(s) failed to copy onto snapshot ${snapshot.getId()}`);
+      }
+    }
+
+    log.info(`[Offsite][Snapshot] Created superseded-refresh snapshot ${snapshot.getId()} from evergreen opportunity ${evergreenOpportunity.getId()} for siteId ${siteId}, auditType ${auditType}, triggerAuditId ${triggerAuditId || 'unknown'}`);
+  }
+
+  return { opportunityData, opportunityToUpdate: evergreenOpportunity };
+}

--- a/src/common/offsite-snapshot.js
+++ b/src/common/offsite-snapshot.js
@@ -131,7 +131,7 @@ export async function prepareSuppressedRunSnapshot({
     olog.success('snapshot_prepare', `Reusing suppressed-refresh snapshot ${existingSuppressedRunSnapshot.getId()}`, {
       peer: PEER.POSTGRES,
       snapshotId: existingSuppressedRunSnapshot.getId(),
-      triggerAuditId: triggerAuditId || undefined,
+      triggerAuditId,
     });
   } else {
     olog.start('snapshot_prepare', 'Preparing new suppressed-refresh snapshot', {
@@ -181,7 +181,7 @@ export async function prepareSupersededRunSnapshot({
     olog.success('snapshot_prepare', `Reusing superseded-refresh snapshot ${existingSupersededRunSnapshot.getId()}`, {
       peer: PEER.POSTGRES,
       snapshotId: existingSupersededRunSnapshot.getId(),
-      triggerAuditId: triggerAuditId || undefined,
+      triggerAuditId,
     });
   }
 

--- a/src/common/offsite-snapshot.js
+++ b/src/common/offsite-snapshot.js
@@ -11,6 +11,9 @@
  */
 
 import { Opportunity as Oppty } from '@adobe/spacecat-shared-data-access';
+import {
+  createOffsiteLogger, errorField, AUDIT, PEER,
+} from '../utils/offsite-logging.js';
 
 export const SNAPSHOT_TAG = 'offsite-snapshot';
 
@@ -21,20 +24,36 @@ export const SNAPSHOT_KINDS = {
   SUPPRESSED_REFRESH: 'suppressed-refresh',
 };
 
+// Mirrors the mapping in offsite-refresh.js — kept local to avoid a cross-module circular import.
+const AUDIT_SLUG_BY_TYPE = {
+  'cited-analysis': AUDIT.CITED,
+  'reddit-analysis': AUDIT.REDDIT,
+  'youtube-analysis': AUDIT.YOUTUBE,
+};
+
 /**
  * Finds a snapshot by (siteId, auditType, triggerAuditId).
  * Lookup failures propagate to avoid duplicate creation.
+ *
+ * NOTE: This fetches ALL IGNORED opportunities for a site from the DB and filters in-memory.
+ * Since every refresh creates a snapshot, the working set grows over time (one per refresh across
+ * all audit types). For active sites this can reach hundreds of records within months. A
+ * server-side filtered query in the data-access layer would close this gap.
+ * TODO(LLMO-6154 or follow-up): push type+tag filtering to PostgREST.
  */
 export async function findSnapshotByTriggerAuditId({
   dataAccess, siteId, auditType, triggerAuditId, log,
 }) {
   const { Opportunity } = dataAccess;
+  const olog = createOffsiteLogger(log, { audit: AUDIT_SLUG_BY_TYPE[auditType] ?? 'unknown', siteId });
   let opportunities;
 
   try {
     opportunities = await Opportunity.allBySiteIdAndStatus(siteId, Oppty.STATUSES.IGNORED);
   } catch (e) {
-    log.error(`[Offsite][Snapshot] Failed to look up existing auditType ${auditType} snapshots for siteId ${siteId}: ${e.message}`);
+    olog.failure('snapshot_lookup', `Failed to look up existing auditType ${auditType} snapshots`, {
+      peer: PEER.POSTGRES, direction: 'inbound', ...errorField(e),
+    });
     throw e;
   }
 
@@ -83,6 +102,8 @@ export async function prepareSuppressedRunSnapshot({
   evergreenOpportunity,
   log,
 }) {
+  const olog = createOffsiteLogger(log, { audit: AUDIT_SLUG_BY_TYPE[auditType] ?? 'unknown', siteId });
+
   // The suppressed run itself becomes the snapshot; the evergreen remains unchanged.
   const suppressedRunSnapshotData = {
     ...opportunityData,
@@ -95,7 +116,9 @@ export async function prepareSuppressedRunSnapshot({
   };
 
   if (!triggerAuditId) {
-    log.warn('[Offsite][Snapshot] Missing auditId; snapshot idempotency and traceability are unavailable');
+    olog.warn('snapshot_prepare', 'Missing auditId; snapshot idempotency and traceability are unavailable', {
+      reason: 'missing_audit_id',
+    });
   }
 
   const existingSuppressedRunSnapshot = triggerAuditId
@@ -105,9 +128,15 @@ export async function prepareSuppressedRunSnapshot({
     : null;
 
   if (existingSuppressedRunSnapshot) {
-    log.info(`[Offsite][Snapshot] Reusing suppressed-refresh snapshot ${existingSuppressedRunSnapshot.getId()} for siteId ${siteId}, auditType ${auditType}, triggerAuditId ${triggerAuditId}`);
+    olog.success('snapshot_prepare', `Reusing suppressed-refresh snapshot ${existingSuppressedRunSnapshot.getId()}`, {
+      peer: PEER.POSTGRES,
+      snapshotId: existingSuppressedRunSnapshot.getId(),
+      triggerAuditId: triggerAuditId || undefined,
+    });
   } else {
-    log.info(`[Offsite][Snapshot] Preparing new suppressed-refresh snapshot for siteId ${siteId}, auditType ${auditType}, triggerAuditId ${triggerAuditId || 'unknown'}`);
+    olog.start('snapshot_prepare', 'Preparing new suppressed-refresh snapshot', {
+      triggerAuditId: triggerAuditId || undefined,
+    });
   }
 
   return {
@@ -128,14 +157,18 @@ export async function prepareSupersededRunSnapshot({
   evergreenOpportunity,
   log,
 }) {
+  const olog = createOffsiteLogger(log, { audit: AUDIT_SLUG_BY_TYPE[auditType] ?? 'unknown', siteId });
+
   if (!evergreenOpportunity) {
     // First surfaced run: there is no previous evergreen state to preserve.
-    log.debug(`[Offsite][Snapshot] No evergreen opportunity exists; no superseded-refresh snapshot is needed for siteId ${siteId}, auditType ${auditType}`);
+    olog.debug('snapshot_prepare', 'No evergreen opportunity exists; no superseded-refresh snapshot is needed');
     return { opportunityData, opportunityToUpdate: null };
   }
 
   if (!triggerAuditId) {
-    log.warn('[Offsite][Snapshot] Missing auditId; snapshot idempotency and traceability are unavailable');
+    olog.warn('snapshot_prepare', 'Missing auditId; snapshot idempotency and traceability are unavailable', {
+      reason: 'missing_audit_id',
+    });
   }
 
   const existingSupersededRunSnapshot = triggerAuditId
@@ -145,7 +178,11 @@ export async function prepareSupersededRunSnapshot({
     : null;
 
   if (existingSupersededRunSnapshot) {
-    log.info(`[Offsite][Snapshot] Reusing superseded-refresh snapshot ${existingSupersededRunSnapshot.getId()} for siteId ${siteId}, auditType ${auditType}, triggerAuditId ${triggerAuditId}`);
+    olog.success('snapshot_prepare', `Reusing superseded-refresh snapshot ${existingSupersededRunSnapshot.getId()}`, {
+      peer: PEER.POSTGRES,
+      snapshotId: existingSupersededRunSnapshot.getId(),
+      triggerAuditId: triggerAuditId || undefined,
+    });
   }
 
   if (!existingSupersededRunSnapshot) {
@@ -178,21 +215,43 @@ export async function prepareSupersededRunSnapshot({
     const suggestions = await evergreenOpportunity.getSuggestions();
 
     if (suggestions.length > 0) {
-      const { errorItems } = await snapshot.addSuggestions(suggestions.map((suggestion) => ({
-        type: suggestion.getType(),
-        rank: suggestion.getRank(),
-        data: suggestion.getData(),
-        status: suggestion.getStatus(),
-        ...(suggestion.getKpiDeltas() ? { kpiDeltas: suggestion.getKpiDeltas() } : {}),
-        ...(suggestion.getSkipReason() ? { skipReason: suggestion.getSkipReason() } : {}),
-        ...(suggestion.getSkipDetail() ? { skipDetail: suggestion.getSkipDetail() } : {}),
-      })));
-      if (errorItems?.length > 0) {
-        log.error(`[Offsite][Snapshot] ${errorItems.length} suggestion(s) failed to copy onto snapshot ${snapshot.getId()}`);
+      try {
+        const { errorItems } = await snapshot.addSuggestions(suggestions.map((suggestion) => ({
+          type: suggestion.getType(),
+          rank: suggestion.getRank(),
+          data: suggestion.getData(),
+          status: suggestion.getStatus(),
+          ...(suggestion.getKpiDeltas() ? { kpiDeltas: suggestion.getKpiDeltas() } : {}),
+          ...(suggestion.getSkipReason() ? { skipReason: suggestion.getSkipReason() } : {}),
+          ...(suggestion.getSkipDetail() ? { skipDetail: suggestion.getSkipDetail() } : {}),
+        })));
+        if (errorItems?.length > 0) {
+          olog.failure('snapshot_copy_suggestions', `${errorItems.length} suggestion(s) failed to copy onto snapshot ${snapshot.getId()}`, {
+            peer: PEER.POSTGRES, opportunityId: snapshot.getId(),
+          });
+        }
+      } catch (err) {
+        // addSuggestions threw entirely — the snapshot record already exists but has no
+        // suggestions. Delete the orphan so the next delivery recreates the snapshot cleanly.
+        olog.failure('snapshot_copy_suggestions', `addSuggestions threw for snapshot ${snapshot.getId()}; deleting orphan and rethrowing`, {
+          peer: PEER.POSTGRES, opportunityId: snapshot.getId(), ...errorField(err),
+        });
+        try {
+          await snapshot.remove();
+        } catch (removeErr) {
+          olog.failure('snapshot_cleanup', `Failed to delete orphan snapshot ${snapshot.getId()}`, {
+            peer: PEER.POSTGRES, opportunityId: snapshot.getId(), ...errorField(removeErr),
+          });
+        }
+        throw err;
       }
     }
 
-    log.info(`[Offsite][Snapshot] Created superseded-refresh snapshot ${snapshot.getId()} from evergreen opportunity ${evergreenOpportunity.getId()} for siteId ${siteId}, auditType ${auditType}, triggerAuditId ${triggerAuditId || 'unknown'}`);
+    olog.success('snapshot_prepare', `Created superseded-refresh snapshot ${snapshot.getId()} from evergreen opportunity ${evergreenOpportunity.getId()}`, {
+      peer: PEER.POSTGRES,
+      opportunityId: snapshot.getId(),
+      triggerAuditId: triggerAuditId || undefined,
+    });
   }
 
   return { opportunityData, opportunityToUpdate: evergreenOpportunity };

--- a/src/common/offsite-snapshot.js
+++ b/src/common/offsite-snapshot.js
@@ -128,6 +128,8 @@ export async function prepareSuppressedRunSnapshot({
     : null;
 
   if (existingSuppressedRunSnapshot) {
+    // triggerAuditId is provably truthy here: existingSuppressedRunSnapshot can only be set
+    // by the lookup above, which only runs when triggerAuditId is truthy.
     olog.success('snapshot_prepare', `Reusing suppressed-refresh snapshot ${existingSuppressedRunSnapshot.getId()}`, {
       peer: PEER.POSTGRES,
       snapshotId: existingSuppressedRunSnapshot.getId(),
@@ -178,6 +180,8 @@ export async function prepareSupersededRunSnapshot({
     : null;
 
   if (existingSupersededRunSnapshot) {
+    // triggerAuditId is provably truthy here: existingSupersededRunSnapshot can only be set
+    // by the lookup above, which only runs when triggerAuditId is truthy.
     olog.success('snapshot_prepare', `Reusing superseded-refresh snapshot ${existingSupersededRunSnapshot.getId()}`, {
       peer: PEER.POSTGRES,
       snapshotId: existingSupersededRunSnapshot.getId(),

--- a/src/reddit-analysis/guidance-handler.js
+++ b/src/reddit-analysis/guidance-handler.js
@@ -30,6 +30,10 @@ import {
 import {
   createOffsiteLogger, errorField, AUDIT, PEER,
 } from '../utils/offsite-logging.js';
+import {
+  prepareSuppressedRunSnapshot,
+  prepareSupersededRunSnapshot,
+} from '../common/offsite-snapshot.js';
 
 const AUDIT_TYPE = Audit.AUDIT_TYPES.REDDIT_ANALYSIS;
 // Human prefix for the two shared, untouched utils that still log via a passed-in prefix
@@ -147,8 +151,27 @@ export default async function handler(message, context) {
     const evergreenOpportunity = await resolveEvergreenOffsiteOpportunity({
       dataAccess, siteId, auditType, log,
     });
+    const suppressedRun = isSuppressedRun(incomingStatus);
+    const preparedOpportunityPersistence = suppressedRun
+      ? await prepareSuppressedRunSnapshot({
+        dataAccess,
+        siteId,
+        auditType,
+        triggerAuditId: auditId,
+        opportunityData,
+        evergreenOpportunity,
+        log,
+      })
+      : await prepareSupersededRunSnapshot({
+        dataAccess,
+        siteId,
+        auditType,
+        triggerAuditId: auditId,
+        opportunityData,
+        evergreenOpportunity,
+        log,
+      });
 
-    // Suppressed runs create a hidden record; surfaced runs reuse the evergreen record.
     const opportunity = await persistOffsiteOpportunity(
       baseUrl,
       {
@@ -159,12 +182,7 @@ export default async function handler(message, context) {
       context,
       createOpportunityData,
       auditType,
-      {
-        opportunityData,
-        existingOpportunity: isSuppressedRun(incomingStatus)
-          ? null
-          : evergreenOpportunity,
-      },
+      preparedOpportunityPersistence,
     );
 
     const ologOpp = olog.with({ opportunityId: opportunity.getId() });

--- a/src/reddit-analysis/guidance-handler.js
+++ b/src/reddit-analysis/guidance-handler.js
@@ -28,12 +28,12 @@ import {
   isSuppressedRun,
 } from '../common/offsite-refresh.js';
 import {
-  createOffsiteLogger, errorField, AUDIT, PEER,
-} from '../utils/offsite-logging.js';
-import {
   prepareSuppressedRunSnapshot,
   prepareSupersededRunSnapshot,
 } from '../common/offsite-snapshot.js';
+import {
+  createOffsiteLogger, errorField, AUDIT, PEER,
+} from '../utils/offsite-logging.js';
 
 const AUDIT_TYPE = Audit.AUDIT_TYPES.REDDIT_ANALYSIS;
 // Human prefix for the two shared, untouched utils that still log via a passed-in prefix
@@ -151,8 +151,7 @@ export default async function handler(message, context) {
     const evergreenOpportunity = await resolveEvergreenOffsiteOpportunity({
       dataAccess, siteId, auditType, log,
     });
-    const suppressedRun = isSuppressedRun(incomingStatus);
-    const preparedOpportunityPersistence = suppressedRun
+    const preparedOpportunityPersistence = isSuppressedRun(incomingStatus)
       ? await prepareSuppressedRunSnapshot({
         dataAccess,
         siteId,

--- a/src/youtube-analysis/guidance-handler.js
+++ b/src/youtube-analysis/guidance-handler.js
@@ -26,12 +26,12 @@ import {
   isSuppressedRun,
 } from '../common/offsite-refresh.js';
 import {
-  createOffsiteLogger, errorField, AUDIT, PEER,
-} from '../utils/offsite-logging.js';
-import {
   prepareSuppressedRunSnapshot,
   prepareSupersededRunSnapshot,
 } from '../common/offsite-snapshot.js';
+import {
+  createOffsiteLogger, errorField, AUDIT, PEER,
+} from '../utils/offsite-logging.js';
 
 const AUDIT_TYPE = Audit.AUDIT_TYPES.YOUTUBE_ANALYSIS;
 // Human prefix for the two shared, untouched utils that still log via a passed-in prefix
@@ -149,8 +149,7 @@ export default async function handler(message, context) {
     const evergreenOpportunity = await resolveEvergreenOffsiteOpportunity({
       dataAccess, siteId, auditType, log,
     });
-    const suppressedRun = isSuppressedRun(incomingStatus);
-    const preparedOpportunityPersistence = suppressedRun
+    const preparedOpportunityPersistence = isSuppressedRun(incomingStatus)
       ? await prepareSuppressedRunSnapshot({
         dataAccess,
         siteId,

--- a/src/youtube-analysis/guidance-handler.js
+++ b/src/youtube-analysis/guidance-handler.js
@@ -28,6 +28,10 @@ import {
 import {
   createOffsiteLogger, errorField, AUDIT, PEER,
 } from '../utils/offsite-logging.js';
+import {
+  prepareSuppressedRunSnapshot,
+  prepareSupersededRunSnapshot,
+} from '../common/offsite-snapshot.js';
 
 const AUDIT_TYPE = Audit.AUDIT_TYPES.YOUTUBE_ANALYSIS;
 // Human prefix for the two shared, untouched utils that still log via a passed-in prefix
@@ -145,8 +149,27 @@ export default async function handler(message, context) {
     const evergreenOpportunity = await resolveEvergreenOffsiteOpportunity({
       dataAccess, siteId, auditType, log,
     });
+    const suppressedRun = isSuppressedRun(incomingStatus);
+    const preparedOpportunityPersistence = suppressedRun
+      ? await prepareSuppressedRunSnapshot({
+        dataAccess,
+        siteId,
+        auditType,
+        triggerAuditId: auditId,
+        opportunityData,
+        evergreenOpportunity,
+        log,
+      })
+      : await prepareSupersededRunSnapshot({
+        dataAccess,
+        siteId,
+        auditType,
+        triggerAuditId: auditId,
+        opportunityData,
+        evergreenOpportunity,
+        log,
+      });
 
-    // Suppressed runs create a hidden record; surfaced runs reuse the evergreen record.
     const opportunity = await persistOffsiteOpportunity(
       baseUrl,
       {
@@ -157,12 +180,7 @@ export default async function handler(message, context) {
       context,
       createOpportunityData,
       auditType,
-      {
-        opportunityData,
-        existingOpportunity: isSuppressedRun(incomingStatus)
-          ? null
-          : evergreenOpportunity,
-      },
+      preparedOpportunityPersistence,
     );
 
     const ologOpp = olog.with({ opportunityId: opportunity.getId() });

--- a/src/youtube-analysis/opportunity-data-mapper.js
+++ b/src/youtube-analysis/opportunity-data-mapper.js
@@ -28,7 +28,7 @@ export function createOpportunityData({ opportunityData } = {}) {
     description: opportunityData?.description || 'Enhance your company\'s Youtube presence to improve brand sentiment and visibility. '
       + 'A well-managed Youtube presence can influence how your brand is perceived in community discussions.',
     status: opportunityData?.status || 'NEW',
-    tags: opportunityData?.tags || ['Video Content', 'social', 'isElmo'],
+    tags: [...new Set([...(opportunityData?.tags || []), 'Video Content', 'social', 'isElmo'])],
     data: {
       ...(opportunityData?.data || {}),
       dataSources: [...new Set([

--- a/src/youtube-analysis/opportunity-data-mapper.js
+++ b/src/youtube-analysis/opportunity-data-mapper.js
@@ -28,6 +28,7 @@ export function createOpportunityData({ opportunityData } = {}) {
     description: opportunityData?.description || 'Enhance your company\'s Youtube presence to improve brand sentiment and visibility. '
       + 'A well-managed Youtube presence can influence how your brand is perceived in community discussions.',
     status: opportunityData?.status || 'NEW',
+    // Always merge defaults so snapshot tags are preserved alongside content tags.
     tags: [...new Set([...(opportunityData?.tags || []), 'Video Content', 'social', 'isElmo'])],
     data: {
       ...(opportunityData?.data || {}),

--- a/test/audits/cited-analysis/guidance-handler.test.js
+++ b/test/audits/cited-analysis/guidance-handler.test.js
@@ -84,15 +84,29 @@ describe('Cited Analysis Guidance Handler', () => {
     resolveEvergreenOffsiteOpportunityStub = sandbox.stub().callsFake(
       async ({ dataAccess: da, siteId: sid, auditType: at }) => {
         const opps = await da.Opportunity.allBySiteIdAndStatus(sid, 'NEW');
-        return (opps || []).filter((o) => o.getType() === at)
-          .sort((a, b) => new Date(b.getUpdatedAt()) - new Date(a.getUpdatedAt()))[0] || null;
+        const matching = (opps || []).filter((o) => o.getType() === at);
+        if (matching.length === 0) return null;
+        if (matching.length === 1) return matching[0];
+
+        const [evergreen, ...duplicates] = [...matching].sort(
+          (a, b) => new Date(b.getUpdatedAt()) - new Date(a.getUpdatedAt()),
+        );
+        duplicates.forEach((duplicate) => {
+          duplicate.setStatus('IGNORED');
+          duplicate.setUpdatedBy('system');
+        });
+        await da.Opportunity.saveMany(duplicates);
+        return evergreen;
       },
     );
     isSuppressedRunStub = sandbox.stub().callsFake((status) => status === 'IGNORED');
 
     prepareSuppressedRunSnapshotStub = sandbox.stub().callsFake(async ({
-      triggerAuditId, opportunityData, evergreenOpportunity,
+      triggerAuditId, opportunityData, evergreenOpportunity, log: callLog,
     }) => {
+      if (!triggerAuditId) {
+        callLog.warn('[OffsiteSnapshot] Missing auditId; snapshot idempotency and traceability are unavailable');
+      }
       const existingSnapshot = triggerAuditId ? await findSnapshotByTriggerAuditIdStub() : null;
       return {
         opportunityToUpdate: existingSnapshot,
@@ -118,6 +132,9 @@ describe('Cited Analysis Guidance Handler', () => {
         await supersededRunSnapshotCreationStub({
           dataAccess: da, siteId: sid, auditType: at, triggerAuditId, evergreenOpportunity, log: callLog,
         });
+        if (!triggerAuditId) {
+          callLog.warn('[OffsiteSnapshot] Missing auditId; snapshot idempotency and traceability are unavailable');
+        }
       }
       return { opportunityData, opportunityToUpdate: evergreenOpportunity };
     });

--- a/test/audits/cited-analysis/guidance-handler.test.js
+++ b/test/audits/cited-analysis/guidance-handler.test.js
@@ -38,6 +38,8 @@ describe('Cited Analysis Guidance Handler', () => {
   let resolveBrandResultForSiteStub;
   let supersededRunSnapshotCreationStub;
   let findSnapshotByTriggerAuditIdStub;
+  let resolveEvergreenOffsiteOpportunityStub;
+  let isSuppressedRunStub;
   let prepareSuppressedRunSnapshotStub;
   let prepareSupersededRunSnapshotStub;
 
@@ -78,25 +80,29 @@ describe('Cited Analysis Guidance Handler', () => {
     resolveBrandResultForSiteStub = sandbox.stub().resolves({ brand: null, resolved: true });
     supersededRunSnapshotCreationStub = sandbox.stub().resolves(null);
     findSnapshotByTriggerAuditIdStub = sandbox.stub().resolves(null);
+
+    resolveEvergreenOffsiteOpportunityStub = sandbox.stub().callsFake(
+      async ({ dataAccess: da, siteId: sid, auditType: at }) => {
+        const opps = await da.Opportunity.allBySiteIdAndStatus(sid, 'NEW');
+        return (opps || []).filter((o) => o.getType() === at)
+          .sort((a, b) => new Date(b.getUpdatedAt()) - new Date(a.getUpdatedAt()))[0] || null;
+      },
+    );
+    isSuppressedRunStub = sandbox.stub().callsFake((status) => status === 'IGNORED');
+
     prepareSuppressedRunSnapshotStub = sandbox.stub().callsFake(async ({
-      triggerAuditId,
-      opportunityData,
-      evergreenOpportunity,
+      triggerAuditId, opportunityData, evergreenOpportunity,
     }) => {
-      const existingSuppressedRunSnapshot = triggerAuditId
-        ? await findSnapshotByTriggerAuditIdStub()
-        : null;
+      const existingSnapshot = triggerAuditId ? await findSnapshotByTriggerAuditIdStub() : null;
       return {
-        opportunityToUpdate: existingSuppressedRunSnapshot,
+        opportunityToUpdate: existingSnapshot,
         opportunityData: {
           ...opportunityData,
           tags: [...new Set([...(opportunityData.tags || []), 'offsite-snapshot'])],
           data: {
             ...(opportunityData.data || {}),
             snapshot: {
-              ...(evergreenOpportunity
-                ? { evergreenOpportunityId: evergreenOpportunity.getId() }
-                : {}),
+              ...(evergreenOpportunity ? { evergreenOpportunityId: evergreenOpportunity.getId() } : {}),
               kind: 'suppressed-refresh',
               ...(triggerAuditId ? { triggerAuditId } : {}),
             },
@@ -104,27 +110,14 @@ describe('Cited Analysis Guidance Handler', () => {
         },
       };
     });
+
     prepareSupersededRunSnapshotStub = sandbox.stub().callsFake(async ({
-      dataAccess,
-      siteId: refreshSiteId,
-      auditType,
-      triggerAuditId,
-      opportunityData,
-      evergreenOpportunity,
-      log,
+      dataAccess: da, siteId: sid, auditType: at, triggerAuditId, opportunityData, evergreenOpportunity, log: callLog,
     }) => {
       if (evergreenOpportunity) {
         await supersededRunSnapshotCreationStub({
-          dataAccess,
-          siteId: refreshSiteId,
-          auditType,
-          triggerAuditId,
-          evergreenOpportunity,
-          log,
+          dataAccess: da, siteId: sid, auditType: at, triggerAuditId, evergreenOpportunity, log: callLog,
         });
-        if (!triggerAuditId) {
-          log.warn('[OffsiteSnapshot] Missing auditId; snapshot idempotency and traceability are unavailable');
-        }
       }
       return { opportunityData, opportunityToUpdate: evergreenOpportunity };
     });
@@ -135,6 +128,12 @@ describe('Cited Analysis Guidance Handler', () => {
       },
       '../../../src/common/offsite-refresh.js': {
         persistOffsiteOpportunity: convertToOpportunityStub,
+        resolveEvergreenOffsiteOpportunity: resolveEvergreenOffsiteOpportunityStub,
+        isSuppressedRun: isSuppressedRunStub,
+      },
+      '../../../src/common/offsite-snapshot.js': {
+        prepareSuppressedRunSnapshot: prepareSuppressedRunSnapshotStub,
+        prepareSupersededRunSnapshot: prepareSupersededRunSnapshotStub,
       },
       '../../../src/utils/analysis-fetch.js': {
         fetchAnalysisFromPresignedUrl: fetchAnalysisStub,
@@ -144,10 +143,6 @@ describe('Cited Analysis Guidance Handler', () => {
         resolveBrandResultForSite: resolveBrandResultForSiteStub,
         // Use the REAL applyScopeToOpportunity — see import above.
         applyScopeToOpportunity: realApplyScopeToOpportunity,
-      },
-      '../../../src/common/offsite-snapshot.js': {
-        prepareSuppressedRunSnapshot: prepareSuppressedRunSnapshotStub,
-        prepareSupersededRunSnapshot: prepareSupersededRunSnapshotStub,
       },
     });
 

--- a/test/audits/cited-analysis/guidance-handler.test.js
+++ b/test/audits/cited-analysis/guidance-handler.test.js
@@ -36,6 +36,10 @@ describe('Cited Analysis Guidance Handler', () => {
   let fetchAnalysisStub;
   let mockPostMessageOptional;
   let resolveBrandResultForSiteStub;
+  let supersededRunSnapshotCreationStub;
+  let findSnapshotByTriggerAuditIdStub;
+  let prepareSuppressedRunSnapshotStub;
+  let prepareSupersededRunSnapshotStub;
 
   const baseURL = 'https://example.com';
   const siteId = 'test-site-id';
@@ -72,6 +76,58 @@ describe('Cited Analysis Guidance Handler', () => {
     mockPostMessageOptional = sandbox.stub().resolves({ success: true });
     // Default: brand resolved with no match. Per-test cases override.
     resolveBrandResultForSiteStub = sandbox.stub().resolves({ brand: null, resolved: true });
+    supersededRunSnapshotCreationStub = sandbox.stub().resolves(null);
+    findSnapshotByTriggerAuditIdStub = sandbox.stub().resolves(null);
+    prepareSuppressedRunSnapshotStub = sandbox.stub().callsFake(async ({
+      triggerAuditId,
+      opportunityData,
+      evergreenOpportunity,
+    }) => {
+      const existingSuppressedRunSnapshot = triggerAuditId
+        ? await findSnapshotByTriggerAuditIdStub()
+        : null;
+      return {
+        opportunityToUpdate: existingSuppressedRunSnapshot,
+        opportunityData: {
+          ...opportunityData,
+          tags: [...new Set([...(opportunityData.tags || []), 'offsite-snapshot'])],
+          data: {
+            ...(opportunityData.data || {}),
+            snapshot: {
+              ...(evergreenOpportunity
+                ? { evergreenOpportunityId: evergreenOpportunity.getId() }
+                : {}),
+              kind: 'suppressed-refresh',
+              ...(triggerAuditId ? { triggerAuditId } : {}),
+            },
+          },
+        },
+      };
+    });
+    prepareSupersededRunSnapshotStub = sandbox.stub().callsFake(async ({
+      dataAccess,
+      siteId: refreshSiteId,
+      auditType,
+      triggerAuditId,
+      opportunityData,
+      evergreenOpportunity,
+      log,
+    }) => {
+      if (evergreenOpportunity) {
+        await supersededRunSnapshotCreationStub({
+          dataAccess,
+          siteId: refreshSiteId,
+          auditType,
+          triggerAuditId,
+          evergreenOpportunity,
+          log,
+        });
+        if (!triggerAuditId) {
+          log.warn('[OffsiteSnapshot] Missing auditId; snapshot idempotency and traceability are unavailable');
+        }
+      }
+      return { opportunityData, opportunityToUpdate: evergreenOpportunity };
+    });
 
     handler = await esmock('../../../src/cited-analysis/guidance-handler.js', {
       '../../../src/utils/data-access.js': {
@@ -89,6 +145,10 @@ describe('Cited Analysis Guidance Handler', () => {
         // Use the REAL applyScopeToOpportunity — see import above.
         applyScopeToOpportunity: realApplyScopeToOpportunity,
       },
+      '../../../src/common/offsite-snapshot.js': {
+        prepareSuppressedRunSnapshot: prepareSuppressedRunSnapshotStub,
+        prepareSupersededRunSnapshot: prepareSupersededRunSnapshotStub,
+      },
     });
 
     context = new MockContextBuilder()
@@ -101,10 +161,7 @@ describe('Cited Analysis Guidance Handler', () => {
           Audit: {
             findById: sandbox.stub().resolves(mockAudit),
           },
-          // withOverrides() shallow-replaces the whole dataAccess object, so Opportunity
-          // must be provided here too — otherwise resolveEvergreenOpportunity's internal
-          // Opportunity.allBySiteIdAndStatus call throws on `undefined` for every test in
-          // this file that doesn't set its own dataAccess.Opportunity mock below.
+          // withOverrides() replaces dataAccess, so include the default lookup.
           Opportunity: {
             allBySiteIdAndStatus: sandbox.stub().resolves([]),
           },
@@ -1281,10 +1338,10 @@ describe('Cited Analysis Guidance Handler', () => {
       expect(convertToOpportunityStub).to.have.been.calledOnce;
       expect(syncSuggestionsStub).to.have.been.calledOnce;
       expect(mockOpportunity.setStatus).to.have.been.calledWith('IGNORED');
-      // existingOpportunity is explicitly null so persistOffsiteOpportunity creates a record
+      // opportunityToUpdate is explicitly null so persistOffsiteOpportunity creates a record
       // a new opportunity, never reusing (or re-querying for) the visible one.
       const propsArg = convertToOpportunityStub.firstCall.args[5];
-      expect(propsArg).to.have.property('existingOpportunity', null);
+      expect(propsArg).to.have.property('opportunityToUpdate', null);
     });
 
     // Whether nothing exists yet, or the only prior opportunity is already IGNORED, the
@@ -1311,7 +1368,7 @@ describe('Cited Analysis Guidance Handler', () => {
       expect(convertToOpportunityStub).to.have.been.calledOnce;
       expect(mockOpportunity.setStatus).to.have.been.calledWith('IGNORED');
       const propsArg = convertToOpportunityStub.firstCall.args[5];
-      expect(propsArg).to.have.property('existingOpportunity', null);
+      expect(propsArg).to.have.property('opportunityToUpdate', null);
     });
 
     it('should hand the resolved evergreen to persistOffsiteOpportunity for a surfaced run', async () => {
@@ -1332,7 +1389,7 @@ describe('Cited Analysis Guidance Handler', () => {
       // A surfaced (NEW) run must reuse the already-resolved evergreen opportunity directly —
       // never trigger a second, independent query inside persistOffsiteOpportunity.
       const propsArg = convertToOpportunityStub.firstCall.args[5];
-      expect(propsArg.existingOpportunity).to.equal(visibleOpportunity);
+      expect(propsArg.opportunityToUpdate).to.equal(visibleOpportunity);
       expect(context.dataAccess.Opportunity.allBySiteIdAndStatus).to.have.been.calledOnce;
     });
 
@@ -1370,7 +1427,7 @@ describe('Cited Analysis Guidance Handler', () => {
       expect(saveManyStub.firstCall.args[0]).to.deep.equal([older]);
       expect(convertToOpportunityStub).to.have.been.calledOnce;
       // The de-duplicated evergreen opportunity (newer) is what gets reused, not a fresh re-query.
-      expect(convertToOpportunityStub.firstCall.args[5].existingOpportunity).to.equal(newer);
+      expect(convertToOpportunityStub.firstCall.args[5].opportunityToUpdate).to.equal(newer);
     });
 
     it('should propagate the error (badRequest) when duplicate retirement fails, without proceeding', async () => {
@@ -1414,9 +1471,229 @@ describe('Cited Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(400);
       // A transient read failure must never be treated as "nothing exists yet" (which
-      // would otherwise create a duplicate NEW opportunity) — conversion is never attempted.
+      // would otherwise create a duplicate NEW opportunity) — persistence is never attempted.
       expect(convertToOpportunityStub).to.not.have.been.called;
       expect(syncSuggestionsStub).to.not.have.been.called;
+    });
+  });
+
+  describe('Suppressed and superseded run snapshots', () => {
+    const validMessage = (overrides = {}) => ({
+      siteId,
+      auditId,
+      data: {
+        companyName: 'Example Corp',
+        analysis: {
+          suggestions: [
+            {
+              id: 'test_1', rank: 1, type: 'CONTENT_UPDATE', data: { title: 'Test' },
+            },
+          ],
+        },
+      },
+      ...overrides,
+    });
+
+    it('snapshots the evergreen opportunity before a surfaced run overwrites it', async () => {
+      const visibleOpportunity = {
+        getId: sandbox.stub().returns('existing-opp-1'),
+        getType: sandbox.stub().returns('cited-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
+      };
+
+      await handler.default(validMessage(), context);
+
+      expect(supersededRunSnapshotCreationStub).to.have.been.calledOnce;
+      const callArgs = supersededRunSnapshotCreationStub.firstCall.args[0];
+      expect(callArgs.siteId).to.equal(siteId);
+      expect(callArgs.auditType).to.equal('cited-analysis');
+      expect(callArgs.triggerAuditId).to.equal(auditId);
+      expect(callArgs.evergreenOpportunity).to.equal(visibleOpportunity);
+    });
+
+    it('does not attempt a snapshot on a genuine first-ever run (no evergreen exists yet)', async () => {
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([]),
+      };
+
+      await handler.default(validMessage(), context);
+
+      expect(supersededRunSnapshotCreationStub).to.not.have.been.called;
+    });
+
+    it('passes suppressed run snapshot identity in the initial create data, linked to the evergreen', async () => {
+      const visibleOpportunity = {
+        getId: sandbox.stub().returns('existing-opp-1'),
+        getType: sandbox.stub().returns('cited-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
+      };
+
+      const message = validMessage({
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: {
+              status: 'IGNORED',
+              tags: ['custom-tag'],
+              data: { qa: 'suppressed' },
+            },
+            suggestions: [{ id: 'test_1', rank: 1, type: 'CONTENT_UPDATE', data: {} }],
+          },
+        },
+      });
+
+      await handler.default(message, context);
+
+      const propsArg = convertToOpportunityStub.firstCall.args[5];
+      expect(propsArg.opportunityData.tags).to.include.members(['custom-tag', 'offsite-snapshot']);
+      expect(propsArg.opportunityData.data).to.deep.equal({
+        qa: 'suppressed',
+        snapshot: {
+          evergreenOpportunityId: 'existing-opp-1',
+          kind: 'suppressed-refresh',
+          triggerAuditId: auditId,
+        },
+      });
+    });
+
+    it('passes initial suppressed run snapshot identity without a linked evergreen when none exists yet', async () => {
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([]),
+      };
+
+      const message = validMessage({
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: { status: 'IGNORED' },
+            suggestions: [{ id: 'test_1', rank: 1, type: 'CONTENT_UPDATE', data: {} }],
+          },
+        },
+      });
+
+      await handler.default(message, context);
+
+      const propsArg = convertToOpportunityStub.firstCall.args[5];
+      expect(propsArg.opportunityData.tags).to.include('offsite-snapshot');
+      expect(propsArg.opportunityData.data.snapshot).to.deep.equal({
+        kind: 'suppressed-refresh',
+        triggerAuditId: auditId,
+      });
+    });
+
+    it('does not label a surfaced (NEW) run as a snapshot', async () => {
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([]),
+      };
+
+      await handler.default(validMessage(), context);
+    });
+
+    it('reuses and links an initially-unlinked snapshot when redelivered after an evergreen appears', async () => {
+      const existingSuppressedRunSnapshot = {
+        getId: sandbox.stub().returns('snapshot-opp-1'),
+      };
+      findSnapshotByTriggerAuditIdStub.resolves(existingSuppressedRunSnapshot);
+      const visibleOpportunity = {
+        getId: sandbox.stub().returns('existing-opp-1'),
+        getType: sandbox.stub().returns('cited-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
+      };
+
+      const message = validMessage({
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: { status: 'IGNORED' },
+            suggestions: [{ id: 'test_1', rank: 1, type: 'CONTENT_UPDATE', data: {} }],
+          },
+        },
+      });
+
+      await handler.default(message, context);
+
+      const propsArg = convertToOpportunityStub.firstCall.args[5];
+      expect(propsArg.opportunityToUpdate).to.equal(existingSuppressedRunSnapshot);
+      expect(propsArg.opportunityData.data.snapshot.evergreenOpportunityId)
+        .to.equal('existing-opp-1');
+    });
+
+    it('propagates the error (badRequest) when the suppressed-run snapshot idempotency lookup fails', async () => {
+      findSnapshotByTriggerAuditIdStub.rejects(new Error('DB down'));
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([]),
+      };
+
+      const message = validMessage({
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: { status: 'IGNORED' },
+            suggestions: [{ id: 'test_1', rank: 1, type: 'CONTENT_UPDATE', data: {} }],
+          },
+        },
+      });
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(400);
+      expect(convertToOpportunityStub).to.not.have.been.called;
+    });
+
+    it('creates a superseded snapshot for a surfaced refresh when auditId is missing', async () => {
+      const visibleOpportunity = {
+        getId: sandbox.stub().returns('existing-opp-1'),
+        getType: sandbox.stub().returns('cited-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
+      };
+
+      const result = await handler.default(validMessage({ auditId: undefined }), context);
+
+      expect(result.status).to.equal(200);
+      expect(supersededRunSnapshotCreationStub).to.have.been.calledOnce;
+      expect(convertToOpportunityStub).to.have.been.calledOnce;
+      expect(context.log.warn).to.have.been.calledWithMatch(/idempotency.*traceability/i);
+    });
+
+    it('creates a managed suppressed snapshot without lookup when auditId is missing', async () => {
+      const message = validMessage({
+        auditId: undefined,
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: { status: 'IGNORED', data: { qa: 'legacy' } },
+            suggestions: [{ id: 'test_1', rank: 1, type: 'CONTENT_UPDATE', data: {} }],
+          },
+        },
+      });
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(200);
+      expect(findSnapshotByTriggerAuditIdStub).to.not.have.been.called;
+      const propsArg = convertToOpportunityStub.firstCall.args[5];
+      expect(propsArg.opportunityData.tags).to.include('offsite-snapshot');
+      expect(propsArg.opportunityData.data).to.deep.equal({
+        qa: 'legacy',
+        snapshot: { kind: 'suppressed-refresh' },
+      });
+      expect(propsArg.opportunityData.data.snapshot).to.not.have.property('triggerAuditId');
     });
   });
 });

--- a/test/audits/cited-analysis/guidance-handler.test.js
+++ b/test/audits/cited-analysis/guidance-handler.test.js
@@ -1405,6 +1405,9 @@ describe('Cited Analysis Guidance Handler', () => {
       expect(context.dataAccess.Opportunity.allBySiteIdAndStatus).to.have.been.calledOnce;
     });
 
+    // resolveEvergreenOffsiteOpportunityStub intentionally mirrors the duplicate-retirement
+    // logic in offsite-refresh.js (setStatus IGNORED + saveMany), so the assertions below
+    // exercise the stub's fidelity to that real behavior, not just the handler's plumbing.
     it('should lazily retire duplicate NEW opportunities of the same type via saveMany, keeping the most recent as evergreen', async () => {
       const older = {
         getId: sandbox.stub().returns('older-opp'),

--- a/test/audits/reddit-analysis/guidance-handler.test.js
+++ b/test/audits/reddit-analysis/guidance-handler.test.js
@@ -80,15 +80,29 @@ describe('Reddit Analysis Guidance Handler', () => {
     resolveEvergreenOffsiteOpportunityStub = sandbox.stub().callsFake(
       async ({ dataAccess: da, siteId: sid, auditType: at }) => {
         const opps = await da.Opportunity.allBySiteIdAndStatus(sid, 'NEW');
-        return (opps || []).filter((o) => o.getType() === at)
-          .sort((a, b) => new Date(b.getUpdatedAt()) - new Date(a.getUpdatedAt()))[0] || null;
+        const matching = (opps || []).filter((o) => o.getType() === at);
+        if (matching.length === 0) return null;
+        if (matching.length === 1) return matching[0];
+
+        const [evergreen, ...duplicates] = [...matching].sort(
+          (a, b) => new Date(b.getUpdatedAt()) - new Date(a.getUpdatedAt()),
+        );
+        duplicates.forEach((duplicate) => {
+          duplicate.setStatus('IGNORED');
+          duplicate.setUpdatedBy('system');
+        });
+        await da.Opportunity.saveMany(duplicates);
+        return evergreen;
       },
     );
     isSuppressedRunStub = sandbox.stub().callsFake((status) => status === 'IGNORED');
 
     prepareSuppressedRunSnapshotStub = sandbox.stub().callsFake(async ({
-      triggerAuditId, opportunityData, evergreenOpportunity,
+      triggerAuditId, opportunityData, evergreenOpportunity, log: callLog,
     }) => {
+      if (!triggerAuditId) {
+        callLog.warn('[OffsiteSnapshot] Missing auditId; snapshot idempotency and traceability are unavailable');
+      }
       const existingSnapshot = triggerAuditId ? await findSnapshotByTriggerAuditIdStub() : null;
       return {
         opportunityToUpdate: existingSnapshot,
@@ -114,6 +128,9 @@ describe('Reddit Analysis Guidance Handler', () => {
         await supersededRunSnapshotCreationStub({
           dataAccess: da, siteId: sid, auditType: at, triggerAuditId, evergreenOpportunity, log: callLog,
         });
+        if (!triggerAuditId) {
+          callLog.warn('[OffsiteSnapshot] Missing auditId; snapshot idempotency and traceability are unavailable');
+        }
       }
       return { opportunityData, opportunityToUpdate: evergreenOpportunity };
     });

--- a/test/audits/reddit-analysis/guidance-handler.test.js
+++ b/test/audits/reddit-analysis/guidance-handler.test.js
@@ -36,6 +36,8 @@ describe('Reddit Analysis Guidance Handler', () => {
   let resolveBrandResultForSiteStub;
   let supersededRunSnapshotCreationStub;
   let findSnapshotByTriggerAuditIdStub;
+  let resolveEvergreenOffsiteOpportunityStub;
+  let isSuppressedRunStub;
   let prepareSuppressedRunSnapshotStub;
   let prepareSupersededRunSnapshotStub;
 
@@ -75,25 +77,28 @@ describe('Reddit Analysis Guidance Handler', () => {
     resolveBrandResultForSiteStub = sandbox.stub().resolves({ brand: null, resolved: true });
     supersededRunSnapshotCreationStub = sandbox.stub().resolves(null);
     findSnapshotByTriggerAuditIdStub = sandbox.stub().resolves(null);
+    resolveEvergreenOffsiteOpportunityStub = sandbox.stub().callsFake(
+      async ({ dataAccess: da, siteId: sid, auditType: at }) => {
+        const opps = await da.Opportunity.allBySiteIdAndStatus(sid, 'NEW');
+        return (opps || []).filter((o) => o.getType() === at)
+          .sort((a, b) => new Date(b.getUpdatedAt()) - new Date(a.getUpdatedAt()))[0] || null;
+      },
+    );
+    isSuppressedRunStub = sandbox.stub().callsFake((status) => status === 'IGNORED');
+
     prepareSuppressedRunSnapshotStub = sandbox.stub().callsFake(async ({
-      triggerAuditId,
-      opportunityData,
-      evergreenOpportunity,
+      triggerAuditId, opportunityData, evergreenOpportunity,
     }) => {
-      const existingSuppressedRunSnapshot = triggerAuditId
-        ? await findSnapshotByTriggerAuditIdStub()
-        : null;
+      const existingSnapshot = triggerAuditId ? await findSnapshotByTriggerAuditIdStub() : null;
       return {
-        opportunityToUpdate: existingSuppressedRunSnapshot,
+        opportunityToUpdate: existingSnapshot,
         opportunityData: {
           ...opportunityData,
           tags: [...new Set([...(opportunityData.tags || []), 'offsite-snapshot'])],
           data: {
             ...(opportunityData.data || {}),
             snapshot: {
-              ...(evergreenOpportunity
-                ? { evergreenOpportunityId: evergreenOpportunity.getId() }
-                : {}),
+              ...(evergreenOpportunity ? { evergreenOpportunityId: evergreenOpportunity.getId() } : {}),
               kind: 'suppressed-refresh',
               ...(triggerAuditId ? { triggerAuditId } : {}),
             },
@@ -101,27 +106,14 @@ describe('Reddit Analysis Guidance Handler', () => {
         },
       };
     });
+
     prepareSupersededRunSnapshotStub = sandbox.stub().callsFake(async ({
-      dataAccess,
-      siteId: refreshSiteId,
-      auditType,
-      triggerAuditId,
-      opportunityData,
-      evergreenOpportunity,
-      log,
+      dataAccess: da, siteId: sid, auditType: at, triggerAuditId, opportunityData, evergreenOpportunity, log: callLog,
     }) => {
       if (evergreenOpportunity) {
         await supersededRunSnapshotCreationStub({
-          dataAccess,
-          siteId: refreshSiteId,
-          auditType,
-          triggerAuditId,
-          evergreenOpportunity,
-          log,
+          dataAccess: da, siteId: sid, auditType: at, triggerAuditId, evergreenOpportunity, log: callLog,
         });
-        if (!triggerAuditId) {
-          log.warn('[OffsiteSnapshot] Missing auditId; snapshot idempotency and traceability are unavailable');
-        }
       }
       return { opportunityData, opportunityToUpdate: evergreenOpportunity };
     });
@@ -132,6 +124,12 @@ describe('Reddit Analysis Guidance Handler', () => {
       },
       '../../../src/common/offsite-refresh.js': {
         persistOffsiteOpportunity: convertToOpportunityStub,
+        resolveEvergreenOffsiteOpportunity: resolveEvergreenOffsiteOpportunityStub,
+        isSuppressedRun: isSuppressedRunStub,
+      },
+      '../../../src/common/offsite-snapshot.js': {
+        prepareSuppressedRunSnapshot: prepareSuppressedRunSnapshotStub,
+        prepareSupersededRunSnapshot: prepareSupersededRunSnapshotStub,
       },
       '../../../src/utils/slack-utils.js': { postMessageOptional: mockPostMessageOptional },
       '../../../src/utils/analysis-fetch.js': {
@@ -140,10 +138,6 @@ describe('Reddit Analysis Guidance Handler', () => {
       '../../../src/utils/brand-resolver.js': {
         resolveBrandResultForSite: resolveBrandResultForSiteStub,
         applyScopeToOpportunity: realApplyScopeToOpportunity,
-      },
-      '../../../src/common/offsite-snapshot.js': {
-        prepareSuppressedRunSnapshot: prepareSuppressedRunSnapshotStub,
-        prepareSupersededRunSnapshot: prepareSupersededRunSnapshotStub,
       },
     });
 

--- a/test/audits/reddit-analysis/guidance-handler.test.js
+++ b/test/audits/reddit-analysis/guidance-handler.test.js
@@ -1224,6 +1224,9 @@ describe('Reddit Analysis Guidance Handler', () => {
       expect(context.dataAccess.Opportunity.allBySiteIdAndStatus).to.have.been.calledOnce;
     });
 
+    // resolveEvergreenOffsiteOpportunityStub intentionally mirrors the duplicate-retirement
+    // logic in offsite-refresh.js (setStatus IGNORED + saveMany), so the assertions below
+    // exercise the stub's fidelity to that real behavior, not just the handler's plumbing.
     it('should lazily retire duplicate NEW opportunities of the same type via saveMany, keeping the most recent as evergreen', async () => {
       const older = {
         getId: sandbox.stub().returns('older-opp'),

--- a/test/audits/reddit-analysis/guidance-handler.test.js
+++ b/test/audits/reddit-analysis/guidance-handler.test.js
@@ -34,6 +34,10 @@ describe('Reddit Analysis Guidance Handler', () => {
   let fetchAnalysisStub;
   let mockPostMessageOptional;
   let resolveBrandResultForSiteStub;
+  let supersededRunSnapshotCreationStub;
+  let findSnapshotByTriggerAuditIdStub;
+  let prepareSuppressedRunSnapshotStub;
+  let prepareSupersededRunSnapshotStub;
 
   const baseURL = 'https://example.com';
   const siteId = 'test-site-id';
@@ -69,6 +73,58 @@ describe('Reddit Analysis Guidance Handler', () => {
     fetchAnalysisStub = sandbox.stub();
     mockPostMessageOptional = sandbox.stub().resolves({ success: true });
     resolveBrandResultForSiteStub = sandbox.stub().resolves({ brand: null, resolved: true });
+    supersededRunSnapshotCreationStub = sandbox.stub().resolves(null);
+    findSnapshotByTriggerAuditIdStub = sandbox.stub().resolves(null);
+    prepareSuppressedRunSnapshotStub = sandbox.stub().callsFake(async ({
+      triggerAuditId,
+      opportunityData,
+      evergreenOpportunity,
+    }) => {
+      const existingSuppressedRunSnapshot = triggerAuditId
+        ? await findSnapshotByTriggerAuditIdStub()
+        : null;
+      return {
+        opportunityToUpdate: existingSuppressedRunSnapshot,
+        opportunityData: {
+          ...opportunityData,
+          tags: [...new Set([...(opportunityData.tags || []), 'offsite-snapshot'])],
+          data: {
+            ...(opportunityData.data || {}),
+            snapshot: {
+              ...(evergreenOpportunity
+                ? { evergreenOpportunityId: evergreenOpportunity.getId() }
+                : {}),
+              kind: 'suppressed-refresh',
+              ...(triggerAuditId ? { triggerAuditId } : {}),
+            },
+          },
+        },
+      };
+    });
+    prepareSupersededRunSnapshotStub = sandbox.stub().callsFake(async ({
+      dataAccess,
+      siteId: refreshSiteId,
+      auditType,
+      triggerAuditId,
+      opportunityData,
+      evergreenOpportunity,
+      log,
+    }) => {
+      if (evergreenOpportunity) {
+        await supersededRunSnapshotCreationStub({
+          dataAccess,
+          siteId: refreshSiteId,
+          auditType,
+          triggerAuditId,
+          evergreenOpportunity,
+          log,
+        });
+        if (!triggerAuditId) {
+          log.warn('[OffsiteSnapshot] Missing auditId; snapshot idempotency and traceability are unavailable');
+        }
+      }
+      return { opportunityData, opportunityToUpdate: evergreenOpportunity };
+    });
 
     handler = await esmock('../../../src/reddit-analysis/guidance-handler.js', {
       '../../../src/utils/data-access.js': {
@@ -84,6 +140,10 @@ describe('Reddit Analysis Guidance Handler', () => {
       '../../../src/utils/brand-resolver.js': {
         resolveBrandResultForSite: resolveBrandResultForSiteStub,
         applyScopeToOpportunity: realApplyScopeToOpportunity,
+      },
+      '../../../src/common/offsite-snapshot.js': {
+        prepareSuppressedRunSnapshot: prepareSuppressedRunSnapshotStub,
+        prepareSupersededRunSnapshot: prepareSupersededRunSnapshotStub,
       },
     });
 
@@ -1100,10 +1160,10 @@ describe('Reddit Analysis Guidance Handler', () => {
       expect(convertToOpportunityStub).to.have.been.calledOnce;
       expect(syncSuggestionsStub).to.have.been.calledOnce;
       expect(mockOpportunity.setStatus).to.have.been.calledWith('IGNORED');
-      // existingOpportunity is explicitly null so persistOffsiteOpportunity creates a record
+      // opportunityToUpdate is explicitly null so persistOffsiteOpportunity creates a record
       // a new opportunity, never reusing (or re-querying for) the visible one.
       const propsArg = convertToOpportunityStub.firstCall.args[5];
-      expect(propsArg).to.have.property('existingOpportunity', null);
+      expect(propsArg).to.have.property('opportunityToUpdate', null);
     });
 
     // Whether nothing exists yet, or the only prior opportunity is already IGNORED, the
@@ -1130,7 +1190,7 @@ describe('Reddit Analysis Guidance Handler', () => {
       expect(convertToOpportunityStub).to.have.been.calledOnce;
       expect(mockOpportunity.setStatus).to.have.been.calledWith('IGNORED');
       const propsArg = convertToOpportunityStub.firstCall.args[5];
-      expect(propsArg).to.have.property('existingOpportunity', null);
+      expect(propsArg).to.have.property('opportunityToUpdate', null);
     });
 
     it('should hand the resolved evergreen to persistOffsiteOpportunity for a surfaced run', async () => {
@@ -1149,7 +1209,7 @@ describe('Reddit Analysis Guidance Handler', () => {
       await handler.default(message, context);
 
       const propsArg = convertToOpportunityStub.firstCall.args[5];
-      expect(propsArg.existingOpportunity).to.equal(visibleOpportunity);
+      expect(propsArg.opportunityToUpdate).to.equal(visibleOpportunity);
       expect(context.dataAccess.Opportunity.allBySiteIdAndStatus).to.have.been.calledOnce;
     });
 
@@ -1186,7 +1246,7 @@ describe('Reddit Analysis Guidance Handler', () => {
       expect(saveManyStub).to.have.been.calledOnce;
       expect(saveManyStub.firstCall.args[0]).to.deep.equal([older]);
       expect(convertToOpportunityStub).to.have.been.calledOnce;
-      expect(convertToOpportunityStub.firstCall.args[5].existingOpportunity).to.equal(newer);
+      expect(convertToOpportunityStub.firstCall.args[5].opportunityToUpdate).to.equal(newer);
     });
 
     it('should propagate the error (badRequest) when duplicate retirement fails, without proceeding', async () => {
@@ -1230,9 +1290,219 @@ describe('Reddit Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(400);
       // A transient read failure must never be treated as "nothing exists yet" (which
-      // would otherwise create a duplicate NEW opportunity) — conversion is never attempted.
+      // would otherwise create a duplicate NEW opportunity) — persistence is never attempted.
       expect(convertToOpportunityStub).to.not.have.been.called;
       expect(syncSuggestionsStub).to.not.have.been.called;
+    });
+  });
+
+  describe('Suppressed and superseded run snapshots', () => {
+    const validMessage = (overrides = {}) => ({
+      siteId,
+      auditId,
+      data: {
+        companyName: 'Example Corp',
+        analysis: {
+          suggestions: [
+            { id: 'test_1', priority: 'HIGH', title: 'Test', description: 'Test' },
+          ],
+        },
+      },
+      ...overrides,
+    });
+
+    it('snapshots the evergreen opportunity before a surfaced run overwrites it', async () => {
+      const visibleOpportunity = {
+        getId: sandbox.stub().returns('existing-opp-1'),
+        getType: sandbox.stub().returns('reddit-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
+      };
+
+      await handler.default(validMessage(), context);
+
+      expect(supersededRunSnapshotCreationStub).to.have.been.calledOnce;
+      const callArgs = supersededRunSnapshotCreationStub.firstCall.args[0];
+      expect(callArgs.siteId).to.equal(siteId);
+      expect(callArgs.auditType).to.equal('reddit-analysis');
+      expect(callArgs.triggerAuditId).to.equal(auditId);
+      expect(callArgs.evergreenOpportunity).to.equal(visibleOpportunity);
+    });
+
+    it('does not attempt a snapshot on a genuine first-ever run (no evergreen exists yet)', async () => {
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([]),
+      };
+
+      await handler.default(validMessage(), context);
+
+      expect(supersededRunSnapshotCreationStub).to.not.have.been.called;
+    });
+
+    it('passes suppressed run snapshot identity in the initial create data, linked to the evergreen', async () => {
+      const visibleOpportunity = {
+        getId: sandbox.stub().returns('existing-opp-1'),
+        getType: sandbox.stub().returns('reddit-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
+      };
+
+      const message = validMessage({
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: {
+              status: 'IGNORED',
+              tags: ['custom-tag'],
+              data: { qa: 'suppressed' },
+            },
+            suggestions: [{ id: 'test_1', priority: 'HIGH', title: 'Test', description: 'Test' }],
+          },
+        },
+      });
+
+      await handler.default(message, context);
+
+      const propsArg = convertToOpportunityStub.firstCall.args[5];
+      expect(propsArg.opportunityData.tags).to.include.members(['custom-tag', 'offsite-snapshot']);
+      expect(propsArg.opportunityData.data).to.deep.equal({
+        qa: 'suppressed',
+        snapshot: {
+          evergreenOpportunityId: 'existing-opp-1',
+          kind: 'suppressed-refresh',
+          triggerAuditId: auditId,
+        },
+      });
+    });
+
+    it('passes initial suppressed run snapshot identity without a linked evergreen when none exists yet', async () => {
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([]),
+      };
+
+      const message = validMessage({
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: { status: 'IGNORED' },
+            suggestions: [{ id: 'test_1', priority: 'HIGH', title: 'Test', description: 'Test' }],
+          },
+        },
+      });
+
+      await handler.default(message, context);
+
+      const propsArg = convertToOpportunityStub.firstCall.args[5];
+      expect(propsArg.opportunityData.tags).to.include('offsite-snapshot');
+      expect(propsArg.opportunityData.data.snapshot).to.deep.equal({
+        kind: 'suppressed-refresh',
+        triggerAuditId: auditId,
+      });
+    });
+
+    it('does not label a surfaced (NEW) run as a snapshot', async () => {
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([]),
+      };
+
+      await handler.default(validMessage(), context);
+    });
+
+    it('reuses a snapshot already tagged for this auditId instead of creating a duplicate on suppressed-run redelivery', async () => {
+      const existingSuppressedRunSnapshot = {
+        getId: sandbox.stub().returns('snapshot-opp-1'),
+      };
+      findSnapshotByTriggerAuditIdStub.resolves(existingSuppressedRunSnapshot);
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([]),
+      };
+
+      const message = validMessage({
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: { status: 'IGNORED' },
+            suggestions: [{ id: 'test_1', priority: 'HIGH', title: 'Test', description: 'Test' }],
+          },
+        },
+      });
+
+      await handler.default(message, context);
+
+      const propsArg = convertToOpportunityStub.firstCall.args[5];
+      expect(propsArg.opportunityToUpdate).to.equal(existingSuppressedRunSnapshot);
+    });
+
+    it('propagates the error (badRequest) when the suppressed-run snapshot idempotency lookup fails', async () => {
+      findSnapshotByTriggerAuditIdStub.rejects(new Error('DB down'));
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([]),
+      };
+
+      const message = validMessage({
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: { status: 'IGNORED' },
+            suggestions: [{ id: 'test_1', priority: 'HIGH', title: 'Test', description: 'Test' }],
+          },
+        },
+      });
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(400);
+      expect(convertToOpportunityStub).to.not.have.been.called;
+    });
+
+    it('creates a superseded snapshot for a surfaced refresh when auditId is missing', async () => {
+      const visibleOpportunity = {
+        getId: sandbox.stub().returns('existing-opp-1'),
+        getType: sandbox.stub().returns('reddit-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
+      };
+
+      const result = await handler.default(validMessage({ auditId: undefined }), context);
+
+      expect(result.status).to.equal(200);
+      expect(supersededRunSnapshotCreationStub).to.have.been.calledOnce;
+      expect(convertToOpportunityStub).to.have.been.calledOnce;
+      expect(context.log.warn).to.have.been.calledWithMatch(/idempotency.*traceability/i);
+    });
+
+    it('creates a managed suppressed snapshot without lookup when auditId is missing', async () => {
+      const message = validMessage({
+        auditId: undefined,
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: { status: 'IGNORED', data: { qa: 'legacy' } },
+            suggestions: [{ id: 'test_1', priority: 'HIGH', title: 'Test', description: 'Test' }],
+          },
+        },
+      });
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(200);
+      expect(findSnapshotByTriggerAuditIdStub).to.not.have.been.called;
+      const propsArg = convertToOpportunityStub.firstCall.args[5];
+      expect(propsArg.opportunityData.tags).to.include('offsite-snapshot');
+      expect(propsArg.opportunityData.data).to.deep.equal({
+        qa: 'legacy',
+        snapshot: { kind: 'suppressed-refresh' },
+      });
+      expect(propsArg.opportunityData.data.snapshot).to.not.have.property('triggerAuditId');
     });
   });
 });

--- a/test/audits/youtube-analysis/guidance-handler.test.js
+++ b/test/audits/youtube-analysis/guidance-handler.test.js
@@ -103,15 +103,29 @@ describe('YouTube Analysis Guidance Handler', () => {
     resolveEvergreenOffsiteOpportunityStub = sandbox.stub().callsFake(
       async ({ dataAccess: da, siteId: sid, auditType: at }) => {
         const opps = await da.Opportunity.allBySiteIdAndStatus(sid, 'NEW');
-        return (opps || []).filter((o) => o.getType() === at)
-          .sort((a, b) => new Date(b.getUpdatedAt()) - new Date(a.getUpdatedAt()))[0] || null;
+        const matching = (opps || []).filter((o) => o.getType() === at);
+        if (matching.length === 0) return null;
+        if (matching.length === 1) return matching[0];
+
+        const [evergreen, ...duplicates] = [...matching].sort(
+          (a, b) => new Date(b.getUpdatedAt()) - new Date(a.getUpdatedAt()),
+        );
+        duplicates.forEach((duplicate) => {
+          duplicate.setStatus('IGNORED');
+          duplicate.setUpdatedBy('system');
+        });
+        await da.Opportunity.saveMany(duplicates);
+        return evergreen;
       },
     );
     isSuppressedRunStub = sandbox.stub().callsFake((status) => status === 'IGNORED');
 
     prepareSuppressedRunSnapshotStub = sandbox.stub().callsFake(async ({
-      triggerAuditId, opportunityData, evergreenOpportunity,
+      triggerAuditId, opportunityData, evergreenOpportunity, log: callLog,
     }) => {
+      if (!triggerAuditId) {
+        callLog.warn('[OffsiteSnapshot] Missing auditId; snapshot idempotency and traceability are unavailable');
+      }
       const existingSnapshot = triggerAuditId ? await findSnapshotByTriggerAuditIdStub() : null;
       return {
         opportunityToUpdate: existingSnapshot,
@@ -137,6 +151,9 @@ describe('YouTube Analysis Guidance Handler', () => {
         await supersededRunSnapshotCreationStub({
           dataAccess: da, siteId: sid, auditType: at, triggerAuditId, evergreenOpportunity, log: callLog,
         });
+        if (!triggerAuditId) {
+          callLog.warn('[OffsiteSnapshot] Missing auditId; snapshot idempotency and traceability are unavailable');
+        }
       }
       return { opportunityData, opportunityToUpdate: evergreenOpportunity };
     });

--- a/test/audits/youtube-analysis/guidance-handler.test.js
+++ b/test/audits/youtube-analysis/guidance-handler.test.js
@@ -36,6 +36,8 @@ describe('YouTube Analysis Guidance Handler', () => {
   let resolveBrandResultForSiteStub;
   let supersededRunSnapshotCreationStub;
   let findSnapshotByTriggerAuditIdStub;
+  let resolveEvergreenOffsiteOpportunityStub;
+  let isSuppressedRunStub;
   let prepareSuppressedRunSnapshotStub;
   let prepareSupersededRunSnapshotStub;
 
@@ -98,25 +100,28 @@ describe('YouTube Analysis Guidance Handler', () => {
     resolveBrandResultForSiteStub = sandbox.stub().resolves({ brand: null, resolved: true });
     supersededRunSnapshotCreationStub = sandbox.stub().resolves(null);
     findSnapshotByTriggerAuditIdStub = sandbox.stub().resolves(null);
+    resolveEvergreenOffsiteOpportunityStub = sandbox.stub().callsFake(
+      async ({ dataAccess: da, siteId: sid, auditType: at }) => {
+        const opps = await da.Opportunity.allBySiteIdAndStatus(sid, 'NEW');
+        return (opps || []).filter((o) => o.getType() === at)
+          .sort((a, b) => new Date(b.getUpdatedAt()) - new Date(a.getUpdatedAt()))[0] || null;
+      },
+    );
+    isSuppressedRunStub = sandbox.stub().callsFake((status) => status === 'IGNORED');
+
     prepareSuppressedRunSnapshotStub = sandbox.stub().callsFake(async ({
-      triggerAuditId,
-      opportunityData,
-      evergreenOpportunity,
+      triggerAuditId, opportunityData, evergreenOpportunity,
     }) => {
-      const existingSuppressedRunSnapshot = triggerAuditId
-        ? await findSnapshotByTriggerAuditIdStub()
-        : null;
+      const existingSnapshot = triggerAuditId ? await findSnapshotByTriggerAuditIdStub() : null;
       return {
-        opportunityToUpdate: existingSuppressedRunSnapshot,
+        opportunityToUpdate: existingSnapshot,
         opportunityData: {
           ...opportunityData,
           tags: [...new Set([...(opportunityData.tags || []), 'offsite-snapshot'])],
           data: {
             ...(opportunityData.data || {}),
             snapshot: {
-              ...(evergreenOpportunity
-                ? { evergreenOpportunityId: evergreenOpportunity.getId() }
-                : {}),
+              ...(evergreenOpportunity ? { evergreenOpportunityId: evergreenOpportunity.getId() } : {}),
               kind: 'suppressed-refresh',
               ...(triggerAuditId ? { triggerAuditId } : {}),
             },
@@ -124,27 +129,14 @@ describe('YouTube Analysis Guidance Handler', () => {
         },
       };
     });
+
     prepareSupersededRunSnapshotStub = sandbox.stub().callsFake(async ({
-      dataAccess,
-      siteId: refreshSiteId,
-      auditType,
-      triggerAuditId,
-      opportunityData,
-      evergreenOpportunity,
-      log,
+      dataAccess: da, siteId: sid, auditType: at, triggerAuditId, opportunityData, evergreenOpportunity, log: callLog,
     }) => {
       if (evergreenOpportunity) {
         await supersededRunSnapshotCreationStub({
-          dataAccess,
-          siteId: refreshSiteId,
-          auditType,
-          triggerAuditId,
-          evergreenOpportunity,
-          log,
+          dataAccess: da, siteId: sid, auditType: at, triggerAuditId, evergreenOpportunity, log: callLog,
         });
-        if (!triggerAuditId) {
-          log.warn('[OffsiteSnapshot] Missing auditId; snapshot idempotency and traceability are unavailable');
-        }
       }
       return { opportunityData, opportunityToUpdate: evergreenOpportunity };
     });
@@ -158,6 +150,12 @@ describe('YouTube Analysis Guidance Handler', () => {
       },
       '../../../src/common/offsite-refresh.js': {
         persistOffsiteOpportunity: mockConvertToOpportunity,
+        resolveEvergreenOffsiteOpportunity: resolveEvergreenOffsiteOpportunityStub,
+        isSuppressedRun: isSuppressedRunStub,
+      },
+      '../../../src/common/offsite-snapshot.js': {
+        prepareSuppressedRunSnapshot: prepareSuppressedRunSnapshotStub,
+        prepareSupersededRunSnapshot: prepareSupersededRunSnapshotStub,
       },
       '../../../src/utils/slack-utils.js': {
         postMessageOptional: mockPostMessageOptional,
@@ -165,10 +163,6 @@ describe('YouTube Analysis Guidance Handler', () => {
       '../../../src/utils/brand-resolver.js': {
         resolveBrandResultForSite: resolveBrandResultForSiteStub,
         applyScopeToOpportunity: realApplyScopeToOpportunity,
-      },
-      '../../../src/common/offsite-snapshot.js': {
-        prepareSuppressedRunSnapshot: prepareSuppressedRunSnapshotStub,
-        prepareSupersededRunSnapshot: prepareSupersededRunSnapshotStub,
       },
     });
 

--- a/test/audits/youtube-analysis/guidance-handler.test.js
+++ b/test/audits/youtube-analysis/guidance-handler.test.js
@@ -1215,6 +1215,9 @@ describe('YouTube Analysis Guidance Handler', () => {
       expect(context.dataAccess.Opportunity.allBySiteIdAndStatus).to.have.been.calledOnce;
     });
 
+    // resolveEvergreenOffsiteOpportunityStub intentionally mirrors the duplicate-retirement
+    // logic in offsite-refresh.js (setStatus IGNORED + saveMany), so the assertions below
+    // exercise the stub's fidelity to that real behavior, not just the handler's plumbing.
     it('should lazily retire duplicate NEW opportunities of the same type via saveMany, keeping the most recent as evergreen', async () => {
       const older = {
         getId: sandbox.stub().returns('older-opp'),

--- a/test/audits/youtube-analysis/guidance-handler.test.js
+++ b/test/audits/youtube-analysis/guidance-handler.test.js
@@ -34,6 +34,10 @@ describe('YouTube Analysis Guidance Handler', () => {
   let mockSyncSuggestions;
   let mockPostMessageOptional;
   let resolveBrandResultForSiteStub;
+  let supersededRunSnapshotCreationStub;
+  let findSnapshotByTriggerAuditIdStub;
+  let prepareSuppressedRunSnapshotStub;
+  let prepareSupersededRunSnapshotStub;
 
   const siteId = 'test-site-id';
   const auditId = 'test-audit-id';
@@ -92,6 +96,58 @@ describe('YouTube Analysis Guidance Handler', () => {
     mockSyncSuggestions = sandbox.stub().resolves();
     mockPostMessageOptional = sandbox.stub().resolves({ success: true });
     resolveBrandResultForSiteStub = sandbox.stub().resolves({ brand: null, resolved: true });
+    supersededRunSnapshotCreationStub = sandbox.stub().resolves(null);
+    findSnapshotByTriggerAuditIdStub = sandbox.stub().resolves(null);
+    prepareSuppressedRunSnapshotStub = sandbox.stub().callsFake(async ({
+      triggerAuditId,
+      opportunityData,
+      evergreenOpportunity,
+    }) => {
+      const existingSuppressedRunSnapshot = triggerAuditId
+        ? await findSnapshotByTriggerAuditIdStub()
+        : null;
+      return {
+        opportunityToUpdate: existingSuppressedRunSnapshot,
+        opportunityData: {
+          ...opportunityData,
+          tags: [...new Set([...(opportunityData.tags || []), 'offsite-snapshot'])],
+          data: {
+            ...(opportunityData.data || {}),
+            snapshot: {
+              ...(evergreenOpportunity
+                ? { evergreenOpportunityId: evergreenOpportunity.getId() }
+                : {}),
+              kind: 'suppressed-refresh',
+              ...(triggerAuditId ? { triggerAuditId } : {}),
+            },
+          },
+        },
+      };
+    });
+    prepareSupersededRunSnapshotStub = sandbox.stub().callsFake(async ({
+      dataAccess,
+      siteId: refreshSiteId,
+      auditType,
+      triggerAuditId,
+      opportunityData,
+      evergreenOpportunity,
+      log,
+    }) => {
+      if (evergreenOpportunity) {
+        await supersededRunSnapshotCreationStub({
+          dataAccess,
+          siteId: refreshSiteId,
+          auditType,
+          triggerAuditId,
+          evergreenOpportunity,
+          log,
+        });
+        if (!triggerAuditId) {
+          log.warn('[OffsiteSnapshot] Missing auditId; snapshot idempotency and traceability are unavailable');
+        }
+      }
+      return { opportunityData, opportunityToUpdate: evergreenOpportunity };
+    });
 
     guidanceHandler = await esmock('../../../src/youtube-analysis/guidance-handler.js', {
       '../../../src/utils/analysis-fetch.js': {
@@ -109,6 +165,10 @@ describe('YouTube Analysis Guidance Handler', () => {
       '../../../src/utils/brand-resolver.js': {
         resolveBrandResultForSite: resolveBrandResultForSiteStub,
         applyScopeToOpportunity: realApplyScopeToOpportunity,
+      },
+      '../../../src/common/offsite-snapshot.js': {
+        prepareSuppressedRunSnapshot: prepareSuppressedRunSnapshotStub,
+        prepareSupersededRunSnapshot: prepareSupersededRunSnapshotStub,
       },
     });
 
@@ -412,7 +472,7 @@ describe('YouTube Analysis Guidance Handler', () => {
         context,
         sinon.match.any,
         sinon.match.any,
-        { opportunityData: {}, existingOpportunity: null },
+        { opportunityData: {}, opportunityToUpdate: null },
       );
     });
 
@@ -1091,10 +1151,10 @@ describe('YouTube Analysis Guidance Handler', () => {
       expect(mockConvertToOpportunity).to.have.been.calledOnce;
       expect(mockSyncSuggestions).to.have.been.calledOnce;
       expect(mockOpportunity.setStatus).to.have.been.calledWith('IGNORED');
-      // existingOpportunity is explicitly null so persistOffsiteOpportunity creates a record
+      // opportunityToUpdate is explicitly null so persistOffsiteOpportunity creates a record
       // a new opportunity, never reusing (or re-querying for) the visible one.
       const propsArg = mockConvertToOpportunity.firstCall.args[5];
-      expect(propsArg).to.have.property('existingOpportunity', null);
+      expect(propsArg).to.have.property('opportunityToUpdate', null);
     });
 
     // Whether nothing exists yet, or the only prior opportunity is already IGNORED, the
@@ -1121,7 +1181,7 @@ describe('YouTube Analysis Guidance Handler', () => {
       expect(mockConvertToOpportunity).to.have.been.calledOnce;
       expect(mockOpportunity.setStatus).to.have.been.calledWith('IGNORED');
       const propsArg = mockConvertToOpportunity.firstCall.args[5];
-      expect(propsArg).to.have.property('existingOpportunity', null);
+      expect(propsArg).to.have.property('opportunityToUpdate', null);
     });
 
     it('should hand the resolved evergreen to persistOffsiteOpportunity for a surfaced run', async () => {
@@ -1140,7 +1200,7 @@ describe('YouTube Analysis Guidance Handler', () => {
       await guidanceHandler.default(message, context);
 
       const propsArg = mockConvertToOpportunity.firstCall.args[5];
-      expect(propsArg.existingOpportunity).to.equal(visibleOpportunity);
+      expect(propsArg.opportunityToUpdate).to.equal(visibleOpportunity);
       expect(context.dataAccess.Opportunity.allBySiteIdAndStatus).to.have.been.calledOnce;
     });
 
@@ -1177,7 +1237,7 @@ describe('YouTube Analysis Guidance Handler', () => {
       expect(saveManyStub).to.have.been.calledOnce;
       expect(saveManyStub.firstCall.args[0]).to.deep.equal([older]);
       expect(mockConvertToOpportunity).to.have.been.calledOnce;
-      expect(mockConvertToOpportunity.firstCall.args[5].existingOpportunity).to.equal(newer);
+      expect(mockConvertToOpportunity.firstCall.args[5].opportunityToUpdate).to.equal(newer);
     });
 
     it('should propagate the error (badRequest) when duplicate retirement fails, without proceeding', async () => {
@@ -1221,9 +1281,219 @@ describe('YouTube Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(400);
       // A transient read failure must never be treated as "nothing exists yet" (which
-      // would otherwise create a duplicate NEW opportunity) — conversion is never attempted.
+      // would otherwise create a duplicate NEW opportunity) — persistence is never attempted.
       expect(mockConvertToOpportunity).to.not.have.been.called;
       expect(mockSyncSuggestions).to.not.have.been.called;
+    });
+  });
+
+  describe('Suppressed and superseded run snapshots', () => {
+    const validMessage = (overrides = {}) => ({
+      siteId,
+      auditId,
+      data: {
+        companyName: 'Example Corp',
+        analysis: {
+          suggestions: [
+            { id: 'test_1', priority: 'HIGH', title: 'Test', description: 'Test' },
+          ],
+        },
+      },
+      ...overrides,
+    });
+
+    it('snapshots the evergreen opportunity before a surfaced run overwrites it', async () => {
+      const visibleOpportunity = {
+        getId: sandbox.stub().returns('existing-opp-1'),
+        getType: sandbox.stub().returns('youtube-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
+      };
+
+      await guidanceHandler.default(validMessage(), context);
+
+      expect(supersededRunSnapshotCreationStub).to.have.been.calledOnce;
+      const callArgs = supersededRunSnapshotCreationStub.firstCall.args[0];
+      expect(callArgs.siteId).to.equal(siteId);
+      expect(callArgs.auditType).to.equal('youtube-analysis');
+      expect(callArgs.triggerAuditId).to.equal(auditId);
+      expect(callArgs.evergreenOpportunity).to.equal(visibleOpportunity);
+    });
+
+    it('does not attempt a snapshot on a genuine first-ever run (no evergreen exists yet)', async () => {
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([]),
+      };
+
+      await guidanceHandler.default(validMessage(), context);
+
+      expect(supersededRunSnapshotCreationStub).to.not.have.been.called;
+    });
+
+    it('passes suppressed run snapshot identity in the initial create data, linked to the evergreen', async () => {
+      const visibleOpportunity = {
+        getId: sandbox.stub().returns('existing-opp-1'),
+        getType: sandbox.stub().returns('youtube-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
+      };
+
+      const message = validMessage({
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: {
+              status: 'IGNORED',
+              tags: ['custom-tag'],
+              data: { qa: 'suppressed' },
+            },
+            suggestions: [{ id: 'test_1', priority: 'HIGH', title: 'Test', description: 'Test' }],
+          },
+        },
+      });
+
+      await guidanceHandler.default(message, context);
+
+      const propsArg = mockConvertToOpportunity.firstCall.args[5];
+      expect(propsArg.opportunityData.tags).to.include.members(['custom-tag', 'offsite-snapshot']);
+      expect(propsArg.opportunityData.data).to.deep.equal({
+        qa: 'suppressed',
+        snapshot: {
+          evergreenOpportunityId: 'existing-opp-1',
+          kind: 'suppressed-refresh',
+          triggerAuditId: auditId,
+        },
+      });
+    });
+
+    it('passes initial suppressed run snapshot identity without a linked evergreen when none exists yet', async () => {
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([]),
+      };
+
+      const message = validMessage({
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: { status: 'IGNORED' },
+            suggestions: [{ id: 'test_1', priority: 'HIGH', title: 'Test', description: 'Test' }],
+          },
+        },
+      });
+
+      await guidanceHandler.default(message, context);
+
+      const propsArg = mockConvertToOpportunity.firstCall.args[5];
+      expect(propsArg.opportunityData.tags).to.include('offsite-snapshot');
+      expect(propsArg.opportunityData.data.snapshot).to.deep.equal({
+        kind: 'suppressed-refresh',
+        triggerAuditId: auditId,
+      });
+    });
+
+    it('does not label a surfaced (NEW) run as a snapshot', async () => {
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([]),
+      };
+
+      await guidanceHandler.default(validMessage(), context);
+    });
+
+    it('reuses a snapshot already tagged for this auditId instead of creating a duplicate on suppressed-run redelivery', async () => {
+      const existingSuppressedRunSnapshot = {
+        getId: sandbox.stub().returns('snapshot-opp-1'),
+      };
+      findSnapshotByTriggerAuditIdStub.resolves(existingSuppressedRunSnapshot);
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([]),
+      };
+
+      const message = validMessage({
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: { status: 'IGNORED' },
+            suggestions: [{ id: 'test_1', priority: 'HIGH', title: 'Test', description: 'Test' }],
+          },
+        },
+      });
+
+      await guidanceHandler.default(message, context);
+
+      const propsArg = mockConvertToOpportunity.firstCall.args[5];
+      expect(propsArg.opportunityToUpdate).to.equal(existingSuppressedRunSnapshot);
+    });
+
+    it('propagates the error (badRequest) when the suppressed-run snapshot idempotency lookup fails', async () => {
+      findSnapshotByTriggerAuditIdStub.rejects(new Error('DB down'));
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([]),
+      };
+
+      const message = validMessage({
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: { status: 'IGNORED' },
+            suggestions: [{ id: 'test_1', priority: 'HIGH', title: 'Test', description: 'Test' }],
+          },
+        },
+      });
+
+      const result = await guidanceHandler.default(message, context);
+
+      expect(result.status).to.equal(400);
+      expect(mockConvertToOpportunity).to.not.have.been.called;
+    });
+
+    it('creates a superseded snapshot for a surfaced refresh when auditId is missing', async () => {
+      const visibleOpportunity = {
+        getId: sandbox.stub().returns('existing-opp-1'),
+        getType: sandbox.stub().returns('youtube-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
+      };
+
+      const result = await guidanceHandler.default(validMessage({ auditId: undefined }), context);
+
+      expect(result.status).to.equal(200);
+      expect(supersededRunSnapshotCreationStub).to.have.been.calledOnce;
+      expect(mockConvertToOpportunity).to.have.been.calledOnce;
+      expect(context.log.warn).to.have.been.calledWithMatch(/idempotency.*traceability/i);
+    });
+
+    it('creates a managed suppressed snapshot without lookup when auditId is missing', async () => {
+      const message = validMessage({
+        auditId: undefined,
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: { status: 'IGNORED', data: { qa: 'legacy' } },
+            suggestions: [{ id: 'test_1', priority: 'HIGH', title: 'Test', description: 'Test' }],
+          },
+        },
+      });
+
+      const result = await guidanceHandler.default(message, context);
+
+      expect(result.status).to.equal(200);
+      expect(findSnapshotByTriggerAuditIdStub).to.not.have.been.called;
+      const propsArg = mockConvertToOpportunity.firstCall.args[5];
+      expect(propsArg.opportunityData.tags).to.include('offsite-snapshot');
+      expect(propsArg.opportunityData.data).to.deep.equal({
+        qa: 'legacy',
+        snapshot: { kind: 'suppressed-refresh' },
+      });
+      expect(propsArg.opportunityData.data.snapshot).to.not.have.property('triggerAuditId');
     });
   });
 });

--- a/test/audits/youtube-analysis/opportunity-data-mapper.test.js
+++ b/test/audits/youtube-analysis/opportunity-data-mapper.test.js
@@ -41,7 +41,7 @@ describe('YouTube Analysis Opportunity Data Mapper', () => {
       expect(result.description).to.equal(opportunityData.description);
       expect(result.runbook).to.equal(opportunityData.runbook);
       expect(result.status).to.equal(opportunityData.status);
-      expect(result.tags).to.deep.equal(['Video Content', 'Youtube']);
+      expect(result.tags).to.deep.equal(['Video Content', 'Youtube', 'social', 'isElmo']);
       expect(result.data.dataSources).to.deep.equal(['Site', 'Page']);
       expect(result.origin).to.equal('AUTOMATION');
       expect(result.type).to.equal('youtube-analysis');

--- a/test/common/offsite-refresh-integration.test.js
+++ b/test/common/offsite-refresh-integration.test.js
@@ -60,6 +60,13 @@ describe('offsite refresh handler composition', () => {
     };
     const syncSuggestions = sandbox.stub().resolves();
     const checkGoogleConnection = sandbox.stub().resolves(true);
+    const prepareSuppressedRunSnapshot = sandbox.stub();
+    const prepareSupersededRunSnapshot = sandbox.stub().callsFake(
+      async ({ opportunityData, evergreenOpportunity: evergreenOpportunityToRefresh }) => ({
+        opportunityData,
+        opportunityToUpdate: evergreenOpportunityToRefresh,
+      }),
+    );
     const log = {
       info: sandbox.spy(),
       error: sandbox.spy(),
@@ -92,6 +99,10 @@ describe('offsite refresh handler composition', () => {
     const handler = await esmock('../../src/cited-analysis/guidance-handler.js', {
       '../../src/common/opportunity-utils.js': {
         checkGoogleConnection,
+      },
+      '../../src/common/offsite-snapshot.js': {
+        prepareSuppressedRunSnapshot,
+        prepareSupersededRunSnapshot,
       },
       '../../src/utils/data-access.js': {
         syncSuggestions,

--- a/test/common/offsite-refresh.test.js
+++ b/test/common/offsite-refresh.test.js
@@ -303,7 +303,7 @@ describe('offsite-refresh', () => {
         context,
         () => ({ data: {}, status: 'IGNORED' }),
         'reddit-analysis',
-        { existingOpportunity: null },
+        { opportunityToUpdate: null },
       );
 
       expect(log.info).to.have.been.calledWith(
@@ -337,7 +337,7 @@ describe('offsite-refresh', () => {
         context,
         () => ({ data: {} }),
         'cited-analysis',
-        { existingOpportunity: evergreen },
+        { opportunityToUpdate: evergreen },
       );
 
       expect(log.info).to.have.been.calledWith(
@@ -359,7 +359,7 @@ describe('offsite-refresh', () => {
         context,
         () => ({ data: {}, status: 'NEW' }),
         'youtube-analysis',
-        { existingOpportunity: null },
+        { opportunityToUpdate: null },
       )).to.be.rejectedWith('db exploded');
 
       expect(log.error).to.have.been.calledWith(

--- a/test/common/offsite-snapshot-integration.test.js
+++ b/test/common/offsite-snapshot-integration.test.js
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import esmock from 'esmock';
+import { applyScopeToOpportunity as realApplyScopeToOpportunity } from '../../src/utils/brand-resolver.js';
+import { MockContextBuilder } from '../shared.js';
+
+use(sinonChai);
+
+// Exercises the real cited handler, snapshot helpers, mapper, and persistence helper.
+describe('offsite-snapshot real-composition integration (cited-analysis)', () => {
+  let sandbox;
+  let handler;
+  let syncSuggestionsStub;
+  let resolveBrandResultForSiteStub;
+  let checkGoogleConnectionStub;
+  let context;
+
+  const siteId = 'test-site-id';
+  const auditId = 'trigger-audit-1';
+  const baseURL = 'https://example.com';
+
+  // Stateful fake matching model getter/setter behavior.
+  function makeMutableOpportunity({
+    id, type = 'cited-analysis', tags = [], data = {}, status = 'NEW',
+  }) {
+    const state = { tags: [...tags], data: { ...data }, status };
+    return {
+      getId: () => id,
+      getType: () => type,
+      getTags: () => state.tags,
+      getData: () => state.data,
+      getStatus: () => state.status,
+      getScopeType: () => state.scopeType,
+      getScopeId: () => state.scopeId,
+      setTags: sandbox.stub().callsFake((t) => { state.tags = t; }),
+      setData: sandbox.stub().callsFake((d) => { state.data = d; }),
+      setStatus: sandbox.stub().callsFake((s) => { state.status = s; }),
+      setScopeType: sandbox.stub().callsFake((t) => { state.scopeType = t; }),
+      setScopeId: sandbox.stub().callsFake((i) => { state.scopeId = i; }),
+      setAuditId: sandbox.stub(),
+      setUpdatedBy: sandbox.stub(),
+      save: sandbox.stub().resolves(),
+      getSuggestions: sandbox.stub().resolves([]),
+      addSuggestions: sandbox.stub().resolves({ errorItems: [] }),
+    };
+  }
+
+  const buildMessage = ({ status = 'IGNORED' } = {}) => ({
+    siteId,
+    auditId,
+    data: {
+      companyName: 'Acme',
+      analysis: {
+        opportunity: { status, type: 'cited-analysis' },
+        suggestions: [{
+          id: 'suggestion-1', type: 'CONTENT_UPDATE', rank: 1, data: {},
+        }],
+      },
+    },
+  });
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+
+    syncSuggestionsStub = sandbox.stub().resolves();
+    // Brand resolution hits PostgREST in production; stub it so the test never touches the
+    // network, but keep the REAL applyScopeToOpportunity so scope-setter composition is
+    // still exercised end-to-end.
+    resolveBrandResultForSiteStub = sandbox.stub().resolves({ brand: null, resolved: true });
+    // GoogleClient.createFrom makes a real external call; stub only this leaf so the real
+    // convertToOpportunity (imported transitively, unmocked) never reaches the network.
+    checkGoogleConnectionStub = sandbox.stub().resolves(true);
+
+    handler = await esmock('../../src/cited-analysis/guidance-handler.js', {
+      '../../src/utils/data-access.js': {
+        syncSuggestions: syncSuggestionsStub,
+      },
+      '../../src/utils/brand-resolver.js': {
+        resolveBrandResultForSite: resolveBrandResultForSiteStub,
+        applyScopeToOpportunity: realApplyScopeToOpportunity,
+      },
+      '../../src/common/opportunity-utils.js': {
+        checkGoogleConnection: checkGoogleConnectionStub,
+      },
+    });
+
+    context = new MockContextBuilder()
+      .withSandbox(sandbox)
+      .withOverrides({
+        dataAccess: {
+          Site: {
+            findById: sandbox.stub().resolves({
+              getId: () => siteId,
+              getBaseURL: () => baseURL,
+              getOrganizationId: () => 'org-1',
+            }),
+          },
+          Audit: {
+            findById: sandbox.stub().resolves({
+              getId: () => auditId,
+              getAuditResult: () => ({}),
+            }),
+          },
+          Opportunity: {
+            allBySiteIdAndStatus: sandbox.stub().resolves([]),
+            create: sandbox.stub(),
+          },
+        },
+      })
+      .build();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('initial-create identity: the very first Opportunity.create() call for a suppressed run with no pre-existing evergreen already carries status IGNORED, the offsite-snapshot tag, and data.snapshot', async () => {
+    // No NEW evergreen and no IGNORED snapshot exist yet for this site/type — genuine
+    // first-ever suppressed run.
+    context.dataAccess.Opportunity.allBySiteIdAndStatus.resolves([]);
+    context.dataAccess.Opportunity.create.callsFake(async (payload) => makeMutableOpportunity({
+      id: 'snapshot-created-1',
+      type: payload.type,
+      tags: payload.tags,
+      data: payload.data,
+      status: payload.status,
+    }));
+
+    const result = await handler.default(buildMessage({ status: 'IGNORED' }), context);
+
+    expect(result.status).to.equal(200);
+    expect(context.dataAccess.Opportunity.create).to.have.been.calledOnce;
+
+    const [payload] = context.dataAccess.Opportunity.create.firstCall.args;
+    // These fields must already be correct on THIS call — no separate later save() is
+    // required to make the row identifiable as a managed snapshot.
+    expect(payload.status).to.equal('IGNORED');
+    expect(payload.tags).to.include('offsite-snapshot');
+    expect(payload.data.snapshot).to.deep.equal({
+      kind: 'suppressed-refresh',
+      triggerAuditId: auditId,
+    });
+    // No evergreen existed yet, so there is nothing to link to.
+    expect(payload.data.snapshot).to.not.have.property('evergreenOpportunityId');
+
+    // syncSuggestions still runs against the real created+saved opportunity — confirms the
+    // real composition didn't short-circuit before reaching the suggestion-sync step.
+    expect(syncSuggestionsStub).to.have.been.calledOnce;
+  });
+
+  it('unlinked -> linked redelivery: reusing a previously-unlinked snapshot on redelivery after an evergreen now exists persists evergreenOpportunityId via save(), without a duplicate Opportunity.create()', async () => {
+    const unlinkedSnapshot = makeMutableOpportunity({
+      id: 'snapshot-1',
+      tags: ['offsite-snapshot'],
+      data: { snapshot: { kind: 'suppressed-refresh', triggerAuditId: auditId } },
+      status: 'IGNORED',
+    });
+    const evergreenOpportunity = makeMutableOpportunity({
+      id: 'evergreen-1',
+      tags: [],
+      data: { dashboard: { sov: 0.4 } },
+      status: 'NEW',
+    });
+
+    context.dataAccess.Opportunity.allBySiteIdAndStatus.callsFake(async (_siteId, status) => (
+      status === 'NEW' ? [evergreenOpportunity] : [unlinkedSnapshot]
+    ));
+
+    const result = await handler.default(buildMessage({ status: 'IGNORED' }), context);
+
+    expect(result.status).to.equal(200);
+    // The relink must be a reuse, not a second creation.
+    expect(context.dataAccess.Opportunity.create).to.not.have.been.called;
+    expect(unlinkedSnapshot.save).to.have.been.called;
+
+    // The persisted state (read back via getData(), not the constructor args) now carries
+    // the evergreen linkage — proving the relink was actually applied to the object that
+    // gets saved, not merely computed and discarded.
+    const persistedData = unlinkedSnapshot.getData();
+    expect(persistedData.snapshot).to.deep.equal({
+      evergreenOpportunityId: 'evergreen-1',
+      kind: 'suppressed-refresh',
+      triggerAuditId: auditId,
+    });
+
+    // The evergreen opportunity itself is untouched by the suppressed run's relink.
+    expect(evergreenOpportunity.save).to.not.have.been.called;
+  });
+});

--- a/test/common/offsite-snapshot.test.js
+++ b/test/common/offsite-snapshot.test.js
@@ -1,0 +1,644 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
+import {
+  SNAPSHOT_TAG,
+  SNAPSHOT_KINDS,
+  buildSnapshotData,
+  findSnapshotByTriggerAuditId,
+  prepareSuppressedRunSnapshot,
+  prepareSupersededRunSnapshot,
+} from '../../src/common/offsite-snapshot.js';
+
+use(sinonChai);
+use(chaiAsPromised);
+
+describe('offsite-snapshot', () => {
+  let sandbox;
+  let log;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    log = {
+      info: sandbox.spy(), error: sandbox.spy(), warn: sandbox.spy(), debug: sandbox.spy(),
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  const makeSnapshotOpportunity = ({
+    id = 'snapshot-1',
+    type = 'cited-analysis',
+    tags = [SNAPSHOT_TAG],
+    snapshot = { triggerAuditId: 'audit-1' },
+  } = {}) => ({
+    getId: () => id,
+    getType: () => type,
+    getTags: () => tags,
+    getData: () => ({ snapshot }),
+  });
+
+  const makeEvergreenOpportunity = ({
+    suggestions = [],
+    scopeType,
+    scopeId,
+    tags = ['existing-tag'],
+    data = { sentiment: { score: 0.8 } },
+  } = {}) => ({
+    getId: () => 'evergreen-1',
+    getSiteId: () => 'site-1',
+    getAuditId: () => 'source-audit-1',
+    getType: () => 'cited-analysis',
+    getOrigin: () => 'AUTOMATION',
+    getTitle: () => 'Cited analysis opportunity',
+    getDescription: () => 'description',
+    getRunbook: () => '',
+    getGuidance: () => undefined,
+    getTags: () => tags,
+    getData: () => data,
+    getScopeType: () => scopeType,
+    getScopeId: () => scopeId,
+    getSuggestions: sandbox.stub().resolves(suggestions),
+  });
+
+  describe('buildSnapshotData', () => {
+    it('adds snapshot metadata to plain nested source data without mutation', () => {
+      const sourceData = { sentiment: { score: 0.8 } };
+
+      const result = buildSnapshotData(sourceData, {
+        evergreenOpportunityId: 'evergreen-1',
+        kind: SNAPSHOT_KINDS.SUPERSEDED_REFRESH,
+        triggerAuditId: 'audit-1',
+      });
+
+      expect(result).to.deep.equal({
+        sentiment: { score: 0.8 },
+        snapshot: {
+          evergreenOpportunityId: 'evergreen-1',
+          kind: SNAPSHOT_KINDS.SUPERSEDED_REFRESH,
+          triggerAuditId: 'audit-1',
+        },
+      });
+      expect(sourceData).to.deep.equal({ sentiment: { score: 0.8 } });
+    });
+
+    it('omits absent evergreenOpportunityId and triggerAuditId', () => {
+      const result = buildSnapshotData(
+        { qa: 'suppressed' },
+        { kind: SNAPSHOT_KINDS.SUPPRESSED_REFRESH },
+      );
+
+      expect(result).to.deep.equal({
+        qa: 'suppressed',
+        snapshot: { kind: SNAPSHOT_KINDS.SUPPRESSED_REFRESH },
+      });
+      expect(result.snapshot).to.not.have.property('evergreenOpportunityId');
+      expect(result.snapshot).to.not.have.property('triggerAuditId');
+    });
+  });
+
+  describe('findSnapshotByTriggerAuditId', () => {
+    it('returns null when no IGNORED opportunities exist', async () => {
+      const dataAccess = { Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) } };
+
+      const result = await findSnapshotByTriggerAuditId({
+        dataAccess, siteId: 'site-1', auditType: 'cited-analysis', triggerAuditId: 'audit-1', log,
+      });
+
+      expect(result).to.be.null;
+    });
+
+    it('logs and rethrows lookup failures', async () => {
+      const dataAccess = {
+        Opportunity: { allBySiteIdAndStatus: sandbox.stub().rejects(new Error('DB down')) },
+      };
+
+      await expect(findSnapshotByTriggerAuditId({
+        dataAccess, siteId: 'site-1', auditType: 'cited-analysis', triggerAuditId: 'audit-1', log,
+      })).to.be.rejectedWith('DB down');
+      expect(log.error).to.have.been.calledWith(
+        sinon.match(/Failed to look up existing auditType cited-analysis snapshots/),
+      );
+    });
+
+    it('returns null when the lookup resolves to a falsy value', async () => {
+      const dataAccess = {
+        Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves(null) },
+      };
+
+      const result = await findSnapshotByTriggerAuditId({
+        dataAccess, siteId: 'site-1', auditType: 'cited-analysis', triggerAuditId: 'audit-1', log,
+      });
+
+      expect(result).to.be.null;
+    });
+
+    it('matches type, managed tag, and triggerAuditId', async () => {
+      const wrongType = makeSnapshotOpportunity({ type: 'youtube-analysis' });
+      const untagged = makeSnapshotOpportunity({ tags: [] });
+      const wrongAudit = makeSnapshotOpportunity({
+        snapshot: { triggerAuditId: 'audit-999' },
+      });
+      const matching = makeSnapshotOpportunity();
+      const dataAccess = {
+        Opportunity: {
+          allBySiteIdAndStatus: sandbox.stub().resolves([
+            wrongType, untagged, wrongAudit, matching,
+          ]),
+        },
+      };
+
+      const result = await findSnapshotByTriggerAuditId({
+        dataAccess, siteId: 'site-1', auditType: 'cited-analysis', triggerAuditId: 'audit-1', log,
+      });
+
+      expect(result).to.equal(matching);
+    });
+
+    it('ignores an opportunity without a tags array', async () => {
+      const untagged = makeSnapshotOpportunity({ tags: null });
+      const dataAccess = {
+        Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([untagged]) },
+      };
+
+      const result = await findSnapshotByTriggerAuditId({
+        dataAccess, siteId: 'site-1', auditType: 'cited-analysis', triggerAuditId: 'audit-1', log,
+      });
+
+      expect(result).to.be.null;
+    });
+
+    it('reuses an unlinked snapshot despite a new evergreen link', async () => {
+      const unlinked = makeSnapshotOpportunity({
+        snapshot: {
+          kind: SNAPSHOT_KINDS.SUPPRESSED_REFRESH,
+          triggerAuditId: 'audit-1',
+        },
+      });
+      const dataAccess = {
+        Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([unlinked]) },
+      };
+
+      const result = await findSnapshotByTriggerAuditId({
+        dataAccess, siteId: 'site-1', auditType: 'cited-analysis', triggerAuditId: 'audit-1', log,
+      });
+
+      expect(result).to.equal(unlinked);
+    });
+  });
+
+  describe('prepareSuppressedRunSnapshot', () => {
+    it('builds managed mapper input and reuses a snapshot for the trigger audit', async () => {
+      const existingSuppressedRunSnapshot = makeSnapshotOpportunity();
+      const dataAccess = {
+        Opportunity: {
+          allBySiteIdAndStatus: sandbox.stub().resolves([existingSuppressedRunSnapshot]),
+        },
+      };
+      const opportunityData = {
+        status: 'IGNORED',
+        tags: ['custom-tag'],
+        data: { qa: 'suppressed' },
+      };
+
+      const result = await prepareSuppressedRunSnapshot({
+        dataAccess,
+        siteId: 'site-1',
+        auditType: 'cited-analysis',
+        triggerAuditId: 'audit-1',
+        opportunityData,
+        evergreenOpportunity: { getId: () => 'evergreen-1' },
+        log,
+      });
+
+      expect(result).to.deep.equal({
+        opportunityData: {
+          status: 'IGNORED',
+          tags: ['custom-tag', SNAPSHOT_TAG],
+          data: {
+            qa: 'suppressed',
+            snapshot: {
+              evergreenOpportunityId: 'evergreen-1',
+              kind: SNAPSHOT_KINDS.SUPPRESSED_REFRESH,
+              triggerAuditId: 'audit-1',
+            },
+          },
+        },
+        opportunityToUpdate: existingSuppressedRunSnapshot,
+      });
+      expect(opportunityData).to.deep.equal({
+        status: 'IGNORED',
+        tags: ['custom-tag'],
+        data: { qa: 'suppressed' },
+      });
+      expect(log.info).to.have.been.calledWith(sinon.match(/Reusing suppressed-refresh snapshot snapshot-1/));
+    });
+
+    it('builds a managed snapshot without lookup when triggerAuditId is missing', async () => {
+      const allBySiteIdAndStatus = sandbox.stub();
+
+      const result = await prepareSuppressedRunSnapshot({
+        dataAccess: { Opportunity: { allBySiteIdAndStatus } },
+        siteId: 'site-1',
+        auditType: 'cited-analysis',
+        triggerAuditId: undefined,
+        opportunityData: { status: 'IGNORED', data: { qa: 'suppressed' } },
+        evergreenOpportunity: { getId: () => 'evergreen-1' },
+        log,
+      });
+
+      expect(result).to.deep.equal({
+        opportunityData: {
+          status: 'IGNORED',
+          tags: [SNAPSHOT_TAG],
+          data: {
+            qa: 'suppressed',
+            snapshot: {
+              evergreenOpportunityId: 'evergreen-1',
+              kind: SNAPSHOT_KINDS.SUPPRESSED_REFRESH,
+            },
+          },
+        },
+        opportunityToUpdate: null,
+      });
+      expect(allBySiteIdAndStatus).to.not.have.been.called;
+      expect(log.warn).to.have.been.calledWith(sinon.match(/idempotency.*traceability/i));
+      expect(log.info).to.have.been.calledWith(sinon.match(/Preparing new suppressed-refresh snapshot/));
+    });
+
+    it('does not duplicate an existing snapshot tag', async () => {
+      const result = await prepareSuppressedRunSnapshot({
+        dataAccess: {},
+        siteId: 'site-1',
+        auditType: 'cited-analysis',
+        opportunityData: { status: 'IGNORED', tags: [SNAPSHOT_TAG] },
+        evergreenOpportunity: null,
+        log,
+      });
+
+      expect(result.opportunityData.tags).to.deep.equal([SNAPSHOT_TAG]);
+    });
+  });
+
+  describe('prepareSupersededRunSnapshot', () => {
+    it('creates no snapshot and targets creation when no evergreen exists', async () => {
+      const lookup = sandbox.stub();
+      const create = sandbox.stub();
+      const opportunityData = { status: 'NEW' };
+
+      const result = await prepareSupersededRunSnapshot({
+        dataAccess: { Opportunity: { allBySiteIdAndStatus: lookup, create } },
+        siteId: 'site-1',
+        auditType: 'cited-analysis',
+        triggerAuditId: 'audit-1',
+        opportunityData,
+        evergreenOpportunity: null,
+        log,
+      });
+
+      expect(result).to.deep.equal({ opportunityData, opportunityToUpdate: null });
+      expect(lookup).to.not.have.been.called;
+      expect(create).to.not.have.been.called;
+      expect(log.debug).to.have.been.calledWith(sinon.match(/no superseded-refresh snapshot is needed/i));
+    });
+
+    it('reuses an existing superseded snapshot and targets the evergreen refresh', async () => {
+      const existingSupersededRunSnapshot = makeSnapshotOpportunity();
+      const evergreenOpportunity = { getId: () => 'evergreen-1' };
+      const create = sandbox.stub();
+      const opportunityData = { status: 'NEW' };
+
+      const result = await prepareSupersededRunSnapshot({
+        dataAccess: {
+          Opportunity: {
+            allBySiteIdAndStatus: sandbox.stub().resolves([existingSupersededRunSnapshot]),
+            create,
+          },
+        },
+        siteId: 'site-1',
+        auditType: 'cited-analysis',
+        triggerAuditId: 'audit-1',
+        opportunityData,
+        evergreenOpportunity,
+        log,
+      });
+
+      expect(result).to.deep.equal({
+        opportunityData,
+        opportunityToUpdate: evergreenOpportunity,
+      });
+      expect(create).to.not.have.been.called;
+      expect(log.info).to.have.been.calledWith(sinon.match(/Reusing superseded-refresh snapshot snapshot-1/));
+    });
+
+    it('creates an IGNORED managed snapshot preserving fields, scope, and data', async () => {
+      const evergreenOpportunity = makeEvergreenOpportunity({
+        scopeType: 'brand',
+        scopeId: 'brand-1',
+      });
+      const created = {
+        getId: () => 'snapshot-1',
+        addSuggestions: sandbox.stub().resolves({ errorItems: [] }),
+      };
+      const create = sandbox.stub().resolves(created);
+      const opportunityData = { status: 'NEW' };
+
+      const result = await prepareSupersededRunSnapshot({
+        dataAccess: {
+          Opportunity: {
+            allBySiteIdAndStatus: sandbox.stub().resolves([]),
+            create,
+          },
+        },
+        siteId: 'site-1',
+        auditType: 'cited-analysis',
+        triggerAuditId: 'audit-1',
+        opportunityData,
+        evergreenOpportunity,
+        log,
+      });
+
+      expect(result).to.deep.equal({
+        opportunityData,
+        opportunityToUpdate: evergreenOpportunity,
+      });
+      expect(create).to.have.been.calledWith({
+        siteId: 'site-1',
+        auditId: 'source-audit-1',
+        type: 'cited-analysis',
+        origin: 'AUTOMATION',
+        title: 'Cited analysis opportunity',
+        description: 'description',
+        runbook: '',
+        guidance: undefined,
+        tags: ['existing-tag', SNAPSHOT_TAG],
+        status: 'IGNORED',
+        scopeType: 'brand',
+        scopeId: 'brand-1',
+        data: {
+          sentiment: { score: 0.8 },
+          snapshot: {
+            evergreenOpportunityId: 'evergreen-1',
+            kind: SNAPSHOT_KINDS.SUPERSEDED_REFRESH,
+            triggerAuditId: 'audit-1',
+          },
+        },
+      });
+      expect(log.info).to.have.been.calledWith(
+        sinon.match(/Created superseded-refresh snapshot snapshot-1 from evergreen opportunity evergreen-1/),
+      );
+    });
+
+    it('omits scope fields for an unscoped evergreen and deduplicates the snapshot tag', async () => {
+      const evergreenOpportunity = makeEvergreenOpportunity({ tags: [SNAPSHOT_TAG] });
+      const create = sandbox.stub().resolves({
+        getId: () => 'snapshot-1',
+        addSuggestions: sandbox.stub(),
+      });
+
+      await prepareSupersededRunSnapshot({
+        dataAccess: {
+          Opportunity: {
+            allBySiteIdAndStatus: sandbox.stub().resolves([]),
+            create,
+          },
+        },
+        siteId: 'site-1',
+        auditType: 'cited-analysis',
+        triggerAuditId: 'audit-1',
+        opportunityData: { status: 'NEW' },
+        evergreenOpportunity,
+        log,
+      });
+
+      const [payload] = create.firstCall.args;
+      expect(payload.tags).to.deep.equal([SNAPSHOT_TAG]);
+      expect(payload).to.not.have.property('scopeType');
+      expect(payload).to.not.have.property('scopeId');
+    });
+
+    it('adds the snapshot tag when the evergreen has no tags array', async () => {
+      const evergreenOpportunity = makeEvergreenOpportunity({ tags: null });
+      const create = sandbox.stub().resolves({
+        getId: () => 'snapshot-1',
+        addSuggestions: sandbox.stub(),
+      });
+
+      await prepareSupersededRunSnapshot({
+        dataAccess: {
+          Opportunity: {
+            allBySiteIdAndStatus: sandbox.stub().resolves([]),
+            create,
+          },
+        },
+        siteId: 'site-1',
+        auditType: 'cited-analysis',
+        triggerAuditId: 'audit-1',
+        opportunityData: {},
+        evergreenOpportunity,
+        log,
+      });
+
+      expect(create.firstCall.args[0].tags).to.deep.equal([SNAPSHOT_TAG]);
+    });
+
+    it('copies suggestion fields exactly', async () => {
+      const suggestion = {
+        getType: () => 'CONTENT_UPDATE',
+        getRank: () => 1,
+        getData: () => ({ suggestionValue: 'value' }),
+        getStatus: () => 'SKIPPED',
+        getKpiDeltas: () => ({ trafficLift: 0.1 }),
+        getSkipReason: () => 'not-applicable',
+        getSkipDetail: () => 'Reviewed and dismissed',
+      };
+      const evergreenOpportunity = makeEvergreenOpportunity({ suggestions: [suggestion] });
+      const addSuggestions = sandbox.stub().resolves({ errorItems: [] });
+      const create = sandbox.stub().resolves({
+        getId: () => 'snapshot-1',
+        addSuggestions,
+      });
+
+      await prepareSupersededRunSnapshot({
+        dataAccess: {
+          Opportunity: {
+            allBySiteIdAndStatus: sandbox.stub().resolves([]),
+            create,
+          },
+        },
+        siteId: 'site-1',
+        auditType: 'cited-analysis',
+        triggerAuditId: 'audit-1',
+        opportunityData: {},
+        evergreenOpportunity,
+        log,
+      });
+
+      expect(addSuggestions).to.have.been.calledWith([{
+        type: 'CONTENT_UPDATE',
+        rank: 1,
+        data: { suggestionValue: 'value' },
+        status: 'SKIPPED',
+        kpiDeltas: { trafficLift: 0.1 },
+        skipReason: 'not-applicable',
+        skipDetail: 'Reviewed and dismissed',
+      }]);
+    });
+
+    it('omits absent optional suggestion fields', async () => {
+      const suggestion = {
+        getType: () => 'CONTENT_UPDATE',
+        getRank: () => 1,
+        getData: () => ({ suggestionValue: 'value' }),
+        getStatus: () => 'FIXED',
+        getKpiDeltas: () => undefined,
+        getSkipReason: () => undefined,
+        getSkipDetail: () => undefined,
+      };
+      const evergreenOpportunity = makeEvergreenOpportunity({ suggestions: [suggestion] });
+      const addSuggestions = sandbox.stub().resolves({ errorItems: [] });
+      const create = sandbox.stub().resolves({
+        getId: () => 'snapshot-1',
+        addSuggestions,
+      });
+
+      await prepareSupersededRunSnapshot({
+        dataAccess: {
+          Opportunity: {
+            allBySiteIdAndStatus: sandbox.stub().resolves([]),
+            create,
+          },
+        },
+        siteId: 'site-1',
+        auditType: 'cited-analysis',
+        triggerAuditId: 'audit-1',
+        opportunityData: {},
+        evergreenOpportunity,
+        log,
+      });
+
+      expect(addSuggestions).to.have.been.calledWith([{
+        type: 'CONTENT_UPDATE',
+        rank: 1,
+        data: { suggestionValue: 'value' },
+        status: 'FIXED',
+      }]);
+    });
+
+    it('skips suggestion persistence when the evergreen has no suggestions', async () => {
+      const evergreenOpportunity = makeEvergreenOpportunity();
+      const addSuggestions = sandbox.stub();
+      const create = sandbox.stub().resolves({
+        getId: () => 'snapshot-1',
+        addSuggestions,
+      });
+
+      await prepareSupersededRunSnapshot({
+        dataAccess: {
+          Opportunity: {
+            allBySiteIdAndStatus: sandbox.stub().resolves([]),
+            create,
+          },
+        },
+        siteId: 'site-1',
+        auditType: 'cited-analysis',
+        triggerAuditId: 'audit-1',
+        opportunityData: {},
+        evergreenOpportunity,
+        log,
+      });
+
+      expect(addSuggestions).to.not.have.been.called;
+    });
+
+    it('logs partial suggestion copy failures without throwing', async () => {
+      const suggestion = {
+        getType: () => 'CONTENT_UPDATE',
+        getRank: () => 1,
+        getData: () => ({}),
+        getStatus: () => 'NEW',
+        getKpiDeltas: () => undefined,
+        getSkipReason: () => undefined,
+        getSkipDetail: () => undefined,
+      };
+      const evergreenOpportunity = makeEvergreenOpportunity({ suggestions: [suggestion] });
+      const create = sandbox.stub().resolves({
+        getId: () => 'snapshot-1',
+        addSuggestions: sandbox.stub().resolves({ errorItems: [{}] }),
+      });
+
+      await prepareSupersededRunSnapshot({
+        dataAccess: {
+          Opportunity: {
+            allBySiteIdAndStatus: sandbox.stub().resolves([]),
+            create,
+          },
+        },
+        siteId: 'site-1',
+        auditType: 'cited-analysis',
+        triggerAuditId: 'audit-1',
+        opportunityData: {},
+        evergreenOpportunity,
+        log,
+      });
+
+      expect(log.error).to.have.been.calledWith(sinon.match(/1 suggestion\(s\) failed to copy/));
+    });
+
+    it('creates a managed snapshot without trigger metadata when auditId is missing', async () => {
+      const evergreenOpportunity = makeEvergreenOpportunity();
+      const create = sandbox.stub().resolves({
+        getId: () => 'snapshot-1',
+        addSuggestions: sandbox.stub(),
+      });
+
+      const result = await prepareSupersededRunSnapshot({
+        dataAccess: { Opportunity: { create } },
+        siteId: 'site-1',
+        auditType: 'cited-analysis',
+        triggerAuditId: undefined,
+        opportunityData: { status: 'NEW' },
+        evergreenOpportunity,
+        log,
+      });
+
+      expect(result.opportunityToUpdate).to.equal(evergreenOpportunity);
+      expect(create.firstCall.args[0].data.snapshot).to.deep.equal({
+        evergreenOpportunityId: 'evergreen-1',
+        kind: SNAPSHOT_KINDS.SUPERSEDED_REFRESH,
+      });
+      expect(log.warn).to.have.been.calledWith(sinon.match(/idempotency.*traceability/i));
+    });
+
+    it('propagates idempotency lookup failures', async () => {
+      await expect(prepareSupersededRunSnapshot({
+        dataAccess: {
+          Opportunity: {
+            allBySiteIdAndStatus: sandbox.stub().rejects(new Error('DB down')),
+          },
+        },
+        siteId: 'site-1',
+        auditType: 'cited-analysis',
+        triggerAuditId: 'audit-1',
+        opportunityData: {},
+        evergreenOpportunity: { getId: () => 'evergreen-1' },
+        log,
+      })).to.be.rejectedWith('DB down');
+    });
+  });
+});

--- a/test/common/offsite-snapshot.test.js
+++ b/test/common/offsite-snapshot.test.js
@@ -200,6 +200,18 @@ describe('offsite-snapshot', () => {
 
       expect(result).to.equal(unlinked);
     });
+
+    it('emits audit=unknown when the auditType is not in the slug map (defensive fallback)', async () => {
+      const dataAccess = {
+        Opportunity: { allBySiteIdAndStatus: sandbox.stub().rejects(new Error('DB down')) },
+      };
+
+      await expect(findSnapshotByTriggerAuditId({
+        dataAccess, siteId: 'site-1', auditType: 'not-a-real-audit', triggerAuditId: 'audit-1', log,
+      })).to.be.rejectedWith('DB down');
+
+      expect(log.error).to.have.been.calledWith(sinon.match(/audit=unknown/));
+    });
   });
 
   describe('prepareSuppressedRunSnapshot', () => {
@@ -292,6 +304,20 @@ describe('offsite-snapshot', () => {
       });
 
       expect(result.opportunityData.tags).to.deep.equal([SNAPSHOT_TAG]);
+    });
+
+    it('emits audit=unknown when the auditType is not in the slug map (defensive fallback)', async () => {
+      await prepareSuppressedRunSnapshot({
+        dataAccess: {},
+        siteId: 'site-1',
+        auditType: 'not-a-real-audit',
+        triggerAuditId: undefined,
+        opportunityData: { status: 'IGNORED' },
+        evergreenOpportunity: null,
+        log,
+      });
+
+      expect(log.warn).to.have.been.calledWith(sinon.match(/audit=unknown/));
     });
   });
 
@@ -709,6 +735,25 @@ describe('offsite-snapshot', () => {
         evergreenOpportunity: { getId: () => 'evergreen-1' },
         log,
       })).to.be.rejectedWith('DB down');
+    });
+
+    it('emits audit=unknown when the auditType is not in the slug map (defensive fallback)', async () => {
+      const create = sandbox.stub().resolves({
+        getId: () => 'snapshot-1',
+        addSuggestions: sandbox.stub(),
+      });
+
+      await prepareSupersededRunSnapshot({
+        dataAccess: { Opportunity: { create } },
+        siteId: 'site-1',
+        auditType: 'not-a-real-audit',
+        triggerAuditId: undefined,
+        opportunityData: { status: 'NEW' },
+        evergreenOpportunity: makeEvergreenOpportunity(),
+        log,
+      });
+
+      expect(log.warn).to.have.been.calledWith(sinon.match(/audit=unknown/));
     });
   });
 });

--- a/test/common/offsite-snapshot.test.js
+++ b/test/common/offsite-snapshot.test.js
@@ -600,6 +600,76 @@ describe('offsite-snapshot', () => {
       expect(log.error).to.have.been.calledWith(sinon.match(/1 suggestion\(s\) failed to copy/));
     });
 
+    it('deletes the orphan snapshot and rethrows when addSuggestions fully rejects', async () => {
+      const addSuggestionsError = new Error('DB write failed');
+      const remove = sandbox.stub().resolves();
+      const create = sandbox.stub().resolves({
+        getId: () => 'snapshot-1',
+        addSuggestions: sandbox.stub().rejects(addSuggestionsError),
+        remove,
+      });
+      const suggestion = {
+        getType: () => 'CONTENT_UPDATE',
+        getRank: () => 1,
+        getData: () => ({}),
+        getStatus: () => 'NEW',
+        getKpiDeltas: () => undefined,
+        getSkipReason: () => undefined,
+        getSkipDetail: () => undefined,
+      };
+      const evergreenOpportunity = makeEvergreenOpportunity({ suggestions: [suggestion] });
+
+      await expect(prepareSupersededRunSnapshot({
+        dataAccess: {
+          Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]), create },
+        },
+        siteId: 'site-1',
+        auditType: 'cited-analysis',
+        triggerAuditId: 'audit-1',
+        opportunityData: {},
+        evergreenOpportunity,
+        log,
+      })).to.be.rejectedWith('DB write failed');
+
+      expect(remove).to.have.been.calledOnce;
+      expect(log.error).to.have.been.calledWith(sinon.match(/addSuggestions threw.*deleting orphan/i));
+    });
+
+    it('still rethrows the original addSuggestions error when orphan removal also fails', async () => {
+      const addSuggestionsError = new Error('DB write failed');
+      const remove = sandbox.stub().rejects(new Error('delete also failed'));
+      const create = sandbox.stub().resolves({
+        getId: () => 'snapshot-1',
+        addSuggestions: sandbox.stub().rejects(addSuggestionsError),
+        remove,
+      });
+      const suggestion = {
+        getType: () => 'CONTENT_UPDATE',
+        getRank: () => 1,
+        getData: () => ({}),
+        getStatus: () => 'NEW',
+        getKpiDeltas: () => undefined,
+        getSkipReason: () => undefined,
+        getSkipDetail: () => undefined,
+      };
+      const evergreenOpportunity = makeEvergreenOpportunity({ suggestions: [suggestion] });
+
+      await expect(prepareSupersededRunSnapshot({
+        dataAccess: {
+          Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]), create },
+        },
+        siteId: 'site-1',
+        auditType: 'cited-analysis',
+        triggerAuditId: 'audit-1',
+        opportunityData: {},
+        evergreenOpportunity,
+        log,
+      })).to.be.rejectedWith('DB write failed');
+
+      expect(remove).to.have.been.calledOnce;
+      expect(log.error).to.have.been.calledWith(sinon.match(/Failed to delete orphan snapshot/i));
+    });
+
     it('creates a managed snapshot without trigger metadata when auditId is missing', async () => {
       const evergreenOpportunity = makeEvergreenOpportunity();
       const create = sandbox.stub().resolves({

--- a/test/common/opportunity.test.js
+++ b/test/common/opportunity.test.js
@@ -238,7 +238,7 @@ describe('persistOffsiteOpportunity', () => {
     sandbox.restore();
   });
 
-  const buildExistingOpportunity = (existingData) => ({
+  const buildOpportunityToUpdate = (existingData) => ({
     getType: () => 'cited-analysis',
     getData: sandbox.stub().returns(existingData),
     setAuditId: sandbox.stub(),
@@ -257,12 +257,12 @@ describe('persistOffsiteOpportunity', () => {
       dashboard: { sentiment: 'negative', sov: 0.1 },
       fullAnalysis: { suggestions: ['old'] },
     };
-    const existingOpportunity = buildExistingOpportunity(existingData);
+    const opportunityToUpdate = buildOpportunityToUpdate(existingData);
 
     const context = {
       dataAccess: {
         Opportunity: {
-          allBySiteIdAndStatus: sandbox.stub().resolves([existingOpportunity]),
+          allBySiteIdAndStatus: sandbox.stub().resolves([opportunityToUpdate]),
         },
       },
       log: { info: sandbox.spy(), error: sandbox.spy(), debug: sandbox.spy() },
@@ -284,31 +284,31 @@ describe('persistOffsiteOpportunity', () => {
       context,
       createOpportunityData,
       'cited-analysis',
-      { opportunityData: {}, existingOpportunity },
+      { opportunityData: {}, opportunityToUpdate },
     );
 
     expect(result.getId()).to.equal('existing-opp-id');
     // fullAnalysis is absent from the latest mapped data, so it must disappear — not
     // linger merged in from the prior run. setData is called with exactly the new data.
-    expect(existingOpportunity.setData).to.have.been.calledWith({
+    expect(opportunityToUpdate.setData).to.have.been.calledWith({
       dataSources: ['ai-search'],
       dashboard: { sentiment: 'positive', sov: 0.42 },
     });
-    expect(existingOpportunity.setData.firstCall.args[0]).to.not.have.property('fullAnalysis');
+    expect(opportunityToUpdate.setData.firstCall.args[0]).to.not.have.property('fullAnalysis');
   });
 
   it('applies the same wholesale-replace behavior for reddit-analysis and youtube-analysis', async () => {
     for (const auditType of ['reddit-analysis', 'youtube-analysis']) {
-      const existingOpportunity = buildExistingOpportunity({
+      const opportunityToUpdate = buildOpportunityToUpdate({
         dashboard: { sov: 0.1 },
         staleTopic: { id: 'old-only-field' },
       });
-      existingOpportunity.getType = () => auditType;
+      opportunityToUpdate.getType = () => auditType;
 
       const context = {
         dataAccess: {
           Opportunity: {
-            allBySiteIdAndStatus: sandbox.stub().resolves([existingOpportunity]),
+            allBySiteIdAndStatus: sandbox.stub().resolves([opportunityToUpdate]),
           },
         },
         log: { info: sandbox.spy(), error: sandbox.spy(), debug: sandbox.spy() },
@@ -323,18 +323,18 @@ describe('persistOffsiteOpportunity', () => {
         context,
         createOpportunityData,
         auditType,
-        { existingOpportunity },
+        { opportunityToUpdate },
       );
 
-      expect(existingOpportunity.setData).to.have.been.calledWith({
+      expect(opportunityToUpdate.setData).to.have.been.calledWith({
         dashboard: { sov: 0.77 },
       });
-      expect(existingOpportunity.setData.firstCall.args[0]).to.not.have.property('staleTopic');
+      expect(opportunityToUpdate.setData.firstCall.args[0]).to.not.have.property('staleTopic');
     }
   });
 
   it('rejects non-offsite audit types before mutating an opportunity', async () => {
-    const existingOpportunity = buildExistingOpportunity({ staleField: 'must-survive' });
+    const opportunityToUpdate = buildOpportunityToUpdate({ staleField: 'must-survive' });
     const context = {
       dataAccess: { Opportunity: { create: sandbox.stub() } },
       log: { info: sandbox.spy(), error: sandbox.spy(), debug: sandbox.spy() },
@@ -346,12 +346,12 @@ describe('persistOffsiteOpportunity', () => {
       context,
       () => ({ data: { newField: 'new' } }),
       'prerender',
-      { existingOpportunity },
+      { opportunityToUpdate },
     )).to.be.rejectedWith('Unsupported offsite audit type: prerender');
 
-    expect(existingOpportunity.setAuditId).to.not.have.been.called;
-    expect(existingOpportunity.setData).to.not.have.been.called;
-    expect(existingOpportunity.save).to.not.have.been.called;
+    expect(opportunityToUpdate.setAuditId).to.not.have.been.called;
+    expect(opportunityToUpdate.setData).to.not.have.been.called;
+    expect(opportunityToUpdate.save).to.not.have.been.called;
   });
 
   it('requires callers to provide the pre-resolved target explicitly', async () => {
@@ -368,7 +368,7 @@ describe('persistOffsiteOpportunity', () => {
       createOpportunityData,
       'cited-analysis',
       { opportunityData: {} },
-    )).to.be.rejectedWith('existingOpportunity must be explicitly provided');
+    )).to.be.rejectedWith('opportunityToUpdate must be explicitly provided');
 
     expect(createOpportunityData).to.not.have.been.called;
     expect(context.dataAccess.Opportunity.create).to.not.have.been.called;
@@ -388,8 +388,8 @@ describe('persistOffsiteOpportunity', () => {
         context,
         createOpportunityData,
         'cited-analysis',
-        { opportunityData: {}, existingOpportunity: invalidTarget },
-      )).to.be.rejectedWith('existingOpportunity must be an opportunity or null');
+        { opportunityData: {}, opportunityToUpdate: invalidTarget },
+      )).to.be.rejectedWith('opportunityToUpdate must be an opportunity or null');
 
       expect(createOpportunityData).to.not.have.been.called;
       expect(context.dataAccess.Opportunity.create).to.not.have.been.called;
@@ -398,7 +398,7 @@ describe('persistOffsiteOpportunity', () => {
 
   it('removes GSC from mapped data when the site has no Google connection', async () => {
     checkGoogleConnectionStub.resolves(false);
-    const existingOpportunity = buildExistingOpportunity({ staleField: 'old' });
+    const opportunityToUpdate = buildOpportunityToUpdate({ staleField: 'old' });
     const context = {
       dataAccess: { Opportunity: { create: sandbox.stub() } },
       log: { info: sandbox.spy(), error: sandbox.spy(), debug: sandbox.spy() },
@@ -410,17 +410,17 @@ describe('persistOffsiteOpportunity', () => {
       context,
       () => ({ data: { dataSources: ['GSC', 'Site'] } }),
       'cited-analysis',
-      { existingOpportunity },
+      { opportunityToUpdate },
     );
 
-    expect(existingOpportunity.setData).to.have.been.calledWith({
+    expect(opportunityToUpdate.setData).to.have.been.calledWith({
       dataSources: ['Site'],
     });
   });
 
-  describe('pre-resolved existingOpportunity (bypasses the internal query)', () => {
-    it('uses a provided existingOpportunity directly without querying allBySiteIdAndStatus', async () => {
-      const existingOpportunity = buildExistingOpportunity({ dashboard: { sov: 0.1 } });
+  describe('pre-resolved opportunityToUpdate (bypasses the internal query)', () => {
+    it('uses a provided opportunityToUpdate directly without querying allBySiteIdAndStatus', async () => {
+      const opportunityToUpdate = buildOpportunityToUpdate({ dashboard: { sov: 0.1 } });
       const allBySiteIdAndStatusStub = sandbox.stub().resolves([]);
       const context = {
         dataAccess: { Opportunity: { allBySiteIdAndStatus: allBySiteIdAndStatusStub } },
@@ -434,15 +434,15 @@ describe('persistOffsiteOpportunity', () => {
         context,
         createOpportunityData,
         'cited-analysis',
-        { existingOpportunity },
+        { opportunityToUpdate },
       );
 
       expect(result.getId()).to.equal('existing-opp-id');
       expect(allBySiteIdAndStatusStub).to.not.have.been.called;
-      expect(existingOpportunity.setData).to.have.been.calledWith({ dashboard: { sov: 0.77 } });
+      expect(opportunityToUpdate.setData).to.have.been.calledWith({ dashboard: { sov: 0.77 } });
     });
 
-    it('forces creation when existingOpportunity is explicitly null, without querying', async () => {
+    it('forces creation when opportunityToUpdate is explicitly null, without querying', async () => {
       const allBySiteIdAndStatusStub = sandbox.stub().resolves([]);
       const createStub = sandbox.stub().resolves({ getId: () => 'new-opp-id' });
       const context = {
@@ -459,7 +459,7 @@ describe('persistOffsiteOpportunity', () => {
         context,
         createOpportunityData,
         'cited-analysis',
-        { existingOpportunity: null },
+        { opportunityToUpdate: null },
       );
 
       expect(result.getId()).to.equal('new-opp-id');
@@ -482,7 +482,7 @@ describe('persistOffsiteOpportunity', () => {
         context,
         () => ({ data: {}, status: 'IGNORED' }),
         'cited-analysis',
-        { existingOpportunity: null },
+        { opportunityToUpdate: null },
       )).to.be.rejectedWith('create failed');
 
       expect(context.log.error).to.have.been.calledWith(
@@ -511,7 +511,7 @@ describe('persistOffsiteOpportunity', () => {
         context,
         createOpportunityData,
         'cited-analysis',
-        { existingOpportunity: null },
+        { opportunityToUpdate: null },
       );
 
       expect(createStub.firstCall.args[0]).to.have.property('status', 'IGNORED');
@@ -536,7 +536,7 @@ describe('persistOffsiteOpportunity', () => {
         context,
         createOpportunityData,
         'cited-analysis',
-        { existingOpportunity: null },
+        { opportunityToUpdate: null },
       );
 
       expect(createStub.firstCall.args[0]).to.not.have.property('status');


### PR DESCRIPTION
## Scope

https://jira.corp.adobe.com/browse/LLMO-6152

Preserve offsite refresh history without changing the customer-visible evergreen opportunity introduced in #2765. A surfaced refresh snapshots the evergreen state it is about to replace; a suppressed refresh is stored directly as an inert snapshot.

This is a stacked PR on #2765 (`LLMO-6122`).

## Implementation

**Dedicated snapshot workflow**

Added `src/common/offsite-snapshot.js` with explicit `prepareSupersededRunSnapshot` and `prepareSuppressedRunSnapshot` workflows backed by shared metadata, tagging, and lookup helpers.

Managed snapshots are `IGNORED`, tagged `offsite-snapshot`, and contain `data.snapshot` metadata:

- `kind`: `superseded-refresh` or `suppressed-refresh`
- `evergreenOpportunityId`: included when an evergreen exists
- `triggerAuditId`: identifies the incoming refresh when available

**Superseded refresh snapshots**

Before a surfaced refresh overwrites an existing evergreen opportunity, its data, scope, audit identity, and suggestions—including review statuses and metadata—are copied to a snapshot. A first surfaced run has no previous state to preserve.

**Suppressed refresh snapshots**

A suppressed run is persisted as a tagged snapshot from its initial write. It links to the evergreen opportunity when one exists and never mutates that evergreen record.

**Redelivery handling**

When `triggerAuditId` is available, `findSnapshotByTriggerAuditId` reuses an existing snapshot for the same site, audit type, and triggering audit. An initially unlinked suppressed snapshot can receive its evergreen link on redelivery. Without an audit ID, the record is still managed snapshot history, but idempotency and traceability are unavailable.

## Testing

- Full unit and integration suite, lint, and build pass.
- Dedicated unit and real-composition integration tests cover both snapshot workflows and redelivery reuse.
- All three guidance handlers cover surfaced, suppressed, first-run, missing-audit-ID, and scope-preservation paths.
- Local Postgres/PostgREST scenarios verified real persistence, suggestion copying, and unlinked-to-linked redelivery.

## Out of Scope

- Guided snapshot restore (LLMO-6153)
- Automatic snapshot deletion (LLMO-6154)
- New Backoffice UI
- Retroactive tagging of existing ignored opportunities
- Wikipedia analysis
- Repair of a partially copied snapshot after a mid-copy failure
- Atomic locking for truly concurrent redelivery
- Server-side indexed snapshot lookup

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Rares Cheseli", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```