### PR TITLE
fix(offsite): reuse active brand opportunity instead of duplicating it (23505)

### DIFF
--- a/src/cited-analysis/guidance-handler.js
+++ b/src/cited-analysis/guidance-handler.js
@@ -33,7 +33,7 @@ const LOG_PREFIX = '[Cited]';
  */
 export default async function handler(message, context) {
   const { log, dataAccess } = context;
-  const { Site, Audit: AuditModel } = dataAccess;
+  const { Site, Audit: AuditModel, Opportunity } = dataAccess;
   // Note: any inbound `brandId` from Mystique is informational only. Scope is
   // re-resolved server-side via resolveBrandResultForSite; trusting the inbound
   // value would let a tampered message re-attribute the opportunity.
@@ -97,6 +97,20 @@ export default async function handler(message, context) {
 
     const auditType = opportunityData.type || AUDIT_TYPE;
 
+    // Brand-scoped analyses are unique per (scopeType, scopeId, type) in Postgres
+    // (idx_opportunities_unique_active_scope, covering NEW + IN_PROGRESS). auditId
+    // changes on every run, so match/reuse the existing active brand opportunity by
+    // scope and update it in place; creating a second row and stamping the same
+    // brand scope collides (23505 duplicate key) and aborts before syncSuggestions.
+    const resolvedBrandId = brandResult?.brand?.brandId;
+    let existingOpportunity;
+    if (resolvedBrandId && typeof Opportunity?.allByScope === 'function') {
+      const scoped = await Opportunity.allByScope('brand', resolvedBrandId);
+      existingOpportunity = scoped.find(
+        (oppty) => oppty.getType() === auditType
+          && ['NEW', 'IN_PROGRESS'].includes(oppty.getStatus()),
+      );
+    }
     const opportunity = await convertToOpportunity(
       baseUrl,
       {
@@ -108,7 +122,10 @@ export default async function handler(message, context) {
       createOpportunityData,
       auditType,
       { opportunityData },
-      (oppty) => oppty.getAuditId() === auditId,
+      (oppty) => (resolvedBrandId
+        ? oppty.getScopeType?.() === 'brand' && oppty.getScopeId?.() === resolvedBrandId
+        : oppty.getAuditId() === auditId),
+      existingOpportunity,
     );
 
     // Persist the opportunity (with scope) BEFORE syncing suggestions. Reversed

--- a/src/common/opportunity.js
+++ b/src/common/opportunity.js
@@ -30,13 +30,16 @@ import { checkGoogleConnection } from './opportunity-utils.js';
   */
 
 // eslint-disable-next-line max-len
-export async function convertToOpportunity(auditUrl, auditData, context, createOpportunityData, auditType, props = {}, comparisonFn = undefined) {
+export async function convertToOpportunity(auditUrl, auditData, context, createOpportunityData, auditType, props = {}, comparisonFn = undefined, existingOpportunity = undefined) {
   const opportunityInstance = createOpportunityData(props);
   const { dataAccess, log } = context;
   const { Opportunity } = dataAccess;
-  let opportunity;
+  // Callers may pre-resolve the existing opportunity (e.g. brand-scoped analyses
+  // look it up by scope across NEW + IN_PROGRESS, which the NEW-only fetch below
+  // cannot see). When provided, reuse it and skip the fetch.
+  let opportunity = existingOpportunity;
 
-  if (auditType !== 'high-organic-low-ctr') {
+  if (!opportunity && auditType !== 'high-organic-low-ctr') {
     try {
       // eslint-disable-next-line max-len
       const opportunities = await Opportunity.allBySiteIdAndStatus(auditData.siteId, Oppty.STATUSES.NEW);

--- a/src/reddit-analysis/guidance-handler.js
+++ b/src/reddit-analysis/guidance-handler.js
@@ -33,7 +33,7 @@ const LOG_PREFIX = '[Reddit]';
  */
 export default async function handler(message, context) {
   const { log, dataAccess } = context;
-  const { Site, Audit: AuditModel } = dataAccess;
+  const { Site, Audit: AuditModel, Opportunity } = dataAccess;
   // Note: any inbound `brandId` from Mystique is informational only. Scope is
   // re-resolved server-side via resolveBrandResultForSite; trusting the inbound
   // value would let a tampered message re-attribute the opportunity.
@@ -97,6 +97,20 @@ export default async function handler(message, context) {
 
     const auditType = opportunityData.type || AUDIT_TYPE;
 
+    // Brand-scoped analyses are unique per (scopeType, scopeId, type) in Postgres
+    // (idx_opportunities_unique_active_scope, covering NEW + IN_PROGRESS). auditId
+    // changes on every run, so match/reuse the existing active brand opportunity by
+    // scope and update it in place; creating a second row and stamping the same
+    // brand scope collides (23505 duplicate key) and aborts before syncSuggestions.
+    const resolvedBrandId = brandResult?.brand?.brandId;
+    let existingOpportunity;
+    if (resolvedBrandId && typeof Opportunity?.allByScope === 'function') {
+      const scoped = await Opportunity.allByScope('brand', resolvedBrandId);
+      existingOpportunity = scoped.find(
+        (oppty) => oppty.getType() === auditType
+          && ['NEW', 'IN_PROGRESS'].includes(oppty.getStatus()),
+      );
+    }
     const opportunity = await convertToOpportunity(
       baseUrl,
       {
@@ -108,7 +122,10 @@ export default async function handler(message, context) {
       createOpportunityData,
       auditType,
       { opportunityData },
-      (oppty) => oppty.getAuditId() === auditId,
+      (oppty) => (resolvedBrandId
+        ? oppty.getScopeType?.() === 'brand' && oppty.getScopeId?.() === resolvedBrandId
+        : oppty.getAuditId() === auditId),
+      existingOpportunity,
     );
 
     // Persist the opportunity (with scope) BEFORE syncing suggestions; see

--- a/src/youtube-analysis/guidance-handler.js
+++ b/src/youtube-analysis/guidance-handler.js
@@ -31,7 +31,7 @@ const LOG_PREFIX = '[YouTube]';
  */
 export default async function handler(message, context) {
   const { log, dataAccess } = context;
-  const { Site, Audit: AuditModel } = dataAccess;
+  const { Site, Audit: AuditModel, Opportunity } = dataAccess;
   // Note: any inbound `brandId` from Mystique is informational only. Scope is
   // re-resolved server-side via resolveBrandResultForSite; trusting the inbound
   // value would let a tampered message re-attribute the opportunity.
@@ -95,6 +95,20 @@ export default async function handler(message, context) {
 
     const auditType = opportunityData.type || AUDIT_TYPE;
 
+    // Brand-scoped analyses are unique per (scopeType, scopeId, type) in Postgres
+    // (idx_opportunities_unique_active_scope, covering NEW + IN_PROGRESS). auditId
+    // changes on every run, so match/reuse the existing active brand opportunity by
+    // scope and update it in place; creating a second row and stamping the same
+    // brand scope collides (23505 duplicate key) and aborts before syncSuggestions.
+    const resolvedBrandId = brandResult?.brand?.brandId;
+    let existingOpportunity;
+    if (resolvedBrandId && typeof Opportunity?.allByScope === 'function') {
+      const scoped = await Opportunity.allByScope('brand', resolvedBrandId);
+      existingOpportunity = scoped.find(
+        (oppty) => oppty.getType() === auditType
+          && ['NEW', 'IN_PROGRESS'].includes(oppty.getStatus()),
+      );
+    }
     const opportunity = await convertToOpportunity(
       baseUrl,
       {
@@ -106,7 +120,10 @@ export default async function handler(message, context) {
       createOpportunityData,
       auditType,
       { opportunityData },
-      (oppty) => oppty.getAuditId() === auditId,
+      (oppty) => (resolvedBrandId
+        ? oppty.getScopeType?.() === 'brand' && oppty.getScopeId?.() === resolvedBrandId
+        : oppty.getAuditId() === auditId),
+      existingOpportunity,
     );
 
     // Persist the opportunity (with scope) BEFORE syncing suggestions; see

--- a/test/audits/cited-analysis/guidance-handler.test.js
+++ b/test/audits/cited-analysis/guidance-handler.test.js
@@ -174,7 +174,7 @@ describe('Cited Analysis Guidance Handler', () => {
       expect(propsArg.opportunityData).to.deep.equal(opportunityData);
     });
 
-    it('should pass comparisonFn that matches by auditId', async () => {
+    it('should pass comparisonFn that matches by auditId when no brand is resolved', async () => {
       const message = {
         siteId,
         auditId,
@@ -196,6 +196,55 @@ describe('Cited Analysis Guidance Handler', () => {
       expect(comparisonFn).to.be.a('function');
       expect(comparisonFn({ getAuditId: () => auditId })).to.be.true;
       expect(comparisonFn({ getAuditId: () => 'different-audit-id' })).to.be.false;
+    });
+
+    it('should match/reuse the existing brand opportunity (NEW or IN_PROGRESS) when a brand is resolved', async () => {
+      const brandId = 'brand-uuid-123';
+      resolveBrandResultForSiteStub.resolves({ brand: { brandId }, resolved: true });
+      const inProgressOppty = {
+        getType: () => 'cited-analysis',
+        getStatus: () => 'IN_PROGRESS',
+        getScopeType: () => 'brand',
+        getScopeId: () => brandId,
+      };
+      context.dataAccess.Opportunity = {
+        allByScope: sinon.stub().resolves([inProgressOppty]),
+      };
+
+      const message = {
+        siteId,
+        auditId,
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            suggestions: [
+              {
+                id: 'test_1', rank: 1, type: 'CONTENT_UPDATE', data: { title: 'Test' },
+              },
+            ],
+          },
+        },
+      };
+
+      await handler.default(message, context);
+
+      // The active IN_PROGRESS brand opportunity is looked up by scope and passed
+      // to convertToOpportunity so it is reused instead of duplicated (23505).
+      expect(context.dataAccess.Opportunity.allByScope).to.have.been.calledWith('brand', brandId);
+      expect(convertToOpportunityStub.firstCall.args[7]).to.equal(inProgressOppty);
+
+      // And the comparison fn matches by brand scope, not auditId.
+      const comparisonFn = convertToOpportunityStub.firstCall.args[6];
+      expect(comparisonFn({
+        getScopeType: () => 'brand',
+        getScopeId: () => brandId,
+        getAuditId: () => 'different-audit-id',
+      })).to.be.true;
+      expect(comparisonFn({
+        getScopeType: () => 'brand',
+        getScopeId: () => 'other-brand',
+        getAuditId: () => auditId,
+      })).to.be.false;
     });
 
     it('should set status from opportunityData when provided by Mystique', async () => {

--- a/test/audits/reddit-analysis/guidance-handler.test.js
+++ b/test/audits/reddit-analysis/guidance-handler.test.js
@@ -170,7 +170,7 @@ describe('Reddit Analysis Guidance Handler', () => {
       expect(propsArg.opportunityData).to.deep.equal(opportunityData);
     });
 
-    it('should pass comparisonFn that matches by auditId', async () => {
+    it('should pass comparisonFn that matches by auditId when no brand is resolved', async () => {
       const message = {
         siteId,
         auditId,
@@ -190,6 +190,53 @@ describe('Reddit Analysis Guidance Handler', () => {
       expect(comparisonFn).to.be.a('function');
       expect(comparisonFn({ getAuditId: () => auditId })).to.be.true;
       expect(comparisonFn({ getAuditId: () => 'different-audit-id' })).to.be.false;
+    });
+
+    it('should match/reuse the existing brand opportunity (NEW or IN_PROGRESS) when a brand is resolved', async () => {
+      const brandId = 'brand-uuid-123';
+      resolveBrandResultForSiteStub.resolves({ brand: { brandId }, resolved: true });
+      const inProgressOppty = {
+        getType: () => 'reddit-analysis',
+        getStatus: () => 'IN_PROGRESS',
+        getScopeType: () => 'brand',
+        getScopeId: () => brandId,
+      };
+      context.dataAccess.Opportunity = {
+        allByScope: sinon.stub().resolves([inProgressOppty]),
+      };
+
+      const message = {
+        siteId,
+        auditId,
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            suggestions: [
+              { id: 'test_1', priority: 'HIGH', title: 'Test', description: 'Test' },
+            ],
+          },
+        },
+      };
+
+      await handler.default(message, context);
+
+      // The active IN_PROGRESS brand opportunity is looked up by scope and passed
+      // to convertToOpportunity so it is reused instead of duplicated (23505).
+      expect(context.dataAccess.Opportunity.allByScope).to.have.been.calledWith('brand', brandId);
+      expect(convertToOpportunityStub.firstCall.args[7]).to.equal(inProgressOppty);
+
+      // And the comparison fn matches by brand scope, not auditId.
+      const comparisonFn = convertToOpportunityStub.firstCall.args[6];
+      expect(comparisonFn({
+        getScopeType: () => 'brand',
+        getScopeId: () => brandId,
+        getAuditId: () => 'different-audit-id',
+      })).to.be.true;
+      expect(comparisonFn({
+        getScopeType: () => 'brand',
+        getScopeId: () => 'other-brand',
+        getAuditId: () => auditId,
+      })).to.be.false;
     });
 
     it('should set status from opportunityData when provided by Mystique', async () => {

--- a/test/audits/youtube-analysis/guidance-handler.test.js
+++ b/test/audits/youtube-analysis/guidance-handler.test.js
@@ -444,7 +444,7 @@ describe('YouTube Analysis Guidance Handler', () => {
       expect(mockOpportunity.setStatus).to.have.been.calledWith('IGNORED');
     });
 
-    it('should pass comparisonFn that matches by auditId', async () => {
+    it('should pass comparisonFn that matches by auditId when no brand is resolved', async () => {
       const message = {
         siteId,
         auditId,
@@ -464,6 +464,53 @@ describe('YouTube Analysis Guidance Handler', () => {
       expect(comparisonFn).to.be.a('function');
       expect(comparisonFn({ getAuditId: () => auditId })).to.be.true;
       expect(comparisonFn({ getAuditId: () => 'different-audit-id' })).to.be.false;
+    });
+
+    it('should match/reuse the existing brand opportunity (NEW or IN_PROGRESS) when a brand is resolved', async () => {
+      const brandId = 'brand-uuid-123';
+      resolveBrandResultForSiteStub.resolves({ brand: { brandId }, resolved: true });
+      const inProgressOppty = {
+        getType: () => 'youtube-analysis',
+        getStatus: () => 'IN_PROGRESS',
+        getScopeType: () => 'brand',
+        getScopeId: () => brandId,
+      };
+      context.dataAccess.Opportunity = {
+        allByScope: sinon.stub().resolves([inProgressOppty]),
+      };
+
+      const message = {
+        siteId,
+        auditId,
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            suggestions: [
+              { id: 'test_1', priority: 'HIGH', title: 'Test', description: 'Test' },
+            ],
+          },
+        },
+      };
+
+      await guidanceHandler.default(message, context);
+
+      // The active IN_PROGRESS brand opportunity is looked up by scope and passed
+      // to convertToOpportunity so it is reused instead of duplicated (23505).
+      expect(context.dataAccess.Opportunity.allByScope).to.have.been.calledWith('brand', brandId);
+      expect(mockConvertToOpportunity.firstCall.args[7]).to.equal(inProgressOppty);
+
+      // And the comparison fn matches by brand scope, not auditId.
+      const comparisonFn = mockConvertToOpportunity.firstCall.args[6];
+      expect(comparisonFn({
+        getScopeType: () => 'brand',
+        getScopeId: () => brandId,
+        getAuditId: () => 'different-audit-id',
+      })).to.be.true;
+      expect(comparisonFn({
+        getScopeType: () => 'brand',
+        getScopeId: () => 'other-brand',
+        getAuditId: () => auditId,
+      })).to.be.false;
     });
 
     it('should pass rank and data from Mystique suggestion', async () => {


### PR DESCRIPTION
Fixes the duplicate-key failure that left youtube/cited/reddit analysis opportunities with **zero suggestions**.

## Analysis — 23505 on the unique active-scope constraint

Splunk showed:

```
code: 23505
duplicate key value violates unique constraint "idx_opportunities_unique_active_scope"
Key (scope_type, scope_id, type)=(brand, 019d6b16-42da-7999-8161-0492a07dca15, cited-analysis) already exists.
```

`idx_opportunities_unique_active_scope` is a partial unique index on `(scope_type, scope_id, type)` for `status IN ('NEW','IN_PROGRESS')` — i.e. a brand may have only **one** active opportunity of a given analysis type.

The guidance handlers asked `convertToOpportunity` to find the existing opportunity with a comparison fn that matched by **`auditId`**. `auditId` is regenerated on every analysis run, so a brand-scoped re-run never matched the row created by the previous run:

1. `convertToOpportunity` finds nothing → creates a **second** opportunity row.
2. On save, the handler stamps the resolved **brand scope** onto it.
3. That collides with the still-active row from the previous run → **23505**.
4. The handler throws **before** `syncSuggestions`, so no suggestions persist.

`convertToOpportunity`'s own fetch also only looked at `NEW`, so an opportunity a user had moved to `IN_PROGRESS` was invisible and re-collided on the next run.

## Fix

When a brand is resolved:

- Resolve the existing **active** brand opportunity by scope via `Opportunity.allByScope('brand', brandId)`, matching `NEW` **and** `IN_PROGRESS`, and pass it into `convertToOpportunity` so it is updated **in place**.
- Match by **brand scope** `(scopeType, scopeId)` instead of `auditId`.
- Fall back to the previous `auditId` match for the site-level (no-brand) path.

`convertToOpportunity` gains an optional `existingOpportunity` param; when provided it skips the `NEW`-only fetch.

## Changes

- `src/{youtube,reddit,cited}-analysis/guidance-handler.js`: scope-aware lookup + reuse of the active brand opportunity.
- `src/common/opportunity.js`: accept a pre-resolved `existingOpportunity`.
- Test suites: brand-scope comparison-fn cases + reuse of an `IN_PROGRESS` brand opportunity.

## Test plan

- `mocha` youtube/cited/reddit guidance-handler suites — 114 passing
- lint clean
- Verify in env: a localized brand-scoped RACQ cited/reddit/youtube re-run updates the existing opportunity and persists suggestions (no 23505).

## Follow-ups (separate PRs)

- **#2783** (stacked cleanup): drop the redundant `fullAnalysis` blob + refresh the dashboard when an opportunity is reused.
- Mystique's silent S3 delivery failure (`save_result_to_s3` swallows exceptions → null `presignedUrl`) can independently cause "no opportunity" for reddit/cited; tracked separately in the `mystique` repo.