### PR TITLE
fix(backlinks): bump mysticat-shared-seo-client to 1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@adobe/helix-shared-wrap": "2.0.2",
         "@adobe/helix-status": "10.1.5",
         "@adobe/helix-universal-logger": "3.0.29",
-        "@adobe/mysticat-shared-seo-client": "1.6.0",
+        "@adobe/mysticat-shared-seo-client": "1.7.0",
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
         "@adobe/spacecat-shared-athena-client": "1.11.0",
         "@adobe/spacecat-shared-data-access": "3.81.0",
@@ -574,9 +574,9 @@
       }
     },
     "node_modules/@adobe/mysticat-shared-seo-client": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@adobe/mysticat-shared-seo-client/-/mysticat-shared-seo-client-1.6.0.tgz",
-      "integrity": "sha512-paGGUK49+W0Gs9vLXAN4e6rsfluR9xIXoHXCAvi3aKB3Utem6nBMDnep0Q3NsG/QyAB3CRc6b34s8Phy67NVSw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@adobe/mysticat-shared-seo-client/-/mysticat-shared-seo-client-1.7.0.tgz",
+      "integrity": "sha512-9NN1IygAE1DAOOF9Cdb8pjittfKmLPzeRcCZ63E7ZVkhxd/jQbAvG/rmiulwt8Iw582MO/v6WJK8xG9qAvmj5Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@adobe/helix-shared-wrap": "2.0.2",
     "@adobe/helix-status": "10.1.5",
     "@adobe/helix-universal-logger": "3.0.29",
-    "@adobe/mysticat-shared-seo-client": "1.6.0",
+    "@adobe/mysticat-shared-seo-client": "1.7.0",
     "@adobe/spacecat-helix-content-sdk": "1.4.33",
     "@adobe/spacecat-shared-athena-client": "1.11.0",
     "@adobe/spacecat-shared-data-access": "3.81.0",


### PR DESCRIPTION
## Summary

- Bumps `@adobe/mysticat-shared-seo-client` from `1.6.0` → `1.7.0`
- Updates `package-lock.json` to match

**Root cause:** The original SITES-46957 PR added code in `handler.js` calling `seoClient.hasNewBrokenBacklinksEndpoint()`, but the `package.json` was not updated to reference the new version of `mysticat-shared-seo-client` that contains that method and `getBrokenBacklinksV2`. This caused a runtime `TypeError` in production on every broken-backlinks audit run.

## Test plan

- [x] CI passes
- [x] After merge + deploy, trigger `@spacecat run audit kpmg.com broken-backlinks` and verify Splunk shows `Broken backlinks audit using v2 (OAuth2) endpoint` instead of a TypeError
