### PR TITLE
fix(image-alt-text): preserve REJECTED suggestions in outdate sweep (SITES-44646)

### DIFF
--- a/src/image-alt-text/guidance-missing-alt-text-handler.js
+++ b/src/image-alt-text/guidance-missing-alt-text-handler.js
@@ -98,9 +98,12 @@ async function clearSuggestionsForPagesAndCalculateMetrics(
     }
     return pageUrl && pageUrlSet.has(pageUrl);
   }).filter((suggestion) => {
-    // REJECTED preserved alongside SKIPPED — both are operator decisions
-    // whose updatedAt must not be bumped by guidance replies (SITES-44646).
-    const IGNORED_STATUSES = ['SKIPPED', 'REJECTED', 'FIXED', 'OUTDATED'];
+    // Rule (SITES-44646): don't bump updatedAt on suggestions whose state
+    // isn't changing. FIXED / OUTDATED stay as-is; NEW / PENDING_VALIDATION /
+    // SKIPPED / REJECTED transition to OUTDATED here because Mystique reported
+    // the issue as resolved for these pages — a real state change, so the
+    // updatedAt bump is legitimate.
+    const IGNORED_STATUSES = ['FIXED', 'OUTDATED'];
     return !IGNORED_STATUSES.includes(suggestion.getStatus());
   });
 

--- a/src/image-alt-text/guidance-missing-alt-text-handler.js
+++ b/src/image-alt-text/guidance-missing-alt-text-handler.js
@@ -98,7 +98,9 @@ async function clearSuggestionsForPagesAndCalculateMetrics(
     }
     return pageUrl && pageUrlSet.has(pageUrl);
   }).filter((suggestion) => {
-    const IGNORED_STATUSES = ['SKIPPED', 'FIXED', 'OUTDATED'];
+    // REJECTED preserved alongside SKIPPED — both are operator decisions
+    // whose updatedAt must not be bumped by guidance replies (SITES-44646).
+    const IGNORED_STATUSES = ['SKIPPED', 'REJECTED', 'FIXED', 'OUTDATED'];
     return !IGNORED_STATUSES.includes(suggestion.getStatus());
   });
 

--- a/src/image-alt-text/guidance-missing-alt-text-handler.js
+++ b/src/image-alt-text/guidance-missing-alt-text-handler.js
@@ -98,12 +98,9 @@ async function clearSuggestionsForPagesAndCalculateMetrics(
     }
     return pageUrl && pageUrlSet.has(pageUrl);
   }).filter((suggestion) => {
-    // Rule (SITES-44646): don't bump updatedAt on suggestions whose state
-    // isn't changing. FIXED / OUTDATED stay as-is; NEW / PENDING_VALIDATION /
-    // SKIPPED / REJECTED transition to OUTDATED here because Mystique reported
-    // the issue as resolved for these pages — a real state change, so the
-    // updatedAt bump is legitimate.
-    const IGNORED_STATUSES = ['FIXED', 'OUTDATED'];
+    // REJECTED preserved alongside SKIPPED — both are operator decisions
+    // whose updatedAt must not be bumped by guidance replies (SITES-44646).
+    const IGNORED_STATUSES = ['SKIPPED', 'REJECTED', 'FIXED', 'OUTDATED'];
     return !IGNORED_STATUSES.includes(suggestion.getStatus());
   });
 

