### PR TITLE
fix(llmo-4010): guard edge-deployed suggestions in summarization and …

### DIFF
--- a/src/readability/opportunities/guidance-handler.js
+++ b/src/readability/opportunities/guidance-handler.js
@@ -232,6 +232,12 @@ export default async function handler(message, context) {
       };
     },
     mergeDataFunction: (existingData, newData) => {
+      // Do not overwrite data (including shouldOptimize) for suggestions already deployed to
+      // the edge CDN, or mid-IVE geo-experiment (edgeOptimizeStatus is set before
+      // edgeDeployed) (LLMO-4010, LLMO-6168)
+      if (existingData.edgeDeployed || existingData.edgeOptimizeStatus) {
+        return { ...existingData };
+      }
       if (newData.shouldExclude) {
         const merged = {
           ...existingData,

--- a/src/readability/opportunities/guidance-handler.js
+++ b/src/readability/opportunities/guidance-handler.js
@@ -232,6 +232,12 @@ export default async function handler(message, context) {
       };
     },
     mergeDataFunction: (existingData, newData) => {
+      // Do not overwrite data (including shouldOptimize) for suggestions already deployed to
+      // the edge CDN, or mid-IVE geo-experiment (edgeOptimizeStatus is set before
+      // edgeDeployed) (LLMO-4010, LLMO-6168)
+      if (existingData.edgeDeployed || existingData.edgeOptimizeStatus) {
+        return { ...existingData };
+      }
       if (newData.shouldExclude) {
         const merged = {
           ...existingData,
@@ -260,10 +266,17 @@ export default async function handler(message, context) {
       delete merged.seoImpact;
       return enrichSuggestionDataForAutoOptimize(merged);
     },
-    mergeStatusFunction: (existing, newDataItem, mergeCtx) => (
-      newDataItem.shouldExclude
+    mergeStatusFunction: (existing, newDataItem, mergeCtx) => {
+      // Do not flip status (e.g. to a terminal SKIPPED) for suggestions already deployed to
+      // the edge CDN, or mid-IVE geo-experiment — keep the deployed state (LLMO-4010, LLMO-6168)
+      const existingData = existing.getData?.() || {};
+      if (existingData.edgeDeployed || existingData.edgeOptimizeStatus) {
+        return null;
+      }
+      return newDataItem.shouldExclude
         ? SuggestionModel.STATUSES.SKIPPED
-        : defaultMergeStatusFunction(existing, newDataItem, mergeCtx)),
+        : defaultMergeStatusFunction(existing, newDataItem, mergeCtx);
+    },
   });
 
   // Delete the S3 response file only after syncSuggestions succeeds

--- a/src/summarization/guidance-handler.js
+++ b/src/summarization/guidance-handler.js
@@ -57,6 +57,15 @@ async function addSuggestions(
       rank: 10,
       data: suggestion,
     }),
+    mergeDataFunction: (existingData, newData) => {
+      // Do not overwrite data (including shouldOptimize) for suggestions already deployed to
+      // the edge CDN, or mid-IVE geo-experiment (edgeOptimizeStatus is set before
+      // edgeDeployed) (LLMO-4010, LLMO-6168)
+      if (existingData.edgeDeployed || existingData.edgeOptimizeStatus) {
+        return { ...existingData };
+      }
+      return { ...existingData, ...newData };
+    },
     scrapedUrlsSet,
   });
 }

--- a/test/audits/readability/guidance-handler.test.js
+++ b/test/audits/readability/guidance-handler.test.js
@@ -901,6 +901,106 @@ describe('Readability Opportunities Guidance Handler', () => {
 
       expect(merged.url).to.equal('https://example.com/page1');
     });
