### PR TITLE
feat(offsite): report DRS / Mystique / total phase timings to Slack

### DIFF
--- a/src/cited-analysis/guidance-handler.js
+++ b/src/cited-analysis/guidance-handler.js
@@ -20,6 +20,7 @@ import { createOpportunityData } from './opportunity-data-mapper.js';
 import { postMessageOptional, buildAnalysisVisibilityMessage } from '../utils/slack-utils.js';
 import { resolveBrandResultForSite, applyScopeToOpportunity } from '../utils/brand-resolver.js';
 import { fetchAnalysisFromPresignedUrl } from '../utils/analysis-fetch.js';
+import { buildOffsiteTimingLines } from '../utils/offsite-audit-utils.js';
 import {
   isValidOffsiteAnalysis,
   persistOffsiteOpportunity,
@@ -159,7 +160,8 @@ export default async function handler(message, context) {
 
     if (auditId) {
       const auditRecord = await AuditModel.findById(auditId);
-      const slackContext = auditRecord?.getAuditResult()?.slackContext;
+      const auditResultData = auditRecord?.getAuditResult();
+      const slackContext = auditResultData?.slackContext;
       if (slackContext) {
         const { channelId, threadTs } = slackContext;
 
@@ -175,7 +177,11 @@ export default async function handler(message, context) {
           verdict: opportunityData.qaVerdict,
         });
 
-        await postMessageOptional(context, channelId, slackMessage, { threadTs });
+        // Append DRS / Mystique / total phase timings (from anchors on the audit result).
+        const timingLines = buildOffsiteTimingLines(auditResultData?.timings);
+        const fullMessage = timingLines ? `${slackMessage}\n${timingLines}` : slackMessage;
+
+        await postMessageOptional(context, channelId, fullMessage, { threadTs });
       }
     }
 

--- a/src/cited-analysis/handler.js
+++ b/src/cited-analysis/handler.js
@@ -241,6 +241,10 @@ async function fetchStoreData(siteId, context, site) {
 async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
   const { log } = context;
   const siteId = site.getId();
+  // Phase-timing anchor for the Mystique phase; combined with the DRS timings threaded in
+  // via auditContext (from the offsite-brand-presence DRS status handler) in the guidance
+  // handler to report DRS / Mystique / total durations.
+  const analysisStartedAt = Date.now();
 
   log.info(`${LOG_PREFIX} Starting Cited analysis audit for site: ${siteId}`);
   log.info(`${LOG_PREFIX} auditContext: ${JSON.stringify(auditContext)}`);
@@ -296,6 +300,7 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
         config: { ...citedConfig, urlLimit },
         storeData,
         ...(slackContext && { slackContext }),
+        timings: { analysisStartedAt, ...(auditContext.timings || {}) },
       },
       fullAuditRef: url,
     };

--- a/src/offsite-brand-presence/drs-status-handler.js
+++ b/src/offsite-brand-presence/drs-status-handler.js
@@ -13,6 +13,7 @@
 import { ok } from '@adobe/spacecat-shared-http-utils';
 import DrsClient from '@adobe/spacecat-shared-drs-client';
 import { postMessageOptional } from '../utils/slack-utils.js';
+import { formatDuration } from '../utils/offsite-audit-utils.js';
 import {
   DRS_POLL_INTERVAL_SECONDS,
   DRS_TERMINAL_STATUSES,
@@ -131,9 +132,10 @@ function computeReadyAuditTypes(statuses, deadlineReached, alreadyTriggered) {
  * @param {string} siteId - The site ID
  * @param {object} slackContext - { channelId, threadTs } forwarded to the triggered audits
  * @param {object} context - Universal context (sqs, dataAccess, log)
+ * @param {number} [drsStartedAt] - Epoch ms when DRS scraping was triggered (phase timing)
  * @returns {Promise<string[]>} Audit types that were dispatched or intentionally skipped
  */
-async function triggerAnalysisAudits(auditTypes, siteId, slackContext, context) {
+async function triggerAnalysisAudits(auditTypes, siteId, slackContext, context, drsStartedAt) {
   const { sqs, dataAccess, log } = context;
 
   const handled = [];
@@ -141,6 +143,9 @@ async function triggerAnalysisAudits(auditTypes, siteId, slackContext, context) 
     return handled;
   }
 
+  // The bucket's jobs are terminal now, so this is when DRS scraping finished for the
+  // analysis types being dispatched. Paired with drsStartedAt it gives the DRS duration.
+  const drsCompletedAt = Date.now();
   const configuration = await dataAccess.Configuration.findLatest();
   const queueUrl = configuration.getQueues().audits;
   for (const type of auditTypes) {
@@ -158,7 +163,12 @@ async function triggerAnalysisAudits(auditTypes, siteId, slackContext, context) 
         siteId,
         // DRS scraping is already done, so the analysis audit must analyze the available
         // data rather than request another scrape (prevents a scrape→analyze loop).
-        auditContext: { slackContext, drsScrapeRequested: true },
+        // timings carry the DRS phase boundaries so the analysis can report scrape duration.
+        auditContext: {
+          slackContext,
+          drsScrapeRequested: true,
+          ...(Number.isFinite(drsStartedAt) && { timings: { drsStartedAt, drsCompletedAt } }),
+        },
       });
       log.info(`${LOG_PREFIX} Triggered ${type} for site ${siteId}`);
       handled.push(type);
@@ -179,7 +189,7 @@ async function triggerAnalysisAudits(auditTypes, siteId, slackContext, context) 
  *   error: string|undefined}>} statuses - Resolved per-job statuses
  * @returns {string} Slack message text
  */
