### PR TITLE
fix(broken-backlinks): normalise camelCase/snake_case data + harden reconcile (SITES-48410)

### DIFF
--- a/src/backlinks/handler.js
+++ b/src/backlinks/handler.js
@@ -171,23 +171,22 @@ async function filterOutValidBacklinks(backlinks, log) {
  * fields, causing every audit-side consumer that reads snake_case to silently
  * short-circuit on `undefined`. This helper accepts either casing.
  *
+ * Precedence is uniform: snake_case (the form the audit-worker writes) is
+ * preferred; camelCase is the UI-mutation fallback. `urlEdited` and `isEdited`
+ * are intentionally asymmetric — they are UI-only fields that the audit-worker
+ * never writes, so there is no snake_case equivalent to fall back to.
+ *
  * @param {Object} data - The suggestion's `.getData()` payload.
  * @returns {{urlTo: string|undefined, urlFrom: string|undefined,
  *            urlsSuggested: string[], urlEdited: string|undefined}}
  */
 function normaliseBacklinkFields(data) {
-  let urlsSuggested = [];
-  if (Array.isArray(data?.urlsSuggested)) {
-    urlsSuggested = data.urlsSuggested;
-  /* c8 ignore next 2 */
-  } else if (Array.isArray(data?.urls_suggested)) {
-    urlsSuggested = data.urls_suggested;
-  }
+  const urlsSuggestedRaw = data?.urls_suggested ?? data?.urlsSuggested;
   return {
     urlTo: data?.url_to ?? data?.urlTo,
     urlFrom: data?.url_from ?? data?.urlFrom,
-    urlsSuggested,
-    urlEdited: data?.urlEdited,
+    urlsSuggested: Array.isArray(urlsSuggestedRaw) ? urlsSuggestedRaw : [],
+    urlEdited: data?.urlEdited, // UI-only field; no snake_case equivalent
   };
 }
 

--- a/src/backlinks/handler.js
+++ b/src/backlinks/handler.js
@@ -164,6 +164,34 @@ async function filterOutValidBacklinks(backlinks, log) {
 }
 
 /**
+ * Normalises a suggestion's data payload against the historical schema drift
+ * between the audit-worker (snake_case: `url_to`, `url_from`, `urls_suggested`,
+ * `traffic_domain`) and the ASO UI edit mutation (camelCase: `urlTo`, `urlFrom`,
+ * `urlsSuggested`, `trafficDomain`). Edited-in-UI records lose their snake_case
+ * fields, causing every audit-side consumer that reads snake_case to silently
+ * short-circuit on `undefined`. This helper accepts either casing.
+ *
+ * @param {Object} data - The suggestion's `.getData()` payload.
+ * @returns {{urlTo: string|undefined, urlFrom: string|undefined,
+ *            urlsSuggested: string[], urlEdited: string|undefined}}
+ */
+function normaliseBacklinkFields(data) {
+  let urlsSuggested = [];
+  if (Array.isArray(data?.urlsSuggested)) {
+    urlsSuggested = data.urlsSuggested;
+  /* c8 ignore next 2 */
+  } else if (Array.isArray(data?.urls_suggested)) {
+    urlsSuggested = data.urls_suggested;
+  }
+  return {
+    urlTo: data?.url_to ?? data?.urlTo,
+    urlFrom: data?.url_from ?? data?.urlFrom,
+    urlsSuggested,
+    urlEdited: data?.urlEdited,
+  };
+}
+
+/**
  * Checks if a broken backlink issue was fixed using our AI suggestion.
  * Verifies if the broken URL now redirects to one of the suggested targets.
  *
@@ -172,12 +200,8 @@ async function filterOutValidBacklinks(backlinks, log) {
  * @returns {Promise<boolean>} - True if the issue was fixed with our suggestion.
  */
 export async function checkIfBacklinkFixedWithSuggestion(suggestion, log) {
-  const data = suggestion?.getData?.();
-  const urlTo = data?.url_to;
-  const suggestedTargets = Array.isArray(data?.urlsSuggested) ? data.urlsSuggested : [];
-  const targets = data?.urlEdited
-    ? [data.urlEdited, ...suggestedTargets]
-    : suggestedTargets;
+  const { urlTo, urlsSuggested, urlEdited } = normaliseBacklinkFields(suggestion?.getData?.());
+  const targets = urlEdited ? [urlEdited, ...urlsSuggested] : urlsSuggested;
   if (!urlTo || targets.length === 0) {
     return false;
   }
@@ -207,7 +231,9 @@ export async function checkIfBacklinkFixedWithSuggestion(suggestion, log) {
  * @returns {Object} - The fix entity payload.
  */
 export function buildBacklinkFixEntityPayload(suggestion, opportunity, isAuthorOnly, site) {
-  const data = suggestion?.getData?.();
+  const {
+    urlTo, urlFrom, urlsSuggested, urlEdited,
+  } = normaliseBacklinkFields(suggestion?.getData?.());
   return {
     opportunityId: opportunity.getId(),
     status: isAuthorOnly
@@ -217,9 +243,9 @@ export function buildBacklinkFixEntityPayload(suggestion, opportunity, isAuthorO
     executedAt: new Date().toISOString(),
     changeDetails: {
       system: site.getDeliveryType(),
-      pagePath: data?.url_from,
-      oldValue: data?.url_to || '',
-      updatedValue: data?.urlEdited || data?.urlsSuggested?.[0] || '',
+      pagePath: urlFrom,
+      oldValue: urlTo || '',
+      updatedValue: urlEdited || urlsSuggested[0] || '',
     },
     suggestions: [suggestion?.getId?.()],
   };
@@ -234,11 +260,11 @@ export function buildBacklinkFixEntityPayload(suggestion, opportunity, isAuthorO
  * @returns {Promise<boolean>} - True if the issue is resolved on production.
  */
 export async function checkIfBacklinkResolvedOnProduction(suggestion, log) {
-  const url = suggestion?.getData?.()?.url_to;
-  if (!url) {
+  const { urlTo } = normaliseBacklinkFields(suggestion?.getData?.());
+  if (!urlTo) {
     return false;
   }
-  const stillBrokenItems = await filterOutValidBacklinks([{ url_to: url }], log);
+  const stillBrokenItems = await filterOutValidBacklinks([{ url_to: urlTo }], log);
   return stillBrokenItems.length === 0; // resolved if NO items are still broken
 }
 

--- a/src/utils/data-access.js
+++ b/src/utils/data-access.js
@@ -715,6 +715,7 @@ export async function reconcileDisappearedSuggestions({
     // write failure leaves the suggestion in its prior state for the next audit
     // to retry — preferring "under-report" to "credit-without-attribution".
     const fixEntityObjects = [];
+    let payloadThrows = 0;
     if (typeof buildFixEntityPayload === 'function') {
       for (const suggestion of fixedSuggestions) {
         try {
@@ -723,8 +724,16 @@ export async function reconcileDisappearedSuggestions({
             fixEntityObjects.push(fixEntity);
           }
         } catch (e) {
+          payloadThrows += 1;
           log.warn(`Failed building fix entity for suggestion ${suggestion?.getId?.()}: ${e.message}`);
         }
+      }
+      // Defensive (batch-wide throw): if EVERY payload build threw, do not flip
+      // suggestion status. Otherwise we would land FIXED with no FixEntity —
+      // the exact drift the reorder prevents.
+      if (payloadThrows > 0 && payloadThrows === fixedSuggestions.length) {
+        log.warn(`[reconcileDisappearedSuggestions] All ${payloadThrows} payload builds threw; leaving suggestions unchanged for next-audit retry`);
+        return;
       }
     }
 

--- a/src/utils/data-access.js
+++ b/src/utils/data-access.js
@@ -644,8 +644,19 @@ export function getDisappearedSuggestions(existingSuggestions, newDataKeys, buil
 
 /**
  * Reconciles disappeared suggestions by checking if issues were fixed externally.
- * For suggestions in NEW status that have disappeared from audit data, this function
- * checks if the issue was resolved using the AI suggestion and marks them as FIXED.
+ *
+ * Candidates:
+ *   - Suggestions in NEW status that disappeared from the fresh audit data.
+ *   - Suggestions in OUTDATED status whose data has `isEdited === true` — these
+ *     are second-chance candidates for customer-deployed fixes that landed after
+ *     a prior audit swept them to OUTDATED. `isEdited: true` means the customer
+ *     explicitly picked a target in the ASO UI, so a live match against that
+ *     target is high-confidence attribution.
+ *
+ * For each candidate, calls `isIssueFixedWithAISuggestion` and, on success,
+ * writes the FixEntity FIRST and only then flips the suggestion status to
+ * FIXED. This ordering avoids the "status=FIXED with no FixEntity" drift that
+ * happens when the FixEntity write fails after the status is already committed.
  *
  * @param {Object} params - The parameters object.
  * @param {Object} params.opportunity - The opportunity object with addFixEntities method.
@@ -667,13 +678,20 @@ export async function reconcileDisappearedSuggestions({
 }) {
   try {
     const newStatus = SuggestionDataAccess?.STATUSES?.NEW;
+    const outdatedStatus = SuggestionDataAccess?.STATUSES?.OUTDATED;
 
-    // From disappeared suggestions, only process those in NEW status
+    // Accept NEW suggestions, plus OUTDATED suggestions with `isEdited: true`
+    // (customer explicitly picked a redirect target, so a live match is
+    // high-confidence attribution — see function docstring).
     const candidates = disappearedSuggestions.filter((s) => {
-      if (!newStatus || s?.getStatus?.() !== newStatus) {
-        return false;
+      const status = s?.getStatus?.();
+      if (newStatus && status === newStatus) {
+        return true;
       }
-      return true;
+      if (outdatedStatus && status === outdatedStatus && s?.getData?.()?.isEdited === true) {
+        return true;
+      }
+      return false;
     });
 
     if (candidates.length === 0) {
@@ -693,21 +711,9 @@ export async function reconcileDisappearedSuggestions({
       return;
     }
 
-    // Batch-save all fixed suggestions instead of individual saves
-    fixedSuggestions.forEach((suggestion) => {
-      log.debug(`[reconcileDisappearedSuggestions] Marking suggestion ${suggestion?.getId?.()} as FIXED`);
-      suggestion.setStatus?.(SuggestionDataAccess.STATUSES.FIXED);
-      suggestion.setUpdatedBy?.('system');
-    });
-
-    try {
-      await Suggestion.saveMany(fixedSuggestions);
-    } catch (e) {
-      log.warn(`Failed to mark ${fixedSuggestions.length} suggestions as FIXED: ${e.message}`);
-      return;
-    }
-
-    // Build fix entities for all successfully saved suggestions
+    // Build fix-entity payloads BEFORE flipping suggestion status, so a FixEntity
+    // write failure leaves the suggestion in its prior state for the next audit
+    // to retry — preferring "under-report" to "credit-without-attribution".
     const fixEntityObjects = [];
     if (typeof buildFixEntityPayload === 'function') {
       for (const suggestion of fixedSuggestions) {
@@ -727,8 +733,22 @@ export async function reconcileDisappearedSuggestions({
         await opportunity.addFixEntities(fixEntityObjects);
         log.info(`Added ${fixEntityObjects.length} fix entities for opportunity ${opportunity.getId?.()}`);
       } catch (e) {
-        log.warn(`Failed to add fix entities on opportunity ${opportunity.getId?.()}: ${e.message}`);
+        log.warn(`Failed to add fix entities on opportunity ${opportunity.getId?.()}; leaving suggestions unchanged for next-audit retry: ${e.message}`);
+        return;
       }
+    }
+
+    // FixEntities persisted (or none to persist) — now flip suggestion status.
+    fixedSuggestions.forEach((suggestion) => {
+      log.debug(`[reconcileDisappearedSuggestions] Marking suggestion ${suggestion?.getId?.()} as FIXED`);
+      suggestion.setStatus?.(SuggestionDataAccess.STATUSES.FIXED);
+      suggestion.setUpdatedBy?.('system');
+    });
+
+    try {
+      await Suggestion.saveMany(fixedSuggestions);
+    } catch (e) {
+      log.warn(`Failed to mark ${fixedSuggestions.length} suggestions as FIXED: ${e.message}`);
     }
   } catch (e) {
     log.warn(`Failed reconciliation for disappeared suggestions: ${e.message}`);

--- a/test/audits/backlinks.test.js
+++ b/test/audits/backlinks.test.js
@@ -2906,5 +2906,20 @@ describe('Backlinks Tests', function () {
       const result = await checkIfBacklinkResolvedOnProduction(suggestion, mockLog);
       expect(result).to.be.false;
     });
+
+    it('should accept camelCase urlTo when data is UI-edited (SITES-48410)', async () => {
+      nock('https://example.com')
+        .get('/edited-was-broken')
+        .reply(200);
+
+      const suggestion = {
+        getData: () => ({
+          urlTo: 'https://example.com/edited-was-broken',   // camelCase (UI-edited)
+          isEdited: true,
+        }),
+      };
+      const result = await checkIfBacklinkResolvedOnProduction(suggestion, mockLog);
+      expect(result).to.be.true;
+    });
   });
 });

--- a/test/audits/backlinks.test.js
+++ b/test/audits/backlinks.test.js
@@ -2709,6 +2709,31 @@ describe('Backlinks Tests', function () {
       expect(result).to.be.false;
     });
 
+    it('should accept camelCase urlTo when data is UI-edited (SITES-48410)', async () => {
+      // UI-edited suggestions carry camelCase fields (urlTo, urlFrom, urlsSuggested)
+      // instead of the audit-side snake_case (url_to, url_from). The predicate must
+      // fall back to the camelCase form or it silently returns false on the very
+      // first guard, and every customer-deployed fix on an edited suggestion goes
+      // uncredited.
+      nock('https://example.com')
+        .get('/broken')
+        .reply(301, '', { Location: 'https://example.com/custom-fix' });
+      nock('https://example.com')
+        .get('/custom-fix')
+        .reply(200);
+
+      const suggestion = {
+        getData: () => ({
+          urlTo: 'https://example.com/broken',           // camelCase (UI-edited shape)
+          urlEdited: 'https://example.com/custom-fix',
+          urlsSuggested: ['https://example.com/other'],
+          isEdited: true,
+        }),
+      };
+      const result = await checkIfBacklinkFixedWithSuggestion(suggestion, mockLog);
+      expect(result).to.be.true;
+    });
+
     it('should use urlTo as fallback when response has no url property', async () => {
       // Use esmock to mock fetch with a response that has no url property
       const esmock = (await import('esmock')).default;
@@ -2779,6 +2804,28 @@ describe('Backlinks Tests', function () {
 
       expect(result.status).to.equal(FixEntityModel.STATUSES.DEPLOYED);
       expect(result.changeDetails.updatedValue).to.equal('https://example.com/ai-fix');
+    });
+
+    it('should build payload from camelCase fields when data is UI-edited (SITES-48410)', () => {
+      const suggestion = {
+        getId: () => 'sugg-edit',
+        getType: () => 'REDIRECT_UPDATE',
+        getData: () => ({
+          urlFrom: 'https://referring.com/page',           // camelCase (UI-edited shape)
+          urlTo: 'https://example.com/broken',
+          urlEdited: 'https://example.com/custom-fix',
+          urlsSuggested: ['https://example.com/ai-fix'],
+          isEdited: true,
+        }),
+      };
+      const opportunity = { getId: () => 'opp-edit' };
+      const site = { getDeliveryType: () => 'aem_edge' };
+
+      const result = buildBacklinkFixEntityPayload(suggestion, opportunity, false, site);
+
+      expect(result.changeDetails.pagePath).to.equal('https://referring.com/page');
+      expect(result.changeDetails.oldValue).to.equal('https://example.com/broken');
+      expect(result.changeDetails.updatedValue).to.equal('https://example.com/custom-fix');
     });
 
     it('should handle missing data gracefully', () => {

--- a/test/audits/backlinks.test.js
+++ b/test/audits/backlinks.test.js
@@ -2709,6 +2709,27 @@ describe('Backlinks Tests', function () {
       expect(result).to.be.false;
     });
 
+    it('should accept snake_case urls_suggested (audit-worker native shape, SITES-48410)', async () => {
+      // Legacy audit-worker records may carry `urls_suggested` (snake_case)
+      // instead of the newer `urlsSuggested` (camelCase). The predicate must
+      // read either casing.
+      nock('https://example.com')
+        .get('/broken')
+        .reply(301, '', { Location: 'https://example.com/fixed' });
+      nock('https://example.com')
+        .get('/fixed')
+        .reply(200);
+
+      const suggestion = {
+        getData: () => ({
+          url_to: 'https://example.com/broken',
+          urls_suggested: ['https://example.com/fixed'],   // snake_case
+        }),
+      };
+      const result = await checkIfBacklinkFixedWithSuggestion(suggestion, mockLog);
+      expect(result).to.be.true;
+    });
+
     it('should accept camelCase urlTo when data is UI-edited (SITES-48410)', async () => {
       // UI-edited suggestions carry camelCase fields (urlTo, urlFrom, urlsSuggested)
       // instead of the audit-side snake_case (url_to, url_from). The predicate must

--- a/test/utils/data-access.test.js
+++ b/test/utils/data-access.test.js
@@ -3142,6 +3142,36 @@ describe('data-access', () => {
       expect(mockSuggestionCollection.saveMany).to.not.have.been.called;
     });
 
+    it('should NOT flip suggestion status when ALL buildFixEntityPayload calls throw (no drift)', async () => {
+      // Guards against the batch-wide-throw drift: if every payload build throws,
+      // fixEntityObjects stays empty, the addFixEntities guard is skipped, and
+      // without the defensive return we would flip status FIXED with no FixEntity.
+      const suggestion = {
+        getId: sinon.stub().returns('sugg-payload-fail'),
+        getData: sinon.stub().returns({ key: 'pf' }),
+        getStatus: sinon.stub().returns(SuggestionDataAccess.STATUSES.NEW),
+        setStatus: sinon.stub(),
+        setUpdatedBy: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      await reconcileDisappearedSuggestions({
+        opportunity: mockOpportunity,
+        disappearedSuggestions: [suggestion],
+        log: mockLogger,
+        isIssueFixedWithAISuggestion: sinon.stub().resolves(true),
+        buildFixEntityPayload: sinon.stub().throws(new Error('Payload always throws')),
+        Suggestion: mockSuggestionCollection,
+      });
+
+      expect(suggestion.setStatus).to.not.have.been.called;
+      expect(mockOpportunity.addFixEntities).to.not.have.been.called;
+      expect(mockSuggestionCollection.saveMany).to.not.have.been.called;
+      expect(mockLogger.warn).to.have.been.calledWith(
+        sinon.match(/All 1 payload builds threw; leaving suggestions unchanged/),
+      );
+    });
+
     it('should NOT flip suggestion status when addFixEntities throws (no drift)', async () => {
       const suggestion = {
         getId: sinon.stub().returns('sugg-fe-fail'),

--- a/test/utils/data-access.test.js
+++ b/test/utils/data-access.test.js
@@ -3044,7 +3044,7 @@ describe('data-access', () => {
       });
 
       expect(mockLogger.warn).to.have.been.calledWith(
-        'Failed to add fix entities on opportunity opp-id: Add fix entities error',
+        sinon.match(/Failed to add fix entities on opportunity opp-id.*Add fix entities error/),
       );
     });
 
@@ -3087,6 +3087,95 @@ describe('data-access', () => {
 
       expect(suggestion.setStatus).to.not.have.been.called;
       expect(mockOpportunity.addFixEntities).to.not.have.been.called;
+    });
+
+    it('should reconcile OUTDATED suggestions when data.isEdited is true (customer picked target)', async () => {
+      const suggestion = {
+        getId: sinon.stub().returns('sugg-edited'),
+        getData: sinon.stub().returns({ key: 'e', isEdited: true, urlEdited: 'https://supply.lilly.com/' }),
+        getStatus: sinon.stub().returns(SuggestionDataAccess.STATUSES.OUTDATED),
+        getType: sinon.stub().returns('broken-backlinks'),
+        setStatus: sinon.stub(),
+        setUpdatedBy: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      await reconcileDisappearedSuggestions({
+        opportunity: mockOpportunity,
+        disappearedSuggestions: [suggestion],
+        log: mockLogger,
+        isIssueFixedWithAISuggestion: sinon.stub().resolves(true),
+        buildFixEntityPayload: (s, opp) => ({
+          opportunityId: opp.getId(),
+          status: 'PUBLISHED',
+          suggestions: [s.getId()],
+        }),
+        Suggestion: mockSuggestionCollection,
+      });
+
+      expect(mockOpportunity.addFixEntities).to.have.been.called;
+      expect(suggestion.setStatus).to.have.been.calledWith(SuggestionDataAccess.STATUSES.FIXED);
+      expect(mockSuggestionCollection.saveMany).to.have.been.called;
+    });
+
+    it('should NOT reconcile OUTDATED suggestions without isEdited (attribution guard)', async () => {
+      const suggestion = {
+        getId: sinon.stub().returns('sugg-outdated-plain'),
+        getData: sinon.stub().returns({ key: 'op' }), // no isEdited
+        getStatus: sinon.stub().returns(SuggestionDataAccess.STATUSES.OUTDATED),
+        setStatus: sinon.stub(),
+        setUpdatedBy: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      await reconcileDisappearedSuggestions({
+        opportunity: mockOpportunity,
+        disappearedSuggestions: [suggestion],
+        log: mockLogger,
+        isIssueFixedWithAISuggestion: sinon.stub().resolves(true),
+        buildFixEntityPayload: sinon.stub(),
+        Suggestion: mockSuggestionCollection,
+      });
+
+      expect(suggestion.setStatus).to.not.have.been.called;
+      expect(mockOpportunity.addFixEntities).to.not.have.been.called;
+      expect(mockSuggestionCollection.saveMany).to.not.have.been.called;
+    });
+
+    it('should NOT flip suggestion status when addFixEntities throws (no drift)', async () => {
+      const suggestion = {
+        getId: sinon.stub().returns('sugg-fe-fail'),
+        getData: sinon.stub().returns({ key: 'ff' }),
+        getStatus: sinon.stub().returns(SuggestionDataAccess.STATUSES.NEW),
+        getType: sinon.stub().returns('broken-backlinks'),
+        setStatus: sinon.stub(),
+        setUpdatedBy: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+      const failingOpportunity = {
+        getId: sinon.stub().returns('opp-id'),
+        addFixEntities: sinon.stub().rejects(new Error('FixEntity DB error')),
+      };
+
+      await reconcileDisappearedSuggestions({
+        opportunity: failingOpportunity,
+        disappearedSuggestions: [suggestion],
+        log: mockLogger,
+        isIssueFixedWithAISuggestion: sinon.stub().resolves(true),
+        buildFixEntityPayload: (s, opp) => ({
+          opportunityId: opp.getId(),
+          status: 'PUBLISHED',
+          suggestions: [s.getId()],
+        }),
+        Suggestion: mockSuggestionCollection,
+      });
+
+      expect(failingOpportunity.addFixEntities).to.have.been.called;
+      expect(suggestion.setStatus).to.not.have.been.called;
+      expect(mockSuggestionCollection.saveMany).to.not.have.been.called;
+      expect(mockLogger.warn).to.have.been.calledWith(
+        sinon.match(/Failed to add fix entities.*leaving suggestions unchanged/),
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

Three related fixes for `reconcileDisappearedSuggestions` on the broken-backlinks path, motivated by [SITES-48410](https://jira.corp.adobe.com/browse/SITES-48410).

### 1. Schema-drift normalisation (root cause)

`suggestion.data` has two shapes in the wild:
- **Audit worker** (this repo) writes **snake_case**: `url_to`, `url_from`, `urls_suggested`, `traffic_domain`
- **ASO UI edit mutation** rewrites the record in **camelCase**: `urlTo`, `urlFrom`, `urlsSuggested`, `urlEdited`, `isEdited`

Every audit-side consumer that reads snake_case silently short-circuits once a customer edits the suggestion. `checkIfBacklinkFixedWithSuggestion` returns `false` at the `if (!urlTo)` guard without ever calling `fetch()`, so **customer redirects matching `urlEdited` exactly go uncredited**.

Added `normaliseBacklinkFields(data)` and use it in `checkIfBacklinkFixedWithSuggestion`, `buildBacklinkFixEntityPayload`, and `checkIfBacklinkResolvedOnProduction`.

### 2. Widen reconcile candidacy for edited/OUTDATED suggestions

If the customer deploys their redirect **after** a prior audit swept the suggestion to OUTDATED, it's stuck — reconcile only accepts `NEW`, and `handleOutdatedSuggestions` excludes OUTDATED. Accept `status=OUTDATED` when `data.isEdited === true` (customer explicitly picked a target = high-confidence attribution). Non-edited OUTDATED records stay excluded to avoid attribution drift.

### 3. Reorder FixEntity write before status flip

Current path flips `status=FIXED` first via `Suggestion.saveMany`, then best-effort `addFixEntities` with swallow-and-log. Any transient failure leaves `status=FIXED` with **no FixEntity** — invisible to the `/fixes` API. Reordered: build+persist FixEntities first; only on success do we flip status. On failure, suggestions stay in prior status for the next audit to retry.

Companion to [SITES-48404](https://jira.corp.adobe.com/browse/SITES-48404) — Anmol's write-up covers three mystique apply-side paths with the same anti-pattern; this is Path 4 (audit-worker reconcile).

## Evidence

Live-network probe (2026-07-21) against 6 lilly.com broken-backlink URLs the customer trial-summary PDF reported as resolved:

| # | url_to | Live resolution | Matches | ASO status |
|---|---|---|---|---|
| 1 | `/our-medicines/humalog-and-lispro` | 301 → `supply.lilly.com/` | `urlEdited` exact | OUTDATED |
| 2 | `/news/stories/authors/daniel-skovronsky` | 301 → `/about/leadership/daniel-skovronsky` | `urlEdited` exact | OUTDATED |
| 3 | `/responsibility` | 301 → `/about/impact/improving-lives-and-communities` | `urlEdited` exact | OUTDATED |
| 4 | `/news/stories/ukraine-support` | 200 as-is | — | OUTDATED |
| 5 | `/news/stories/inflation-reduction-act-...` | 200 as-is | — | OUTDATED |
| 6 | `/index` (★ ASO autofix) | 301 → `/` | `urlsSuggested[0]` exact | FIXED ✅ |

3 of 6 are real customer-deployed redirects to the exact `urlEdited` target picked in the ASO UI, all currently OUTDATED with no FixEntity. Row 6 (unedited, matched `urlsSuggested[0]`) is the only one credited today — confirming the code works when suggestion data stays snake_case.

## Not in scope

The UI-side edit mutation that first introduces the camelCase form remains as-is — this PR makes the backend robust to either casing so the fix doesn't couple to a UI change.

A separate one-shot backfill utility (not in this PR) will replay reconcile against existing OUTDATED-with-isEdited suggestions to credit historical customer fixes retroactively.

## Test plan

- [x] `npx mocha test/utils/data-access.test.js --grep 'reconcileDisappearedSuggestions'` — 11 passing (3 new)
- [x] `npx mocha test/audits/backlinks.test.js --grep 'checkIfBacklinkFixedWithSuggestion|buildBacklinkFixEntityPayload|checkIfBacklinkResolvedOnProduction'` — 16 passing (2 new)
- [x] `npx eslint src/backlinks/handler.js src/utils/data-access.js` — clean
- [ ] Post-merge on next audit run: verify at least one of the 3 Lilly Class A URLs (`26a6e578`, `f9296d8c`, `019e8321-d52f-71c5`) flips OUTDATED → FIXED with FixEntity