### PR TITLE
fix(broken-backlinks): bump mysticat-shared-seo-client to 1.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@adobe/helix-shared-wrap": "2.0.2",
         "@adobe/helix-status": "10.1.5",
         "@adobe/helix-universal-logger": "3.0.29",
-        "@adobe/mysticat-shared-seo-client": "1.7.0",
+        "@adobe/mysticat-shared-seo-client": "1.8.0",
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
         "@adobe/spacecat-shared-athena-client": "1.11.0",
         "@adobe/spacecat-shared-data-access": "4.11.0",
@@ -574,9 +574,9 @@
       }
     },
     "node_modules/@adobe/mysticat-shared-seo-client": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@adobe/mysticat-shared-seo-client/-/mysticat-shared-seo-client-1.7.0.tgz",
-      "integrity": "sha512-9NN1IygAE1DAOOF9Cdb8pjittfKmLPzeRcCZ63E7ZVkhxd/jQbAvG/rmiulwt8Iw582MO/v6WJK8xG9qAvmj5Q==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@adobe/mysticat-shared-seo-client/-/mysticat-shared-seo-client-1.8.0.tgz",
+      "integrity": "sha512-bAwgWSw7bClDqmvWTtWUIwnp2BOgcNXe3NwlSj8rG4ClgBNMUhsi/zFl2R1rHPNGw/j7QUNKiUyLIdWO295Z+g==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@adobe/helix-shared-wrap": "2.0.2",
     "@adobe/helix-status": "10.1.5",
     "@adobe/helix-universal-logger": "3.0.29",
-    "@adobe/mysticat-shared-seo-client": "1.7.0",
+    "@adobe/mysticat-shared-seo-client": "1.8.0",
     "@adobe/spacecat-helix-content-sdk": "1.4.33",
     "@adobe/spacecat-shared-athena-client": "1.11.0",
     "@adobe/spacecat-shared-data-access": "4.11.0",


### PR DESCRIPTION
## Summary

- Bumps `@adobe/mysticat-shared-seo-client` from `1.7.0` to `1.8.0`
- Picks up the fix for Semrush returning HTTP 404 when no broken backlinks match the filter — the client now returns an empty result instead of throwing an error

## Test plan

- [x] All existing tests pass at 100% coverage
- [ ] Verify broken-backlinks audit no longer errors in production for domains with no matching results