### PR TITLE
fix(toc): consume presigned-URL guidance reply from Mystique

### DIFF
--- a/src/toc/guidance-handler.js
+++ b/src/toc/guidance-handler.js
@@ -12,6 +12,37 @@
 
 import { badRequest, notFound, ok } from '@adobe/spacecat-shared-http-utils';
 import { isEligibleTocSuggestion } from './eligibility-utils.js';
+import { fetchAnalysisFromPresignedUrl } from '../utils/analysis-fetch.js';
+
+const LOG_PREFIX = '[TOC Guidance]';
+
+/**
+ * Downloads JSON data from a presigned URL using the shared analysis-fetch helper
+ * (SSRF guard, size cap, log scrub of query-string credentials). Mystique's reply
+ * carries a presigned URL instead of inlining headings + generated prompts, since
+ * inlining blew past SQS's 262144-byte message limit once a batch had enough
+ * suggestions (LLMO-5792).
+ *
+ * @param {string} presignedUrl - The presigned S3 URL
+ * @param {Object} log - Logger instance
+ * @returns {Promise<Object>} - The parsed JSON data
+ * @throws {Error} - If the URL is not allowlisted, fetch fails, response is too
+ *   large, or the body is missing the required `suggestions` array.
+ */
+async function downloadFromPresignedUrl(presignedUrl, log) {
+  const data = await fetchAnalysisFromPresignedUrl(presignedUrl, {
+    log,
+    prefix: LOG_PREFIX,
+  });
+
+  if (!data || !Array.isArray(data.suggestions)) {
+    const errorMsg = 'Downloaded data is missing required suggestions array';
+    log.error(`${LOG_PREFIX} ${errorMsg}`);
+    throw new Error(errorMsg);
+  }
+
+  return data;
+}
 
 /**
  * Mystique's guidance:table-of-contents reply carries prompts keyed by page URL, not by
@@ -55,7 +86,7 @@ export default async function handler(message, context) {
     Site, Audit, Opportunity, Suggestion,
   } = dataAccess;
   const { siteId, auditId, data } = message;
-  const { opportunityId, suggestions } = data || {};
+  const { opportunityId, presignedUrl } = data || {};
 
   log.debug(`[TOC Guidance] Message received in TOC guidance handler: ${JSON.stringify(message, null, 2)}`);
 
@@ -82,9 +113,17 @@ export default async function handler(message, context) {
     return badRequest('Site ID mismatch');
   }
 
-  if (!suggestions || !Array.isArray(suggestions)) {
-    log.error(`[TOC Guidance] Invalid suggestions format. Expected array, got: ${typeof suggestions}. Message: ${JSON.stringify(message)}`);
-    return badRequest('Invalid suggestions format');
+  if (!presignedUrl) {
+    log.error(`[TOC Guidance] Missing presignedUrl in Mystique response for siteId: ${siteId}`);
+    return badRequest('Missing presignedUrl');
+  }
+
+  let suggestions;
+  try {
+    ({ suggestions } = await downloadFromPresignedUrl(presignedUrl, log));
+  } catch (error) {
+    log.error(`[TOC Guidance] Error downloading suggestions from presigned URL for opportunityId=${opportunityId}: ${error.message}`, error);
+    return badRequest(`Failed to download suggestions: ${error.message}`);
   }
 
   if (suggestions.length === 0) {

--- a/test/audits/toc/guidance-handler.test.js
+++ b/test/audits/toc/guidance-handler.test.js
@@ -13,9 +13,9 @@
 import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
+import esmock from 'esmock';
 import { ok, notFound, badRequest } from '@adobe/spacecat-shared-http-utils';
 import { Suggestion as SuggestionDataAccess } from '@adobe/spacecat-shared-data-access';
-import handler from '../../../src/toc/guidance-handler.js';
 
 use(sinonChai);
 
@@ -27,6 +27,8 @@ describe('TOC Guidance Handler', () => {
   let siteStub;
   let auditStub;
   let opportunityStub;
+  let fetchStub;
+  let handler;
 
   const makeSuggestion = (data, status = SuggestionDataAccess.STATUSES.NEW) => ({
     getData: sinon.stub().returns(data),
@@ -34,7 +36,7 @@ describe('TOC Guidance Handler', () => {
     getStatus: sinon.stub().returns(status),
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     logStub = {
       debug: sinon.stub(),
       info: sinon.stub(),
@@ -70,17 +72,28 @@ describe('TOC Guidance Handler', () => {
       siteId: 'site-123',
       data: {
         opportunityId: 'opp-123',
-        suggestions: [
-          {
-            url: 'https://example.com/page1',
-            title: 'Page 1',
-            headings: ['Intro', 'Details'],
-            prompts: [{ id: 'p1', prompt: 'What is X?', type: 'Non-Branded' }],
-            hasPrompts: true,
-          },
-        ],
+        presignedUrl: 'https://s3.example.com/toc-suggestions.json?X-Amz-Signature=abc',
       },
     };
+
+    // Stub the shared analysis-fetch helper directly (no need to fake a Response).
+    fetchStub = sinon.stub().resolves({
+      suggestions: [
+        {
+          url: 'https://example.com/page1',
+          title: 'Page 1',
+          headings: ['Intro', 'Details'],
+          prompts: [{ id: 'p1', prompt: 'What is X?', type: 'Non-Branded' }],
+          hasPrompts: true,
+        },
+      ],
+    });
+
+    handler = await esmock('../../../src/toc/guidance-handler.js', {
+      '../../../src/utils/analysis-fetch.js': {
+        fetchAnalysisFromPresignedUrl: fetchStub,
+      },
+    });
   });
 
   afterEach(() => {
@@ -94,6 +107,7 @@ describe('TOC Guidance Handler', () => {
     expect(dataAccessStub.Site.findById).to.have.been.calledWith('site-123');
     expect(dataAccessStub.Audit.findById).to.have.been.calledWith('audit-123');
     expect(dataAccessStub.Opportunity.findById).to.have.been.calledWith('opp-123');
+    expect(fetchStub).to.have.been.calledWith(message.data.presignedUrl, sinon.match.object);
     expect(dataAccessStub.Suggestion.saveMany).to.have.been.calledOnce;
     const [saved] = dataAccessStub.Suggestion.saveMany.getCall(0).args[0];
     expect(saved.setData).to.have.been.calledWith(sinon.match({
@@ -111,9 +125,9 @@ describe('TOC Guidance Handler', () => {
       makeSuggestion({ url: shared, checkType: 'missing-toc' }),
       makeSuggestion({ url: shared, checkType: 'single-heading' }),
     ]);
-    message.data.suggestions = [
-      { url: shared, prompts: [{ id: 'p1' }], hasPrompts: true },
-    ];
+    fetchStub.resolves({
+      suggestions: [{ url: shared, prompts: [{ id: 'p1' }], hasPrompts: true }],
+    });
 
     const result = await handler(message, context);
 
@@ -138,7 +152,7 @@ describe('TOC Guidance Handler', () => {
   });
 
   it('should default prompts to an empty array and hasPrompts to false when Mystique omits them', async () => {
-    message.data.suggestions = [{ url: 'https://example.com/page1' }];
+    fetchStub.resolves({ suggestions: [{ url: 'https://example.com/page1' }] });
 
     const result = await handler(message, context);
 
@@ -186,26 +200,45 @@ describe('TOC Guidance Handler', () => {
     expect(logStub.error).to.have.been.calledWith(sinon.match(/Site ID mismatch/));
   });
 
-  it('should return badRequest when suggestions is not an array', async () => {
-    message.data.suggestions = 'not an array';
+  it('should return badRequest when presignedUrl is missing', async () => {
+    delete message.data.presignedUrl;
 
     const result = await handler(message, context);
 
     expect(result.status).to.equal(badRequest().status);
-    expect(logStub.error).to.have.been.calledWith(sinon.match(/Invalid suggestions format/));
+    expect(logStub.error).to.have.been.calledWith(sinon.match(/Missing presignedUrl/));
+    expect(fetchStub).to.not.have.been.called;
   });
 
-  it('should return badRequest when suggestions is null', async () => {
-    message.data.suggestions = null;
+  it('should return badRequest when message.data is missing entirely', async () => {
+    delete message.data;
 
     const result = await handler(message, context);
 
     expect(result.status).to.equal(badRequest().status);
-    expect(logStub.error).to.have.been.calledWith(sinon.match(/Invalid suggestions format/));
+    expect(logStub.error).to.have.been.calledWith(sinon.match(/Missing presignedUrl/));
+  });
+
+  it('should return badRequest when the presigned-URL download fails', async () => {
+    fetchStub.rejects(new Error('analysis fetch failed: 500 Internal Server Error'));
+
+    const result = await handler(message, context);
+
+    expect(result.status).to.equal(badRequest().status);
+    expect(logStub.error).to.have.been.calledWith(sinon.match(/Error downloading suggestions from presigned URL/));
+  });
+
+  it('should return badRequest when the downloaded payload is missing a suggestions array', async () => {
+    fetchStub.resolves({ notSuggestions: [] });
+
+    const result = await handler(message, context);
+
+    expect(result.status).to.equal(badRequest().status);
+    expect(logStub.error).to.have.been.calledWith(sinon.match(/Downloaded data is missing required suggestions array/));
   });
 
   it('should return ok when suggestions array is empty', async () => {
-    message.data.suggestions = [];
+    fetchStub.resolves({ suggestions: [] });
 
     const result = await handler(message, context);
 
@@ -236,15 +269,6 @@ describe('TOC Guidance Handler', () => {
     expect(result.status).to.equal(ok().status);
     expect(dataAccessStub.Suggestion.saveMany).to.not.have.been.called;
     expect(logStub.warn).to.have.been.calledWith(sinon.match(/No matching suggestion found for URL/));
-  });
-
-  it('should return badRequest when message.data is missing entirely', async () => {
-    delete message.data;
-
-    const result = await handler(message, context);
-
-    expect(result.status).to.equal(badRequest().status);
-    expect(logStub.error).to.have.been.calledWith(sinon.match(/Invalid suggestions format/));
   });
 
   it('should treat a falsy getSuggestions() resolution as no existing suggestions', async () => {


### PR DESCRIPTION
## Summary
- Mystique's `guidance:table-of-contents` reply used to inline headings + generated prompts for every suggestion into one SQS message, which exceeded SQS's 262144-byte limit once a batch had enough suggestions and left the opportunity's suggestions with no prompts persisted.
- Companion Mystique-side PR now replies with a presigned S3 download URL instead (mirroring the existing pattern already used by `src/prerender/guidance-handler.js`). This PR updates the TOC handler to download suggestions via the shared `fetchAnalysisFromPresignedUrl` helper (`src/utils/analysis-fetch.js`) rather than reading them inline from the message.
- **Must deploy together with the corresponding Mystique PR** — this changes the completion-callback message's wire format (`presignedUrl` instead of inline `suggestions`).

## Changes
- `src/toc/guidance-handler.js`: reads `presignedUrl` from the message, downloads + validates via the shared `fetchAnalysisFromPresignedUrl` helper, then processes the downloaded suggestions exactly as before (per-URL matching, `Suggestion.saveMany`)
- `test/audits/toc/guidance-handler.test.js`: updated to mock the presigned-URL fetch (esmock, same pattern as `test/audits/prerender/guidance-handler.test.js`)

## Test plan
- [x] `npm run test:spec -- test/audits/toc/guidance-handler.test.js` — 16/16 passing
- [x] Coverage for `src/toc/guidance-handler.js`: 100% lines/branches/functions/statements
- [x] `npx eslint src/toc/guidance-handler.js` — clean

Jira: https://jira.corp.adobe.com/browse/LLMO-5792

🤖 Generated with [Claude Code](https://claude.com/claude-code)