### PR TITLE
feat(evergreen-offsite-opportunities): reuse active IN_PROGRESS opportunity on refresh (LLMO-6122)

### DIFF
--- a/src/common/offsite-refresh.js
+++ b/src/common/offsite-refresh.js
@@ -14,6 +14,12 @@ import { Opportunity as Oppty } from '@adobe/spacecat-shared-data-access';
 import { DATA_SOURCES, OFFSITE_AUDIT_TYPES } from './constants.js';
 import { checkGoogleConnection } from './opportunity-utils.js';
 
+// An offsite opportunity is unique per (scopeType, scopeId, type) while active, where active
+// means NEW or IN_PROGRESS (idx_opportunities_unique_active_scope). Both statuses must be
+// treated as the reusable evergreen; a customer-activated (IN_PROGRESS) opportunity that is
+// not reused would be recreated and collide with the existing row on save.
+const ACTIVE_OFFSITE_STATUSES = [Oppty.STATUSES.NEW, Oppty.STATUSES.IN_PROGRESS];
+
 /**
  * Validates the payload shape and rejects a declared opportunity type that differs from
  * the handler-owned audit type.
@@ -110,9 +116,12 @@ export async function persistOffsiteOpportunity(
 }
 
 /**
- * Resolves the evergreen offsite opportunity (status NEW).
+ * Resolves the evergreen offsite opportunity (active status: NEW or IN_PROGRESS).
  *
- * If duplicates exist, keeps the most recently updated one and retires the rest to IGNORED.
+ * A customer-activated (IN_PROGRESS) opportunity is reused in place, not treated as absent —
+ * otherwise the refresh would create a second row and collide with it on the active-scope
+ * unique index. If duplicates exist, keeps the most recently updated one and retires the
+ * rest to IGNORED.
  *
  * @param {Object} params
  * @param {Object} params.dataAccess - The data access object (from audit-worker context).
@@ -126,15 +135,18 @@ export async function resolveEvergreenOffsiteOpportunity({
   dataAccess, siteId, auditType, log,
 }) {
   const { Opportunity } = dataAccess;
-  let opportunities;
+  let activeOpportunities;
   try {
-    opportunities = await Opportunity.allBySiteIdAndStatus(siteId, Oppty.STATUSES.NEW);
+    const opportunitiesByStatus = await Promise.all(
+      ACTIVE_OFFSITE_STATUSES.map((status) => Opportunity.allBySiteIdAndStatus(siteId, status)),
+    );
+    activeOpportunities = opportunitiesByStatus.flatMap((list) => list || []);
   } catch (e) {
     log.error(`[OffsiteRefresh] Failed to fetch opportunities for siteId ${siteId}: ${e.message}`);
     throw e;
   }
 
-  const matchingOpportunities = (opportunities || [])
+  const matchingOpportunities = activeOpportunities
     .filter((opportunity) => opportunity.getType() === auditType);
   if (matchingOpportunities.length === 0) {
     return null;
@@ -147,7 +159,7 @@ export async function resolveEvergreenOffsiteOpportunity({
     (a, b) => new Date(b.getUpdatedAt()) - new Date(a.getUpdatedAt()),
   );
 
-  log.info(`[OffsiteRefresh] Found ${matchingOpportunities.length} NEW ${auditType} opportunities for siteId ${siteId}; retiring ${duplicates.length} duplicate(s), keeping ${evergreenOpportunity.getId()} as the evergreen opportunity`);
+  log.info(`[OffsiteRefresh] Found ${matchingOpportunities.length} active ${auditType} opportunities for siteId ${siteId}; retiring ${duplicates.length} duplicate(s), keeping ${evergreenOpportunity.getId()} as the evergreen opportunity`);
 
   duplicates.forEach((duplicate) => {
     duplicate.setStatus(Oppty.STATUSES.IGNORED);

--- a/test/audits/cited-analysis/guidance-handler.test.js
+++ b/test/audits/cited-analysis/guidance-handler.test.js
@@ -1113,9 +1113,11 @@ describe('Cited Analysis Guidance Handler', () => {
         getStatus: sandbox.stub().returns('NEW'),
         getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
       };
-      context.dataAccess.Opportunity = {
-        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
-      };
+      // The resolver queries each active status; the visible one is NEW.
+      const allBySiteIdAndStatus = sandbox.stub();
+      allBySiteIdAndStatus.withArgs(siteId, 'NEW').resolves([visibleOpportunity]);
+      allBySiteIdAndStatus.withArgs(siteId, 'IN_PROGRESS').resolves([]);
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus };
 
       const message = validMessage({
         data: {
@@ -1173,9 +1175,10 @@ describe('Cited Analysis Guidance Handler', () => {
         getStatus: sandbox.stub().returns('NEW'),
         getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
       };
-      context.dataAccess.Opportunity = {
-        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
-      };
+      const allBySiteIdAndStatus = sandbox.stub();
+      allBySiteIdAndStatus.withArgs(siteId, 'NEW').resolves([visibleOpportunity]);
+      allBySiteIdAndStatus.withArgs(siteId, 'IN_PROGRESS').resolves([]);
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus };
 
       const message = validMessage();
 
@@ -1185,7 +1188,41 @@ describe('Cited Analysis Guidance Handler', () => {
       // never trigger a second, independent query inside persistOffsiteOpportunity.
       const propsArg = convertToOpportunityStub.firstCall.args[5];
       expect(propsArg.existingOpportunity).to.equal(visibleOpportunity);
-      expect(context.dataAccess.Opportunity.allBySiteIdAndStatus).to.have.been.calledOnce;
+      // The resolver queries each active status (NEW and IN_PROGRESS) once; the single lookup
+      // is shared with persistOffsiteOpportunity, which is stubbed and never re-queries.
+      expect(context.dataAccess.Opportunity.allBySiteIdAndStatus).to.have.been.calledTwice;
+    });
+
+    it('should reuse a customer-activated IN_PROGRESS opportunity in place on a surfaced run', async () => {
+      // A customer-activated (IN_PROGRESS) opportunity is invisible to a NEW-only lookup, so a
+      // refresh would recreate it and collide on the active-scope unique index — dropping its
+      // suggestions. It must be reused in place, not retired and not recreated.
+      const inProgressOpportunity = {
+        getId: sandbox.stub().returns('in-progress-opp'),
+        getType: sandbox.stub().returns('cited-analysis'),
+        getStatus: sandbox.stub().returns('IN_PROGRESS'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+        setStatus: sandbox.stub(),
+        setUpdatedBy: sandbox.stub(),
+      };
+      const allBySiteIdAndStatus = sandbox.stub();
+      allBySiteIdAndStatus.withArgs(siteId, 'NEW').resolves([]);
+      allBySiteIdAndStatus.withArgs(siteId, 'IN_PROGRESS').resolves([inProgressOpportunity]);
+      const saveManyStub = sandbox.stub().resolves();
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus, saveMany: saveManyStub };
+
+      const message = validMessage();
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(200);
+      // Reused directly as the evergreen target, never retired or recreated.
+      expect(convertToOpportunityStub).to.have.been.calledOnce;
+      expect(convertToOpportunityStub.firstCall.args[5].existingOpportunity)
+        .to.equal(inProgressOpportunity);
+      expect(inProgressOpportunity.setStatus).to.not.have.been.called;
+      expect(saveManyStub).to.not.have.been.called;
+      expect(syncSuggestionsStub).to.have.been.calledOnce;
     });
 
     it('should lazily retire duplicate NEW opportunities of the same type via saveMany, keeping the most recent as evergreen', async () => {
@@ -1206,8 +1243,11 @@ describe('Cited Analysis Guidance Handler', () => {
         setUpdatedBy: sandbox.stub(),
       };
       const saveManyStub = sandbox.stub().resolves();
+      const allBySiteIdAndStatus = sandbox.stub();
+      allBySiteIdAndStatus.withArgs(siteId, 'NEW').resolves([older, newer]);
+      allBySiteIdAndStatus.withArgs(siteId, 'IN_PROGRESS').resolves([]);
       context.dataAccess.Opportunity = {
-        allBySiteIdAndStatus: sandbox.stub().resolves([older, newer]),
+        allBySiteIdAndStatus,
         saveMany: saveManyStub,
       };
 
@@ -1242,8 +1282,11 @@ describe('Cited Analysis Guidance Handler', () => {
         setStatus: sandbox.stub(),
         setUpdatedBy: sandbox.stub(),
       };
+      const allBySiteIdAndStatus = sandbox.stub();
+      allBySiteIdAndStatus.withArgs(siteId, 'NEW').resolves([older, newer]);
+      allBySiteIdAndStatus.withArgs(siteId, 'IN_PROGRESS').resolves([]);
       context.dataAccess.Opportunity = {
-        allBySiteIdAndStatus: sandbox.stub().resolves([older, newer]),
+        allBySiteIdAndStatus,
         saveMany: sandbox.stub().rejects(new Error('save failed')),
       };
 

--- a/test/audits/reddit-analysis/guidance-handler.test.js
+++ b/test/audits/reddit-analysis/guidance-handler.test.js
@@ -984,9 +984,11 @@ describe('Reddit Analysis Guidance Handler', () => {
         getStatus: sandbox.stub().returns('NEW'),
         getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
       };
-      context.dataAccess.Opportunity = {
-        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
-      };
+      // The resolver queries each active status; the visible one is NEW.
+      const allBySiteIdAndStatus = sandbox.stub();
+      allBySiteIdAndStatus.withArgs(siteId, 'NEW').resolves([visibleOpportunity]);
+      allBySiteIdAndStatus.withArgs(siteId, 'IN_PROGRESS').resolves([]);
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus };
 
       const message = validMessage({
         data: {
@@ -1044,9 +1046,10 @@ describe('Reddit Analysis Guidance Handler', () => {
         getStatus: sandbox.stub().returns('NEW'),
         getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
       };
-      context.dataAccess.Opportunity = {
-        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
-      };
+      const allBySiteIdAndStatus = sandbox.stub();
+      allBySiteIdAndStatus.withArgs(siteId, 'NEW').resolves([visibleOpportunity]);
+      allBySiteIdAndStatus.withArgs(siteId, 'IN_PROGRESS').resolves([]);
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus };
 
       const message = validMessage();
 
@@ -1054,7 +1057,41 @@ describe('Reddit Analysis Guidance Handler', () => {
 
       const propsArg = convertToOpportunityStub.firstCall.args[5];
       expect(propsArg.existingOpportunity).to.equal(visibleOpportunity);
-      expect(context.dataAccess.Opportunity.allBySiteIdAndStatus).to.have.been.calledOnce;
+      // The resolver queries each active status (NEW and IN_PROGRESS) once; the single lookup
+      // is shared with persistOffsiteOpportunity, which is stubbed and never re-queries.
+      expect(context.dataAccess.Opportunity.allBySiteIdAndStatus).to.have.been.calledTwice;
+    });
+
+    it('should reuse a customer-activated IN_PROGRESS opportunity in place on a surfaced run', async () => {
+      // A customer-activated (IN_PROGRESS) opportunity is invisible to a NEW-only lookup, so a
+      // refresh would recreate it and collide on the active-scope unique index — dropping its
+      // suggestions. It must be reused in place, not retired and not recreated.
+      const inProgressOpportunity = {
+        getId: sandbox.stub().returns('in-progress-opp'),
+        getType: sandbox.stub().returns('reddit-analysis'),
+        getStatus: sandbox.stub().returns('IN_PROGRESS'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+        setStatus: sandbox.stub(),
+        setUpdatedBy: sandbox.stub(),
+      };
+      const allBySiteIdAndStatus = sandbox.stub();
+      allBySiteIdAndStatus.withArgs(siteId, 'NEW').resolves([]);
+      allBySiteIdAndStatus.withArgs(siteId, 'IN_PROGRESS').resolves([inProgressOpportunity]);
+      const saveManyStub = sandbox.stub().resolves();
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus, saveMany: saveManyStub };
+
+      const message = validMessage();
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(200);
+      // Reused directly as the evergreen target, never retired or recreated.
+      expect(convertToOpportunityStub).to.have.been.calledOnce;
+      expect(convertToOpportunityStub.firstCall.args[5].existingOpportunity)
+        .to.equal(inProgressOpportunity);
+      expect(inProgressOpportunity.setStatus).to.not.have.been.called;
+      expect(saveManyStub).to.not.have.been.called;
+      expect(syncSuggestionsStub).to.have.been.calledOnce;
     });
 
     it('should lazily retire duplicate NEW opportunities of the same type via saveMany, keeping the most recent as evergreen', async () => {
@@ -1075,8 +1112,11 @@ describe('Reddit Analysis Guidance Handler', () => {
         setUpdatedBy: sandbox.stub(),
       };
       const saveManyStub = sandbox.stub().resolves();
+      const allBySiteIdAndStatus = sandbox.stub();
+      allBySiteIdAndStatus.withArgs(siteId, 'NEW').resolves([older, newer]);
+      allBySiteIdAndStatus.withArgs(siteId, 'IN_PROGRESS').resolves([]);
       context.dataAccess.Opportunity = {
-        allBySiteIdAndStatus: sandbox.stub().resolves([older, newer]),
+        allBySiteIdAndStatus,
         saveMany: saveManyStub,
       };
 
@@ -1110,8 +1150,11 @@ describe('Reddit Analysis Guidance Handler', () => {
         setStatus: sandbox.stub(),
         setUpdatedBy: sandbox.stub(),
       };
+      const allBySiteIdAndStatus = sandbox.stub();
+      allBySiteIdAndStatus.withArgs(siteId, 'NEW').resolves([older, newer]);
+      allBySiteIdAndStatus.withArgs(siteId, 'IN_PROGRESS').resolves([]);
       context.dataAccess.Opportunity = {
-        allBySiteIdAndStatus: sandbox.stub().resolves([older, newer]),
+        allBySiteIdAndStatus,
         saveMany: sandbox.stub().rejects(new Error('save failed')),
       };
 

--- a/test/audits/youtube-analysis/guidance-handler.test.js
+++ b/test/audits/youtube-analysis/guidance-handler.test.js
@@ -988,9 +988,11 @@ describe('YouTube Analysis Guidance Handler', () => {
         getStatus: sandbox.stub().returns('NEW'),
         getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
       };
-      context.dataAccess.Opportunity = {
-        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
-      };
+      // The resolver queries each active status; the visible one is NEW.
+      const allBySiteIdAndStatus = sandbox.stub();
+      allBySiteIdAndStatus.withArgs(siteId, 'NEW').resolves([visibleOpportunity]);
+      allBySiteIdAndStatus.withArgs(siteId, 'IN_PROGRESS').resolves([]);
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus };
 
       const message = validMessage({
         data: {
@@ -1048,9 +1050,10 @@ describe('YouTube Analysis Guidance Handler', () => {
         getStatus: sandbox.stub().returns('NEW'),
         getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
       };
-      context.dataAccess.Opportunity = {
-        allBySiteIdAndStatus: sandbox.stub().resolves([visibleOpportunity]),
-      };
+      const allBySiteIdAndStatus = sandbox.stub();
+      allBySiteIdAndStatus.withArgs(siteId, 'NEW').resolves([visibleOpportunity]);
+      allBySiteIdAndStatus.withArgs(siteId, 'IN_PROGRESS').resolves([]);
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus };
 
       const message = validMessage();
 
@@ -1058,7 +1061,41 @@ describe('YouTube Analysis Guidance Handler', () => {
 
       const propsArg = mockConvertToOpportunity.firstCall.args[5];
       expect(propsArg.existingOpportunity).to.equal(visibleOpportunity);
-      expect(context.dataAccess.Opportunity.allBySiteIdAndStatus).to.have.been.calledOnce;
+      // The resolver queries each active status (NEW and IN_PROGRESS) once; the single lookup
+      // is shared with persistOffsiteOpportunity, which is stubbed and never re-queries.
+      expect(context.dataAccess.Opportunity.allBySiteIdAndStatus).to.have.been.calledTwice;
+    });
+
+    it('should reuse a customer-activated IN_PROGRESS opportunity in place on a surfaced run', async () => {
+      // A customer-activated (IN_PROGRESS) opportunity is invisible to a NEW-only lookup, so a
+      // refresh would recreate it and collide on the active-scope unique index — dropping its
+      // suggestions. It must be reused in place, not retired and not recreated.
+      const inProgressOpportunity = {
+        getId: sandbox.stub().returns('in-progress-opp'),
+        getType: sandbox.stub().returns('youtube-analysis'),
+        getStatus: sandbox.stub().returns('IN_PROGRESS'),
+        getUpdatedAt: sandbox.stub().returns('2026-01-01T00:00:00.000Z'),
+        setStatus: sandbox.stub(),
+        setUpdatedBy: sandbox.stub(),
+      };
+      const allBySiteIdAndStatus = sandbox.stub();
+      allBySiteIdAndStatus.withArgs(siteId, 'NEW').resolves([]);
+      allBySiteIdAndStatus.withArgs(siteId, 'IN_PROGRESS').resolves([inProgressOpportunity]);
+      const saveManyStub = sandbox.stub().resolves();
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus, saveMany: saveManyStub };
+
+      const message = validMessage();
+
+      const result = await guidanceHandler.default(message, context);
+
+      expect(result.status).to.equal(200);
+      // Reused directly as the evergreen target, never retired or recreated.
+      expect(mockConvertToOpportunity).to.have.been.calledOnce;
+      expect(mockConvertToOpportunity.firstCall.args[5].existingOpportunity)
+        .to.equal(inProgressOpportunity);
+      expect(inProgressOpportunity.setStatus).to.not.have.been.called;
+      expect(saveManyStub).to.not.have.been.called;
+      expect(mockSyncSuggestions).to.have.been.calledOnce;
     });
 
     it('should lazily retire duplicate NEW opportunities of the same type via saveMany, keeping the most recent as evergreen', async () => {
@@ -1079,8 +1116,11 @@ describe('YouTube Analysis Guidance Handler', () => {
         setUpdatedBy: sandbox.stub(),
       };
       const saveManyStub = sandbox.stub().resolves();
+      const allBySiteIdAndStatus = sandbox.stub();
+      allBySiteIdAndStatus.withArgs(siteId, 'NEW').resolves([older, newer]);
+      allBySiteIdAndStatus.withArgs(siteId, 'IN_PROGRESS').resolves([]);
       context.dataAccess.Opportunity = {
-        allBySiteIdAndStatus: sandbox.stub().resolves([older, newer]),
+        allBySiteIdAndStatus,
         saveMany: saveManyStub,
       };
 
@@ -1114,8 +1154,11 @@ describe('YouTube Analysis Guidance Handler', () => {
         setStatus: sandbox.stub(),
         setUpdatedBy: sandbox.stub(),
       };
+      const allBySiteIdAndStatus = sandbox.stub();
+      allBySiteIdAndStatus.withArgs(siteId, 'NEW').resolves([older, newer]);
+      allBySiteIdAndStatus.withArgs(siteId, 'IN_PROGRESS').resolves([]);
       context.dataAccess.Opportunity = {
-        allBySiteIdAndStatus: sandbox.stub().resolves([older, newer]),
+        allBySiteIdAndStatus,
         saveMany: sandbox.stub().rejects(new Error('save failed')),
       };
 

--- a/test/common/offsite-refresh-integration.test.js
+++ b/test/common/offsite-refresh-integration.test.js
@@ -67,6 +67,9 @@ describe('offsite refresh handler composition', () => {
     const audit = {
       getAuditResult: () => ({}),
     };
+    const allBySiteIdAndStatus = sandbox.stub();
+    allBySiteIdAndStatus.withArgs(siteId, 'NEW').resolves([evergreenOpportunity]);
+    allBySiteIdAndStatus.withArgs(siteId, 'IN_PROGRESS').resolves([]);
     const context = {
       log,
       dataAccess: {
@@ -77,7 +80,7 @@ describe('offsite refresh handler composition', () => {
           findById: sandbox.stub().resolves(audit),
         },
         Opportunity: {
-          allBySiteIdAndStatus: sandbox.stub().resolves([evergreenOpportunity]),
+          allBySiteIdAndStatus,
           saveMany: sandbox.stub().resolves(),
           create: sandbox.stub(),
         },

--- a/test/common/offsite-refresh.test.js
+++ b/test/common/offsite-refresh.test.js
@@ -132,20 +132,83 @@ describe('offsite-refresh', () => {
       expect(log.error).to.have.been.calledWith(sinon.match(/DB down/));
     });
 
-    it('returns the single matching opportunity without touching it', async () => {
+    it('returns the single matching NEW opportunity without touching it', async () => {
       const only = {
         getType: () => 'cited-analysis',
         getId: () => 'only-opp',
       };
-      const dataAccess = {
-        Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([only]) },
-      };
+      const allBySiteIdAndStatus = sandbox.stub();
+      allBySiteIdAndStatus.withArgs('site-1', 'NEW').resolves([only]);
+      allBySiteIdAndStatus.withArgs('site-1', 'IN_PROGRESS').resolves([]);
+      const dataAccess = { Opportunity: { allBySiteIdAndStatus } };
 
       const result = await resolveEvergreenOffsiteOpportunity({
         dataAccess, siteId: 'site-1', auditType: 'cited-analysis', log,
       });
 
       expect(result).to.equal(only);
+    });
+
+    it('reuses a customer-activated IN_PROGRESS opportunity in place, without retiring it', async () => {
+      // The refresh must not treat an IN_PROGRESS opportunity as absent: recreating it would
+      // collide with the existing row on the active-scope unique index and drop suggestions.
+      const inProgress = {
+        getType: () => 'cited-analysis',
+        getId: () => 'in-progress-opp',
+        setStatus: sandbox.stub(),
+        setUpdatedBy: sandbox.stub(),
+      };
+      const allBySiteIdAndStatus = sandbox.stub();
+      allBySiteIdAndStatus.withArgs('site-1', 'NEW').resolves([]);
+      allBySiteIdAndStatus.withArgs('site-1', 'IN_PROGRESS').resolves([inProgress]);
+      const saveManyStub = sandbox.stub().resolves();
+      const dataAccess = {
+        Opportunity: { allBySiteIdAndStatus, saveMany: saveManyStub },
+      };
+
+      const result = await resolveEvergreenOffsiteOpportunity({
+        dataAccess, siteId: 'site-1', auditType: 'cited-analysis', log,
+      });
+
+      expect(result).to.equal(inProgress);
+      expect(inProgress.setStatus).to.not.have.been.called;
+      expect(saveManyStub).to.not.have.been.called;
+    });
+
+    it('retires the NEW duplicate and keeps the more recent IN_PROGRESS one as evergreen', async () => {
+      // Legacy leftovers can span both active statuses; convergence must keep a single active
+      // opportunity regardless of which status the survivor holds.
+      const staleNew = {
+        getType: () => 'cited-analysis',
+        getId: () => 'stale-new',
+        getUpdatedAt: () => '2025-01-01T00:00:00.000Z',
+        setStatus: sandbox.stub(),
+        setUpdatedBy: sandbox.stub(),
+      };
+      const activeInProgress = {
+        getType: () => 'cited-analysis',
+        getId: () => 'active-in-progress',
+        getUpdatedAt: () => '2026-01-01T00:00:00.000Z',
+        setStatus: sandbox.stub(),
+        setUpdatedBy: sandbox.stub(),
+      };
+      const allBySiteIdAndStatus = sandbox.stub();
+      allBySiteIdAndStatus.withArgs('site-1', 'NEW').resolves([staleNew]);
+      allBySiteIdAndStatus.withArgs('site-1', 'IN_PROGRESS').resolves([activeInProgress]);
+      const saveManyStub = sandbox.stub().resolves();
+      const dataAccess = {
+        Opportunity: { allBySiteIdAndStatus, saveMany: saveManyStub },
+      };
+
+      const result = await resolveEvergreenOffsiteOpportunity({
+        dataAccess, siteId: 'site-1', auditType: 'cited-analysis', log,
+      });
+
+      expect(result).to.equal(activeInProgress);
+      expect(staleNew.setStatus).to.have.been.calledWith('IGNORED');
+      expect(activeInProgress.setStatus).to.not.have.been.called;
+      expect(saveManyStub).to.have.been.calledOnce;
+      expect(saveManyStub.firstCall.args[0]).to.deep.equal([staleNew]);
     });
 
     it('ignores opportunities of a different type', async () => {
@@ -184,9 +247,12 @@ describe('offsite-refresh', () => {
         setUpdatedBy: sandbox.stub(),
       };
       const saveManyStub = sandbox.stub().resolves();
+      const allBySiteIdAndStatus = sandbox.stub();
+      allBySiteIdAndStatus.withArgs('site-1', 'NEW').resolves([oldest, newest, middle]);
+      allBySiteIdAndStatus.withArgs('site-1', 'IN_PROGRESS').resolves([]);
       const dataAccess = {
         Opportunity: {
-          allBySiteIdAndStatus: sandbox.stub().resolves([oldest, newest, middle]),
+          allBySiteIdAndStatus,
           saveMany: saveManyStub,
         },
       };
@@ -220,9 +286,12 @@ describe('offsite-refresh', () => {
         setStatus: sandbox.stub(),
         setUpdatedBy: sandbox.stub(),
       };
+      const allBySiteIdAndStatus = sandbox.stub();
+      allBySiteIdAndStatus.withArgs('site-1', 'NEW').resolves([older, newer]);
+      allBySiteIdAndStatus.withArgs('site-1', 'IN_PROGRESS').resolves([]);
       const dataAccess = {
         Opportunity: {
-          allBySiteIdAndStatus: sandbox.stub().resolves([older, newer]),
+          allBySiteIdAndStatus,
           saveMany: sandbox.stub().rejects(new Error('save failed')),
         },
       };


### PR DESCRIPTION
## Scope

https://jira.corp.adobe.com/browse/LLMO-6122

Follow-up to the merged evergreen offsite work: reuse a customer-activated (`IN_PROGRESS`) offsite opportunity on refresh instead of only reusing `NEW`.

This folds in the fix from the closed `#2782` so cited, Reddit, and YouTube refreshes converge on the single active opportunity regardless of its status.

## Problem

An offsite opportunity is unique per `(scope_type, scope_id, type)` while active, where active means `NEW` **or** `IN_PROGRESS` (`idx_opportunities_unique_active_scope`). The resolver only queried `NEW`, so once a customer opened an opportunity in the Workspace (moving it to `IN_PROGRESS`), the next weekly refresh:

1. did not see the active row and created a second opportunity;
2. stamped the same brand scope on it and saved;
3. collided on the unique index (`23505 duplicate key`);
4. threw before `syncSuggestions`, leaving the opportunity with zero suggestions.

## Implementation

- `resolveEvergreenOffsiteOpportunity` now resolves the evergreen opportunity across both active statuses (`NEW` and `IN_PROGRESS`) via one query per status, then applies the existing keep-most-recent / retire-duplicates convergence.
- Brand-scoped opportunities carry their `siteId`, so the existing site-based lookup resolves the same rows the unique index protects; no new query surface is needed.
- Production change is confined to `src/common/offsite-refresh.js`.

## Testing

- Focused, lint, and full unit/integration suite pass with 100% coverage.
- Resolver and all three guidance-handler suites cover reusing an `IN_PROGRESS` opportunity in place (not retired) and convergence when duplicates span both active statuses.
- Local Postgres/PostgREST E2E: a brand-scoped opportunity activated to `IN_PROGRESS` is reused in place on a surfaced refresh (same opportunity ID, suggestions persisted, no `23505`, exactly one active row); prior evergreen scenarios (first run, repeat refresh, suppressed run isolation, duplicate retirement) still pass.

## Known behavior / follow-up

On a surfaced refresh the reused opportunity's status is set from the incoming run, so an `IN_PROGRESS` opportunity returns to `NEW`. This matches the prior handler behavior and the closed `#2782`; preserving customer activation across refreshes would be a separate change.

## Out of Scope

- Preserving `IN_PROGRESS` across refreshes (status-downgrade avoidance)
- Snapshot creation, restore, and retention
- Suggestion retention or deterministic suggestion deduplication
- Wikipedia analysis

Made with [Cursor](https://cursor.com)