### PR TITLE
chore(deps): bump @adobe/spacecat-shared-data-access to 4.11.0 (LLMO-6401)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@adobe/mysticat-shared-seo-client": "1.7.0",
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
         "@adobe/spacecat-shared-athena-client": "1.11.0",
-        "@adobe/spacecat-shared-data-access": "3.81.0",
+        "@adobe/spacecat-shared-data-access": "4.11.0",
         "@adobe/spacecat-shared-drs-client": "1.13.0",
         "@adobe/spacecat-shared-google-client": "1.6.3",
         "@adobe/spacecat-shared-gpt-client": "1.7.1",
@@ -1359,9 +1359,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "3.81.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-3.81.0.tgz",
-      "integrity": "sha512-OuFPk2Z9WltfvwEgwx7qWKdaKnA9W01Z5/EorP0Bx0damsypJkVeZ2+gVSJfnANcUFb2nI65fGEuhLI436L/ag==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.11.0.tgz",
+      "integrity": "sha512-/Xi8wisTxX68Gy65QQIv2bnvSPPNT3UQw0GBMuMjv4E6tw/B5MXun4SohWFE5aDjZAZKl2ScLmLka6MdgkmFXQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@adobe/mysticat-shared-seo-client": "1.7.0",
     "@adobe/spacecat-helix-content-sdk": "1.4.33",
     "@adobe/spacecat-shared-athena-client": "1.11.0",
-    "@adobe/spacecat-shared-data-access": "3.81.0",
+    "@adobe/spacecat-shared-data-access": "4.11.0",
     "@adobe/spacecat-shared-drs-client": "1.13.0",
     "@adobe/spacecat-shared-google-client": "1.6.3",
     "@adobe/spacecat-shared-gpt-client": "1.7.1",


### PR DESCRIPTION
## Summary
- Bump `@adobe/spacecat-shared-data-access` from `3.81.0` to `4.11.0` to pick up the `WEEKLY_OFFSITE` job interval added in adobe/spacecat-shared#1834.
- Without this, `Configuration.findLatest()` fails once `global-config.json` uses `"interval": "weekly-offsite"` for offsite audits — blocking dispatch, DRS handoff, and Mystique analysis paths in audit-worker.

## Why manual
Renovate has major updates disabled for this package in `renovate.json5`.

## Test plan
- [x] `npm test` passes locally
- [ ] CI green
- [ ] Merge before updating offsite audit intervals in `global-config.json`


Made with [Cursor](https://cursor.com)