-function buildSummary(baseURL, statuses) {
+function buildSummary(baseURL, statuses, drsStartedAt) {
   const allTerminal = statuses.every((s) => DRS_TERMINAL_STATUSES.has(s.status));
   const header = allTerminal
     ? `:checkered_flag: *offsite-brand-presence* DRS jobs *complete* for *${baseURL}*:`
@@ -194,6 +204,10 @@ function buildSummary(baseURL, statuses) {
     } else {
       lines.push(`• ${label} → ${s.status}`);
     }
+  }
+  const elapsed = Number.isFinite(drsStartedAt) ? formatDuration(Date.now() - drsStartedAt) : null;
+  if (elapsed) {
+    lines.push(`• DRS scraping elapsed: ~${elapsed}`);
   }
   return lines.join('\n');
 }
@@ -220,7 +234,7 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
   const { Configuration } = dataAccess;
   const { siteId, auditContext = {} } = message;
   const {
-    baseURL, slackContext = {}, jobs = [], deadline, triggeredAuditTypes = [],
+    baseURL, slackContext = {}, jobs = [], deadline, triggeredAuditTypes = [], drsStartedAt,
   } = auditContext;
   const { channelId, threadTs } = slackContext;
 
@@ -253,7 +267,7 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
   let handled = [];
   try {
     const readyTypes = computeReadyAuditTypes(statuses, deadlineReached, alreadyTriggered);
-    handled = await triggerAnalysisAudits(readyTypes, siteId, slackContext, context);
+    handled = await triggerAnalysisAudits(readyTypes, siteId, slackContext, context, drsStartedAt);
   } catch (err) {
     log.warn(`${LOG_PREFIX} Failed to trigger analysis audits for ${baseURL}: ${err.message}`);
   }
@@ -284,7 +298,8 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
   // before the message is deleted could redeliver and post the summary twice. There is
   // no idempotency key; a duplicate Slack summary is preferable to the complexity of
   // deduplication for a best-effort notification.
-  await postMessageOptional(context, channelId, buildSummary(baseURL, statuses), { threadTs });
+  const summary = buildSummary(baseURL, statuses, drsStartedAt);
+  await postMessageOptional(context, channelId, summary, { threadTs });
   log.info(`${LOG_PREFIX} Posted completion summary for ${baseURL} (${statuses.length} jobs)`);
 
   return ok();

