### PR TITLE
feat(preflight): add body-size and lorem-ipsum in-process handlers (SITES-48265)

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "hedy -v --test-bundle",
     "deploy": "hedy -v --deploy --aws-deploy-bucket=spacecat-prod-deploy --pkgVersion=latest --aws-reserved-concurrency=100",
     "deploy-stage": "hedy -v --deploy --aws-deploy-bucket=spacecat-stage-deploy --pkgVersion=latest --aws-reserved-concurrency=10",
-    "deploy-dev": "hedy -v --deploy --pkgVersion=ci$CI_BUILD_NUM -l latest --aws-deploy-bucket=spacecat-dev-deploy --cleanup-ci=24h --aws-reserved-concurrency=10",
+    "deploy-dev": "hedy -v --deploy --pkgVersion=ci$CI_BUILD_NUM -l clotton --aws-deploy-bucket=spacecat-dev-deploy --cleanup-ci=24h --aws-reserved-concurrency=10",
     "deploy-secrets": "hedy --aws-update-secrets --params-file=secrets/secrets.env",
     "prepare": "husky",
     "local-build": "sam build",

--- a/src/preflight/audit-constants.js
+++ b/src/preflight/audit-constants.js
@@ -15,8 +15,11 @@
  * Single source of truth for check identifiers shared between handler and sub-handlers.
  */
 export const AUDIT_ALT_TEXT = 'alt-text';
+export const AUDIT_BODY_SIZE = 'body-size';
+export const AUDIT_LOREM_IPSUM = 'lorem-ipsum';
 
 /**
  * Preflight audit type (category) constants for the audit result object.
  */
 export const PREFLIGHT_AUDIT_TYPE_ACCESSIBILITY = 'accessibility';
+export const PREFLIGHT_AUDIT_TYPE_SEO = 'seo';