+
+    it('should not overwrite data for edge-deployed suggestions', async () => {
+      const message = {
+        auditId: 'audit-123',
+        siteId: 'site-1',
+        data: { s3ResultsPath: 'results/path.json' },
+      };
+
+      await handler.default(message, mockContext);
+
+      const syncArgs = syncSuggestionsStub.getCall(0).args[0];
+      const { mergeDataFunction } = syncArgs;
+
+      const existingData = {
+        pageUrl: 'https://example.com/page1',
+        selector: '#content p:nth-child(1)',
+        improvedText: 'Previously improved text.',
+        shouldOptimize: true,
+        edgeDeployed: true,
+        transformRules: { op: 'replace', value: 'Previously improved text.', selector: '#content p:nth-child(1)' },
+      };
+      const newData = {
+        pageUrl: 'https://example.com/page1',
+        selector: '#content p:nth-child(1)',
+        improvedText: 'Newer improved text.',
+        shouldOptimize: false,
+      };
+
+      const result = mergeDataFunction(existingData, newData);
+
+      expect(result.edgeDeployed).to.equal(true);
+      expect(result.shouldOptimize).to.equal(true);
+      expect(result.improvedText).to.equal('Previously improved text.');
+      expect(result.transformRules.value).to.equal('Previously improved text.');
+    });
+
+    it('should not overwrite data for suggestions mid-IVE geo-experiment (edgeOptimizeStatus)', async () => {
+      const message = {
+        auditId: 'audit-123',
+        siteId: 'site-1',
+        data: { s3ResultsPath: 'results/path.json' },
+      };
+
+      await handler.default(message, mockContext);
+
+      const syncArgs = syncSuggestionsStub.getCall(0).args[0];
+      const { mergeDataFunction } = syncArgs;
+
+      const existingData = {
+        pageUrl: 'https://example.com/page1',
+        selector: '#content p:nth-child(1)',
+        improvedText: 'Previously improved text.',
+        shouldOptimize: true,
+        edgeOptimizeStatus: 'in_progress',
+        transformRules: { op: 'replace', value: 'Previously improved text.', selector: '#content p:nth-child(1)' },
+      };
+      const newData = {
+        pageUrl: 'https://example.com/page1',
+        selector: '#content p:nth-child(1)',
+        improvedText: 'Newer improved text.',
+        shouldOptimize: false,
+      };
+
+      const result = mergeDataFunction(existingData, newData);
+
+      expect(result.edgeOptimizeStatus).to.equal('in_progress');
+      expect(result.shouldOptimize).to.equal(true);
+      expect(result.improvedText).to.equal('Previously improved text.');
+      expect(result.transformRules.value).to.equal('Previously improved text.');
+    });
+
+    it('should not overwrite edge-deployed data even when newData has shouldExclude', async () => {
+      const message = {
+        auditId: 'audit-123',
+        siteId: 'site-1',
+        data: { s3ResultsPath: 'results/path.json' },
+      };
+
+      await handler.default(message, mockContext);
+
+      const syncArgs = syncSuggestionsStub.getCall(0).args[0];
+      const { mergeDataFunction } = syncArgs;
+
+      const existingData = {
+        pageUrl: 'https://example.com/page1',
+        selector: '#content p:nth-child(1)',
+        improvedText: 'Deployed text.',
+        edgeDeployed: true,
+      };
+      const newData = {
+        shouldExclude: true,
+        exclusionReason: 'citation_block',
+      };
+
+      const result = mergeDataFunction(existingData, newData);
+
+      expect(result.edgeDeployed).to.equal(true);
+      expect(result.improvedText).to.equal('Deployed text.');
+      expect(result.shouldExclude).to.be.undefined;
+    });
   });
 
   describe('mergeStatusFunction', () => {

--- a/test/audits/readability/guidance-handler.test.js
+++ b/test/audits/readability/guidance-handler.test.js
@@ -901,6 +901,106 @@ describe('Readability Opportunities Guidance Handler', () => {
 
       expect(merged.url).to.equal('https://example.com/page1');
     });
+
+    it('should not overwrite data for edge-deployed suggestions', async () => {
+      const message = {
+        auditId: 'audit-123',
+        siteId: 'site-1',
+        data: { s3ResultsPath: 'results/path.json' },
+      };
+
+      await handler.default(message, mockContext);
+
+      const syncArgs = syncSuggestionsStub.getCall(0).args[0];
+      const { mergeDataFunction } = syncArgs;
+
+      const existingData = {
+        pageUrl: 'https://example.com/page1',
+        selector: '#content p:nth-child(1)',
+        improvedText: 'Previously improved text.',
+        shouldOptimize: true,
+        edgeDeployed: true,
+        transformRules: { op: 'replace', value: 'Previously improved text.', selector: '#content p:nth-child(1)' },
+      };
+      const newData = {
+        pageUrl: 'https://example.com/page1',
+        selector: '#content p:nth-child(1)',
+        improvedText: 'Newer improved text.',
+        shouldOptimize: false,
+      };
+
+      const result = mergeDataFunction(existingData, newData);
+
+      expect(result.edgeDeployed).to.equal(true);
+      expect(result.shouldOptimize).to.equal(true);
+      expect(result.improvedText).to.equal('Previously improved text.');
+      expect(result.transformRules.value).to.equal('Previously improved text.');
+    });
+
+    it('should not overwrite data for suggestions mid-IVE geo-experiment (edgeOptimizeStatus)', async () => {
+      const message = {
+        auditId: 'audit-123',
+        siteId: 'site-1',
+        data: { s3ResultsPath: 'results/path.json' },
+      };
+
+      await handler.default(message, mockContext);
+
+      const syncArgs = syncSuggestionsStub.getCall(0).args[0];
+      const { mergeDataFunction } = syncArgs;
+
+      const existingData = {
+        pageUrl: 'https://example.com/page1',
+        selector: '#content p:nth-child(1)',
+        improvedText: 'Previously improved text.',
+        shouldOptimize: true,
+        edgeOptimizeStatus: 'in_progress',
+        transformRules: { op: 'replace', value: 'Previously improved text.', selector: '#content p:nth-child(1)' },
+      };
+      const newData = {
+        pageUrl: 'https://example.com/page1',
+        selector: '#content p:nth-child(1)',
+        improvedText: 'Newer improved text.',
+        shouldOptimize: false,
+      };
+
+      const result = mergeDataFunction(existingData, newData);
+
+      expect(result.edgeOptimizeStatus).to.equal('in_progress');
+      expect(result.shouldOptimize).to.equal(true);
+      expect(result.improvedText).to.equal('Previously improved text.');
+      expect(result.transformRules.value).to.equal('Previously improved text.');
+    });
+
+    it('should not overwrite edge-deployed data even when newData has shouldExclude', async () => {
+      const message = {
+        auditId: 'audit-123',
+        siteId: 'site-1',
+        data: { s3ResultsPath: 'results/path.json' },
+      };
+
+      await handler.default(message, mockContext);
+
+      const syncArgs = syncSuggestionsStub.getCall(0).args[0];
+      const { mergeDataFunction } = syncArgs;
+
+      const existingData = {
+        pageUrl: 'https://example.com/page1',
+        selector: '#content p:nth-child(1)',
+        improvedText: 'Deployed text.',
+        edgeDeployed: true,
+      };
+      const newData = {
+        shouldExclude: true,
+        exclusionReason: 'citation_block',
+      };
+
+      const result = mergeDataFunction(existingData, newData);
+
+      expect(result.edgeDeployed).to.equal(true);
+      expect(result.improvedText).to.equal('Deployed text.');
+      expect(result.shouldExclude).to.be.undefined;
+    });
   });
 
   describe('mergeStatusFunction', () => {
@@ -960,6 +1060,46 @@ describe('Readability Opportunities Guidance Handler', () => {
       expect(defaultMergeStatusStub.firstCall.args[0]).to.equal(mockExisting);
       expect(defaultMergeStatusStub.firstCall.args[2]).to.equal(mergeCtx);
       expect(result).to.equal(null);
+    });
+
+    it('should keep status (return null) for edge-deployed suggestions even when excluded', async () => {
+      await handler.default({
+        auditId: 'audit-123',
+        siteId: 'site-1',
+        data: { s3ResultsPath: 'results/path.json' },
+      }, mockContext);
+
+      const { mergeStatusFunction, newData } = syncSuggestionsStub.getCall(0).args[0];
+      const mockExisting = {
+        getStatus: () => 'NEW',
+        getData: () => ({ edgeDeployed: true }),
+      };
+      const mergeCtx = { log: logStub, site: {} };
+
+      const result = mergeStatusFunction(mockExisting, { ...newData[0], shouldExclude: true }, mergeCtx);
+
+      expect(result).to.equal(null);
+      expect(defaultMergeStatusStub).to.not.have.been.called;
+    });
+
+    it('should keep status (return null) for suggestions mid-IVE geo-experiment (edgeOptimizeStatus)', async () => {
+      await handler.default({
+        auditId: 'audit-123',
+        siteId: 'site-1',
+        data: { s3ResultsPath: 'results/path.json' },
+      }, mockContext);
+
+      const { mergeStatusFunction, newData } = syncSuggestionsStub.getCall(0).args[0];
+      const mockExisting = {
+        getStatus: () => 'NEW',
+        getData: () => ({ edgeOptimizeStatus: 'in_progress' }),
+      };
+      const mergeCtx = { log: logStub, site: {} };
+
+      const result = mergeStatusFunction(mockExisting, { ...newData[0], shouldExclude: true }, mergeCtx);
+
+      expect(result).to.equal(null);
+      expect(defaultMergeStatusStub).to.not.have.been.called;
     });
   });
 });