--- a/src/image-alt-text/handler.js
+++ b/src/image-alt-text/handler.js
@@ -422,7 +422,9 @@ export async function processAltTextWithMystique(context) {
 
       // Filter suggestions with URLs not in current pageUrls
       const pageUrlSet = new Set(pageUrls);
-      const IGNORED_STATUSES = ['SKIPPED', 'FIXED', 'OUTDATED'];
+      // REJECTED preserved alongside SKIPPED — both are operator decisions
+      // whose updatedAt must not be bumped by subsequent audit runs (SITES-44646).
+      const IGNORED_STATUSES = ['SKIPPED', 'REJECTED', 'FIXED', 'OUTDATED'];
 
       const suggestionsToOutdate = existingSuggestions.filter((suggestion) => {
         const rec = suggestion.getData()?.recommendations?.[0];

--- a/src/image-alt-text/handler.js
+++ b/src/image-alt-text/handler.js
@@ -422,13 +422,9 @@ export async function processAltTextWithMystique(context) {
 
       // Filter suggestions with URLs not in current pageUrls
       const pageUrlSet = new Set(pageUrls);
-      // Rule (SITES-44646): don't bump updatedAt on suggestions whose state
-      // isn't changing. FIXED / OUTDATED remain as-is; NEW / PENDING_VALIDATION /
-      // SKIPPED / REJECTED transition to OUTDATED when the page falls out of
-      // scope — that IS a legitimate state change (issue no longer detected),
-      // so the updatedAt bump is expected. Preserving SKIPPED / REJECTED here
-      // would leave them stuck on a non-existent issue.
-      const IGNORED_STATUSES = ['FIXED', 'OUTDATED'];
+      // REJECTED preserved alongside SKIPPED — both are operator decisions
+      // whose updatedAt must not be bumped by subsequent audit runs (SITES-44646).
+      const IGNORED_STATUSES = ['SKIPPED', 'REJECTED', 'FIXED', 'OUTDATED'];
 
       const suggestionsToOutdate = existingSuggestions.filter((suggestion) => {
         const rec = suggestion.getData()?.recommendations?.[0];

--- a/src/image-alt-text/handler.js
+++ b/src/image-alt-text/handler.js
@@ -422,9 +422,13 @@ export async function processAltTextWithMystique(context) {
 
       // Filter suggestions with URLs not in current pageUrls
       const pageUrlSet = new Set(pageUrls);
-      // REJECTED preserved alongside SKIPPED — both are operator decisions
-      // whose updatedAt must not be bumped by subsequent audit runs (SITES-44646).
-      const IGNORED_STATUSES = ['SKIPPED', 'REJECTED', 'FIXED', 'OUTDATED'];
+      // Rule (SITES-44646): don't bump updatedAt on suggestions whose state
+      // isn't changing. FIXED / OUTDATED remain as-is; NEW / PENDING_VALIDATION /
+      // SKIPPED / REJECTED transition to OUTDATED when the page falls out of
+      // scope — that IS a legitimate state change (issue no longer detected),
+      // so the updatedAt bump is expected. Preserving SKIPPED / REJECTED here
+      // would leave them stuck on a non-existent issue.
+      const IGNORED_STATUSES = ['FIXED', 'OUTDATED'];
 
       const suggestionsToOutdate = existingSuggestions.filter((suggestion) => {
         const rec = suggestion.getData()?.recommendations?.[0];

--- a/test/audits/image-alt-text/guidance-missing-alt-text-handler.test.js
+++ b/test/audits/image-alt-text/guidance-missing-alt-text-handler.test.js
@@ -540,41 +540,38 @@ describe('Missing Alt Text Guidance Handler', () => {
     );
   });
 
-  it('should handle case when no existing suggestions need to be removed', async () => {
-    // Terminal statuses SKIPPED / REJECTED / FIXED must not be flipped to OUTDATED
-    // by guidance replies (SITES-44646).
-    const existingSuggestions = [
-      {
-        getData: () => ({
-          recommendations: [{
-            id: 'suggestion-1',
-            pageUrl: 'https://example.com/page1',
-            imageUrl: 'https://example.com/image1.jpg',
-          }],
-        }),
-        getStatus: () => 'SKIPPED',
-      },
-      {
-        getData: () => ({
-          recommendations: [{
-            id: 'suggestion-2',
-            pageUrl: 'https://example.com/page2',
-            imageUrl: 'https://example.com/image2.jpg',
-          }],
-        }),
-        getStatus: () => 'FIXED',
-      },
-      {
-        getData: () => ({
-          recommendations: [{
-            id: 'suggestion-3',
-            pageUrl: 'https://example.com/page1',
-            imageUrl: 'https://example.com/image3.jpg',
-          }],
-        }),
-        getStatus: () => 'REJECTED',
-      },
-    ];
+  it('outdates SKIPPED/REJECTED when Mystique reports issue resolved; preserves FIXED (SITES-44646)', async () => {
+    const skippedSuggestion = {
+      getData: () => ({
+        recommendations: [{
+          id: 'suggestion-1',
+          pageUrl: 'https://example.com/page1',
+          imageUrl: 'https://example.com/image1.jpg',
+        }],
+      }),
+      getStatus: () => 'SKIPPED',
+    };
+    const fixedSuggestion = {
+      getData: () => ({
+        recommendations: [{
+          id: 'suggestion-2',
+          pageUrl: 'https://example.com/page2',
+          imageUrl: 'https://example.com/image2.jpg',
+        }],
+      }),
+      getStatus: () => 'FIXED',
+    };
+    const rejectedSuggestion = {
+      getData: () => ({
+        recommendations: [{
+          id: 'suggestion-3',
+          pageUrl: 'https://example.com/page1',
+          imageUrl: 'https://example.com/image3.jpg',
+        }],
+      }),
+      getStatus: () => 'REJECTED',
+    };
+    const existingSuggestions = [skippedSuggestion, fixedSuggestion, rejectedSuggestion];
 
     mockOpportunity.getSuggestions.returns(existingSuggestions);
 
@@ -582,7 +579,14 @@ describe('Missing Alt Text Guidance Handler', () => {
 
     expect(result.status).to.equal(200);
 
-    expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.not.have.been.called;
+    // SKIPPED and REJECTED transition to OUTDATED (real state change → updatedAt bump);
+    // FIXED is preserved (no state change).
+    expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledOnce;
+    const [passedSuggestions, targetStatus] = context.dataAccess.Suggestion
+      .bulkUpdateStatus.firstCall.args;
+    expect(targetStatus).to.equal('OUTDATED');
+    expect(passedSuggestions).to.have.members([skippedSuggestion, rejectedSuggestion]);
+    expect(passedSuggestions).to.not.include(fixedSuggestion);
     expect(getProjectedMetricsStub).to.have.been.called;
   });
 

--- a/test/audits/image-alt-text/guidance-missing-alt-text-handler.test.js
+++ b/test/audits/image-alt-text/guidance-missing-alt-text-handler.test.js
@@ -540,38 +540,41 @@ describe('Missing Alt Text Guidance Handler', () => {
     );
   });
 
-  it('outdates SKIPPED/REJECTED when Mystique reports issue resolved; preserves FIXED (SITES-44646)', async () => {
-    const skippedSuggestion = {
-      getData: () => ({
-        recommendations: [{
-          id: 'suggestion-1',
-          pageUrl: 'https://example.com/page1',
-          imageUrl: 'https://example.com/image1.jpg',
-        }],
-      }),
-      getStatus: () => 'SKIPPED',
-    };
-    const fixedSuggestion = {
-      getData: () => ({
-        recommendations: [{
-          id: 'suggestion-2',
-          pageUrl: 'https://example.com/page2',
-          imageUrl: 'https://example.com/image2.jpg',
-        }],
-      }),
-      getStatus: () => 'FIXED',
-    };
-    const rejectedSuggestion = {
-      getData: () => ({
-        recommendations: [{
-          id: 'suggestion-3',
-          pageUrl: 'https://example.com/page1',
-          imageUrl: 'https://example.com/image3.jpg',
-        }],
-      }),
-      getStatus: () => 'REJECTED',
-    };
-    const existingSuggestions = [skippedSuggestion, fixedSuggestion, rejectedSuggestion];
+  it('should handle case when no existing suggestions need to be removed', async () => {
+    // Terminal statuses SKIPPED / REJECTED / FIXED must not be flipped to OUTDATED
+    // by guidance replies (SITES-44646).
+    const existingSuggestions = [
+      {
+        getData: () => ({
+          recommendations: [{
+            id: 'suggestion-1',
+            pageUrl: 'https://example.com/page1',
+            imageUrl: 'https://example.com/image1.jpg',
+          }],
+        }),
+        getStatus: () => 'SKIPPED',
+      },
+      {
+        getData: () => ({
+          recommendations: [{
+            id: 'suggestion-2',
+            pageUrl: 'https://example.com/page2',
+            imageUrl: 'https://example.com/image2.jpg',
+          }],
+        }),
+        getStatus: () => 'FIXED',
+      },
+      {
+        getData: () => ({
+          recommendations: [{
+            id: 'suggestion-3',
+            pageUrl: 'https://example.com/page1',
+            imageUrl: 'https://example.com/image3.jpg',
+          }],
+        }),
+        getStatus: () => 'REJECTED',
+      },
+    ];
 
     mockOpportunity.getSuggestions.returns(existingSuggestions);
 
@@ -579,14 +582,7 @@ describe('Missing Alt Text Guidance Handler', () => {
 
     expect(result.status).to.equal(200);
 
-    // SKIPPED and REJECTED transition to OUTDATED (real state change → updatedAt bump);
-    // FIXED is preserved (no state change).
-    expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledOnce;
-    const [passedSuggestions, targetStatus] = context.dataAccess.Suggestion
-      .bulkUpdateStatus.firstCall.args;
-    expect(targetStatus).to.equal('OUTDATED');
-    expect(passedSuggestions).to.have.members([skippedSuggestion, rejectedSuggestion]);
-    expect(passedSuggestions).to.not.include(fixedSuggestion);
+    expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.not.have.been.called;
     expect(getProjectedMetricsStub).to.have.been.called;
   });
 

--- a/test/audits/image-alt-text/guidance-missing-alt-text-handler.test.js
+++ b/test/audits/image-alt-text/guidance-missing-alt-text-handler.test.js
@@ -541,7 +541,8 @@ describe('Missing Alt Text Guidance Handler', () => {
   });
 
   it('should handle case when no existing suggestions need to be removed', async () => {
-    // Set up existing suggestions that are all SKIPPED or FIXED
+    // Terminal statuses SKIPPED / REJECTED / FIXED must not be flipped to OUTDATED
+    // by guidance replies (SITES-44646).
     const existingSuggestions = [
       {
         getData: () => ({
@@ -562,6 +563,16 @@ describe('Missing Alt Text Guidance Handler', () => {
           }],
         }),
         getStatus: () => 'FIXED',
+      },
+      {
+        getData: () => ({
+          recommendations: [{
+            id: 'suggestion-3',
+            pageUrl: 'https://example.com/page1',
+            imageUrl: 'https://example.com/image3.jpg',
+          }],
+        }),
+        getStatus: () => 'REJECTED',
       },
     ];
 

--- a/test/audits/image-alt-text/handler.test.js
+++ b/test/audits/image-alt-text/handler.test.js
@@ -543,45 +543,44 @@ describe('Image Alt Text Handler', () => {
         );
       });
 
-      it('outdates NEW/PENDING_VALIDATION/SKIPPED/REJECTED when page is off-scan; preserves FIXED/OUTDATED (SITES-44646)', async () => {
-        const skippedSuggestion = {
-          getData: () => ({
-            recommendations: [{
-              pageUrl: 'https://example.com/old-page',
-              imageUrl: 'https://example.com/image1.jpg',
-            }],
-          }),
-          getStatus: () => 'SKIPPED',
-        };
-        const fixedSuggestion = {
-          getData: () => ({
-            recommendations: [{
-              pageUrl: 'https://example.com/another-old-page',
-              imageUrl: 'https://example.com/image2.jpg',
-            }],
-          }),
-          getStatus: () => 'FIXED',
-        };
-        const outdatedSuggestion = {
-          getData: () => ({
-            recommendations: [{
-              pageUrl: 'https://example.com/third-old-page',
-              imageUrl: 'https://example.com/image3.jpg',
-            }],
-          }),
-          getStatus: () => 'OUTDATED',
-        };
-        const rejectedSuggestion = {
-          getData: () => ({
-            recommendations: [{
-              pageUrl: 'https://example.com/rejected-page',
-              imageUrl: 'https://example.com/image4.jpg',
-            }],
-          }),
-          getStatus: () => 'REJECTED',
-        };
+      it('should NOT re-process suggestions already in SKIPPED, REJECTED, FIXED, or OUTDATED status', async () => {
         const existingSuggestions = [
-          skippedSuggestion, fixedSuggestion, outdatedSuggestion, rejectedSuggestion,
+          {
+            getData: () => ({
+              recommendations: [{
+                pageUrl: 'https://example.com/old-page',
+                imageUrl: 'https://example.com/image1.jpg',
+              }],
+            }),
+            getStatus: () => 'SKIPPED',
+          },
+          {
+            getData: () => ({
+              recommendations: [{
+                pageUrl: 'https://example.com/another-old-page',
+                imageUrl: 'https://example.com/image2.jpg',
+              }],
+            }),
+            getStatus: () => 'FIXED',
+          },
+          {
+            getData: () => ({
+              recommendations: [{
+                pageUrl: 'https://example.com/third-old-page',
+                imageUrl: 'https://example.com/image3.jpg',
+              }],
+            }),
+            getStatus: () => 'OUTDATED',
+          },
+          {
+            getData: () => ({
+              recommendations: [{
+                pageUrl: 'https://example.com/rejected-page',
+                imageUrl: 'https://example.com/image4.jpg',
+              }],
+            }),
+            getStatus: () => 'REJECTED',
+          },
         ];
 
         const mockOpportunity = {
@@ -601,13 +600,8 @@ describe('Image Alt Text Handler', () => {
 
         await handlerModule.processAltTextWithMystique(context);
 
-        // SKIPPED and REJECTED get outdated (issue no longer detected for these pages);
-        // FIXED and OUTDATED are preserved (no state change).
-        expect(bulkUpdateStatusStub).to.have.been.calledOnce;
-        const [passedSuggestions, targetStatus] = bulkUpdateStatusStub.firstCall.args;
-        expect(targetStatus).to.equal('OUTDATED');
-        expect(passedSuggestions).to.have.members([skippedSuggestion, rejectedSuggestion]);
-        expect(passedSuggestions).to.not.include.members([fixedSuggestion, outdatedSuggestion]);
+        // bulkUpdateStatus should NOT be called since all suggestions are in ignored statuses
+        expect(bulkUpdateStatusStub).to.not.have.been.called;
       });
 
       it('should pass imageUrlsWithAltText from existing NEW suggestions to Mystique', async () => {

--- a/test/audits/image-alt-text/handler.test.js
+++ b/test/audits/image-alt-text/handler.test.js
@@ -543,44 +543,45 @@ describe('Image Alt Text Handler', () => {
         );
       });
 
-      it('should NOT re-process suggestions already in SKIPPED, REJECTED, FIXED, or OUTDATED status', async () => {
+      it('outdates NEW/PENDING_VALIDATION/SKIPPED/REJECTED when page is off-scan; preserves FIXED/OUTDATED (SITES-44646)', async () => {
+        const skippedSuggestion = {
+          getData: () => ({
+            recommendations: [{
+              pageUrl: 'https://example.com/old-page',
+              imageUrl: 'https://example.com/image1.jpg',
+            }],
+          }),
+          getStatus: () => 'SKIPPED',
+        };
+        const fixedSuggestion = {
+          getData: () => ({
+            recommendations: [{
+              pageUrl: 'https://example.com/another-old-page',
+              imageUrl: 'https://example.com/image2.jpg',
+            }],
+          }),
+          getStatus: () => 'FIXED',
+        };
+        const outdatedSuggestion = {
+          getData: () => ({
+            recommendations: [{
+              pageUrl: 'https://example.com/third-old-page',
+              imageUrl: 'https://example.com/image3.jpg',
+            }],
+          }),
+          getStatus: () => 'OUTDATED',
+        };
+        const rejectedSuggestion = {
+          getData: () => ({
+            recommendations: [{
+              pageUrl: 'https://example.com/rejected-page',
+              imageUrl: 'https://example.com/image4.jpg',
+            }],
+          }),
+          getStatus: () => 'REJECTED',
+        };
         const existingSuggestions = [
-          {
-            getData: () => ({
-              recommendations: [{
-                pageUrl: 'https://example.com/old-page',
-                imageUrl: 'https://example.com/image1.jpg',
-              }],
-            }),
-            getStatus: () => 'SKIPPED',
-          },
-          {
-            getData: () => ({
-              recommendations: [{
-                pageUrl: 'https://example.com/another-old-page',
-                imageUrl: 'https://example.com/image2.jpg',
-              }],
-            }),
-            getStatus: () => 'FIXED',
-          },
-          {
-            getData: () => ({
-              recommendations: [{
-                pageUrl: 'https://example.com/third-old-page',
-                imageUrl: 'https://example.com/image3.jpg',
-              }],
-            }),
-            getStatus: () => 'OUTDATED',
-          },
-          {
-            getData: () => ({
-              recommendations: [{
-                pageUrl: 'https://example.com/rejected-page',
-                imageUrl: 'https://example.com/image4.jpg',
-              }],
-            }),
-            getStatus: () => 'REJECTED',
-          },
+          skippedSuggestion, fixedSuggestion, outdatedSuggestion, rejectedSuggestion,
         ];
 
         const mockOpportunity = {
@@ -600,8 +601,13 @@ describe('Image Alt Text Handler', () => {
 
         await handlerModule.processAltTextWithMystique(context);
 
-        // bulkUpdateStatus should NOT be called since all suggestions are in ignored statuses
-        expect(bulkUpdateStatusStub).to.not.have.been.called;
+        // SKIPPED and REJECTED get outdated (issue no longer detected for these pages);
+        // FIXED and OUTDATED are preserved (no state change).
+        expect(bulkUpdateStatusStub).to.have.been.calledOnce;
+        const [passedSuggestions, targetStatus] = bulkUpdateStatusStub.firstCall.args;
+        expect(targetStatus).to.equal('OUTDATED');
+        expect(passedSuggestions).to.have.members([skippedSuggestion, rejectedSuggestion]);
+        expect(passedSuggestions).to.not.include.members([fixedSuggestion, outdatedSuggestion]);
       });
 
       it('should pass imageUrlsWithAltText from existing NEW suggestions to Mystique', async () => {

--- a/test/audits/image-alt-text/handler.test.js
+++ b/test/audits/image-alt-text/handler.test.js
@@ -543,7 +543,7 @@ describe('Image Alt Text Handler', () => {
         );
       });
 
-      it('should NOT re-process suggestions already in SKIPPED, FIXED, or OUTDATED status', async () => {
+      it('should NOT re-process suggestions already in SKIPPED, REJECTED, FIXED, or OUTDATED status', async () => {
         const existingSuggestions = [
           {
             getData: () => ({
@@ -571,6 +571,15 @@ describe('Image Alt Text Handler', () => {
               }],
             }),
             getStatus: () => 'OUTDATED',
+          },
+          {
+            getData: () => ({
+              recommendations: [{
+                pageUrl: 'https://example.com/rejected-page',
+                imageUrl: 'https://example.com/image4.jpg',
+              }],
+            }),
+            getStatus: () => 'REJECTED',
           },
         ];
 


### PR DESCRIPTION
## Summary

Follow-up to [PR #2758](https://github.com/adobe/spacecat-audit-worker/pull/2758) and [PR #2787](https://github.com/adobe/spacecat-audit-worker/pull/2787).

The alt-text audit's `IGNORED_STATUSES` list preserved SKIPPED / FIXED / OUTDATED but **did not preserve REJECTED**. So on every audit run, a REJECTED alt-text suggestion whose page fell out of the current top-pages scan (or that appeared in a Mystique guidance reply) was flipped to OUTDATED — destroying the operator's decision AND bumping `updatedAt`.

## Fix

Add `'REJECTED'` to both `IGNORED_STATUSES` lists:
- [src/image-alt-text/handler.js:425](src/image-alt-text/handler.js#L425) — audit run outdate sweep
- [src/image-alt-text/guidance-missing-alt-text-handler.js:101](src/image-alt-text/guidance-missing-alt-text-handler.js#L101) — Mystique guidance callback

Matches the `FROZEN_STATUSES` contract from the shared `syncSuggestions` freeze.

## Test plan

- [x] Extended the existing SKIPPED/FIXED/OUTDATED preservation test in `handler.test.js` to also cover REJECTED
- [x] Extended the guidance handler's "no suggestions need to be removed" test to include a REJECTED suggestion
- [x] 125 alt-text tests passing
- [x] 100% coverage (lines / branches / statements / functions) on the two modified files
- [x] Lint clean

Fixes: [SITES-44646](https://jira.corp.adobe.com/browse/SITES-44646) (medium-severity fanout M1 + M2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)