### PR TITLE
feat(offsite): self-heal empty URL store on individual analysis runs

### DIFF
--- a/src/cited-analysis/handler.js
+++ b/src/cited-analysis/handler.js
@@ -306,13 +306,37 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
     };
   } catch (error) {
     if (error instanceof StoreEmptyError) {
-      log.error(`${LOG_PREFIX} Store data missing: ${error.message}`);
+      const { slackContext } = auditContext;
+      const { channelId, threadTs } = slackContext || {};
+      // A scoped scrape already ran and the store is STILL empty → the brand has no
+      // cited URLs to analyze. Report a terminal message instead of looping.
+      if (auditContext.drsScrapeRequested) {
+        log.error(`${LOG_PREFIX} URL store still empty after scrape: ${error.message}`);
+        await postMessageOptional(
+          context,
+          channelId,
+          `:warning: *cited-analysis* for *${site.getBaseURL()}* — no cited URLs found to analyze.`,
+          { threadTs },
+        );
+        return {
+          auditResult: { success: false, error: error.message, storeName: error.storeName },
+          fullAuditRef: url,
+        };
+      }
+      // First individual run with an empty store: collect + scrape just this bucket via a
+      // domain-scoped offsite-brand-presence run, which re-triggers this analysis when DRS
+      // completes — no need to run offsite-brand-presence for all buckets manually.
+      log.info(`${LOG_PREFIX} URL store empty, requesting a scoped scrape for top-cited`);
+      await postMessageOptional(
+        context,
+        channelId,
+        `:mag: *cited-analysis* for *${site.getBaseURL()}* — no stored URLs yet; `
+          + 'collecting & scraping cited URLs first, will retry automatically.',
+        { threadTs },
+      );
+      await requestOffsiteScrape(context, siteId, 'top-cited', slackContext);
       return {
-        auditResult: {
-          success: false,
-          error: error.message,
-          storeName: error.storeName,
-        },
+        auditResult: { success: false, status: 'pending_scrape', error: error.message },
         fullAuditRef: url,
       };
     }

--- a/src/reddit-analysis/handler.js
+++ b/src/reddit-analysis/handler.js
@@ -185,13 +185,37 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
     };
   } catch (error) {
     if (error instanceof StoreEmptyError) {
-      log.error(`${LOG_PREFIX} Store data missing: ${error.message}`);
+      const { slackContext } = auditContext;
+      const { channelId, threadTs } = slackContext || {};
+      // A scoped scrape already ran and the store is STILL empty → the brand has no
+      // Reddit URLs to analyze. Report a terminal message instead of looping.
+      if (auditContext.drsScrapeRequested) {
+        log.error(`${LOG_PREFIX} URL store still empty after scrape: ${error.message}`);
+        await postMessageOptional(
+          context,
+          channelId,
+          `:warning: *reddit-analysis* for *${site.getBaseURL()}* — no Reddit URLs found to analyze.`,
+          { threadTs },
+        );
+        return {
+          auditResult: { success: false, error: error.message, storeName: error.storeName },
+          fullAuditRef: url,
+        };
+      }
+      // First individual run with an empty store: collect + scrape just this bucket via a
+      // domain-scoped offsite-brand-presence run, which re-triggers this analysis when DRS
+      // completes — no need to run offsite-brand-presence for all buckets manually.
+      log.info(`${LOG_PREFIX} URL store empty, requesting a scoped scrape for reddit.com`);
+      await postMessageOptional(
+        context,
+        channelId,
+        `:mag: *reddit-analysis* for *${site.getBaseURL()}* — no stored URLs yet; `
+          + 'collecting & scraping Reddit URLs first, will retry automatically.',
+        { threadTs },
+      );
+      await requestOffsiteScrape(context, siteId, 'reddit.com', slackContext);
       return {
-        auditResult: {
-          success: false,
-          error: error.message,
-          storeName: error.storeName,
-        },
+        auditResult: { success: false, status: 'pending_scrape', error: error.message },
         fullAuditRef: url,
       };
     }

--- a/src/youtube-analysis/handler.js
+++ b/src/youtube-analysis/handler.js
@@ -185,13 +185,37 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
     };
   } catch (error) {
     if (error instanceof StoreEmptyError) {
-      log.error(`${LOG_PREFIX} Store data missing: ${error.message}`);
+      const { slackContext } = auditContext;
+      const { channelId, threadTs } = slackContext || {};
+      // A scoped scrape already ran and the store is STILL empty → the brand has no
+      // YouTube URLs to analyze. Report a terminal message instead of looping.
+      if (auditContext.drsScrapeRequested) {
+        log.error(`${LOG_PREFIX} URL store still empty after scrape: ${error.message}`);
+        await postMessageOptional(
+          context,
+          channelId,
+          `:warning: *youtube-analysis* for *${site.getBaseURL()}* — no YouTube URLs found to analyze.`,
+          { threadTs },
+        );
+        return {
+          auditResult: { success: false, error: error.message, storeName: error.storeName },
+          fullAuditRef: url,
+        };
+      }
+      // First individual run with an empty store: collect + scrape just this bucket via a
+      // domain-scoped offsite-brand-presence run, which re-triggers this analysis when DRS
+      // completes — no need to run offsite-brand-presence for all buckets manually.
+      log.info(`${LOG_PREFIX} URL store empty, requesting a scoped scrape for youtube.com`);
+      await postMessageOptional(
+        context,
+        channelId,
+        `:mag: *youtube-analysis* for *${site.getBaseURL()}* — no stored URLs yet; `
+          + 'collecting & scraping YouTube URLs first, will retry automatically.',
+        { threadTs },
+      );
+      await requestOffsiteScrape(context, siteId, 'youtube.com', slackContext);
       return {
-        auditResult: {
-          success: false,
-          error: error.message,
-          storeName: error.storeName,
-        },
+        auditResult: { success: false, status: 'pending_scrape', error: error.message },
         fullAuditRef: url,
       };
     }

--- a/test/audits/cited-analysis/handler.test.js
+++ b/test/audits/cited-analysis/handler.test.js
@@ -343,14 +343,43 @@ describe('Cited Analysis Handler', function () {
       expect(result.auditResult.error).to.include('Network failure');
     });
 
-    it('should return error when urlStore returns empty', async () => {
+    it('requests a scoped scrape and notifies Slack when the urlStore is empty on a first run', async () => {
       mockStoreClient.getUrls.rejects(new StoreEmptyError('urlStore', siteId, 'No top-cited-analysis URLs found'));
 
-      const result = await citedAnalysisHandler.default.runner(baseURL, context, mockSite);
+      const result = await citedAnalysisHandler.default.runner(
+        baseURL,
+        context,
+        mockSite,
+        { slackContext: { channelId: 'C1', threadTs: 'T1' } },
+      );
 
       expect(result.auditResult.success).to.be.false;
-      expect(result.auditResult.error).to.include('urlStore returned empty results');
+      expect(result.auditResult.status).to.equal('pending_scrape');
+      expect(context.sqs.sendMessage).to.have.been.calledOnce;
+      const msg = context.sqs.sendMessage.firstCall.args[1];
+      expect(msg.type).to.equal('offsite-brand-presence');
+      expect(msg.auditContext.messageData.domainScope).to.equal('top-cited');
+      expect(mockPostMessageOptional).to.have.been.calledWithMatch(
+        sinon.match.any,
+        'C1',
+        sinon.match(/no stored URLs yet/),
+        { threadTs: 'T1' },
+      );
+    });
+
+    it('reports no URLs found (terminal) when the store is still empty after a scrape', async () => {
+      mockStoreClient.getUrls.rejects(new StoreEmptyError('urlStore', siteId, 'No top-cited-analysis URLs found'));
+
+      const result = await citedAnalysisHandler.default.runner(
+        baseURL,
+        context,
+        mockSite,
+        { drsScrapeRequested: true },
+      );
+
+      expect(result.auditResult.success).to.be.false;
       expect(result.auditResult.storeName).to.equal('urlStore');
+      expect(context.sqs.sendMessage).to.not.have.been.called;
       expect(context.log.error).to.have.been.called;
     });
 

--- a/test/audits/reddit-analysis/handler.test.js
+++ b/test/audits/reddit-analysis/handler.test.js
@@ -302,14 +302,43 @@ describe('Reddit Analysis Handler', function () {
       expect(context.log.warn).to.have.been.calledWithMatch(/Failed to request DRS scrape/);
     });
 
-    it('should return error when urlStore returns empty', async () => {
+    it('requests a scoped scrape and notifies Slack when the urlStore is empty on a first run', async () => {
       mockStoreClient.getUrls.rejects(new StoreEmptyError('urlStore', siteId, 'No reddit-analysis URLs found'));
 
-      const result = await redditAnalysisHandler.default.runner(baseURL, context, mockSite);
+      const result = await redditAnalysisHandler.default.runner(
+        baseURL,
+        context,
+        mockSite,
+        { slackContext: { channelId: 'C1', threadTs: 'T1' } },
+      );
 
       expect(result.auditResult.success).to.be.false;
-      expect(result.auditResult.error).to.include('urlStore returned empty results');
+      expect(result.auditResult.status).to.equal('pending_scrape');
+      expect(context.sqs.sendMessage).to.have.been.calledOnce;
+      const msg = context.sqs.sendMessage.firstCall.args[1];
+      expect(msg.type).to.equal('offsite-brand-presence');
+      expect(msg.auditContext.messageData.domainScope).to.equal('reddit.com');
+      expect(mockPostMessageOptional).to.have.been.calledWithMatch(
+        sinon.match.any,
+        'C1',
+        sinon.match(/no stored URLs yet/),
+        { threadTs: 'T1' },
+      );
+    });
+
+    it('reports no URLs found (terminal) when the store is still empty after a scrape', async () => {
+      mockStoreClient.getUrls.rejects(new StoreEmptyError('urlStore', siteId, 'No reddit-analysis URLs found'));
+
+      const result = await redditAnalysisHandler.default.runner(
+        baseURL,
+        context,
+        mockSite,
+        { drsScrapeRequested: true },
+      );
+
+      expect(result.auditResult.success).to.be.false;
       expect(result.auditResult.storeName).to.equal('urlStore');
+      expect(context.sqs.sendMessage).to.not.have.been.called;
       expect(context.log.error).to.have.been.called;
     });
 

--- a/test/audits/youtube-analysis/handler.test.js
+++ b/test/audits/youtube-analysis/handler.test.js
@@ -292,14 +292,43 @@ describe('YouTube Analysis Handler', function () {
       expect(context.log.error).to.have.been.calledWithMatch(/No DRS content available after scraping/);
     });
 
-    it('should return error when urlStore returns empty', async () => {
+    it('requests a scoped scrape and notifies Slack when the urlStore is empty on a first run', async () => {
       mockStoreClient.getUrls.rejects(new StoreEmptyError('urlStore', siteId, 'No youtube-analysis URLs found'));
 
-      const result = await youtubeAnalysisHandler.default.runner(baseURL, context, mockSite);
+      const result = await youtubeAnalysisHandler.default.runner(
+        baseURL,
+        context,
+        mockSite,
+        { slackContext: { channelId: 'C1', threadTs: 'T1' } },
+      );
 
       expect(result.auditResult.success).to.be.false;
-      expect(result.auditResult.error).to.include('urlStore returned empty results');
+      expect(result.auditResult.status).to.equal('pending_scrape');
+      expect(context.sqs.sendMessage).to.have.been.calledOnce;
+      const msg = context.sqs.sendMessage.firstCall.args[1];
+      expect(msg.type).to.equal('offsite-brand-presence');
+      expect(msg.auditContext.messageData.domainScope).to.equal('youtube.com');
+      expect(mockPostMessageOptional).to.have.been.calledWithMatch(
+        sinon.match.any,
+        'C1',
+        sinon.match(/no stored URLs yet/),
+        { threadTs: 'T1' },
+      );
+    });
+
+    it('reports no URLs found (terminal) when the store is still empty after a scrape', async () => {
+      mockStoreClient.getUrls.rejects(new StoreEmptyError('urlStore', siteId, 'No youtube-analysis URLs found'));
+
+      const result = await youtubeAnalysisHandler.default.runner(
+        baseURL,
+        context,
+        mockSite,
+        { drsScrapeRequested: true },
+      );
+
+      expect(result.auditResult.success).to.be.false;
       expect(result.auditResult.storeName).to.equal('urlStore');
+      expect(context.sqs.sendMessage).to.not.have.been.called;
       expect(context.log.error).to.have.been.called;
     });
 


### PR DESCRIPTION
## Problem

Running an offsite analysis individually — `@spacecat run audit <site> reddit-analysis` (or youtube/cited) — **fails silently** when the URL store has no URLs for that bucket. The store is normally populated by `offsite-brand-presence`, so a standalone run hits `StoreEmptyError` and returns `success:false` with **no Slack signal** (observed on `lot.com`: the analysis card posts, then nothing).

There are two distinct empty states, handled very differently before this PR:

| State | Meaning | Before |
|---|---|---|
| `DrsNoContentAvailableError` | URLs in store, not scraped yet | **self-heals** via `requestOffsiteScrape` |
| `StoreEmptyError` | **zero URLs** in store | **fails silently** |

## Fix

`StoreEmptyError` now mirrors the existing self-heal: it triggers a **domain-scoped** `offsite-brand-presence` run (`requestOffsiteScrape` with `messageData.domainScope`) that collects + scrapes **only that bucket** — `reddit.com` / `youtube.com` / `top-cited` — and re-triggers the analysis when DRS completes. **No need to run `offsite-brand-presence` for all three buckets manually.**

- Posts a Slack note: `:mag: … no stored URLs yet; collecting & scraping Reddit URLs first, will retry automatically.`
- Loop guard: if the run is already a re-triggered one (`drsScrapeRequested`) and the store is *still* empty → posts a terminal `:warning: … no Reddit URLs found to analyze.` and stops (no infinite scrape→analyze loop).

This reuses the exact mechanism the `DrsNoContentAvailableError` path already uses, so the two empty states are now consistent.

## Tests

- Unit tests only. Per handler: replaced the old "returns error on empty store" test with a first-run self-heal test (asserts scoped `offsite-brand-presence` dispatch + Slack note) and added a terminal drsScrapeRequested case. All three `handler.js` at **100%** coverage; 124 passing; lint clean.
- (Full local `npm test` still aborts on the unrelated pre-existing `filterBySiteScope` import error in `src/prerender/handler.js` — not touched here.)