--- a/test/audits/summarization/guidance-handler.test.js
+++ b/test/audits/summarization/guidance-handler.test.js
@@ -691,4 +691,108 @@ describe('summarization guidance handler', () => {
     expect(keyPointsBuildKeyResult).to.equal('https://adobe.com/test-h1-key-points');
   });
 
+  it('should not overwrite data for edge-deployed suggestions', async () => {
+    Opportunity.allBySiteId.resolves([]);
+    Opportunity.create.resolves(dummyOpportunity);
+
+    const message = {
+      auditId: 'audit-id',
+      siteId: 'site-id',
+      data: {
+        presignedUrl: 'https://s3.amazonaws.com/bucket/summaries.json',
+      },
+    };
+    await handler(message, context);
+
+    const syncArgs = syncSuggestionsStub.getCall(0).args[0];
+    const { mergeDataFunction } = syncArgs;
+    expect(mergeDataFunction).to.be.a('function');
+
+    const existingData = {
+      url: 'https://adobe.com/page1',
+      shouldOptimize: true,
+      edgeDeployed: true,
+      transformRules: { selector: 'h1', action: 'insertAfter' },
+    };
+    const newData = {
+      url: 'https://adobe.com/page1',
+      shouldOptimize: false,
+      transformRules: { selector: 'h2', action: 'replace' },
+    };
+
+    const result = mergeDataFunction(existingData, newData);
+
+    expect(result.edgeDeployed).to.equal(true);
+    expect(result.shouldOptimize).to.equal(true);
+    expect(result.transformRules.selector).to.equal('h1');
+  });
+
+  it('should not overwrite data for suggestions mid-IVE geo-experiment (edgeOptimizeStatus)', async () => {
+    Opportunity.allBySiteId.resolves([]);
+    Opportunity.create.resolves(dummyOpportunity);
+
+    const message = {
+      auditId: 'audit-id',
+      siteId: 'site-id',
+      data: {
+        presignedUrl: 'https://s3.amazonaws.com/bucket/summaries.json',
+      },
+    };
+    await handler(message, context);
+
+    const syncArgs = syncSuggestionsStub.getCall(0).args[0];
+    const { mergeDataFunction } = syncArgs;
+
+    const existingData = {
+      url: 'https://adobe.com/page1',
+      shouldOptimize: true,
+      edgeOptimizeStatus: 'in_progress',
+      transformRules: { selector: 'h1', action: 'insertAfter' },
+    };
+    const newData = {
+      url: 'https://adobe.com/page1',
+      shouldOptimize: false,
+      transformRules: { selector: 'h2', action: 'replace' },
+    };
+
+    const result = mergeDataFunction(existingData, newData);
+
+    expect(result.edgeOptimizeStatus).to.equal('in_progress');
+    expect(result.shouldOptimize).to.equal(true);
+    expect(result.transformRules.selector).to.equal('h1');
+  });
+
+  it('should merge normally when edgeDeployed is not set', async () => {
+    Opportunity.allBySiteId.resolves([]);
+    Opportunity.create.resolves(dummyOpportunity);
+
+    const message = {
+      auditId: 'audit-id',
+      siteId: 'site-id',
+      data: {
+        presignedUrl: 'https://s3.amazonaws.com/bucket/summaries.json',
+      },
+    };
+    await handler(message, context);
+
+    const syncArgs = syncSuggestionsStub.getCall(0).args[0];
+    const { mergeDataFunction } = syncArgs;
+
+    const existingData = {
+      url: 'https://adobe.com/page1',
+      shouldOptimize: true,
+      transformRules: { selector: 'h1', action: 'insertAfter' },
+    };
+    const newData = {
+      url: 'https://adobe.com/page1',
+      shouldOptimize: false,
+      transformRules: { selector: 'h2', action: 'replace' },
+    };
+
+    const result = mergeDataFunction(existingData, newData);
+
+    expect(result.shouldOptimize).to.equal(false);
+    expect(result.transformRules.selector).to.equal('h2');
+  });
+
 });


### PR DESCRIPTION
## Description

Audit re-runs were overwriting suggestion data (including `shouldOptimize`) for
suggestions already deployed to the edge CDN, causing stale "Fixed" tab data and
rollback validation failures. [PR #2429](https://github.com/adobe/spacecat-audit-worker/pull/2429)
guarded `headings`, `toc`, and `faqs`; this extends the same guard to the two
remaining affected audit types: **summarization** and **readability**.

Both `mergeDataFunction`s now early-return existing data unchanged when
`existingData.edgeDeployed` or `existingData.edgeOptimizeStatus` is set (matching
the `toc` mid-IVE geo-experiment guard from LLMO-6168). Summarization had no
`mergeDataFunction` at all; readability had one lacking the guard.

## Related Issues

- Fixes LLMO-4010
- Follows up on #2429 (headings/toc/faqs) and LLMO-6168 (`edgeOptimizeStatus` guard)

Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [x] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

