### PR TITLE
feat(offsite-suggestions-deletion): Outdated suggestions deletion after 30 days (LLMO-6124)

### DIFF
--- a/docs/specs/2026-07-16-offsite-outdated-suggestion-retention.md
+++ b/docs/specs/2026-07-16-offsite-outdated-suggestion-retention.md
@@ -1,0 +1,103 @@
+# Offsite Opportunities — Outdated Suggestion Retention
+
+- **Status:** Implemented
+- **Date:** 2026-07-16
+- **Jira:** LLMO-6124
+- **Related:** [offsite-snapshot-retention spec](2026-07-20-offsite-snapshot-retention.md),
+  [offsite-snapshot-preservation spec](2026-07-15-offsite-snapshot-preservation.md)
+
+## Problem statement
+
+`syncSuggestions` marks a suggestion `OUTDATED` on the evergreen opportunity when it no longer
+appears in a fresh refresh. Unlike snapshots (LLMO-6154), the evergreen opportunity itself is
+never IGNORED and never removed, so nothing in the snapshot-retention pass ever revisits its
+suggestions. `OUTDATED` rows on the evergreen accumulate weekly, forever, across every site and
+audit type — an unbounded growth path distinct from (and not covered by) snapshot retention.
+
+## Goals
+
+1. Permanently delete `OUTDATED` suggestions on the evergreen opportunity once they pass a
+   retention window (30 days, independently tunable from the snapshot window).
+2. Run deletion as a side effect of a successful refresh, immediately after suggestion sync and
+   before snapshot deletion, so no separate scheduled infrastructure is needed for the common
+   case.
+3. Never delete a customer-visible decision: every status other than `OUTDATED` (`NEW`,
+   `IN_PROGRESS`, `FIXED`, `APPROVED`, `SKIPPED`, `REJECTED`, `ERROR`, `PENDING_VALIDATION`) is
+   protected regardless of age.
+4. Never let a retention failure fail the refresh that triggered it.
+
+Non-goals: a dedicated `outdatedAt` column or schema migration, customer-controlled keep/pin
+markers, deleting any status other than `OUTDATED`, deterministic suggestion deduplication,
+scheduled/infrastructure-level sweepers, soft deletion, per-customer retention configuration,
+Wikipedia analysis, one-time migration/backfill.
+
+## Technical design
+
+### Eligibility
+
+`isOutdatedSuggestionExpired(suggestion, retentionCutoff)` returns true only when:
+- `suggestion.getStatus() === OUTDATED`, and
+- `getUpdatedAt()` is present, parses to a valid date, and is strictly before the cutoff
+  (`OUTDATED_SUGGESTION_RETENTION_DAYS`, 30 days).
+
+A missing or unparseable `updatedAt` is retained — deletion cannot be proven safe without a
+valid timestamp. A suggestion freshly marked `OUTDATED` by this refresh's own `syncSuggestions`
+call has a fresh `updatedAt`, so it is never deleted in the same run it was demoted in.
+
+### Bulk deletion, chunked
+
+`deleteExpiredOutdatedSuggestions({ dataAccess, opportunity, siteId, auditType, log })` reads the
+just-synchronized opportunity's suggestions, filters to expired `OUTDATED` rows, and deletes them
+via `Suggestion.removeByIds`, chunked into batches of at most
+`OUTDATED_SUGGESTION_DELETE_BATCH_SIZE` (100) to bound the PostgREST `DELETE ... IN (...)` URL
+length. Batches run concurrently via `Promise.all`; each batch's success/failure is isolated —
+one failed batch does not block or roll back the others. Dependent fix-entity rows cascade-delete
+through the existing data model.
+
+This mirrors `removeOpportunityWithSuggestions`
+(`src/experimentation-opportunities/guidance-high-organic-low-ctr-handler.js`) and the snapshot
+retention pattern (LLMO-6154): a bulk `removeByIds` per batch, not a `Promise.all` over individual
+`.remove()` calls, per CLAUDE.md's N+1 rule.
+
+### Structured logging
+
+Emits via `createOffsiteLogger`, using events `outdated_suggestion_lookup` (read failure),
+`outdated_suggestion_delete` (one structured line per batch — a single `Deleted N ... (s)` line
+carrying that batch's `suggestionIds`, not one line per suggestion, to avoid a hot-loop logging
+anti-pattern), and `outdated_suggestion_retention_summary` (one line per invocation, always
+emitted). The summary's `outcome` reflects whether any batch failed
+(`outcome=failure` when `failed > 0`, `outcome=success` otherwise) so an alerting query keyed on
+`outcome=failure` cannot miss a partial-batch failure by only checking the per-batch events.
+
+### Refresh integration
+
+Each guidance handler (`cited-analysis`, `reddit-analysis`, `youtube-analysis`) calls
+`deleteExpiredOutdatedSuggestions` once, immediately after `syncSuggestions` succeeds and before
+`deleteExpiredSnapshots`, wrapped in try/catch so a retention failure never changes the handler's
+response. It does not run when the refresh itself fails before that point (malformed payload,
+sync failure, no-suggestions early return).
+
+## Alternatives
+
+- **A dedicated `outdatedAt` timestamp column:** would decouple eligibility from `updatedAt`
+  (which any other status-changing write could also touch), but requires a data-access schema
+  migration; deferred.
+- **Delete unconditionally by count** (e.g. keep only the N most recent `OUTDATED` rows):
+  rejected — age-based deletion is simpler to reason about and matches the snapshot window's
+  semantics.
+- **Sequential (non-concurrent) batch processing:** would further bound connection usage for a
+  very large backlog, at the cost of a slower pass; not adopted here since each batch is already
+  a single bulk call (not per-record), keeping worst-case concurrency at (backlog size / 100)
+  requests rather than one per suggestion.
+
+## Success criteria
+
+- `npm test` green with 100% coverage gate.
+- An `OUTDATED` suggestion older than 30 days with a valid `updatedAt` is deleted on the next
+  refresh for its opportunity.
+- Every other status, and any `OUTDATED` row with a missing/invalid `updatedAt`, is never deleted
+  regardless of age.
+- Retention never fails the refresh that triggered it.
+- `outdated_suggestion_retention_summary outcome=failure` is queryable in Splunk via
+  `domain=offsite event=outdated_suggestion_retention_summary outcome=failure` whenever any batch
+  fails, independent of whether other batches in the same run succeeded.

--- a/src/cited-analysis/guidance-handler.js
+++ b/src/cited-analysis/guidance-handler.js
@@ -34,7 +34,10 @@ import {
 import {
   createOffsiteLogger, errorField, AUDIT, PEER,
 } from '../utils/offsite-logging.js';
-import { deleteExpiredSnapshots } from '../common/offsite-retention.js';
+import {
+  deleteExpiredSnapshots,
+  deleteExpiredOutdatedSuggestions,
+} from '../common/offsite-retention.js';
 
 const AUDIT_TYPE = Audit.AUDIT_TYPES.CITED_ANALYSIS;
 // Human prefix for the two shared, untouched utils that still log via a passed-in prefix
@@ -224,7 +227,18 @@ export default async function handler(message, context) {
     });
     logOffsiteLlmUsage(log, HUMAN_PREFIX, siteId, opportunityData.llmUsage);
 
