### PR TITLE
fix(data-access): transition SKIPPED/REJECTED to OUTDATED in shared helpers when audit no longer detects the issue (SITES-48663)

### DIFF
--- a/src/utils/data-access.js
+++ b/src/utils/data-access.js
@@ -258,12 +258,16 @@ export const handleOutdatedSuggestions = async ({
 
   const existingOutdatedSuggestions = existingSuggestions
     .filter((existing) => !newDataKeys.has(buildKey(existing.getData())))
+    // SITES-44646: when a suggestion's issue is no longer detected, transition
+    // it to OUTDATED — including SKIPPED and REJECTED (operator decisions on a
+    // now non-existent issue is a nonsense state; the state IS changing so the
+    // updatedAt bump is legitimate). Preserve FIXED (customer already resolved),
+    // APPROVED / IN_PROGRESS (in-flight work), OUTDATED (already terminal),
+    // and ERROR (needs re-dispatch via defaultMergeStatusFunction).
     .filter((existing) => ![
       SuggestionDataAccess.STATUSES.OUTDATED,
       SuggestionDataAccess.STATUSES.FIXED,
       SuggestionDataAccess.STATUSES.ERROR,
-      SuggestionDataAccess.STATUSES.SKIPPED,
-      SuggestionDataAccess.STATUSES.REJECTED,
       SuggestionDataAccess.STATUSES.APPROVED,
       SuggestionDataAccess.STATUSES.IN_PROGRESS,
     ].includes(existing.getStatus()))
@@ -974,8 +978,10 @@ export async function syncSuggestionsWithPublishDetection({
 
 /**
  * Resolves the existing NEW opportunity for the given site and audit type when no issues are
- * detected. Marks actionable suggestions (NEW, PENDING_VALIDATION) as OUTDATED while preserving
- * suggestions already in terminal states (FIXED, SKIPPED, REJECTED, APPROVED, IN_PROGRESS).
+ * detected. Marks NEW / PENDING_VALIDATION / SKIPPED / REJECTED suggestions as OUTDATED —
+ * SKIPPED and REJECTED are operator decisions on a now non-existent issue, so transitioning
+ * them to OUTDATED is a legitimate state change (SITES-44646). Preserves FIXED (customer
+ * already resolved), APPROVED / IN_PROGRESS (in-flight work), and existing OUTDATED / ERROR.
  *
  * @param {string} siteId - The site ID.
  * @param {string} auditType - The audit type (e.g. 'canonical', 'broken-backlinks').
@@ -995,6 +1001,8 @@ export async function resolveOpportunityIfNoIssues(siteId, auditType, dataAccess
       const suggestionsToOutdate = (suggestions || []).filter((s) => [
         SuggestionDataAccess.STATUSES.NEW,
         SuggestionDataAccess.STATUSES.PENDING_VALIDATION,
+        SuggestionDataAccess.STATUSES.SKIPPED,
+        SuggestionDataAccess.STATUSES.REJECTED,
       ].includes(s.getStatus()));
       if (suggestionsToOutdate.length > 0) {
         await dataAccess.Suggestion

--- a/src/utils/data-access.js
+++ b/src/utils/data-access.js
@@ -259,11 +259,12 @@ export const handleOutdatedSuggestions = async ({
   const existingOutdatedSuggestions = existingSuggestions
     .filter((existing) => !newDataKeys.has(buildKey(existing.getData())))
     // SITES-44646: when a suggestion's issue is no longer detected, transition
-    // it to OUTDATED — including SKIPPED and REJECTED (operator decisions on a
-    // now non-existent issue is a nonsense state; the state IS changing so the
-    // updatedAt bump is legitimate). Preserve FIXED (customer already resolved),
-    // APPROVED / IN_PROGRESS (in-flight work), OUTDATED (already terminal),
-    // and ERROR (needs re-dispatch via defaultMergeStatusFunction).
+    // it to OUTDATED — including SKIPPED and REJECTED (an operator decision
+    // that referred to an issue no longer detected is stale; the state IS
+    // changing so the updatedAt bump is legitimate). Preserve FIXED (customer
+    // already resolved), APPROVED / IN_PROGRESS (in-flight work), OUTDATED
+    // (already terminal), and ERROR (needs re-dispatch via
+    // defaultMergeStatusFunction).
     .filter((existing) => ![
       SuggestionDataAccess.STATUSES.OUTDATED,
       SuggestionDataAccess.STATUSES.FIXED,
@@ -979,9 +980,10 @@ export async function syncSuggestionsWithPublishDetection({
 /**
  * Resolves the existing NEW opportunity for the given site and audit type when no issues are
  * detected. Marks NEW / PENDING_VALIDATION / SKIPPED / REJECTED suggestions as OUTDATED —
- * SKIPPED and REJECTED are operator decisions on a now non-existent issue, so transitioning
- * them to OUTDATED is a legitimate state change (SITES-44646). Preserves FIXED (customer
- * already resolved), APPROVED / IN_PROGRESS (in-flight work), and existing OUTDATED / ERROR.
+ * SKIPPED and REJECTED are operator decisions referring to an issue that is no longer
+ * detected, so transitioning them to OUTDATED is a legitimate state change (SITES-44646).
+ * Preserves FIXED (customer already resolved), APPROVED / IN_PROGRESS (in-flight work),
+ * and existing OUTDATED / ERROR.
  *
  * @param {string} siteId - The site ID.
  * @param {string} auditType - The audit type (e.g. 'canonical', 'broken-backlinks').

--- a/test/audits/backlinks.test.js
+++ b/test/audits/backlinks.test.js
@@ -879,7 +879,7 @@ describe('Backlinks Tests', function () {
       expect(mockOpportunity.save).to.have.been.calledOnce;
     });
 
-    it('should only mark NEW and PENDING_VALIDATION suggestions OUTDATED, preserving FIXED/SKIPPED/REJECTED', async () => {
+    it('marks NEW/PENDING_VALIDATION/SKIPPED/REJECTED as OUTDATED, preserving FIXED (SITES-44646 Case B)', async () => {
       configuration.isHandlerEnabledForSite.returns(true);
       context.audit.getAuditResult.returns({ success: true, brokenBacklinks: [] });
 
@@ -905,10 +905,15 @@ describe('Backlinks Tests', function () {
 
       await generateSuggestionData(context);
 
-      expect(bulkUpdateStatusStub).to.have.been.calledOnceWith(
-        [newSuggestion, pendingSuggestion],
-        'OUTDATED',
-      );
+      // SKIPPED and REJECTED transition to OUTDATED alongside NEW/PENDING_VALIDATION
+      // (audit no longer detects the issue → legitimate state change → updatedAt bump).
+      expect(bulkUpdateStatusStub).to.have.been.calledOnce;
+      const [passed, targetStatus] = bulkUpdateStatusStub.firstCall.args;
+      expect(targetStatus).to.equal('OUTDATED');
+      expect(passed).to.have.members([
+        newSuggestion, pendingSuggestion, skippedSuggestion, rejectedSuggestion,
+      ]);
+      expect(passed).to.not.include(fixedSuggestion);
     });
 
     it('logs error and still returns complete when opportunity lookup fails on no-backlinks path', async () => {

--- a/test/audits/canonical.test.js
+++ b/test/audits/canonical.test.js
@@ -2968,7 +2968,7 @@ describe('Canonical URL Tests', () => {
         expect(mockOpportunity.save).to.have.been.calledOnce;
       });
 
-      it('should only mark NEW and PENDING_VALIDATION suggestions as OUTDATED, preserving FIXED/SKIPPED/REJECTED', async () => {
+      it('marks NEW/PENDING_VALIDATION/SKIPPED/REJECTED as OUTDATED, preserving FIXED (SITES-44646 Case B)', async () => {
         const scrapedContent = {
           url: 'https://example.com/page1',
           finalUrl: 'https://example.com/page1',
@@ -3028,10 +3028,15 @@ describe('Canonical URL Tests', () => {
 
         await processScrapedContentMocked(testContext);
 
-        expect(bulkUpdateStatusStub).to.have.been.calledOnceWith(
-          [newSuggestion, pendingSuggestion],
-          'OUTDATED',
-        );
+        // SKIPPED and REJECTED transition to OUTDATED alongside NEW/PENDING_VALIDATION
+        // (audit no longer detects the issue → legitimate state change → updatedAt bump).
+        expect(bulkUpdateStatusStub).to.have.been.calledOnce;
+        const [passed, targetStatus] = bulkUpdateStatusStub.firstCall.args;
+        expect(targetStatus).to.equal('OUTDATED');
+        expect(passed).to.have.members([
+          newSuggestion, pendingSuggestion, skippedSuggestion, rejectedSuggestion,
+        ]);
+        expect(passed).to.not.include(fixedSuggestion);
       });
 
       it('should log error and still return success when opportunity lookup fails on no-issues path', async () => {

--- a/test/metatags/metatags.test.js
+++ b/test/metatags/metatags.test.js
@@ -2062,7 +2062,7 @@ describe('Meta Tags', () => {
         expect(metatagsOppty.save).to.have.been.calledOnce;
       });
 
-      it('should only mark NEW and PENDING_VALIDATION suggestions OUTDATED, preserving FIXED/SKIPPED/REJECTED (metatags)', async () => {
+      it('marks NEW/PENDING_VALIDATION/SKIPPED/REJECTED as OUTDATED, preserving FIXED (metatags, SITES-44646 Case B)', async () => {
         const mockValidateDetectedIssues = sinon.stub().resolves({});
         const auditStub = await esmock('../../src/metatags/handler.js', {
           '../../src/support/utils.js': { calculateCPCValue: sinon.stub().resolves(2) },
@@ -2083,10 +2083,15 @@ describe('Meta Tags', () => {
 
         await auditStub.runAuditAndGenerateSuggestions(context);
 
-        expect(dataAccessStub.Suggestion.bulkUpdateStatus).to.have.been.calledOnceWith(
-          [newSuggestion, pendingSuggestion],
-          'OUTDATED',
-        );
+        // SKIPPED and REJECTED transition to OUTDATED alongside NEW/PENDING_VALIDATION
+        // (audit no longer detects the issue → legitimate state change → updatedAt bump).
+        expect(dataAccessStub.Suggestion.bulkUpdateStatus).to.have.been.calledOnce;
+        const [passed, targetStatus] = dataAccessStub.Suggestion.bulkUpdateStatus.firstCall.args;
+        expect(targetStatus).to.equal('OUTDATED');
+        expect(passed).to.have.members([
+          newSuggestion, pendingSuggestion, skippedSuggestion, rejectedSuggestion,
+        ]);
+        expect(passed).to.not.include(fixedSuggestion);
       });
 
       it('should log error and still return complete when opportunity lookup fails on no-issues path (metatags)', async () => {

--- a/test/utils/data-access.test.js
+++ b/test/utils/data-access.test.js
@@ -1269,10 +1269,9 @@ describe('data-access', () => {
         .calledOnceWith([existingSuggestions[0]]);
     });
 
-    it('should not mark REJECTED suggestions as OUTDATED when they do not appear in new audit data', async () => {
+    it('marks SKIPPED and REJECTED as OUTDATED when their issue is no longer detected (SITES-44646 Case B)', async () => {
       const buildKeyWithUrl = (data) => `${data.url}|${data.key}`;
 
-      // Existing REJECTED suggestion that doesn't appear in new audit
       const existingSuggestions = [
         {
           id: '1',
@@ -1286,14 +1285,20 @@ describe('data-access', () => {
           getData: sinon.stub().returns({ url: 'https://example.com/page2', key: 'page2' }),
           getStatus: sinon.stub().returns('NEW'),
         },
+        {
+          id: '3',
+          data: { url: 'https://example.com/page4', key: 'page4' },
+          getData: sinon.stub().returns({ url: 'https://example.com/page4', key: 'page4' }),
+          getStatus: sinon.stub().returns(SuggestionDataAccess.STATUSES.SKIPPED),
+        },
       ];
 
-      // New audit data only has page3 (page1 and page2 are not in new data)
       const newData = [{ url: 'https://example.com/page3', key: 'page3' }];
       const scrapedUrlsSet = new Set([
         'https://example.com/page1',
         'https://example.com/page2',
         'https://example.com/page3',
+        'https://example.com/page4',
       ]);
 
       mockOpportunity.getSuggestions.resolves(existingSuggestions);
@@ -1308,18 +1313,20 @@ describe('data-access', () => {
         scrapedUrlsSet,
       });
 
-      // Verify that bulkUpdateStatus was called only with NEW suggestion (not REJECTED)
-      expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledOnceWith(
-        [existingSuggestions[1]], // Only the NEW suggestion, not REJECTED
-        'OUTDATED',
-      );
-      expect(mockLogger.info).to.have.been.calledWith('[SuggestionSync] Final count of suggestions to mark as OUTDATED: 1');
+      // NEW / SKIPPED / REJECTED all transition to OUTDATED — issue is gone,
+      // legitimate state change so the updatedAt bump is expected.
+      expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledOnce;
+      const [passed, targetStatus] = context.dataAccess.Suggestion.bulkUpdateStatus.firstCall.args;
+      expect(targetStatus).to.equal('OUTDATED');
+      expect(passed).to.have.members([
+        existingSuggestions[0], existingSuggestions[1], existingSuggestions[2],
+      ]);
+      expect(mockLogger.info).to.have.been.calledWith('[SuggestionSync] Final count of suggestions to mark as OUTDATED: 3');
     });
 
-    it('should not mark REJECTED suggestions as OUTDATED even when scrapedUrlsSet is null', async () => {
+    it('marks SKIPPED and REJECTED as OUTDATED even when scrapedUrlsSet is null (SITES-44646 Case B)', async () => {
       const buildKeyWithUrl = (data) => `${data.url}|${data.key}`;
 
-      // Existing REJECTED and NEW suggestions that don't appear in new audit
       const existingSuggestions = [
         {
           id: '1',
@@ -1333,11 +1340,15 @@ describe('data-access', () => {
           getData: sinon.stub().returns({ key: 'page2' }),
           getStatus: sinon.stub().returns('NEW'),
         },
+        {
+          id: '3',
+          data: { url: 'https://example.com/page4', key: 'page4' },
+          getData: sinon.stub().returns({ key: 'page4' }),
+          getStatus: sinon.stub().returns(SuggestionDataAccess.STATUSES.SKIPPED),
+        },
       ];
 
-      // New audit data only has page3 (page1 and page2 are not in new data)
       const newData = [{ url: 'https://example.com/page3', key: 'page3' }];
-      // scrapedUrlsSet is null (no URL filtering)
       mockOpportunity.getSuggestions.resolves(existingSuggestions);
       mockOpportunity.addSuggestions.resolves({ errorItems: [], createdItems: newData });
 
@@ -1347,15 +1358,16 @@ describe('data-access', () => {
         context,
         buildKey: buildKeyWithUrl,
         mapNewSuggestion,
-        scrapedUrlsSet: null, // Explicitly null
+        scrapedUrlsSet: null,
       });
 
-      // Verify that bulkUpdateStatus was called only with NEW suggestion (not REJECTED)
-      expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledOnceWith(
-        [existingSuggestions[1]], // Only the NEW suggestion, not REJECTED
-        'OUTDATED',
-      );
-      expect(mockLogger.info).to.have.been.calledWith('[SuggestionSync] Final count of suggestions to mark as OUTDATED: 1');
+      expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledOnce;
+      const [passed, targetStatus] = context.dataAccess.Suggestion.bulkUpdateStatus.firstCall.args;
+      expect(targetStatus).to.equal('OUTDATED');
+      expect(passed).to.have.members([
+        existingSuggestions[0], existingSuggestions[1], existingSuggestions[2],
+      ]);
+      expect(mockLogger.info).to.have.been.calledWith('[SuggestionSync] Final count of suggestions to mark as OUTDATED: 3');
     });
 
     it('should not mark APPROVED or IN_PROGRESS suggestions as OUTDATED', async () => {
@@ -3877,14 +3889,18 @@ describe('data-access', () => {
       expect(bulkUpdateStatusStub).to.not.have.been.called;
     });
 
-    it('resolves matching opportunity and marks NEW/PENDING_VALIDATION suggestions OUTDATED', async () => {
+    it('resolves matching opportunity and marks NEW/PENDING_VALIDATION/SKIPPED/REJECTED as OUTDATED (SITES-44646 Case B)', async () => {
       const newSuggestion = { getId: () => 's-new', getStatus: () => 'NEW' };
       const pendingSuggestion = { getId: () => 's-pending', getStatus: () => 'PENDING_VALIDATION' };
+      const skippedSuggestion = { getId: () => 's-skipped', getStatus: () => 'SKIPPED' };
+      const rejectedSuggestion = { getId: () => 's-rejected', getStatus: () => 'REJECTED' };
       const opportunity = {
         getId: sinon.stub().returns('oppty-1'),
         getType: () => 'canonical',
         setStatus: sinon.stub(),
-        getSuggestions: sinon.stub().resolves([newSuggestion, pendingSuggestion]),
+        getSuggestions: sinon.stub().resolves([
+          newSuggestion, pendingSuggestion, skippedSuggestion, rejectedSuggestion,
+        ]),
         setUpdatedBy: sinon.stub(),
         save: sinon.stub().resolves(),
       };
@@ -3893,23 +3909,27 @@ describe('data-access', () => {
       await resolveOpportunityIfNoIssues('site-1', 'canonical', dataAccess, log);
 
       expect(opportunity.setStatus).to.have.been.calledOnce;
-      expect(bulkUpdateStatusStub).to.have.been.calledOnceWith(
-        [newSuggestion, pendingSuggestion],
-        'OUTDATED',
-      );
+      // SKIPPED and REJECTED transition to OUTDATED alongside NEW/PENDING_VALIDATION
+      // (issue no longer detected → legitimate state change → updatedAt bump).
+      expect(bulkUpdateStatusStub).to.have.been.calledOnce;
+      const [passed, targetStatus] = bulkUpdateStatusStub.firstCall.args;
+      expect(targetStatus).to.equal('OUTDATED');
+      expect(passed).to.have.members([
+        newSuggestion, pendingSuggestion, skippedSuggestion, rejectedSuggestion,
+      ]);
       expect(opportunity.setUpdatedBy).to.have.been.calledOnceWith('system');
       expect(opportunity.save).to.have.been.calledOnce;
     });
 
-    it('preserves FIXED, SKIPPED, REJECTED suggestions and does not call bulkUpdateStatus', async () => {
+    it('preserves FIXED / APPROVED / IN_PROGRESS and does not call bulkUpdateStatus when only those exist', async () => {
       const opportunity = {
         getId: sinon.stub().returns('oppty-1'),
         getType: () => 'canonical',
         setStatus: sinon.stub(),
         getSuggestions: sinon.stub().resolves([
           { getId: () => 's-fixed', getStatus: () => 'FIXED' },
-          { getId: () => 's-skipped', getStatus: () => 'SKIPPED' },
-          { getId: () => 's-rejected', getStatus: () => 'REJECTED' },
+          { getId: () => 's-approved', getStatus: () => 'APPROVED' },
+          { getId: () => 's-in-progress', getStatus: () => 'IN_PROGRESS' },
         ]),
         setUpdatedBy: sinon.stub(),
         save: sinon.stub().resolves(),


### PR DESCRIPTION
## Summary

Follow-up to [SITES-44646](https://jira.corp.adobe.com/browse/SITES-44646). Tracks: [SITES-48663](https://jira.corp.adobe.com/browse/SITES-48663).

The Case A leak (issue **still detected** but SKIPPED/REJECTED `updatedAt` bumped every scan) was fixed by the `FROZEN_STATUSES` guard in `syncSuggestions` (`main` + [PR #2787](https://github.com/adobe/spacecat-audit-worker/pull/2787) + [PR #2790](https://github.com/adobe/spacecat-audit-worker/pull/2790)).

**This PR fixes Case B:** when the audit run **no longer detects** a suggestion's underlying issue, SKIPPED / REJECTED are now transitioned to OUTDATED alongside NEW / PENDING_VALIDATION. That's a legitimate state change — an operator's SKIPPED / REJECTED decision referred to an issue the audit no longer detects — and the accompanying `updatedAt` bump correctly reflects the transition (giving the ASO dashboard the "Moved to OUTDATED" signal).

Preserved as before: FIXED (customer already resolved), APPROVED / IN_PROGRESS (in-flight work), OUTDATED (already terminal), ERROR (needs re-dispatch via `defaultMergeStatusFunction`).

## Changes

- [`src/utils/data-access.js`](src/utils/data-access.js):
  - `handleOutdatedSuggestions` — remove SKIPPED / REJECTED from the exclusion filter (per-suggestion Case B: issue for this specific suggestion no longer detected while audit finds other issues).
  - `resolveOpportunityIfNoIssues` — include SKIPPED / REJECTED in the `suggestionsToOutdate` filter alongside NEW / PENDING_VALIDATION (whole-opportunity Case B: audit finds no issues at all).

- Test updates to reflect the new contract:
  - [`test/utils/data-access.test.js`](test/utils/data-access.test.js)
  - [`test/audits/backlinks.test.js`](test/audits/backlinks.test.js)
  - [`test/audits/canonical.test.js`](test/audits/canonical.test.js)
  - [`test/metatags/metatags.test.js`](test/metatags/metatags.test.js)

## Blast radius

Every audit that goes through `syncSuggestions`: canonical, broken-backlinks, meta-tags, sitemap, hreflang, TOC, redirect-chains, LLM-blocked, wikipedia-analysis, summarization, and others. All of them will start emitting a legitimate `updatedAt` bump when SKIPPED/REJECTED transitions to OUTDATED.

## Test plan

- [x] `npx mocha test/utils/data-access.test.js` — 143 passing
- [x] `npx mocha test/audits/backlinks.test.js test/audits/canonical.test.js test/metatags/metatags.test.js test/utils/data-access.test.js` — 468 passing
- [x] Full `npm test` — passing except two pre-existing flaky cdn-detector timeout tests, unrelated to this change
- [ ] Verify next weekend's audit runs surface a "Moved to Outdated" transition for SKIPPED/REJECTED suggestions whose issue is resolved, and current SKIPPED/REJECTED counts drop as expected

Fixes: [SITES-48663](https://jira.corp.adobe.com/browse/SITES-48663) (parent: [SITES-44646](https://jira.corp.adobe.com/browse/SITES-44646))

🤖 Generated with [Claude Code](https://claude.com/claude-code)