--- a/src/preflight/body-size.js
+++ b/src/preflight/body-size.js
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { load as cheerioLoad } from 'cheerio';
+import { saveIntermediateResults } from './utils.js';
+import { getDomElementSelector, toElementTargets } from './utils/dom-selector.js';
+import { AUDIT_BODY_SIZE, PREFLIGHT_AUDIT_TYPE_SEO } from './audit-constants.js';
+
+/**
+ * Preflight audit handler for detecting thin body content.
+ *
+ * Flags pages whose visible body text is between 1 and 100 characters — a
+ * strong signal that the page is a stub, a template placeholder, or has not
+ * yet been populated with real content.
+ *
+ * @param {Object} context - Audit context from the preflight system
+ * @param {Object} auditContext - Preflight audit context
+ * @returns {Promise<{processing: boolean}>}
+ */
+export default async function bodySize(context, auditContext) {
+  const { site, job, log } = context;
+  const {
+    previewUrls,
+    step,
+    audits,
+    auditsResult,
+    scrapedObjects,
+    timeExecutionBreakdown,
+  } = auditContext;
+
+  const startTime = Date.now();
+  const startTimestamp = new Date().toISOString();
+
+  previewUrls.forEach((url) => {
+    audits.get(url).audits.push({
+      name: AUDIT_BODY_SIZE,
+      type: PREFLIGHT_AUDIT_TYPE_SEO,
+      opportunities: [],
+    });
+  });
+
+  const auditMap = new Map();
+  previewUrls.forEach((url) => {
+    const pageResult = audits.get(url);
+    if (pageResult) {
+      const audit = pageResult.audits.find((a) => a.name === AUDIT_BODY_SIZE);
+      if (audit) {
+        auditMap.set(url, audit);
+      }
+    }
+  });
+
+  scrapedObjects.forEach(({ data }) => {
+    const { finalUrl, scrapeResult: { rawBody } } = data;
+    const pageUrl = finalUrl.replace(/\/$/, '');
+    const audit = auditMap.get(pageUrl);
+
+    if (!audit) {
+      log.warn(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}. No audit entry for URL: ${pageUrl}`);
+      return;
+    }
+
+    const $ = cheerioLoad(rawBody);
+    const textContent = $('body').text().replace(/\n/g, '').trim();
+
+    if (textContent.length > 0 && textContent.length <= 100) {
+      audit.opportunities.push({
+        check: 'content-length',
+        issue: 'Body content length is below 100 characters',
+        seoImpact: 'Moderate',
+        seoRecommendation: 'Add more meaningful content to the page',
+        ...toElementTargets(getDomElementSelector($('body').get(0))),
+      });
+    }
+  });
+
+  const endTime = Date.now();
+  const endTimestamp = new Date().toISOString();
+  const elapsed = ((endTime - startTime) / 1000).toFixed(2);
+
+  log.info(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. ${AUDIT_BODY_SIZE} audit completed in ${elapsed} seconds`);
+
+  timeExecutionBreakdown.push({
+    name: AUDIT_BODY_SIZE,
+    duration: `${elapsed} seconds`,
+    startTime: startTimestamp,
+    endTime: endTimestamp,
+  });
+
+  await saveIntermediateResults(context, auditsResult, 'body-size audit');
+
+  return { processing: false };
+}

--- a/src/preflight/handler.js
+++ b/src/preflight/handler.js
@@ -21,7 +21,7 @@ import {
   getPrefixedPageAuthToken, isValidUrls, saveIntermediateResults,
 } from './utils.js';
 import { getDomElementSelector, toElementTargets } from './utils/dom-selector.js';
-import { AUDIT_ALT_TEXT } from './audit-constants.js';
+import { AUDIT_ALT_TEXT, AUDIT_BODY_SIZE, AUDIT_LOREM_IPSUM } from './audit-constants.js';
 import { PreflightError } from './error-constants.js';
 import canonical from './canonical.js';
 import metatags from './metatags.js';
@@ -31,6 +31,8 @@ import accessibility from './accessibility.js';
 import headings from './headings.js';
 import formAccessibility from './form-accessibility.js';
 import altText from './alt-text.js';
+import bodySize from './body-size.js';
+import loremIpsum from './lorem-ipsum.js';
 
 const { AUDIT_STEP_DESTINATIONS } = Audit;
 export const PREFLIGHT_STEP_IDENTIFY = 'identify';
@@ -59,14 +61,12 @@ export const PREFLIGHT_META_TAGS_WAIT_MS = 5000;
 export const AUDIT_CANONICAL = 'canonical';
 export const AUDIT_LINKS = 'links';
 export const AUDIT_METATAGS = 'metatags';
-export const AUDIT_BODY_SIZE = 'body-size';
-export const AUDIT_LOREM_IPSUM = 'lorem-ipsum';
 export const AUDIT_H1_COUNT = 'h1-count';
 export const AUDIT_ACCESSIBILITY = 'accessibility';
 export const AUDIT_READABILITY = 'readability';
 export const AUDIT_HEADINGS = 'headings';
 export const AUDIT_FORM_ACCESSIBILITY = 'form-accessibility';
-export { AUDIT_ALT_TEXT } from './audit-constants.js';
+export { AUDIT_ALT_TEXT, AUDIT_BODY_SIZE, AUDIT_LOREM_IPSUM } from './audit-constants.js';
 
 const AVAILABLE_CHECKS = [
   AUDIT_CANONICAL,
@@ -91,6 +91,8 @@ export const PREFLIGHT_HANDLERS = {
   accessibility,
   'form-accessibility': formAccessibility,
   [AUDIT_ALT_TEXT]: altText,
+  [AUDIT_BODY_SIZE]: bodySize,
+  [AUDIT_LOREM_IPSUM]: loremIpsum,
 };
 
 export async function scrapePages(context) {
@@ -250,24 +252,45 @@ export const preflightAudit = async (context) => {
     }));
     const audits = new Map(auditsResult.map((r) => [r.pageUrl, r]));
 
-    const bodySizeEnabled = enabledChecks.includes(AUDIT_BODY_SIZE);
-    const loremIpsumEnabled = enabledChecks.includes(AUDIT_LOREM_IPSUM);
+    const handlerPayload = {
+      authHeader,
+      previewBaseURL,
+      previewUrls,
+      step,
+      audits,
+      auditsResult,
+      s3Keys,
+      scrapedObjects,
+      pageAuthToken,
+      urls,
+      timeExecutionBreakdown,
+    };
+
+    const runHandlers = (keys) => keys.reduce(
+      async (accPromise, key) => {
+        const acc = await accPromise;
+        const res = await PREFLIGHT_HANDLERS[key](context, handlerPayload);
+        return [...acc, res];
+      },
+      Promise.resolve([]),
+    );
+
+    // Checks that run before the h1-count DOM block so their audit entries appear first.
+    const PRE_DOM_HANDLER_KEYS = [AUDIT_BODY_SIZE, AUDIT_LOREM_IPSUM];
+    const allHandlersToRun = Object.keys(PREFLIGHT_HANDLERS)
+      .filter((key) => enabledChecks.includes(key));
+    const preDomHandlers = allHandlersToRun.filter((k) => PRE_DOM_HANDLER_KEYS.includes(k));
+    const postDomHandlers = allHandlersToRun.filter((k) => !PRE_DOM_HANDLER_KEYS.includes(k));
+
+    const preDomResults = await runHandlers(preDomHandlers);
+
     const h1CountEnabled = enabledChecks.includes(AUDIT_H1_COUNT);
-    // DOM-based checks: body size, lorem ipsum, h1 count
-    if (bodySizeEnabled || loremIpsumEnabled || h1CountEnabled) {
+    if (h1CountEnabled) {
       const domStartTime = Date.now();
       const domStartTimestamp = new Date().toISOString();
       previewUrls.forEach((url) => {
         const pageResult = audits.get(url);
-        if (bodySizeEnabled) {
-          pageResult.audits.push({ name: AUDIT_BODY_SIZE, type: 'seo', opportunities: [] });
-        }
-        if (loremIpsumEnabled) {
-          pageResult.audits.push({ name: AUDIT_LOREM_IPSUM, type: 'seo', opportunities: [] });
-        }
-        if (h1CountEnabled) {
-          pageResult.audits.push({ name: AUDIT_H1_COUNT, type: 'seo', opportunities: [] });
-        }
+        pageResult.audits.push({ name: AUDIT_H1_COUNT, type: 'seo', opportunities: [] });
       });
 
       scrapedObjects.forEach(({ data }) => {
@@ -279,84 +302,29 @@ export const preflightAudit = async (context) => {
           pageResult.audits.map((auditEntry) => [auditEntry.name, auditEntry]),
         );
 
-        const textContent = $('body').text().replace(/\n/g, '').trim();
+        const headingCount = $('h1').length;
+        if (headingCount !== 1) {
+          const h1Elements = $('h1').toArray();
 
-        if (bodySizeEnabled) {
-          if (textContent.length > 0 && textContent.length <= 100) {
-            auditsByName[AUDIT_BODY_SIZE].opportunities.push({
-              check: 'content-length',
-              issue: 'Body content length is below 100 characters',
-              seoImpact: 'Moderate',
-              seoRecommendation: 'Add more meaningful content to the page',
-              ...toElementTargets(getDomElementSelector($('body').get(0))),
-            });
-          }
-        }
+          const h1Selectors = h1Elements
+            .map((el) => getDomElementSelector(el))
+            .filter(Boolean);
+          const fallbackElement = $('body > main').get(0) || $('body').get(0);
+          const fallbackSelector = getDomElementSelector(fallbackElement);
 
-        if (loremIpsumEnabled && /lorem ipsum/i.test(textContent)) {
-          const allLoremElements = $('p, div, span, li, section, article, h1, h2, h3, h4, h5, h6')
-            .toArray()
-            .filter((el) => /lorem ipsum/i.test($(el).text()));
-          // Keep only innermost matches — discard ancestors whose text matched
-          // solely because a descendant contains "Lorem ipsum".
-          const loremElements = allLoremElements.filter(
-            (el) => !allLoremElements.some((other) => {
-              if (other === el) {
-                return false;
-              }
-              let cursor = other.parent;
-              while (cursor) {
-                if (cursor === el) {
-                  return true;
-                }
-                cursor = cursor.parent;
-              }
-              return false;
-            }),
-          );
-          const loremSelectors = loremElements.map(
-            (el) => getDomElementSelector(el),
-          ).filter(Boolean);
-          const fallbackSelector = loremSelectors.length === 0
-            ? getDomElementSelector($('body').get(0))
-            : null;
-          auditsByName[AUDIT_LOREM_IPSUM].opportunities.push({
-            check: 'placeholder-text',
-            issue: 'Found Lorem ipsum placeholder text in the page content',
+          auditsByName[AUDIT_H1_COUNT].opportunities.push({
+            check: headingCount > 1 ? 'multiple-h1' : 'missing-h1',
+            issue:
+              headingCount > 1
+                ? `Found ${headingCount} H1 tags`
+                : 'No H1 tag found on the page',
             seoImpact: 'High',
-            seoRecommendation: 'Replace placeholder text with meaningful content',
+            seoRecommendation:
+              'Use exactly one H1 tag per page for better SEO structure',
             ...toElementTargets(
-              loremSelectors.length > 0 ? loremSelectors : fallbackSelector,
-              10,
+              headingCount > 0 ? h1Selectors : fallbackSelector,
             ),
           });
-        }
-
-        if (h1CountEnabled) {
-          const headingCount = $('h1').length;
-          if (headingCount !== 1) {
-            const h1Elements = $('h1').toArray();
-
-            const h1Selectors = h1Elements
-              .map((el) => getDomElementSelector(el))
-              .filter(Boolean);
-            const fallbackElement = $('body > main').get(0) || $('body').get(0);
-            const fallbackSelector = getDomElementSelector(fallbackElement);
-
-            auditsByName[AUDIT_H1_COUNT].opportunities.push({
-              check: headingCount > 1 ? 'multiple-h1' : 'missing-h1',
-              issue:
-                headingCount > 1
-                  ? `Found ${headingCount} H1 tags`
-                  : 'No H1 tag found on the page',
-              seoImpact: 'High',
-              seoRecommendation:
-                'Use exactly one H1 tag per page for better SEO structure',
-              ...toElementTargets(
-                headingCount > 0 ? h1Selectors : fallbackSelector,
-              ),
-            });
-          }
         }
       });
       const domEndTime = Date.now();
@@ -374,29 +342,8 @@ export const preflightAudit = async (context) => {
       await saveIntermediateResults(context, auditsResult, 'DOM-based audit');
     }
 
-    // Execute only enabled preflight handlers
-    const handlersToRun = Object.keys(PREFLIGHT_HANDLERS)
-      .filter((key) => enabledChecks.includes(key));
-    const handlerResults = await handlersToRun.reduce(
-      async (accPromise, handler) => {
-        const acc = await accPromise;
-        const res = await PREFLIGHT_HANDLERS[handler](context, {
-          authHeader,
-          previewBaseURL,
-          previewUrls,
-          step,
-          audits,
-          auditsResult,
-          s3Keys,
-          scrapedObjects,
-          pageAuthToken,
-          urls,
-          timeExecutionBreakdown,
-        });
-        return [...acc, res];
-      },
-      Promise.resolve([]),
-    );
+    const postDomResults = await runHandlers(postDomHandlers);
+    const handlerResults = [...preDomResults, ...postDomResults];
 
     const endTime = Date.now();
     const endTimestamp = new Date().toISOString();

--- a/src/preflight/lorem-ipsum.js
+++ b/src/preflight/lorem-ipsum.js
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { load as cheerioLoad } from 'cheerio';
+import { saveIntermediateResults } from './utils.js';
+import { getDomElementSelector, toElementTargets } from './utils/dom-selector.js';
+import { AUDIT_LOREM_IPSUM, PREFLIGHT_AUDIT_TYPE_SEO } from './audit-constants.js';
+
+const LOREM_IPSUM_PATTERN = /lorem ipsum/i;
+const LOREM_IPSUM_TAGS = 'p, div, span, li, section, article, h1, h2, h3, h4, h5, h6';
+const MAX_LOREM_SELECTORS = 10;
+
+/**
+ * Returns true if `other` is a DOM ancestor of `el`.
+ */
+function isAncestorOf(el, other) {
+  let cursor = other.parent;
+  while (cursor) {
+    if (cursor === el) {
+      return true;
+    }
+    cursor = cursor.parent;
+  }
+  return false;
+}
+
+/**
+ * Preflight audit handler for detecting Lorem ipsum placeholder text.
+ *
+ * Scans the page for "Lorem ipsum" text and reports the innermost elements
+ * containing it, up to a maximum of 10 selectors. This catches pages where
+ * authors have not replaced template placeholder content before publishing.
+ *
+ * @param {Object} context - Audit context from the preflight system
+ * @param {Object} auditContext - Preflight audit context
+ * @returns {Promise<{processing: boolean}>}
+ */
+export default async function loremIpsum(context, auditContext) {
+  const { site, job, log } = context;
+  const {
+    previewUrls,
+    step,
+    audits,
+    auditsResult,
+    scrapedObjects,
+    timeExecutionBreakdown,
+  } = auditContext;
+
+  const startTime = Date.now();
+  const startTimestamp = new Date().toISOString();
+
+  previewUrls.forEach((url) => {
+    audits.get(url).audits.push({
+      name: AUDIT_LOREM_IPSUM,
+      type: PREFLIGHT_AUDIT_TYPE_SEO,
+      opportunities: [],
+    });
+  });
+
+  const auditMap = new Map();
+  previewUrls.forEach((url) => {
+    const pageResult = audits.get(url);
+    if (pageResult) {
+      const audit = pageResult.audits.find((a) => a.name === AUDIT_LOREM_IPSUM);
+      if (audit) {
+        auditMap.set(url, audit);
+      }
+    }
+  });
+
+  scrapedObjects.forEach(({ data }) => {
+    const { finalUrl, scrapeResult: { rawBody } } = data;
+    const pageUrl = finalUrl.replace(/\/$/, '');
+    const audit = auditMap.get(pageUrl);
+
+    if (!audit) {
+      log.warn(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}. No audit entry for URL: ${pageUrl}`);
+      return;
+    }
+
+    const $ = cheerioLoad(rawBody);
+    const textContent = $('body').text().replace(/\n/g, '').trim();
+
+    if (!LOREM_IPSUM_PATTERN.test(textContent)) {
+      return;
+    }
+
+    const allLoremElements = $(LOREM_IPSUM_TAGS)
+      .toArray()
+      .filter((el) => LOREM_IPSUM_PATTERN.test($(el).text()));
+
+    // Keep only innermost matches — discard ancestors whose text matched
+    // solely because a descendant contains "Lorem ipsum".
+    const loremElements = allLoremElements.filter(
+      (el) => !allLoremElements.some((other) => other !== el && isAncestorOf(el, other)),
+    );
+
+    const loremSelectors = loremElements
+      .map((el) => getDomElementSelector(el))
+      .filter(Boolean);
+
+    const fallbackSelector = loremSelectors.length === 0
+      ? getDomElementSelector($('body').get(0))
+      : null;
+
+    audit.opportunities.push({
+      check: 'placeholder-text',
+      issue: 'Found Lorem ipsum placeholder text in the page content',
+      seoImpact: 'High',
+      seoRecommendation: 'Replace placeholder text with meaningful content',
+      ...toElementTargets(
+        loremSelectors.length > 0 ? loremSelectors : fallbackSelector,
+        MAX_LOREM_SELECTORS,
+      ),
+    });
+  });
+
+  const endTime = Date.now();
+  const endTimestamp = new Date().toISOString();
+  const elapsed = ((endTime - startTime) / 1000).toFixed(2);
+
+  log.info(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. ${AUDIT_LOREM_IPSUM} audit completed in ${elapsed} seconds`);
+
+  timeExecutionBreakdown.push({
+    name: AUDIT_LOREM_IPSUM,
+    duration: `${elapsed} seconds`,
+    startTime: startTimestamp,
+    endTime: endTimestamp,
+  });
+
+  await saveIntermediateResults(context, auditsResult, 'lorem-ipsum audit');
+
+  return { processing: false };
+}

--- a/test/audits/preflight-body-size.test.js
+++ b/test/audits/preflight-body-size.test.js
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinonChai from 'sinon-chai';
+import sinon from 'sinon';
+import bodySize from '../../src/preflight/body-size.js';
+
+use(sinonChai);
+
+describe('Preflight Body Size Audit', () => {
+  let context;
+  let auditContext;
+  let log;
+
+  beforeEach(() => {
+    log = {
+      info: sinon.stub(),
+      warn: sinon.stub(),
+      error: sinon.stub(),
+      debug: sinon.stub(),
+    };
+
+    context = {
+      site: { getId: () => 'site-123' },
+      job: { getId: () => 'job-123' },
+      step: 'identify',
+      env: { S3_SCRAPER_BUCKET_NAME: 'test-bucket' },
+      log,
+      s3Client: {},
+      dataAccess: {
+        AsyncJob: {
+          findById: sinon.stub().resolves({
+            setResult: sinon.stub(),
+            save: sinon.stub().resolves(),
+          }),
+        },
+      },
+    };
+
+    auditContext = {
+      previewUrls: ['https://example.com/page1'],
+      step: 'identify',
+      audits: new Map([['https://example.com/page1', { audits: [] }]]),
+      auditsResult: [{ pageUrl: 'https://example.com/page1', audits: [] }],
+      scrapedObjects: [],
+      timeExecutionBreakdown: [],
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('creates a body-size audit entry for each page', async () => {
+    auditContext.scrapedObjects = [{
+      data: {
+        finalUrl: 'https://example.com/page1',
+        scrapeResult: { rawBody: '<html><body><p>Normal length content here.</p></body></html>' },
+      },
+    }];
+
+    await bodySize(context, auditContext);
+
+    const pageAudit = auditContext.audits.get('https://example.com/page1');
+    expect(pageAudit.audits).to.have.lengthOf(1);
+    expect(pageAudit.audits[0]).to.deep.include({ name: 'body-size', type: 'seo' });
+  });
+
+  it('flags pages with body text between 1 and 100 characters', async () => {
+    auditContext.scrapedObjects = [{
+      data: {
+        finalUrl: 'https://example.com/page1',
+        scrapeResult: { rawBody: '<html><body>Short</body></html>' },
+      },
+    }];
+
+    await bodySize(context, auditContext);
+
+    const audit = auditContext.audits.get('https://example.com/page1').audits[0];
+    expect(audit.opportunities).to.have.lengthOf(1);
+    expect(audit.opportunities[0]).to.deep.include({
+      check: 'content-length',
+      issue: 'Body content length is below 100 characters',
+      seoImpact: 'Moderate',
+      seoRecommendation: 'Add more meaningful content to the page',
+    });
+  });
+
+  it('does not flag pages with body text longer than 100 characters', async () => {
+    const longText = 'a'.repeat(101);
+    auditContext.scrapedObjects = [{
+      data: {
+        finalUrl: 'https://example.com/page1',
+        scrapeResult: { rawBody: `<html><body><p>${longText}</p></body></html>` },
+      },
+    }];
+
+    await bodySize(context, auditContext);
+
+    const audit = auditContext.audits.get('https://example.com/page1').audits[0];
+    expect(audit.opportunities).to.have.lengthOf(0);
+  });
+
+  it('does not flag pages with empty body text', async () => {
+    auditContext.scrapedObjects = [{
+      data: {
+        finalUrl: 'https://example.com/page1',
+        scrapeResult: { rawBody: '<html><body></body></html>' },
+      },
+    }];
+
+    await bodySize(context, auditContext);
+
+    const audit = auditContext.audits.get('https://example.com/page1').audits[0];
+    expect(audit.opportunities).to.have.lengthOf(0);
+  });
+
+  it('flags page with exactly 100 characters of body text', async () => {
+    const text = 'a'.repeat(100);
+    auditContext.scrapedObjects = [{
+      data: {
+        finalUrl: 'https://example.com/page1',
+        scrapeResult: { rawBody: `<html><body>${text}</body></html>` },
+      },
+    }];
+
+    await bodySize(context, auditContext);
+
+    const audit = auditContext.audits.get('https://example.com/page1').audits[0];
+    expect(audit.opportunities).to.have.lengthOf(1);
+  });
+
+  it('does not flag page with exactly 101 characters of body text', async () => {
+    const text = 'a'.repeat(101);
+    auditContext.scrapedObjects = [{
+      data: {
+        finalUrl: 'https://example.com/page1',
+        scrapeResult: { rawBody: `<html><body>${text}</body></html>` },
+      },
+    }];
+
+    await bodySize(context, auditContext);
+
+    const audit = auditContext.audits.get('https://example.com/page1').audits[0];
+    expect(audit.opportunities).to.have.lengthOf(0);
+  });
+
+  it('logs a warning when no audit entry exists for a scraped URL', async () => {
+    auditContext.scrapedObjects = [{
+      data: {
+        finalUrl: 'https://example.com/unknown',
+        scrapeResult: { rawBody: '<html><body>Short</body></html>' },
+      },
+    }];
+
+    await bodySize(context, auditContext);
+
+    expect(log.warn).to.have.been.calledWithMatch('[preflight-audit]');
+  });
+
+  it('adds timing information to the execution breakdown', async () => {
+    auditContext.scrapedObjects = [{
+      data: {
+        finalUrl: 'https://example.com/page1',
+        scrapeResult: { rawBody: '<html><body></body></html>' },
+      },
+    }];
+
+    await bodySize(context, auditContext);
+
+    expect(auditContext.timeExecutionBreakdown).to.have.lengthOf(1);
+    expect(auditContext.timeExecutionBreakdown[0]).to.include({
+      name: 'body-size',
+    });
+    expect(auditContext.timeExecutionBreakdown[0]).to.have.property('duration');
+    expect(auditContext.timeExecutionBreakdown[0]).to.have.property('startTime');
+    expect(auditContext.timeExecutionBreakdown[0]).to.have.property('endTime');
+  });
+
+  it('returns { processing: false }', async () => {
+    auditContext.scrapedObjects = [];
+    const result = await bodySize(context, auditContext);
+    expect(result).to.deep.equal({ processing: false });
+  });
+
+  it('strips trailing slash from finalUrl when looking up audit', async () => {
+    auditContext.scrapedObjects = [{
+      data: {
+        finalUrl: 'https://example.com/page1/',
+        scrapeResult: { rawBody: '<html><body>Short</body></html>' },
+      },
+    }];
+
+    await bodySize(context, auditContext);
+
+    const audit = auditContext.audits.get('https://example.com/page1').audits[0];
+    expect(audit.opportunities).to.have.lengthOf(1);
+  });
+});

--- a/test/audits/preflight-lorem-ipsum.test.js
+++ b/test/audits/preflight-lorem-ipsum.test.js
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinonChai from 'sinon-chai';
+import sinon from 'sinon';
+import loremIpsum from '../../src/preflight/lorem-ipsum.js';
+
+use(sinonChai);
+
+describe('Preflight Lorem Ipsum Audit', () => {
+  let context;
+  let auditContext;
+  let log;
+
+  beforeEach(() => {
+    log = {
+      info: sinon.stub(),
+      warn: sinon.stub(),
+      error: sinon.stub(),
+      debug: sinon.stub(),
+    };
+
+    context = {
+      site: { getId: () => 'site-123' },
+      job: { getId: () => 'job-123' },
+      step: 'identify',
+      env: { S3_SCRAPER_BUCKET_NAME: 'test-bucket' },
+      log,
+      s3Client: {},
+      dataAccess: {
+        AsyncJob: {
+          findById: sinon.stub().resolves({
+            setResult: sinon.stub(),
+            save: sinon.stub().resolves(),
+          }),
+        },
+      },
+    };
+
+    auditContext = {
+      previewUrls: ['https://example.com/page1'],
+      step: 'identify',
+      audits: new Map([['https://example.com/page1', { audits: [] }]]),
+      auditsResult: [{ pageUrl: 'https://example.com/page1', audits: [] }],
+      scrapedObjects: [],
+      timeExecutionBreakdown: [],
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('creates a lorem-ipsum audit entry for each page', async () => {
+    auditContext.scrapedObjects = [{
+      data: {
+        finalUrl: 'https://example.com/page1',
+        scrapeResult: { rawBody: '<html><body><p>Normal content here.</p></body></html>' },
+      },
+    }];
+
+    await loremIpsum(context, auditContext);
+
+    const pageAudit = auditContext.audits.get('https://example.com/page1');
+    expect(pageAudit.audits).to.have.lengthOf(1);
+    expect(pageAudit.audits[0]).to.deep.include({ name: 'lorem-ipsum', type: 'seo' });
+  });
+
+  it('flags pages containing "Lorem ipsum" text', async () => {
+    auditContext.scrapedObjects = [{
+      data: {
+        finalUrl: 'https://example.com/page1',
+        scrapeResult: { rawBody: '<html><body><p>Lorem ipsum dolor sit amet.</p></body></html>' },
+      },
+    }];
+
+    await loremIpsum(context, auditContext);
+
+    const audit = auditContext.audits.get('https://example.com/page1').audits[0];
+    expect(audit.opportunities).to.have.lengthOf(1);
+    expect(audit.opportunities[0]).to.deep.include({
+      check: 'placeholder-text',
+      issue: 'Found Lorem ipsum placeholder text in the page content',
+      seoImpact: 'High',
+      seoRecommendation: 'Replace placeholder text with meaningful content',
+    });
+  });
+
+  it('does not flag pages with no Lorem ipsum text', async () => {
+    auditContext.scrapedObjects = [{
+      data: {
+        finalUrl: 'https://example.com/page1',
+        scrapeResult: { rawBody: '<html><body><p>Real content here.</p></body></html>' },
+      },
+    }];
+
+    await loremIpsum(context, auditContext);
+
+    const audit = auditContext.audits.get('https://example.com/page1').audits[0];
+    expect(audit.opportunities).to.have.lengthOf(0);
+  });
+
+  it('matches Lorem ipsum case-insensitively', async () => {
+    auditContext.scrapedObjects = [{
+      data: {
+        finalUrl: 'https://example.com/page1',
+        scrapeResult: { rawBody: '<html><body><p>LOREM IPSUM dolor sit amet.</p></body></html>' },
+      },
+    }];
+
+    await loremIpsum(context, auditContext);
+
+    const audit = auditContext.audits.get('https://example.com/page1').audits[0];
+    expect(audit.opportunities).to.have.lengthOf(1);
+  });
+
+  it('keeps only innermost elements when lorem ipsum is in nested tags', async () => {
+    auditContext.scrapedObjects = [{
+      data: {
+        finalUrl: 'https://example.com/page1',
+        scrapeResult: {
+          rawBody: `<html><body>
+            <div id="outer">
+              <p id="inner">Lorem ipsum dolor sit amet.</p>
+            </div>
+          </body></html>`,
+        },
+      },
+    }];
+
+    await loremIpsum(context, auditContext);
+
+    const audit = auditContext.audits.get('https://example.com/page1').audits[0];
+    expect(audit.opportunities).to.have.lengthOf(1);
+    // Should include the innermost element (p), not the outer div
+    const { elements } = audit.opportunities[0];
+    expect(elements).to.have.lengthOf(1);
+    expect(elements[0].selector).to.include('p');
+  });
+
+  it('falls back to body selector when no element selectors are found', async () => {
+    // Text is in body directly with no block-level element
+    auditContext.scrapedObjects = [{
+      data: {
+        finalUrl: 'https://example.com/page1',
+        scrapeResult: {
+          rawBody: '<html><body>Lorem ipsum dolor sit amet.</body></html>',
+        },
+      },
+    }];
+
+    await loremIpsum(context, auditContext);
+
+    const audit = auditContext.audits.get('https://example.com/page1').audits[0];
+    expect(audit.opportunities).to.have.lengthOf(1);
+    // elements may be present (body fallback) or absent — either is valid
+    expect(audit.opportunities[0]).to.have.property('check', 'placeholder-text');
+  });
+
+  it('caps elements at 10 when many lorem ipsum elements exist', async () => {
+    const paragraphs = Array.from({ length: 15 }, (_, i) => `<p id="p${i}">Lorem ipsum ${i}</p>`).join('');
+    auditContext.scrapedObjects = [{
+      data: {
+        finalUrl: 'https://example.com/page1',
+        scrapeResult: { rawBody: `<html><body>${paragraphs}</body></html>` },
+      },
+    }];
+
+    await loremIpsum(context, auditContext);
+
+    const audit = auditContext.audits.get('https://example.com/page1').audits[0];
+    expect(audit.opportunities).to.have.lengthOf(1);
+    expect(audit.opportunities[0].elements).to.have.lengthOf(10);
+  });
+
+  it('logs a warning when no audit entry exists for a scraped URL', async () => {
+    auditContext.scrapedObjects = [{
+      data: {
+        finalUrl: 'https://example.com/unknown',
+        scrapeResult: { rawBody: '<html><body><p>Lorem ipsum.</p></body></html>' },
+      },
+    }];
+
+    await loremIpsum(context, auditContext);
+
+    expect(log.warn).to.have.been.calledWithMatch('[preflight-audit]');
+  });
+
+  it('adds timing information to the execution breakdown', async () => {
+    auditContext.scrapedObjects = [{
+      data: {
+        finalUrl: 'https://example.com/page1',
+        scrapeResult: { rawBody: '<html><body><p>Normal content.</p></body></html>' },
+      },
+    }];
+
+    await loremIpsum(context, auditContext);
+
+    expect(auditContext.timeExecutionBreakdown).to.have.lengthOf(1);
+    expect(auditContext.timeExecutionBreakdown[0]).to.include({ name: 'lorem-ipsum' });
+    expect(auditContext.timeExecutionBreakdown[0]).to.have.property('duration');
+    expect(auditContext.timeExecutionBreakdown[0]).to.have.property('startTime');
+    expect(auditContext.timeExecutionBreakdown[0]).to.have.property('endTime');
+  });
+
+  it('returns { processing: false }', async () => {
+    auditContext.scrapedObjects = [];
+    const result = await loremIpsum(context, auditContext);
+    expect(result).to.deep.equal({ processing: false });
+  });
+
+  it('strips trailing slash from finalUrl when looking up audit', async () => {
+    auditContext.scrapedObjects = [{
+      data: {
+        finalUrl: 'https://example.com/page1/',
+        scrapeResult: { rawBody: '<html><body><p>Lorem ipsum dolor.</p></body></html>' },
+      },
+    }];
+
+    await loremIpsum(context, auditContext);
+
+    const audit = auditContext.audits.get('https://example.com/page1').audits[0];
+    expect(audit.opportunities).to.have.lengthOf(1);
+  });
+});

--- a/test/audits/preflight.test.js
+++ b/test/audits/preflight.test.js
@@ -1581,7 +1581,7 @@ describe('Preflight Audit', () => {
 
         // Verify breakdown structure
         const { breakdown } = pageResult.profiling;
-        const expectedChecks = ['dom', 'canonical', 'metatags', 'links', 'headings', 'readability', 'alt-text'];
+        const expectedChecks = ['body-size', 'lorem-ipsum', 'dom', 'canonical', 'metatags', 'links', 'headings', 'readability', 'alt-text'];
 
         expect(breakdown).to.be.an('array');
         expect(breakdown).to.have.lengthOf(expectedChecks.length);
@@ -1600,9 +1600,9 @@ describe('Preflight Audit', () => {
       await preflightAuditFunction(context);
 
       // Verify that AsyncJob.findById was called for job metadata update, each intermediate save and final save
-      // (total of 9 calls: 1 metadata update + 7 intermediate saves (incl. alt-text) + 1 final)
+      // (total of 11 calls: 1 metadata update + 9 intermediate saves (body-size, lorem-ipsum, dom, canonical, metatags, links, headings, readability, alt-text) + 1 final)
       expect(context.dataAccess.AsyncJob.findById).to.have.been.called;
-      expect(context.dataAccess.AsyncJob.findById.callCount).to.equal(9);
+      expect(context.dataAccess.AsyncJob.findById.callCount).to.equal(11);
     });
 
     it('handles errors during intermediate saves gracefully', async () => {


### PR DESCRIPTION
## Summary

- Adds dedicated `body-size.js` handler: detects pages with body text ≤ 100 characters, shapes to `check: 'content-length'`
- Adds dedicated `lorem-ipsum.js` handler: detects placeholder text, deduplicates to innermost elements (cap 10), shapes to `check: 'placeholder-text'`
- Both run in a **pre-DOM phase** in `handler.js` so their audit entries appear first in the result array
- Adds `AUDIT_BODY_SIZE`, `AUDIT_LOREM_IPSUM`, `PREFLIGHT_AUDIT_TYPE_SEO` to `audit-constants.js` to avoid circular imports

> ⚠️ **Do not merge** — draft PR exists to trigger `branch-deploy` CI for dev alias testing only.

## Test plan

- [ ] CI passes (unit + integration tests)
- [ ] `branch-deploy` deploys to `clotton` alias in dev
- [ ] Controlled S3 injection test confirms `placeholder-text` / `content-length` audit entries appear in job results

🤖 Generated with [Claude Code](https://claude.com/claude-code)