### PR TITLE
fix(experimentation-ess): query metadata via cheerio instead of doc.head.querySelectorAll (SITES-47215)

### DIFF
--- a/src/experimentation-ess/common.js
+++ b/src/experimentation-ess/common.js
@@ -36,13 +36,16 @@ let log = console;
 /**
  * Retrieves the content of metadata tags.
  * @param {string} name The metadata name (or property)
- * @param {Document} doc Document object to query for metadata. Defaults to the window's document
+ * @param {import('cheerio').CheerioAPI} $ Cheerio instance for the loaded page (see cheerioLoad)
  * @returns {string} The metadata value(s)
  */
-function getMetadata(name, doc) {
+export function getMetadata(name, $) {
   const attr = name && name.includes(':') ? 'property' : 'name';
-  const meta = [...doc.head.querySelectorAll(`meta[${attr}="${name}"]`)]
-    .map((m) => m.content)
+  // Pages are parsed with cheerio (cheerioLoad), not a DOM Document, so query via the
+  // cheerio API rather than doc.head.querySelectorAll (SITES-47215).
+  const meta = $(`head meta[${attr}="${name}"]`)
+    .map((_, el) => $(el).attr('content') ?? '')
+    .get()
     .join(', ');
   return meta || '';
 }

--- a/test/audits/experimentation-ess-common.test.js
+++ b/test/audits/experimentation-ess-common.test.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import { expect } from 'chai';
+import { load as cheerioLoad } from 'cheerio';
+import { getMetadata } from '../../src/experimentation-ess/common.js';
+
+describe('experimentation-ess common getMetadata', () => {
+  // Regression guard for SITES-47215: pages are parsed with cheerio, not a DOM Document.
+  // The previous doc.head.querySelectorAll implementation threw
+  // "Cannot read properties of undefined (reading 'querySelectorAll')" on every page fetch.
+  const html = `
+    <html>
+      <head>
+        <meta name="experiment" content="my-experiment">
+        <meta name="experiment-status" content="active">
+        <meta property="og:title" content="Hello">
+        <meta name="experiment-variants" content="control, challenger">
+        <meta name="empty-meta">
+      </head>
+      <body><p>ignored</p></body>
+    </html>`;
+  let $;
+
+  beforeEach(() => {
+    $ = cheerioLoad(html);
+  });
+
+  it('does not throw and reads a name-based meta tag from a cheerio instance', () => {
+    expect(() => getMetadata('experiment', $)).to.not.throw();
+    expect(getMetadata('experiment', $)).to.equal('my-experiment');
+    expect(getMetadata('experiment-status', $)).to.equal('active');
+  });
+
+  it('uses the property attribute when the name contains a colon', () => {
+    expect(getMetadata('og:title', $)).to.equal('Hello');
+  });
+
+  it('returns an empty string for a missing tag or a tag without content', () => {
+    expect(getMetadata('does-not-exist', $)).to.equal('');
+    expect(getMetadata('empty-meta', $)).to.equal('');
+  });
+
+  it('joins multiple matching tags (comma-separated)', () => {
+    const multi = cheerioLoad(`
+      <head>
+        <meta name="experiment-audience" content="mobile">
+        <meta name="experiment-audience" content="desktop">
+      </head>`);
+    expect(getMetadata('experiment-audience', multi)).to.equal('mobile, desktop');
+  });
+});


### PR DESCRIPTION
## Related Issues

[SITES-47215](https://jira.corp.adobe.com/browse/SITES-47215) (fix 2 of 3; see also #2805 for the persister/`getId` fix)

## Problem

During `experimentation-ess-all`, every experiment-page metadata fetch logs `TypeError: Cannot read properties of undefined (reading 'querySelectorAll')` (reproduced on prod and dev). `getExperimentMetaDataFromExperimentPage` parses the page with `cheerioLoad(html)` and passes the cheerio instance to `getMetadata`, but `getMetadata` used DOM APIs — `doc.head.querySelectorAll(...)` and `m.content`. A cheerio instance has no `.head`, so the lookup throws. The error is swallowed per-URL, so experiments are persisted with **missing metadata** (status, dates, variants, conversion event) rather than failing loudly.

## Fix

Rewrite `getMetadata` to use the cheerio API (`$('head meta[...]')` / `.attr('content')`), preserving the existing head-scoped lookup, name-vs-property attribute selection, and comma-join of multiple matches.

## Tests

Adds `test/audits/experimentation-ess-common.test.js` (module was previously untested — it's `/* c8 ignore */`): reads name- and property-based meta tags from a cheerio instance, returns `''` for missing/empty tags, and joins multiple matches.

## Verification

- Unit test passes; `eslint` clean.
- Dev re-run of `experimentation-ess-all` to confirm the `querySelectorAll` errors are gone and metadata is populated (pending deploy).

## Not in scope (SITES-47215)

Independent of this: #2805 (persister `getId`, merged/queued separately) and the cross-account IAM / resource-based policy on `statistics-service` for p-values.
