### PR TITLE
feat(summarization): persist sourceEvidence and depthLift on suggestion

### DIFF
--- a/src/summarization/utils.js
+++ b/src/summarization/utils.js
@@ -61,7 +61,7 @@ export function getJsonSummarySuggestion(suggestions, urlToContentHash = {}) {
 
     // depthLift is a page-level signal (mean burial weight of facts behind prompts, 0..1).
     // Stored on both suggestion records so the UI can use it for High Impact URL ranking.
-    const depthLift = typeof suggestion.depthLift === 'number' ? suggestion.depthLift : 0;
+    const depthLift = Number.isFinite(suggestion.depthLift) ? suggestion.depthLift : 0;
 
     // handle page level summary - only add if summary text is present and not already on page
     const pageSummaryText = suggestion.pageSummary?.formatted_summary;
@@ -85,7 +85,7 @@ export function getJsonSummarySuggestion(suggestions, urlToContentHash = {}) {
         // path (build_summarization_inputs) can use them as summary_sources without
         // needing to re-fetch the raw page.
         sourceEvidence: Array.isArray(suggestion.pageSummary?.source_evidence)
-          ? suggestion.pageSummary.source_evidence : [],
+          ? suggestion.pageSummary.source_evidence.filter((e) => typeof e === 'string').slice(0, 50) : [],
       });
     }
 
@@ -110,7 +110,7 @@ export function getJsonSummarySuggestion(suggestions, urlToContentHash = {}) {
         // keyPoints.items). Persisted so on-demand regeneration can use them as
         // kp_sources without re-fetching the raw page.
         sourceEvidence: Array.isArray(suggestion.keyPoints?.source_evidence)
-          ? suggestion.keyPoints.source_evidence : [],
+          ? suggestion.keyPoints.source_evidence.filter((e) => typeof e === 'string').slice(0, 50) : [],
       });
     }
   });

--- a/src/summarization/utils.js
+++ b/src/summarization/utils.js
@@ -75,6 +75,12 @@ export function getJsonSummarySuggestion(suggestions, urlToContentHash = {}) {
         scrapedAt,
         contentHash,
         prompts: summaryPrompts,
+        // Verbatim raw-page sentences the summary was derived from (captured by the
+        // gen_summary_crew QA task). Persisted here so the on-demand prompt-regeneration
+        // path (build_summarization_inputs) can use them as summary_sources without
+        // needing to re-fetch the raw page.
+        sourceEvidence: Array.isArray(suggestion.pageSummary?.source_evidence)
+          ? suggestion.pageSummary.source_evidence : [],
       });
     }
 
@@ -94,6 +100,11 @@ export function getJsonSummarySuggestion(suggestions, urlToContentHash = {}) {
         scrapedAt,
         contentHash,
         prompts: keyPointsPrompts,
+        // Verbatim raw-page sentences each key point was derived from (parallel to
+        // keyPoints.items). Persisted so on-demand regeneration can use them as
+        // kp_sources without re-fetching the raw page.
+        sourceEvidence: Array.isArray(suggestion.keyPoints?.source_evidence)
+          ? suggestion.keyPoints.source_evidence : [],
       });
     }
   });

