### PR TITLE
fix(experimentation-ess): update existing experiment instead of duplicate insert (SITES-47215)

### DIFF
--- a/src/experimentation-ess/common.js
+++ b/src/experimentation-ess/common.js
@@ -723,9 +723,26 @@ export async function postProcessor(auditUrl, auditData, context) {
           }
         }
       }
+      // update the existing record in place instead of inserting a duplicate: under v3
+      // (Aurora/PostgREST) Experiment.create is a strict INSERT, so re-running the audit
+      // would violate the unique_site_exp (site_id, exp_id) constraint. v2 (DynamoDB)
+      // create was an upsert, which masked this (SITES-47215).
+      existingExperiment
+        .setName(experimentData.name)
+        .setUrl(experimentData.url)
+        .setStartDate(experimentData.startDate)
+        .setEndDate(experimentData.endDate)
+        .setStatus(experimentData.status)
+        .setType(experimentData.type)
+        .setVariants(experimentData.variants)
+        .setConversionEventName(experimentData.conversionEventName)
+        .setConversionEventValue(experimentData.conversionEventValue);
+      // eslint-disable-next-line no-await-in-loop
+      await existingExperiment.save();
+    } else {
+      // eslint-disable-next-line no-await-in-loop
+      await Experiment.create(experimentData);
     }
-    // eslint-disable-next-line no-await-in-loop
-    await Experiment.create(experimentData);
   }
   log.info(`Experiments data for site ${auditData.siteId} has been upserted`);
 }

--- a/test/audits/experimentation-ess-postprocessor.test.js
+++ b/test/audits/experimentation-ess-postprocessor.test.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { postProcessor } from '../../src/experimentation-ess/common.js';
+
+use(sinonChai);
+
+describe('experimentation-ess postProcessor persistence (SITES-47215)', () => {
+  const sandbox = sinon.createSandbox();
+  let context;
+  let Experiment;
+  let auditData;
+
+  const SETTERS = [
+    'setName', 'setUrl', 'setStartDate', 'setEndDate', 'setStatus',
+    'setType', 'setVariants', 'setConversionEventName', 'setConversionEventValue',
+  ];
+
+  beforeEach(() => {
+    Experiment = {
+      allBySiteIdAndExpId: sandbox.stub(),
+      create: sandbox.stub().resolves({}),
+    };
+    context = {
+      log: { info: sandbox.stub(), error: sandbox.stub() },
+      dataAccess: { Experiment },
+    };
+    // fresh per test — the merge logic mutates experiment.variants in place
+    auditData = {
+      siteId: 'site-1',
+      auditResult: [{
+        id: 'nav-mobile-left-right',
+        label: 'Nav experiment',
+        url: 'https://www.example.com/',
+        startDate: '2026-07-01',
+        endDate: '2026-07-31',
+        status: 'ACTIVE',
+        type: 'full',
+        variants: [{ name: 'control' }, { name: 'challenger-1' }],
+        conversionEventName: 'click',
+        conversionEventValue: 'cta',
+      }],
+    };
+  });
+
+  afterEach(() => sandbox.restore());
+
+  it('creates a new Experiment when none exists', async () => {
+    Experiment.allBySiteIdAndExpId.resolves([]);
+
+    await postProcessor('https://www.example.com/', auditData, context);
+
+    expect(Experiment.create).to.have.been.calledOnce;
+    expect(Experiment.create.firstCall.args[0]).to.include({
+      siteId: 'site-1',
+      expId: 'nav-mobile-left-right',
+      status: 'ACTIVE',
+    });
+  });
+
+  // Regression guard: before the fix the post-processor always called Experiment.create,
+  // which under v3 (Aurora) is a strict INSERT and threw
+  // "duplicate key value violates unique constraint unique_site_exp" on every re-run.
+  it('updates the existing Experiment instead of inserting a duplicate', async () => {
+    const existing = {
+      startDate: '2026-06-01', // earlier than audit -> should win
+      endDate: '2026-08-31', // later than audit -> should win
+      url: 'https://www.example.com/existing', // already set -> preserved
+      variants: [{ name: 'control', split: '0.5' }],
+      save: sandbox.stub().resolves(),
+    };
+    SETTERS.forEach((m) => { existing[m] = sandbox.stub().returns(existing); });
+    Experiment.allBySiteIdAndExpId.resolves([existing]);
+
+    await postProcessor('https://www.example.com/', auditData, context);
+
+    // the core regression assertion: no duplicate INSERT
+    expect(Experiment.create).to.not.have.been.called;
+    expect(existing.save).to.have.been.calledOnce;
+    // merged values are applied via setters
+    expect(existing.setStatus).to.have.been.calledWith('ACTIVE');
+    expect(existing.setStartDate).to.have.been.calledWith('2026-06-01');
+    expect(existing.setEndDate).to.have.been.calledWith('2026-08-31');
+    expect(existing.setUrl).to.have.been.calledWith('https://www.example.com/existing');
+  });
+});


### PR DESCRIPTION
## Related Issues

[SITES-47215](https://jira.corp.adobe.com/browse/SITES-47215) (fix 3 of 3; see also #2805 persister/`getId` and #2806 cheerio metadata)

## Problem

`experimentation-ess-all` fails on every **re-run** for a site with:
`[experiment] Failed to create — [23505] duplicate key value violates unique constraint "unique_site_exp" (site_id, exp_id)` → `DataAccessError: Failed to create at ExperimentCollection.create` (reproduced on dev).

The `postProcessor` fetches the existing experiment (`allBySiteIdAndExpId`), merges fields, then **always** calls `Experiment.create()` — even when the experiment already exists. It never updates. The `"…has been upserted"` log is misleading; there is no update path.

This is a v2→v3 data-access regression: under v2 (DynamoDB/ElectroDB, retired) `create` was a `put`/upsert and re-runs silently overwrote; under v3 (PostgREST/Aurora, current) `create` is a strict `INSERT`, so the second run per site violates the unique constraint. Net effect: the audit works once per site, then fails on every subsequent run.

## Fix

In `postProcessor`, when an existing experiment is found, update it in place via the entity setters + `save()`; only call `Experiment.create()` for genuinely new experiments. Merge logic is unchanged.

## Tests

Adds `test/audits/experimentation-ess-postprocessor.test.js`:
- new experiment → `Experiment.create` is called
- existing experiment → `Experiment.create` is **not** called and `save()` is called with the merged values (regression guard for the duplicate-key failure)

## Verification

- Unit tests pass; `eslint` clean.
- End-to-end: dev re-run of `experimentation-ess-all` on a site that already has experiments should now complete via the update path instead of the duplicate-key error (pending deploy).

## Note

Pre-existing (out of scope): the merge reads `existingExperiment.startDate/.url/.variants` as direct properties; if the v3 entity only exposes getters these fall back to the new values. Preserved as-is here; flagged for a separate follow-up.
