### PR TITLE
fix(offsite-brand-presence): dispatch analysis audits per-bucket + raise DRS poll budget

### DIFF
--- a/src/offsite-brand-presence/constants.js
+++ b/src/offsite-brand-presence/constants.js
@@ -68,9 +68,10 @@ export const REDDIT_URL_REGEX = /^https:\/\/(www)?\.?reddit\.com\/([rt]|user)\/[
 export const DRS_POLL_INTERVAL_SECONDS = 300; // 5 minutes between polls
 // The top-cited bucket scrapes arbitrary third-party web pages via BrightData, which is
 // substantially slower than the structured youtube/reddit collectors and can exceed an
-// hour. A 60-minute budget caused top-cited to time out while the other datasets finished,
-// so cited-analysis was never auto-triggered. Give the poller enough room to see the
-// slow scrape terminalize. (LLMO)
+// hour. Each analysis audit is now dispatched as soon as its own bucket finishes (see the
+// drs-status handler), so this budget only bounds how long the poller waits for a straggler
+// like top-cited before giving up — a 60-minute budget caused cited-analysis to be dropped
+// while the faster buckets finished. Give the slow scrape room to terminalize. (LLMO)
 export const DRS_POLL_MAX_WAIT_SECONDS = 10800; // 3 hour total budget
 export const DRS_STATUS_AUDIT_TYPE = 'offsite-brand-presence-drs-status';
 export const DRS_TERMINAL_STATUSES = new Set([

--- a/src/offsite-brand-presence/constants.js
+++ b/src/offsite-brand-presence/constants.js
@@ -66,7 +66,12 @@ export const REDDIT_URL_REGEX = /^https:\/\/(www)?\.?reddit\.com\/([rt]|user)\/[
 
 // DRS job completion polling (offsite-brand-presence-drs-status handler).
 export const DRS_POLL_INTERVAL_SECONDS = 300; // 5 minutes between polls
-export const DRS_POLL_MAX_WAIT_SECONDS = 3600; // 60 minute total budget
+// The top-cited bucket scrapes arbitrary third-party web pages via BrightData, which is
+// substantially slower than the structured youtube/reddit collectors and can exceed an
+// hour. A 60-minute budget caused top-cited to time out while the other datasets finished,
+// so cited-analysis was never auto-triggered. Give the poller enough room to see the
+// slow scrape terminalize. (LLMO)
+export const DRS_POLL_MAX_WAIT_SECONDS = 10800; // 3 hour total budget
 export const DRS_STATUS_AUDIT_TYPE = 'offsite-brand-presence-drs-status';
 export const DRS_TERMINAL_STATUSES = new Set([
   'COMPLETED',

--- a/src/offsite-brand-presence/drs-status-handler.js
+++ b/src/offsite-brand-presence/drs-status-handler.js
@@ -70,57 +70,103 @@ async function hasRecentAudit(siteId, auditType, dataAccess, log) {
 }
 
 /**
- * Triggers the downstream analysis audits for every domain whose scrape jobs produced
- * usable data (a DRS_SUCCESS_STATUSES terminal status). Each audit type is triggered at
- * most once. The originating Slack context is forwarded so each analysis audit posts its
- * results to the same thread. Domains that failed, were cancelled, or are still running
- * at the deadline are skipped — there is no fresh data to analyze.
+ * Groups the per-job statuses by the analysis audit type that consumes them and returns
+ * the audit types that are ready to dispatch on this poll.
  *
- * An audit type is also skipped when a recent audit of the same type already exists for
- * the site (within AUDIT_TRIGGER_COOLDOWN_MS). This prevents duplicate analysis runs
- * caused by SQS at-least-once redelivery of the poll completion message.
+ * An audit type is ready when at least one of its jobs reached a DRS_SUCCESS_STATUSES
+ * status AND either:
+ *   - every job feeding that audit type is terminal (so Mystique analyzes complete data —
+ *     e.g. youtube-analysis waits for both youtube_videos and youtube_comments), or
+ *   - the polling deadline has passed (best-effort dispatch with whatever finished).
+ *
+ * Audit types already dispatched on an earlier poll (tracked in `alreadyTriggered`) are
+ * excluded so each type is triggered at most once. Different audit types are independent:
+ * a fast bucket (reddit) is returned as soon as it is ready without waiting for a slow one
+ * (top-cited/cited-analysis).
  *
  * @param {Array<{domain: string, status: string|undefined}>} statuses - Per-job statuses
+ * @param {boolean} deadlineReached - Whether the overall polling deadline has passed
+ * @param {Set<string>} alreadyTriggered - Audit types dispatched on a previous poll
+ * @returns {string[]} Audit types to trigger now
+ */
+function computeReadyAuditTypes(statuses, deadlineReached, alreadyTriggered) {
+  const groups = new Map();
+  for (const s of statuses) {
+    const auditType = resolveAnalysisAuditType(s.domain);
+    if (!auditType) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    if (!groups.has(auditType)) {
+      groups.set(auditType, []);
+    }
+    groups.get(auditType).push(s);
+  }
+
+  const ready = [];
+  for (const [auditType, groupJobs] of groups) {
+    if (alreadyTriggered.has(auditType)) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    const allGroupTerminal = groupJobs.every((s) => DRS_TERMINAL_STATUSES.has(s.status));
+    const anySuccess = groupJobs.some((s) => DRS_SUCCESS_STATUSES.has(s.status));
+    if (anySuccess && (allGroupTerminal || deadlineReached)) {
+      ready.push(auditType);
+    }
+  }
+  return ready;
+}
+
+/**
+ * Triggers the given downstream analysis audit types, forwarding the originating Slack
+ * context so each posts its results to the same thread.
+ *
+ * An audit type is skipped (but still reported as handled) when a recent audit of the same
+ * type already exists for the site (within AUDIT_TRIGGER_COOLDOWN_MS); this dedupes SQS
+ * at-least-once redelivery. A per-type send failure is logged and the type is NOT reported
+ * as handled, so the next poll retries it.
+ *
+ * @param {string[]} auditTypes - Analysis audit types to trigger
  * @param {string} siteId - The site ID
  * @param {object} slackContext - { channelId, threadTs } forwarded to the triggered audits
  * @param {object} context - Universal context (sqs, dataAccess, log)
+ * @returns {Promise<string[]>} Audit types that were dispatched or intentionally skipped
  */
-async function triggerAnalysisAudits(statuses, siteId, slackContext, context) {
+async function triggerAnalysisAudits(auditTypes, siteId, slackContext, context) {
   const { sqs, dataAccess, log } = context;
 
-  const auditTypes = new Set();
-  for (const s of statuses) {
-    if (DRS_SUCCESS_STATUSES.has(s.status)) {
-      const auditType = resolveAnalysisAuditType(s.domain);
-      if (auditType) {
-        auditTypes.add(auditType);
-      }
-    }
-  }
-
-  if (auditTypes.size === 0) {
-    return;
+  const handled = [];
+  if (auditTypes.length === 0) {
+    return handled;
   }
 
   const configuration = await dataAccess.Configuration.findLatest();
   const queueUrl = configuration.getQueues().audits;
   for (const type of auditTypes) {
-    // eslint-disable-next-line no-await-in-loop
-    if (await hasRecentAudit(siteId, type, dataAccess, log)) {
-      log.info(`${LOG_PREFIX} Skipping ${type} for site ${siteId} — recent audit exists`);
-      // eslint-disable-next-line no-continue
-      continue;
+    try {
+      // eslint-disable-next-line no-await-in-loop
+      if (await hasRecentAudit(siteId, type, dataAccess, log)) {
+        log.info(`${LOG_PREFIX} Skipping ${type} for site ${siteId} — recent audit exists`);
+        handled.push(type);
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      // eslint-disable-next-line no-await-in-loop
+      await sqs.sendMessage(queueUrl, {
+        type,
+        siteId,
+        // DRS scraping is already done, so the analysis audit must analyze the available
+        // data rather than request another scrape (prevents a scrape→analyze loop).
+        auditContext: { slackContext, drsScrapeRequested: true },
+      });
+      log.info(`${LOG_PREFIX} Triggered ${type} for site ${siteId}`);
+      handled.push(type);
+    } catch (err) {
+      log.warn(`${LOG_PREFIX} Failed to trigger ${type} analysis audit for site ${siteId}: ${err.message}`);
     }
-    // eslint-disable-next-line no-await-in-loop
-    await sqs.sendMessage(queueUrl, {
-      type,
-      siteId,
-      // DRS scraping is already done, so the analysis audit must analyze the available
-      // data rather than request another scrape (prevents a scrape→analyze loop).
-      auditContext: { slackContext, drsScrapeRequested: true },
-    });
-    log.info(`${LOG_PREFIX} Triggered ${type} for site ${siteId}`);
   }
+  return handled;
 }
 
 /**
@@ -157,8 +203,15 @@ function buildSummary(baseURL, statuses) {
  * manual Slack run. Re-enqueues itself with an SQS delay until every job is terminal
  * or the deadline passes, then posts a single completion summary to the Slack thread.
  *
+ * Each downstream analysis audit is dispatched as soon as its own dataset(s) reach a
+ * terminal success status, rather than waiting for every bucket to finish. This keeps a
+ * fast bucket (e.g. reddit) from being held back by a slow one (e.g. top-cited, which
+ * scrapes arbitrary third-party pages via BrightData and can take far longer). The set of
+ * already-dispatched audit types travels with the re-enqueued poll message so each type is
+ * triggered at most once across the poll lifecycle.
+ *
  * @param {object} message - SQS message with auditContext { baseURL, slackContext,
- *   jobs: [{domain, datasetId, jobId}], deadline }
+ *   jobs: [{domain, datasetId, jobId}], deadline, triggeredAuditTypes? }
  * @param {object} context - Universal context (log, sqs, dataAccess, env)
  * @returns {Promise<Response>}
  */
@@ -167,7 +220,7 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
   const { Configuration } = dataAccess;
   const { siteId, auditContext = {} } = message;
   const {
-    baseURL, slackContext = {}, jobs = [], deadline,
+    baseURL, slackContext = {}, jobs = [], deadline, triggeredAuditTypes = [],
   } = auditContext;
   const { channelId, threadTs } = slackContext;
 
@@ -190,36 +243,49 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
 
   const terminalCount = statuses.filter((s) => DRS_TERMINAL_STATUSES.has(s.status)).length;
   const allTerminal = terminalCount === statuses.length;
-
   const now = Date.now();
-  if (!allTerminal && now < deadline) {
+  const deadlineReached = now >= deadline;
+
+  // Dispatch the analysis audits for any buckets that just became ready, so early-finishing
+  // datasets go to Mystique immediately instead of waiting for the slowest job. Best-effort:
+  // a failure here must not abort the poll loop or cause the message to be redelivered.
+  const alreadyTriggered = new Set(triggeredAuditTypes);
+  let handled = [];
+  try {
+    const readyTypes = computeReadyAuditTypes(statuses, deadlineReached, alreadyTriggered);
+    handled = await triggerAnalysisAudits(readyTypes, siteId, slackContext, context);
+  } catch (err) {
+    log.warn(`${LOG_PREFIX} Failed to trigger analysis audits for ${baseURL}: ${err.message}`);
+  }
+  const nextTriggered = [...alreadyTriggered, ...handled];
+
+  // Keep polling until every job is terminal or the deadline passes. Carry the set of
+  // already-dispatched audit types forward so they are not re-triggered on later polls.
+  if (!allTerminal && !deadlineReached) {
     const delaySeconds = Math.min(
       DRS_POLL_INTERVAL_SECONDS,
       Math.max(0, Math.ceil((deadline - now) / 1000)),
       SQS_MAX_DELAY_SECONDS,
     );
     const configuration = await Configuration.findLatest();
-    await sqs.sendMessage(configuration.getQueues().audits, message, null, delaySeconds);
+    const nextMessage = {
+      ...message,
+      auditContext: { ...auditContext, triggeredAuditTypes: nextTriggered },
+    };
+    await sqs.sendMessage(configuration.getQueues().audits, nextMessage, null, delaySeconds);
     log.info(`${LOG_PREFIX} ${terminalCount}/${statuses.length} jobs terminal for ${baseURL}, re-polling in ${delaySeconds}s`);
     return ok();
   }
 
+  // Final poll (all jobs terminal or deadline reached): post the one-time completion
+  // summary. Analysis audits for terminal buckets were already dispatched above.
+  //
   // Accepted trade-off: SQS at-least-once delivery means a crash after this post but
   // before the message is deleted could redeliver and post the summary twice. There is
   // no idempotency key; a duplicate Slack summary is preferable to the complexity of
   // deduplication for a best-effort notification.
   await postMessageOptional(context, channelId, buildSummary(baseURL, statuses), { threadTs });
   log.info(`${LOG_PREFIX} Posted completion summary for ${baseURL} (${statuses.length} jobs)`);
-
-  // Auto-trigger the analysis audits for domains whose scrapes succeeded, so the
-  // offsite-brand-presence run no longer needs reddit/youtube/cited/wikipedia to be
-  // triggered manually. Best-effort: a failure here must not cause the message to be
-  // redelivered (which would re-post the summary and re-trigger the audits).
-  try {
-    await triggerAnalysisAudits(statuses, siteId, slackContext, context);
-  } catch (err) {
-    log.warn(`${LOG_PREFIX} Failed to trigger analysis audits for ${baseURL}: ${err.message}`);
-  }
 
   return ok();
 }

--- a/test/audits/offsite-brand-presence-drs-status.test.js
+++ b/test/audits/offsite-brand-presence-drs-status.test.js
@@ -139,14 +139,18 @@ describe('offsite-brand-presence DRS status handler', () => {
 
     expect(result.status).to.equal(200);
     expect(mockPostMessageOptional).to.not.have.been.called;
-    expect(context.sqs.sendMessage).to.have.been.calledOnce;
-    const [queueUrl, sentMessage, groupId, delaySeconds] = context.sqs.sendMessage.firstCall.args;
+    // The completed reddit bucket is dispatched now; the poll is re-enqueued for youtube.
+    const pollCall = context.sqs.sendMessage.getCalls()
+      .find((c) => c.args[1].type === 'offsite-brand-presence-drs-status');
+    expect(pollCall).to.not.be.undefined;
+    const [queueUrl, sentMessage, groupId, delaySeconds] = pollCall.args;
     expect(queueUrl).to.equal('audits-queue-url');
-    expect(sentMessage.type).to.equal('offsite-brand-presence-drs-status');
     expect(sentMessage.auditContext.jobs).to.have.length(2);
     // The absolute deadline must be preserved across re-enqueues so the wait budget
     // genuinely bounds total polling time regardless of SQS delivery jitter.
     expect(sentMessage.auditContext.deadline).to.equal(originalDeadline);
+    // Already-dispatched audit types travel with the poll so they are not re-triggered.
+    expect(sentMessage.auditContext.triggeredAuditTypes).to.include('reddit-analysis');
     expect(groupId).to.equal(null);
     expect(delaySeconds).to.equal(300);
   });
@@ -187,7 +191,10 @@ describe('offsite-brand-presence DRS status handler', () => {
 
     expect(result.status).to.equal(200);
     expect(mockPostMessageOptional).to.not.have.been.called;
-    expect(context.sqs.sendMessage).to.have.been.calledOnce;
+    // reddit completed → dispatched now; youtube errored (non-terminal) → keep polling.
+    const sentTypes = context.sqs.sendMessage.getCalls().map((c) => c.args[1].type);
+    expect(sentTypes).to.include('reddit-analysis');
+    expect(sentTypes).to.include('offsite-brand-presence-drs-status');
     expect(log.warn).to.have.been.calledWithMatch(/getJob failed for job-2/);
   });
 
@@ -298,7 +305,7 @@ describe('offsite-brand-presence DRS status handler', () => {
 
       expect(result.status).to.equal(200);
       expect(mockPostMessageOptional).to.have.been.calledOnce;
-      expect(log.warn).to.have.been.calledWithMatch(/Failed to trigger analysis audits/);
+      expect(log.warn).to.have.been.calledWithMatch(/Failed to trigger .* analysis audit for site/);
     });
 
     it('skips an audit type when a recent audit exists within the cooldown window', async () => {
@@ -344,6 +351,69 @@ describe('offsite-brand-presence DRS status handler', () => {
       expect(types).to.include('reddit-analysis');
       expect(types).to.include('youtube-analysis');
       expect(log.warn).to.have.been.calledWithMatch(/Failed to check recent/);
+    });
+
+    it('dispatches a completed bucket immediately while still polling for a slower one', async () => {
+      mockGetJob.withArgs('job-1').resolves({ status: 'COMPLETED' }); // reddit
+      mockGetJob.withArgs('job-2').resolves({ status: 'RUNNING' }); // youtube
+
+      await handler.default(buildMessage(), context);
+
+      const sentTypes = context.sqs.sendMessage.getCalls().map((c) => c.args[1].type);
+      expect(sentTypes).to.include('reddit-analysis');
+      expect(sentTypes).to.not.include('youtube-analysis');
+      // Still polling for the running youtube job; no summary until everything resolves.
+      expect(sentTypes).to.include('offsite-brand-presence-drs-status');
+      expect(mockPostMessageOptional).to.not.have.been.called;
+    });
+
+    it('does not re-dispatch an audit type already triggered on a previous poll', async () => {
+      mockGetJob.withArgs('job-1').resolves({ status: 'COMPLETED' }); // reddit
+      mockGetJob.withArgs('job-2').resolves({ status: 'RUNNING' }); // youtube
+
+      await handler.default(
+        buildMessage({ triggeredAuditTypes: ['reddit-analysis'] }),
+        context,
+      );
+
+      const sentTypes = context.sqs.sendMessage.getCalls().map((c) => c.args[1].type);
+      expect(sentTypes).to.not.include('reddit-analysis');
+      const pollCall = context.sqs.sendMessage.getCalls()
+        .find((c) => c.args[1].type === 'offsite-brand-presence-drs-status');
+      expect(pollCall.args[1].auditContext.triggeredAuditTypes).to.include('reddit-analysis');
+    });
+
+    it('waits for all datasets of an audit type before dispatching it', async () => {
+      mockGetJob.withArgs('job-yv').resolves({ status: 'COMPLETED' });
+      mockGetJob.withArgs('job-yc').resolves({ status: 'RUNNING' });
+
+      await handler.default(buildMessage({
+        jobs: [
+          { domain: 'youtube.com', datasetId: 'youtube_videos', jobId: 'job-yv' },
+          { domain: 'youtube.com', datasetId: 'youtube_comments', jobId: 'job-yc' },
+        ],
+      }), context);
+
+      // One dataset still running → hold youtube-analysis; only the poll is re-enqueued.
+      const sentTypes = context.sqs.sendMessage.getCalls().map((c) => c.args[1].type);
+      expect(sentTypes).to.deep.equal(['offsite-brand-presence-drs-status']);
+    });
+
+    it('dispatches with partial data at the deadline if a dataset is still running', async () => {
+      mockGetJob.withArgs('job-yv').resolves({ status: 'COMPLETED' });
+      mockGetJob.withArgs('job-yc').resolves({ status: 'RUNNING' });
+
+      await handler.default(buildMessage({
+        jobs: [
+          { domain: 'youtube.com', datasetId: 'youtube_videos', jobId: 'job-yv' },
+          { domain: 'youtube.com', datasetId: 'youtube_comments', jobId: 'job-yc' },
+        ],
+        deadline: Date.now() - 1,
+      }), context);
+
+      const sentTypes = context.sqs.sendMessage.getCalls().map((c) => c.args[1].type);
+      expect(sentTypes).to.include('youtube-analysis');
+      expect(mockPostMessageOptional).to.have.been.calledOnce;
     });
   });
 });

--- a/test/audits/offsite-brand-presence-drs-status.test.js
+++ b/test/audits/offsite-brand-presence-drs-status.test.js
@@ -399,6 +399,20 @@ describe('offsite-brand-presence DRS status handler', () => {
       expect(sentTypes).to.deep.equal(['offsite-brand-presence-drs-status']);
     });
 
+    it('does not fail the run when resolving the audits queue throws', async () => {
+      mockGetJob.withArgs('job-1').resolves({ status: 'COMPLETED' });
+      mockGetJob.withArgs('job-2').resolves({ status: 'COMPLETED' });
+      // Rejecting Configuration.findLatest makes triggerAnalysisAudits throw before its
+      // per-type try/catch, exercising the handler's outer safety net.
+      context.dataAccess.Configuration.findLatest.rejects(new Error('config down'));
+
+      const result = await handler.default(buildMessage(), context);
+
+      expect(result.status).to.equal(200);
+      expect(mockPostMessageOptional).to.have.been.calledOnce;
+      expect(log.warn).to.have.been.calledWithMatch(/Failed to trigger analysis audits for/);
+    });
+
     it('dispatches with partial data at the deadline if a dataset is still running', async () => {
       mockGetJob.withArgs('job-yv').resolves({ status: 'COMPLETED' });
       mockGetJob.withArgs('job-yc').resolves({ status: 'RUNNING' });


### PR DESCRIPTION
## Summary
The offsite-brand-presence DRS status poller used to trigger **all** downstream analysis audits in a single batch, only once *every* scrape job was terminal or the 60-minute deadline passed. This coupled fast buckets to slow ones and dropped slow ones entirely:

- A completed `reddit`/`youtube` scrape had to wait for the slow `top-cited` BrightData scrape before any analysis was sent to Mystique.
- When `top-cited` (arbitrary third-party pages, ~70 URLs) didn't terminalize inside the 60-min budget, `cited-analysis` was **never triggered** — even though the scrape finished shortly after.

This PR makes two changes:

### 1. Per-bucket dispatch (`drs-status-handler.js`)
- Each analysis audit is dispatched **as soon as its own dataset(s)** reach a terminal success status, independently of the other buckets.
- An audit type fires once **all of its jobs** are terminal (so Mystique gets complete data — e.g. `youtube-analysis` waits for both `youtube_videos` and `youtube_comments`), or, **at the deadline**, best-effort with whatever finished (preserving prior timeout behavior).
- The set of already-dispatched audit types travels with the re-enqueued poll message (`auditContext.triggeredAuditTypes`) so each type is triggered **at most once** across the poll lifecycle. The existing `AUDIT_TRIGGER_COOLDOWN_MS` guard still dedupes SQS redelivery.
- The poller keeps re-enqueuing for stragglers and posts the single Slack summary when all jobs are terminal or the deadline is reached.

### 2. Raise the poll budget (`constants.js`)
- `DRS_POLL_MAX_WAIT_SECONDS` `3600` → `10800`. With per-bucket dispatch, this now only bounds how long we wait for a **straggler** (top-cited) before giving up — fast buckets are no longer delayed by it.

### Net effect
- `reddit`/`youtube` analysis dispatch to Mystique immediately when ready (no more waiting on the slowest bucket).
- `cited-analysis` is triggered as soon as the slow top-cited scrape completes, up to the 3h straggler budget.

### Observed incident (us.kisqali.com, 2026-07-17)
5 DRS jobs submitted; youtube/reddit went terminal within ~5 min but `top-cited` (jobId `6b0251a7…`) never terminalized within 60 min → poller posted "still running (timed out waiting)" and never triggered `cited-analysis`. A later manual `cited-analysis` run succeeded instantly because the DRS store already had the (now-complete) content.

## Changes
- `src/offsite-brand-presence/drs-status-handler.js`: per-audit-type readiness (`computeReadyAuditTypes`), per-poll dispatch, `triggeredAuditTypes` tracking carried across re-enqueues, resilient per-type triggering.
- `src/offsite-brand-presence/constants.js`: `DRS_POLL_MAX_WAIT_SECONDS` `3600` → `10800`.
- `test/audits/offsite-brand-presence-drs-status.test.js`: updated existing tests for early dispatch + 4 new tests (early dispatch while polling, no re-dispatch of already-triggered types, wait-for-all-datasets, deadline partial dispatch).

## Test plan
- [x] `npx mocha test/audits/offsite-brand-presence-drs-status.test.js` — 23 passing.
- [x] `npx mocha test/audits/offsite-brand-presence-drs-status.test.js test/audits/offsite-brand-presence.test.js test/audits/cited-analysis/handler.test.js` — 157 passing.
- [x] Lint clean on changed files.