### PR TITLE
fix(toc): treat edgeOptimizeStatus as present-check, not value-check (LLMO-6168)

### DIFF
--- a/src/toc/handler.js
+++ b/src/toc/handler.js
@@ -718,7 +718,7 @@ export async function opportunityAndSuggestions(auditUrl, auditData, context) {
     // Do not overwrite data for suggestions already deployed to the edge CDN, or mid-IVE
     // geo-experiment (edgeOptimizeStatus is set before edgeDeployed) (LLMO-6168)
     if (existingSuggestion.edgeDeployed
-      || existingSuggestion.edgeOptimizeStatus === 'EXPERIMENT_IN_PROGRESS') {
+      || existingSuggestion.edgeOptimizeStatus) {
       return { ...existingSuggestion };
     }
     const converted = { ...newSuggestion };

--- a/src/utils/data-access.js
+++ b/src/utils/data-access.js
@@ -280,7 +280,7 @@ export const handleOutdatedSuggestions = async ({
         // Preserve suggestions mid-IVE geo-experiment: edgeOptimizeStatus is set before
         // edgeDeployed, so without this a suggestion the audit no longer detects an issue
         // for could flip to OUTDATED while its experiment is still running (LLMO-6168).
-        || data?.edgeOptimizeStatus === 'EXPERIMENT_IN_PROGRESS'
+        || data?.edgeOptimizeStatus
         // Preserve externally / manually-authored suggestions. Records published
         // through the backoffice write path (e.g. cwv-workbench guidance) live on
         // the shared audit-owned opportunity but are NOT part of THIS audit's

--- a/test/audits/toc.test.js
+++ b/test/audits/toc.test.js
@@ -2597,7 +2597,7 @@ describe('TOC (Table of Contents) Audit', () => {
       expect(merged.isEdited).to.equal(true);
     });
 
-    it('returns existing suggestion unchanged when edgeOptimizeStatus is EXPERIMENT_IN_PROGRESS (LLMO-6168)', async () => {
+    it('returns existing suggestion unchanged when edgeOptimizeStatus is present, regardless of value (LLMO-6168)', async () => {
       const convertToOpportunityStub = sinon.stub().resolves({
         getId: () => 'test-opportunity-id',
       });
@@ -2633,7 +2633,7 @@ describe('TOC (Table of Contents) Audit', () => {
       const existingSuggestion = {
         url: 'https://example.com/page1',
         isEdited: true,
-        edgeOptimizeStatus: 'EXPERIMENT_IN_PROGRESS',
+        edgeOptimizeStatus: 'EXPERIMENT_COMPLETE',
         transformRules: {
           value: [{ text: 'Experiment Title', level: 1 }],
         },
@@ -2648,8 +2648,9 @@ describe('TOC (Table of Contents) Audit', () => {
       const merged = capturedMergeDataFunction(existingSuggestion, newSuggestion);
 
       // Must return existing data unchanged — a suggestion mid-IVE-experiment must not be
-      // clobbered by a subsequent audit run, even before edgeDeployed is set
-      expect(merged.edgeOptimizeStatus).to.equal('EXPERIMENT_IN_PROGRESS');
+      // clobbered by a subsequent audit run, even before edgeDeployed is set. This holds for
+      // any edgeOptimizeStatus value, not just EXPERIMENT_IN_PROGRESS.
+      expect(merged.edgeOptimizeStatus).to.equal('EXPERIMENT_COMPLETE');
       expect(merged.transformRules.value).to.deep.equal([{ text: 'Experiment Title', level: 1 }]);
       expect(merged.isEdited).to.equal(true);
     });

--- a/test/utils/data-access.test.js
+++ b/test/utils/data-access.test.js
@@ -1463,7 +1463,7 @@ describe('data-access', () => {
       expect(mockLogger.info).to.have.been.calledWith('[SuggestionSync] Final count of suggestions to mark as OUTDATED: 1');
     });
 
-    it('should not mark suggestions mid-IVE-experiment as OUTDATED (LLMO-6168)', async () => {
+    it('should not mark suggestions with any edgeOptimizeStatus present as OUTDATED (LLMO-6168)', async () => {
       const buildKeyWithUrl = (data) => `${data.url}|${data.key}`;
 
       const existingSuggestions = [
@@ -1480,18 +1480,30 @@ describe('data-access', () => {
         },
         {
           id: '2',
-          data: { url: 'https://example.com/page2', key: 'page2' },
+          data: {
+            url: 'https://example.com/page2', key: 'page2', edgeOptimizeStatus: 'EXPERIMENT_COMPLETE',
+          },
           getId: sinon.stub().returns('2'),
-          getData: sinon.stub().returns({ url: 'https://example.com/page2', key: 'page2' }),
+          getData: sinon.stub().returns({
+            url: 'https://example.com/page2', key: 'page2', edgeOptimizeStatus: 'EXPERIMENT_COMPLETE',
+          }),
+          getStatus: sinon.stub().returns('NEW'),
+        },
+        {
+          id: '3',
+          data: { url: 'https://example.com/page3', key: 'page3' },
+          getId: sinon.stub().returns('3'),
+          getData: sinon.stub().returns({ url: 'https://example.com/page3', key: 'page3' }),
           getStatus: sinon.stub().returns('NEW'),
         },
       ];
 
-      const newData = [{ url: 'https://example.com/page3', key: 'page3' }];
+      const newData = [{ url: 'https://example.com/page4', key: 'page4' }];
       const scrapedUrlsSet = new Set([
         'https://example.com/page1',
         'https://example.com/page2',
         'https://example.com/page3',
+        'https://example.com/page4',
       ]);
 
       mockOpportunity.getSuggestions.resolves(existingSuggestions);
@@ -1506,8 +1518,11 @@ describe('data-access', () => {
         scrapedUrlsSet,
       });
 
+      // page1 (EXPERIMENT_IN_PROGRESS) and page2 (EXPERIMENT_COMPLETE) are preserved
+      // regardless of the specific status value — only page3, with no edgeOptimizeStatus
+      // at all, gets marked OUTDATED.
       expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledOnceWith(
-        [existingSuggestions[1]],
+        [existingSuggestions[2]],
         'OUTDATED',
       );
       expect(mockLogger.info).to.have.been.calledWith('[SuggestionSync] Final count of suggestions to mark as OUTDATED: 1');


### PR DESCRIPTION
## Summary
- In `src/toc/handler.js`, the suggestion merge guard now skips overwriting existing data whenever `edgeOptimizeStatus` is present at all, instead of only when it equals `'EXPERIMENT_IN_PROGRESS'`.
- In `src/utils/data-access.js`, the stale-suggestion cleanup (`handleOutdatedSuggestions`) applies the same presence-based exemption so suggestions aren't marked `OUTDATED` while carrying any `edgeOptimizeStatus`.
- Updated tests in `test/audits/toc.test.js` and `test/utils/data-access.test.js` to cover a non-`EXPERIMENT_IN_PROGRESS` status value, proving the guard is presence-based rather than tied to a specific value.

## Test plan
- [x] `npm run test:spec -- test/audits/toc.test.js test/utils/data-access.test.js` — 337 passing
- [x] `eslint --fix` via pre-commit hook ran clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)