--- a/src/summarization/utils.js
+++ b/src/summarization/utils.js
@@ -59,6 +59,10 @@ export function getJsonSummarySuggestion(suggestions, urlToContentHash = {}) {
     const keyPointsPrompts = Array.isArray(suggestion.keyPointsPrompts)
       ? suggestion.keyPointsPrompts : [];
 
+    // depthLift is a page-level signal (mean burial weight of facts behind prompts, 0..1).
+    // Stored on both suggestion records so the UI can use it for High Impact URL ranking.
+    const depthLift = typeof suggestion.depthLift === 'number' ? suggestion.depthLift : 0;
+
     // handle page level summary - only add if summary text is present and not already on page
     const pageSummaryText = suggestion.pageSummary?.formatted_summary;
     const pageSummaryAlreadyPresent = suggestion.page_summary_present === true
@@ -75,6 +79,7 @@ export function getJsonSummarySuggestion(suggestions, urlToContentHash = {}) {
         scrapedAt,
         contentHash,
         prompts: summaryPrompts,
+        depthLift,
         // Verbatim raw-page sentences the summary was derived from (captured by the
         // gen_summary_crew QA task). Persisted here so the on-demand prompt-regeneration
         // path (build_summarization_inputs) can use them as summary_sources without
@@ -100,6 +105,7 @@ export function getJsonSummarySuggestion(suggestions, urlToContentHash = {}) {
         scrapedAt,
         contentHash,
         prompts: keyPointsPrompts,
+        depthLift,
         // Verbatim raw-page sentences each key point was derived from (parallel to
         // keyPoints.items). Persisted so on-demand regeneration can use them as
         // kp_sources without re-fetching the raw page.

--- a/test/audits/summarization/utils.test.js
+++ b/test/audits/summarization/utils.test.js
@@ -694,6 +694,68 @@ describe('summarization utils', () => {
         expect(result[0].depthLift).to.equal(0);
         expect(result[1].depthLift).to.equal(0);
       });
+
+      it('should default depthLift to 0 for NaN and Infinity', () => {
+        for (const val of [NaN, Infinity, -Infinity]) {
+          const suggestions = [{
+            pageUrl: 'https://example.com/page1',
+            depthLift: val,
+            pageSummary: {
+              title: 'Test Page',
+              formatted_summary: 'Test summary',
+              heading_selector: 'h1',
+              insertion_method: 'insertAfter',
+            },
+            keyPoints: { formatted_items: ['Key 1'] },
+          }];
+          const result = getJsonSummarySuggestion(suggestions);
+          expect(result[0].depthLift).to.equal(0, `expected 0 for depthLift=${val}`);
+        }
+      });
+    });
+
+    describe('sourceEvidence validation', () => {
+      it('should filter out non-string elements from sourceEvidence', () => {
+        const suggestions = [{
+          pageUrl: 'https://example.com/page1',
+          pageSummary: {
+            title: 'Test Page',
+            formatted_summary: 'Test summary',
+            heading_selector: 'h1',
+            insertion_method: 'insertAfter',
+            source_evidence: ['valid string', 42, null, undefined, 'another valid'],
+          },
+          keyPoints: {
+            formatted_items: ['Key 1'],
+            source_evidence: [true, 'valid kp', {}, 'another kp'],
+          },
+        }];
+
+        const result = getJsonSummarySuggestion(suggestions);
+
+        expect(result[0].sourceEvidence).to.deep.equal(['valid string', 'another valid']);
+        expect(result[1].sourceEvidence).to.deep.equal(['valid kp', 'another kp']);
+      });
+
+      it('should cap sourceEvidence at 50 entries', () => {
+        const bigArray = Array.from({ length: 60 }, (_, i) => `evidence ${i}`);
+        const suggestions = [{
+          pageUrl: 'https://example.com/page1',
+          pageSummary: {
+            title: 'Test Page',
+            formatted_summary: 'Test summary',
+            heading_selector: 'h1',
+            insertion_method: 'insertAfter',
+            source_evidence: bigArray,
+          },
+          keyPoints: { formatted_items: ['Key 1'], source_evidence: bigArray },
+        }];
+
+        const result = getJsonSummarySuggestion(suggestions);
+
+        expect(result[0].sourceEvidence).to.have.length(50);
+        expect(result[1].sourceEvidence).to.have.length(50);
+      });
     });
 
     describe('sourceEvidence persistence', () => {

--- a/test/audits/summarization/utils.test.js
+++ b/test/audits/summarization/utils.test.js
@@ -637,6 +637,65 @@ describe('summarization utils', () => {
       expect(result[1].contentHash).to.be.null;
     });
 
+    describe('depthLift persistence', () => {
+      it('should persist depthLift on both summary and key-points suggestions', () => {
+        const suggestions = [{
+          pageUrl: 'https://example.com/page1',
+          depthLift: 0.5783,
+          pageSummary: {
+            title: 'Test Page',
+            formatted_summary: 'Test summary',
+            heading_selector: 'h1',
+            insertion_method: 'insertAfter',
+          },
+          keyPoints: { formatted_items: ['Key 1', 'Key 2'] },
+        }];
+
+        const result = getJsonSummarySuggestion(suggestions);
+
+        expect(result).to.have.length(2);
+        expect(result[0].depthLift).to.equal(0.5783);
+        expect(result[1].depthLift).to.equal(0.5783);
+      });
+
+      it('should default depthLift to 0 when absent', () => {
+        const suggestions = [{
+          pageUrl: 'https://example.com/page1',
+          pageSummary: {
+            title: 'Test Page',
+            formatted_summary: 'Test summary',
+            heading_selector: 'h1',
+            insertion_method: 'insertAfter',
+          },
+          keyPoints: { formatted_items: ['Key 1'] },
+        }];
+
+        const result = getJsonSummarySuggestion(suggestions);
+
+        expect(result[0].depthLift).to.equal(0);
+        expect(result[1].depthLift).to.equal(0);
+      });
+
+      it('should default depthLift to 0 when value is not a number', () => {
+        const suggestions = [{
+          pageUrl: 'https://example.com/page1',
+          depthLift: 'invalid',
+          pageSummary: {
+            title: 'Test Page',
+            formatted_summary: 'Test summary',
+            heading_selector: 'h1',
+            insertion_method: 'insertAfter',
+          },
+          keyPoints: { formatted_items: ['Key 1'] },
+        }];
+
+        const result = getJsonSummarySuggestion(suggestions);
+
+        expect(result[0].depthLift).to.equal(0);
+        expect(result[1].depthLift).to.equal(0);
+      });
+    });
+
     describe('sourceEvidence persistence', () => {
       it('should persist source_evidence from pageSummary onto the summary suggestion', () => {
         const sourceEvidence = ['Raw sentence A from page.', 'Raw sentence B from page.'];

--- a/test/audits/summarization/utils.test.js
+++ b/test/audits/summarization/utils.test.js
@@ -636,6 +636,68 @@ describe('summarization utils', () => {
       expect(result[0].contentHash).to.be.null;
       expect(result[1].contentHash).to.be.null;
     });
+
+    describe('sourceEvidence persistence', () => {
+      it('should persist source_evidence from pageSummary onto the summary suggestion', () => {
+        const sourceEvidence = ['Raw sentence A from page.', 'Raw sentence B from page.'];
+        const suggestions = [{
+          pageUrl: 'https://example.com/page1',
+          pageSummary: {
+            title: 'Test Page',
+            formatted_summary: 'Test summary',
+            heading_selector: 'h1',
+            insertion_method: 'insertAfter',
+            source_evidence: sourceEvidence,
+          },
+          keyPoints: { formatted_items: ['Key 1'] },
+        }];
+
+        const result = getJsonSummarySuggestion(suggestions);
+
+        expect(result[0].keyPoints).to.be.false;
+        expect(result[0].sourceEvidence).to.deep.equal(sourceEvidence);
+      });
+
+      it('should persist source_evidence from keyPoints onto the key-points suggestion', () => {
+        const kpEvidence = ['Sentence for Key 1.', 'Sentence for Key 2.'];
+        const suggestions = [{
+          pageUrl: 'https://example.com/page1',
+          pageSummary: {
+            title: 'Test Page',
+            formatted_summary: 'Test summary',
+            heading_selector: 'h1',
+            insertion_method: 'insertAfter',
+          },
+          keyPoints: {
+            formatted_items: ['Key 1', 'Key 2'],
+            source_evidence: kpEvidence,
+          },
+        }];
+
+        const result = getJsonSummarySuggestion(suggestions);
+
+        expect(result[1].keyPoints).to.be.true;
+        expect(result[1].sourceEvidence).to.deep.equal(kpEvidence);
+      });
+
+      it('should default sourceEvidence to empty array when source_evidence is absent', () => {
+        const suggestions = [{
+          pageUrl: 'https://example.com/page1',
+          pageSummary: {
+            title: 'Test Page',
+            formatted_summary: 'Test summary',
+            heading_selector: 'h1',
+            insertion_method: 'insertAfter',
+          },
+          keyPoints: { formatted_items: ['Key 1'] },
+        }];
+
+        const result = getJsonSummarySuggestion(suggestions);
+
+        expect(result[0].sourceEvidence).to.deep.equal([]);
+        expect(result[1].sourceEvidence).to.deep.equal([]);
+      });
+    });
   });
 });
 


### PR DESCRIPTION
## Summary

Persists two new fields onto suggestion records in the DB via \`getJsonSummarySuggestion\` in \`src/summarization/utils.js\`:

- **\`sourceEvidence\`** — verbatim raw-page sentences captured by the gen_summary_crew that ground each key point / summary fact. Used by the on-demand prompt-regeneration path (\`build_summarization_inputs\`) as \`kp_sources\` / \`summary_sources\`, closing the gap where re-generation had no evidence anchoring (mystique PR #3395).
- **\`depthLift\`** — page-level signal (0..1) measuring how deeply buried the facts behind a page's prompts are in the page content. Used for High Impact URL ranking: \`High Impact = agentic_traffic × depth_lift\`. Stored on both suggestion records (summary + key-points) so the UI can use it without extra fetching.

Both fields default safely when absent: \`sourceEvidence → []\`, \`depthLift → 0\`. Backward compatible with existing suggestions and the existing-summary/key-points path.

## Test plan

- [ ] \`npm run test:spec -- test/audits/summarization/utils.test.js\` — 28 tests covering both fields (present, absent, invalid-type cases)
- [ ] Full \`npm test\` passes
- [ ] Verify suggestions in DB have \`sourceEvidence\` and \`depthLift\` populated after a summarization audit run

## Related

- mystique PR: https://git.corp.adobe.com/experience-platform/mystique/pull/3553 — computes \`depth_lift\` signal, captures verbatim \`source_evidence\` per key point and summary fact

🤖 Generated with [Claude Code](https://claude.com/claude-code)