-    // Retention must not fail an otherwise successful refresh.
+    // Expired suggestion deletion must not fail an otherwise successful refresh.
+    try {
+      await deleteExpiredOutdatedSuggestions({
+        dataAccess, opportunity, siteId, auditType, log,
+      });
+    } catch (error) {
+      ologOpp.failure('outdated_suggestion_delete', `Unexpected expired OUTDATED suggestion deletion failure for auditType ${auditType}`, {
+        peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
+      }, error);
+    }
+
+    // Expired snapshot deletion must not fail an otherwise successful refresh.
     try {
       await deleteExpiredSnapshots({
         dataAccess, siteId, auditType, log,

--- a/src/common/offsite-retention.js
+++ b/src/common/offsite-retention.js
@@ -11,7 +11,7 @@
  */
 
 import { subDays } from 'date-fns';
-import { Opportunity as Oppty } from '@adobe/spacecat-shared-data-access';
+import { Opportunity as Oppty, Suggestion as Sugg } from '@adobe/spacecat-shared-data-access';
 import { isOffsiteSnapshot } from './offsite-snapshot.js';
 import {
   createOffsiteLogger, errorField, AUDIT, PEER,
@@ -112,4 +112,117 @@ export async function deleteExpiredSnapshots({
   });
 
   return snapshotIds.length;
+}
+
+export const OUTDATED_SUGGESTION_RETENTION_DAYS = 30;
+
+// Bounds the PostgREST DELETE-IN request URL.
+export const OUTDATED_SUGGESTION_DELETE_BATCH_SIZE = 100;
+
+function chunk(items, size) {
+  const batches = [];
+  for (let index = 0; index < items.length; index += size) {
+    batches.push(items.slice(index, index + size));
+  }
+  return batches;
+}
+
+/**
+ * Returns true only for an OUTDATED suggestion with a valid updatedAt before the cutoff.
+ * Invalid timestamps are retained because deletion cannot be proven safe.
+ */
+export function isOutdatedSuggestionExpired(suggestion, retentionCutoff) {
+  if (suggestion.getStatus() !== Sugg.STATUSES.OUTDATED) {
+    return false;
+  }
+  const updatedAt = suggestion.getUpdatedAt();
+  if (!updatedAt) {
+    return false;
+  }
+  const updatedAtTime = new Date(updatedAt).getTime();
+  if (Number.isNaN(updatedAtTime)) {
+    return false;
+  }
+  return updatedAtTime < retentionCutoff.getTime();
+}
+
+/**
+ * Deletes expired OUTDATED suggestions in bounded batches without interrupting refresh.
+ */
+export async function deleteExpiredOutdatedSuggestions({
+  dataAccess, opportunity, siteId, auditType, log,
+}) {
+  const { Suggestion } = dataAccess;
+  const emptyRetentionSummary = {
+    scanned: 0, eligible: 0, deleted: 0, failed: 0,
+  };
+  const opportunityId = opportunity.getId();
+  const olog = createOffsiteLogger(log, {
+    audit: AUDIT_SLUG_BY_TYPE[auditType] ?? 'unknown', siteId, opportunityId,
+  });
+
+  let opportunitySuggestions;
+  try {
+    opportunitySuggestions = await opportunity.getSuggestions() || [];
+  } catch (error) {
+    olog.failure('outdated_suggestion_lookup', `Failed to read suggestions for expired OUTDATED suggestion deletion, auditType ${auditType}`, {
+      peer: PEER.POSTGRES, direction: 'inbound', ...errorField(error),
+    });
+    return emptyRetentionSummary;
+  }
+
+  const retentionCutoff = subDays(new Date(), OUTDATED_SUGGESTION_RETENTION_DAYS);
+  const expiredOutdatedSuggestions = opportunitySuggestions
+    .filter((suggestion) => isOutdatedSuggestionExpired(suggestion, retentionCutoff));
+  const suggestionBatches = chunk(
+    expiredOutdatedSuggestions,
+    OUTDATED_SUGGESTION_DELETE_BATCH_SIZE,
+  );
+
+  const batchResults = await Promise.all(
+    suggestionBatches.map(async (suggestionBatch) => {
+      const suggestionIds = suggestionBatch.map((suggestion) => suggestion.getId());
+      try {
+        // Dependent fix-entity rows cascade-delete with their suggestions.
+        await Suggestion.removeByIds(suggestionIds);
+        olog.success('outdated_suggestion_delete', `Deleted ${suggestionIds.length} expired OUTDATED suggestion(s) for auditType ${auditType}`, {
+          peer: PEER.POSTGRES, direction: 'outbound', suggestionIds,
+        });
+        return { deleted: suggestionBatch.length, failed: 0 };
+      } catch (error) {
+        olog.failure('outdated_suggestion_delete', `Failed to delete ${suggestionBatch.length} expired OUTDATED suggestion(s), auditType ${auditType}`, {
+          peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
+        });
+        return { deleted: 0, failed: suggestionBatch.length };
+      }
+    }),
+  );
+  const deletionTotals = batchResults.reduce(
+    (summary, batchResult) => ({
+      deleted: summary.deleted + batchResult.deleted,
+      failed: summary.failed + batchResult.failed,
+    }),
+    { deleted: 0, failed: 0 },
+  );
+  const retentionSummary = {
+    scanned: opportunitySuggestions.length,
+    eligible: expiredOutdatedSuggestions.length,
+    ...deletionTotals,
+  };
+
+  const summaryFields = {
+    peer: PEER.POSTGRES,
+    direction: 'outbound',
+    scanned: retentionSummary.scanned,
+    eligible: retentionSummary.eligible,
+    deleted: retentionSummary.deleted,
+    failed: retentionSummary.failed,
+  };
+  if (retentionSummary.failed > 0) {
+    olog.failure('outdated_suggestion_retention_summary', `Expired OUTDATED suggestion deletion summary for auditType ${auditType}`, summaryFields);
+  } else {
+    olog.success('outdated_suggestion_retention_summary', `Expired OUTDATED suggestion deletion summary for auditType ${auditType}`, summaryFields);
+  }
+
+  return retentionSummary;
 }

--- a/src/reddit-analysis/guidance-handler.js
+++ b/src/reddit-analysis/guidance-handler.js
@@ -34,7 +34,10 @@ import {
 import {
   createOffsiteLogger, errorField, AUDIT, PEER,
 } from '../utils/offsite-logging.js';
-import { deleteExpiredSnapshots } from '../common/offsite-retention.js';
+import {
+  deleteExpiredSnapshots,
+  deleteExpiredOutdatedSuggestions,
+} from '../common/offsite-retention.js';
 
 const AUDIT_TYPE = Audit.AUDIT_TYPES.REDDIT_ANALYSIS;
 // Human prefix for the two shared, untouched utils that still log via a passed-in prefix
@@ -224,7 +227,18 @@ export default async function handler(message, context) {
     });
     logOffsiteLlmUsage(log, HUMAN_PREFIX, siteId, opportunityData.llmUsage);
 
-    // Retention must not fail an otherwise successful refresh.
+    // Expired suggestion deletion must not fail an otherwise successful refresh.
+    try {
+      await deleteExpiredOutdatedSuggestions({
+        dataAccess, opportunity, siteId, auditType, log,
+      });
+    } catch (error) {
+      ologOpp.failure('outdated_suggestion_delete', `Unexpected expired OUTDATED suggestion deletion failure for auditType ${auditType}`, {
+        peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
+      }, error);
+    }
+
+    // Expired snapshot deletion must not fail an otherwise successful refresh.
     try {
       await deleteExpiredSnapshots({
         dataAccess, siteId, auditType, log,

--- a/src/youtube-analysis/guidance-handler.js
+++ b/src/youtube-analysis/guidance-handler.js
@@ -32,7 +32,10 @@ import {
 import {
   createOffsiteLogger, errorField, AUDIT, PEER,
 } from '../utils/offsite-logging.js';
-import { deleteExpiredSnapshots } from '../common/offsite-retention.js';
+import {
+  deleteExpiredSnapshots,
+  deleteExpiredOutdatedSuggestions,
+} from '../common/offsite-retention.js';
 
 const AUDIT_TYPE = Audit.AUDIT_TYPES.YOUTUBE_ANALYSIS;
 // Human prefix for the two shared, untouched utils that still log via a passed-in prefix
@@ -222,7 +225,18 @@ export default async function handler(message, context) {
     });
     logOffsiteLlmUsage(log, HUMAN_PREFIX, siteId, opportunityData.llmUsage);
 
-    // Retention must not fail an otherwise successful refresh.
+    // Expired suggestion deletion must not fail an otherwise successful refresh.
+    try {
+      await deleteExpiredOutdatedSuggestions({
+        dataAccess, opportunity, siteId, auditType, log,
+      });
+    } catch (error) {
+      ologOpp.failure('outdated_suggestion_delete', `Unexpected expired OUTDATED suggestion deletion failure for auditType ${auditType}`, {
+        peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
+      }, error);
+    }
+
+    // Expired snapshot deletion must not fail an otherwise successful refresh.
     try {
       await deleteExpiredSnapshots({
         dataAccess, siteId, auditType, log,

--- a/test/audits/cited-analysis/guidance-handler.test.js
+++ b/test/audits/cited-analysis/guidance-handler.test.js
@@ -43,6 +43,7 @@ describe('Cited Analysis Guidance Handler', () => {
   let prepareSuppressedRunSnapshotStub;
   let prepareSupersededRunSnapshotStub;
   let deleteExpiredSnapshotsStub;
+  let deleteExpiredOutdatedSuggestionsStub;
 
   const baseURL = 'https://example.com';
   const siteId = 'test-site-id';
@@ -140,6 +141,9 @@ describe('Cited Analysis Guidance Handler', () => {
       return { opportunityData, opportunityToUpdate: evergreenOpportunity };
     });
     deleteExpiredSnapshotsStub = sandbox.stub().resolves(0);
+    deleteExpiredOutdatedSuggestionsStub = sandbox.stub().resolves({
+      scanned: 0, eligible: 0, deleted: 0, failed: 0,
+    });
 
     handler = await esmock('../../../src/cited-analysis/guidance-handler.js', {
       '../../../src/utils/data-access.js': {
@@ -165,6 +169,7 @@ describe('Cited Analysis Guidance Handler', () => {
       },
       '../../../src/common/offsite-retention.js': {
         deleteExpiredSnapshots: deleteExpiredSnapshotsStub,
+        deleteExpiredOutdatedSuggestions: deleteExpiredOutdatedSuggestionsStub,
       },
     });
 
@@ -1798,6 +1803,86 @@ describe('Cited Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(400);
       expect(deleteExpiredSnapshotsStub).to.not.have.been.called;
+    });
+  });
+
+  describe('Outdated-suggestion retention', () => {
+    const validMessage = (overrides = {}) => ({
+      siteId,
+      auditId,
+      data: {
+        companyName: 'Example Corp',
+        analysis: {
+          suggestions: [
+            {
+              id: 'test_1', rank: 1, type: 'CONTENT_UPDATE', data: { title: 'Test' },
+            },
+          ],
+        },
+      },
+      ...overrides,
+    });
+
+    it('prunes the refreshed opportunity after a surfaced (NEW) run, scoped correctly', async () => {
+      const visibleOpportunity = {
+        getId: sandbox.stub().returns('existing-opp-1'),
+        getType: sandbox.stub().returns('cited-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
+      };
+
+      const result = await handler.default(validMessage(), context);
+
+      expect(result.status).to.equal(200);
+      expect(deleteExpiredOutdatedSuggestionsStub).to.have.been.calledOnce;
+      const callArgs = deleteExpiredOutdatedSuggestionsStub.firstCall.args[0];
+      expect(callArgs.siteId).to.equal(siteId);
+      expect(callArgs.auditType).to.equal('cited-analysis');
+      expect(callArgs.opportunity).to.equal(mockOpportunity);
+    });
+
+    it('runs suggestion retention after sync and before snapshot deletion', async () => {
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus: sandbox.stub().resolves([]) };
+      await handler.default(validMessage(), context);
+      expect(deleteExpiredOutdatedSuggestionsStub).to.have.been.calledAfter(syncSuggestionsStub);
+      expect(deleteExpiredOutdatedSuggestionsStub)
+        .to.have.been.calledBefore(deleteExpiredSnapshotsStub);
+    });
+
+    it('does NOT run retention when the handler returns before a successful sync', async () => {
+      // syncSuggestions throwing means the refresh never completed — retention must not run.
+      syncSuggestionsStub.rejects(new Error('sync blew up'));
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus: sandbox.stub().resolves([]) };
+
+      const result = await handler.default(validMessage(), context);
+
+      expect(result.status).to.equal(400);
+      expect(deleteExpiredOutdatedSuggestionsStub).to.not.have.been.called;
+    });
+
+    it('does NOT run retention on the empty-suggestions early return (204)', async () => {
+      const result = await handler.default(validMessage({
+        data: { companyName: 'Example Corp', analysis: { suggestions: [] } },
+      }), context);
+      expect(result.status).to.equal(204);
+      expect(deleteExpiredOutdatedSuggestionsStub).to.not.have.been.called;
+    });
+
+    it('still returns ok() when retention throws (local try/catch second safety net)', async () => {
+      deleteExpiredOutdatedSuggestionsStub.rejects(new Error('retention blew up'));
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus: sandbox.stub().resolves([]) };
+
+      const result = await handler.default(validMessage(), context);
+
+      expect(result.status).to.equal(200);
+      expect(context.log.error).to.have.been.calledWith(
+        sinon.match(/event=outdated_suggestion_delete/)
+          .and(sinon.match(/outcome=failure/))
+          .and(sinon.match(/errorMessage="retention blew up"/)),
+      );
     });
   });
 });

--- a/test/audits/reddit-analysis/guidance-handler.test.js
+++ b/test/audits/reddit-analysis/guidance-handler.test.js
@@ -41,6 +41,7 @@ describe('Reddit Analysis Guidance Handler', () => {
   let prepareSuppressedRunSnapshotStub;
   let prepareSupersededRunSnapshotStub;
   let deleteExpiredSnapshotsStub;
+  let deleteExpiredOutdatedSuggestionsStub;
 
   const baseURL = 'https://example.com';
   const siteId = 'test-site-id';
@@ -136,6 +137,9 @@ describe('Reddit Analysis Guidance Handler', () => {
       return { opportunityData, opportunityToUpdate: evergreenOpportunity };
     });
     deleteExpiredSnapshotsStub = sandbox.stub().resolves(0);
+    deleteExpiredOutdatedSuggestionsStub = sandbox.stub().resolves({
+      scanned: 0, eligible: 0, deleted: 0, failed: 0,
+    });
 
     handler = await esmock('../../../src/reddit-analysis/guidance-handler.js', {
       '../../../src/utils/data-access.js': {
@@ -160,6 +164,7 @@ describe('Reddit Analysis Guidance Handler', () => {
       },
       '../../../src/common/offsite-retention.js': {
         deleteExpiredSnapshots: deleteExpiredSnapshotsStub,
+        deleteExpiredOutdatedSuggestions: deleteExpiredOutdatedSuggestionsStub,
       },
     });
 
@@ -1606,6 +1611,86 @@ describe('Reddit Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(400);
       expect(deleteExpiredSnapshotsStub).to.not.have.been.called;
+    });
+  });
+
+  describe('Outdated-suggestion retention', () => {
+    const validMessage = (overrides = {}) => ({
+      siteId,
+      auditId,
+      data: {
+        companyName: 'Example Corp',
+        analysis: {
+          suggestions: [
+            {
+              id: 'test_1', rank: 1, type: 'CONTENT_UPDATE', data: { title: 'Test' },
+            },
+          ],
+        },
+      },
+      ...overrides,
+    });
+
+    it('prunes the refreshed opportunity after a surfaced (NEW) run, scoped correctly', async () => {
+      const visibleOpportunity = {
+        getId: sandbox.stub().returns('existing-opp-1'),
+        getType: sandbox.stub().returns('reddit-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
+      };
+
+      const result = await handler.default(validMessage(), context);
+
+      expect(result.status).to.equal(200);
+      expect(deleteExpiredOutdatedSuggestionsStub).to.have.been.calledOnce;
+      const callArgs = deleteExpiredOutdatedSuggestionsStub.firstCall.args[0];
+      expect(callArgs.siteId).to.equal(siteId);
+      expect(callArgs.auditType).to.equal('reddit-analysis');
+      expect(callArgs.opportunity).to.equal(mockOpportunity);
+    });
+
+    it('runs suggestion retention after sync and before snapshot deletion', async () => {
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus: sandbox.stub().resolves([]) };
+      await handler.default(validMessage(), context);
+      expect(deleteExpiredOutdatedSuggestionsStub).to.have.been.calledAfter(syncSuggestionsStub);
+      expect(deleteExpiredOutdatedSuggestionsStub)
+        .to.have.been.calledBefore(deleteExpiredSnapshotsStub);
+    });
+
+    it('does NOT run retention when the handler returns before a successful sync', async () => {
+      // syncSuggestions throwing means the refresh never completed — retention must not run.
+      syncSuggestionsStub.rejects(new Error('sync blew up'));
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus: sandbox.stub().resolves([]) };
+
+      const result = await handler.default(validMessage(), context);
+
+      expect(result.status).to.equal(400);
+      expect(deleteExpiredOutdatedSuggestionsStub).to.not.have.been.called;
+    });
+
+    it('does NOT run retention on the empty-suggestions early return (204)', async () => {
+      const result = await handler.default(validMessage({
+        data: { companyName: 'Example Corp', analysis: { suggestions: [] } },
+      }), context);
+      expect(result.status).to.equal(204);
+      expect(deleteExpiredOutdatedSuggestionsStub).to.not.have.been.called;
+    });
+
+    it('still returns ok() when retention throws (local try/catch second safety net)', async () => {
+      deleteExpiredOutdatedSuggestionsStub.rejects(new Error('retention blew up'));
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus: sandbox.stub().resolves([]) };
+
+      const result = await handler.default(validMessage(), context);
+
+      expect(result.status).to.equal(200);
+      expect(context.log.error).to.have.been.calledWith(
+        sinon.match(/event=outdated_suggestion_delete/)
+          .and(sinon.match(/outcome=failure/))
+          .and(sinon.match(/errorMessage="retention blew up"/)),
+      );
     });
   });
 });

--- a/test/audits/youtube-analysis/guidance-handler.test.js
+++ b/test/audits/youtube-analysis/guidance-handler.test.js
@@ -41,6 +41,7 @@ describe('YouTube Analysis Guidance Handler', () => {
   let prepareSuppressedRunSnapshotStub;
   let prepareSupersededRunSnapshotStub;
   let deleteExpiredSnapshotsStub;
+  let deleteExpiredOutdatedSuggestionsStub;
 
   const siteId = 'test-site-id';
   const auditId = 'test-audit-id';
@@ -159,6 +160,9 @@ describe('YouTube Analysis Guidance Handler', () => {
       return { opportunityData, opportunityToUpdate: evergreenOpportunity };
     });
     deleteExpiredSnapshotsStub = sandbox.stub().resolves(0);
+    deleteExpiredOutdatedSuggestionsStub = sandbox.stub().resolves({
+      scanned: 0, eligible: 0, deleted: 0, failed: 0,
+    });
 
     guidanceHandler = await esmock('../../../src/youtube-analysis/guidance-handler.js', {
       '../../../src/utils/analysis-fetch.js': {
@@ -185,6 +189,7 @@ describe('YouTube Analysis Guidance Handler', () => {
       },
       '../../../src/common/offsite-retention.js': {
         deleteExpiredSnapshots: deleteExpiredSnapshotsStub,
+        deleteExpiredOutdatedSuggestions: deleteExpiredOutdatedSuggestionsStub,
       },
     });
 
@@ -1597,6 +1602,86 @@ describe('YouTube Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(400);
       expect(deleteExpiredSnapshotsStub).to.not.have.been.called;
+    });
+  });
+
+  describe('Outdated-suggestion retention', () => {
+    const validMessage = (overrides = {}) => ({
+      siteId,
+      auditId,
+      data: {
+        companyName: 'Example Corp',
+        analysis: {
+          suggestions: [
+            {
+              id: 'test_1', rank: 1, type: 'CONTENT_UPDATE', data: { title: 'Test' },
+            },
+          ],
+        },
+      },
+      ...overrides,
+    });
+
+    it('prunes the refreshed opportunity after a surfaced (NEW) run, scoped correctly', async () => {
+      const visibleOpportunity = {
+        getId: sandbox.stub().returns('existing-opp-1'),
+        getType: sandbox.stub().returns('youtube-analysis'),
+        getStatus: sandbox.stub().returns('NEW'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
+      };
+
+      const result = await guidanceHandler.default(validMessage(), context);
+
+      expect(result.status).to.equal(200);
+      expect(deleteExpiredOutdatedSuggestionsStub).to.have.been.calledOnce;
+      const callArgs = deleteExpiredOutdatedSuggestionsStub.firstCall.args[0];
+      expect(callArgs.siteId).to.equal(siteId);
+      expect(callArgs.auditType).to.equal('youtube-analysis');
+      expect(callArgs.opportunity).to.equal(mockOpportunity);
+    });
+
+    it('runs suggestion retention after sync and before snapshot deletion', async () => {
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus: sandbox.stub().resolves([]) };
+      await guidanceHandler.default(validMessage(), context);
+      expect(deleteExpiredOutdatedSuggestionsStub).to.have.been.calledAfter(mockSyncSuggestions);
+      expect(deleteExpiredOutdatedSuggestionsStub)
+        .to.have.been.calledBefore(deleteExpiredSnapshotsStub);
+    });
+
+    it('does NOT run retention when the handler returns before a successful sync', async () => {
+      // syncSuggestions throwing means the refresh never completed — retention must not run.
+      mockSyncSuggestions.rejects(new Error('sync blew up'));
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus: sandbox.stub().resolves([]) };
+
+      const result = await guidanceHandler.default(validMessage(), context);
+
+      expect(result.status).to.equal(400);
+      expect(deleteExpiredOutdatedSuggestionsStub).to.not.have.been.called;
+    });
+
+    it('does NOT run retention on the empty-suggestions early return (204)', async () => {
+      const result = await guidanceHandler.default(validMessage({
+        data: { companyName: 'Example Corp', analysis: { suggestions: [] } },
+      }), context);
+      expect(result.status).to.equal(204);
+      expect(deleteExpiredOutdatedSuggestionsStub).to.not.have.been.called;
+    });
+
+    it('still returns ok() when retention throws (local try/catch second safety net)', async () => {
+      deleteExpiredOutdatedSuggestionsStub.rejects(new Error('retention blew up'));
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus: sandbox.stub().resolves([]) };
+
+      const result = await guidanceHandler.default(validMessage(), context);
+
+      expect(result.status).to.equal(200);
+      expect(context.log.error).to.have.been.calledWith(
+        sinon.match(/event=outdated_suggestion_delete/)
+          .and(sinon.match(/outcome=failure/))
+          .and(sinon.match(/errorMessage="retention blew up"/)),
+      );
     });
   });
 });

