### PR TITLE
fix(experimentation-ess): return created audit from persistOnlyMetadata (SITES-47215)

### DIFF
--- a/src/experimentation-ess/all.js
+++ b/src/experimentation-ess/all.js
@@ -19,12 +19,15 @@ const DAYS = 180;
 
 let log = console;
 
-async function persistOnlyMetadata(auditData, context) {
+export async function persistOnlyMetadata(auditData, context) {
   // persists only the audit metadata, as the
   // whole audit result will be bigger than the allowed size in dynamo
   const { dataAccess } = context;
   const { Audit } = dataAccess;
-  await Audit.create({
+  // must return the created Audit: the framework (base-audit.js processAuditResult)
+  // dereferences the persister's return value via audit.getId(). Returning undefined
+  // here throws "Cannot read properties of undefined (reading 'getId')" (SITES-47215).
+  return Audit.create({
     ...auditData,
     auditResult: [], // deliberately overrides the result
   });

--- a/test/audits/experimentation-ess-all.test.js
+++ b/test/audits/experimentation-ess-all.test.js
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { persistOnlyMetadata } from '../../src/experimentation-ess/all.js';
+
+use(sinonChai);
+
+describe('experimentation-ess-all persistOnlyMetadata', () => {
+  const sandbox = sinon.createSandbox();
+  let context;
+  let createdAudit;
+  const auditData = {
+    siteId: 'da39921f-9a02-41db-b491-02c98330d956',
+    auditType: 'experimentation-ess-all',
+    auditResult: [{ experiment: 'foo' }],
+    fullAuditRef: 'https://www.example.com/',
+  };
+
+  beforeEach(() => {
+    createdAudit = { getId: () => 'audit-123' };
+    context = {
+      dataAccess: { Audit: { create: sandbox.stub().resolves(createdAudit) } },
+    };
+  });
+
+  afterEach(() => sandbox.restore());
+
+  // Regression guard for SITES-47215: the framework (base-audit.js processAuditResult)
+  // dereferences the persister's return via audit.getId(); returning undefined threw
+  // "Cannot read properties of undefined (reading 'getId')" and failed every ess-all run.
+  it('returns the created audit so audit.getId() is available downstream', async () => {
+    const result = await persistOnlyMetadata(auditData, context);
+
+    expect(result).to.equal(createdAudit);
+    expect(result.getId()).to.equal('audit-123');
+  });
+
+  it('persists the metadata but overrides auditResult with an empty array', async () => {
+    await persistOnlyMetadata(auditData, context);
+
+    expect(context.dataAccess.Audit.create).to.have.been.calledOnce;
+    const persisted = context.dataAccess.Audit.create.firstCall.args[0];
+    expect(persisted.siteId).to.equal(auditData.siteId);
+    expect(persisted.auditType).to.equal('experimentation-ess-all');
+    expect(persisted.fullAuditRef).to.equal(auditData.fullAuditRef);
+    expect(persisted.auditResult).to.deep.equal([]);
+  });
+});


### PR DESCRIPTION
## Related Issues

[SITES-47215](https://jira.corp.adobe.com/browse/SITES-47215)

## Problem

`experimentation-ess-all` fails on every run (reproduced in prod: bamboohr, ran 344.6s then errored with `TypeError: Cannot read properties of undefined (reading 'getId')` at `RunnerAudit.processAuditResult`).

Root cause: the framework persists the audit and then dereferences the persister's return value — `const audit = await this.persister(...)` then `audit.getId()` (`src/common/base-audit.js:143,149,165`). The `experimentation-ess-all` persister `persistOnlyMetadata` called `Audit.create(...)` but did **not return it**, so `audit` was `undefined`. `experimentation-ess-daily` uses the default persister (which returns a `getId` shim), which is why only `-all` failed. Regression dates to the 2026-06-10 persist-result refactor of `base-audit.js` (`4db760efe`).

## Fix

`persistOnlyMetadata` now returns the created audit (matching `defaultPersister`).

## Tests

Adds `test/audits/experimentation-ess-all.test.js` — the first test for this module (the dir is `/* c8 ignore */`). Guards that the persister returns the created audit and preserves the `auditResult: []` override.

## Verification

- New test passes; `eslint` clean on the source change.
- Not runtime-verified end-to-end here (needs redeploy + re-run of `experimentation-ess-all`).

## Not in scope (tracked in SITES-47215)

This fixes only the fatal crash. Still open: the cheerio↔DOM mismatch in `common.js getMetadata`, the cross-account IAM denial invoking `statistics-service` (p-values), and independent verification of the V2→V3 (Aurora) data migration.
