### PR TITLE
fix(sync): LLMO-6483 preserve manually-edited suggestions during re-audit

### DIFF
--- a/src/experimentation-opportunities/guidance-high-organic-low-ctr-handler.js
+++ b/src/experimentation-opportunities/guidance-high-organic-low-ctr-handler.js
@@ -14,20 +14,12 @@ import { notFound, ok } from '@adobe/spacecat-shared-http-utils';
 import { Suggestion as SuggestionModel } from '@adobe/spacecat-shared-data-access';
 import { convertToOpportunityEntity } from './opportunity-data-mapper.js';
 import { HIGH_ORGANIC_LOW_CTR_OPPTY_TYPE } from './handler.js';
-import { warnOnInvalidSuggestionData } from '../utils/data-access.js';
+import { isManuallyEditedSuggestion, warnOnInvalidSuggestionData } from '../utils/data-access.js';
 
 const MAX_HIGH_ORGANIC_LOW_CTR_OPPORTUNITIES = 3;
 
-/**
- * Checks if any suggestions in the array were manually modified (updatedBy !== 'system')
- * @param {Array} suggestions - Array of suggestion objects
- * @returns {boolean} - True if any suggestion was manually modified
- */
 function hasManuallyModifiedSuggestions(suggestions) {
-  return suggestions.some((suggestion) => {
-    const suggestionUpdatedBy = suggestion.getUpdatedBy();
-    return suggestionUpdatedBy && suggestionUpdatedBy !== 'system';
-  });
+  return suggestions.some(isManuallyEditedSuggestion);
 }
 
 /**

--- a/src/utils/data-access.js
+++ b/src/utils/data-access.js
@@ -36,9 +36,12 @@ export const AUTHOR_ONLY_OPPORTUNITY_TYPES = [
 
 /**
  * True when a suggestion was last touched by a non-system actor (typically a
- * customer email stamped by the API). Used to skip regenerating/overwriting
+ * customer email stamped by the PATCH API). Used to skip regenerating/overwriting
  * that suggestion's data on subsequent audits (LLMO-6483).
- * Applies regardless of suggestion status (NEW, APPROVED/deployed, etc.).
+ *
+ * This checks the entity-level `updatedBy` field — distinct from the alt-text
+ * domain-specific `data.recommendations[].isManuallyEdited` flag used in
+ * image-alt-text handlers.
  *
  * @param {Object} suggestion - Suggestion entity (or mock).
  * @returns {boolean}
@@ -428,9 +431,11 @@ export const isTBYBSite = checkIsTBYBSite;
  * Handles outdated suggestions by updating their status, either to OUTDATED or the provided one.
  * Updates existing suggestions with new data if they match based on the provided key.
  * For REJECTED suggestions that appear again, preserves REJECTED status.
- * Suggestions with updatedBy set to a non-system actor (customer edits) are not
- * regenerated on re-audit — data/status/rank are left unchanged. Applies to both
- * NEW and deployed (e.g. APPROVED / IN_PROGRESS) suggestions (LLMO-6483).
+ * Suggestions with updatedBy set to a non-system actor (customer edits) are
+ * protected from data overwrites when they are still present in the current
+ * audit data (matched-key path). They are also excluded from the OUTDATED and
+ * reconcile-disappeared paths. Note: this is distinct from the alt-text
+ * domain-specific `isManuallyEdited` data flag (LLMO-6483).
  *
  * Prepares new suggestions from the new data and adds them to the opportunity.
  * Maps new data to suggestion objects using the provided mapping function.
@@ -710,6 +715,9 @@ export async function reconcileDisappearedSuggestions({
     // (customer explicitly picked a redirect target, so a live match is
     // high-confidence attribution — see function docstring).
     const candidates = disappearedSuggestions.filter((s) => {
+      if (isManuallyEditedSuggestion(s)) {
+        return false;
+      }
       const status = s?.getStatus?.();
       if (newStatus && status === newStatus) {
         return true;

--- a/src/utils/data-access.js
+++ b/src/utils/data-access.js
@@ -312,7 +312,8 @@ export const handleOutdatedSuggestions = async ({
         return suggestionUrl && scrapedUrlsSet.has(suggestionUrl);
       }
       return true;
-    });
+    })
+    .filter((existing) => !isManuallyEditedSuggestion(existing));
 
   // prevents JSON.stringify overflow
   log.info(`[SuggestionSync] Final count of suggestions to mark as ${statusToSetForOutdated}: ${existingOutdatedSuggestions.length}`);

--- a/src/utils/data-access.js
+++ b/src/utils/data-access.js
@@ -35,6 +35,20 @@ export const AUTHOR_ONLY_OPPORTUNITY_TYPES = [
 ];
 
 /**
+ * True when a suggestion was last touched by a non-system actor (typically a
+ * customer email stamped by the API). Used to skip regenerating/overwriting
+ * that suggestion's data on subsequent audits (LLMO-6483).
+ * Applies regardless of suggestion status (NEW, APPROVED/deployed, etc.).
+ *
+ * @param {Object} suggestion - Suggestion entity (or mock).
+ * @returns {boolean}
+ */
+export function isManuallyEditedSuggestion(suggestion) {
+  const updatedBy = suggestion?.getUpdatedBy?.();
+  return Boolean(updatedBy && updatedBy !== 'system');
+}
+
+/**
  * Validates suggestion data against the Joi schema for the given opportunity type.
  * Logs a warning if validation fails but does not block the operation.
  *
@@ -412,7 +426,10 @@ export const isTBYBSite = checkIsTBYBSite;
  * Synchronizes existing suggestions with new data.
  * Handles outdated suggestions by updating their status, either to OUTDATED or the provided one.
  * Updates existing suggestions with new data if they match based on the provided key.
- * For REJECTED suggestions that appear again, preserves REJECTED status
+ * For REJECTED suggestions that appear again, preserves REJECTED status.
+ * Suggestions with updatedBy set to a non-system actor (customer edits) are not
+ * regenerated on re-audit — data/status/rank are left unchanged. Applies to both
+ * NEW and deployed (e.g. APPROVED / IN_PROGRESS) suggestions (LLMO-6483).
  *
  * Prepares new suggestions from the new data and adds them to the opportunity.
  * Maps new data to suggestion objects using the provided mapping function.
@@ -526,11 +543,11 @@ export async function syncSuggestions({
       return;
     }
 
-    // Suggestions manually edited by a customer (updatedBy is set to their
-    // email, not 'system') must not have their data overwritten by a re-audit.
-    const updatedBy = existing.getUpdatedBy?.();
-    if (updatedBy && updatedBy !== 'system') {
-      log.debug(`Skipping manually-edited suggestion ${existingKey} (updatedBy: ${updatedBy})`);
+    // Do not regenerate a customer-edited suggestion on re-audit (LLMO-6483).
+    // Applies to NEW and deployed statuses alike. updatedBy may be a user email
+    // — never log it (PII).
+    if (isManuallyEditedSuggestion(existing)) {
+      log.debug(`Skipping manually-edited suggestion ${existingKey}`);
       return;
     }
 

--- a/src/utils/data-access.js
+++ b/src/utils/data-access.js
@@ -526,6 +526,14 @@ export async function syncSuggestions({
       return;
     }
 
+    // Suggestions manually edited by a customer (updatedBy is set to their
+    // email, not 'system') must not have their data overwritten by a re-audit.
+    const updatedBy = existing.getUpdatedBy?.();
+    if (updatedBy && updatedBy !== 'system') {
+      log.debug(`Skipping manually-edited suggestion ${existingKey} (updatedBy: ${updatedBy})`);
+      return;
+    }
+
     const newDataItem = newDataByKey.get(existingKey);
     // mergeDataFunction must return a new object (not mutate existingData)
     // for deepEqual comparison to work correctly

--- a/test/utils/data-access.test.js
+++ b/test/utils/data-access.test.js
@@ -1093,8 +1093,14 @@ describe('data-access', () => {
         (msg) => /Skipping manually-edited suggestion/.test(msg),
       );
       expect(skipMsg).to.be.a('string');
-      // Must not log the customer email (PII)
-      expect(skipMsg).to.not.include('customer@example.com');
+      // Must not log the customer email (PII) in ANY log call
+      const allLogMessages = [
+        ...mockLogger.debug.args,
+        ...mockLogger.info.args,
+        ...mockLogger.warn.args,
+      ].flat().filter((a) => typeof a === 'string');
+      const piiLeak = allLogMessages.find((msg) => msg.includes('customer@example.com'));
+      expect(piiLeak, 'customer email must not appear in any log message').to.be.undefined;
     });
 
     it('should not overwrite a manually-edited deployed (APPROVED) suggestion', async () => {

--- a/test/utils/data-access.test.js
+++ b/test/utils/data-access.test.js
@@ -1053,6 +1053,82 @@ describe('data-access', () => {
       );
     });
 
+    it('should not overwrite a manually-edited suggestion (updatedBy is a user email)', async () => {
+      const suggestionsData = [
+        { key: '1', title: 'customer edited title', url: 'https://example.com/page1' },
+      ];
+      const existingSuggestions = [{
+        id: '1',
+        data: suggestionsData[0],
+        getData: sinon.stub().returns(suggestionsData[0]),
+        setData: sinon.stub(),
+        setRank: sinon.stub(),
+        save: sinon.stub().resolves(),
+        getStatus: sinon.stub().returns(SuggestionDataAccess.STATUSES.NEW),
+        setStatus: sinon.stub(),
+        setUpdatedBy: sinon.stub().returnsThis(),
+        getUpdatedBy: sinon.stub().returns('customer@example.com'),
+      }];
+
+      const newData = [
+        { key: '1', title: 'LLM regenerated title', url: 'https://example.com/page1' },
+      ];
+
+      mockOpportunity.getSuggestions.resolves(existingSuggestions);
+
+      await syncSuggestions({
+        context,
+        opportunity: mockOpportunity,
+        newData,
+        buildKey,
+        mapNewSuggestion,
+      });
+
+      expect(existingSuggestions[0].setData).to.not.have.been.called;
+      expect(existingSuggestions[0].setStatus).to.not.have.been.called;
+      expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
+      const debugMessages = mockLogger.debug.args.map((a) => a[0]);
+      const found = debugMessages.some(
+        (msg) => /Skipping manually-edited suggestion/.test(msg),
+      );
+      expect(found).to.be.true;
+    });
+
+    it('should update a suggestion when updatedBy is system (not manually edited)', async () => {
+      const suggestionsData = [
+        { key: '1', title: 'old title', url: 'https://example.com/page1' },
+      ];
+      const existingSuggestions = [{
+        id: '1',
+        data: suggestionsData[0],
+        getData: sinon.stub().returns(suggestionsData[0]),
+        setData: sinon.stub(),
+        setRank: sinon.stub(),
+        save: sinon.stub().resolves(),
+        getStatus: sinon.stub().returns(SuggestionDataAccess.STATUSES.NEW),
+        setStatus: sinon.stub(),
+        setUpdatedBy: sinon.stub().returnsThis(),
+        getUpdatedBy: sinon.stub().returns('system'),
+      }];
+
+      const newData = [
+        { key: '1', title: 'new title', url: 'https://example.com/page1' },
+      ];
+
+      mockOpportunity.getSuggestions.resolves(existingSuggestions);
+
+      await syncSuggestions({
+        context,
+        opportunity: mockOpportunity,
+        newData,
+        buildKey,
+        mapNewSuggestion,
+      });
+
+      expect(existingSuggestions[0].setData).to.have.been.calledOnce;
+      expect(context.dataAccess.Suggestion.saveMany).to.have.been.calledOnce;
+    });
+
     it('should allow FIXED suggestion to be updated when custom mergeStatusFunction detects regression', async () => {
       const suggestionsData = [
         { key: '1', title: 'old title', url: 'https://example.com/page1' },

--- a/test/utils/data-access.test.js
+++ b/test/utils/data-access.test.js
@@ -3143,6 +3143,29 @@ describe('data-access', () => {
       expect(mockOpportunity.addFixEntities).to.have.been.called;
     });
 
+    it('should skip manually-edited NEW suggestions even when issue is fixed', async () => {
+      const suggestion = {
+        getId: sinon.stub().returns('sugg-1'),
+        getData: sinon.stub().returns({ key: '1' }),
+        getStatus: sinon.stub().returns(SuggestionDataAccess.STATUSES.NEW),
+        getUpdatedBy: sinon.stub().returns('customer@example.com'),
+        setStatus: sinon.stub(),
+        setUpdatedBy: sinon.stub(),
+      };
+
+      await reconcileDisappearedSuggestions({
+        opportunity: mockOpportunity,
+        disappearedSuggestions: [suggestion],
+        log: mockLogger,
+        isIssueFixedWithAISuggestion: sinon.stub().resolves(true),
+        buildFixEntityPayload: sinon.stub(),
+        Suggestion: mockSuggestionCollection,
+      });
+
+      expect(suggestion.setStatus).to.not.have.been.called;
+      expect(mockSuggestionCollection.saveMany).to.not.have.been.called;
+    });
+
     it('should skip suggestions not in NEW status', async () => {
       const suggestion = {
         getId: sinon.stub().returns('sugg-1'),

--- a/test/utils/data-access.test.js
+++ b/test/utils/data-access.test.js
@@ -21,6 +21,7 @@ import {
   getAuditTargetUrls,
   syncSuggestions,
   syncSuggestionsWithPublishDetection,
+  handleOutdatedSuggestions,
   getImsOrgId,
   retrieveAuditById,
   keepSameDataFunction,
@@ -2139,6 +2140,40 @@ describe('data-access', () => {
           'OUTDATED',
         );
         expect(mockLogger.info).to.have.been.calledWith('[SuggestionSync] Final count of suggestions to mark as OUTDATED: 2');
+      });
+
+      it('should not mark a manually-edited suggestion as OUTDATED even when its key disappears', async () => {
+        const existingSuggestions = [
+          {
+            id: '1',
+            data: { url: 'https://example.com/page1', key: 'page1' },
+            getData: sinon.stub().returns({ url: 'https://example.com/page1', key: 'page1' }),
+            getStatus: sinon.stub().returns('NEW'),
+            getUpdatedBy: sinon.stub().returns('customer@example.com'),
+          },
+          {
+            id: '2',
+            data: { url: 'https://example.com/page2', key: 'page2' },
+            getData: sinon.stub().returns({ url: 'https://example.com/page2', key: 'page2' }),
+            getStatus: sinon.stub().returns('NEW'),
+            getUpdatedBy: sinon.stub().returns(null),
+          },
+        ];
+
+        const newDataKeys = new Set();
+
+        await handleOutdatedSuggestions({
+          context,
+          existingSuggestions,
+          newDataKeys,
+          buildKey: (data) => data.key,
+        });
+
+        // Only suggestion 2 (not manually edited) should be marked OUTDATED
+        expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledOnce;
+        const [outdatedList] = context.dataAccess.Suggestion.bulkUpdateStatus.firstCall.args;
+        expect(outdatedList).to.have.lengthOf(1);
+        expect(outdatedList[0].id).to.equal('2');
       });
 
       it('should handle mixed scenario: some URLs scraped, some not', async () => {

--- a/test/utils/data-access.test.js
+++ b/test/utils/data-access.test.js
@@ -1053,7 +1053,7 @@ describe('data-access', () => {
       );
     });
 
-    it('should not overwrite a manually-edited suggestion (updatedBy is a user email)', async () => {
+    it('should not overwrite a manually-edited NEW suggestion (updatedBy is a user email)', async () => {
       const suggestionsData = [
         { key: '1', title: 'customer edited title', url: 'https://example.com/page1' },
       ];
@@ -1088,10 +1088,119 @@ describe('data-access', () => {
       expect(existingSuggestions[0].setStatus).to.not.have.been.called;
       expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
       const debugMessages = mockLogger.debug.args.map((a) => a[0]);
-      const found = debugMessages.some(
+      const skipMsg = debugMessages.find(
         (msg) => /Skipping manually-edited suggestion/.test(msg),
       );
-      expect(found).to.be.true;
+      expect(skipMsg).to.be.a('string');
+      // Must not log the customer email (PII)
+      expect(skipMsg).to.not.include('customer@example.com');
+    });
+
+    it('should not overwrite a manually-edited deployed (APPROVED) suggestion', async () => {
+      const suggestionsData = [
+        { key: '1', title: 'customer edited title', url: 'https://example.com/page1' },
+      ];
+      const existingSuggestions = [{
+        id: '1',
+        data: suggestionsData[0],
+        getData: sinon.stub().returns(suggestionsData[0]),
+        setData: sinon.stub(),
+        setRank: sinon.stub(),
+        save: sinon.stub().resolves(),
+        getStatus: sinon.stub().returns(SuggestionDataAccess.STATUSES.APPROVED),
+        setStatus: sinon.stub(),
+        setUpdatedBy: sinon.stub().returnsThis(),
+        getUpdatedBy: sinon.stub().returns('customer@example.com'),
+      }];
+
+      const newData = [
+        { key: '1', title: 'LLM regenerated title', url: 'https://example.com/page1' },
+      ];
+
+      mockOpportunity.getSuggestions.resolves(existingSuggestions);
+
+      await syncSuggestions({
+        context,
+        opportunity: mockOpportunity,
+        newData,
+        buildKey,
+        mapNewSuggestion,
+      });
+
+      expect(existingSuggestions[0].setData).to.not.have.been.called;
+      expect(existingSuggestions[0].setStatus).to.not.have.been.called;
+      expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
+    });
+
+    it('should not overwrite a manually-edited deployed (IN_PROGRESS) suggestion', async () => {
+      const suggestionsData = [
+        { key: '1', title: 'customer edited title', url: 'https://example.com/page1' },
+      ];
+      const existingSuggestions = [{
+        id: '1',
+        data: suggestionsData[0],
+        getData: sinon.stub().returns(suggestionsData[0]),
+        setData: sinon.stub(),
+        setRank: sinon.stub(),
+        save: sinon.stub().resolves(),
+        getStatus: sinon.stub().returns(SuggestionDataAccess.STATUSES.IN_PROGRESS),
+        setStatus: sinon.stub(),
+        setUpdatedBy: sinon.stub().returnsThis(),
+        getUpdatedBy: sinon.stub().returns('customer@example.com'),
+      }];
+
+      const newData = [
+        { key: '1', title: 'LLM regenerated title', url: 'https://example.com/page1' },
+      ];
+
+      mockOpportunity.getSuggestions.resolves(existingSuggestions);
+
+      await syncSuggestions({
+        context,
+        opportunity: mockOpportunity,
+        newData,
+        buildKey,
+        mapNewSuggestion,
+      });
+
+      expect(existingSuggestions[0].setData).to.not.have.been.called;
+      expect(existingSuggestions[0].setStatus).to.not.have.been.called;
+      expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
+    });
+
+    it('should update a suggestion when updatedBy is null (legacy, not manually edited)', async () => {
+      const suggestionsData = [
+        { key: '1', title: 'old title', url: 'https://example.com/page1' },
+      ];
+      const existingSuggestions = [{
+        id: '1',
+        data: suggestionsData[0],
+        getData: sinon.stub().returns(suggestionsData[0]),
+        setData: sinon.stub(),
+        setRank: sinon.stub(),
+        save: sinon.stub().resolves(),
+        getStatus: sinon.stub().returns(SuggestionDataAccess.STATUSES.NEW),
+        setStatus: sinon.stub(),
+        setUpdatedBy: sinon.stub().returnsThis(),
+        getUpdatedBy: sinon.stub().returns(null),
+      }];
+
+      const newData = [
+        { key: '1', title: 'new title', url: 'https://example.com/page1' },
+      ];
+
+      mockOpportunity.getSuggestions.resolves(existingSuggestions);
+
+      await syncSuggestions({
+        context,
+        opportunity: mockOpportunity,
+        newData,
+        buildKey,
+        mapNewSuggestion,
+      });
+
+      expect(existingSuggestions[0].setData).to.have.been.calledOnce;
+      expect(context.dataAccess.Suggestion.saveMany).to.have.been.calledOnce;
     });
 
     it('should update a suggestion when updatedBy is system (not manually edited)', async () => {


### PR DESCRIPTION
## Summary

When a customer edits a suggestion via the PATCH API, `updatedBy` is stamped with their email. `syncSuggestions` now treats such suggestions as frozen — skipping data merge, OUTDATED transitions, and reconcile-disappeared processing — preventing subsequent audit runs from overwriting customer edits.

### What changed

- **`src/utils/data-access.js`**
  - New shared helper `isManuallyEditedSuggestion` — true when `updatedBy` is set and ≠ `'system'`
  - **syncSuggestions matched-key path**: skips data merge for manually-edited suggestions
  - **handleOutdatedSuggestions**: excludes manually-edited suggestions from OUTDATED transition
  - **reconcileDisappearedSuggestions**: excludes manually-edited suggestions from FIXED transition (prevents `updatedBy='system'` from erasing the manual-edit marker)
  - JSDoc disambiguates entity-level `updatedBy` from the alt-text domain-specific `data.recommendations[].isManuallyEdited` flag

- **`src/experimentation-opportunities/guidance-high-organic-low-ctr-handler.js`**
  - `hasManuallyModifiedSuggestions` now delegates to the shared `isManuallyEditedSuggestion` helper (removes duplicate predicate)

- **`test/utils/data-access.test.js`** — 5 new tests:
  - manually-edited NEW suggestion → data merge skipped
  - manually-edited APPROVED suggestion → data merge skipped
  - manually-edited IN\_PROGRESS suggestion → data merge skipped
  - `updatedBy: 'system'` → updated as usual
  - manually-edited suggestion whose key disappears → NOT marked OUTDATED
  - PII regression: customer email must not appear in any log call

### How it works

| `updatedBy` value | Behavior |
|---|---|
| `null` / `undefined` | Normal merge (backward-compatible) |
| `'system'` | Normal merge (set by audit runs) |
| `'user@company.com'` | **Frozen** — data, status, and rank preserved across all three mutation paths |

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues

- [LLMO-6483](https://jira.corp.adobe.com/browse/LLMO-6483) — Manually edited suggestions should not be overwritten by subsequent audit runs

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Duy Nguyen", "Valerii Naida", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```