--- a/test/common/offsite-retention.test.js
+++ b/test/common/offsite-retention.test.js
@@ -15,12 +15,17 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import chaiAsPromised from 'chai-as-promised';
 import { subDays } from 'date-fns';
+import { Suggestion as SuggestionModel } from '@adobe/spacecat-shared-data-access';
 import { SNAPSHOT_TAG } from '../../src/common/offsite-snapshot.js';
 import {
   SNAPSHOT_RETENTION_DAYS,
   MAX_DELETIONS_PER_RUN,
   findExpiredSnapshots,
   deleteExpiredSnapshots,
+  OUTDATED_SUGGESTION_RETENTION_DAYS,
+  OUTDATED_SUGGESTION_DELETE_BATCH_SIZE,
+  isOutdatedSuggestionExpired,
+  deleteExpiredOutdatedSuggestions,
 } from '../../src/common/offsite-retention.js';
 
 use(sinonChai);
@@ -62,9 +67,516 @@ describe('offsite-retention', () => {
     getSuggestions: sandbox.stub().resolves(suggestions),
   });
 
+  const { STATUSES } = SuggestionModel;
+
+  const buildSuggestion = ({
+    id,
+    status = STATUSES.OUTDATED,
+    updatedAt,
+  }) => ({
+    getId: () => id,
+    getStatus: () => status,
+    getUpdatedAt: () => updatedAt,
+  });
+
   describe('SNAPSHOT_RETENTION_DAYS', () => {
     it('is 30 days', () => {
       expect(SNAPSHOT_RETENTION_DAYS).to.equal(30);
+    });
+  });
+
+  describe('OUTDATED_SUGGESTION_RETENTION_DAYS', () => {
+    it('is 30 days, tunable independently of the snapshot window', () => {
+      expect(OUTDATED_SUGGESTION_RETENTION_DAYS).to.equal(30);
+    });
+  });
+
+  describe('isOutdatedSuggestionExpired', () => {
+    const retentionCutoff = subDays(new Date(), OUTDATED_SUGGESTION_RETENTION_DAYS);
+
+    it('is true for an OUTDATED suggestion older than the window', () => {
+      expect(isOutdatedSuggestionExpired(
+        buildSuggestion({ id: 'expired', updatedAt: daysAgo(31) }),
+        retentionCutoff,
+      )).to.be.true;
+    });
+
+    it('is true one millisecond before the cutoff instant (strict "<" is satisfied)', () => {
+      const justOlder = new Date(retentionCutoff.getTime() - 1).toISOString();
+      expect(isOutdatedSuggestionExpired(
+        buildSuggestion({ id: 'just-expired', updatedAt: justOlder }),
+        retentionCutoff,
+      )).to.be.true;
+    });
+
+    it('is false exactly at the cutoff instant (predicate is strict "<", not "<=")', () => {
+      const atCutoff = new Date(retentionCutoff.getTime()).toISOString();
+      expect(isOutdatedSuggestionExpired(
+        buildSuggestion({ id: 'at-cutoff', updatedAt: atCutoff }),
+        retentionCutoff,
+      )).to.be.false;
+    });
+
+    it('is false for an OUTDATED suggestion younger than the window', () => {
+      expect(isOutdatedSuggestionExpired(
+        buildSuggestion({ id: 'recent', updatedAt: daysAgo(1) }),
+        retentionCutoff,
+      )).to.be.false;
+    });
+
+    it('retains (never deletes) an OUTDATED row with a null updated_at', () => {
+      expect(isOutdatedSuggestionExpired(
+        buildSuggestion({ id: 'null-timestamp', updatedAt: null }),
+        retentionCutoff,
+      )).to.be.false;
+    });
+
+    it('retains (never deletes) an OUTDATED row with an undefined updated_at', () => {
+      expect(isOutdatedSuggestionExpired(
+        buildSuggestion({ id: 'missing-timestamp', updatedAt: undefined }),
+        retentionCutoff,
+      )).to.be.false;
+    });
+
+    it('retains (never deletes) an OUTDATED row with an unparseable updated_at', () => {
+      expect(isOutdatedSuggestionExpired(
+        buildSuggestion({ id: 'invalid-timestamp', updatedAt: 'not-a-date' }),
+        retentionCutoff,
+      )).to.be.false;
+    });
+
+    it('is false for any non-OUTDATED status even when old', () => {
+      [
+        STATUSES.NEW, STATUSES.PENDING_VALIDATION, STATUSES.IN_PROGRESS,
+        STATUSES.APPROVED, STATUSES.FIXED, STATUSES.SKIPPED, STATUSES.REJECTED,
+        STATUSES.ERROR,
+      ].forEach((status) => {
+        expect(isOutdatedSuggestionExpired(
+          buildSuggestion({ id: `protected-${status}`, status, updatedAt: daysAgo(99) }),
+          retentionCutoff,
+        ), status).to.be.false;
+      });
+    });
+  });
+
+  const buildOpportunity = ({ id = 'evergreen-1', suggestions = [], getSuggestions } = {}) => ({
+    getId: () => id,
+    getSuggestions: getSuggestions || sandbox.stub().resolves(suggestions),
+  });
+
+  describe('deleteExpiredOutdatedSuggestions', () => {
+    it('emits audit=unknown when the auditType is not in the slug map (defensive fallback)', async () => {
+      const removeByIds = sandbox.stub().resolves();
+      const expiredOutdatedSuggestion = buildSuggestion({ id: 'old', updatedAt: daysAgo(31) });
+
+      await deleteExpiredOutdatedSuggestions({
+        dataAccess: { Suggestion: { removeByIds } },
+        opportunity: buildOpportunity({ suggestions: [expiredOutdatedSuggestion] }),
+        siteId,
+        auditType: 'not-a-real-audit',
+        log,
+      });
+
+      expect(log.info).to.have.been.calledWith(sinon.match(/audit=unknown/));
+    });
+
+    it('deletes only the OUTDATED suggestions older than the window, in one bulk call', async () => {
+      const expiredOutdatedSuggestion = buildSuggestion({
+        id: 'old', updatedAt: daysAgo(31),
+      });
+      const recentOutdatedSuggestion = buildSuggestion({
+        id: 'fresh', updatedAt: daysAgo(2),
+      });
+      const activeSuggestion = buildSuggestion({
+        id: 'active', status: STATUSES.NEW, updatedAt: daysAgo(99),
+      });
+      const removeByIds = sandbox.stub().resolves();
+      const dataAccess = { Suggestion: { removeByIds } };
+
+      const retentionSummary = await deleteExpiredOutdatedSuggestions({
+        dataAccess,
+        opportunity: buildOpportunity({
+          suggestions: [
+            expiredOutdatedSuggestion,
+            recentOutdatedSuggestion,
+            activeSuggestion,
+          ],
+        }),
+        siteId,
+        auditType,
+        log,
+      });
+
+      expect(removeByIds).to.have.been.calledOnceWithExactly(['old']);
+      expect(retentionSummary).to.deep.equal({
+        scanned: 3, eligible: 1, deleted: 1, failed: 0,
+      });
+    });
+
+    it('deletes ALL eligible rows (not just the first) in one bulk call, mixed with ineligible', async () => {
+      const now = new Date('2026-01-15T12:00:00.000Z');
+      sandbox.useFakeTimers(now);
+      const retentionCutoff = subDays(now, OUTDATED_SUGGESTION_RETENTION_DAYS);
+      const firstExpiredSuggestion = buildSuggestion({
+        id: 'expired-1', updatedAt: daysAgo(31),
+      });
+      const secondExpiredSuggestion = buildSuggestion({
+        id: 'expired-2', updatedAt: daysAgo(45),
+      });
+      const boundaryExpiredSuggestion = buildSuggestion({
+        id: 'expired-boundary',
+        updatedAt: new Date(retentionCutoff.getTime() - 1).toISOString(),
+      });
+      const recentOutdatedSuggestion = buildSuggestion({
+        id: 'young', updatedAt: daysAgo(2),
+      });
+      const cutoffSuggestion = buildSuggestion({
+        id: 'at-cutoff', updatedAt: retentionCutoff.toISOString(),
+      });
+      const activeSuggestion = buildSuggestion({
+        id: 'new', status: STATUSES.NEW, updatedAt: daysAgo(99),
+      });
+      const fixedSuggestion = buildSuggestion({
+        id: 'fixed', status: STATUSES.FIXED, updatedAt: daysAgo(99),
+      });
+      const approvedSuggestion = buildSuggestion({
+        id: 'approved', status: STATUSES.APPROVED, updatedAt: daysAgo(99),
+      });
+
+      const removeByIds = sandbox.stub().resolves();
+      const opportunitySuggestions = [
+        recentOutdatedSuggestion,
+        firstExpiredSuggestion,
+        activeSuggestion,
+        secondExpiredSuggestion,
+        fixedSuggestion,
+        cutoffSuggestion,
+        boundaryExpiredSuggestion,
+        approvedSuggestion,
+      ];
+
+      const retentionSummary = await deleteExpiredOutdatedSuggestions({
+        dataAccess: { Suggestion: { removeByIds } },
+        opportunity: buildOpportunity({ suggestions: opportunitySuggestions }),
+        siteId,
+        auditType,
+        log,
+      });
+
+      expect(removeByIds).to.have.been.calledOnce;
+      const suggestionIds = removeByIds.firstCall.args[0];
+      expect([...suggestionIds].sort())
+        .to.deep.equal(['expired-1', 'expired-2', 'expired-boundary']);
+      expect(retentionSummary).to.deep.equal({
+        scanned: 8, eligible: 3, deleted: 3, failed: 0,
+      });
+    });
+
+    it('retains a suggestion newly marked OUTDATED during this refresh', async () => {
+      // Sync refreshes updatedAt when changing status to OUTDATED, making the row recent.
+      const now = new Date('2026-02-01T00:00:00.000Z');
+      sandbox.useFakeTimers(now);
+
+      let freshUpdatedAt = subDays(now, 120).toISOString();
+      const freshlyOutdatedSuggestion = {
+        getId: () => 'freshly-outdated',
+        getStatus: () => STATUSES.OUTDATED,
+        getUpdatedAt: () => freshUpdatedAt,
+      };
+      const expiredOutdatedSuggestion = buildSuggestion({
+        id: 'stale-outdated',
+        updatedAt: subDays(now, 90).toISOString(),
+      });
+
+      freshUpdatedAt = now.toISOString();
+
+      const removeByIds = sandbox.stub().resolves();
+      const retentionSummary = await deleteExpiredOutdatedSuggestions({
+        dataAccess: { Suggestion: { removeByIds } },
+        opportunity: buildOpportunity({
+          suggestions: [freshlyOutdatedSuggestion, expiredOutdatedSuggestion],
+        }),
+        siteId,
+        auditType,
+        log,
+      });
+
+      expect(removeByIds).to.have.been.calledOnceWithExactly(['stale-outdated']);
+      expect(retentionSummary).to.deep.equal({
+        scanned: 2, eligible: 1, deleted: 1, failed: 0,
+      });
+    });
+
+    it('protects every non-OUTDATED status and keeps younger OUTDATED rows', async () => {
+      const recentOutdatedSuggestion = buildSuggestion({ id: 'kept', updatedAt: daysAgo(5) });
+      const fixedSuggestion = buildSuggestion({
+        id: 'fixed', status: STATUSES.FIXED, updatedAt: daysAgo(99),
+      });
+      const skippedSuggestion = buildSuggestion({
+        id: 'skipped', status: STATUSES.SKIPPED, updatedAt: daysAgo(99),
+      });
+      const removeByIds = sandbox.stub().resolves();
+
+      const retentionSummary = await deleteExpiredOutdatedSuggestions({
+        dataAccess: { Suggestion: { removeByIds } },
+        opportunity: buildOpportunity({
+          suggestions: [recentOutdatedSuggestion, fixedSuggestion, skippedSuggestion],
+        }),
+        siteId,
+        auditType,
+        log,
+      });
+
+      expect(removeByIds).to.not.have.been.called;
+      expect(retentionSummary).to.deep.equal({
+        scanned: 3, eligible: 0, deleted: 0, failed: 0,
+      });
+    });
+
+    it('is a no-op (never calls removeByIds) when nothing is eligible', async () => {
+      const removeByIds = sandbox.stub().rejects(new Error('should not be called with []'));
+      const retentionSummary = await deleteExpiredOutdatedSuggestions({
+        dataAccess: { Suggestion: { removeByIds } },
+        opportunity: buildOpportunity({ suggestions: [] }),
+        siteId,
+        auditType,
+        log,
+      });
+      expect(removeByIds).to.not.have.been.called;
+      expect(retentionSummary.deleted).to.equal(0);
+      expect(retentionSummary.scanned).to.equal(0);
+      expect(log.info).to.have.been.calledWith(
+        sinon.match(/event=outdated_suggestion_retention_summary/)
+          .and(sinon.match(/outcome=success/))
+          .and(sinon.match(/scanned=0/))
+          .and(sinon.match(/eligible=0/))
+          .and(sinon.match(/deleted=0/))
+          .and(sinon.match(/failed=0/)),
+      );
+    });
+
+    it('treats a falsy getSuggestions result as an empty set', async () => {
+      const retentionSummary = await deleteExpiredOutdatedSuggestions({
+        dataAccess: { Suggestion: { removeByIds: sandbox.stub() } },
+        opportunity: buildOpportunity({ getSuggestions: sandbox.stub().resolves(null) }),
+        siteId,
+        auditType,
+        log,
+      });
+      expect(retentionSummary.scanned).to.equal(0);
+    });
+
+    it('logs identifiers and returns a zeroed summary when reading suggestions fails', async () => {
+      const retentionSummary = await deleteExpiredOutdatedSuggestions({
+        dataAccess: { Suggestion: { removeByIds: sandbox.stub() } },
+        opportunity: buildOpportunity({
+          getSuggestions: sandbox.stub().rejects(new Error('read fail')),
+        }),
+        siteId,
+        auditType,
+        log,
+      });
+      expect(retentionSummary).to.deep.equal({
+        scanned: 0, eligible: 0, deleted: 0, failed: 0,
+      });
+      expect(log.error).to.have.been.calledWith(
+        sinon.match(/event=outdated_suggestion_lookup/)
+          .and(sinon.match(/outcome=failure/))
+          .and(sinon.match(/opportunityId=evergreen-1/))
+          .and(sinon.match(/siteId=site-1/))
+          .and(sinon.match(/audit=cited/))
+          .and(sinon.match(/errorMessage="read fail"/)),
+      );
+    });
+
+    it('records a failed batch without logging its suggestions as deleted', async () => {
+      const expiredOutdatedSuggestion = buildSuggestion({
+        id: 'old', updatedAt: daysAgo(31),
+      });
+      const removeByIds = sandbox.stub().rejects(new Error('DELETE failed'));
+
+      const retentionSummary = await deleteExpiredOutdatedSuggestions({
+        dataAccess: { Suggestion: { removeByIds } },
+        opportunity: buildOpportunity({ suggestions: [expiredOutdatedSuggestion] }),
+        siteId,
+        auditType,
+        log,
+      });
+
+      expect(retentionSummary).to.deep.equal({
+        scanned: 1, eligible: 1, deleted: 0, failed: 1,
+      });
+      expect(log.error).to.have.been.calledWith(
+        sinon.match(/event=outdated_suggestion_delete/)
+          .and(sinon.match(/outcome=failure/))
+          .and(sinon.match(/opportunityId=evergreen-1/))
+          .and(sinon.match(/siteId=site-1/))
+          .and(sinon.match(/errorMessage="DELETE failed"/)),
+      );
+      expect(log.info).to.not.have.been.calledWith(
+        sinon.match(/Deleted expired OUTDATED suggestion/),
+      );
+    });
+
+    it('never passes a missing/invalid updated_at row to removeByIds (retained end-to-end)', async () => {
+      const missingTimestampSuggestion = buildSuggestion({
+        id: 'null-dated', updatedAt: null,
+      });
+      const invalidTimestampSuggestion = buildSuggestion({
+        id: 'invalid-dated', updatedAt: 'garbage',
+      });
+      const expiredOutdatedSuggestion = buildSuggestion({
+        id: 'genuinely-old', updatedAt: daysAgo(60),
+      });
+      const removeByIds = sandbox.stub().resolves();
+
+      const retentionSummary = await deleteExpiredOutdatedSuggestions({
+        dataAccess: { Suggestion: { removeByIds } },
+        opportunity: buildOpportunity({
+          suggestions: [
+            missingTimestampSuggestion,
+            invalidTimestampSuggestion,
+            expiredOutdatedSuggestion,
+          ],
+        }),
+        siteId,
+        auditType,
+        log,
+      });
+
+      expect(removeByIds).to.have.been.calledOnceWithExactly(['genuinely-old']);
+      expect(retentionSummary).to.deep.equal({
+        scanned: 3, eligible: 1, deleted: 1, failed: 0,
+      });
+    });
+
+    it('chunks a large eligible set into <= batch-size removeByIds calls covering every id once', async () => {
+      const suggestionCount = OUTDATED_SUGGESTION_DELETE_BATCH_SIZE * 2 + 7;
+      const opportunitySuggestions = Array.from(
+        { length: suggestionCount },
+        (_, index) => buildSuggestion({
+          id: `old-${index}`,
+          updatedAt: daysAgo(40),
+        }),
+      );
+      const removeByIds = sandbox.stub().resolves();
+
+      const retentionSummary = await deleteExpiredOutdatedSuggestions({
+        dataAccess: { Suggestion: { removeByIds } },
+        opportunity: buildOpportunity({ suggestions: opportunitySuggestions }),
+        siteId,
+        auditType,
+        log,
+      });
+
+      const expectedBatchCount = Math.ceil(
+        suggestionCount / OUTDATED_SUGGESTION_DELETE_BATCH_SIZE,
+      );
+      expect(removeByIds.callCount).to.equal(expectedBatchCount);
+      removeByIds.getCalls().forEach((call) => {
+        expect(call.args[0].length).to.be.at.most(OUTDATED_SUGGESTION_DELETE_BATCH_SIZE);
+      });
+      const deletedSuggestionIds = removeByIds.getCalls()
+        .flatMap((call) => call.args[0]);
+      expect(deletedSuggestionIds).to.have.lengthOf(suggestionCount);
+      expect(new Set(deletedSuggestionIds).size).to.equal(suggestionCount);
+      const expectedSuggestionIds = opportunitySuggestions
+        .map((suggestion) => suggestion.getId())
+        .sort();
+      expect([...new Set(deletedSuggestionIds)].sort()).to.deep.equal(expectedSuggestionIds);
+      expect(retentionSummary).to.deep.equal({
+        scanned: suggestionCount,
+        eligible: suggestionCount,
+        deleted: suggestionCount,
+        failed: 0,
+      });
+    });
+
+    it('isolates a failed batch and omits successful logs for its suggestions', async () => {
+      const suggestionCount = OUTDATED_SUGGESTION_DELETE_BATCH_SIZE + 5;
+      const opportunitySuggestions = Array.from(
+        { length: suggestionCount },
+        (_, index) => buildSuggestion({
+          id: `old-${index}`,
+          updatedAt: daysAgo(40),
+        }),
+      );
+      const failedSuggestionId = `old-${suggestionCount - 1}`;
+      const removeByIds = sandbox.stub().callsFake(async (suggestionIds) => {
+        if (suggestionIds.includes(failedSuggestionId)) {
+          throw new Error('batch DELETE failed');
+        }
+      });
+
+      const retentionSummary = await deleteExpiredOutdatedSuggestions({
+        dataAccess: { Suggestion: { removeByIds } },
+        opportunity: buildOpportunity({ suggestions: opportunitySuggestions }),
+        siteId,
+        auditType,
+        log,
+      });
+
+      expect(removeByIds.callCount).to.equal(2);
+      expect(retentionSummary).to.deep.equal({
+        scanned: suggestionCount,
+        eligible: suggestionCount,
+        deleted: OUTDATED_SUGGESTION_DELETE_BATCH_SIZE,
+        failed: suggestionCount - OUTDATED_SUGGESTION_DELETE_BATCH_SIZE,
+      });
+      expect(log.error).to.have.been.calledWith(
+        sinon.match(/Failed to delete 5 expired OUTDATED suggestion\(s\)/)
+          .and(sinon.match(/errorMessage="batch DELETE failed"/)),
+      );
+      expect(log.info).to.not.have.been.calledWith(
+        sinon.match(new RegExp(`suggestionIds=.*\\b${failedSuggestionId}\\b`)),
+      );
+      // A partial failure must surface at outcome=failure on the summary, not success — an
+      // alerting query keyed on outcome=failure must not miss a partial-batch failure.
+      expect(log.error).to.have.been.calledWith(
+        sinon.match(/event=outdated_suggestion_retention_summary/)
+          .and(sinon.match(/outcome=failure/))
+          .and(sinon.match(`failed=${suggestionCount - OUTDATED_SUGGESTION_DELETE_BATCH_SIZE}`)),
+      );
+    });
+
+    it('logs each deletion only after its batch succeeds and emits a summary', async () => {
+      const expiredOutdatedSuggestion = buildSuggestion({
+        id: 'old',
+        updatedAt: daysAgo(40),
+      });
+      const removeByIds = sandbox.stub().resolves();
+
+      const retentionSummary = await deleteExpiredOutdatedSuggestions({
+        dataAccess: { Suggestion: { removeByIds } },
+        opportunity: buildOpportunity({ suggestions: [expiredOutdatedSuggestion] }),
+        siteId,
+        auditType,
+        log,
+      });
+
+      expect(retentionSummary).to.deep.equal({
+        scanned: 1, eligible: 1, deleted: 1, failed: 0,
+      });
+      expect(removeByIds).to.have.been.calledBefore(log.info);
+      expect(log.info).to.have.been.calledWith(
+        sinon.match(/Deleted 1 expired OUTDATED suggestion\(s\)/)
+          .and(sinon.match(/event=outdated_suggestion_delete/))
+          .and(sinon.match(/outcome=success/))
+          .and(sinon.match(/opportunityId=evergreen-1/))
+          .and(sinon.match(/siteId=site-1/))
+          .and(sinon.match(/suggestionIds=old/)),
+      );
+      expect(log.info).to.have.been.calledWith(
+        sinon.match(/Expired OUTDATED suggestion deletion summary/)
+          .and(sinon.match(/event=outdated_suggestion_retention_summary/))
+          .and(sinon.match(/outcome=success/))
+          .and(sinon.match(/opportunityId=evergreen-1/))
+          .and(sinon.match(/siteId=site-1/))
+          .and(sinon.match(/scanned=1/))
+          .and(sinon.match(/eligible=1/))
+          .and(sinon.match(/deleted=1/))
+          .and(sinon.match(/failed=0/)),
+      );
     });
   });
 


