### PR TITLE
feat(wikipedia-analysis): report to Slack when the audit can't run

### DIFF
--- a/src/wikipedia-analysis/guidance-handler.js
+++ b/src/wikipedia-analysis/guidance-handler.js
@@ -65,6 +65,29 @@ function getRankFromPriority(priority) {
 }
 
 /**
+ * Posts an audit-outcome message to the Slack thread the audit was triggered from,
+ * if a slackContext was captured on the audit. No-op when there is no auditId,
+ * no audit record, or no slackContext (e.g. a non-Slack-triggered run).
+ * @param {Object} context - Context object with data access
+ * @param {string} auditId - The audit ID
+ * @param {string} text - The message text to post
+ * @returns {Promise<void>}
+ */
+async function postWikipediaOutcomeToSlack(context, auditId, text) {
+  if (!auditId) {
+    return;
+  }
+  const { dataAccess } = context;
+  const auditRecord = await dataAccess.Audit.findById(auditId);
+  const slackContext = auditRecord?.getAuditResult()?.slackContext;
+  if (!slackContext) {
+    return;
+  }
+  const { channelId, threadTs } = slackContext;
+  await postMessageOptional(context, channelId, text, { threadTs });
+}
+
+/**
  * Handles Mystique response for Wikipedia analysis
  * @param {Object} message - Message from Mystique with analysis results
  * @param {Object} context - Context object with data access and logger
@@ -79,6 +102,25 @@ export default async function handler(message, context) {
   const { siteId, auditId, data } = message;
 
   log.info(`${LOG_PREFIX} Received Wikipedia analysis guidance for siteId: ${siteId}, auditId: ${auditId}`);
+
+  const site = await Site.findById(siteId);
+  if (!site) {
+    log.error(`[Wikipedia] Site not found for siteId: ${siteId}`);
+    return notFound('Site not found');
+  }
+  const baseUrl = site.getBaseURL();
+
+  // Mystique couldn't complete the analysis (e.g. an upstream producer/service
+  // failure). Report it to the Slack thread instead of failing silently, then stop.
+  if (data?.error) {
+    log.error(`${LOG_PREFIX} Mystique returned an error for siteId: ${siteId}, auditId: ${auditId}: ${data.errorMessage}`);
+    await postWikipediaOutcomeToSlack(
+      context,
+      auditId,
+      `:warning: *wikipedia-analysis* audit for *${baseUrl}* couldn't run — the analysis failed${data.errorMessage ? ` (${data.errorMessage})` : ''}.`,
+    );
+    return noContent();
+  }
 
   // Handle presigned URL (large response) or direct analysis data
   let analysisData = data?.analysis;
@@ -102,12 +144,6 @@ export default async function handler(message, context) {
     return badRequest('Analysis data is required');
   }
 
-  const site = await Site.findById(siteId);
-  if (!site) {
-    log.error(`[Wikipedia] Site not found for siteId: ${siteId}`);
-    return notFound('Site not found');
-  }
-
   // Check if audit exists
   if (auditId) {
     const audit = await AuditModel.findById(auditId);
@@ -119,12 +155,20 @@ export default async function handler(message, context) {
 
   try {
     const brandResult = await resolveBrandResultForSite(context, site);
-    const baseUrl = site.getBaseURL();
-    const { suggestions = [], company, industryAnalysis } = analysisData;
+    const {
+      suggestions = [], company, industryAnalysis, wikipediaUrl,
+    } = analysisData;
 
-    // If no suggestions, return early
+    // No suggestions means either no Wikipedia page exists to analyze, or the page
+    // was analyzed but had nothing to improve. Report the outcome to Slack — this
+    // path used to return silently, so a Slack-triggered run showed only the trigger.
     if (suggestions.length === 0) {
       log.info(`${LOG_PREFIX} No suggestions found in analysis`);
+      const outcomeMessage = wikipediaUrl
+        ? `:white_check_mark: *wikipedia-analysis* audit finished for *${baseUrl}*\n`
+          + '• Wikipedia page analyzed — no improvement suggestions found'
+        : `:warning: *wikipedia-analysis* audit for *${baseUrl}* couldn't run — no Wikipedia page was found to analyze`;
+      await postWikipediaOutcomeToSlack(context, auditId, outcomeMessage);
       return noContent();
     }
 
@@ -173,20 +217,12 @@ export default async function handler(message, context) {
 
     log.info(`${LOG_PREFIX} Successfully processed Wikipedia analysis for site: ${siteId}, company: ${company}, ${suggestions.length} suggestions`);
 
-    if (auditId) {
-      const auditRecord = await AuditModel.findById(auditId);
-      const slackContext = auditRecord?.getAuditResult()?.slackContext;
-      if (slackContext) {
-        const { channelId, threadTs } = slackContext;
-        await postMessageOptional(
-          context,
-          channelId,
-          `:white_check_mark: *wikipedia-analysis* audit finished for *${baseUrl}*\n`
-          + `• ${suggestions.length} suggestion${suggestions.length === 1 ? '' : 's'} processed`,
-          { threadTs },
-        );
-      }
-    }
+    await postWikipediaOutcomeToSlack(
+      context,
+      auditId,
+      `:white_check_mark: *wikipedia-analysis* audit finished for *${baseUrl}*\n`
+      + `• ${suggestions.length} suggestion${suggestions.length === 1 ? '' : 's'} processed`,
+    );
 
     return ok();
   } catch (error) {

--- a/src/wikipedia-analysis/guidance-handler.js
+++ b/src/wikipedia-analysis/guidance-handler.js
@@ -77,14 +77,22 @@ async function postWikipediaOutcomeToSlack(context, auditId, text) {
   if (!auditId) {
     return;
   }
-  const { dataAccess } = context;
-  const auditRecord = await dataAccess.Audit.findById(auditId);
-  const slackContext = auditRecord?.getAuditResult()?.slackContext;
-  if (!slackContext) {
-    return;
+  const { log, dataAccess } = context;
+  // Posting is a best-effort side-effect: a DB/lookup failure here must never crash
+  // the primary handler (this runs on graceful noContent paths, some outside the
+  // main try/catch). postMessageOptional already swallows Slack API errors; guard
+  // the preceding findById the same way.
+  try {
+    const auditRecord = await dataAccess.Audit.findById(auditId);
+    const slackContext = auditRecord?.getAuditResult()?.slackContext;
+    if (!slackContext) {
+      return;
+    }
+    const { channelId, threadTs } = slackContext;
+    await postMessageOptional(context, channelId, text, { threadTs });
+  } catch (e) {
+    log.warn(`${LOG_PREFIX} Failed to post outcome to Slack: ${e.message}`);
   }
-  const { channelId, threadTs } = slackContext;
-  await postMessageOptional(context, channelId, text, { threadTs });
 }
 
 /**

--- a/test/audits/wikipedia-analysis/guidance-handler.test.js
+++ b/test/audits/wikipedia-analysis/guidance-handler.test.js
@@ -22,7 +22,11 @@ import { MockContextBuilder } from '../../shared.js';
 use(sinonChai);
 use(chaiAsPromised);
 
-describe('Wikipedia Analysis Guidance Handler', () => {
+describe('Wikipedia Analysis Guidance Handler', function () {
+  // esmock deep-loads the handler tree under coverage instrumentation, so the first
+  // beforeEach can exceed mocha's 2s default.
+  this.timeout(10000);
+
   let sandbox;
   let context;
   let mockSite;
@@ -663,6 +667,110 @@ describe('Wikipedia Analysis Guidance Handler', () => {
 
       const callText = mockPostMessageOptional.firstCall.args[2];
       expect(callText).to.include('1 suggestion processed');
+    });
+
+    it('reports that the audit could not run when no Wikipedia page was found', async () => {
+      mockAudit.getAuditResult.returns({
+        slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },
+      });
+
+      const message = {
+        siteId,
+        auditId,
+        data: { analysis: { company: 'Example Corp', suggestions: [], wikipediaUrl: '' } },
+      };
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(204);
+      expect(mockPostMessageOptional).to.have.been.calledOnce;
+      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(callText).to.include(':warning:');
+      expect(callText).to.include(baseURL);
+      expect(callText).to.include("couldn't run");
+      expect(callText).to.include('no Wikipedia page was found');
+    });
+
+    it('reports a finished-but-empty result when a Wikipedia page was analyzed with no suggestions', async () => {
+      mockAudit.getAuditResult.returns({
+        slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },
+      });
+
+      const message = {
+        siteId,
+        auditId,
+        data: {
+          analysis: {
+            company: 'Example Corp',
+            suggestions: [],
+            wikipediaUrl: 'https://en.wikipedia.org/wiki/Example_Corp',
+          },
+        },
+      };
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(204);
+      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(callText).to.include(':white_check_mark:');
+      expect(callText).to.include('audit finished');
+      expect(callText).to.include('no improvement suggestions found');
+    });
+
+    it('reports that the audit could not run when Mystique returns an error', async () => {
+      mockAudit.getAuditResult.returns({
+        slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },
+      });
+
+      const message = {
+        siteId,
+        auditId,
+        data: { error: true, errorMessage: 'Wikipedia analysis failed' },
+      };
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(204);
+      expect(mockPostMessageOptional).to.have.been.calledOnce;
+      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(callText).to.include(':warning:');
+      expect(callText).to.include("couldn't run");
+      expect(callText).to.include('Wikipedia analysis failed');
+      expect(context.log.error).to.have.been.calledWith(sinon.match(/Mystique returned an error/));
+    });
+
+    it('reports a Mystique error without a parenthetical when no errorMessage is provided', async () => {
+      mockAudit.getAuditResult.returns({
+        slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },
+      });
+
+      const message = {
+        siteId,
+        auditId,
+        data: { error: true },
+      };
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(204);
+      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(callText).to.include("couldn't run");
+      expect(callText).to.not.include('(');
+    });
+
+    it('does not post an outcome message for an empty result when there is no slackContext', async () => {
+      mockAudit.getAuditResult.returns({});
+
+      const message = {
+        siteId,
+        auditId,
+        data: { analysis: { company: 'Example Corp', suggestions: [], wikipediaUrl: '' } },
+      };
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(204);
+      expect(mockPostMessageOptional).to.not.have.been.called;
     });
   });
 

--- a/test/audits/wikipedia-analysis/guidance-handler.test.js
+++ b/test/audits/wikipedia-analysis/guidance-handler.test.js
@@ -758,6 +758,25 @@ describe('Wikipedia Analysis Guidance Handler', function () {
       expect(callText).to.not.include('(');
     });
 
+    it('does not crash the handler when the Slack-context lookup fails', async () => {
+      // A notification side-effect must never turn a graceful noContent into a 500.
+      // The data.error path posts before any audit-existence lookup, so the only
+      // Audit.findById is the guarded one inside the helper.
+      context.dataAccess.Audit.findById.rejects(new Error('DB down'));
+
+      const message = {
+        siteId,
+        auditId,
+        data: { error: true, errorMessage: 'Wikipedia analysis failed' },
+      };
+
+      const result = await handler.default(message, context);
+
+      expect(result.status).to.equal(204);
+      expect(mockPostMessageOptional).to.not.have.been.called;
+      expect(context.log.warn).to.have.been.calledWith(sinon.match(/Failed to post outcome to Slack/));
+    });
+
     it('does not post an outcome message for an empty result when there is no slackContext', async () => {
       mockAudit.getAuditResult.returns({});
 


### PR DESCRIPTION
## Problem

A Slack-triggered `wikipedia-analysis` run posts the `:adobe-run: Triggering…` message, then goes **silent** whenever there is nothing to surface. The most common case is a site with **no Wikipedia page** — the operator never learns the audit couldn't run.

Traced end-to-end: Mystique's `WikipediaAnalysisAssemblyProducer` still returns `data.analysis` when no page exists, but with an empty `wikipediaUrl` and no `suggestions`. The audit-worker guidance handler then hit `suggestions.length === 0` and `return noContent()` silently.

## Change

`src/wikipedia-analysis/guidance-handler.js` now posts an outcome message to the audit's Slack thread (when a `slackContext` was captured) for the cases that previously returned silently:

- **Mystique error** (`data.error`) → `:warning: … couldn't run — the analysis failed (…)`. This also adds the `data.error` guard the handler was missing (cited/youtube/reddit already have it).
- **No suggestions + empty `wikipediaUrl`** → `:warning: … couldn't run — no Wikipedia page was found to analyze`.
- **No suggestions + a `wikipediaUrl` present** → `:white_check_mark: … audit finished — Wikipedia page analyzed, no improvement suggestions found`.

The audit-thread posting is factored into a small `postWikipediaOutcomeToSlack` helper reused by the error, empty, and success paths. Posting still happens only when `auditId` + `slackContext` exist (unchanged condition), so non-Slack runs stay silent.

## Tests

- Unit tests only. Added cases for the no-page, page-analyzed-empty, Mystique-error (with and without an errorMessage), and no-slackContext paths.
- `src/wikipedia-analysis/guidance-handler.js` at 100% coverage.

## Note

Both this PR and #2794 (off-site zero-suggestion auto-ignore) touch `wikipedia-analysis/guidance-handler.js`. This one is intended to land **first**; #2794 will need a small rebase afterward.