### PR TITLE
fix(offsite): auto-ignore opportunities when suggestions fail to persist

### DIFF
--- a/src/cited-analysis/guidance-handler.js
+++ b/src/cited-analysis/guidance-handler.js
@@ -142,20 +142,30 @@ export default async function handler(message, context) {
     });
     await opportunity.save();
 
-    await syncSuggestions({
-      context,
-      opportunity,
-      newData: suggestions,
-      buildKey: (suggestion) => `cited::${suggestion.id}`,
-      mapNewSuggestion: (suggestion) => ({
-        opportunityId: opportunity.getId(),
-        type: suggestion.type || 'CONTENT_UPDATE',
-        rank: suggestion.rank,
-        data: suggestion.data,
-      }),
-    });
-
-    log.info(`${LOG_PREFIX} Successfully processed cited analysis for site: ${siteId}, company: ${companyName}, ${suggestions.length} suggestions`);
+    // syncSuggestions throws when every suggestion fails to store (e.g. a DB conflict),
+    // which would leave the opportunity NEW/visible with nothing attached. Catch that and
+    // auto-ignore the empty opportunity instead of surfacing it or retrying.
+    let emptyPersist = false;
+    try {
+      await syncSuggestions({
+        context,
+        opportunity,
+        newData: suggestions,
+        buildKey: (suggestion) => `cited::${suggestion.id}`,
+        mapNewSuggestion: (suggestion) => ({
+          opportunityId: opportunity.getId(),
+          type: suggestion.type || 'CONTENT_UPDATE',
+          rank: suggestion.rank,
+          data: suggestion.data,
+        }),
+      });
+      log.info(`${LOG_PREFIX} Successfully processed cited analysis for site: ${siteId}, company: ${companyName}, ${suggestions.length} suggestions`);
+    } catch (syncError) {
+      log.warn(`${LOG_PREFIX} No suggestions persisted (${syncError.message}); ignoring opportunity ${opportunity.getId()}`);
+      opportunity.setStatus('IGNORED');
+      await opportunity.save();
+      emptyPersist = true;
+    }
 
     if (auditId) {
       const auditRecord = await AuditModel.findById(auditId);
@@ -166,13 +176,14 @@ export default async function handler(message, context) {
         // Visibility is the QA gate's decision, carried on the opportunity status
         // (NEW = customer-visible, IGNORED = suppressed). The gate may surface a
         // payload after dropping bad items, so its decision is authoritative over
-        // the raw rate.
+        // the raw rate. emptyPersist overrides this with a warning when nothing stored.
         const slackMessage = buildAnalysisVisibilityMessage({
           analysisName: 'cited-analysis',
           baseUrl,
           suggestionsCount: suggestions.length,
           isVisible: incomingStatus !== 'IGNORED',
           verdict: opportunityData.qaVerdict,
+          emptyPersist,
         });
 
         await postMessageOptional(context, channelId, slackMessage, { threadTs });

--- a/src/reddit-analysis/guidance-handler.js
+++ b/src/reddit-analysis/guidance-handler.js
@@ -142,20 +142,30 @@ export default async function handler(message, context) {
     });
     await opportunity.save();
 
-    await syncSuggestions({
-      context,
-      opportunity,
-      newData: suggestions,
-      buildKey: (suggestion) => `reddit::${suggestion.id}`,
-      mapNewSuggestion: (suggestion) => ({
-        opportunityId: opportunity.getId(),
-        type: suggestion.type || 'CONTENT_UPDATE',
-        rank: suggestion.rank,
-        data: suggestion.data,
-      }),
-    });
-
-    log.info(`${LOG_PREFIX} Successfully processed Reddit analysis for site: ${siteId}, company: ${companyName}, ${suggestions.length} suggestions`);
+    // syncSuggestions throws when every suggestion fails to store (e.g. a DB conflict),
+    // which would leave the opportunity NEW/visible with nothing attached. Catch that and
+    // auto-ignore the empty opportunity instead of surfacing it or retrying.
+    let emptyPersist = false;
+    try {
+      await syncSuggestions({
+        context,
+        opportunity,
+        newData: suggestions,
+        buildKey: (suggestion) => `reddit::${suggestion.id}`,
+        mapNewSuggestion: (suggestion) => ({
+          opportunityId: opportunity.getId(),
+          type: suggestion.type || 'CONTENT_UPDATE',
+          rank: suggestion.rank,
+          data: suggestion.data,
+        }),
+      });
+      log.info(`${LOG_PREFIX} Successfully processed Reddit analysis for site: ${siteId}, company: ${companyName}, ${suggestions.length} suggestions`);
+    } catch (syncError) {
+      log.warn(`${LOG_PREFIX} No suggestions persisted (${syncError.message}); ignoring opportunity ${opportunity.getId()}`);
+      opportunity.setStatus('IGNORED');
+      await opportunity.save();
+      emptyPersist = true;
+    }
 
     if (auditId) {
       const auditRecord = await AuditModel.findById(auditId);
@@ -164,13 +174,15 @@ export default async function handler(message, context) {
         const { channelId, threadTs } = slackContext;
 
         // Visibility is the QA gate's decision, carried on the opportunity status
-        // (NEW = customer-visible, IGNORED = suppressed).
+        // (NEW = customer-visible, IGNORED = suppressed). emptyPersist overrides this
+        // with a warning when nothing stored.
         const slackMessage = buildAnalysisVisibilityMessage({
           analysisName: 'reddit-analysis',
           baseUrl,
           suggestionsCount: suggestions.length,
           isVisible: incomingStatus !== 'IGNORED',
           verdict: opportunityData.qaVerdict,
+          emptyPersist,
         });
 
         await postMessageOptional(context, channelId, slackMessage, { threadTs });

--- a/src/utils/slack-utils.js
+++ b/src/utils/slack-utils.js
@@ -103,12 +103,18 @@ export async function postMessageOptional(context, channelId, text, options = {}
  * items are actually the clean survivors. The raw rate is only shown when the
  * opportunity is hidden, where it is the reason for suppression.
  *
+ * When `emptyPersist` is true, the suggestions failed to store (e.g. a DB conflict) so
+ * the opportunity was auto-ignored. This uses a warning tone to stand apart from a QA-gate
+ * suppression, so operators can tell a storage failure from a quality decision.
+ *
  * @param {object} params
  * @param {string} params.analysisName - e.g. 'cited-analysis'
  * @param {string} params.baseUrl - Site base URL
  * @param {number} params.suggestionsCount - Number of suggestions processed
  * @param {boolean} params.isVisible - Whether the opportunity is customer-visible
  * @param {object} [params.verdict] - The qaVerdict stamp (rate, rateDetermined, droppedUrls)
+ * @param {boolean} [params.emptyPersist] - True when suggestions failed to persist and the
+ *   opportunity was auto-ignored
  * @returns {string} The formatted Slack message
  */
 export function buildAnalysisVisibilityMessage({
@@ -117,7 +123,14 @@ export function buildAnalysisVisibilityMessage({
   suggestionsCount,
   isVisible,
   verdict,
+  emptyPersist = false,
 }) {
+  if (emptyPersist) {
+    return `:warning: *${analysisName}* audit finished for *${baseUrl}*\n`
+      + '• 0 suggestions persisted\n'
+      + '• :see_no_evil: Not visible in the UI — no suggestions stored (auto-ignored)';
+  }
+
   const suggestionsLine = `• ${suggestionsCount} suggestion${suggestionsCount === 1 ? '' : 's'} processed`;
 
   let note = '';

--- a/src/wikipedia-analysis/guidance-handler.js
+++ b/src/wikipedia-analysis/guidance-handler.js
@@ -17,7 +17,7 @@ import { Audit } from '@adobe/spacecat-shared-data-access';
 import { syncSuggestions } from '../utils/data-access.js';
 import { createOpportunityData } from './opportunity-data-mapper.js';
 import { convertToOpportunity } from '../common/opportunity.js';
-import { postMessageOptional } from '../utils/slack-utils.js';
+import { postMessageOptional, buildAnalysisVisibilityMessage } from '../utils/slack-utils.js';
 import { resolveBrandResultForSite, applyScopeToOpportunity } from '../utils/brand-resolver.js';
 import { fetchAnalysisFromPresignedUrl } from '../utils/analysis-fetch.js';
 
@@ -158,33 +158,43 @@ export default async function handler(message, context) {
     });
     await opportunity.save();
 
-    await syncSuggestions({
-      context,
-      opportunity,
-      newData: suggestions,
-      buildKey: (suggestion) => `wikipedia::${suggestion.id}`,
-      mapNewSuggestion: (suggestion) => ({
-        opportunityId: opportunity.getId(),
-        type: 'CONTENT_UPDATE',
-        rank: getRankFromPriority(suggestion.priority),
-        data: suggestion,
-      }),
-    });
-
-    log.info(`${LOG_PREFIX} Successfully processed Wikipedia analysis for site: ${siteId}, company: ${company}, ${suggestions.length} suggestions`);
+    // syncSuggestions throws when every suggestion fails to store (e.g. a DB conflict),
+    // which would leave the opportunity NEW/visible with nothing attached. Catch that and
+    // auto-ignore the empty opportunity instead of surfacing it or retrying.
+    let emptyPersist = false;
+    try {
+      await syncSuggestions({
+        context,
+        opportunity,
+        newData: suggestions,
+        buildKey: (suggestion) => `wikipedia::${suggestion.id}`,
+        mapNewSuggestion: (suggestion) => ({
+          opportunityId: opportunity.getId(),
+          type: 'CONTENT_UPDATE',
+          rank: getRankFromPriority(suggestion.priority),
+          data: suggestion,
+        }),
+      });
+      log.info(`${LOG_PREFIX} Successfully processed Wikipedia analysis for site: ${siteId}, company: ${company}, ${suggestions.length} suggestions`);
+    } catch (syncError) {
+      log.warn(`${LOG_PREFIX} No suggestions persisted (${syncError.message}); ignoring opportunity ${opportunity.getId()}`);
+      opportunity.setStatus('IGNORED');
+      await opportunity.save();
+      emptyPersist = true;
+    }
 
     if (auditId) {
       const auditRecord = await AuditModel.findById(auditId);
       const slackContext = auditRecord?.getAuditResult()?.slackContext;
       if (slackContext) {
         const { channelId, threadTs } = slackContext;
-        await postMessageOptional(
-          context,
-          channelId,
-          `:white_check_mark: *wikipedia-analysis* audit finished for *${baseUrl}*\n`
-          + `• ${suggestions.length} suggestion${suggestions.length === 1 ? '' : 's'} processed`,
-          { threadTs },
-        );
+        // On success keep the plain completion message; when nothing stored, reuse the
+        // shared warning message so the auto-ignore reads the same as the other analyses.
+        const slackMessage = emptyPersist
+          ? buildAnalysisVisibilityMessage({ analysisName: 'wikipedia-analysis', baseUrl, emptyPersist: true })
+          : `:white_check_mark: *wikipedia-analysis* audit finished for *${baseUrl}*\n`
+            + `• ${suggestions.length} suggestion${suggestions.length === 1 ? '' : 's'} processed`;
+        await postMessageOptional(context, channelId, slackMessage, { threadTs });
       }
     }
 

--- a/src/youtube-analysis/guidance-handler.js
+++ b/src/youtube-analysis/guidance-handler.js
@@ -140,20 +140,30 @@ export default async function handler(message, context) {
     });
     await opportunity.save();
 
-    await syncSuggestions({
-      context,
-      opportunity,
-      newData: suggestions,
-      buildKey: (suggestion) => `youtube::${suggestion.id}`,
-      mapNewSuggestion: (suggestion) => ({
-        opportunityId: opportunity.getId(),
-        type: suggestion.type || 'CONTENT_UPDATE',
-        rank: suggestion.rank,
-        data: suggestion.data,
-      }),
-    });
-
-    log.info(`${LOG_PREFIX} Successfully processed YouTube analysis for site: ${siteId}, company: ${companyName}, ${suggestions.length} suggestions`);
+    // syncSuggestions throws when every suggestion fails to store (e.g. a DB conflict),
+    // which would leave the opportunity NEW/visible with nothing attached. Catch that and
+    // auto-ignore the empty opportunity instead of surfacing it or retrying.
+    let emptyPersist = false;
+    try {
+      await syncSuggestions({
+        context,
+        opportunity,
+        newData: suggestions,
+        buildKey: (suggestion) => `youtube::${suggestion.id}`,
+        mapNewSuggestion: (suggestion) => ({
+          opportunityId: opportunity.getId(),
+          type: suggestion.type || 'CONTENT_UPDATE',
+          rank: suggestion.rank,
+          data: suggestion.data,
+        }),
+      });
+      log.info(`${LOG_PREFIX} Successfully processed YouTube analysis for site: ${siteId}, company: ${companyName}, ${suggestions.length} suggestions`);
+    } catch (syncError) {
+      log.warn(`${LOG_PREFIX} No suggestions persisted (${syncError.message}); ignoring opportunity ${opportunity.getId()}`);
+      opportunity.setStatus('IGNORED');
+      await opportunity.save();
+      emptyPersist = true;
+    }
 
     if (auditId) {
       const audit = await AuditModel.findById(auditId);
@@ -162,13 +172,15 @@ export default async function handler(message, context) {
         const { channelId, threadTs } = slackContext;
 
         // Visibility is the QA gate's decision, carried on the opportunity status
-        // (NEW = customer-visible, IGNORED = suppressed).
+        // (NEW = customer-visible, IGNORED = suppressed). emptyPersist overrides this
+        // with a warning when nothing stored.
         const slackMessage = buildAnalysisVisibilityMessage({
           analysisName: 'youtube-analysis',
           baseUrl,
           suggestionsCount: suggestions.length,
           isVisible: incomingStatus !== 'IGNORED',
           verdict: opportunityData.qaVerdict,
+          emptyPersist,
         });
 
         await postMessageOptional(context, channelId, slackMessage, { threadTs });

--- a/test/audits/cited-analysis/guidance-handler.test.js
+++ b/test/audits/cited-analysis/guidance-handler.test.js
@@ -651,6 +651,30 @@ describe('Cited Analysis Guidance Handler', () => {
       expect(callText).to.include('2 suggestions processed');
     });
 
+    it('auto-ignores the opportunity and posts a warning when suggestions fail to persist', async () => {
+      syncSuggestionsStub.rejects(new Error('Failed to create suggestions'));
+      mockAudit.getAuditResult.returns({
+        slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },
+      });
+
+      const message = {
+        siteId,
+        auditId,
+        data: { analysis: mockAnalysisData, companyName: 'Example Corp' },
+      };
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(200);
+      expect(mockOpportunity.setStatus).to.have.been.calledWith('IGNORED');
+      expect(mockOpportunity.save).to.have.been.calledTwice;
+      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(callText).to.include(':warning:');
+      expect(callText).to.include('0 suggestions persisted');
+      expect(callText).to.include('auto-ignored');
+      expect(context.log.info).to.not.have.been.calledWith(sinon.match(/Successfully processed cited analysis/));
+    });
+
     it('reports a visible opportunity as below threshold without the raw rate', async () => {
       mockAudit.getAuditResult.returns({
         slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },

--- a/test/audits/reddit-analysis/guidance-handler.test.js
+++ b/test/audits/reddit-analysis/guidance-handler.test.js
@@ -497,6 +497,29 @@ describe('Reddit Analysis Guidance Handler', () => {
       expect(callText).to.include('2 suggestions processed');
     });
 
+    it('auto-ignores the opportunity and posts a warning when suggestions fail to persist', async () => {
+      syncSuggestionsStub.rejects(new Error('Failed to create suggestions'));
+      mockAudit.getAuditResult.returns({
+        slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },
+      });
+
+      const message = {
+        siteId,
+        auditId,
+        data: { analysis: mockAnalysisData, companyName: 'Example Corp' },
+      };
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(200);
+      expect(mockOpportunity.setStatus).to.have.been.calledWith('IGNORED');
+      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(callText).to.include(':warning:');
+      expect(callText).to.include('0 suggestions persisted');
+      expect(callText).to.include('auto-ignored');
+      expect(context.log.info).to.not.have.been.calledWith(sinon.match(/Successfully processed Reddit analysis/));
+    });
+
     it('reports a visible opportunity as below threshold without the raw rate', async () => {
       mockAudit.getAuditResult.returns({
         slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },

--- a/test/audits/wikipedia-analysis/guidance-handler.test.js
+++ b/test/audits/wikipedia-analysis/guidance-handler.test.js
@@ -56,6 +56,7 @@ describe('Wikipedia Analysis Guidance Handler', () => {
       getId: sandbox.stub().returns('opp-123'),
       getData: sandbox.stub().returns({ existingData: true }),
       setData: sandbox.stub(),
+      setStatus: sandbox.stub(),
       setScopeType: sandbox.stub(),
       setScopeId: sandbox.stub(),
       save: sandbox.stub().resolves(),
@@ -604,6 +605,30 @@ describe('Wikipedia Analysis Guidance Handler', () => {
       expect(callText).to.include('audit finished');
       expect(callText).to.include(baseURL);
       expect(callText).to.include('2 suggestions processed');
+    });
+
+    it('auto-ignores the opportunity and posts a warning when suggestions fail to persist', async () => {
+      syncSuggestionsStub.rejects(new Error('Failed to create suggestions'));
+      mockAudit.getAuditResult.returns({
+        slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },
+      });
+
+      const message = {
+        siteId,
+        auditId,
+        data: { analysis: mockAnalysisData },
+      };
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(200);
+      expect(mockOpportunity.setStatus).to.have.been.calledWith('IGNORED');
+      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(callText).to.include(':warning:');
+      expect(callText).to.include('wikipedia-analysis');
+      expect(callText).to.include('0 suggestions persisted');
+      expect(callText).to.include('auto-ignored');
+      expect(context.log.info).to.not.have.been.calledWith(sinon.match(/Successfully processed Wikipedia analysis/));
     });
 
     it('should not send Slack notification when no slackContext on audit', async () => {

--- a/test/audits/youtube-analysis/guidance-handler.test.js
+++ b/test/audits/youtube-analysis/guidance-handler.test.js
@@ -688,6 +688,29 @@ describe('YouTube Analysis Guidance Handler', () => {
       expect(callText).to.include('1 suggestion processed');
     });
 
+    it('auto-ignores the opportunity and posts a warning when suggestions fail to persist', async () => {
+      mockSyncSuggestions.rejects(new Error('Failed to create suggestions'));
+      mockAudit.getAuditResult.returns({
+        slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },
+      });
+
+      const message = {
+        siteId,
+        auditId,
+        data: { analysis: mockAnalysisData, companyName: 'Example Corp' },
+      };
+
+      const result = await guidanceHandler.default(message, context);
+
+      expect(result.status).to.equal(200);
+      expect(mockOpportunity.setStatus).to.have.been.calledWith('IGNORED');
+      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(callText).to.include(':warning:');
+      expect(callText).to.include('0 suggestions persisted');
+      expect(callText).to.include('auto-ignored');
+      expect(context.log.info).to.not.have.been.calledWith(sinon.match(/Successfully processed YouTube analysis/));
+    });
+
     it('reports a visible opportunity as below threshold without the raw rate', async () => {
       mockAudit.getAuditResult.returns({
         slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },

--- a/test/utils/slack-utils.test.js
+++ b/test/utils/slack-utils.test.js
@@ -239,5 +239,20 @@ describe('Slack Utils', () => {
       expect(buildAnalysisVisibilityMessage({ ...base, suggestionsCount: 2, isVisible: true }))
         .to.include('2 suggestions processed');
     });
+
+    it('reports a persistence failure with a warning tone when emptyPersist is set', () => {
+      const msg = buildAnalysisVisibilityMessage({
+        ...base,
+        isVisible: true,
+        verdict: { rate: 0.9, rateDetermined: true },
+        emptyPersist: true,
+      });
+      expect(msg).to.include(':warning:');
+      expect(msg).to.include('cited-analysis');
+      expect(msg).to.include('0 suggestions persisted');
+      expect(msg).to.include('Not visible in the UI — no suggestions stored (auto-ignored)');
+      // The verdict-driven note is suppressed for a persistence failure.
+      expect(msg).to.not.include('hallucination');
+    });
   });
 });


### PR DESCRIPTION
## Problem

For the offsite analyses (**cited**, **youtube**, **reddit**, **wikipedia**), the guidance handler persists the opportunity **before** syncing its suggestions. When Mystique returns suggestions but they all fail to store (e.g. a DB conflict), `syncSuggestions` **throws** — leaving the opportunity persisted as `NEW`/customer-visible with **0 suggestions attached**, and no Slack notification. Operators see an empty, misleading opportunity and get no signal that anything went wrong.

## Fix

Wrap the existing `syncSuggestions` call in each of the four offsite guidance handlers in a `try/catch`. On failure:
- set the opportunity to `IGNORED` and save it (so it is not surfaced empty),
- post a warning-toned Slack completion message noting that 0 suggestions persisted,
- return `ok()` (no SQS retry — a re-run would just re-conflict).

`buildAnalysisVisibilityMessage` gains an `emptyPersist` flag so the warning renders consistently and is visually distinct from a QA-gate (hallucination) suppression:

```
:warning: *cited-analysis* audit finished for *https://site.com*
• 0 suggestions persisted
• :see_no_evil: Not visible in the UI — no suggestions stored (auto-ignored)
```

The healthy path (≥1 suggestion) and the existing empty-payload path (`suggestions.length === 0` → `noContent()`, no opportunity created) are unchanged.

## Tests

- Unit tests only. Added one `emptyPersist` test per handler (triggered by making `syncSuggestions` reject) plus a `buildAnalysisVisibilityMessage` case.
- All four `guidance-handler.js` and `slack-utils.js` at 100% coverage.