### PR TITLE
fix: bump @adobe/spacecat-shared-html-analyzer to 1.3.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@adobe/spacecat-shared-drs-client": "1.13.0",
         "@adobe/spacecat-shared-google-client": "1.6.3",
         "@adobe/spacecat-shared-gpt-client": "1.7.1",
-        "@adobe/spacecat-shared-html-analyzer": "1.3.3",
+        "@adobe/spacecat-shared-html-analyzer": "1.3.4",
         "@adobe/spacecat-shared-http-utils": "1.33.1",
         "@adobe/spacecat-shared-ims-client": "1.14.0",
         "@adobe/spacecat-shared-rum-api-client": "2.44.0",
@@ -3085,9 +3085,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-html-analyzer": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-html-analyzer/-/spacecat-shared-html-analyzer-1.3.3.tgz",
-      "integrity": "sha512-cuyDRnnvt0PCXW1P0PSkYfM4R43Xw6BZJF96/7h7EiT6LxiyhTUUytHBJWShBn0eRa/ACjEHDrR2UDdUzlK+dQ==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-html-analyzer/-/spacecat-shared-html-analyzer-1.3.4.tgz",
+      "integrity": "sha512-Bo6GG6JUrhTWbIUHiNQGm2blhDSnYoPDmTt7EocIfIkQaosVKKSJs7a6DgwHKdWi8SxTYhQxyyktuA5S5iOt4Q==",
       "license": "Apache-2.0",
       "dependencies": {
         "cheerio": "^1.0.0-rc.12",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "@adobe/spacecat-shared-drs-client": "1.13.0",
     "@adobe/spacecat-shared-google-client": "1.6.3",
     "@adobe/spacecat-shared-gpt-client": "1.7.1",
-    "@adobe/spacecat-shared-html-analyzer": "1.3.3",
+    "@adobe/spacecat-shared-html-analyzer": "1.3.4",
     "@adobe/spacecat-shared-http-utils": "1.33.1",
     "@adobe/spacecat-shared-ims-client": "1.14.0",
     "@adobe/spacecat-shared-rum-api-client": "2.44.0",


### PR DESCRIPTION
## Summary
- Bumps `@adobe/spacecat-shared-html-analyzer` from `1.3.3` to `1.3.4`
- Picks up the fix for Kaltura PlayKit video player controls (Play, Seek, Unmute, timestamps) leaking into prerendered/AI agent content view — see [spacecat-shared#1838](https://github.com/adobe/spacecat-shared/pull/1838)
- Related Jira: [LLMO-6427](https://jira.corp.adobe.com/browse/LLMO-6427)
- Used by `src/page-citability/analyzer.js` and `src/prerender/utils/html-comparator.js`

## Test plan
- [x] `npm run lint` passes
- [x] `npx mocha test/audits/prerender/handler.test.js` — 291 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)