### PR TITLE
fix(offsite): don't let a pending_scrape run block its own post-scrape re-trigger

### DIFF
--- a/src/offsite-brand-presence/drs-status-handler.js
+++ b/src/offsite-brand-presence/drs-status-handler.js
@@ -62,6 +62,14 @@ async function hasRecentAudit(siteId, auditType, dataAccess, log) {
     if (!latest) {
       return false;
     }
+    // A `pending_scrape` run is the analysis itself, waiting for the DRS scrape this poll
+    // just completed — it requested the scrape and must NOT suppress its own re-trigger.
+    // (Without this, an individual analysis run that self-heals an empty URL store never
+    // reaches Mystique: its pending_scrape audit trips the cooldown for the whole hour.)
+    // Only a real completed/in-progress analysis within the window dedupes redelivered polls.
+    if (latest.getAuditResult?.()?.status === 'pending_scrape') {
+      return false;
+    }
     const auditedAt = new Date(latest.getAuditedAt()).getTime();
     return (Date.now() - auditedAt) < AUDIT_TRIGGER_COOLDOWN_MS;
   } catch (err) {

--- a/test/audits/offsite-brand-presence-drs-status.test.js
+++ b/test/audits/offsite-brand-presence-drs-status.test.js
@@ -358,6 +358,26 @@ describe('offsite-brand-presence DRS status handler', () => {
       expect(log.info).to.have.been.calledWithMatch(/Skipping reddit-analysis.*recent audit exists/);
     });
 
+    it('triggers within the cooldown when the recent audit is a pending_scrape run', async () => {
+      // A pending_scrape run is the analysis waiting for the DRS scrape this poll just
+      // completed — it must not block its own re-trigger, even inside the cooldown window.
+      mockGetJob.withArgs('job-1').resolves({ status: 'COMPLETED' });
+      mockGetJob.withArgs('job-2').resolves({ status: 'COMPLETED' });
+
+      const pendingScrapeAudit = {
+        getAuditedAt: () => new Date(Date.now() - AUDIT_TRIGGER_COOLDOWN_MS / 2).toISOString(),
+        getAuditResult: () => ({ success: false, status: 'pending_scrape' }),
+      };
+      context.dataAccess.LatestAudit.findBySiteIdAndAuditType
+        .withArgs(SITE_ID, 'reddit-analysis').resolves(pendingScrapeAudit);
+
+      await handler.default(buildMessage(), context);
+
+      const types = context.sqs.sendMessage.getCalls().map((c) => c.args[1].type);
+      expect(types).to.include('reddit-analysis');
+      expect(types).to.include('youtube-analysis');
+    });
+
     it('triggers the audit when the most recent audit is older than the cooldown window', async () => {
       mockGetJob.withArgs('job-1').resolves({ status: 'COMPLETED' });
       mockGetJob.withArgs('job-2').resolves({ status: 'COMPLETED' });


### PR DESCRIPTION
## Problem (observed on `ups.com`)

`@spacecat run audit ups.com reddit-analysis` self-healed correctly — empty URL store → scoped offsite-brand-presence run → DRS jobs → `:checkered_flag: DRS jobs complete` — but then **nothing reached Mystique**. No suggestions, no further messages.

Root cause: the self-heal's first run persists a `reddit-analysis` audit with `auditResult.status = 'pending_scrape'`. When the DRS status handler later tries to re-trigger `reddit-analysis` (after the scrape it requested finishes), `hasRecentAudit` — a purely time-based 1-hour cooldown meant to dedupe redelivered polls — sees that `pending_scrape` audit as a "recent audit" and **skips the re-trigger**. So the analysis that was *waiting for* the scrape is blocked by its own waiting-marker for the whole hour.

This affects both the new `StoreEmptyError` self-heal (#2801) and the pre-existing `DrsNoContentAvailableError` self-heal.

## Fix

`hasRecentAudit` now ignores a latest audit whose result `status === 'pending_scrape'` — that run is the analysis waiting for the very scrape this poll just completed, so it must not suppress its own re-trigger. A genuinely completed/in-progress analysis (`pending_analysis` / success) within the window still dedupes redelivered polls, so the intended redelivery protection is intact.

One-line guard in `hasRecentAudit` (`LatestAudit extends Audit`, so `getAuditResult()` is available).

## Tests

- Added a drs-status-handler case: a `pending_scrape` latest audit within the cooldown window still triggers the analysis. Existing "skip within cooldown" / "trigger when older" cases unchanged. `drs-status-handler.js` at **100%** coverage; 28 passing; lint clean.