### PR TITLE
docs: add offsite cited-URL Semrush migration plan

### DIFF
--- a/docs/plans/2026-07-17-offsite-cited-urls-semrush-migration.md
+++ b/docs/plans/2026-07-17-offsite-cited-urls-semrush-migration.md
@@ -1,0 +1,328 @@
+# Migrate Offsite Cited-URL Sourcing to the Semrush API
+
+**Status:** Draft / proposal
+**Author:** (TBD)
+**Date:** 2026-07-17
+**Scope:** `spacecat-audit-worker` (`offsite-brand-presence` audit) + `spacecat-api-service` (SR AI Visibility layer)
+
+---
+
+## 1. Goal
+
+Today the `offsite-brand-presence` audit selects the cited URLs it feeds to DRS
+(YouTube, Reddit, and top third-party "cited" sources) from **weekly Brand-Presence
+Excel sheets read out of SharePoint**. We want to source those same URLs — filtered
+by platform and ordered by citation count — from the **Semrush API** instead.
+
+Downstream of URL selection (URL store, DRS scraping, poll, and the
+`cited-analysis` / `youtube-analysis` / `reddit-analysis` audits that hand off to
+Mystique) is **unchanged**. This migration only replaces the *data acquisition and
+ranking input*.
+
+---
+
+## 2. Current pipeline (what we are replacing)
+
+All in `spacecat-audit-worker/src/offsite-brand-presence/`.
+
+| Step | Code | Notes |
+|---|---|---|
+| Determine weeks | `getPreviousWeeks` (`utils/offsite-brand-presence-enrichment.js`) | multi-week window |
+| Load data | `loadBrandPresenceData` (`utils/offsite-brand-presence-enrichment.js:~368`) | reads `brandpresence-*-wNN-YYYY` sheets from SharePoint via `createLLMOSharepointClient`; `Sources` column holds cited URLs |
+| Parse + classify | `extractUrlsAndTopics` → `classifyAndNormalize` (`handler.js:259`, `:165`) | splits `row.Sources` on `[;\n]`, filters `ACCEPTED_REGIONS`, drops owned/social/brand-lookalike hosts, classifies `youtube.com`/`reddit.com` by regex, tags `wikipedia.org` as excluded. Builds `allUrls: Map<url, { count, domain }>` where **`count` = citation frequency** |
+| Rank + bucket | `selectTopUrls(allUrls, DRS_URLS_LIMIT, excluded)` (`handler.js:644`) | sort by `count` desc → `topByDomain['youtube.com']`, `topByDomain['reddit.com']` (cap 70 each) + `topCited` (top 70, excl. offsite + wikipedia) |
+| Store | `addUrlsToUrlStore` (`handler.js:316`) | writes `AuditUrl` tagged with `youtube-analysis` / `reddit-analysis` / `cited-analysis` |
+| Scrape | `triggerDrsScraping` → `@adobe/spacecat-shared-drs-client` | YouTube videos/comments, Reddit posts/comments, top-cited via BrightData |
+| Poll + trigger | `offsite-brand-presence-drs-status` handler | fires the analysis audits when each bucket completes |
+
+Relevant constants (`offsite-brand-presence/constants.js`):
+
+```js
+export const OFFSITE_DOMAINS = { 'youtube.com': {...}, 'reddit.com': {...} };
+export const CITED_ANALYSIS_DRS_CONFIG = { auditType: CITED_ANALYSIS, ... };
+export const DRS_URLS_LIMIT = 70;
+export const ACCEPTED_REGIONS = new Set(['US','GB','CA','AU','IE','NZ']);
+export const YOUTUBE_URL_REGEX = /.../;  export const REDDIT_URL_REGEX = /.../;
+export const TOP_CITED_EXCLUDED_DOMAINS = ['wikipedia.org'];
+```
+
+**Migration surface = produce `allUrls: Map<url, { count, domain }>` from Semrush,
+then let the existing `classifyAndNormalize` / `selectTopUrls` / DRS path run
+unchanged.** `count` must be a citation-volume proxy so the top-70 ranking is
+preserved.
+
+---
+
+## 3. Which URLs? — `MENTIONS_TARGET` vs the (B) union
+
+Semrush's `sources` universe is **all URLs cited in AI answers for the brand's
+prompts**. The source-category enum (`third-party/ai-seo-ts/v2/source/enums_pb.d.ts`)
+only sub-classifies those cited URLs by whether their content mentions the brand —
+it is a **separate axis** from how many times a URL was cited:
+
+| Category | Meaning | Notes |
+|---|---|---|
+| `OWNED_BY_TARGET` (1) | Brand's own URLs | today's `/brands/cited-pages` "owned" tab; **excluded** from offsite scraping |
+| `MENTIONS_TARGET` (2) | Non-owned cited URLs Semrush **already classified as mentioning the brand** | narrower set; a URL can be here with *few* citations (citation count is independent) |
+| `MISSES_TARGET` (3) | Non-owned cited URLs that do **not** mention the brand | |
+
+Two options:
+
+- **Option A — `MENTIONS_TARGET` only.** Non-owned URLs Semrush is *already sure*
+  mention the brand. Smaller, pre-filtered set. Changes behavior: the top-cited
+  bucket shrinks and only ever contains pages Semrush thinks mention the brand.
+- **Option B — union of `MENTIONS_TARGET` + `MISSES_TARGET`.** All non-owned cited
+  URLs — i.e. the URL Inspector "cited third-party" concept. Whether the page
+  actually mentions the brand is decided **downstream** by the DRS scrape + the
+  cited/sentiment analysis in Mystique, not pre-filtered by Semrush.
+
+> **Recommendation: Option B (union).** This matches today's behavior — the current
+> `classifyAndNormalize` keeps *all* earned, non-owned, non-social cited URLs and
+> never pre-filters on "mentions the brand." Use Option A only if you deliberately
+> want a tighter, mentions-confirmed cited bucket.
+
+Implementation note: a single `sources` gRPC call takes **one** category, so the
+union is **two calls (`MENTIONS_TARGET` + `MISSES_TARGET`) merged**, or one call
+with `UNSPECIFIED` (0) filtered to drop `OWNED_BY_TARGET` — to be confirmed against
+the gRPC behavior.
+
+---
+
+## 4. The time-window constraint (read before choosing an option)
+
+Semrush SR data is a **point-in-time snapshot, not a rolling date range**. The
+request field `SourcesRequest.target_date` accepts `YYYY-MM` (monthly) **or**
+`YYYY-MM-DD` (single day) — there is no "last 7 days" range on the v2 gRPC API.
+(`Range` in the request is pagination only: `limit`/`offset`.)
+
+Consequence for weekly audit runs:
+- A `YYYY-MM` snapshot is month-to-date and grows through the month. Two runs a week
+  apart return a **heavily overlapping** set. The URL store already dedups
+  (`addUrlsToUrlStore` skips existing URLs), so weekly runs effectively **top up**
+  with newly-cited URLs and the set only fully refreshes at **month rollover**.
+- This is a **behavior change** from today's multi-week Excel aggregation.
+
+The **only** Semrush surface that supports a true weekly rolling window is the
+**v4-raw Element-level API** (`start_date`/`end_date`, daily granularity). That
+drives the choice between Option 1 and Option 2 below.
+
+---
+
+## 5. Implementation options — easiest → hardest
+
+### Option 1 — HTTP via SR AI Visibility (snapshot). **Easiest. Recommended default.**
+
+Reuse the Semrush integration already wired into `spacecat-api-service` (gRPC
+transport, auth, normalization). The audit-worker calls a new HTTP endpoint.
+
+**Trade-off:** snapshot semantics (monthly/daily), not weekly ranges (see §4). Best
+when weekly freshness is not a hard requirement.
+
+#### 5.1 Backend changes (`spacecat-api-service`)
+
+The exposed `/brands/cited-pages` hardcodes owned URLs and cannot serve third-party:
+
+```js
+// src/support/ai-visibility/handlers/brands.js  (handleBrandCitedPages)
+const listReq = {
+  country, llm: llmEnum, target,
+  category: SOURCE_CATEGORY_ENUM.OWNED_BY_TARGET,   // <-- owned only
+  order, range: { limit, offset },
+};
+```
+
+Add a third-party cited-URLs endpoint:
+
+1. **New handler** `handleBrandCitedSourceUrls(sp, clients)` in
+   `src/support/ai-visibility/handlers/brands.js`:
+   - Read `domain`, `country`/`region`, `month` (`YYYY-MM`), `engine` (`llm`),
+     `limit`, `offset`, and a new `category` (default = union).
+   - For **Option B (union)**: call `clients.sourceClient.sources(...)` once per
+     category (`MENTIONS_TARGET`, `MISSES_TARGET`), `order: { by: PROMPTS_COUNT }`,
+     merge by URL, sum `prompts_count`.
+   - For **Option A**: single call with `MENTIONS_TARGET`.
+   - Map rows with the existing `mapSourceRowToCitedPage` → `{ pageUrl, responses }`.
+2. **Register the route** in `src/controllers/ai-visibility.js` `ROUTE_MAP` and
+   `src/routes/index.js`:
+   ```js
+   // ROUTE_MAP
+   ['/brands/cited-source-urls', handleBrandCitedSourceUrls],
+   // routes/index.js
+   'GET /llmo/ai-visibility/brands/cited-source-urls': aiVisibilityController.getBrandsCitedSourceUrls,
+   ```
+3. **Tests** in `test/support/ai-visibility/handlers/brands.test.js`.
+
+**Proposed API**
+
+```
+GET /llmo/ai-visibility/brands/cited-source-urls
+  ?domain=adobe.com
+  &region=US
+  &month=2026-06            # YYYY-MM snapshot (or YYYY-MM-DD)
+  &engine=ALL
+  &category=union           # union | mentions
+  &limit=200&offset=0
+```
+
+```jsonc
+// 200
+{
+  "data": [
+    { "pageUrl": "https://www.reddit.com/r/.../comments/...", "responses": 42 },
+    { "pageUrl": "https://www.youtube.com/watch?v=...",       "responses": 31 }
+  ],
+  "total": 1234, "offset": 0, "limit": 200
+}
+```
+
+#### 5.2 Audit-worker changes (`spacecat-audit-worker`)
+
+The worker has **no** SR/Semrush client today (confirmed) — add a thin HTTP client.
+
+1. **New module** `src/offsite-brand-presence/semrush-source.js`:
+   `loadCitedUrlsFromSemrush(site, context, { regions, month, engine, category })`
+   - For each region in `ACCEPTED_REGIONS`, call
+     `/llmo/ai-visibility/brands/cited-source-urls` with pagination, collecting
+     **enough** rows to fill 70 YouTube + 70 Reddit + 70 top-cited (these are
+     long-tail, so page well past 70 total — e.g. until `offset >= total` or a page
+     cap).
+   - Build `allUrls: Map<url, { count, domain }>`, `count = sum(responses)` across
+     regions, `domain = null` (let `classifyAndNormalize` assign it), shaped
+     **exactly** like today's `extractUrlsAndTopics` output.
+   - Config: base URL (spacecat-api-service) + auth from `context.env`.
+2. **Swap the source** in `handler.js` behind a flag:
+   ```js
+   const raw = useSemrushSource
+     ? await loadCitedUrlsFromSemrush(site, context, { regions: [...ACCEPTED_REGIONS], month, engine, category })
+     : await loadBrandPresenceData(...);   // legacy SharePoint path
+   ```
+   Feed `raw` through the **existing** `classifyAndNormalize` (keeps YouTube/Reddit
+   regex filtering, owned/social/brand exclusion, wikipedia tagging), then
+   `selectTopUrls(allUrls, DRS_URLS_LIMIT, ...)` unchanged.
+3. **Topic enrichment** (`trackTopicUrl`) has no Semrush equivalent from
+   cited-source-urls alone — either drop topic enrichment on the Semrush path or
+   backfill it from another SR endpoint (decide during build).
+
+#### 5.3 Parameter / semantics mapping
+
+| Concept | Today | Semrush (Option 1) | Action |
+|---|---|---|---|
+| Time window | multi-week aggregation | monthly/daily snapshot | pick `month=YYYY-MM` (month-to-date) — see §4 |
+| Region | `ACCEPTED_REGIONS` (US/GB/CA/AU/IE/NZ) | `country` enum (`resolveCountry`, WW→US) | one call per region, aggregate |
+| Citation count | # appearances in `Sources` | `responses` / `prompts_count` | ranking proxy — validate top-70 overlap |
+| Engine | model-agnostic | `llm` (default `ALL`) | default `ALL` |
+| Owned exclusion | `classifyAndNormalize` drops owned | exclude `OWNED_BY_TARGET` | category selection |
+
+---
+
+### Option 2 — v4-raw Element API (weekly range). **Hardest. Needed for 100% behavioral replacement.**
+
+Use Semrush's Element-level API directly — the same data the URL Inspector UI shows,
+and the **only** path that supports a true weekly rolling window
+(`start_date`/`end_date`).
+
+**When to choose:** weekly freshness is non-negotiable and you want to preserve
+today's rolling multi-week semantics exactly.
+
+**Cost:** does **not** reuse the SR gRPC layer — the worker (or a new
+api-service endpoint) must talk to Semrush directly with an API key, workspace id,
+element ids, and a region→project mapping.
+
+#### 5.4 Elements (from the Brand Presence Data API mapping)
+
+> Concrete workspace/element IDs and the environment host are **internal** — do not
+> commit them to this public repo. Pull the actual values from the internal
+> *Brand Presence & URL Inspector Data API — Semrush Mapping* doc at build time
+> (URL Inspector §1.3 "Cited Domains" and §1.4 "Domain URLs" elements).
+
+```
+Base (backend):  https://api.semrush.com/apis/v4-raw/external-api/v1/
+                 workspaces/{WORKSPACE_ID}/products/ai/elements/{ELEMENT_ID}/data
+Workspace:       {WORKSPACE_ID}                 # internal — see mapping doc
+
+Cited Domains (rollup):  {CITED_DOMAINS_ELEMENT_ID}   # internal — URL Inspector §1.3
+Domain URLs (per-URL):   {DOMAIN_URLS_ELEMENT_ID}     # internal — URL Inspector §1.4 / §1.2
+```
+
+`POST` body (per PDF), with a true date range:
+
+```jsonc
+{
+  "render_data": {
+    "filters": {
+      "simple": { "CBF_date__start": "2026-06-11", "CBF_date__end": "2026-06-17" },
+      "advanced": { "op": "and", "filters": [
+        { "op": "eq", "val": "search-gpt", "col": "CBF_model" }
+        // + hostname scoping for youtube.com / reddit.com (confirm exact CBF column
+        //   for third-party source hostname against the Element-level API guide)
+      ]}
+    }
+  }
+}
+```
+
+Returned per-URL fields (`domain-urls`): `urlId`, `url`, `contentType`,
+`citations`, `promptsCited`, `categories`, `regions`, `totalCount`.
+
+#### 5.5 Flow (Option 2)
+
+1. **Per platform** (`youtube.com`, `reddit.com`): call `domain-urls` scoped to that
+   hostname over the trailing weekly window, order by `citations`, take top 70.
+2. **Top-cited bucket**: call `cited-domains` for the top third-party hostnames
+   (exclude owned + offsite + `wikipedia.org`), then `domain-urls` per hostname to
+   collect URLs, merge, rank by `citations`, take top 70. (Or a broader
+   all-third-party element if available — confirm.)
+3. Build `allUrls: Map<url, { count: citations, domain }>` → feed the existing
+   `classifyAndNormalize` / `selectTopUrls` path unchanged.
+4. **Where the call lives:** either (a) new `spacecat-api-service` endpoint that
+   proxies the element API (keeps the key server-side, mirrors Option 1's transport),
+   or (b) a direct client in the worker. (a) preferred for secret handling.
+
+#### 5.6 Extra work vs Option 1
+
+- Secret management for the Semrush API key (env/secret store) — never in the worker
+  bundle.
+- Region → Semrush `CBF_project` mapping (regions map to projects in Semrush).
+- Confirm the exact `CBF_*` column for third-party hostname scoping.
+- Two-hop retrieval for the top-cited bucket (`cited-domains` → `domain-urls`).
+
+---
+
+## 6. Recommendation & difficulty ladder
+
+| | Option 1 — HTTP / SR snapshot | Option 2 — Element API / weekly |
+|---|---|---|
+| Difficulty | **Low** | **High** |
+| Reuses existing Semrush transport/auth | Yes | No |
+| Time window | Monthly/daily snapshot | True weekly range (matches today) |
+| Behavioral parity with today | Approximate (snapshot) | 100% (rolling window) |
+| New secrets/config | Minimal | Semrush key + workspace/element ids + region→project map |
+| Retrieval hops | 1 endpoint | 2 (domains → urls) for top-cited |
+
+- **Start with Option 1 (union / Option B category).** Simplest, reuses everything,
+  ships behind a flag; accept snapshot semantics.
+- **Escalate to Option 2 only if** weekly freshness / exact rolling-window parity is
+  required.
+- Both feed the **same** `classifyAndNormalize` → `selectTopUrls` → DRS path; the
+  only difference is the loader module and the time-window semantics.
+
+---
+
+## 7. Rollout
+
+1. Land backend endpoint (Option 1) + tests.
+2. Land worker loader + flag (`useSemrushSource`, per-site/env).
+3. **Shadow-run**: compute Semrush top-70 (youtube/reddit/cited) and diff against the
+   current SharePoint-selected set for a known site; confirm parity with the URL
+   Inspector view already validated.
+4. Cut over per site; retire the SharePoint read once parity holds.
+
+---
+
+## 8. Open decisions
+
+- [ ] Category: **Option B (union)** [recommended] vs Option A (`MENTIONS_TARGET`).
+- [ ] Window: **monthly snapshot (Option 1)** [recommended] vs weekly range (Option 2).
+- [ ] Topic enrichment on the Semrush path: drop vs backfill.
+- [ ] Union mechanics: two-call merge vs `UNSPECIFIED` minus owned (confirm gRPC).
+- [ ] Option 2 only: exact `CBF_*` column for third-party hostname scoping.

--- a/docs/plans/2026-07-17-offsite-cited-urls-semrush-migration.md
+++ b/docs/plans/2026-07-17-offsite-cited-urls-semrush-migration.md
@@ -10,9 +10,10 @@
 ## 1. Goal
 
 Today the `offsite-brand-presence` audit selects the cited URLs it feeds to DRS
-(YouTube, Reddit, and top third-party "cited" sources) from **weekly Brand-Presence
-Excel sheets read out of SharePoint**. We want to source those same URLs — filtered
-by platform and ordered by citation count — from the **Semrush API** instead.
+(YouTube, Reddit, and top third-party "cited" sources) from **internal Brand-Presence
+execution data** — PostgREST for brandalf-enabled orgs, with a SharePoint Excel
+fallback. We want to source those same URLs — filtered by platform and ordered by
+citation count — from the **Semrush API** instead.
 
 Downstream of URL selection (URL store, DRS scraping, poll, and the
 `cited-analysis` / `youtube-analysis` / `reddit-analysis` audits that hand off to
@@ -28,7 +29,7 @@ All in `spacecat-audit-worker/src/offsite-brand-presence/`.
 | Step | Code | Notes |
 |---|---|---|
 | Determine weeks | `getPreviousWeeks` (`utils/offsite-brand-presence-enrichment.js`) | multi-week window |
-| Load data | `loadBrandPresenceData` (`utils/offsite-brand-presence-enrichment.js:~368`) | reads `brandpresence-*-wNN-YYYY` sheets from SharePoint via `createLLMOSharepointClient`; `Sources` column holds cited URLs |
+| Load data | `loadBrandPresenceData` (`utils/offsite-brand-presence-enrichment.js:~368`) | **two paths, same downstream shape:** (1) **PostgREST** — for brandalf-enabled orgs, `loadBrandPresenceDataFromPostgrest` (`utils/offsite-brand-presence-postgrest.js`) reads `brand_presence_executions` + nested `brand_presence_sources` over the multi-week window from `getPreviousWeeks`, maps rows to the legacy `{ Sources, Region, Prompt, ... }` shape (`Sources` = cited URLs). Defaults to **`US` region only** (`DEFAULT_REGION_CODE`). (2) **SharePoint** — for non-brandalf orgs, or when PostgREST returns no rows, reads `brandpresence-*-wNN-YYYY` Excel sheets via `createLLMOSharepointClient`; `Sources` column holds cited URLs |
 | Parse + classify | `extractUrlsAndTopics` → `classifyAndNormalize` (`handler.js:259`, `:165`) | splits `row.Sources` on `[;\n]`, filters `ACCEPTED_REGIONS`, drops owned/social/brand-lookalike hosts, classifies `youtube.com`/`reddit.com` by regex, tags `wikipedia.org` as excluded. Builds `allUrls: Map<url, { count, domain }>` where **`count` = citation frequency** |
 | Rank + bucket | `selectTopUrls(allUrls, DRS_URLS_LIMIT, excluded)` (`handler.js:644`) | sort by `count` desc → `topByDomain['youtube.com']`, `topByDomain['reddit.com']` (cap 70 each) + `topCited` (top 70, excl. offsite + wikipedia) |
 | Store | `addUrlsToUrlStore` (`handler.js:316`) | writes `AuditUrl` tagged with `youtube-analysis` / `reddit-analysis` / `cited-analysis` |
@@ -50,6 +51,12 @@ export const TOP_CITED_EXCLUDED_DOMAINS = ['wikipedia.org'];
 then let the existing `classifyAndNormalize` / `selectTopUrls` / DRS path run
 unchanged.** `count` must be a citation-volume proxy so the top-70 ranking is
 preserved.
+
+**Data-source note:** Semrush replaces whichever path `loadBrandPresenceData` took
+(PostgREST or SharePoint). The PostgREST path is increasingly the live path for
+brandalf orgs; SharePoint remains the fallback. Region behavior also differs today:
+PostgREST is US-only, while `ACCEPTED_REGIONS` allows six markets — the Semrush
+loader should call per region (see §5.3).
 
 ---
 

--- a/docs/plans/2026-07-17-offsite-cited-urls-semrush-migration.md
+++ b/docs/plans/2026-07-17-offsite-cited-urls-semrush-migration.md
@@ -7,6 +7,31 @@
 
 ---
 
+> ### Update 2026-08-03 — a simpler path now exists (see §5, Option 0)
+>
+> This plan (2026-07-17) assumed **no Semrush citation-data surface existed** yet — hence
+> Options 1 & 2 both *build* one (a new SR AI Visibility endpoint, or a direct v4-raw
+> Element client). That premise is now **outdated.**
+>
+> A **Semrush-backed Serenity URL-Inspector data surface is live** (feature flag
+> `url-inspector-sr` = Green/Done, elmo [PR #2349](https://github.com/adobe/project-elmo-ui/pull/2349)).
+> It already exposes exactly what off-site needs, per brand + platform + date range:
+>
+> - `GET .../serenity/brand-presence/url-inspector/cited-domains` — one row per cited
+>   hostname (citations / URLs / prompts counts).
+> - `GET .../serenity/brand-presence/url-inspector/domain-urls?hostname=…` — the per-URL
+>   drilldown within a hostname, with citation counts.
+>
+> Consumed today in `project-elmo-ui` via `src/api/serenityApi.ts` +
+> `src/hooks/url-inspector-sr/`. See the wiki
+> [Project Serenity: LLMO × Semrush API for Brand Presence Data](https://wiki.corp.adobe.com/spaces/AEMSites/pages/3928196548).
+>
+> **Recommended approach is now "Option 0": reuse these live endpoints** rather than build
+> a new one. Options 1 & 2 below are retained as historical alternatives. Tracked under
+> epic [LLMO-6488](https://jira.corp.adobe.com/browse/LLMO-6488).
+
+---
+
 ## 1. Goal
 
 Today the `offsite-brand-presence` audit selects the cited URLs it feeds to DRS
@@ -117,7 +142,43 @@ drives the choice between Option 1 and Option 2 below.
 
 ## 5. Implementation options — easiest → hardest
 
-### Option 1 — HTTP via SR AI Visibility (snapshot). **Easiest. Recommended default.**
+### Option 0 — Reuse the live Serenity URL-Inspector data surface. **RECOMMENDED — supersedes Options 1 & 2.**
+
+The Semrush cited-URL data is **already exposed and consumed by the UI** (see the
+2026-08-03 update banner). Off-site should consume the same two endpoints instead of
+building a new backend surface:
+
+- `cited-domains` → cited hostnames + citation/URL/prompt counts (dominant content type).
+- `domain-urls?hostname=…` → the per-URL list within a hostname, with citation counts.
+
+**Flow (mirrors today's selection, feeds the existing DRS path unchanged):**
+
+1. Call `cited-domains` (scoped by brand + `platform` + `startDate`/`endDate`) to get the
+   cited hostnames and their rollups.
+2. Call `domain-urls?hostname=youtube.com` and `hostname=reddit.com`, plus the top
+   third-party hostnames (exclude owned + `wikipedia.org`), collecting enough rows to fill
+   70 per bucket (`DRS_URLS_LIMIT`).
+3. Build `allUrls: Map<url, { count, domain }>` with `count = citations`, shaped **exactly**
+   like today's `extractUrlsAndTopics` output, then run the existing
+   `classifyAndNormalize` → `selectTopUrls` → DRS path unchanged.
+
+**Why this supersedes 1 & 2:**
+
+- **vs Option 1** — no new `spacecat-api-service` endpoint to build; the surface exists and
+  is production-validated by the `url-inspector-sr` dashboard.
+- **vs Option 2** — no direct v4-raw Semrush client, no API-key/workspace/element-id secret
+  management in the worker; the endpoints already take a `startDate`/`endDate` range
+  (weekly window), so the rolling-window concern that motivated Option 2 is addressed.
+
+**Open items** (carried into the child tickets under LLMO-6488): where the surface is served
+(LLMO gateway — **not** spacecat-api-service's serenity controller, which is prompts/markets
+only) and the server-to-server auth for calling it from the audit-worker; region + platform
+param mapping; per-URL prompt attribution (`url-prompts`) and topic/category enrichment; and
+shadow-run parity before cutover.
+
+---
+
+### Option 1 — HTTP via SR AI Visibility (snapshot). **Superseded by Option 0** (kept for history).
 
 Reuse the Semrush integration already wired into `spacecat-api-service` (gRPC
 transport, auth, normalization). The audit-worker calls a new HTTP endpoint.
@@ -222,7 +283,7 @@ The worker has **no** SR/Semrush client today (confirmed) — add a thin HTTP cl
 
 ---
 
-### Option 2 — v4-raw Element API (weekly range). **Hardest. Needed for 100% behavioral replacement.**
+### Option 2 — v4-raw Element API (weekly range). **Superseded by Option 0** (kept for history; was "needed for 100% behavioral replacement" when no proxied range surface existed).
 
 Use Semrush's Element-level API directly — the same data the URL Inspector UI shows,
 and the **only** path that supports a true weekly rolling window
@@ -297,39 +358,46 @@ Returned per-URL fields (`domain-urls`): `urlId`, `url`, `contentType`,
 
 ## 6. Recommendation & difficulty ladder
 
-| | Option 1 — HTTP / SR snapshot | Option 2 — Element API / weekly |
-|---|---|---|
-| Difficulty | **Low** | **High** |
-| Reuses existing Semrush transport/auth | Yes | No |
-| Time window | Monthly/daily snapshot | True weekly range (matches today) |
-| Behavioral parity with today | Approximate (snapshot) | 100% (rolling window) |
-| New secrets/config | Minimal | Semrush key + workspace/element ids + region→project map |
-| Retrieval hops | 1 endpoint | 2 (domains → urls) for top-cited |
+| | **Option 0 — live Serenity URL-Inspector** | Option 1 — HTTP / SR snapshot | Option 2 — Element API / weekly |
+|---|---|---|---|
+| Difficulty | **Lowest** | Low | High |
+| New backend endpoint to build | **None (already live)** | New SR AI Visibility endpoint | Direct v4-raw client |
+| Time window | Range (`startDate`/`endDate`) | Monthly/daily snapshot | True weekly range |
+| Behavioral parity with today | Range-based (matches today) | Approximate (snapshot) | 100% (rolling window) |
+| New secrets/config | Server-to-server auth to the surface | Minimal | Semrush key + workspace/element ids + region→project map |
+| Retrieval hops | 2 (domains → urls) for top-cited | 1 endpoint | 2 (domains → urls) for top-cited |
 
-- **Start with Option 1 (union / Option B category).** Simplest, reuses everything,
-  ships behind a flag; accept snapshot semantics.
-- **Escalate to Option 2 only if** weekly freshness / exact rolling-window parity is
-  required.
-- Both feed the **same** `classifyAndNormalize` → `selectTopUrls` → DRS path; the
-  only difference is the loader module and the time-window semantics.
+- **Use Option 0.** The cited-URL data surface already exists, is production-validated by
+  the `url-inspector-sr` dashboard, and takes a date range — so it needs no new backend
+  endpoint (Option 1) and no direct Semrush client with secret management (Option 2).
+- Options 1 & 2 are retained only as historical alternatives; revisit them only if Option 0's
+  surface turns out to be unavailable server-to-server or missing a required field.
+- All three feed the **same** `classifyAndNormalize` → `selectTopUrls` → DRS path; the only
+  difference is the loader module and the retrieval transport.
 
 ---
 
-## 7. Rollout
+## 7. Rollout (Option 0)
 
-1. Land backend endpoint (Option 1) + tests.
-2. Land worker loader + flag (`useSemrushSource`, per-site/env).
+1. Confirm the `serenity/brand-presence/url-inspector/{cited-domains,domain-urls}` surface
+   is reachable server-to-server from the audit-worker (auth) — LLMO-6707 / loader ticket.
+2. Land worker loader + flag (`useSemrushSource`, per-site/env) — LLMO-6709.
 3. **Shadow-run**: compute Semrush top-70 (youtube/reddit/cited) and diff against the
-   current SharePoint-selected set for a known site; confirm parity with the URL
-   Inspector view already validated.
-4. Cut over per site; retire the SharePoint read once parity holds.
+   current PostgREST/SharePoint-selected set for a known site; confirm parity with the URL
+   Inspector view already validated — LLMO-6711.
+4. Cut over per site; retire the SharePoint/PostgREST off-site read once parity holds.
 
 ---
 
 ## 8. Open decisions
 
-- [ ] Category: **Option B (union)** [recommended] vs Option A (`MENTIONS_TARGET`).
-- [ ] Window: **monthly snapshot (Option 1)** [recommended] vs weekly range (Option 2).
-- [ ] Topic enrichment on the Semrush path: drop vs backfill.
-- [ ] Union mechanics: two-call merge vs `UNSPECIFIED` minus owned (confirm gRPC).
-- [ ] Option 2 only: exact `CBF_*` column for third-party hostname scoping.
+- [ ] **Approach: Option 0 (reuse live Serenity URL-Inspector)** [recommended] vs the
+      historical Options 1 / 2.
+- [ ] Where the surface is served + server-to-server auth from the audit-worker.
+- [ ] Region + platform param mapping (`ACCEPTED_REGIONS` ↔ region, `platform=search-gpt`).
+- [ ] Per-URL prompt attribution: backfill via `url-prompts` vs invert vs drop.
+- [ ] Topic/category enrichment on the Semrush path: drop vs backfill.
+
+> Tracked under epic [LLMO-6488](https://jira.corp.adobe.com/browse/LLMO-6488): LLMO-6707
+> (this doc update), LLMO-6709 (loader), LLMO-6710 (region/platform mapping), LLMO-6712
+> (prompt attribution), LLMO-6708 (topic enrichment), LLMO-6711 (parity + cutover).

--- a/docs/plans/2026-07-17-offsite-cited-urls-semrush-migration.md
+++ b/docs/plans/2026-07-17-offsite-cited-urls-semrush-migration.md
@@ -162,19 +162,32 @@ building a new backend surface:
    like today's `extractUrlsAndTopics` output, then run the existing
    `classifyAndNormalize` → `selectTopUrls` → DRS path unchanged.
 
+**Where it's served + auth (confirmed 2026-08-05):** these are **spacecat-api-service**
+endpoints — the *Elements proxy*, `src/controllers/elements.js` (`listCitedDomains`,
+`listDomainUrls`, `listUrlPrompts`), routed at
+`/v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/*` (latest
+`main`, 37 serenity routes). `llmo.experiencecloud.live/api/v1` is an edge alias in front of
+api-service; the worker calls the same host it already targets via `SPACECAT_API_URI`. The
+proxy's `resolveElementsImsToken` / `requireImsBearer` authenticates an IMS caller and
+forwards the `Authorization: Bearer` to Semrush, so the worker uses a **service IMS token**
+and **no `x-promise-token` is required** (that header is only for non-IMS browser callers).
+
 **Why this supersedes 1 & 2:**
 
-- **vs Option 1** — no new `spacecat-api-service` endpoint to build; the surface exists and
-  is production-validated by the `url-inspector-sr` dashboard.
+- **vs Option 1** — no new `spacecat-api-service` endpoint to build; the Elements proxy
+  already serves this and is production-validated by the `url-inspector-sr` dashboard.
 - **vs Option 2** — no direct v4-raw Semrush client, no API-key/workspace/element-id secret
   management in the worker; the endpoints already take a `startDate`/`endDate` range
   (weekly window), so the rolling-window concern that motivated Option 2 is addressed.
 
-**Open items** (carried into the child tickets under LLMO-6488): where the surface is served
-(LLMO gateway — **not** spacecat-api-service's serenity controller, which is prompts/markets
-only) and the server-to-server auth for calling it from the audit-worker; region + platform
-param mapping; per-URL prompt attribution (`url-prompts`) and topic/category enrichment; and
-shadow-run parity before cutover.
+**Open items** (carried into the child tickets under LLMO-6488): confirm the worker's
+**service IMS token** is authorized upstream by Semrush (the only residual auth item — no
+server-to-server build needed); region + platform param mapping (surface is **multi-engine** —
+`search-gpt` and `google-ai-mode` both return data; omit `platform` to aggregate, or list
+engines to sum); per-URL prompt attribution (`url-prompts`, blocked while `urlId` returns
+empty) and topic/category enrichment (`categories` empty today); and shadow-run parity before
+cutover. Loader landed in
+[spacecat-audit-worker#2847](https://github.com/adobe/spacecat-audit-worker/pull/2847).
 
 ---
 
@@ -379,8 +392,11 @@ Returned per-URL fields (`domain-urls`): `urlId`, `url`, `contentType`,
 
 ## 7. Rollout (Option 0)
 
-1. Confirm the `serenity/brand-presence/url-inspector/{cited-domains,domain-urls}` surface
-   is reachable server-to-server from the audit-worker (auth) — LLMO-6707 / loader ticket.
+1. Confirm the worker's **service IMS token** is accepted by Semrush. api-service's Elements
+   wrapper (`requireImsBearer`) forwards the `Authorization: Bearer` **unchanged** to Semrush
+   (`docs/elements/semrush-elements-api-reference.md` §Authentication — "the user's own IMS
+   token is the auth mechanism"), so a service/technical token only works if Semrush authorizes
+   it. This is the one real open auth risk — LLMO-6709.
 2. Land worker loader + flag (`useSemrushSource`, per-site/env) — LLMO-6709.
 3. **Shadow-run**: compute Semrush top-70 (youtube/reddit/cited) and diff against the
    current PostgREST/SharePoint-selected set for a known site; confirm parity with the URL
@@ -393,8 +409,12 @@ Returned per-URL fields (`domain-urls`): `urlId`, `url`, `contentType`,
 
 - [ ] **Approach: Option 0 (reuse live Serenity URL-Inspector)** [recommended] vs the
       historical Options 1 / 2.
-- [ ] Where the surface is served + server-to-server auth from the audit-worker.
-- [ ] Region + platform param mapping (`ACCEPTED_REGIONS` ↔ region, `platform=search-gpt`).
+- [x] Where the surface is served: **spacecat-api-service** Elements wrapper (`elements.js`),
+      base `SPACECAT_API_URI`. Auth = the caller's IMS `Authorization: Bearer` forwarded
+      **unchanged** to Semrush (no S2S credential). **Open:** does Semrush accept the worker's
+      *service* IMS token (the wrapper is designed around a real user's token)?
+- [ ] Region + platform param mapping (`ACCEPTED_REGIONS` ↔ region). Surface is multi-engine
+      (`search-gpt` + `google-ai-mode` confirmed); omit `platform` to aggregate.
 - [ ] Per-URL prompt attribution: backfill via `url-prompts` vs invert vs drop.
 - [ ] Topic/category enrichment on the Semrush path: drop vs backfill.
 

--- a/docs/plans/2026-07-17-offsite-cited-urls-semrush-migration.md
+++ b/docs/plans/2026-07-17-offsite-cited-urls-semrush-migration.md
@@ -162,6 +162,12 @@ building a new backend surface:
    like today's `extractUrlsAndTopics` output, then run the existing
    `classifyAndNormalize` → `selectTopUrls` → DRS path unchanged.
 
+**Source strategy (Semrush-first, legacy fallback):** the runner tries Semrush first when the
+flag is on; if it yields no usable URLs (auth failure, no brand, outage, empty), it **falls back
+to the legacy `loadBrandPresenceData`** (PostgREST → SharePoint on `main`) so a Semrush problem
+can never silently zero out offsite. Flag off = legacy only. `domain-urls` is requested with
+`pageSize=100` (covers the per-surface top-70 in one page).
+
 **Where it's served + auth (confirmed 2026-08-05):** these are **spacecat-api-service**
 endpoints — the *Elements proxy*, `src/controllers/elements.js` (`listCitedDomains`,
 `listDomainUrls`, `listUrlPrompts`), routed at


### PR DESCRIPTION
Plan to migrate the offsite-brand-presence audit's cited-URL sourcing (youtube/reddit/top-cited, ranked by citations, fed to DRS) from the SharePoint/PostgREST Brand-Presence data to the Semrush API.

## Update 2026-08-03 — recommended approach is now "Option 0"

Since this plan was written (2026-07-17), the **Semrush-backed Serenity URL-Inspector data surface went live** (feature flag `url-inspector-sr` = Green/Done, elmo adobe/project-elmo-ui#2349). It already exposes exactly what off-site needs:

- `GET .../serenity/brand-presence/url-inspector/cited-domains` — cited hostnames + citation/URL/prompt counts
- `GET .../serenity/brand-presence/url-inspector/domain-urls?hostname=…` — per-URL drilldown within a hostname, with citation counts

So the doc now recommends **Option 0 — reuse these live endpoints** (no new backend endpoint, no direct Semrush client), and marks the original Option 1 (build a new SR AI Visibility endpoint) and Option 2 (direct v4-raw Element client) as **superseded / historical**. See §5 Option 0 and the update banner at the top of the doc.

## Related Issues

Epic: LLMO-6488 (Off-Site | Semrush migration)

- LLMO-6707 — update this migration plan (this PR)
- LLMO-6709 — audit-worker Semrush cited-URL loader
- LLMO-6710 — region + platform/engine param mapping
- LLMO-6712 — decide per-URL prompt attribution (spike)
- LLMO-6708 — decide topic/category enrichment on the Semrush path
- LLMO-6711 — shadow-run parity validation + per-site cutover

Thanks for contributing!