### PR DESCRIPTION
## Scope

https://jira.corp.adobe.com/browse/LLMO-6124

Hard-delete only `OUTDATED` offsite suggestions older than 30 days after a successful refresh, keeping evergreen recommendation history bounded without deleting customer decisions or adding a scheduler. See [the spec](docs/specs/2026-07-16-offsite-outdated-suggestion-retention.md) for the full design.

This is a stacked PR on #2772 (`LLMO-6154`). The chain is `main` ← `LLMO-6122` ← `LLMO-6152` ← `LLMO-6154` ← `LLMO-6124`.

## Implementation

**Explicit eligibility policy**

`isOutdatedSuggestionExpired` selects only `OUTDATED` suggestions whose valid `updatedAt` is strictly before the 30-day cutoff. Exactly 30 days old is retained. Missing or invalid timestamps are retained because safe deletion cannot be proven, and every other suggestion status remains protected regardless of age.

**Bounded hard deletion**

`deleteExpiredOutdatedSuggestions` reads the just-synchronized opportunity and deletes eligible IDs through `Suggestion.removeByIds` in batches of at most 100, keeping PostgREST `DELETE ... IN (...)` URLs bounded.

Batch failures are isolated and returned in `{ scanned, eligible, deleted, failed }`; successful batches continue even if another fails. Dependent fix-entity rows cascade-delete through the existing data model.

