### PR TITLE
fix: classify .md/.markdown URLs as md content type (LLMO-6399)

### DIFF
--- a/src/cdn-logs-report/utils/agentic-traffic-mapper.js
+++ b/src/cdn-logs-report/utils/agentic-traffic-mapper.js
@@ -73,6 +73,9 @@ function inferContentType(urlPath = '') {
   if (/\.txt$/.test(path)) {
     return 'txt';
   }
+  if (/\.(md|markdown)$/.test(path)) {
+    return 'md';
+  }
   if (!path || path.endsWith('/') || !path.split('/').pop().includes('.')) {
     return 'html';
   }

--- a/test/audits/cdn-logs-report/agentic-traffic-mapper.test.js
+++ b/test/audits/cdn-logs-report/agentic-traffic-mapper.test.js
@@ -431,6 +431,9 @@ describe('agentic traffic mapper', () => {
       { agent_type: 'Chatbots', user_agent_display: 'ChatGPT-User', status: 200, number_of_hits: 1, avg_ttfb_ms: 10, country_code: 'US', url: '/guide.pdf', host: 'www.example.com', product: 'Docs', category: 'Asset' },
       { agent_type: 'Chatbots', user_agent_display: 'ChatGPT-User', status: 200, number_of_hits: 1, avg_ttfb_ms: 10, country_code: 'US', url: '/index.htm', host: 'www.example.com', product: 'Docs', category: 'Asset' },
       { agent_type: 'Chatbots', user_agent_display: 'ChatGPT-User', status: 200, number_of_hits: 1, avg_ttfb_ms: 10, country_code: 'US', url: '/notes.txt', host: 'www.example.com', product: 'Docs', category: 'Asset' },
+      { agent_type: 'Chatbots', user_agent_display: 'ChatGPT-User', status: 200, number_of_hits: 1, avg_ttfb_ms: 10, country_code: 'US', url: '/foo.md', host: 'www.example.com', product: 'Docs', category: 'Asset' },
+      { agent_type: 'Chatbots', user_agent_display: 'ChatGPT-User', status: 200, number_of_hits: 1, avg_ttfb_ms: 10, country_code: 'US', url: '/foo.markdown', host: 'www.example.com', product: 'Docs', category: 'Asset' },
+      { agent_type: 'Chatbots', user_agent_display: 'ChatGPT-User', status: 200, number_of_hits: 1, avg_ttfb_ms: 10, country_code: 'US', url: '/FOO.MD', host: 'www.example.com', product: 'Docs', category: 'Asset' },
     ], site, {
       log: { warn: sinon.spy() },
       dataAccess: {
@@ -449,6 +452,9 @@ describe('agentic traffic mapper', () => {
       'pdf',
       'html',
       'txt',
+      'md',
+      'md',
+      'md',
     ]);
   });
 


### PR DESCRIPTION
## Problem

In the Agentic Traffic dashboard, filtering by the **MD** content type returns no results, while filtering the same view by URL containing `.md` returns hits. The two should be equivalent.

Root cause: `inferContentType(urlPath)` in `src/cdn-logs-report/utils/agentic-traffic-mapper.js` classifies URLs by file extension but has **no branch for `.md`**. Markdown URLs fall through to `return 'other'`, so they are stored as content type `other` and never match the `md` filter that the dashboard always offers. Markdown is already a first-class known content type upstream in `cdn-logs-analysis` (its SQL filters `response_content_type` to `text/html|application/pdf|text/markdown`), so it deserves its own bucket.

## Change

Add a `.md`/`.markdown` -> `md` branch to `inferContentType`, placed after the `.txt` check and before the no-extension catch-all:

```js
if (/\.(md|markdown)$/.test(path)) {
  return 'md';
}
```

## Tests

Extended the existing extension-classification case with `/foo.md`, `/foo.markdown`, and `/FOO.MD` (case-insensitivity). Full suite passes (9114 passing), 100% coverage gate met; changed file at 100/100/100/100.

## Follow-ups (not in this PR)

- Existing rollup rows classified `other` need a data backfill to reclassify to `md`.
- project-elmo-ui hardcodes the content-type list in two places (`src/constants/filters.ts` and `src/utils/filterHandlers.ts`); keep them in sync with the mapper output.

Ref: LLMO-6399