--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -740,8 +740,17 @@ async function notifyDrsResults(drsResults, baseURL, context, channelId, threadT
  * @param {object} context - The execution context (sqs, dataAccess, log)
  * @param {string} channelId - Slack channel ID
  * @param {string} threadTs - Slack thread timestamp
+ * @param {number} drsStartedAt - Epoch ms when DRS scraping was triggered (phase timing)
  */
-async function scheduleDrsStatusPoll(drsResults, baseURL, siteId, context, channelId, threadTs) {
+async function scheduleDrsStatusPoll(
+  drsResults,
+  baseURL,
+  siteId,
+  context,
+  channelId,
+  threadTs,
+  drsStartedAt,
+) {
   const { sqs, dataAccess, log } = context;
 
   if (!channelId || !threadTs) {
@@ -765,6 +774,7 @@ async function scheduleDrsStatusPoll(drsResults, baseURL, siteId, context, chann
       slackContext: { channelId, threadTs },
       jobs,
       deadline: Date.now() + DRS_POLL_MAX_WAIT_SECONDS * 1000,
+      drsStartedAt,
     },
   }, null, DRS_POLL_INTERVAL_SECONDS);
 
@@ -882,6 +892,9 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
   }
 
   const storedByDomain = await addUrlsToUrlStore(siteId, topByDomain, topCited, dataAccess, log);
+  // Phase timing anchor: when DRS scraping is triggered. Threaded through the poll and
+  // the downstream analysis audits so each can report how long its scrape took.
+  const drsStartedAt = Date.now();
   const { skipped, results: drsResults } = await triggerDrsScraping(
     storedByDomain,
     siteId,
@@ -899,7 +912,15 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
     // must not fail the run, which already submitted the DRS jobs (POST /jobs is not
     // idempotent) and posted the initial notification. Re-running would duplicate both.
     try {
-      await scheduleDrsStatusPoll(drsResults, baseURL, siteId, context, channelId, threadTs);
+      await scheduleDrsStatusPoll(
+        drsResults,
+        baseURL,
+        siteId,
+        context,
+        channelId,
+        threadTs,
+        drsStartedAt,
+      );
     } catch (err) {
       log.warn(`${LOG_PREFIX} Failed to schedule DRS status poll: ${err.message}`);
     }

--- a/src/reddit-analysis/guidance-handler.js
+++ b/src/reddit-analysis/guidance-handler.js
@@ -20,6 +20,7 @@ import { createOpportunityData } from './opportunity-data-mapper.js';
 import { postMessageOptional, buildAnalysisVisibilityMessage } from '../utils/slack-utils.js';
 import { resolveBrandResultForSite, applyScopeToOpportunity } from '../utils/brand-resolver.js';
 import { fetchAnalysisFromPresignedUrl } from '../utils/analysis-fetch.js';
+import { buildOffsiteTimingLines } from '../utils/offsite-audit-utils.js';
 import {
   isValidOffsiteAnalysis,
   persistOffsiteOpportunity,
@@ -159,7 +160,8 @@ export default async function handler(message, context) {
 
     if (auditId) {
       const auditRecord = await AuditModel.findById(auditId);
-      const slackContext = auditRecord?.getAuditResult()?.slackContext;
+      const auditResultData = auditRecord?.getAuditResult();
+      const slackContext = auditResultData?.slackContext;
       if (slackContext) {
         const { channelId, threadTs } = slackContext;
 
@@ -173,7 +175,11 @@ export default async function handler(message, context) {
           verdict: opportunityData.qaVerdict,
         });
 
-        await postMessageOptional(context, channelId, slackMessage, { threadTs });
+        // Append DRS / Mystique / total phase timings (from anchors on the audit result).
+        const timingLines = buildOffsiteTimingLines(auditResultData?.timings);
+        const fullMessage = timingLines ? `${slackMessage}\n${timingLines}` : slackMessage;
+
+        await postMessageOptional(context, channelId, fullMessage, { threadTs });
       }
     }
 

--- a/src/reddit-analysis/handler.js
+++ b/src/reddit-analysis/handler.js
@@ -126,6 +126,10 @@ async function fetchStoreData(siteId, context, site) {
 async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
   const { log } = context;
   const siteId = site.getId();
+  // Phase-timing anchor for the Mystique phase; combined with the DRS timings threaded in
+  // via auditContext (from the offsite-brand-presence DRS status handler) in the guidance
+  // handler to report DRS / Mystique / total durations.
+  const analysisStartedAt = Date.now();
 
   log.info(`${LOG_PREFIX} Starting Reddit analysis audit for site: ${siteId}`);
   log.info(`${LOG_PREFIX} auditContext: ${JSON.stringify(auditContext)}`);
@@ -175,6 +179,7 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
         config: { ...redditConfig, urlLimit },
         storeData,
         ...(slackContext && { slackContext }),
+        timings: { analysisStartedAt, ...(auditContext.timings || {}) },
       },
       fullAuditRef: url,
     };

--- a/src/utils/offsite-audit-utils.js
+++ b/src/utils/offsite-audit-utils.js
@@ -42,6 +42,67 @@ export const NON_EARNED_EXCLUDED_DOMAINS = Object.freeze([
   'groupon.com',
 ]);
 
+/**
+ * Formats a millisecond duration as a compact human string (e.g. `42s`, `3m`, `3m 10s`).
+ * Returns null for a missing/negative/non-finite input so callers can omit the line.
+ *
+ * @param {number} ms - Duration in milliseconds
+ * @returns {string|null}
+ */
+export function formatDuration(ms) {
+  if (!Number.isFinite(ms) || ms < 0) {
+    return null;
+  }
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) {
+    return `${totalSeconds}s`;
+  }
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`;
+}
+
+/**
+ * Builds the Slack phase-timing lines for an offsite analysis (cited/youtube/reddit),
+ * from the timing anchors persisted on the audit result.
+ *
+ * - When a DRS scrape ran this cycle (drsStartedAt + drsCompletedAt present): reports the
+ *   DRS scrape duration, the Mystique suggestion-generation duration (analysis start → now),
+ *   and their sum as the total.
+ * - When no scrape ran (content already scraped): reports DRS as n/a and Mystique = total.
+ *
+ * Returns '' when there is no usable timing anchor, so the caller appends nothing.
+ *
+ * @param {object} [timings] - { analysisStartedAt, drsStartedAt?, drsCompletedAt? } (epoch ms)
+ * @param {number} [nowMs] - Completion instant (defaults to Date.now())
+ * @returns {string} Newline-joined Slack lines, or '' when timings are unusable
+ */
+export function buildOffsiteTimingLines(timings, nowMs = Date.now()) {
+  if (!timings || !Number.isFinite(timings.analysisStartedAt)) {
+    return '';
+  }
+  const mystique = formatDuration(nowMs - timings.analysisStartedAt);
+  if (mystique === null) {
+    return '';
+  }
+
+  const { drsStartedAt, drsCompletedAt } = timings;
+  const hasDrs = Number.isFinite(drsStartedAt) && Number.isFinite(drsCompletedAt);
+  const drsMs = hasDrs ? drsCompletedAt - drsStartedAt : null;
+  const drs = hasDrs ? formatDuration(drsMs) : null;
+
+  if (drs === null) {
+    return '• DRS scrape: already scraped (n/a)\n'
+      + `• Suggestion generation (Mystique): ${mystique}\n`
+      + `• Total: ${mystique}`;
+  }
+
+  const total = formatDuration(drsMs + (nowMs - timings.analysisStartedAt));
+  return `• DRS scrape: ${drs}\n`
+    + `• Suggestion generation (Mystique): ${mystique}\n`
+    + `• Total (DRS + Mystique): ${total}`;
+}
+
 // Tokens shorter than this are dropped from brand-token matching: a 1-2 char
 // substring would match almost any host and turn the branded filter into a
 // blunt instrument.

--- a/src/youtube-analysis/guidance-handler.js
+++ b/src/youtube-analysis/guidance-handler.js
@@ -18,6 +18,7 @@ import { createOpportunityData } from './opportunity-data-mapper.js';
 import { postMessageOptional, buildAnalysisVisibilityMessage } from '../utils/slack-utils.js';
 import { resolveBrandResultForSite, applyScopeToOpportunity } from '../utils/brand-resolver.js';
 import { fetchAnalysisFromPresignedUrl } from '../utils/analysis-fetch.js';
+import { buildOffsiteTimingLines } from '../utils/offsite-audit-utils.js';
 import {
   isValidOffsiteAnalysis,
   persistOffsiteOpportunity,
@@ -157,7 +158,8 @@ export default async function handler(message, context) {
 
     if (auditId) {
       const audit = await AuditModel.findById(auditId);
-      const slackContext = audit?.getAuditResult()?.slackContext;
+      const auditResultData = audit?.getAuditResult();
+      const slackContext = auditResultData?.slackContext;
       if (slackContext) {
         const { channelId, threadTs } = slackContext;
 
@@ -171,7 +173,11 @@ export default async function handler(message, context) {
           verdict: opportunityData.qaVerdict,
         });
 
-        await postMessageOptional(context, channelId, slackMessage, { threadTs });
+        // Append DRS / Mystique / total phase timings (from anchors on the audit result).
+        const timingLines = buildOffsiteTimingLines(auditResultData?.timings);
+        const fullMessage = timingLines ? `${slackMessage}\n${timingLines}` : slackMessage;
+
+        await postMessageOptional(context, channelId, fullMessage, { threadTs });
       }
     }
 

--- a/src/youtube-analysis/handler.js
+++ b/src/youtube-analysis/handler.js
@@ -126,6 +126,10 @@ async function fetchStoreData(siteId, context, site) {
 async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
   const { log } = context;
   const siteId = site.getId();
+  // Phase-timing anchor for the Mystique phase; combined with the DRS timings threaded in
+  // via auditContext (from the offsite-brand-presence DRS status handler) in the guidance
+  // handler to report DRS / Mystique / total durations.
+  const analysisStartedAt = Date.now();
 
   log.info(`${LOG_PREFIX} Starting YouTube analysis audit for site: ${siteId}`);
   log.info(`${LOG_PREFIX} auditContext: ${JSON.stringify(auditContext)}`);
@@ -175,6 +179,7 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
         config: { ...youtubeConfig, urlLimit },
         storeData,
         ...(slackContext && { slackContext }),
+        timings: { analysisStartedAt, ...(auditContext.timings || {}) },
       },
       fullAuditRef: url,
     };

--- a/test/audits/cited-analysis/guidance-handler.test.js
+++ b/test/audits/cited-analysis/guidance-handler.test.js
@@ -594,6 +594,31 @@ describe('Cited Analysis Guidance Handler', () => {
       expect(callText).to.include(baseURL);
     });
 
+    it('appends DRS / Mystique / total phase timings when present on the audit result', async () => {
+      const now = Date.now();
+      mockAudit.getAuditResult.returns({
+        slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },
+        timings: {
+          drsStartedAt: now - 100_000,
+          drsCompletedAt: now - 60_000,
+          analysisStartedAt: now - 30_000,
+        },
+      });
+
+      const message = {
+        siteId,
+        auditId,
+        data: { analysis: mockAnalysisData, companyName: 'Example Corp' },
+      };
+
+      await handler.default(message, context);
+
+      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(callText).to.include('• DRS scrape:');
+      expect(callText).to.include('Suggestion generation (Mystique):');
+      expect(callText).to.include('Total (DRS + Mystique):');
+    });
+
     it('should not send Slack notification when no slackContext on audit', async () => {
       mockAudit.getAuditResult.returns({});
 

--- a/test/audits/offsite-brand-presence-drs-status.test.js
+++ b/test/audits/offsite-brand-presence-drs-status.test.js
@@ -106,6 +106,26 @@ describe('offsite-brand-presence DRS status handler', () => {
     expect(text).to.not.include('status update');
   });
 
+  it('appends the DRS scraping elapsed time when drsStartedAt is present', async () => {
+    mockGetJob.withArgs('job-1').resolves({ status: 'COMPLETED' });
+    mockGetJob.withArgs('job-2').resolves({ status: 'COMPLETED' });
+
+    await handler.default(buildMessage({ drsStartedAt: Date.now() - 5000 }), context);
+
+    const text = mockPostMessageOptional.firstCall.args[2];
+    expect(text).to.include('DRS scraping elapsed: ~');
+  });
+
+  it('omits the elapsed line when drsStartedAt is absent', async () => {
+    mockGetJob.withArgs('job-1').resolves({ status: 'COMPLETED' });
+    mockGetJob.withArgs('job-2').resolves({ status: 'COMPLETED' });
+
+    await handler.default(buildMessage(), context);
+
+    const text = mockPostMessageOptional.firstCall.args[2];
+    expect(text).to.not.include('DRS scraping elapsed');
+  });
+
   it('includes the error message for a failed job', async () => {
     mockGetJob.withArgs('job-1').resolves({ status: 'COMPLETED' });
     mockGetJob.withArgs('job-2').resolves({ status: 'FAILED', error_message: 'boom' });
@@ -244,6 +264,20 @@ describe('offsite-brand-presence DRS status handler', () => {
           drsScrapeRequested: true,
         },
       });
+    });
+
+    it('forwards DRS phase timings to the triggered analysis audit when drsStartedAt is set', async () => {
+      mockGetJob.withArgs('job-1').resolves({ status: 'COMPLETED' });
+      mockGetJob.withArgs('job-2').resolves({ status: 'COMPLETED' });
+      const drsStartedAt = Date.now() - 5000;
+
+      await handler.default(buildMessage({ drsStartedAt }), context);
+
+      const reddit = context.sqs.sendMessage.getCalls()
+        .find((c) => c.args[1].type === 'reddit-analysis');
+      const { timings } = reddit.args[1].auditContext;
+      expect(timings.drsStartedAt).to.equal(drsStartedAt);
+      expect(timings.drsCompletedAt).to.be.a('number').and.to.be.at.least(drsStartedAt);
     });
 
     it('maps top-cited to cited-analysis and does not trigger wikipedia-analysis', async () => {

--- a/test/audits/reddit-analysis/guidance-handler.test.js
+++ b/test/audits/reddit-analysis/guidance-handler.test.js
@@ -440,6 +440,31 @@ describe('Reddit Analysis Guidance Handler', () => {
       expect(callText).to.include(baseURL);
     });
 
+    it('appends DRS / Mystique / total phase timings when present on the audit result', async () => {
+      const now = Date.now();
+      mockAudit.getAuditResult.returns({
+        slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },
+        timings: {
+          drsStartedAt: now - 100_000,
+          drsCompletedAt: now - 60_000,
+          analysisStartedAt: now - 30_000,
+        },
+      });
+
+      const message = {
+        siteId,
+        auditId,
+        data: { analysis: mockAnalysisData, companyName: 'Example Corp' },
+      };
+
+      await handler.default(message, context);
+
+      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(callText).to.include('• DRS scrape:');
+      expect(callText).to.include('Suggestion generation (Mystique):');
+      expect(callText).to.include('Total (DRS + Mystique):');
+    });
+
     it('should not send Slack notification when no slackContext on audit', async () => {
       mockAudit.getAuditResult.returns({});
 

--- a/test/audits/youtube-analysis/guidance-handler.test.js
+++ b/test/audits/youtube-analysis/guidance-handler.test.js
@@ -634,6 +634,31 @@ describe('YouTube Analysis Guidance Handler', () => {
       expect(callText).to.include('2 suggestions processed');
     });
 
+    it('appends DRS / Mystique / total phase timings when present on the audit result', async () => {
+      const now = Date.now();
+      mockAudit.getAuditResult.returns({
+        slackContext: { channelId: SLACK_CHANNEL_ID, threadTs: SLACK_THREAD_TS },
+        timings: {
+          drsStartedAt: now - 100_000,
+          drsCompletedAt: now - 60_000,
+          analysisStartedAt: now - 30_000,
+        },
+      });
+
+      const message = {
+        siteId,
+        auditId,
+        data: { analysis: mockAnalysisData, companyName: 'Example Corp' },
+      };
+
+      await guidanceHandler.default(message, context);
+
+      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(callText).to.include('• DRS scrape:');
+      expect(callText).to.include('Suggestion generation (Mystique):');
+      expect(callText).to.include('Total (DRS + Mystique):');
+    });
+
     it('should not send Slack notification when no slackContext on audit', async () => {
       mockAudit.getAuditResult.returns({});
 

--- a/test/utils/offsite-audit-utils.test.js
+++ b/test/utils/offsite-audit-utils.test.js
@@ -22,6 +22,8 @@ import {
   computeBrandTokens,
   isExcludedCitedHost,
   toApexHost,
+  formatDuration,
+  buildOffsiteTimingLines,
 } from '../../src/utils/offsite-audit-utils.js';
 
 use(sinonChai);
@@ -354,6 +356,65 @@ describe('offsite-audit-utils', () => {
       expect(toApexHost(undefined)).to.equal('');
       expect(toApexHost('   ')).to.equal('');
       expect(toApexHost('http://[bad')).to.equal('');
+    });
+  });
+
+  describe('formatDuration', () => {
+    it('returns null for missing, negative, or non-finite input', () => {
+      expect(formatDuration(undefined)).to.equal(null);
+      expect(formatDuration(NaN)).to.equal(null);
+      expect(formatDuration(-1)).to.equal(null);
+      expect(formatDuration(Infinity)).to.equal(null);
+    });
+
+    it('formats sub-minute durations as seconds', () => {
+      expect(formatDuration(0)).to.equal('0s');
+      expect(formatDuration(42_000)).to.equal('42s');
+      expect(formatDuration(59_400)).to.equal('59s');
+    });
+
+    it('formats whole minutes without a seconds part', () => {
+      expect(formatDuration(180_000)).to.equal('3m');
+    });
+
+    it('formats minutes with a remaining seconds part', () => {
+      expect(formatDuration(190_000)).to.equal('3m 10s');
+    });
+  });
+
+  describe('buildOffsiteTimingLines', () => {
+    const now = 1_000_000;
+
+    it('returns empty string when timings are missing or lack analysisStartedAt', () => {
+      expect(buildOffsiteTimingLines(undefined, now)).to.equal('');
+      expect(buildOffsiteTimingLines({}, now)).to.equal('');
+      expect(buildOffsiteTimingLines({ analysisStartedAt: 'x' }, now)).to.equal('');
+    });
+
+    it('reports DRS, Mystique, and total when DRS timings are present', () => {
+      const timings = {
+        drsStartedAt: now - 100_000, // DRS scrape started 100s before "now"
+        drsCompletedAt: now - 60_000, // finished 40s later → DRS = 40s
+        analysisStartedAt: now - 30_000, // analysis (Mystique) started 30s before now
+      };
+      const lines = buildOffsiteTimingLines(timings, now);
+      expect(lines).to.include('• DRS scrape: 40s');
+      expect(lines).to.include('• Suggestion generation (Mystique): 30s');
+      // total = DRS (40s) + Mystique (30s) = 70s → rendered as minutes+seconds
+      expect(lines).to.include('• Total (DRS + Mystique): 1m 10s');
+    });
+
+    it('reports DRS as n/a when no scrape ran this cycle', () => {
+      const lines = buildOffsiteTimingLines({ analysisStartedAt: now - 45_000 }, now);
+      expect(lines).to.include('• DRS scrape: already scraped (n/a)');
+      expect(lines).to.include('• Suggestion generation (Mystique): 45s');
+      expect(lines).to.include('• Total: 45s');
+      expect(lines).to.not.include('DRS + Mystique');
+    });
+
+    it('returns empty string when the elapsed Mystique time is not computable', () => {
+      // analysisStartedAt in the future → negative elapsed → no usable duration.
+      expect(buildOffsiteTimingLines({ analysisStartedAt: now + 5_000 }, now)).to.equal('');
     });
   });
 });


### PR DESCRIPTION
## What

Adds per-phase timing to the offsite analyses (**cited-analysis**, **youtube-analysis**, **reddit-analysis**) and the **offsite-brand-presence** orchestrator, surfaced in the Slack thread the audit was triggered from.

Each analysis' guidance-handler completion message now appends:
```
• DRS scrape: 42s
• Suggestion generation (Mystique): 3m 10s
• Total (DRS + Mystique): 3m 52s
```
The offsite-brand-presence DRS-complete summary gains an overall `• DRS scraping elapsed: ~Ns` line.

## How (cross-invocation timing)

The phases span 4 Lambda/SQS hops, so timing anchors are threaded through `auditContext` and persisted on the analysis `auditResult.timings`:

- **`t0` drsStartedAt** — stamped in the `offsite-brand-presence` runner when DRS scraping is triggered; carried in the DRS status-poll message.
- **`t1` drsCompletedAt** — stamped per bucket in the DRS status handler when it dispatches that analysis; forwarded (with `t0`) in the analysis-trigger `auditContext.timings`.
- **`analysisStartedAt`** — stamped at the top of each analysis runner; combined with the DRS anchors onto `auditResult.timings`.
- **`t3`** — "now" in the guidance handler when Mystique replies.

Durations: **DRS = t1−t0**, **Mystique = t3−analysisStartedAt**, **Total = DRS + Mystique** (the sum of the two reported phases, so it always reconciles).

**No-scrape / already-scraped run:** reports `• DRS scrape: already scraped (n/a)` with total = Mystique.

Shared `formatDuration` + `buildOffsiteTimingLines` helpers live in `utils/offsite-audit-utils.js`.

### Trade-off (intentional)
"Mystique" is measured from the analysis audit starting (not the exact SQS send to Mystique), so it includes the analysis' own store-fetch + message-build (usually a few seconds) — dominated by Mystique's LLM work. Chosen to avoid an extra audit-record write in the post-processor. Surfacing is Slack-only.

## Tests

- Unit tests only. Added coverage for `formatDuration` / `buildOffsiteTimingLines` (all branches), the DRS status handler (elapsed line + timings forwarded to the trigger), and each guidance handler (timing lines appended). All changed source files at **100%** coverage.
- Note: the full local `npm test` currently aborts on an unrelated pre-existing module-load error (`filterBySiteScope` not exported by the locally-installed `@adobe/spacecat-shared-utils`, imported by `src/prerender/handler.js`) — not touched by this PR. Verified via the targeted offsite suites (407 passing).