### PR TITLE
feat(offsite-snapshots-deletion): Outdated snapshots deletion after 30 days (LLMO-6154)

### DIFF
--- a/docs/decisions/004-offsite-snapshot-retention-window.md
+++ b/docs/decisions/004-offsite-snapshot-retention-window.md
@@ -1,0 +1,68 @@
+# 004 — 30-Day Retention Window for Offsite Snapshot Opportunities
+
+- **Status:** Accepted
+- **Date:** 2026-07-20
+
+## Context
+
+The offsite snapshot-preservation feature (LLMO-6152) writes an IGNORED+tagged `Opportunity`
+record (a "snapshot") before every surfaced refresh overwrites the evergreen, and for every
+suppressed run. Because a snapshot is created on **every** refresh — weekly per site per audit
+type (cited/reddit/youtube) — the working set grows without bound if nothing ever removes old
+ones. LLMO-6154 adds automatic deletion of snapshots past a retention window.
+
+This is a permanent, irreversible deletion policy (the snapshot `Opportunity` and its
+cascade-linked `Suggestion` records are hard-deleted, not soft-deleted), so the window itself is
+the kind of non-obvious, long-term trade-off CLAUDE.md requires an ADR for.
+
+## Decision
+
+Snapshots older than **30 days** (`SNAPSHOT_RETENTION_DAYS` in `offsite-retention.js`) are
+permanently deleted. The cutoff is evaluated as `getCreatedAt() < now - 30d` (strict
+less-than: a snapshot exactly 30 days old is retained one more cycle).
+
+Deletion runs as a side effect of a successful refresh in each of the three guidance handlers
+(cited/reddit/youtube), scoped to `(siteId, auditType)`, immediately after the refresh commits.
+It is wrapped in try/catch at the call site so a retention failure never fails the refresh
+itself (see `docs/specs/2026-07-20-offsite-snapshot-retention.md`).
+
+### Why 30 days
+
+- Snapshots exist to support debugging, QA retrospectives, and the not-yet-built snapshot
+  restore feature (LLMO-6153). 30 days covers a full weekly-refresh cycle with margin (four
+  refreshes) for someone to notice and act on a regression before its "before" state is gone.
+- It bounds storage growth to roughly one snapshot per site per audit type per week within the
+  window, rather than an unbounded history — the problem this ADR's parent feature exists to
+  solve.
+- No SLA, compliance, or contractual retention requirement drove the number; it is a product
+  judgment call, not a constraint. There is no per-customer override; all sites share the same
+  window.
+
+### Interaction with snapshot restore (LLMO-6153)
+
+Restore is not yet built. Once it exists, a restore request against a snapshot this window has
+already deleted will simply fail (the record is gone) — this ADR does not attempt to reserve
+extra buffer for that case. If restore ships with its own retention expectations (e.g. "restore
+must be possible for N days"), reconcile `SNAPSHOT_RETENTION_DAYS` against that requirement at
+that time rather than guessing now.
+
+## Alternatives Considered
+
+- **Shorter window (e.g. 14 days):** tighter storage bound, but only covers two refresh cycles —
+  too little margin for someone to notice and act on a regression.
+- **Longer window (e.g. 90 days):** more restore-friendly, but multiplies the steady-state
+  storage growth this feature is meant to bound, with no concrete requirement driving the need.
+- **No fixed window; keep everything:** rejected — this is exactly the unbounded-growth problem
+  LLMO-6154 exists to close.
+- **Per-customer configurable window:** deferred. Adds configuration surface with no current
+  demand; can be added later without changing the deletion mechanism.
+
+## Consequences
+
+- Any as-yet-unbuilt tooling that reads snapshots (e.g. restore, LLMO-6153) must treat "snapshot
+  no longer exists" as an expected, handled case once older than 30 days.
+- Changing `SNAPSHOT_RETENTION_DAYS` changes deletion behavior for all sites uniformly and takes
+  effect on each site's next refresh (no backfill/immediate sweep).
+- This ADR governs only the *window*. It does not cover sites that stop refreshing entirely
+  (disabled or offboarded audits) — see the "Known limitation" section in
+  `docs/specs/2026-07-20-offsite-snapshot-retention.md` for that gap.

--- a/docs/specs/2026-07-20-offsite-snapshot-retention.md
+++ b/docs/specs/2026-07-20-offsite-snapshot-retention.md
@@ -1,0 +1,123 @@
+# Offsite Opportunities — Automatic Snapshot Retention
+
+- **Status:** Implemented
+- **Date:** 2026-07-20
+- **Jira:** LLMO-6154
+- **Related:** [offsite-snapshot-preservation spec](2026-07-15-offsite-snapshot-preservation.md),
+  [ADR 004 — 30-day retention window](../decisions/004-offsite-snapshot-retention-window.md)
+
+## Problem statement
+
+The offsite snapshot-preservation feature (LLMO-6152) creates an IGNORED+tagged `Opportunity`
+snapshot record on every refresh, for every audit type, for every site. Nothing removes old
+snapshots, so the working set grows without bound — this is a stated non-goal of LLMO-6152,
+tracked here as its follow-up.
+
+## Goals
+
+1. Permanently delete managed offsite snapshots (and their cascade-linked suggestions) once they
+   pass a retention window (30 days — see ADR 004).
+2. Run deletion as a side effect of a successful refresh, scoped to `(siteId, auditType)`, so no
+   separate scheduled infrastructure is needed for the common case.
+3. Never let a retention failure fail the refresh that triggered it.
+4. Avoid the N+1 concurrent-write pattern CLAUDE.md documents as a connection-pool risk.
+
+Non-goals: a scheduled/infrastructure-level sweep for sites that stop refreshing entirely (see
+"Known limitation" below), snapshot restore (LLMO-6153), configurable per-customer retention
+windows.
+
+## Technical design
+
+### Lookup
+
+`findExpiredSnapshots({ dataAccess, siteId, auditType, log })` fetches all IGNORED opportunities
+for the site (same in-memory-scan approach as `findSnapshotByTriggerAuditId` in
+`offsite-snapshot.js` — see that spec's "Known limitation" section, which applies here too),
+filters to managed snapshots of the given `auditType` (`isOffsiteSnapshot`) whose
+`getCreatedAt()` is strictly older than `now - SNAPSHOT_RETENTION_DAYS`, and returns them sorted
+oldest-first. A lookup failure is logged (`retention_lookup outcome=failure`) and swallowed —
+`findExpiredSnapshots` returns `[]` rather than throwing, so a transient read failure degrades to
+"nothing to delete this cycle" instead of blocking the refresh.
+
+### Deletion — bulk, not per-record
+
+`deleteExpiredSnapshots` takes at most `MAX_DELETIONS_PER_RUN` (50) of the oldest expired
+snapshots (bounding the blast radius when a dormant site resumes refreshing after months of
+backlog) and deletes them in two bulk calls:
+
+1. Sequentially read each snapshot's suggestions (`snapshot.getSuggestions()`) and collect their
+   IDs. This is sequential, not concurrent, to avoid a read-side fan-out against the shared
+   connection pool.
+2. `Suggestion.removeByIds(suggestionIds)` — one chunked bulk delete for all collected suggestion
+   IDs (skipped if none exist).
+3. `Opportunity.removeByIds(snapshotIds)` — one chunked bulk delete for the snapshot
+   opportunities themselves.
+
+This mirrors the existing `removeOpportunityWithSuggestions` pattern in
+`src/experimentation-opportunities/guidance-high-organic-low-ctr-handler.js`, batched across the
+whole expired set instead of one opportunity at a time. It deliberately avoids the pattern
+CLAUDE.md's "Database Query Patterns — Avoiding N+1" section lists as `BAD`: a concurrent
+`Promise.all` over individual `.remove()` calls, which — because each snapshot's cascade delete
+also removes its own suggestions — would fan out to roughly
+`expired * (1 + suggestionsPerSnapshot)` concurrent requests against the 200-connection pool.
+That fan-out is worst exactly when a dormant or newly re-enabled site's backlog makes `expired`
+large, which is the scenario this feature exists to bound.
+
+**Trade-off:** the earlier per-record implementation isolated failures — one bad record didn't
+block the rest, and each success/failure was logged individually. The bulk implementation does
+not preserve that: a single `removeByIds` failure throws for the whole batch. This is an
+accepted trade-off, not an oversight — bulk delete is the only way to avoid the N+1 write
+fan-out, and the call site still guarantees a failure here never fails the refresh (see below).
+
+### Call site
+
+Each guidance handler (`cited-analysis`, `reddit-analysis`, `youtube-analysis`) calls
+`deleteExpiredSnapshots` once, after a successful refresh commits, wrapped in try/catch:
+
+```js
+try {
+  await deleteExpiredSnapshots({ dataAccess, siteId, auditType, log });
+} catch (error) {
+  ologOpp.failure('retention_delete', ..., { ...errorField(error) }, error);
+}
+```
+
+A retention failure is logged (`retention_delete outcome=failure`) and does not affect the
+handler's response.
+
+### Structured logging
+
+`findExpiredSnapshots` and `deleteExpiredSnapshots` emit via `createOffsiteLogger`
+(`offsite-logging.js`), using events `retention_lookup` and `retention_delete`. The success
+summary (`retention_delete outcome=success`, fields `eligible`/`deleted`) is only emitted when at
+least one snapshot was actually deleted, to avoid an INFO line on every refresh across three
+audit types × N sites × every scheduled run when there is nothing to report.
+
+### Known limitation — dormant vs. disabled/offboarded sites
+
+Deletion only runs as a side effect of a refresh. A **dormant** site (audits still enabled, just
+not recently triggered) self-heals: its next refresh, whenever it happens, runs retention scoped
+to that site. A site whose audit has been **disabled** or that has been **offboarded** never
+refreshes again, so its snapshots (and their cascade-linked suggestions) are never revisited and
+accumulate indefinitely. Bounding that case requires a scheduled or infrastructure-level sweep,
+which is explicitly out of scope for this change; track it as a separate follow-up rather than
+relying on this mechanism to cover it.
+
+## Alternatives
+
+- **Scheduled sweep job** as the primary mechanism: covers the disabled/offboarded gap above,
+  but is another moving part to operate and monitor, and doesn't fit this PR's scope (piggybacking
+  on the refresh that's already touching that site/audit type). Tracked as a future follow-up
+  instead of blocking this change.
+- **Soft-delete / archive instead of hard-delete:** avoids permanent data loss and would simplify
+  a future restore feature (LLMO-6153), but requires a data-access schema change; deferred.
+
+## Success criteria
+
+- `npm test` green with 100% coverage gate.
+- A snapshot older than 30 days is deleted (with its suggestions) on the next refresh for its
+  `(siteId, auditType)`.
+- A snapshot at or under 30 days old is never deleted.
+- Deletion never fails the refresh that triggered it.
+- `retention_delete outcome=success` and `outcome=failure` are queryable in Splunk via
+  `domain=offsite event=retention_delete`.

--- a/src/cited-analysis/guidance-handler.js
+++ b/src/cited-analysis/guidance-handler.js
@@ -34,6 +34,7 @@ import {
 import {
   createOffsiteLogger, errorField, AUDIT, PEER,
 } from '../utils/offsite-logging.js';
+import { deleteExpiredSnapshots } from '../common/offsite-retention.js';
 
 const AUDIT_TYPE = Audit.AUDIT_TYPES.CITED_ANALYSIS;
 // Human prefix for the two shared, untouched utils that still log via a passed-in prefix
@@ -222,6 +223,15 @@ export default async function handler(message, context) {
       count: suggestions.length,
     });
     logOffsiteLlmUsage(log, HUMAN_PREFIX, siteId, opportunityData.llmUsage);
+
+    // Retention must not fail an otherwise successful refresh.
+    try {
+      await deleteExpiredSnapshots({
+        dataAccess, siteId, auditType, log,
+      });
+    } catch (error) {
+      log.error(`[Offsite][Retention] Unexpected failure siteId=${siteId} auditType=${auditType} error=${error.message}`);
+    }
 
     if (auditId) {
       const auditRecord = await AuditModel.findById(auditId);

--- a/src/cited-analysis/guidance-handler.js
+++ b/src/cited-analysis/guidance-handler.js
@@ -230,7 +230,9 @@ export default async function handler(message, context) {
         dataAccess, siteId, auditType, log,
       });
     } catch (error) {
-      log.error(`[Offsite][Retention] Unexpected failure siteId=${siteId} auditType=${auditType} error=${error.message}`);
+      ologOpp.failure('retention_delete', `Unexpected retention failure for auditType ${auditType}`, {
+        peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
+      }, error);
     }
 
     if (auditId) {

--- a/src/common/offsite-retention.js
+++ b/src/common/offsite-retention.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { subDays, differenceInDays } from 'date-fns';
+import { Opportunity as Oppty } from '@adobe/spacecat-shared-data-access';
+import { isOffsiteSnapshot } from './offsite-snapshot.js';
+
+export const SNAPSHOT_RETENTION_DAYS = 30;
+
+/**
+ * Finds managed offsite snapshots older than the retention cutoff, oldest first.
+ */
+export async function findExpiredSnapshots({
+  dataAccess, siteId, auditType, log,
+}) {
+  const { Opportunity } = dataAccess;
+
+  let ignoredOpportunities;
+
+  try {
+    ignoredOpportunities = await Opportunity
+      .allBySiteIdAndStatus(siteId, Oppty.STATUSES.IGNORED);
+  } catch (error) {
+    log.error(`[Offsite][Retention] Failed to find snapshots siteId=${siteId} auditType=${auditType} error=${error.message}`);
+    return [];
+  }
+
+  const retentionCutoff = subDays(new Date(), SNAPSHOT_RETENTION_DAYS);
+
+  return (ignoredOpportunities || [])
+    .filter((opportunity) => isOffsiteSnapshot(opportunity, auditType)
+      && new Date(opportunity.getCreatedAt()) < retentionCutoff)
+    .sort((firstOpportunity, secondOpportunity) => (
+      new Date(firstOpportunity.getCreatedAt()) - new Date(secondOpportunity.getCreatedAt())
+    ));
+}
+
+/**
+ * Deletes expired snapshots without interrupting the refresh that invoked retention.
+ */
+export async function deleteExpiredSnapshots({
+  dataAccess, siteId, auditType, log,
+}) {
+  const expiredSnapshots = await findExpiredSnapshots({
+    dataAccess, siteId, auditType, log,
+  });
+
+  const deletionResults = await Promise.all(expiredSnapshots.map(async (snapshot) => {
+    const snapshotAgeDays = differenceInDays(new Date(), new Date(snapshot.getCreatedAt()));
+    const triggerAuditId = snapshot.getData()?.snapshot?.triggerAuditId || 'unknown';
+
+    try {
+      // Dependent suggestions cascade-delete with the snapshot opportunity.
+      await snapshot.remove();
+
+      log.info(`[Offsite][Retention] Deleted snapshot opportunityId=${snapshot.getId()} `
+        + `siteId=${siteId} auditType=${auditType} triggerAuditId=${triggerAuditId} `
+        + `snapshotAgeDays=${snapshotAgeDays}`);
+
+      return true;
+    } catch (error) {
+      log.error(`[Offsite][Retention] Failed to delete snapshot opportunityId=${snapshot.getId()} `
+        + `siteId=${siteId} auditType=${auditType} triggerAuditId=${triggerAuditId} `
+        + `snapshotAgeDays=${snapshotAgeDays} error=${error.message}`);
+
+      return false;
+    }
+  }));
+
+  const deletedSnapshotCount = deletionResults.filter(Boolean).length;
+  const failedSnapshotCount = expiredSnapshots.length - deletedSnapshotCount;
+
+  log.info(`[Offsite][Retention] Snapshot deletion summary siteId=${siteId} `
+    + `auditType=${auditType} eligible=${expiredSnapshots.length} `
+    + `deleted=${deletedSnapshotCount} failed=${failedSnapshotCount}`);
+
+  return deletedSnapshotCount;
+}

--- a/src/common/offsite-retention.js
+++ b/src/common/offsite-retention.js
@@ -10,11 +10,27 @@
  * governing permissions and limitations under the License.
  */
 
-import { subDays, differenceInDays } from 'date-fns';
+import { subDays } from 'date-fns';
 import { Opportunity as Oppty } from '@adobe/spacecat-shared-data-access';
 import { isOffsiteSnapshot } from './offsite-snapshot.js';
+import {
+  createOffsiteLogger, errorField, AUDIT, PEER,
+} from '../utils/offsite-logging.js';
 
+// See docs/decisions/004-offsite-snapshot-retention-window.md for the rationale.
 export const SNAPSHOT_RETENTION_DAYS = 30;
+
+// Bounds the blast radius of a single invocation — e.g. a dormant site's first refresh after
+// months, when many snapshots become eligible at once. findExpiredSnapshots sorts oldest-first,
+// so any remainder beyond this cap drains across subsequent refreshes rather than all at once.
+export const MAX_DELETIONS_PER_RUN = 50;
+
+// Mirrors the mapping in offsite-snapshot.js — kept local to avoid a cross-module circular import.
+const AUDIT_SLUG_BY_TYPE = {
+  'cited-analysis': AUDIT.CITED,
+  'reddit-analysis': AUDIT.REDDIT,
+  'youtube-analysis': AUDIT.YOUTUBE,
+};
 
 /**
  * Finds managed offsite snapshots older than the retention cutoff, oldest first.
@@ -23,6 +39,7 @@ export async function findExpiredSnapshots({
   dataAccess, siteId, auditType, log,
 }) {
   const { Opportunity } = dataAccess;
+  const olog = createOffsiteLogger(log, { audit: AUDIT_SLUG_BY_TYPE[auditType] ?? 'unknown', siteId });
 
   let ignoredOpportunities;
 
@@ -30,7 +47,9 @@ export async function findExpiredSnapshots({
     ignoredOpportunities = await Opportunity
       .allBySiteIdAndStatus(siteId, Oppty.STATUSES.IGNORED);
   } catch (error) {
-    log.error(`[Offsite][Retention] Failed to find snapshots siteId=${siteId} auditType=${auditType} error=${error.message}`);
+    olog.failure('retention_lookup', `Failed to find snapshots for auditType ${auditType}`, {
+      peer: PEER.POSTGRES, direction: 'inbound', ...errorField(error),
+    });
     return [];
   }
 
@@ -46,42 +65,51 @@ export async function findExpiredSnapshots({
 
 /**
  * Deletes expired snapshots without interrupting the refresh that invoked retention.
+ *
+ * Deletion is batched (bulk `removeByIds`) rather than per-record, per CLAUDE.md's N+1 rule:
+ * a concurrent `Promise.all` over individual `.remove()` calls would fan out to
+ * `expired * (1 + suggestionsPerSnapshot)` concurrent requests against the shared connection
+ * pool — worst-case exactly when a dormant site resumes refreshing after an accumulated
+ * backlog. Suggestions are read sequentially (not concurrently) ahead of the bulk removes to
+ * avoid a similar read-side fan-out; batch sizes are bounded by MAX_DELETIONS_PER_RUN.
+ *
+ * This trades per-record failure isolation for the bulk pattern: a failure here throws and is
+ * caught by the caller (retention must not fail an otherwise successful refresh), rather than
+ * reporting a partial success/failure count.
  */
 export async function deleteExpiredSnapshots({
   dataAccess, siteId, auditType, log,
 }) {
-  const expiredSnapshots = await findExpiredSnapshots({
+  const { Opportunity, Suggestion } = dataAccess;
+  const olog = createOffsiteLogger(log, { audit: AUDIT_SLUG_BY_TYPE[auditType] ?? 'unknown', siteId });
+
+  const allExpiredSnapshots = await findExpiredSnapshots({
     dataAccess, siteId, auditType, log,
   });
+  const expiredSnapshots = allExpiredSnapshots.slice(0, MAX_DELETIONS_PER_RUN);
 
-  const deletionResults = await Promise.all(expiredSnapshots.map(async (snapshot) => {
-    const snapshotAgeDays = differenceInDays(new Date(), new Date(snapshot.getCreatedAt()));
-    const triggerAuditId = snapshot.getData()?.snapshot?.triggerAuditId || 'unknown';
+  if (expiredSnapshots.length === 0) {
+    return 0;
+  }
 
-    try {
-      // Dependent suggestions cascade-delete with the snapshot opportunity.
-      await snapshot.remove();
+  const suggestionIds = [];
+  for (const snapshot of expiredSnapshots) {
+    // Sequential by design — see function doc.
+    // eslint-disable-next-line no-await-in-loop
+    const suggestions = await snapshot.getSuggestions();
+    suggestionIds.push(...suggestions.map((suggestion) => suggestion.getId()));
+  }
 
-      log.info(`[Offsite][Retention] Deleted snapshot opportunityId=${snapshot.getId()} `
-        + `siteId=${siteId} auditType=${auditType} triggerAuditId=${triggerAuditId} `
-        + `snapshotAgeDays=${snapshotAgeDays}`);
+  if (suggestionIds.length > 0) {
+    await Suggestion.removeByIds(suggestionIds);
+  }
 
-      return true;
-    } catch (error) {
-      log.error(`[Offsite][Retention] Failed to delete snapshot opportunityId=${snapshot.getId()} `
-        + `siteId=${siteId} auditType=${auditType} triggerAuditId=${triggerAuditId} `
-        + `snapshotAgeDays=${snapshotAgeDays} error=${error.message}`);
+  const snapshotIds = expiredSnapshots.map((snapshot) => snapshot.getId());
+  await Opportunity.removeByIds(snapshotIds);
 
-      return false;
-    }
-  }));
+  olog.success('retention_delete', `Deleted ${snapshotIds.length} expired snapshot(s) for auditType ${auditType}`, {
+    peer: PEER.POSTGRES, direction: 'outbound', eligible: allExpiredSnapshots.length, deleted: snapshotIds.length,
+  });
 
-  const deletedSnapshotCount = deletionResults.filter(Boolean).length;
-  const failedSnapshotCount = expiredSnapshots.length - deletedSnapshotCount;
-
-  log.info(`[Offsite][Retention] Snapshot deletion summary siteId=${siteId} `
-    + `auditType=${auditType} eligible=${expiredSnapshots.length} `
-    + `deleted=${deletedSnapshotCount} failed=${failedSnapshotCount}`);
-
-  return deletedSnapshotCount;
+  return snapshotIds.length;
 }

--- a/src/common/offsite-snapshot.js
+++ b/src/common/offsite-snapshot.js
@@ -31,6 +31,12 @@ const AUDIT_SLUG_BY_TYPE = {
   'youtube-analysis': AUDIT.YOUTUBE,
 };
 
+/** Returns true for a managed snapshot of the requested audit type. */
+export function isOffsiteSnapshot(opportunity, auditType) {
+  return opportunity.getType() === auditType
+    && (opportunity.getTags() || []).includes(SNAPSHOT_TAG);
+}
+
 /**
  * Finds a snapshot by (siteId, auditType, triggerAuditId).
  * Lookup failures propagate to avoid duplicate creation.
@@ -60,8 +66,7 @@ export async function findSnapshotByTriggerAuditId({
   return (opportunities || []).find((opportunity) => {
     const snapshotMetadata = opportunity.getData()?.snapshot;
 
-    return opportunity.getType() === auditType
-      && (opportunity.getTags() || []).includes(SNAPSHOT_TAG)
+    return isOffsiteSnapshot(opportunity, auditType)
       && snapshotMetadata?.triggerAuditId === triggerAuditId;
   }) || null;
 }

--- a/src/reddit-analysis/guidance-handler.js
+++ b/src/reddit-analysis/guidance-handler.js
@@ -34,6 +34,7 @@ import {
 import {
   createOffsiteLogger, errorField, AUDIT, PEER,
 } from '../utils/offsite-logging.js';
+import { deleteExpiredSnapshots } from '../common/offsite-retention.js';
 
 const AUDIT_TYPE = Audit.AUDIT_TYPES.REDDIT_ANALYSIS;
 // Human prefix for the two shared, untouched utils that still log via a passed-in prefix
@@ -222,6 +223,15 @@ export default async function handler(message, context) {
       count: suggestions.length,
     });
     logOffsiteLlmUsage(log, HUMAN_PREFIX, siteId, opportunityData.llmUsage);
+
+    // Retention must not fail an otherwise successful refresh.
+    try {
+      await deleteExpiredSnapshots({
+        dataAccess, siteId, auditType, log,
+      });
+    } catch (error) {
+      log.error(`[Offsite][Retention] Unexpected failure siteId=${siteId} auditType=${auditType} error=${error.message}`);
+    }
 
     if (auditId) {
       const auditRecord = await AuditModel.findById(auditId);

--- a/src/reddit-analysis/guidance-handler.js
+++ b/src/reddit-analysis/guidance-handler.js
@@ -230,7 +230,9 @@ export default async function handler(message, context) {
         dataAccess, siteId, auditType, log,
       });
     } catch (error) {
-      log.error(`[Offsite][Retention] Unexpected failure siteId=${siteId} auditType=${auditType} error=${error.message}`);
+      ologOpp.failure('retention_delete', `Unexpected retention failure for auditType ${auditType}`, {
+        peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
+      }, error);
     }
 
     if (auditId) {

--- a/src/youtube-analysis/guidance-handler.js
+++ b/src/youtube-analysis/guidance-handler.js
@@ -228,7 +228,9 @@ export default async function handler(message, context) {
         dataAccess, siteId, auditType, log,
       });
     } catch (error) {
-      log.error(`[Offsite][Retention] Unexpected failure siteId=${siteId} auditType=${auditType} error=${error.message}`);
+      ologOpp.failure('retention_delete', `Unexpected retention failure for auditType ${auditType}`, {
+        peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
+      }, error);
     }
 
     if (auditId) {

--- a/src/youtube-analysis/guidance-handler.js
+++ b/src/youtube-analysis/guidance-handler.js
@@ -32,6 +32,7 @@ import {
 import {
   createOffsiteLogger, errorField, AUDIT, PEER,
 } from '../utils/offsite-logging.js';
+import { deleteExpiredSnapshots } from '../common/offsite-retention.js';
 
 const AUDIT_TYPE = Audit.AUDIT_TYPES.YOUTUBE_ANALYSIS;
 // Human prefix for the two shared, untouched utils that still log via a passed-in prefix
@@ -220,6 +221,15 @@ export default async function handler(message, context) {
       count: suggestions.length,
     });
     logOffsiteLlmUsage(log, HUMAN_PREFIX, siteId, opportunityData.llmUsage);
+
+    // Retention must not fail an otherwise successful refresh.
+    try {
+      await deleteExpiredSnapshots({
+        dataAccess, siteId, auditType, log,
+      });
+    } catch (error) {
+      log.error(`[Offsite][Retention] Unexpected failure siteId=${siteId} auditType=${auditType} error=${error.message}`);
+    }
 
     if (auditId) {
       const audit = await AuditModel.findById(auditId);

--- a/test/audits/cited-analysis/guidance-handler.test.js
+++ b/test/audits/cited-analysis/guidance-handler.test.js
@@ -1784,9 +1784,20 @@ describe('Cited Analysis Guidance Handler', () => {
       const result = await handler.default(validMessage(), context);
 
       expect(result.status).to.equal(200);
-      expect(context.log.error).to.have.been.calledWith(sinon.match(
-        /\[Offsite\]\[Retention\] Unexpected failure siteId=test-site-id auditType=cited-analysis error=retention blew up/,
-      ));
+      expect(context.log.error).to.have.been.calledWith(
+        sinon.match(/event=retention_delete/)
+          .and(sinon.match(/outcome=failure/))
+          .and(sinon.match(/errorMessage="retention blew up"/)),
+      );
+    });
+
+    it('does not run retention when the refresh itself fails before reaching the success path', async () => {
+      syncSuggestionsStub.rejects(new Error('sync blew up'));
+
+      const result = await handler.default(validMessage(), context);
+
+      expect(result.status).to.equal(400);
+      expect(deleteExpiredSnapshotsStub).to.not.have.been.called;
     });
   });
 });

--- a/test/audits/cited-analysis/guidance-handler.test.js
+++ b/test/audits/cited-analysis/guidance-handler.test.js
@@ -42,6 +42,7 @@ describe('Cited Analysis Guidance Handler', () => {
   let isSuppressedRunStub;
   let prepareSuppressedRunSnapshotStub;
   let prepareSupersededRunSnapshotStub;
+  let deleteExpiredSnapshotsStub;
 
   const baseURL = 'https://example.com';
   const siteId = 'test-site-id';
@@ -138,6 +139,7 @@ describe('Cited Analysis Guidance Handler', () => {
       }
       return { opportunityData, opportunityToUpdate: evergreenOpportunity };
     });
+    deleteExpiredSnapshotsStub = sandbox.stub().resolves(0);
 
     handler = await esmock('../../../src/cited-analysis/guidance-handler.js', {
       '../../../src/utils/data-access.js': {
@@ -160,6 +162,9 @@ describe('Cited Analysis Guidance Handler', () => {
         resolveBrandResultForSite: resolveBrandResultForSiteStub,
         // Use the REAL applyScopeToOpportunity — see import above.
         applyScopeToOpportunity: realApplyScopeToOpportunity,
+      },
+      '../../../src/common/offsite-retention.js': {
+        deleteExpiredSnapshots: deleteExpiredSnapshotsStub,
       },
     });
 
@@ -1709,6 +1714,79 @@ describe('Cited Analysis Guidance Handler', () => {
         snapshot: { kind: 'suppressed-refresh' },
       });
       expect(propsArg.opportunityData.data.snapshot).to.not.have.property('triggerAuditId');
+    });
+  });
+
+  describe('Snapshot retention', () => {
+    const validMessage = (overrides = {}) => ({
+      siteId,
+      auditId,
+      data: {
+        companyName: 'Example Corp',
+        analysis: {
+          suggestions: [
+            {
+              id: 'test_1', rank: 1, type: 'CONTENT_UPDATE', data: { title: 'Test' },
+            },
+          ],
+        },
+      },
+      ...overrides,
+    });
+
+    it('deletes old snapshots once, scoped to (siteId, auditType), after a surfaced run', async () => {
+      const visibleOpportunity = {
+        getId: sandbox.stub().returns('existing-opp-1'),
+        getType: sandbox.stub().returns('cited-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
+      };
+
+      const result = await handler.default(validMessage(), context);
+
+      expect(result.status).to.equal(200);
+      expect(deleteExpiredSnapshotsStub).to.have.been.calledOnce;
+      const callArgs = deleteExpiredSnapshotsStub.firstCall.args[0];
+      expect(callArgs.siteId).to.equal(siteId);
+      expect(callArgs.auditType).to.equal('cited-analysis');
+    });
+
+    it('deletes old snapshots once after a suppressed run', async () => {
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([]),
+      };
+
+      const message = validMessage({
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: { status: 'IGNORED' },
+            suggestions: [{ id: 'test_1', rank: 1, type: 'CONTENT_UPDATE', data: {} }],
+          },
+        },
+      });
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(200);
+      expect(deleteExpiredSnapshotsStub).to.have.been.calledOnce;
+      const callArgs = deleteExpiredSnapshotsStub.firstCall.args[0];
+      expect(callArgs.siteId).to.equal(siteId);
+      expect(callArgs.auditType).to.equal('cited-analysis');
+    });
+
+    it('still returns ok() when retention throws', async () => {
+      deleteExpiredSnapshotsStub.rejects(new Error('retention blew up'));
+
+      const result = await handler.default(validMessage(), context);
+
+      expect(result.status).to.equal(200);
+      expect(context.log.error).to.have.been.calledWith(sinon.match(
+        /\[Offsite\]\[Retention\] Unexpected failure siteId=test-site-id auditType=cited-analysis error=retention blew up/,
+      ));
     });
   });
 });

--- a/test/audits/reddit-analysis/guidance-handler.test.js
+++ b/test/audits/reddit-analysis/guidance-handler.test.js
@@ -40,6 +40,7 @@ describe('Reddit Analysis Guidance Handler', () => {
   let isSuppressedRunStub;
   let prepareSuppressedRunSnapshotStub;
   let prepareSupersededRunSnapshotStub;
+  let deleteExpiredSnapshotsStub;
 
   const baseURL = 'https://example.com';
   const siteId = 'test-site-id';
@@ -134,6 +135,7 @@ describe('Reddit Analysis Guidance Handler', () => {
       }
       return { opportunityData, opportunityToUpdate: evergreenOpportunity };
     });
+    deleteExpiredSnapshotsStub = sandbox.stub().resolves(0);
 
     handler = await esmock('../../../src/reddit-analysis/guidance-handler.js', {
       '../../../src/utils/data-access.js': {
@@ -155,6 +157,9 @@ describe('Reddit Analysis Guidance Handler', () => {
       '../../../src/utils/brand-resolver.js': {
         resolveBrandResultForSite: resolveBrandResultForSiteStub,
         applyScopeToOpportunity: realApplyScopeToOpportunity,
+      },
+      '../../../src/common/offsite-retention.js': {
+        deleteExpiredSnapshots: deleteExpiredSnapshotsStub,
       },
     });
 
@@ -1517,6 +1522,79 @@ describe('Reddit Analysis Guidance Handler', () => {
         snapshot: { kind: 'suppressed-refresh' },
       });
       expect(propsArg.opportunityData.data.snapshot).to.not.have.property('triggerAuditId');
+    });
+  });
+
+  describe('Snapshot retention', () => {
+    const validMessage = (overrides = {}) => ({
+      siteId,
+      auditId,
+      data: {
+        companyName: 'Example Corp',
+        analysis: {
+          suggestions: [
+            {
+              id: 'test_1', rank: 1, type: 'CONTENT_UPDATE', data: { title: 'Test' },
+            },
+          ],
+        },
+      },
+      ...overrides,
+    });
+
+    it('deletes old snapshots once, scoped to (siteId, auditType), after a surfaced run', async () => {
+      const visibleOpportunity = {
+        getId: sandbox.stub().returns('existing-opp-1'),
+        getType: sandbox.stub().returns('reddit-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
+      };
+
+      const result = await handler.default(validMessage(), context);
+
+      expect(result.status).to.equal(200);
+      expect(deleteExpiredSnapshotsStub).to.have.been.calledOnce;
+      const callArgs = deleteExpiredSnapshotsStub.firstCall.args[0];
+      expect(callArgs.siteId).to.equal(siteId);
+      expect(callArgs.auditType).to.equal('reddit-analysis');
+    });
+
+    it('deletes old snapshots once after a suppressed run', async () => {
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([]),
+      };
+
+      const message = validMessage({
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: { status: 'IGNORED' },
+            suggestions: [{ id: 'test_1', rank: 1, type: 'CONTENT_UPDATE', data: {} }],
+          },
+        },
+      });
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(200);
+      expect(deleteExpiredSnapshotsStub).to.have.been.calledOnce;
+      const callArgs = deleteExpiredSnapshotsStub.firstCall.args[0];
+      expect(callArgs.siteId).to.equal(siteId);
+      expect(callArgs.auditType).to.equal('reddit-analysis');
+    });
+
+    it('still returns ok() when retention throws', async () => {
+      deleteExpiredSnapshotsStub.rejects(new Error('retention blew up'));
+
+      const result = await handler.default(validMessage(), context);
+
+      expect(result.status).to.equal(200);
+      expect(context.log.error).to.have.been.calledWith(sinon.match(
+        /\[Offsite\]\[Retention\] Unexpected failure siteId=test-site-id auditType=reddit-analysis error=retention blew up/,
+      ));
     });
   });
 });

--- a/test/audits/reddit-analysis/guidance-handler.test.js
+++ b/test/audits/reddit-analysis/guidance-handler.test.js
@@ -1592,9 +1592,20 @@ describe('Reddit Analysis Guidance Handler', () => {
       const result = await handler.default(validMessage(), context);
 
       expect(result.status).to.equal(200);
-      expect(context.log.error).to.have.been.calledWith(sinon.match(
-        /\[Offsite\]\[Retention\] Unexpected failure siteId=test-site-id auditType=reddit-analysis error=retention blew up/,
-      ));
+      expect(context.log.error).to.have.been.calledWith(
+        sinon.match(/event=retention_delete/)
+          .and(sinon.match(/outcome=failure/))
+          .and(sinon.match(/errorMessage="retention blew up"/)),
+      );
+    });
+
+    it('does not run retention when the refresh itself fails before reaching the success path', async () => {
+      syncSuggestionsStub.rejects(new Error('sync blew up'));
+
+      const result = await handler.default(validMessage(), context);
+
+      expect(result.status).to.equal(400);
+      expect(deleteExpiredSnapshotsStub).to.not.have.been.called;
     });
   });
 });

--- a/test/audits/youtube-analysis/guidance-handler.test.js
+++ b/test/audits/youtube-analysis/guidance-handler.test.js
@@ -40,6 +40,7 @@ describe('YouTube Analysis Guidance Handler', () => {
   let isSuppressedRunStub;
   let prepareSuppressedRunSnapshotStub;
   let prepareSupersededRunSnapshotStub;
+  let deleteExpiredSnapshotsStub;
 
   const siteId = 'test-site-id';
   const auditId = 'test-audit-id';
@@ -157,6 +158,7 @@ describe('YouTube Analysis Guidance Handler', () => {
       }
       return { opportunityData, opportunityToUpdate: evergreenOpportunity };
     });
+    deleteExpiredSnapshotsStub = sandbox.stub().resolves(0);
 
     guidanceHandler = await esmock('../../../src/youtube-analysis/guidance-handler.js', {
       '../../../src/utils/analysis-fetch.js': {
@@ -180,6 +182,9 @@ describe('YouTube Analysis Guidance Handler', () => {
       '../../../src/utils/brand-resolver.js': {
         resolveBrandResultForSite: resolveBrandResultForSiteStub,
         applyScopeToOpportunity: realApplyScopeToOpportunity,
+      },
+      '../../../src/common/offsite-retention.js': {
+        deleteExpiredSnapshots: deleteExpiredSnapshotsStub,
       },
     });
 
@@ -1508,6 +1513,79 @@ describe('YouTube Analysis Guidance Handler', () => {
         snapshot: { kind: 'suppressed-refresh' },
       });
       expect(propsArg.opportunityData.data.snapshot).to.not.have.property('triggerAuditId');
+    });
+  });
+
+  describe('Snapshot retention', () => {
+    const validMessage = (overrides = {}) => ({
+      siteId,
+      auditId,
+      data: {
+        companyName: 'Example Corp',
+        analysis: {
+          suggestions: [
+            {
+              id: 'test_1', rank: 1, type: 'CONTENT_UPDATE', data: { title: 'Test' },
+            },
+          ],
+        },
+      },
+      ...overrides,
+    });
+
+    it('deletes old snapshots once, scoped to (siteId, auditType), after a surfaced run', async () => {
+      const visibleOpportunity = {
+        getId: sandbox.stub().returns('existing-opp-1'),
+        getType: sandbox.stub().returns('youtube-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
+      };
+
+      const result = await guidanceHandler.default(validMessage(), context);
+
+      expect(result.status).to.equal(200);
+      expect(deleteExpiredSnapshotsStub).to.have.been.calledOnce;
+      const callArgs = deleteExpiredSnapshotsStub.firstCall.args[0];
+      expect(callArgs.siteId).to.equal(siteId);
+      expect(callArgs.auditType).to.equal('youtube-analysis');
+    });
+
+    it('deletes old snapshots once after a suppressed run', async () => {
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([]),
+      };
+
+      const message = validMessage({
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: { status: 'IGNORED' },
+            suggestions: [{ id: 'test_1', rank: 1, type: 'CONTENT_UPDATE', data: {} }],
+          },
+        },
+      });
+
+      const result = await guidanceHandler.default(message, context);
+
+      expect(result.status).to.equal(200);
+      expect(deleteExpiredSnapshotsStub).to.have.been.calledOnce;
+      const callArgs = deleteExpiredSnapshotsStub.firstCall.args[0];
+      expect(callArgs.siteId).to.equal(siteId);
+      expect(callArgs.auditType).to.equal('youtube-analysis');
+    });
+
+    it('still returns ok() when retention throws', async () => {
+      deleteExpiredSnapshotsStub.rejects(new Error('retention blew up'));
+
+      const result = await guidanceHandler.default(validMessage(), context);
+
+      expect(result.status).to.equal(200);
+      expect(context.log.error).to.have.been.calledWith(sinon.match(
+        /\[Offsite\]\[Retention\] Unexpected failure siteId=test-site-id auditType=youtube-analysis error=retention blew up/,
+      ));
     });
   });
 });

--- a/test/audits/youtube-analysis/guidance-handler.test.js
+++ b/test/audits/youtube-analysis/guidance-handler.test.js
@@ -1583,9 +1583,20 @@ describe('YouTube Analysis Guidance Handler', () => {
       const result = await guidanceHandler.default(validMessage(), context);
 
       expect(result.status).to.equal(200);
-      expect(context.log.error).to.have.been.calledWith(sinon.match(
-        /\[Offsite\]\[Retention\] Unexpected failure siteId=test-site-id auditType=youtube-analysis error=retention blew up/,
-      ));
+      expect(context.log.error).to.have.been.calledWith(
+        sinon.match(/event=retention_delete/)
+          .and(sinon.match(/outcome=failure/))
+          .and(sinon.match(/errorMessage="retention blew up"/)),
+      );
+    });
+
+    it('does not run retention when the refresh itself fails before reaching the success path', async () => {
+      mockSyncSuggestions.rejects(new Error('sync blew up'));
+
+      const result = await guidanceHandler.default(validMessage(), context);
+
+      expect(result.status).to.equal(400);
+      expect(deleteExpiredSnapshotsStub).to.not.have.been.called;
     });
   });
 });

--- a/test/common/offsite-retention.test.js
+++ b/test/common/offsite-retention.test.js
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
+import { subDays } from 'date-fns';
+import { SNAPSHOT_TAG } from '../../src/common/offsite-snapshot.js';
+import {
+  SNAPSHOT_RETENTION_DAYS,
+  findExpiredSnapshots,
+  deleteExpiredSnapshots,
+} from '../../src/common/offsite-retention.js';
+
+use(sinonChai);
+use(chaiAsPromised);
+
+describe('offsite-retention', () => {
+  let sandbox;
+  let log;
+
+  const siteId = 'site-1';
+  const auditType = 'cited-analysis';
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    log = {
+      info: sandbox.spy(), error: sandbox.spy(), warn: sandbox.spy(), debug: sandbox.spy(),
+    };
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  const daysAgo = (days) => subDays(new Date(), days).toISOString();
+
+  const buildSnapshotOpportunity = ({
+    id,
+    type = auditType,
+    tags = [SNAPSHOT_TAG],
+    snapshot = { kind: 'superseded-refresh', triggerAuditId: `trigger-${id}` },
+    createdAt,
+    remove,
+  }) => ({
+    getId: () => id,
+    getType: () => type,
+    getTags: () => tags,
+    getData: () => ({ snapshot }),
+    getCreatedAt: () => createdAt,
+    remove: remove || sandbox.stub().resolves(),
+  });
+
+  describe('SNAPSHOT_RETENTION_DAYS', () => {
+    it('is 30 days', () => {
+      expect(SNAPSHOT_RETENTION_DAYS).to.equal(30);
+    });
+  });
+
+  describe('findExpiredSnapshots', () => {
+    it('includes only opportunities that are past the cutoff AND pass isOffsiteSnapshot', async () => {
+      const oldTagged = buildSnapshotOpportunity({ id: 'old-tagged', createdAt: daysAgo(45) });
+      const youngTagged = buildSnapshotOpportunity({ id: 'young-tagged', createdAt: daysAgo(5) });
+      const oldWrongType = buildSnapshotOpportunity({
+        id: 'old-wrong-type', type: 'reddit-analysis', createdAt: daysAgo(45),
+      });
+      const oldUntagged = buildSnapshotOpportunity({
+        id: 'old-untagged', tags: [], createdAt: daysAgo(45),
+      });
+      // null prevents the helper's default metadata from being used.
+      const oldNoSnapshotData = buildSnapshotOpportunity({
+        id: 'old-no-data', snapshot: null, createdAt: daysAgo(45),
+      });
+
+      const dataAccess = {
+        Opportunity: {
+          allBySiteIdAndStatus: sandbox.stub().resolves([
+            oldTagged, youngTagged, oldWrongType, oldUntagged, oldNoSnapshotData,
+          ]),
+        },
+      };
+
+      const expiredSnapshots = await findExpiredSnapshots({
+        dataAccess, siteId, auditType, log,
+      });
+
+      expect(expiredSnapshots.map((opportunity) => opportunity.getId())).to.deep.equal([
+        'old-tagged',
+        'old-no-data',
+      ]);
+    });
+
+    it('queries IGNORED opportunities for the given siteId', async () => {
+      const allBySiteIdAndStatus = sandbox.stub().resolves([]);
+      const dataAccess = { Opportunity: { allBySiteIdAndStatus } };
+
+      await findExpiredSnapshots({
+        dataAccess, siteId, auditType, log,
+      });
+
+      expect(allBySiteIdAndStatus).to.have.been.calledWith(siteId, 'IGNORED');
+    });
+
+    it('returns [] and logs (does not throw) when the lookup rejects', async () => {
+      const dataAccess = {
+        Opportunity: { allBySiteIdAndStatus: sandbox.stub().rejects(new Error('DB down')) },
+      };
+
+      const expiredSnapshots = await findExpiredSnapshots({
+        dataAccess, siteId, auditType, log,
+      });
+
+      expect(expiredSnapshots).to.deep.equal([]);
+      expect(log.error).to.have.been.calledWith(sinon.match(
+        /\[Offsite\]\[Retention\] Failed to find snapshots siteId=site-1 auditType=cited-analysis error=DB down/,
+      ));
+    });
+
+    it('returns [] when the lookup resolves to null/undefined', async () => {
+      const dataAccess = {
+        Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves(null) },
+      };
+
+      const expiredSnapshots = await findExpiredSnapshots({
+        dataAccess, siteId, auditType, log,
+      });
+
+      expect(expiredSnapshots).to.deep.equal([]);
+    });
+
+    it('sorts the result oldest-first', async () => {
+      const older = buildSnapshotOpportunity({ id: 'older', createdAt: daysAgo(90) });
+      const middle = buildSnapshotOpportunity({ id: 'middle', createdAt: daysAgo(60) });
+      const newer = buildSnapshotOpportunity({ id: 'newer', createdAt: daysAgo(40) });
+
+      const dataAccess = {
+        Opportunity: {
+          // Deliberately unsorted input order.
+          allBySiteIdAndStatus: sandbox.stub().resolves([middle, newer, older]),
+        },
+      };
+
+      const expiredSnapshots = await findExpiredSnapshots({
+        dataAccess, siteId, auditType, log,
+      });
+
+      expect(expiredSnapshots.map((opportunity) => opportunity.getId()))
+        .to.deep.equal(['older', 'middle', 'newer']);
+    });
+
+    it('retains a snapshot created exactly 30 days ago', async () => {
+      const now = new Date('2026-01-15T12:00:00.000Z');
+      sandbox.useFakeTimers(now);
+      const exactlyAtCutoff = buildSnapshotOpportunity({
+        id: 'at-cutoff',
+        createdAt: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString(),
+      });
+      const dataAccess = {
+        Opportunity: {
+          allBySiteIdAndStatus: sandbox.stub().resolves([exactlyAtCutoff]),
+        },
+      };
+
+      const expiredSnapshots = await findExpiredSnapshots({
+        dataAccess, siteId, auditType, log,
+      });
+
+      expect(expiredSnapshots).to.deep.equal([]);
+    });
+
+    it('expires a snapshot created one millisecond beyond 30 days ago', async () => {
+      const now = new Date('2026-01-15T12:00:00.000Z');
+      sandbox.useFakeTimers(now);
+      const beyondCutoff = buildSnapshotOpportunity({
+        id: 'beyond-cutoff',
+        createdAt: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000 - 1).toISOString(),
+      });
+      const dataAccess = {
+        Opportunity: {
+          allBySiteIdAndStatus: sandbox.stub().resolves([beyondCutoff]),
+        },
+      };
+
+      const expiredSnapshots = await findExpiredSnapshots({
+        dataAccess, siteId, auditType, log,
+      });
+
+      expect(expiredSnapshots).to.deep.equal([beyondCutoff]);
+    });
+  });
+
+  describe('deleteExpiredSnapshots', () => {
+    it('deletes every expired snapshot and returns the deleted count', async () => {
+      const firstExpiredSnapshot = buildSnapshotOpportunity({
+        id: 'first-expired', createdAt: daysAgo(45),
+      });
+      const secondExpiredSnapshot = buildSnapshotOpportunity({
+        id: 'second-expired', createdAt: daysAgo(60),
+      });
+      const dataAccess = {
+        Opportunity: {
+          allBySiteIdAndStatus: sandbox.stub().resolves([
+            firstExpiredSnapshot, secondExpiredSnapshot,
+          ]),
+        },
+      };
+
+      const deletedSnapshotCount = await deleteExpiredSnapshots({
+        dataAccess, siteId, auditType, log,
+      });
+
+      expect(deletedSnapshotCount).to.equal(2);
+      expect(firstExpiredSnapshot.remove).to.have.been.calledOnce;
+      expect(secondExpiredSnapshot.remove).to.have.been.calledOnce;
+      expect(log.info).to.have.been.calledWith(sinon.match(
+        /Snapshot deletion summary siteId=site-1 auditType=cited-analysis eligible=2 deleted=2 failed=0/,
+      ));
+    });
+
+    it('continues after one deletion fails and counts only successful deletions', async () => {
+      const failingSnapshot = buildSnapshotOpportunity({
+        id: 'failing',
+        createdAt: daysAgo(45),
+        remove: sandbox.stub().rejects(new Error('FK violation')),
+      });
+      const firstDeletedSnapshot = buildSnapshotOpportunity({
+        id: 'deleted-1', createdAt: daysAgo(50),
+      });
+      const secondDeletedSnapshot = buildSnapshotOpportunity({
+        id: 'deleted-2', createdAt: daysAgo(55),
+      });
+      const dataAccess = {
+        Opportunity: {
+          allBySiteIdAndStatus: sandbox.stub().resolves([
+            failingSnapshot, firstDeletedSnapshot, secondDeletedSnapshot,
+          ]),
+        },
+      };
+
+      const deletedSnapshotCount = await deleteExpiredSnapshots({
+        dataAccess, siteId, auditType, log,
+      });
+
+      expect(deletedSnapshotCount).to.equal(2);
+      expect(failingSnapshot.remove).to.have.been.calledOnce;
+      expect(firstDeletedSnapshot.remove).to.have.been.calledOnce;
+      expect(secondDeletedSnapshot.remove).to.have.been.calledOnce;
+      expect(log.error).to.have.been.calledWith(
+        sinon.match(
+          /\[Offsite\]\[Retention\] Failed to delete snapshot opportunityId=failing siteId=site-1 auditType=cited-analysis triggerAuditId=trigger-failing snapshotAgeDays=45 error=FK violation/,
+        ),
+      );
+      expect(log.info).to.have.been.calledWith(
+        sinon.match(
+          /Snapshot deletion summary siteId=site-1 auditType=cited-analysis eligible=3 deleted=2 failed=1/,
+        ),
+      );
+    });
+
+    it('audit-logs each successful deletion with snapshot identity and age', async () => {
+      const snapshot = buildSnapshotOpportunity({
+        id: 'snap-1',
+        snapshot: { kind: 'superseded-refresh', triggerAuditId: 'audit-xyz' },
+        createdAt: daysAgo(45),
+      });
+      const dataAccess = {
+        Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([snapshot]) },
+      };
+
+      await deleteExpiredSnapshots({
+        dataAccess, siteId, auditType, log,
+      });
+
+      expect(log.info).to.have.been.calledWith(sinon.match(
+        /\[Offsite\]\[Retention\] Deleted snapshot opportunityId=snap-1 siteId=site-1 auditType=cited-analysis triggerAuditId=audit-xyz snapshotAgeDays=45/,
+      ));
+    });
+
+    it('logs unknown when triggerAuditId metadata is missing', async () => {
+      const snapshot = buildSnapshotOpportunity({
+        id: 'snap-no-trigger',
+        snapshot: null,
+        createdAt: daysAgo(45),
+      });
+      const dataAccess = {
+        Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([snapshot]) },
+      };
+
+      const deletedSnapshotCount = await deleteExpiredSnapshots({
+        dataAccess, siteId, auditType, log,
+      });
+
+      expect(deletedSnapshotCount).to.equal(1);
+      expect(log.info).to.have.been.calledWith(sinon.match(/triggerAuditId=unknown/));
+    });
+
+    it('returns 0 and logs a zero-candidate summary when nothing is expired', async () => {
+      const youngSnapshot = buildSnapshotOpportunity({ id: 'young', createdAt: daysAgo(5) });
+      const dataAccess = {
+        Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([youngSnapshot]) },
+      };
+
+      const deletedSnapshotCount = await deleteExpiredSnapshots({
+        dataAccess, siteId, auditType, log,
+      });
+
+      expect(deletedSnapshotCount).to.equal(0);
+      expect(youngSnapshot.remove).to.not.have.been.called;
+      expect(log.info).to.have.been.calledWith(sinon.match(
+        /Snapshot deletion summary siteId=site-1 auditType=cited-analysis eligible=0 deleted=0 failed=0/,
+      ));
+    });
+
+    it('returns 0 and logs a summary when finding snapshots fails', async () => {
+      const dataAccess = {
+        Opportunity: { allBySiteIdAndStatus: sandbox.stub().rejects(new Error('DB down')) },
+      };
+
+      const deletedSnapshotCount = await deleteExpiredSnapshots({
+        dataAccess, siteId, auditType, log,
+      });
+
+      expect(deletedSnapshotCount).to.equal(0);
+      expect(log.info).to.have.been.calledWith(sinon.match(
+        /Snapshot deletion summary siteId=site-1 auditType=cited-analysis eligible=0 deleted=0 failed=0/,
+      ));
+    });
+  });
+});

--- a/test/common/offsite-retention.test.js
+++ b/test/common/offsite-retention.test.js
@@ -18,6 +18,7 @@ import { subDays } from 'date-fns';
 import { SNAPSHOT_TAG } from '../../src/common/offsite-snapshot.js';
 import {
   SNAPSHOT_RETENTION_DAYS,
+  MAX_DELETIONS_PER_RUN,
   findExpiredSnapshots,
   deleteExpiredSnapshots,
 } from '../../src/common/offsite-retention.js';
@@ -51,14 +52,14 @@ describe('offsite-retention', () => {
     tags = [SNAPSHOT_TAG],
     snapshot = { kind: 'superseded-refresh', triggerAuditId: `trigger-${id}` },
     createdAt,
-    remove,
+    suggestions = [],
   }) => ({
     getId: () => id,
     getType: () => type,
     getTags: () => tags,
     getData: () => ({ snapshot }),
     getCreatedAt: () => createdAt,
-    remove: remove || sandbox.stub().resolves(),
+    getSuggestions: sandbox.stub().resolves(suggestions),
   });
 
   describe('SNAPSHOT_RETENTION_DAYS', () => {
@@ -121,9 +122,24 @@ describe('offsite-retention', () => {
       });
 
       expect(expiredSnapshots).to.deep.equal([]);
-      expect(log.error).to.have.been.calledWith(sinon.match(
-        /\[Offsite\]\[Retention\] Failed to find snapshots siteId=site-1 auditType=cited-analysis error=DB down/,
-      ));
+      expect(log.error).to.have.been.calledWith(
+        sinon.match(/event=retention_lookup/)
+          .and(sinon.match(/outcome=failure/))
+          .and(sinon.match(/audit=cited/))
+          .and(sinon.match(/errorMessage="DB down"/)),
+      );
+    });
+
+    it('emits audit=unknown when the auditType is not in the slug map (defensive fallback)', async () => {
+      const dataAccess = {
+        Opportunity: { allBySiteIdAndStatus: sandbox.stub().rejects(new Error('DB down')) },
+      };
+
+      await findExpiredSnapshots({
+        dataAccess, siteId, auditType: 'not-a-real-audit', log,
+      });
+
+      expect(log.error).to.have.been.calledWith(sinon.match(/audit=unknown/));
     });
 
     it('returns [] when the lookup resolves to null/undefined', async () => {
@@ -200,19 +216,25 @@ describe('offsite-retention', () => {
   });
 
   describe('deleteExpiredSnapshots', () => {
-    it('deletes every expired snapshot and returns the deleted count', async () => {
+    it('bulk-removes suggestions then snapshots, and returns the deleted count', async () => {
+      const firstSuggestion = { getId: () => 'sugg-1' };
+      const secondSuggestion = { getId: () => 'sugg-2' };
       const firstExpiredSnapshot = buildSnapshotOpportunity({
-        id: 'first-expired', createdAt: daysAgo(45),
+        id: 'first-expired', createdAt: daysAgo(45), suggestions: [firstSuggestion],
       });
       const secondExpiredSnapshot = buildSnapshotOpportunity({
-        id: 'second-expired', createdAt: daysAgo(60),
+        id: 'second-expired', createdAt: daysAgo(60), suggestions: [secondSuggestion],
       });
+      const removeByIdsSuggestion = sandbox.stub().resolves();
+      const removeByIdsOpportunity = sandbox.stub().resolves();
       const dataAccess = {
         Opportunity: {
           allBySiteIdAndStatus: sandbox.stub().resolves([
             firstExpiredSnapshot, secondExpiredSnapshot,
           ]),
+          removeByIds: removeByIdsOpportunity,
         },
+        Suggestion: { removeByIds: removeByIdsSuggestion },
       };
 
       const deletedSnapshotCount = await deleteExpiredSnapshots({
@@ -220,80 +242,27 @@ describe('offsite-retention', () => {
       });
 
       expect(deletedSnapshotCount).to.equal(2);
-      expect(firstExpiredSnapshot.remove).to.have.been.calledOnce;
-      expect(secondExpiredSnapshot.remove).to.have.been.calledOnce;
-      expect(log.info).to.have.been.calledWith(sinon.match(
-        /Snapshot deletion summary siteId=site-1 auditType=cited-analysis eligible=2 deleted=2 failed=0/,
-      ));
+      // Oldest-first ordering from findExpiredSnapshots is preserved into the bulk call.
+      expect(removeByIdsSuggestion).to.have.been.calledOnceWith(['sugg-2', 'sugg-1']);
+      expect(removeByIdsOpportunity).to.have.been.calledOnceWith(['second-expired', 'first-expired']);
+      expect(log.info).to.have.been.calledWith(
+        sinon.match(/event=retention_delete/)
+          .and(sinon.match(/outcome=success/))
+          .and(sinon.match(/eligible=2/))
+          .and(sinon.match(/deleted=2/)),
+      );
     });
 
-    it('continues after one deletion fails and counts only successful deletions', async () => {
-      const failingSnapshot = buildSnapshotOpportunity({
-        id: 'failing',
-        createdAt: daysAgo(45),
-        remove: sandbox.stub().rejects(new Error('FK violation')),
-      });
-      const firstDeletedSnapshot = buildSnapshotOpportunity({
-        id: 'deleted-1', createdAt: daysAgo(50),
-      });
-      const secondDeletedSnapshot = buildSnapshotOpportunity({
-        id: 'deleted-2', createdAt: daysAgo(55),
-      });
+    it('skips the suggestion bulk-remove when no expired snapshot has suggestions', async () => {
+      const snapshot = buildSnapshotOpportunity({ id: 'no-suggestions', createdAt: daysAgo(45) });
+      const removeByIdsSuggestion = sandbox.stub().resolves();
+      const removeByIdsOpportunity = sandbox.stub().resolves();
       const dataAccess = {
         Opportunity: {
-          allBySiteIdAndStatus: sandbox.stub().resolves([
-            failingSnapshot, firstDeletedSnapshot, secondDeletedSnapshot,
-          ]),
+          allBySiteIdAndStatus: sandbox.stub().resolves([snapshot]),
+          removeByIds: removeByIdsOpportunity,
         },
-      };
-
-      const deletedSnapshotCount = await deleteExpiredSnapshots({
-        dataAccess, siteId, auditType, log,
-      });
-
-      expect(deletedSnapshotCount).to.equal(2);
-      expect(failingSnapshot.remove).to.have.been.calledOnce;
-      expect(firstDeletedSnapshot.remove).to.have.been.calledOnce;
-      expect(secondDeletedSnapshot.remove).to.have.been.calledOnce;
-      expect(log.error).to.have.been.calledWith(
-        sinon.match(
-          /\[Offsite\]\[Retention\] Failed to delete snapshot opportunityId=failing siteId=site-1 auditType=cited-analysis triggerAuditId=trigger-failing snapshotAgeDays=45 error=FK violation/,
-        ),
-      );
-      expect(log.info).to.have.been.calledWith(
-        sinon.match(
-          /Snapshot deletion summary siteId=site-1 auditType=cited-analysis eligible=3 deleted=2 failed=1/,
-        ),
-      );
-    });
-
-    it('audit-logs each successful deletion with snapshot identity and age', async () => {
-      const snapshot = buildSnapshotOpportunity({
-        id: 'snap-1',
-        snapshot: { kind: 'superseded-refresh', triggerAuditId: 'audit-xyz' },
-        createdAt: daysAgo(45),
-      });
-      const dataAccess = {
-        Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([snapshot]) },
-      };
-
-      await deleteExpiredSnapshots({
-        dataAccess, siteId, auditType, log,
-      });
-
-      expect(log.info).to.have.been.calledWith(sinon.match(
-        /\[Offsite\]\[Retention\] Deleted snapshot opportunityId=snap-1 siteId=site-1 auditType=cited-analysis triggerAuditId=audit-xyz snapshotAgeDays=45/,
-      ));
-    });
-
-    it('logs unknown when triggerAuditId metadata is missing', async () => {
-      const snapshot = buildSnapshotOpportunity({
-        id: 'snap-no-trigger',
-        snapshot: null,
-        createdAt: daysAgo(45),
-      });
-      const dataAccess = {
-        Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([snapshot]) },
+        Suggestion: { removeByIds: removeByIdsSuggestion },
       };
 
       const deletedSnapshotCount = await deleteExpiredSnapshots({
@@ -301,13 +270,20 @@ describe('offsite-retention', () => {
       });
 
       expect(deletedSnapshotCount).to.equal(1);
-      expect(log.info).to.have.been.calledWith(sinon.match(/triggerAuditId=unknown/));
+      expect(removeByIdsSuggestion).to.not.have.been.called;
+      expect(removeByIdsOpportunity).to.have.been.calledOnceWith(['no-suggestions']);
     });
 
-    it('returns 0 and logs a zero-candidate summary when nothing is expired', async () => {
+    it('returns 0, calls no removeByIds, and does not log when nothing is expired', async () => {
       const youngSnapshot = buildSnapshotOpportunity({ id: 'young', createdAt: daysAgo(5) });
+      const removeByIdsSuggestion = sandbox.stub().resolves();
+      const removeByIdsOpportunity = sandbox.stub().resolves();
       const dataAccess = {
-        Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([youngSnapshot]) },
+        Opportunity: {
+          allBySiteIdAndStatus: sandbox.stub().resolves([youngSnapshot]),
+          removeByIds: removeByIdsOpportunity,
+        },
+        Suggestion: { removeByIds: removeByIdsSuggestion },
       };
 
       const deletedSnapshotCount = await deleteExpiredSnapshots({
@@ -315,15 +291,18 @@ describe('offsite-retention', () => {
       });
 
       expect(deletedSnapshotCount).to.equal(0);
-      expect(youngSnapshot.remove).to.not.have.been.called;
-      expect(log.info).to.have.been.calledWith(sinon.match(
-        /Snapshot deletion summary siteId=site-1 auditType=cited-analysis eligible=0 deleted=0 failed=0/,
-      ));
+      expect(removeByIdsSuggestion).to.not.have.been.called;
+      expect(removeByIdsOpportunity).to.not.have.been.called;
+      expect(log.info).to.not.have.been.called;
     });
 
-    it('returns 0 and logs a summary when finding snapshots fails', async () => {
+    it('returns 0 without calling removeByIds when the lookup fails', async () => {
+      const removeByIdsOpportunity = sandbox.stub().resolves();
       const dataAccess = {
-        Opportunity: { allBySiteIdAndStatus: sandbox.stub().rejects(new Error('DB down')) },
+        Opportunity: {
+          allBySiteIdAndStatus: sandbox.stub().rejects(new Error('DB down')),
+          removeByIds: removeByIdsOpportunity,
+        },
       };
 
       const deletedSnapshotCount = await deleteExpiredSnapshots({
@@ -331,9 +310,92 @@ describe('offsite-retention', () => {
       });
 
       expect(deletedSnapshotCount).to.equal(0);
-      expect(log.info).to.have.been.calledWith(sinon.match(
-        /Snapshot deletion summary siteId=site-1 auditType=cited-analysis eligible=0 deleted=0 failed=0/,
+      expect(removeByIdsOpportunity).to.not.have.been.called;
+    });
+
+    it('emits audit=unknown when the auditType is not in the slug map (defensive fallback)', async () => {
+      const snapshot = buildSnapshotOpportunity({
+        id: 'snap-1', type: 'not-a-real-audit', createdAt: daysAgo(45),
+      });
+      const dataAccess = {
+        Opportunity: {
+          allBySiteIdAndStatus: sandbox.stub().resolves([snapshot]),
+          removeByIds: sandbox.stub().resolves(),
+        },
+        Suggestion: { removeByIds: sandbox.stub().resolves() },
+      };
+
+      await deleteExpiredSnapshots({
+        dataAccess, siteId, auditType: 'not-a-real-audit', log,
+      });
+
+      expect(log.info).to.have.been.calledWith(sinon.match(/audit=unknown/));
+    });
+
+    it('propagates errors from Suggestion.removeByIds (retention must not silently succeed)', async () => {
+      const snapshot = buildSnapshotOpportunity({
+        id: 'snap-1', createdAt: daysAgo(45), suggestions: [{ getId: () => 'sugg-1' }],
+      });
+      const dataAccess = {
+        Opportunity: {
+          allBySiteIdAndStatus: sandbox.stub().resolves([snapshot]),
+          removeByIds: sandbox.stub().resolves(),
+        },
+        Suggestion: { removeByIds: sandbox.stub().rejects(new Error('FK violation')) },
+      };
+
+      await expect(deleteExpiredSnapshots({
+        dataAccess, siteId, auditType, log,
+      })).to.be.rejectedWith('FK violation');
+    });
+
+    it('propagates errors from Opportunity.removeByIds (retention must not silently succeed)', async () => {
+      const snapshot = buildSnapshotOpportunity({ id: 'snap-1', createdAt: daysAgo(45) });
+      const dataAccess = {
+        Opportunity: {
+          allBySiteIdAndStatus: sandbox.stub().resolves([snapshot]),
+          removeByIds: sandbox.stub().rejects(new Error('DB down')),
+        },
+        Suggestion: { removeByIds: sandbox.stub().resolves() },
+      };
+
+      await expect(deleteExpiredSnapshots({
+        dataAccess, siteId, auditType, log,
+      })).to.be.rejectedWith('DB down');
+    });
+
+    it('caps deletions per run at MAX_DELETIONS_PER_RUN, deleting the oldest first', async () => {
+      const totalExpired = MAX_DELETIONS_PER_RUN + 5;
+      // Oldest (largest daysAgo) first, matching findExpiredSnapshots' sort.
+      const expiredSnapshots = Array.from({ length: totalExpired }, (_, index) => (
+        buildSnapshotOpportunity({
+          id: `snap-${totalExpired - index}`,
+          createdAt: daysAgo(45 + (totalExpired - index)),
+        })
       ));
+      const removeByIdsOpportunity = sandbox.stub().resolves();
+      const dataAccess = {
+        Opportunity: {
+          allBySiteIdAndStatus: sandbox.stub().resolves(expiredSnapshots),
+          removeByIds: removeByIdsOpportunity,
+        },
+        Suggestion: { removeByIds: sandbox.stub().resolves() },
+      };
+
+      const deletedSnapshotCount = await deleteExpiredSnapshots({
+        dataAccess, siteId, auditType, log,
+      });
+
+      expect(deletedSnapshotCount).to.equal(MAX_DELETIONS_PER_RUN);
+      const deletedIds = removeByIdsOpportunity.firstCall.args[0];
+      expect(deletedIds).to.have.lengthOf(MAX_DELETIONS_PER_RUN);
+      // The oldest snapshot (snap-<totalExpired>, daysAgo(45 + totalExpired)) must be included.
+      expect(deletedIds).to.include(`snap-${totalExpired}`);
+      // The newest of the expired set (snap-1) is left for a later run.
+      expect(deletedIds).to.not.include('snap-1');
+      expect(log.info).to.have.been.calledWith(
+        sinon.match(`eligible=${totalExpired}`).and(sinon.match(`deleted=${MAX_DELETIONS_PER_RUN}`)),
+      );
     });
   });
 });

--- a/test/common/offsite-retention.test.js
+++ b/test/common/offsite-retention.test.js
@@ -213,9 +213,34 @@ describe('offsite-retention', () => {
 
       expect(expiredSnapshots).to.deep.equal([beyondCutoff]);
     });
+
+    it('retains (does not expire) a snapshot with a missing getCreatedAt() value', async () => {
+      // `new Date(undefined) < cutoff` is false, so a malformed/missing createdAt is retained
+      // forever rather than expired. The datastore always populates createdAt in practice, so
+      // this pins the known (accepted) behavior rather than asserting it is desirable.
+      const missingCreatedAt = buildSnapshotOpportunity({ id: 'missing-created-at', createdAt: undefined });
+      const dataAccess = {
+        Opportunity: {
+          allBySiteIdAndStatus: sandbox.stub().resolves([missingCreatedAt]),
+        },
+      };
+
+      const expiredSnapshots = await findExpiredSnapshots({
+        dataAccess, siteId, auditType, log,
+      });
+
+      expect(expiredSnapshots).to.deep.equal([]);
+    });
   });
 
   describe('deleteExpiredSnapshots', () => {
+    // Pin the clock so daysAgo()-derived fixtures can't flake by straddling a real-clock
+    // day boundary (e.g. a snapshot built as "45 days ago" resolving to 44 or 46 depending
+    // on exactly when the test runs).
+    beforeEach(() => {
+      sandbox.useFakeTimers(new Date('2026-01-15T12:00:00.000Z'));
+    });
+
     it('bulk-removes suggestions then snapshots, and returns the deleted count', async () => {
       const firstSuggestion = { getId: () => 'sugg-1' };
       const secondSuggestion = { getId: () => 'sugg-2' };

--- a/test/common/offsite-snapshot.test.js
+++ b/test/common/offsite-snapshot.test.js
@@ -18,6 +18,7 @@ import {
   SNAPSHOT_TAG,
   SNAPSHOT_KINDS,
   buildSnapshotData,
+  isOffsiteSnapshot,
   findSnapshotByTriggerAuditId,
   prepareSuppressedRunSnapshot,
   prepareSupersededRunSnapshot,
@@ -109,6 +110,30 @@ describe('offsite-snapshot', () => {
       });
       expect(result.snapshot).to.not.have.property('evergreenOpportunityId');
       expect(result.snapshot).to.not.have.property('triggerAuditId');
+    });
+  });
+
+  describe('isOffsiteSnapshot', () => {
+    it('recognizes a tagged opportunity of the requested type', () => {
+      expect(isOffsiteSnapshot(makeSnapshotOpportunity(), 'cited-analysis')).to.be.true;
+    });
+
+    it('rejects a different type or missing managed tag', () => {
+      expect(isOffsiteSnapshot(
+        makeSnapshotOpportunity({ type: 'reddit-analysis' }),
+        'cited-analysis',
+      )).to.be.false;
+      expect(isOffsiteSnapshot(
+        makeSnapshotOpportunity({ tags: [] }),
+        'cited-analysis',
+      )).to.be.false;
+    });
+
+    it('rejects an opportunity without a tags array', () => {
+      expect(isOffsiteSnapshot(
+        makeSnapshotOpportunity({ tags: null }),
+        'cited-analysis',
+      )).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Scope

https://jira.corp.adobe.com/browse/LLMO-6154

Hard-delete managed offsite snapshots older than 30 days after a weekly refresh, keeping operator history bounded without adding a scheduler or changing the evergreen opportunity. See [ADR 004](docs/decisions/004-offsite-snapshot-retention-window.md) for the 30-day rationale and [the spec](docs/specs/2026-07-20-offsite-snapshot-retention.md) for the full design.

This is a stacked PR on #2771 (`LLMO-6152`), which creates the snapshots managed here.

## Implementation

**Shared retention module**

Added `src/common/offsite-retention.js`. `findExpiredSnapshots` loads `IGNORED` opportunities for the site and selects only records of the current audit type carrying the reserved `offsite-snapshot` tag with `createdAt` strictly before the 30-day cutoff. Exactly 30 days old is retained.

The reserved tag is the ownership marker. Optional snapshot provenance metadata is not required for deletion, so a malformed managed snapshot does not become permanent.

**Bulk deletion (not per-record)**

`deleteExpiredSnapshots` deletes at most `MAX_DELETIONS_PER_RUN` (50) of the oldest eligible snapshots per invocation, via two bulk `removeByIds` calls: suggestions first (read sequentially per snapshot, then bulk-removed), then the snapshot opportunities themselves. This mirrors the existing `removeOpportunityWithSuggestions` pattern elsewhere in the repo and avoids the N+1 concurrent-write fan-out that a `Promise.all` over individual `.remove()` calls would produce against the shared connection pool — worst exactly when a dormant site resumes refreshing after an accumulated backlog. The trade-off: a single `removeByIds` failure now fails the whole batch rather than isolating per-record failures; this is documented as a deliberate deviation in the module and the spec.

**Operational logging**

Deletion and lookup failures are logged via the shared `createOffsiteLogger` (structured `key=value` fields), consistent with the rest of the offsite modules. A success summary (`eligible`/`deleted`) is emitted only when at least one snapshot was actually deleted, to avoid a log line on every refresh across three audit types × N sites when there's nothing to report.

**Refresh integration**

Snapshot deletion runs after persistence and suggestion synchronization in cited-analysis, reddit-analysis, and youtube-analysis. Handler-level guards ensure deletion failures cannot turn a successful refresh into a failed response.

`isOffsiteSnapshot` is shared with snapshot redelivery lookup so ownership rules remain consistent.

## Testing

- Full unit and integration suite, lint, and build pass with required coverage.
- Tests cover ownership filtering, strict cutoff boundaries, ordering, lookup failures, bulk deletion (with and without suggestions), the per-run deletion cap, propagated bulk-delete failures, structured logs, and empty passes.
- All three handlers verify deletion after surfaced and suppressed refreshes, non-blocking failure behavior, and that retention is skipped when the refresh itself fails before reaching the success path.
- Local Postgres/PostgREST scenarios verified deletion of 31-day snapshots and dependent suggestions while retaining recent, boundary, untagged, and wrong-type records.

## Out of Scope

- Count-based or same-day snapshot consolidation
- A scheduled or infrastructure-level sweep for sites whose audit is **disabled or offboarded** (as opposed to merely **dormant**): a dormant site self-heals on its next refresh, since retention runs as a side effect of that refresh; a disabled/offboarded site never refreshes again, so its snapshots are never revisited. Bounding that case needs a separate scheduled sweep, tracked as a follow-up.
- Soft deletion or tombstones
- Per-site or per-customer retention configuration
- Snapshot restore and picker behavior (LLMO-6153)
- Wikipedia analysis
- One-time migration or backfill sweep

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Rares Cheseli", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```