### PR TITLE
perf(referral-traffic): skip corpus fetch when rules exist and compile classifier regex once | LLMO-6257

### DIFF
--- a/src/cdn-logs-report/patterns/patterns-uploader.js
+++ b/src/cdn-logs-report/patterns/patterns-uploader.js
@@ -261,13 +261,11 @@ export async function generatePatternsWorkbook(options) {
 export async function generateReferralCategoryRules({ site, context }) {
   const { log } = context;
 
-  const paths = await fetchReferralTopUrls({ site, context });
-  if (paths.length === 0) {
-    log.info('No referral URLs found in DB - skipping referral pattern generation');
-    return false;
-  }
-  log.info(`Fetched ${paths.length} referral URLs for pattern generation`);
-
+  // Create-if-missing gate FIRST: a site that already has category rules skips
+  // before the corpus fetch. fetchReferralTopUrls runs a 5-source partitioned
+  // scan, so fetching it up front would pay that cost on every daily run for
+  // every site even once rules exist. Check existing rules, then fetch the corpus
+  // only when we actually need to generate.
   const existingPatterns = await fetchAgenticUrlClassificationRules(site, context);
   if (existingPatterns && existingPatterns.error) {
     log.info(`Skipping referral patterns for ${site.getId()}; DB rule fetch failed`);
@@ -285,6 +283,13 @@ export async function generateReferralCategoryRules({ site, context }) {
     log.info(`Referral category rules already exist for site ${site.getId()} - skipping generation`);
     return false;
   }
+
+  const paths = await fetchReferralTopUrls({ site, context });
+  if (paths.length === 0) {
+    log.info('No referral URLs found in DB - skipping referral pattern generation');
+    return false;
+  }
+  log.info(`Fetched ${paths.length} referral URLs for pattern generation`);
 
   const domain = new URL(site.getBaseURL()).hostname;
   const productRegexes = await analyzeProducts(domain, paths, context);

--- a/src/llmo-referral-traffic-daily/classify.js
+++ b/src/llmo-referral-traffic-daily/classify.js
@@ -88,7 +88,54 @@ export function canonicalizeUrlPath(path) {
 }
 
 /**
+ * Pre-compiles a site's rules once. Regex compilation is O(rules); doing it here
+ * (instead of inside the per-URL loop) keeps classification O(URLs + rules)
+ * rather than O(URLs * rules). Each entry is {name, re} where re is a compiled
+ * RegExp, or null for an unsafe/uncompilable pattern (treated as no-match, parity
+ * with the SQL _safe_regex_match). Rule order is preserved (first match wins).
+ * @param {Array<{name: string, regex: string}>} rules pre-sorted category rules
+ * @returns {Array<{name: string, re: RegExp|null}>}
+ */
+function compileRules(rules) {
+  if (!Array.isArray(rules)) {
+    return [];
+  }
+  const compiled = [];
+  for (const rule of rules) {
+    if (rule && typeof rule.regex === 'string' && rule.name) {
+      let re = null;
+      try {
+        re = compileRuleRegex(rule.regex);
+      } catch {
+        re = null; // uncompilable regex -> no match (parity with _safe_regex_match)
+      }
+      compiled.push({ name: rule.name, re });
+    }
+  }
+  return compiled;
+}
+
+/**
+ * Resolves the category for a single URL path against already-compiled rules.
+ * First match by rule order wins; null when nothing matches.
+ * @returns {string|null}
+ */
+function matchCompiledRules(compiledRules, urlPath) {
+  if (typeof urlPath !== 'string') {
+    return null;
+  }
+  for (const { name, re } of compiledRules) {
+    if (re && re.test(urlPath)) {
+      return name;
+    }
+  }
+  return null;
+}
+
+/**
  * Resolves the category for a single URL path against a site's active rules.
+ * Compiles the rule regexes on every call; when classifying many URLs prefer
+ * buildClassificationRows, which compiles once. Kept for single-URL callers/tests.
  * @param {Array<{name: string, regex: string}>} rules pre-sorted category rules
  * @param {string} urlPath the URL path to classify
  * @returns {string|null} the matching category name, or null when nothing matches
@@ -97,38 +144,27 @@ export function classifyUrlPath(rules, urlPath) {
   if (!Array.isArray(rules) || typeof urlPath !== 'string') {
     return null;
   }
-  for (const rule of rules) {
-    if (rule && typeof rule.regex === 'string' && rule.name) {
-      let compiled = null;
-      try {
-        compiled = compileRuleRegex(rule.regex);
-      } catch {
-        compiled = null; // uncompilable regex -> no match (parity with _safe_regex_match)
-      }
-      if (compiled && compiled.test(urlPath)) {
-        return rule.name;
-      }
-    }
-  }
-  return null;
+  return matchCompiledRules(compileRules(rules), urlPath);
 }
 
 /**
  * Builds the referral_url_classifications rows for a run: one row per distinct
  * (host, url_path) that matches a rule. Unmatched URLs get no row (category is
  * never empty). Category-only — mirrors the referral_url_classifications shape.
+ * Rules are compiled once up front, then matched against every distinct URL.
  * @returns {Array<{host, url_path, category_name, updated_by}>}
  */
 export function buildClassificationRows(rows, rules, updatedBy) {
   const seen = new Set();
   const classifications = [];
+  const compiledRules = compileRules(rules);
 
   for (const row of rows) {
     const { host, url_path: urlPath } = row;
     const key = `${host}\n${urlPath}`;
     if (!seen.has(key)) {
       seen.add(key);
-      const category = classifyUrlPath(rules, urlPath);
+      const category = matchCompiledRules(compiledRules, urlPath);
       if (category) {
         classifications.push({
           host,

--- a/test/audits/cdn-logs-report/patterns-uploader.test.js
+++ b/test/audits/cdn-logs-report/patterns-uploader.test.js
@@ -593,6 +593,8 @@ describe('generateReferralCategoryRules', () => {
     const result = await generateReferralCategoryRules(options);
 
     expect(result).to.be.false;
+    // Rule-fetch error short-circuits before the corpus fetch too.
+    expect(mockFetchReferralTopUrls).to.not.have.been.called;
     expect(mockAnalyzeProducts).to.not.have.been.called;
     expect(mockReplaceRules).to.not.have.been.called;
     expect(options.context.log.info).to.have.been.calledWith(
@@ -610,6 +612,9 @@ describe('generateReferralCategoryRules', () => {
     const result = await generateReferralCategoryRules(options);
 
     expect(result).to.be.false;
+    // The existing-rules check runs BEFORE the corpus fetch, so a site that
+    // already has rules never pays the fetchReferralTopUrls partitioned scan.
+    expect(mockFetchReferralTopUrls).to.not.have.been.called;
     expect(mockAnalyzeProducts).to.not.have.been.called;
     // Rules already persisted — the whole-site replace RPC must NOT run again
     // (it would churn provenance + purge soft-deletes).

--- a/test/audits/llmo-referral-traffic-daily/classify.test.js
+++ b/test/audits/llmo-referral-traffic-daily/classify.test.js
@@ -106,6 +106,16 @@ describe('referral URL classification', () => {
       const rows = [{ host: 'example.com', url_path: '/electronics' }];
       expect(buildClassificationRows(rows, rules, 'spacecat:optel')).to.deep.equal([]);
     });
+
+    it('yields no rows when rules is not an array (compiles to an empty rule set)', () => {
+      const rows = [{ host: 'example.com', url_path: '/shoes' }];
+      expect(buildClassificationRows(rows, null, 'spacecat:optel')).to.deep.equal([]);
+    });
+
+    it('skips rows whose url_path is not a string', () => {
+      const rows = [{ host: 'example.com', url_path: 123 }];
+      expect(buildClassificationRows(rows, rules, 'spacecat:optel')).to.deep.equal([]);
+    });
   });
 
   describe('isCatastrophicQuantifier', () => {


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Performance follow-ups to the merged LLMO-6257 P2 audit-worker work: skip the referral corpus fetch when a site already has category rules, and compile the classifier's rule regexes once instead of per URL. Behavior-preserving.

## 2. Reasoning
`generateReferralCategoryRules` fetched the corpus (`fetchReferralTopUrls`) before the create-if-missing "rules already exist" check, so every daily `llmo-referral-traffic-daily` run paid a five-source partitioned scan even for sites that already have rules (the steady state). Separately, `classifyUrlPath` recompiled each rule's regex inside the per-URL loop, making `buildClassificationRows` O(URLs × rules) `new RegExp()` compilations per run.

## 3. High-level overview of the changes
- **`patterns-uploader.js`** — reorder `generateReferralCategoryRules` so the existing-rules fetch and the `existingTopicPatterns.length > 0` skip run **before** `fetchReferralTopUrls`. Same skip conditions, same return values, same persisted state — the read-only corpus RPC is simply not called on the skip path.
- **`classify.js`** — compile each rule's regex once (`compileRules` → `{name, re|null}`), then match with `matchCompiledRules`, making `buildClassificationRows` O(URLs + rules). `classifyUrlPath` keeps its signature and exact semantics (first-match-by-order, unsafe/uncompilable regex → no-match parity with SQL `_safe_regex_match`, unmatched → no row). The compiled `RegExp` uses the `i` flag only, so `.test()` is stateless and safe to reuse across URLs.
- **Tests** — assert `fetchReferralTopUrls` is not called on the rules-exist and rule-fetch-error short-circuit paths.

## 4. Required information
- Jira / issue: [LLMO-6257](https://jira.corp.adobe.com/browse/LLMO-6257)
- Spec: `docs/specs/2026-07-21-referral-category-generation-p2.md`
- Pairs with the data-service sibling PR (adds the `traffic_date <= current_date` upper bound to `rpc_referral_traffic_top_urls`).

## 5. Affected / used mysticat-workspace projects
- `mysticat-data-service` — sibling PR bounds the corpus RPC this caller invokes.

## 6. Additional information outside the code
- The corpus RPC's cost was measured live in prod: execution 27ms / planning 64ms. Skipping it once rules exist removes that per-run cost for the steady-state majority of sites.

## 7. Test plan
- **Local (done):** ESLint clean on both files; `llmo-referral-traffic-daily` + `cdn-logs-report` handler/classify/patterns-uploader suites green, including the new corpus-skip assertions.
- **Per-env:** confirm a rules-less site still generates rules on its daily run, and a site with rules skips generation without calling the corpus RPC (log: "already exist - skipping generation").

## 8. Deployment & merge order
Independent; each promotes on its own. Pair with the data-service sibling PR for the full effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
