### PR TITLE
fix(cwv): remove redundant enabled/entitlement check from cwv-auto-suggest and cwv-auto-fix.

### DIFF
--- a/src/cwv/auto-suggest.js
+++ b/src/cwv/auto-suggest.js
@@ -10,7 +10,6 @@
  * governing permissions and limitations under the License.
  */
 
-import { isAuditEnabledForSite } from '../common/index.js';
 import { getCodeInfo } from '../accessibility/utils/data-processing.js';
 import { METRICS, THRESHOLDS } from './kpi-metrics.js';
 
@@ -43,8 +42,6 @@ function getFailingMetricInfo(allMetrics) {
 }
 
 const CWV_AUTO_SUGGEST_MESSAGE_TYPE = 'guidance:cwv';
-const CWV_AUTO_SUGGEST_FEATURE_TOGGLE = 'cwv-auto-suggest';
-const CWV_AUTO_FIX_FEATURE_TOGGLE = 'cwv-auto-fix';
 
 /**
  * Checks if a specific suggestion should receive auto-suggest from Mystique.
@@ -107,11 +104,18 @@ export function shouldSendAutoSuggestForSuggestion(suggestion) {
 
 /**
  * Processes CWV auto-suggest for eligible suggestions.
- * Checks if auto-suggest is enabled, filters suggestions that need guidance,
- * and sends messages to Mystique for AI-powered guidance generation.
+ * Filters suggestions that need guidance and sends messages to Mystique for
+ * AI-powered guidance generation.
  * Sends one message per suggestion that needs auto-suggest (NEW or PENDING_VALIDATION
  * status, no guidance yet — see `shouldSendAutoSuggestForSuggestion`)
- * Includes code repository information (codeBucket, codePath) if auto-fix feature is enabled
+ * Includes code repository information (codeBucket, codePath) whenever a site is provided.
+ *
+ * Entitlement/enablement for `cwv` is already verified upstream — the job-dispatcher's
+ * `isHandlerEnabledForSite` pre-filter for scheduled runs, and `run-audit`'s entitlement +
+ * deny-list check for one-off runs — before this audit ever gets dispatched, so this step
+ * does not re-check `cwv-auto-suggest`/`cwv-auto-fix` (consistent with how every other
+ * audit type's auto-suggest/auto-fix step in this codebase relies on the base audit's own
+ * gating rather than re-checking Configuration for the sub-feature).
  *
  * @param {Object} context - Context object containing log, sqs, env, s3Client
  * @param {Object} opportunity - Opportunity object with siteId, auditId, opportunityId, and data
@@ -123,24 +127,6 @@ export async function processAutoSuggest(context, opportunity, site) {
     log, sqs, env,
   } = context;
 
-  // Check if CWV auto-suggest feature is enabled for this site
-  const isAutoSuggestEnabled = await isAuditEnabledForSite(
-    CWV_AUTO_SUGGEST_FEATURE_TOGGLE,
-    site,
-    context,
-  );
-  if (!isAutoSuggestEnabled) {
-    log.info(`[audit-worker-cwv] siteId: ${site?.getId?.()} | baseURL: ${site?.getBaseURL?.()} | CWV auto-suggest is disabled, skipping`);
-    return;
-  }
-
-  // Check if CWV auto-fix feature is enabled for this site
-  const isAutoFixEnabled = await isAuditEnabledForSite(
-    CWV_AUTO_FIX_FEATURE_TOGGLE,
-    site,
-    context,
-  );
-
   try {
     const siteId = opportunity.getSiteId();
     const auditId = opportunity.getAuditId();
@@ -149,8 +135,7 @@ export async function processAutoSuggest(context, opportunity, site) {
 
     log.info(`[audit-worker-cwv] siteId: ${siteId} | Processing ${suggestions.length} suggestions for CWV auto-suggest, opportunityId: ${opportunityId}`);
 
-    // Get code repository information only if auto-fix is enabled
-    const codeInfo = (isAutoFixEnabled && site) ? await getCodeInfo(site, 'cwv', context) : null;
+    const codeInfo = site ? await getCodeInfo(site, 'cwv', context) : null;
     const hasCodeInfo = codeInfo && codeInfo.codeBucket && codeInfo.codePath && String(codeInfo.codePath).trim() !== '';
 
     // Send one SQS message per suggestion that needs auto-suggest

--- a/test/audits/cwv.test.js
+++ b/test/audits/cwv.test.js
@@ -784,6 +784,8 @@ describe('collectCWVDataAndImportCode Tests', () => {
 
       const mockOppty = {
         getId: () => 'oppty-id',
+        getSiteId: () => 'site-id',
+        getAuditId: () => 'audit-id',
         setAuditId: sandbox.stub(),
         getData: sandbox.stub().returns({}),
         setData: sandbox.stub(),
@@ -821,6 +823,8 @@ describe('collectCWVDataAndImportCode Tests', () => {
 
       const mockOppty = {
         getId: () => 'oppty-id',
+        getSiteId: () => 'site-id',
+        getAuditId: () => 'audit-id',
         setAuditId: sandbox.stub(),
         getData: sandbox.stub().returns({}),
         setData: sandbox.stub(),

--- a/test/audits/cwv/auto-suggest.test.js
+++ b/test/audits/cwv/auto-suggest.test.js
@@ -20,20 +20,13 @@ use(sinonChai);
 describe('CWV Auto-Suggest', () => {
   let processAutoSuggest;
   let shouldSendAutoSuggestForSuggestion;
-  let isAuditEnabledForSite;
   let context;
   let sqsStub;
   let site;
   const sandbox = sinon.createSandbox();
 
   beforeEach(async () => {
-    isAuditEnabledForSite = sandbox.stub().resolves(true);
-
-    ({ processAutoSuggest, shouldSendAutoSuggestForSuggestion } = await esmock('../../../src/cwv/auto-suggest.js', {
-      '../../../src/common/index.js': {
-        isAuditEnabledForSite,
-      },
-    }));
+    ({ processAutoSuggest, shouldSendAutoSuggestForSuggestion } = await esmock('../../../src/cwv/auto-suggest.js'));
 
     site = {
       getId: () => 'test-site-id',
@@ -105,48 +98,14 @@ describe('CWV Auto-Suggest', () => {
       expect(message.data.device_type).to.equal('mobile');
     });
 
-    it('should skip processing when CWV auto-suggest is disabled for the site', async () => {
-      const isAuditEnabledStub = sandbox.stub().resolves(false);
-      const { processAutoSuggest: processDisabled } = await esmock('../../../src/cwv/auto-suggest.js', {
-        '../../../src/common/index.js': {
-          isAuditEnabledForSite: isAuditEnabledStub,
-        },
-      });
-
-      const opportunity = {
-        getSiteId: () => 'site-123',
-        getAuditId: () => 'audit-456',
-        getId: () => 'oppty-789',
-        getType: () => 'cwv',
-        getSuggestions: sandbox.stub().resolves([]),
-      };
-
-      await processDisabled(context, opportunity, site);
-
-      expect(isAuditEnabledStub).to.have.been.calledOnce;
-      expect(opportunity.getSuggestions).to.not.have.been.called;
-      expect(sqsStub).to.not.have.been.called;
-      expect(context.log.info).to.have.been.calledWithMatch(
-        /CWV auto-suggest is disabled, skipping/,
-      );
-    });
-
-    it('should include codeBucket and codePath when auto-fix is enabled', async () => {
+    it('should include codeBucket and codePath when getCodeInfo resolves code info', async () => {
       // Create a new instance with mocked getCodeInfo
       const getCodeInfoStub = sandbox.stub().resolves({
         codeBucket: 'test-bucket',
         codePath: 'code/test-site-id/github/test-owner/test-repo/main/repository.zip',
       });
 
-      // Mock isAuditEnabledForSite to return true for both auto-suggest and auto-fix
-      const isAuditEnabledStub = sandbox.stub();
-      isAuditEnabledStub.onFirstCall().resolves(true); // auto-suggest enabled
-      isAuditEnabledStub.onSecondCall().resolves(true); // auto-fix enabled
-
       const { processAutoSuggest: processWithCode } = await esmock('../../../src/cwv/auto-suggest.js', {
-        '../../../src/common/index.js': {
-          isAuditEnabledForSite: isAuditEnabledStub,
-        },
         '../../../src/accessibility/utils/data-processing.js': {
           getCodeInfo: getCodeInfoStub,
         },
@@ -191,20 +150,10 @@ describe('CWV Auto-Suggest', () => {
       expect(message.data.codePath).to.equal('code/test-site-id/github/test-owner/test-repo/main/repository.zip');
     });
 
-    it('should omit codeBucket and codePath when CWV auto-fix is disabled but auto-suggest is enabled', async () => {
-      const getCodeInfoStub = sandbox.stub().resolves({
-        codeBucket: 'test-bucket',
-        codePath: 'code/test-site-id/github/test-owner/test-repo/main/repository.zip',
-      });
+    it('should omit codeBucket and codePath when getCodeInfo resolves no usable code path', async () => {
+      const getCodeInfoStub = sandbox.stub().resolves(null);
 
-      const isAuditEnabledStub = sandbox.stub();
-      isAuditEnabledStub.onFirstCall().resolves(true);
-      isAuditEnabledStub.onSecondCall().resolves(false);
-
-      const { processAutoSuggest: processAutoFixDisabled } = await esmock('../../../src/cwv/auto-suggest.js', {
-        '../../../src/common/index.js': {
-          isAuditEnabledForSite: isAuditEnabledStub,
-        },
+      const { processAutoSuggest: processNoCodeInfo } = await esmock('../../../src/cwv/auto-suggest.js', {
         '../../../src/accessibility/utils/data-processing.js': {
           getCodeInfo: getCodeInfoStub,
         },
@@ -239,9 +188,9 @@ describe('CWV Auto-Suggest', () => {
         }]),
       };
 
-      await processAutoFixDisabled(context, opportunity, siteWithCode);
+      await processNoCodeInfo(context, opportunity, siteWithCode);
 
-      expect(getCodeInfoStub).to.not.have.been.called;
+      expect(getCodeInfoStub).to.have.been.calledOnce;
       expect(sqsStub.calledOnce).to.be.true;
       const message = sqsStub.firstCall.args[1];
       expect(message.data.type).to.equal('cwv');
@@ -249,16 +198,13 @@ describe('CWV Auto-Suggest', () => {
       expect(message.data).to.not.have.property('codePath');
     });
 
-    it('should include codeBucket and codePath when site has code (auto-fix flag still checked locally)', async () => {
+    it('should include codeBucket and codePath when site has code', async () => {
       const getCodeInfoStub = sandbox.stub().resolves({
         codeBucket: 'test-bucket',
         codePath: 'code/test-site-id/github/test-owner/test-repo/main/repository.zip',
       });
 
       const { processAutoSuggest: processWithCodeInfo } = await esmock('../../../src/cwv/auto-suggest.js', {
-        '../../../src/common/index.js': {
-          isAuditEnabledForSite: sandbox.stub().resolves(true),
-        },
         '../../../src/accessibility/utils/data-processing.js': {
           getCodeInfo: getCodeInfoStub,
         },
@@ -343,7 +289,7 @@ describe('CWV Auto-Suggest', () => {
       expect(message.data.suggestionId).to.equal('sugg-url');
     });
 
-    it('sends messages when opportunity has URL-type suggestions (auto-fix flag still checked locally)', async () => {
+    it('sends messages when opportunity has URL-type suggestions', async () => {
       const opportunity = {
         getSiteId: () => 'site-123',
         getAuditId: () => 'audit-456',


### PR DESCRIPTION
## Summary
`processAutoSuggest` (the auto-suggest/auto-fix step of the `cwv` audit) re-checked `Configuration.isHandlerEnabledForSite` + product-code entitlement for the synthetic `cwv-auto-suggest`/`cwv-auto-fix` handler entries before running. This was redundant: enablement/entitlement for `cwv` itself is already verified upstream before the audit is ever dispatched:
- **Scheduled runs**: `spacecat-jobs-dispatcher`'s `getSitesToAudit` pre-filters sites via `isHandlerEnabledForSite('cwv', site)` before creating the SQS message.
- **One-off runs** (Slack `/run-audit cwv`): already checks `productCodes` entitlement (via `TierClient`) and `isHandlerDisabledForSite('cwv', site)` before queuing.

This also brings `cwv` in line with how every other audit type in this codebase handles its own `-auto-suggest`/`-auto-fix` step — none of them (`broken-backlinks`, `meta-tags`, `product-metatags`, `broken-internal-links`, `alt-text`, `security-vulnerabilities`) re-check Configuration for the sub-feature; they all rely on the base audit's own gating.

## Changes
- Removed the two `isAuditEnabledForSite('cwv-auto-suggest'/'cwv-auto-fix', ...)` calls (and now-unused constants/import) from `src/cwv/auto-suggest.js`.
- `getCodeInfo` (code-repo lookup for auto-fix) is now called whenever a `site` is present, rather than gated behind the removed auto-fix check.
- Updated `test/audits/cwv/auto-suggest.test.js`: removed tests exercising the deleted gate, simplified remaining tests that no longer need to stub `isAuditEnabledForSite`.
- Fixed two pre-existing gaps in `test/audits/cwv.test.js`'s PLG-alert test fixtures (`mockOppty` was missing `getSiteId`/`getAuditId`) — previously masked because the removed check short-circuited before those methods were ever called.

## Testing
- `npm test` — full suite passing, 100% line/branch/statement coverage maintained (this repo enforces a strict 100% global coverage gate).

## Related Issues

Please ensure your pull request adheres to the following guidelines:
- [X] make sure to link the related issues in this description
- [X] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [X] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues
https://jira.corp.adobe.com/browse/SITES-40312

Thanks for contributing!
