### PR TITLE
fix(cwv): only outdate suggestions whose page was observed this run (SITES-48436)

### DIFF
--- a/src/cwv/opportunity-sync.js
+++ b/src/cwv/opportunity-sync.js
@@ -169,6 +169,20 @@ export async function syncOpportunitiesAndSuggestions(context) {
     .map(filterToFailingDeviceMetrics);
   log.info(`[syncOpportunitiesAndSuggestions] site ${site.getId()} - ${cwvData.length} of ${auditResult.cwv.length} CWV entries have failing metrics`);
 
+  // Set of page URLs actually observed in THIS run's RUM data (the full reported
+  // set, before the failing-metrics filter). Passed to syncSuggestions so a
+  // suggestion is only aged out to OUTDATED when its page was measured this run
+  // and dropped from the failing set because it now passes. A URL absent from
+  // this set — bot/WAF-blocked HEAD, dropped from the top-N/threshold selection,
+  // or sparse/empty RUM — is NOT evidence the issue is resolved, so it must not
+  // be marked OUTDATED (SITES-48436). Group/pattern rows carry no scraped-URL
+  // identity and are unaffected by this guard.
+  const scrapedUrlsSet = new Set(
+    auditResult.cwv
+      .filter((entry) => entry.type === 'url')
+      .map((entry) => entry.url),
+  );
+
   // Build minimal audit data object for opportunity creation
   const auditData = {
     siteId: site.getId(),
@@ -198,6 +212,7 @@ export async function syncOpportunitiesAndSuggestions(context) {
     newData: cwvData,
     context,
     buildKey,
+    scrapedUrlsSet,
     bypassValidationForPlg: true,
     // On re-audit: shallow-merge new fields onto existing data, then mark issues
     // OUTDATED for any metric whose failure has resolved (skip list preserves

--- a/test/audits/cwv.test.js
+++ b/test/audits/cwv.test.js
@@ -526,9 +526,10 @@ describe('collectCWVDataAndImportCode Tests', () => {
       expect(oppty.setLastAuditedAt).to.have.been.calledOnce;
       expect(oppty.save).to.have.been.calledTwice;
 
-      // make sure that 1 old suggestion is removed
-      expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.have.been
-        .calledOnceWith([existingSuggestions[0]], 'OUTDATED');
+      // existingSuggestions[0] (NON_EXISTING_URL) is absent from this run's RUM
+      // data, so it is NOT observed this run and must be preserved rather than
+      // aged out — absence is not evidence the issue is fixed (SITES-48436).
+      expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.not.have.been.called;
 
       // make sure that 1 existing suggestion is updated
       expect(existingSuggestions[1].setData).to.have.been.calledOnce;
@@ -539,6 +540,86 @@ describe('collectCWVDataAndImportCode Tests', () => {
       expect(oppty.addSuggestions).to.have.been.calledOnce;
       const suggestionsArg = oppty.addSuggestions.getCall(0).args[0];
       expect(suggestionsArg).to.be.an('array').with.lengthOf(1);
+    });
+
+    it('does not outdate a still-failing suggestion whose page was not observed this run (SITES-48436)', async () => {
+      sinon.stub(GoogleClient, 'createFrom').resolves({});
+      context.dataAccess.Opportunity.allBySiteIdAndStatus.resolves([oppty]);
+
+      // Existing NEW suggestion for a page with genuinely-failing cached metrics
+      // whose URL is ABSENT from this run's RUM data (e.g. WAF-blocked HEAD,
+      // dropped from the top-N/threshold selection, or sparse RUM). Absence is
+      // NOT evidence the issue is fixed, so it must be preserved, not OUTDATED.
+      const stillFailing = {
+        opportunityId: oppty.getId(),
+        getId: () => 'sugg-still-failing',
+        getData: () => ({
+          type: 'url',
+          url: 'https://www.aem.live/waf-blocked-page',
+          metrics: [{ deviceType: 'mobile', lcp: 6000, cls: 1.2, inp: 800 }],
+        }),
+        getStatus: () => 'NEW',
+        setData: sinon.stub(),
+        setUpdatedBy: sinon.stub().returnsThis(),
+        save: sinon.stub(),
+        remove: sinon.stub(),
+      };
+      oppty.getSuggestions.resolves([stillFailing]);
+
+      const stepContext = { ...context, site, audit: mockAudit, finalUrl: auditUrl };
+      await syncOpportunityAndSuggestionsStep(stepContext);
+
+      // The page was not measured this run → not proven fixed → never OUTDATED.
+      expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.not.have.been.called;
+    });
+
+    it('outdates a suggestion whose page was observed this run and now passes (SITES-48436)', async () => {
+      sinon.stub(GoogleClient, 'createFrom').resolves({});
+      context.dataAccess.Opportunity.allBySiteIdAndStatus.resolves([oppty]);
+
+      const nowPassingUrl = 'https://www.aem.live/now-passing';
+      const resolved = {
+        opportunityId: oppty.getId(),
+        getId: () => 'sugg-resolved',
+        getData: () => ({
+          type: 'url',
+          url: nowPassingUrl,
+          metrics: [{ deviceType: 'mobile', lcp: 6000, cls: 1.2, inp: 800 }],
+        }),
+        getStatus: () => 'NEW',
+        setData: sinon.stub(),
+        setUpdatedBy: sinon.stub().returnsThis(),
+        save: sinon.stub(),
+        remove: sinon.stub(),
+      };
+      oppty.getSuggestions.resolves([resolved]);
+
+      // This run DID observe the page, but every metric now passes, so it drops
+      // from the failing set — genuinely resolved → correctly OUTDATED.
+      const passingAudit = {
+        ...mockAudit,
+        getAuditResult: () => ({
+          cwv: [{
+            type: 'url',
+            url: nowPassingUrl,
+            name: 'Now passing',
+            pageviews: 9000,
+            organic: 5000,
+            metrics: [{
+              deviceType: 'mobile', lcp: 1000, cls: 0.01, inp: 100,
+            }],
+          }],
+          auditContext: { interval: 7 },
+        }),
+      };
+
+      const stepContext = {
+        ...context, site, audit: passingAudit, finalUrl: auditUrl,
+      };
+      await syncOpportunityAndSuggestionsStep(stepContext);
+
+      expect(context.dataAccess.Suggestion.bulkUpdateStatus)
+        .to.have.been.calledOnceWith([resolved], 'OUTDATED');
     });
 
     it('creates a new opportunity object when GSC connection returns null', async () => {


### PR DESCRIPTION
## Problem
[SITES-48436](https://jira.corp.adobe.com/browse/SITES-48436) — on bmw.fr, CWV suggestions with clearly-failing cached metrics (CLS up to 1.26, INP up to 900ms) were marked `OUTDATED`, hiding real, actionable CWV issues from the ASO UI.

Root cause: the CWV audit marks a suggestion `OUTDATED` purely because its URL is **absent** from the current run's failing set (`handleOutdatedSuggestions` keys on URL-absence). But a URL can drop out of a run for reasons that have nothing to do with being fixed:
- the HEAD probe was blocked/timed out (bmw.fr is behind a WAF),
- the page fell out of the top-15 / ≥7000-pv/week selection, or
- RUM returned sparse/no data for it.

The audit treated all of these as "resolved" and aged the suggestion out, even though the issue is still live. This is a latent defect for any WAF/CDN-protected or long-tail site, not just bmw.fr.

## Fix
`syncOpportunitiesAndSuggestions` now builds a `scrapedUrlsSet` of the URLs actually observed in this run's RUM data (`auditResult.cwv`, before the failing-metrics filter) and passes it to `syncSuggestions`. This activates the existing "only outdate URLs actually observed this run" guard in `handleOutdatedSuggestions` — the same guard prerender/llm-error-pages already use.

Result:
- page **observed this run and now passing** → `OUTDATED` ✓ (genuinely resolved)
- page **not observed this run** (WAF/HEAD-fail, dropped from selection, sparse RUM) → **preserved** ✓ (absence is not evidence it's fixed)

No shared-code change — `data-access.js` is untouched; only the CWV sync opts into the guard. Group/pattern suggestions have no scraped-URL identity and are unaffected.

## Trade-off
"Only outdate when proven fixed" also means a genuinely-removed page is no longer auto-outdated — it's preserved until a run observes it passing. This is the conservative direction the ticket wants (never hide a live issue). Age-out of truly-removed pages, if needed, is a separate last-seen/retention follow-up.

## Tests
- Regression (red→green): still-failing page absent from the run is **not** OUTDATED.
- Positive: page observed this run and now passing **is** OUTDATED.
- Updated the existing `NON_EXISTING_URL` test, which had asserted the buggy behavior.
- 47 passing, 100% coverage on `opportunity-sync.js`, lint clean.

## Recovery (not in this PR)
bmw.fr's already-stuck rows are being recovered separately (moved to `pending_validation`; the validator re-promotes still-failing ones to `NEW`). This PR prevents recurrence when the CWV audit is re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