**Structured deletion logging**

Emits via `createOffsiteLogger`, consistent with the rest of the offsite modules. Each successful batch logs once (batch size + suggestion IDs), not once per suggestion, to avoid a hot-loop logging anti-pattern. A per-invocation summary (`scanned`/`eligible`/`deleted`/`failed`) is always emitted, with its `outcome` reflecting whether any batch failed (`outcome=failure` when `failed > 0`) so a Splunk query keyed on `outcome=failure` cannot miss a partial-batch failure.

**Refresh integration**

Deletion runs after suggestion synchronization in cited-analysis, reddit-analysis, and youtube-analysis, before expired snapshot deletion. Defensive handler guards keep deletion failures from changing an otherwise successful refresh response.

## Testing

- Full unit and integration suite, lint, and build pass with required coverage.
- Tests cover strict boundaries, invalid timestamps, all protected statuses, empty and multi-row passes, 100-ID batching, isolated batch failures, the partial-failure summary outcome, and synchronization ordering.
- All three handler suites verify invocation and non-blocking errors.
- Local Postgres/PostgREST scenarios verified each supported audit type, protected statuses, suppressed runs, and a 101-item eligible backlog across the batch boundary.

## Out of Scope

- A dedicated `outdatedAt` column or schema migration
- Customer-controlled keep or pin markers
- Deleting any status other than `OUTDATED`
- Deterministic suggestion deduplication
- Cleanup of unrelated orphan tables
- Scheduled or infrastructure-level sweepers
- Soft deletion or per-customer retention configuration
- Wikipedia analysis
- One-time migration or backfill sweep

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```