### PR TITLE
fix(offsite): describe each flow step accurately in Slack/logs

### DIFF
--- a/src/cited-analysis/handler.js
+++ b/src/cited-analysis/handler.js
@@ -26,6 +26,9 @@ import {
   computeBrandTokens,
   isExcludedCitedHost,
   toApexHost,
+  buildAnalysisScrapeStatusMessage,
+  formatDrsExtras,
+  scrapedThisCycle,
 } from '../utils/offsite-audit-utils.js';
 import { CITED_ANALYSIS_DRS_CONFIG } from '../offsite-brand-presence/constants.js';
 import { computeTopicsFromBrandPresence } from '../utils/offsite-brand-presence-enrichment.js';
@@ -196,7 +199,7 @@ async function fetchStoreData(siteId, context, site) {
 
   const drsClient = DrsClient.createFrom(context);
   const { datasetIds } = CITED_ANALYSIS_DRS_CONFIG;
-  const urls = await filterUrlsByDrsStatus(
+  const { urls, counts } = await filterUrlsByDrsStatus(
     curatedUrls,
     datasetIds,
     siteId,
@@ -204,7 +207,7 @@ async function fetchStoreData(siteId, context, site) {
     log,
     LOG_PREFIX,
   );
-  log.info(`${LOG_PREFIX} ${urls.length} cited URLs available in DRS`);
+  log.info(`${LOG_PREFIX} ${urls.length} cited URLs available in DRS${formatDrsExtras(counts)}`);
 
   const topics = await computeTopicsFromBrandPresence(siteId, context, site);
   log.info(`${LOG_PREFIX} Computed ${topics.length} topics from brand presence data`);
@@ -227,6 +230,7 @@ async function fetchStoreData(siteId, context, site) {
   return {
     urls,
     sentimentConfig: { topics, guidelines },
+    drsCounts: counts,
   };
 }
 
@@ -276,23 +280,33 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
 
     const storeData = await fetchStoreData(siteId, context, site);
     log.info(`${LOG_PREFIX} Successfully fetched all store data for ${citedConfig.companyName}`);
+    // Whether this run's DRS scrape produced the content (poll-dispatched) or we are reusing
+    // a prior scrape (direct/scheduled run) changes the log and Slack wording so the thread
+    // reads as a coherent sequence rather than a contradictory "no scrape needed".
+    const scrapedNow = scrapedThisCycle(auditContext);
     log.info(
-      `${LOG_PREFIX} DRS content available for ${storeData.urls.length} URL(s) `
-        + '— no scrape job needed, proceeding to Mystique',
+      scrapedNow
+        ? `${LOG_PREFIX} DRS scrape finished this cycle; ${storeData.urls.length} URL(s) ready, proceeding to Mystique`
+        : `${LOG_PREFIX} Reusing previously scraped DRS content for ${storeData.urls.length} URL(s); no new scrape needed, proceeding to Mystique`,
     );
 
     const urlLimit = resolveMystiqueUrlLimit(auditContext, log, LOG_PREFIX);
 
     const { slackContext } = auditContext;
 
-    // Manual Slack-triggered runs get a notification explaining that no DRS scrape
-    // job was needed (content already available). No-ops on scheduled runs where
+    // Manual Slack-triggered runs get a notification describing the exact DRS state (fresh
+    // scrape this cycle vs. reused prior content). No-ops on scheduled runs where
     // slackContext is absent.
     await postMessageOptional(
       context,
       slackContext?.channelId,
-      `:mag: *cited-analysis* for *${site.getBaseURL()}* — DRS content already available `
-        + `(${storeData.urls.length} URL(s)); no scrape job needed, sending to Mystique.`,
+      buildAnalysisScrapeStatusMessage({
+        analysisName: 'cited-analysis',
+        baseUrl: site.getBaseURL(),
+        urlCount: storeData.urls.length,
+        counts: storeData.drsCounts,
+        scrapedNow,
+      }),
       { threadTs: slackContext?.threadTs },
     );
 
@@ -349,15 +363,31 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
     }
 
     if (error instanceof DrsNoContentAvailableError) {
+      const { slackContext } = auditContext;
+      const { channelId, threadTs } = slackContext || {};
       if (auditContext.drsScrapeRequested) {
+        // A scrape already ran this cycle and DRS still reports no scraped content → terminal.
         log.error(`${LOG_PREFIX} No DRS content available after scraping: ${error.message}`);
+        await postMessageOptional(
+          context,
+          channelId,
+          `:warning: *cited-analysis* for *${site.getBaseURL()}* — DRS reported no scraped content after scraping; nothing to analyze.`,
+          { threadTs },
+        );
         return {
           auditResult: { success: false, error: error.message },
           fullAuditRef: url,
         };
       }
-      log.info(`${LOG_PREFIX} No DRS content yet, requesting a scrape for top-cited`);
-      await requestOffsiteScrape(context, siteId, 'top-cited', auditContext.slackContext, enableBrandProfile);
+      log.info(`${LOG_PREFIX} URLs stored but not scraped in DRS yet, requesting a scrape for top-cited`);
+      await postMessageOptional(
+        context,
+        channelId,
+        `:mag: *cited-analysis* for *${site.getBaseURL()}* — cited URLs are stored but not scraped in DRS yet${formatDrsExtras(error.counts)}; `
+          + 'starting a DRS scrape for top-cited, will analyze automatically when it finishes.',
+        { threadTs },
+      );
+      await requestOffsiteScrape(context, siteId, 'top-cited', slackContext, enableBrandProfile);
       return {
         auditResult: { success: false, status: 'pending_scrape', error: error.message },
         fullAuditRef: url,

--- a/src/offsite-brand-presence/drs-status-handler.js
+++ b/src/offsite-brand-presence/drs-status-handler.js
@@ -207,11 +207,11 @@ async function triggerAnalysisAudits(
  *   error: string|undefined}>} statuses - Resolved per-job statuses
  * @returns {string} Slack message text
  */
-function buildSummary(baseURL, statuses, drsStartedAt) {
+function buildSummary(baseURL, statuses, drsStartedAt, triggeredAuditTypes = []) {
   const allTerminal = statuses.every((s) => DRS_TERMINAL_STATUSES.has(s.status));
   const header = allTerminal
-    ? `:checkered_flag: *offsite-brand-presence* DRS jobs *complete* for *${baseURL}*:`
-    : `:hourglass_flowing_sand: *offsite-brand-presence* DRS jobs *status update* for *${baseURL}* (timed out waiting):`;
+    ? `:checkered_flag: *offsite-brand-presence* — *DRS scraping complete* for *${baseURL}*:`
+    : `:hourglass_flowing_sand: *offsite-brand-presence* — *DRS scraping status update* for *${baseURL}* (timed out waiting):`;
   const lines = [header];
   for (const s of statuses) {
     const label = `\`${s.domain}\` / \`${s.datasetId}\``;
@@ -226,6 +226,9 @@ function buildSummary(baseURL, statuses, drsStartedAt) {
   const elapsed = Number.isFinite(drsStartedAt) ? formatDuration(Date.now() - drsStartedAt) : null;
   if (elapsed) {
     lines.push(`• DRS scraping elapsed: ~${elapsed}`);
+  }
+  if (triggeredAuditTypes.length > 0) {
+    lines.push(`• Analysis dispatched to Mystique for: ${triggeredAuditTypes.join(', ')}`);
   }
   return lines.join('\n');
 }
@@ -335,7 +338,7 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
   // before the message is deleted could redeliver and post the summary twice. There is
   // no idempotency key; a duplicate Slack summary is preferable to the complexity of
   // deduplication for a best-effort notification.
-  const summary = buildSummary(baseURL, statuses, drsStartedAt);
+  const summary = buildSummary(baseURL, statuses, drsStartedAt, nextTriggered);
   await postMessageOptional(context, channelId, summary, { threadTs });
   log.info(`${LOG_PREFIX} Posted completion summary for ${baseURL} (${statuses.length} jobs)`);
 

--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -727,7 +727,8 @@ async function notifyUrlsStored(storedByDomain, baseURL, context, channelId, thr
   await postMessageOptional(
     context,
     channelId,
-    `:package: *offsite-brand-presence* for *${baseURL}* — collected & stored *${total}* URL(s) to scrape (${perBucket}).`,
+    `:package: *offsite-brand-presence* for *${baseURL}* — selected *${total}* top URL(s) to scrape this run (${perBucket}). `
+      + 'The URL store may hold more from earlier runs; each analysis sends the full available store to Mystique.',
     { threadTs },
   );
 }

--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -705,6 +705,34 @@ async function notifyDrsSkipped(reason, baseURL, context, channelId, threadTs) {
 }
 
 /**
+ * Sends a Slack notification for the URL-Store step: how many URLs were selected and stored
+ * for scraping, broken down per bucket. This makes the first phase of the flow (URL Store)
+ * visible in the thread before the DRS scraping messages. No-ops when nothing was stored
+ * (e.g. a scoped run whose bucket is empty) or on scheduled runs (channelId absent).
+ *
+ * @param {Object<string, string[]>} storedByDomain - Stored URLs keyed by bucket
+ * @param {string} baseURL - The site's base URL
+ * @param {object} context - The execution context
+ * @param {string} channelId - Slack channel ID
+ * @param {string} threadTs - Slack thread timestamp
+ */
+async function notifyUrlsStored(storedByDomain, baseURL, context, channelId, threadTs) {
+  const total = Object.values(storedByDomain).reduce((sum, urls) => sum + urls.length, 0);
+  if (total === 0) {
+    return;
+  }
+  const perBucket = Object.entries(storedByDomain)
+    .map(([domain, urls]) => `${domain}: ${urls.length}`)
+    .join(', ');
+  await postMessageOptional(
+    context,
+    channelId,
+    `:package: *offsite-brand-presence* for *${baseURL}* — collected & stored *${total}* URL(s) to scrape (${perBucket}).`,
+    { threadTs },
+  );
+}
+
+/**
  * Sends a Slack notification summarizing DRS job results.
  *
  * @param {Array} drsResults - Array of DRS job result objects
@@ -721,10 +749,12 @@ async function notifyDrsResults(drsResults, baseURL, context, channelId, threadT
   const succeeded = drsResults.filter((r) => r.status === 'success');
   const failed = drsResults.filter((r) => r.status === 'error');
   const lines = [
-    `:white_check_mark: *offsite-brand-presence* DRS jobs for *${baseURL}*:`,
+    `:hourglass_flowing_sand: *offsite-brand-presence* for *${baseURL}* — *DRS scraping started*: `
+      + `submitted ${succeeded.length} scrape job(s), running in the background. `
+      + 'Each bucket\'s analysis (reddit/youtube/cited) is sent to Mystique as soon as its scrape finishes:',
     ...succeeded.map((r) => `• \`${r.domain}\` / \`${r.datasetId}\` → job_id: \`${r.response?.job_id}\``),
     ...(failed.length > 0 ? [
-      `:x: *Failed (${failed.length}):*`,
+      `:x: *Failed to submit (${failed.length}):*`,
       ...failed.map((r) => `• \`${r.domain}\` / \`${r.datasetId}\` → ${r.error}`),
     ] : []),
   ];
@@ -902,6 +932,7 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
   }
 
   const storedByDomain = await addUrlsToUrlStore(siteId, topByDomain, topCited, dataAccess, log);
+  await notifyUrlsStored(storedByDomain, baseURL, context, channelId, threadTs);
   // Phase timing anchor: when DRS scraping is triggered. Threaded through the poll and
   // the downstream analysis audits so each can report how long its scrape took.
   const drsStartedAt = Date.now();

--- a/src/reddit-analysis/handler.js
+++ b/src/reddit-analysis/handler.js
@@ -23,6 +23,9 @@ import {
   resolveMystiqueUrlLimit,
   resolveEnableBrandProfile,
   requestOffsiteScrape,
+  buildAnalysisScrapeStatusMessage,
+  formatDrsExtras,
+  scrapedThisCycle,
 } from '../utils/offsite-audit-utils.js';
 import { OFFSITE_DOMAINS } from '../offsite-brand-presence/constants.js';
 import { computeTopicsFromBrandPresence } from '../utils/offsite-brand-presence-enrichment.js';
@@ -85,8 +88,15 @@ async function fetchStoreData(siteId, context, site) {
 
   const drsClient = DrsClient.createFrom(context);
   const { datasetIds } = OFFSITE_DOMAINS['reddit.com'];
-  const urls = await filterUrlsByDrsStatus(rawUrls, datasetIds, siteId, drsClient, log, LOG_PREFIX);
-  log.info(`${LOG_PREFIX} ${urls.length} Reddit URLs available in DRS`);
+  const { urls, counts } = await filterUrlsByDrsStatus(
+    rawUrls,
+    datasetIds,
+    siteId,
+    drsClient,
+    log,
+    LOG_PREFIX,
+  );
+  log.info(`${LOG_PREFIX} ${urls.length} Reddit URLs available in DRS${formatDrsExtras(counts)}`);
 
   const topics = await computeTopicsFromBrandPresence(siteId, context, site);
   log.info(`${LOG_PREFIX} Computed ${topics.length} topics from brand presence data`);
@@ -112,6 +122,7 @@ async function fetchStoreData(siteId, context, site) {
   return {
     urls,
     sentimentConfig: { topics, guidelines },
+    drsCounts: counts,
   };
 }
 
@@ -155,23 +166,33 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
 
     const storeData = await fetchStoreData(siteId, context, site);
     log.info(`${LOG_PREFIX} Successfully fetched all store data for ${redditConfig.companyName}`);
+    // Whether this run's DRS scrape produced the content (poll-dispatched) or we are reusing
+    // a prior scrape (direct/scheduled run) changes the log and Slack wording so the thread
+    // reads as a coherent sequence rather than a contradictory "no scrape needed".
+    const scrapedNow = scrapedThisCycle(auditContext);
     log.info(
-      `${LOG_PREFIX} DRS content available for ${storeData.urls.length} URL(s) `
-        + '— no scrape job needed, proceeding to Mystique',
+      scrapedNow
+        ? `${LOG_PREFIX} DRS scrape finished this cycle; ${storeData.urls.length} URL(s) ready, proceeding to Mystique`
+        : `${LOG_PREFIX} Reusing previously scraped DRS content for ${storeData.urls.length} URL(s); no new scrape needed, proceeding to Mystique`,
     );
 
     const urlLimit = resolveMystiqueUrlLimit(auditContext, log, LOG_PREFIX);
 
     const { slackContext } = auditContext;
 
-    // Manual Slack-triggered runs get a notification explaining that no DRS scrape
-    // job was needed (content already available). No-ops on scheduled runs where
+    // Manual Slack-triggered runs get a notification describing the exact DRS state (fresh
+    // scrape this cycle vs. reused prior content). No-ops on scheduled runs where
     // slackContext is absent.
     await postMessageOptional(
       context,
       slackContext?.channelId,
-      `:mag: *reddit-analysis* for *${site.getBaseURL()}* — DRS content already available `
-        + `(${storeData.urls.length} URL(s)); no scrape job needed, sending to Mystique.`,
+      buildAnalysisScrapeStatusMessage({
+        analysisName: 'reddit-analysis',
+        baseUrl: site.getBaseURL(),
+        urlCount: storeData.urls.length,
+        counts: storeData.drsCounts,
+        scrapedNow,
+      }),
       { threadTs: slackContext?.threadTs },
     );
 
@@ -228,15 +249,31 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
     }
 
     if (error instanceof DrsNoContentAvailableError) {
+      const { slackContext } = auditContext;
+      const { channelId, threadTs } = slackContext || {};
       if (auditContext.drsScrapeRequested) {
+        // A scrape already ran this cycle and DRS still reports no scraped content → terminal.
         log.error(`${LOG_PREFIX} No DRS content available after scraping: ${error.message}`);
+        await postMessageOptional(
+          context,
+          channelId,
+          `:warning: *reddit-analysis* for *${site.getBaseURL()}* — DRS reported no scraped content after scraping; nothing to analyze.`,
+          { threadTs },
+        );
         return {
           auditResult: { success: false, error: error.message },
           fullAuditRef: url,
         };
       }
-      log.info(`${LOG_PREFIX} No DRS content yet, requesting a scrape for reddit.com`);
-      await requestOffsiteScrape(context, siteId, 'reddit.com', auditContext.slackContext, enableBrandProfile);
+      log.info(`${LOG_PREFIX} URLs stored but not scraped in DRS yet, requesting a scrape for reddit.com`);
+      await postMessageOptional(
+        context,
+        channelId,
+        `:mag: *reddit-analysis* for *${site.getBaseURL()}* — Reddit URLs are stored but not scraped in DRS yet${formatDrsExtras(error.counts)}; `
+          + 'starting a DRS scrape for reddit.com, will analyze automatically when it finishes.',
+        { threadTs },
+      );
+      await requestOffsiteScrape(context, siteId, 'reddit.com', slackContext, enableBrandProfile);
       return {
         auditResult: { success: false, status: 'pending_scrape', error: error.message },
         fullAuditRef: url,

--- a/src/utils/offsite-audit-utils.js
+++ b/src/utils/offsite-audit-utils.js
@@ -263,11 +263,11 @@ function undeterminedDrsCounts(total) {
 
 /**
  * Renders the non-available portion of a DRS status breakdown as a short parenthetical,
- * e.g. ` (3 still scraping, 2 not yet scraped — proceeding with 70 ready)`. Returns '' when
- * the breakdown is undetermined or every URL is already available, so callers can append it
- * unconditionally without adding noise to the common case.
+ * e.g. ` (3 still scraping, 2 not yet scraped)`. Returns '' when the breakdown is undetermined
+ * or every URL is already available, so callers can append it unconditionally without adding
+ * noise to the common case.
  *
- * @param {{available: number, scraping: number, notFound: number, determined: boolean}} [counts]
+ * @param {{scraping: number, notFound: number, determined: boolean}} [counts]
  * @returns {string}
  */
 export function formatDrsExtras(counts) {
@@ -281,27 +281,31 @@ export function formatDrsExtras(counts) {
   if (counts.notFound > 0) {
     parts.push(`${counts.notFound} not yet scraped`);
   }
-  return parts.length > 0
-    ? ` (${parts.join(', ')} — proceeding with ${counts.available} ready)`
-    : '';
+  return parts.length > 0 ? ` (${parts.join(', ')})` : '';
 }
 
 /**
  * Builds the Slack line an analysis audit posts when it has DRS content ready to send to
- * Mystique. The wording is conditioned on whether a DRS scrape actually ran *this cycle*:
- *  - `scrapedThisCycle` true  → "DRS scrape finished; N scraped URL(s) ready …" (the offsite
- *    run scraped this cycle and the poll dispatched this analysis on completion).
- *  - `scrapedThisCycle` false → "reusing previously scraped DRS content …; no new scrape
- *    needed" (a direct/scheduled analysis run consuming a prior scrape).
+ * Mystique. Two things the wording must make unambiguous, because both previously confused
+ * readers of the thread:
  *
- * This replaces the previous unconditional "DRS content already available … no scrape job
- * needed" wording, which contradicted the offsite run's own "scraping started"/"scrape
- * complete" messages in the same Slack thread.
+ *  1. Destination — these URLs are sent to *Mystique for analysis*, NOT submitted to DRS for
+ *     scraping. (Scraping is the offsite-brand-presence run's job; this is the consume side.)
+ *  2. Source/scope — `urlCount` is the count of available URLs in the *full* URL store for
+ *     this audit type (accumulated across runs), not this run's freshly-selected scrape batch.
+ *     That is why it can exceed the "selected N to scrape this run" number the offsite run
+ *     reports (e.g. 156 to Mystique vs. 70 selected this run).
+ *
+ * The lead-in is conditioned on whether a DRS scrape actually ran *this cycle*:
+ *  - `scrapedNow` true  → "DRS scrape finished." (the offsite run scraped this cycle and the
+ *    poll dispatched this analysis on completion).
+ *  - `scrapedNow` false → "reusing previously scraped DRS content (no new scrape needed)."
+ *    (a direct/scheduled analysis run consuming a prior scrape).
  *
  * @param {object} params
  * @param {string} params.analysisName - e.g. 'reddit-analysis'
  * @param {string} params.baseUrl
- * @param {number} params.urlCount - number of available URLs being sent to Mystique
+ * @param {number} params.urlCount - available URLs from the full store being sent to Mystique
  * @param {object} [params.counts] - DRS status breakdown from {@link filterUrlsByDrsStatus}
  * @param {boolean} params.scrapedNow - whether a DRS scrape ran during this cycle
  * @returns {string}
@@ -310,12 +314,11 @@ export function buildAnalysisScrapeStatusMessage({
   analysisName, baseUrl, urlCount, counts, scrapedNow,
 }) {
   const extras = formatDrsExtras(counts);
-  if (scrapedNow) {
-    return `:mag: *${analysisName}* for *${baseUrl}* — DRS scrape finished; `
-      + `*${urlCount}* scraped URL(s) ready${extras}. Sending to Mystique.`;
-  }
-  return `:mag: *${analysisName}* for *${baseUrl}* — reusing previously scraped DRS content `
-    + `(*${urlCount}* URL(s) available${extras}); no new scrape needed. Sending to Mystique.`;
+  const leadIn = scrapedNow
+    ? 'DRS scrape finished.'
+    : 'reusing previously scraped DRS content (no new scrape needed).';
+  return `:mag: *${analysisName}* for *${baseUrl}* — ${leadIn} `
+    + `Sending *${urlCount}* available URL(s) from the URL store to Mystique for analysis${extras}.`;
 }
 
 /**

--- a/src/utils/offsite-audit-utils.js
+++ b/src/utils/offsite-audit-utils.js
@@ -109,7 +109,7 @@ export function buildOffsiteTimingLines(timings, nowMs = Date.now()) {
   const drs = hasDrs ? formatDuration(drsMs) : null;
 
   if (drs === null) {
-    return '• DRS scrape: already scraped (n/a)\n'
+    return '• DRS scrape: reused prior scrape (n/a)\n'
       + `• Suggestion generation (Mystique): ${mystique}\n`
       + `• Total: ${mystique}`;
   }
@@ -246,17 +246,108 @@ export class DrsNoContentAvailableError extends Error {
 }
 
 /**
- * Filters an array of URL objects to only those whose content is already available in DRS.
+ * Builds a per-URL DRS status breakdown that could not be determined (DRS unconfigured or
+ * every lookup failed). The URLs are passed through unfiltered, so they are all treated as
+ * "available" for downstream purposes, but `determined: false` lets callers omit misleading
+ * counts from their logs and Slack messages.
  *
- * Runs one `lookupScrapeResults` call per dataset ID. A URL passes the filter when it has
- * `status === 'available'` in **at least one** of the provided datasets, meaning Mystique
- * will be able to retrieve its scraped content.
+ * @param {number} total
+ * @returns {{total: number, available: number, scraping: number, notFound: number,
+ *   determined: boolean}}
+ */
+function undeterminedDrsCounts(total) {
+  return {
+    total, available: total, scraping: 0, notFound: 0, determined: false,
+  };
+}
+
+/**
+ * Renders the non-available portion of a DRS status breakdown as a short parenthetical,
+ * e.g. ` (3 still scraping, 2 not yet scraped — proceeding with 70 ready)`. Returns '' when
+ * the breakdown is undetermined or every URL is already available, so callers can append it
+ * unconditionally without adding noise to the common case.
  *
- * Falls back gracefully (returns the original list unchanged) when DRS is not configured or
- * every dataset lookup fails / returns null — i.e. when DRS availability cannot be determined.
+ * @param {{available: number, scraping: number, notFound: number, determined: boolean}} [counts]
+ * @returns {string}
+ */
+export function formatDrsExtras(counts) {
+  if (!counts || counts.determined === false) {
+    return '';
+  }
+  const parts = [];
+  if (counts.scraping > 0) {
+    parts.push(`${counts.scraping} still scraping`);
+  }
+  if (counts.notFound > 0) {
+    parts.push(`${counts.notFound} not yet scraped`);
+  }
+  return parts.length > 0
+    ? ` (${parts.join(', ')} — proceeding with ${counts.available} ready)`
+    : '';
+}
+
+/**
+ * Builds the Slack line an analysis audit posts when it has DRS content ready to send to
+ * Mystique. The wording is conditioned on whether a DRS scrape actually ran *this cycle*:
+ *  - `scrapedThisCycle` true  → "DRS scrape finished; N scraped URL(s) ready …" (the offsite
+ *    run scraped this cycle and the poll dispatched this analysis on completion).
+ *  - `scrapedThisCycle` false → "reusing previously scraped DRS content …; no new scrape
+ *    needed" (a direct/scheduled analysis run consuming a prior scrape).
  *
- * Throws a `DrsNoContentAvailableError` when DRS is reachable and successfully responded but
- * reported zero available URLs, meaning scraping has not completed yet.
+ * This replaces the previous unconditional "DRS content already available … no scrape job
+ * needed" wording, which contradicted the offsite run's own "scraping started"/"scrape
+ * complete" messages in the same Slack thread.
+ *
+ * @param {object} params
+ * @param {string} params.analysisName - e.g. 'reddit-analysis'
+ * @param {string} params.baseUrl
+ * @param {number} params.urlCount - number of available URLs being sent to Mystique
+ * @param {object} [params.counts] - DRS status breakdown from {@link filterUrlsByDrsStatus}
+ * @param {boolean} params.scrapedNow - whether a DRS scrape ran during this cycle
+ * @returns {string}
+ */
+export function buildAnalysisScrapeStatusMessage({
+  analysisName, baseUrl, urlCount, counts, scrapedNow,
+}) {
+  const extras = formatDrsExtras(counts);
+  if (scrapedNow) {
+    return `:mag: *${analysisName}* for *${baseUrl}* — DRS scrape finished; `
+      + `*${urlCount}* scraped URL(s) ready${extras}. Sending to Mystique.`;
+  }
+  return `:mag: *${analysisName}* for *${baseUrl}* — reusing previously scraped DRS content `
+    + `(*${urlCount}* URL(s) available${extras}); no new scrape needed. Sending to Mystique.`;
+}
+
+/**
+ * Whether a DRS scrape ran during this audit cycle, inferred from the phase-timing anchors
+ * threaded onto `auditContext.timings` by the offsite-brand-presence DRS status poll. Both
+ * anchors are present only when the poll dispatched this analysis after a scrape completed;
+ * a direct/scheduled run (reusing prior content) has neither.
+ *
+ * @param {object} [auditContext]
+ * @returns {boolean}
+ */
+export function scrapedThisCycle(auditContext) {
+  const t = auditContext?.timings;
+  return Number.isFinite(t?.drsStartedAt) && Number.isFinite(t?.drsCompletedAt);
+}
+
+/**
+ * Filters an array of URL objects to only those whose content is already available in DRS,
+ * and returns a per-URL status breakdown alongside the filtered list.
+ *
+ * Runs one `lookupScrapeResults` call per dataset ID. A URL is counted as `available` when it
+ * has `status === 'available'` in **at least one** of the provided datasets (Mystique can then
+ * retrieve its scraped content); as `scraping` when it is not available anywhere but is
+ * `scraping` in at least one dataset; otherwise it is `notFound`.
+ *
+ * Falls back gracefully (returns the original list unchanged, `counts.determined === false`)
+ * when DRS is not configured or every dataset lookup fails / returns null — i.e. when DRS
+ * availability cannot be determined.
+ *
+ * Throws a `DrsNoContentAvailableError` (with the breakdown attached as `.counts`) when DRS is
+ * reachable and successfully responded but reported zero available URLs, meaning scraping has
+ * not completed yet.
  *
  * @param {Array<{url: string}>} urls - URL objects from the URL Store
  * @param {string[]} datasetIds - DRS dataset IDs to check
@@ -265,7 +356,8 @@ export class DrsNoContentAvailableError extends Error {
  * @param {object|null} drsClient - Configured DrsClient instance (or null / unconfigured)
  * @param {object} [log]
  * @param {string} [logPrefix]
- * @returns {Promise<Array<{url: string}>>} Filtered URL objects
+ * @returns {Promise<{urls: Array<{url: string}>, counts: {total: number, available: number,
+ *   scraping: number, notFound: number, determined: boolean}}>}
  * @throws {DrsNoContentAvailableError} When DRS responded but no URLs are available yet
  */
 export async function filterUrlsByDrsStatus(urls, datasetIds, siteId, drsClient, log, logPrefix) {
@@ -273,11 +365,12 @@ export async function filterUrlsByDrsStatus(urls, datasetIds, siteId, drsClient,
 
   if (!drsClient || !drsClient.isConfigured()) {
     log?.info(`${prefix} DRS client not configured, skipping availability filter`);
-    return urls;
+    return { urls, counts: undeterminedDrsCounts(urls.length) };
   }
 
   const rawUrls = urls.map((item) => item.url);
   const availableUrls = new Set();
+  const scrapingUrls = new Set();
   let atLeastOneLookupSucceeded = false;
 
   for (const datasetId of datasetIds) {
@@ -293,11 +386,14 @@ export async function filterUrlsByDrsStatus(urls, datasetIds, siteId, drsClient,
       for (const result of response.results) {
         if (result.status === 'available') {
           availableUrls.add(result.url);
+        } else if (result.status === 'scraping') {
+          scrapingUrls.add(result.url);
         }
       }
       log?.info(
         `${prefix} DRS lookup datasetId=${datasetId}: `
-        + `${response.summary?.available ?? 0}/${response.summary?.total ?? rawUrls.length} available`,
+        + `${response.summary?.available ?? 0}/${response.summary?.total ?? rawUrls.length} available, `
+        + `${response.summary?.scraping ?? 0} scraping, ${response.summary?.not_found ?? 0} not-found`,
       );
     } catch (error) {
       log?.warn(`${prefix} DRS lookup failed for datasetId=${datasetId}: ${error.message}, skipping`);
@@ -306,21 +402,33 @@ export async function filterUrlsByDrsStatus(urls, datasetIds, siteId, drsClient,
 
   if (!atLeastOneLookupSucceeded) {
     log?.warn(`${prefix} All DRS lookups failed or returned null for datasets [${datasetIds.join(', ')}], skipping availability filter`);
-    return urls;
+    return { urls, counts: undeterminedDrsCounts(urls.length) };
   }
 
-  if (availableUrls.size === 0) {
-    throw new DrsNoContentAvailableError(
+  const total = urls.length;
+  const available = availableUrls.size;
+  // A URL only counts as "scraping" when it is not already available in any dataset — an
+  // in-progress scrape for a URL we can already read shouldn't inflate the scraping tally.
+  const scraping = [...scrapingUrls].filter((url) => !availableUrls.has(url)).length;
+  const notFound = Math.max(0, total - available - scraping);
+  const counts = {
+    total, available, scraping, notFound, determined: true,
+  };
+
+  if (available === 0) {
+    const error = new DrsNoContentAvailableError(
       `No scraped content available in DRS for datasets [${datasetIds.join(', ')}] and siteId: ${siteId}`,
     );
+    error.counts = counts;
+    throw error;
   }
 
   const filtered = urls.filter((item) => availableUrls.has(item.url));
-  const removed = urls.length - filtered.length;
+  const removed = total - filtered.length;
   if (removed > 0) {
-    log?.info(`${prefix} DRS availability filter: removed ${removed} URL(s) not yet scraped, ${filtered.length} remaining`);
+    log?.info(`${prefix} DRS availability filter: removed ${removed} URL(s) not yet scraped (${scraping} scraping, ${notFound} not-found), ${filtered.length} remaining`);
   }
-  return filtered;
+  return { urls: filtered, counts };
 }
 
 export function resolveMystiqueUrlLimit(auditContext, log, logPrefix) {

--- a/src/utils/offsite-audit-utils.js
+++ b/src/utils/offsite-audit-utils.js
@@ -237,11 +237,19 @@ export function isExcludedCitedHost(hostname, brandTokens) {
 /**
  * Error thrown when DRS successfully responded but reported no available scraped content.
  * Signals that scraping has not completed yet for any of the requested URLs.
+ *
+ * @param {string} message
+ * @param {{total: number, available: number, scraping: number, notFound: number,
+ *   determined: boolean}} [counts] - DRS status breakdown at the time of the failure, so
+ *   callers can report why nothing was available (e.g. "67 not yet scraped"). Exposed as a
+ *   constructor parameter rather than a post-hoc property so the contract is explicit and
+ *   survives re-throwing / serialization.
  */
 export class DrsNoContentAvailableError extends Error {
-  constructor(message) {
+  constructor(message, counts) {
     super(message);
     this.name = 'DrsNoContentAvailableError';
+    this.counts = counts;
   }
 }
 
@@ -419,11 +427,10 @@ export async function filterUrlsByDrsStatus(urls, datasetIds, siteId, drsClient,
   };
 
   if (available === 0) {
-    const error = new DrsNoContentAvailableError(
+    throw new DrsNoContentAvailableError(
       `No scraped content available in DRS for datasets [${datasetIds.join(', ')}] and siteId: ${siteId}`,
+      counts,
     );
-    error.counts = counts;
-    throw error;
   }
 
   const filtered = urls.filter((item) => availableUrls.has(item.url));

--- a/src/youtube-analysis/handler.js
+++ b/src/youtube-analysis/handler.js
@@ -23,6 +23,9 @@ import {
   resolveMystiqueUrlLimit,
   resolveEnableBrandProfile,
   requestOffsiteScrape,
+  buildAnalysisScrapeStatusMessage,
+  formatDrsExtras,
+  scrapedThisCycle,
 } from '../utils/offsite-audit-utils.js';
 import { OFFSITE_DOMAINS } from '../offsite-brand-presence/constants.js';
 import { computeTopicsFromBrandPresence } from '../utils/offsite-brand-presence-enrichment.js';
@@ -85,8 +88,15 @@ async function fetchStoreData(siteId, context, site) {
 
   const drsClient = DrsClient.createFrom(context);
   const { datasetIds } = OFFSITE_DOMAINS['youtube.com'];
-  const urls = await filterUrlsByDrsStatus(rawUrls, datasetIds, siteId, drsClient, log, LOG_PREFIX);
-  log.info(`${LOG_PREFIX} ${urls.length} YouTube URLs available in DRS`);
+  const { urls, counts } = await filterUrlsByDrsStatus(
+    rawUrls,
+    datasetIds,
+    siteId,
+    drsClient,
+    log,
+    LOG_PREFIX,
+  );
+  log.info(`${LOG_PREFIX} ${urls.length} YouTube URLs available in DRS${formatDrsExtras(counts)}`);
 
   const topics = await computeTopicsFromBrandPresence(siteId, context, site);
   log.info(`${LOG_PREFIX} Computed ${topics.length} topics from brand presence data`);
@@ -112,6 +122,7 @@ async function fetchStoreData(siteId, context, site) {
   return {
     urls,
     sentimentConfig: { topics, guidelines },
+    drsCounts: counts,
   };
 }
 
@@ -155,23 +166,33 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
 
     const storeData = await fetchStoreData(siteId, context, site);
     log.info(`${LOG_PREFIX} Successfully fetched all store data for ${youtubeConfig.companyName}`);
+    // Whether this run's DRS scrape produced the content (poll-dispatched) or we are reusing
+    // a prior scrape (direct/scheduled run) changes the log and Slack wording so the thread
+    // reads as a coherent sequence rather than a contradictory "no scrape needed".
+    const scrapedNow = scrapedThisCycle(auditContext);
     log.info(
-      `${LOG_PREFIX} DRS content available for ${storeData.urls.length} URL(s) `
-        + '— no scrape job needed, proceeding to Mystique',
+      scrapedNow
+        ? `${LOG_PREFIX} DRS scrape finished this cycle; ${storeData.urls.length} URL(s) ready, proceeding to Mystique`
+        : `${LOG_PREFIX} Reusing previously scraped DRS content for ${storeData.urls.length} URL(s); no new scrape needed, proceeding to Mystique`,
     );
 
     const urlLimit = resolveMystiqueUrlLimit(auditContext, log, LOG_PREFIX);
 
     const { slackContext } = auditContext;
 
-    // Manual Slack-triggered runs get a notification explaining that no DRS scrape
-    // job was needed (content already available). No-ops on scheduled runs where
+    // Manual Slack-triggered runs get a notification describing the exact DRS state (fresh
+    // scrape this cycle vs. reused prior content). No-ops on scheduled runs where
     // slackContext is absent.
     await postMessageOptional(
       context,
       slackContext?.channelId,
-      `:mag: *youtube-analysis* for *${site.getBaseURL()}* — DRS content already available `
-        + `(${storeData.urls.length} URL(s)); no scrape job needed, sending to Mystique.`,
+      buildAnalysisScrapeStatusMessage({
+        analysisName: 'youtube-analysis',
+        baseUrl: site.getBaseURL(),
+        urlCount: storeData.urls.length,
+        counts: storeData.drsCounts,
+        scrapedNow,
+      }),
       { threadTs: slackContext?.threadTs },
     );
 
@@ -228,15 +249,31 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
     }
 
     if (error instanceof DrsNoContentAvailableError) {
+      const { slackContext } = auditContext;
+      const { channelId, threadTs } = slackContext || {};
       if (auditContext.drsScrapeRequested) {
+        // A scrape already ran this cycle and DRS still reports no scraped content → terminal.
         log.error(`${LOG_PREFIX} No DRS content available after scraping: ${error.message}`);
+        await postMessageOptional(
+          context,
+          channelId,
+          `:warning: *youtube-analysis* for *${site.getBaseURL()}* — DRS reported no scraped content after scraping; nothing to analyze.`,
+          { threadTs },
+        );
         return {
           auditResult: { success: false, error: error.message },
           fullAuditRef: url,
         };
       }
-      log.info(`${LOG_PREFIX} No DRS content yet, requesting a scrape for youtube.com`);
-      await requestOffsiteScrape(context, siteId, 'youtube.com', auditContext.slackContext, enableBrandProfile);
+      log.info(`${LOG_PREFIX} URLs stored but not scraped in DRS yet, requesting a scrape for youtube.com`);
+      await postMessageOptional(
+        context,
+        channelId,
+        `:mag: *youtube-analysis* for *${site.getBaseURL()}* — YouTube URLs are stored but not scraped in DRS yet${formatDrsExtras(error.counts)}; `
+          + 'starting a DRS scrape for youtube.com, will analyze automatically when it finishes.',
+        { threadTs },
+      );
+      await requestOffsiteScrape(context, siteId, 'youtube.com', slackContext, enableBrandProfile);
       return {
         auditResult: { success: false, status: 'pending_scrape', error: error.message },
         fullAuditRef: url,

--- a/test/audits/cited-analysis/handler.test.js
+++ b/test/audits/cited-analysis/handler.test.js
@@ -507,7 +507,7 @@ describe('Cited Analysis Handler', function () {
       expect(mockPostMessageOptional).to.have.been.calledWithMatch(
         context,
         'C-test',
-        /reusing previously scraped DRS content .* no new scrape needed\. Sending to Mystique/,
+        /reusing previously scraped DRS content .* Sending .* to Mystique for analysis/,
         { threadTs: '1700000000.123456' },
       );
     });
@@ -521,7 +521,7 @@ describe('Cited Analysis Handler', function () {
       expect(mockPostMessageOptional).to.have.been.calledWithMatch(
         context,
         undefined,
-        /reusing previously scraped DRS content .* no new scrape needed\. Sending to Mystique/,
+        /reusing previously scraped DRS content .* Sending .* to Mystique for analysis/,
         { threadTs: undefined },
       );
     });
@@ -539,7 +539,7 @@ describe('Cited Analysis Handler', function () {
       expect(mockPostMessageOptional).to.have.been.calledWithMatch(
         context,
         'C-test',
-        /DRS scrape finished; .* scraped URL\(s\) ready\. Sending to Mystique/,
+        /DRS scrape finished\. Sending .* to Mystique for analysis/,
         { threadTs: '1700000000.123456' },
       );
     });

--- a/test/audits/cited-analysis/handler.test.js
+++ b/test/audits/cited-analysis/handler.test.js
@@ -99,7 +99,16 @@ describe('Cited Analysis Handler', function () {
     };
 
     mockComputeTopicsFromBrandPresence = sandbox.stub().resolves(mockComputedTopics);
-    mockFilterUrlsByDrsStatus = sandbox.stub().callsFake(async (urls) => urls);
+    mockFilterUrlsByDrsStatus = sandbox.stub().callsFake(async (urls) => ({
+      urls,
+      counts: {
+        total: urls.length,
+        available: urls.length,
+        scraping: 0,
+        notFound: 0,
+        determined: true,
+      },
+    }));
     mockPostMessageOptional = sandbox.stub().resolves({ success: true });
 
     mockDrsClient = { isConfigured: sandbox.stub().returns(true) };
@@ -271,7 +280,12 @@ describe('Cited Analysis Handler', function () {
 
     it('should filter URLs by DRS availability before returning store data', async () => {
       const availableUrl = mockUrls[0];
-      mockFilterUrlsByDrsStatus.callsFake(async () => [availableUrl]);
+      mockFilterUrlsByDrsStatus.callsFake(async () => ({
+        urls: [availableUrl],
+        counts: {
+          total: mockUrls.length, available: 1, scraping: 0, notFound: mockUrls.length - 1, determined: true,
+        },
+      }));
 
       const result = await citedAnalysisHandler.default.runner(baseURL, context, mockSite);
 
@@ -493,7 +507,7 @@ describe('Cited Analysis Handler', function () {
       expect(mockPostMessageOptional).to.have.been.calledWithMatch(
         context,
         'C-test',
-        /no scrape job needed, sending to Mystique/,
+        /reusing previously scraped DRS content .* no new scrape needed\. Sending to Mystique/,
         { threadTs: '1700000000.123456' },
       );
     });
@@ -507,8 +521,26 @@ describe('Cited Analysis Handler', function () {
       expect(mockPostMessageOptional).to.have.been.calledWithMatch(
         context,
         undefined,
-        /no scrape job needed, sending to Mystique/,
+        /reusing previously scraped DRS content .* no new scrape needed\. Sending to Mystique/,
         { threadTs: undefined },
+      );
+    });
+
+    it('reports a fresh scrape when DRS timings are present (poll-dispatched)', async () => {
+      const slackContext = { channelId: 'C-test', threadTs: '1700000000.123456' };
+      const result = await citedAnalysisHandler.default.runner(
+        baseURL,
+        context,
+        mockSite,
+        { slackContext, timings: { drsStartedAt: 1000, drsCompletedAt: 2000 } },
+      );
+
+      expect(result.auditResult.success).to.be.true;
+      expect(mockPostMessageOptional).to.have.been.calledWithMatch(
+        context,
+        'C-test',
+        /DRS scrape finished; .* scraped URL\(s\) ready\. Sending to Mystique/,
+        { threadTs: '1700000000.123456' },
       );
     });
   });

--- a/test/audits/offsite-brand-presence.test.js
+++ b/test/audits/offsite-brand-presence.test.js
@@ -1461,12 +1461,18 @@ describe('Offsite Brand Presence Handler', () => {
 
       await offsiteBrandPresenceRunner(FINAL_URL, context, site, AUDIT_CONTEXT_WITH_SLACK);
 
-      expect(mockPostMessageOptional).to.have.been.calledOnce;
-      const [callCtx, callChannelId, callText, callOptions] = mockPostMessageOptional.firstCall.args;
-      expect(callCtx).to.equal(context);
-      expect(callChannelId).to.equal(SLACK_CHANNEL_ID);
-      expect(callOptions).to.deep.equal({ threadTs: SLACK_THREAD_TS });
-      expect(callText).to.include('offsite-brand-presence');
+      // Two thread replies: the URL-Store step summary, then the DRS scraping-started message.
+      expect(mockPostMessageOptional).to.have.been.calledTwice;
+      const [storeCtx, storeChannelId, storeText, storeOptions] = mockPostMessageOptional
+        .firstCall.args;
+      expect(storeCtx).to.equal(context);
+      expect(storeChannelId).to.equal(SLACK_CHANNEL_ID);
+      expect(storeOptions).to.deep.equal({ threadTs: SLACK_THREAD_TS });
+      expect(storeText).to.include('collected & stored');
+      expect(storeText).to.include(BASE_URL);
+
+      const callText = mockPostMessageOptional.secondCall.args[2];
+      expect(callText).to.include('DRS scraping started');
       expect(callText).to.include(BASE_URL);
       expect(callText).to.include('youtube.com');
       expect(callText).to.include('mock-job');
@@ -1478,8 +1484,8 @@ describe('Offsite Brand Presence Handler', () => {
 
       await offsiteBrandPresenceRunner(FINAL_URL, context, site, AUDIT_CONTEXT_WITH_SLACK);
 
-      expect(mockPostMessageOptional).to.have.been.calledOnce;
-      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(mockPostMessageOptional).to.have.been.calledTwice;
+      const callText = mockPostMessageOptional.secondCall.args[2];
       expect(callText).to.include('reddit.com');
       expect(callText).to.include('mock-job');
       expect(callText).to.not.include(':x:');
@@ -1494,10 +1500,10 @@ describe('Offsite Brand Presence Handler', () => {
 
       await offsiteBrandPresenceRunner(FINAL_URL, context, site, AUDIT_CONTEXT_WITH_SLACK);
 
-      expect(mockPostMessageOptional).to.have.been.calledOnce;
-      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(mockPostMessageOptional).to.have.been.calledTwice;
+      const callText = mockPostMessageOptional.secondCall.args[2];
       expect(callText).to.include(':x:');
-      expect(callText).to.include('Failed (1)');
+      expect(callText).to.include('Failed to submit (1)');
       expect(callText).to.include('400');
       expect(callText).to.include('youtube.com');
       expect(callText).to.include('mock-job');
@@ -1509,8 +1515,10 @@ describe('Offsite Brand Presence Handler', () => {
 
       await offsiteBrandPresenceRunner(FINAL_URL, context, site, AUDIT_CONTEXT_WITH_SLACK);
 
-      expect(mockPostMessageOptional).to.have.been.calledOnce;
-      const [callCtx, callChannelId, callText, callOptions] = mockPostMessageOptional.firstCall.args;
+      // Store summary posts first, then the skip notification.
+      expect(mockPostMessageOptional).to.have.been.calledTwice;
+      const [callCtx, callChannelId, callText, callOptions] = mockPostMessageOptional
+        .secondCall.args;
       expect(callCtx).to.equal(context);
       expect(callChannelId).to.equal(SLACK_CHANNEL_ID);
       expect(callOptions).to.deep.equal({ threadTs: SLACK_THREAD_TS });
@@ -1525,8 +1533,8 @@ describe('Offsite Brand Presence Handler', () => {
 
       await offsiteBrandPresenceRunner(FINAL_URL, context, site, AUDIT_CONTEXT_WITH_SLACK);
 
-      expect(mockPostMessageOptional).to.have.been.calledOnce;
-      const callText = mockPostMessageOptional.firstCall.args[2];
+      expect(mockPostMessageOptional).to.have.been.calledTwice;
+      const callText = mockPostMessageOptional.secondCall.args[2];
       expect(callText).to.match(/skipped/i);
       expect(callText).to.include('imsOrgId');
       expect(callText).to.include(BASE_URL);

--- a/test/audits/offsite-brand-presence.test.js
+++ b/test/audits/offsite-brand-presence.test.js
@@ -1468,7 +1468,8 @@ describe('Offsite Brand Presence Handler', () => {
       expect(storeCtx).to.equal(context);
       expect(storeChannelId).to.equal(SLACK_CHANNEL_ID);
       expect(storeOptions).to.deep.equal({ threadTs: SLACK_THREAD_TS });
-      expect(storeText).to.include('collected & stored');
+      expect(storeText).to.include('selected');
+      expect(storeText).to.include('to scrape this run');
       expect(storeText).to.include(BASE_URL);
 
       const callText = mockPostMessageOptional.secondCall.args[2];

--- a/test/audits/reddit-analysis/handler.test.js
+++ b/test/audits/reddit-analysis/handler.test.js
@@ -92,7 +92,16 @@ describe('Reddit Analysis Handler', function () {
     };
 
     mockComputeTopicsFromBrandPresence = sandbox.stub().resolves(mockComputedTopics);
-    mockFilterUrlsByDrsStatus = sandbox.stub().callsFake(async (urls) => urls);
+    mockFilterUrlsByDrsStatus = sandbox.stub().callsFake(async (urls) => ({
+      urls,
+      counts: {
+        total: urls.length,
+        available: urls.length,
+        scraping: 0,
+        notFound: 0,
+        determined: true,
+      },
+    }));
 
     mockDrsClient = { isConfigured: sandbox.stub().returns(true) };
 
@@ -406,7 +415,12 @@ describe('Reddit Analysis Handler', function () {
 
     it('should filter URLs by DRS availability before returning store data', async () => {
       const availableUrl = mockUrls[0];
-      mockFilterUrlsByDrsStatus.callsFake(async () => [availableUrl]);
+      mockFilterUrlsByDrsStatus.callsFake(async () => ({
+        urls: [availableUrl],
+        counts: {
+          total: mockUrls.length, available: 1, scraping: 0, notFound: mockUrls.length - 1, determined: true,
+        },
+      }));
 
       const result = await redditAnalysisHandler.default.runner(baseURL, context, mockSite);
 
@@ -493,7 +507,7 @@ describe('Reddit Analysis Handler', function () {
       expect(mockPostMessageOptional).to.have.been.calledWithMatch(
         context,
         'C-test',
-        /no scrape job needed, sending to Mystique/,
+        /reusing previously scraped DRS content .* no new scrape needed\. Sending to Mystique/,
         { threadTs: '1700000000.123456' },
       );
     });
@@ -507,8 +521,26 @@ describe('Reddit Analysis Handler', function () {
       expect(mockPostMessageOptional).to.have.been.calledWithMatch(
         context,
         undefined,
-        /no scrape job needed, sending to Mystique/,
+        /reusing previously scraped DRS content .* no new scrape needed\. Sending to Mystique/,
         { threadTs: undefined },
+      );
+    });
+
+    it('reports a fresh scrape when DRS timings are present (poll-dispatched)', async () => {
+      const slackContext = { channelId: 'C-test', threadTs: '1700000000.123456' };
+      const result = await redditAnalysisHandler.default.runner(
+        baseURL,
+        context,
+        mockSite,
+        { slackContext, timings: { drsStartedAt: 1000, drsCompletedAt: 2000 } },
+      );
+
+      expect(result.auditResult.success).to.be.true;
+      expect(mockPostMessageOptional).to.have.been.calledWithMatch(
+        context,
+        'C-test',
+        /DRS scrape finished; .* scraped URL\(s\) ready\. Sending to Mystique/,
+        { threadTs: '1700000000.123456' },
       );
     });
   });

--- a/test/audits/reddit-analysis/handler.test.js
+++ b/test/audits/reddit-analysis/handler.test.js
@@ -507,7 +507,7 @@ describe('Reddit Analysis Handler', function () {
       expect(mockPostMessageOptional).to.have.been.calledWithMatch(
         context,
         'C-test',
-        /reusing previously scraped DRS content .* no new scrape needed\. Sending to Mystique/,
+        /reusing previously scraped DRS content .* Sending .* to Mystique for analysis/,
         { threadTs: '1700000000.123456' },
       );
     });
@@ -521,7 +521,7 @@ describe('Reddit Analysis Handler', function () {
       expect(mockPostMessageOptional).to.have.been.calledWithMatch(
         context,
         undefined,
-        /reusing previously scraped DRS content .* no new scrape needed\. Sending to Mystique/,
+        /reusing previously scraped DRS content .* Sending .* to Mystique for analysis/,
         { threadTs: undefined },
       );
     });
@@ -539,7 +539,7 @@ describe('Reddit Analysis Handler', function () {
       expect(mockPostMessageOptional).to.have.been.calledWithMatch(
         context,
         'C-test',
-        /DRS scrape finished; .* scraped URL\(s\) ready\. Sending to Mystique/,
+        /DRS scrape finished\. Sending .* to Mystique for analysis/,
         { threadTs: '1700000000.123456' },
       );
     });

--- a/test/audits/youtube-analysis/handler.test.js
+++ b/test/audits/youtube-analysis/handler.test.js
@@ -489,7 +489,7 @@ describe('YouTube Analysis Handler', function () {
       expect(mockPostMessageOptional).to.have.been.calledWithMatch(
         context,
         'C-test',
-        /reusing previously scraped DRS content .* no new scrape needed\. Sending to Mystique/,
+        /reusing previously scraped DRS content .* Sending .* to Mystique for analysis/,
         { threadTs: '1700000000.123456' },
       );
     });
@@ -503,7 +503,7 @@ describe('YouTube Analysis Handler', function () {
       expect(mockPostMessageOptional).to.have.been.calledWithMatch(
         context,
         undefined,
-        /reusing previously scraped DRS content .* no new scrape needed\. Sending to Mystique/,
+        /reusing previously scraped DRS content .* Sending .* to Mystique for analysis/,
         { threadTs: undefined },
       );
     });
@@ -521,7 +521,7 @@ describe('YouTube Analysis Handler', function () {
       expect(mockPostMessageOptional).to.have.been.calledWithMatch(
         context,
         'C-test',
-        /DRS scrape finished; .* scraped URL\(s\) ready\. Sending to Mystique/,
+        /DRS scrape finished\. Sending .* to Mystique for analysis/,
         { threadTs: '1700000000.123456' },
       );
     });

--- a/test/audits/youtube-analysis/handler.test.js
+++ b/test/audits/youtube-analysis/handler.test.js
@@ -93,7 +93,16 @@ describe('YouTube Analysis Handler', function () {
     };
 
     mockComputeTopicsFromBrandPresence = sandbox.stub().resolves(mockComputedTopics);
-    mockFilterUrlsByDrsStatus = sandbox.stub().callsFake(async (urls) => urls);
+    mockFilterUrlsByDrsStatus = sandbox.stub().callsFake(async (urls) => ({
+      urls,
+      counts: {
+        total: urls.length,
+        available: urls.length,
+        scraping: 0,
+        notFound: 0,
+        determined: true,
+      },
+    }));
 
     mockDrsClient = { isConfigured: sandbox.stub().returns(true) };
 
@@ -388,7 +397,12 @@ describe('YouTube Analysis Handler', function () {
 
     it('should filter URLs by DRS availability before returning store data', async () => {
       const availableUrl = mockUrls[0];
-      mockFilterUrlsByDrsStatus.callsFake(async () => [availableUrl]);
+      mockFilterUrlsByDrsStatus.callsFake(async () => ({
+        urls: [availableUrl],
+        counts: {
+          total: mockUrls.length, available: 1, scraping: 0, notFound: mockUrls.length - 1, determined: true,
+        },
+      }));
 
       const result = await youtubeAnalysisHandler.default.runner(baseURL, context, mockSite);
 
@@ -475,7 +489,7 @@ describe('YouTube Analysis Handler', function () {
       expect(mockPostMessageOptional).to.have.been.calledWithMatch(
         context,
         'C-test',
-        /no scrape job needed, sending to Mystique/,
+        /reusing previously scraped DRS content .* no new scrape needed\. Sending to Mystique/,
         { threadTs: '1700000000.123456' },
       );
     });
@@ -489,8 +503,26 @@ describe('YouTube Analysis Handler', function () {
       expect(mockPostMessageOptional).to.have.been.calledWithMatch(
         context,
         undefined,
-        /no scrape job needed, sending to Mystique/,
+        /reusing previously scraped DRS content .* no new scrape needed\. Sending to Mystique/,
         { threadTs: undefined },
+      );
+    });
+
+    it('reports a fresh scrape when DRS timings are present (poll-dispatched)', async () => {
+      const slackContext = { channelId: 'C-test', threadTs: '1700000000.123456' };
+      const result = await youtubeAnalysisHandler.default.runner(
+        baseURL,
+        context,
+        mockSite,
+        { slackContext, timings: { drsStartedAt: 1000, drsCompletedAt: 2000 } },
+      );
+
+      expect(result.auditResult.success).to.be.true;
+      expect(mockPostMessageOptional).to.have.been.calledWithMatch(
+        context,
+        'C-test',
+        /DRS scrape finished; .* scraped URL\(s\) ready\. Sending to Mystique/,
+        { threadTs: '1700000000.123456' },
       );
     });
   });

--- a/test/utils/offsite-audit-utils.test.js
+++ b/test/utils/offsite-audit-utils.test.js
@@ -329,19 +329,19 @@ describe('offsite-audit-utils', () => {
     it('reports scraping only', () => {
       expect(formatDrsExtras({
         available: 5, scraping: 3, notFound: 0, determined: true,
-      })).to.equal(' (3 still scraping — proceeding with 5 ready)');
+      })).to.equal(' (3 still scraping)');
     });
 
     it('reports not-found only', () => {
       expect(formatDrsExtras({
         available: 5, scraping: 0, notFound: 2, determined: true,
-      })).to.equal(' (2 not yet scraped — proceeding with 5 ready)');
+      })).to.equal(' (2 not yet scraped)');
     });
 
     it('reports both scraping and not-found', () => {
       expect(formatDrsExtras({
         available: 5, scraping: 3, notFound: 2, determined: true,
-      })).to.equal(' (3 still scraping, 2 not yet scraped — proceeding with 5 ready)');
+      })).to.equal(' (3 still scraping, 2 not yet scraped)');
     });
   });
 
@@ -357,8 +357,8 @@ describe('offsite-audit-utils', () => {
         scrapedNow: true,
       });
       expect(msg).to.equal(
-        ':mag: *reddit-analysis* for *https://example.com* — DRS scrape finished; '
-        + '*12* scraped URL(s) ready. Sending to Mystique.',
+        ':mag: *reddit-analysis* for *https://example.com* — DRS scrape finished. '
+        + 'Sending *12* available URL(s) from the URL store to Mystique for analysis.',
       );
     });
 
@@ -374,8 +374,8 @@ describe('offsite-audit-utils', () => {
       });
       expect(msg).to.equal(
         ':mag: *cited-analysis* for *https://example.com* — reusing previously scraped DRS content '
-        + '(*8* URL(s) available (2 still scraping, 1 not yet scraped — proceeding with 8 ready)); '
-        + 'no new scrape needed. Sending to Mystique.',
+        + '(no new scrape needed). Sending *8* available URL(s) from the URL store to Mystique '
+        + 'for analysis (2 still scraping, 1 not yet scraped).',
       );
     });
   });

--- a/test/utils/offsite-audit-utils.test.js
+++ b/test/utils/offsite-audit-utils.test.js
@@ -27,6 +27,9 @@ import {
   toApexHost,
   formatDuration,
   buildOffsiteTimingLines,
+  formatDrsExtras,
+  buildAnalysisScrapeStatusMessage,
+  scrapedThisCycle,
 } from '../../src/utils/offsite-audit-utils.js';
 import {
   DRS_POLL_INTERVAL_SECONDS,
@@ -97,16 +100,20 @@ describe('offsite-audit-utils', () => {
     const datasetIds = ['dataset_one', 'dataset_two'];
     const siteId = 'site-123';
 
-    it('returns original list when drsClient is null', async () => {
+    it('returns original list with undetermined counts when drsClient is null', async () => {
       const result = await filterUrlsByDrsStatus(urls, datasetIds, siteId, null);
-      expect(result).to.deep.equal(urls);
+      expect(result.urls).to.deep.equal(urls);
+      expect(result.counts).to.deep.equal({
+        total: 3, available: 3, scraping: 0, notFound: 0, determined: false,
+      });
     });
 
     it('returns original list when drsClient is not configured', async () => {
       const log = { info: sandbox.stub() };
       const drsClient = { isConfigured: sandbox.stub().returns(false) };
       const result = await filterUrlsByDrsStatus(urls, datasetIds, siteId, drsClient, log, '[T]');
-      expect(result).to.deep.equal(urls);
+      expect(result.urls).to.deep.equal(urls);
+      expect(result.counts.determined).to.equal(false);
       expect(log.info).to.have.been.calledWith('[T] DRS client not configured, skipping availability filter');
     });
 
@@ -141,12 +148,15 @@ describe('offsite-audit-utils', () => {
 
       const result = await filterUrlsByDrsStatus(urls, datasetIds, siteId, drsClient, log, '[T]');
 
-      expect(result).to.have.lengthOf(2);
-      expect(result.map((u) => u.url)).to.include.members([
+      expect(result.urls).to.have.lengthOf(2);
+      expect(result.urls.map((u) => u.url)).to.include.members([
         'https://example.com/a',
         'https://example.com/b',
       ]);
-      expect(log.info).to.have.been.calledWith('[T] DRS availability filter: removed 1 URL(s) not yet scraped, 2 remaining');
+      expect(result.counts).to.deep.equal({
+        total: 3, available: 2, scraping: 0, notFound: 1, determined: true,
+      });
+      expect(log.info).to.have.been.calledWith('[T] DRS availability filter: removed 1 URL(s) not yet scraped (0 scraping, 1 not-found), 2 remaining');
     });
 
     it('logs summary per dataset', async () => {
@@ -163,7 +173,32 @@ describe('offsite-audit-utils', () => {
 
       await filterUrlsByDrsStatus(urls, ['ds1'], siteId, drsClient, log, '[T]');
 
-      expect(log.info).to.have.been.calledWith('[T] DRS lookup datasetId=ds1: 1/3 available');
+      expect(log.info).to.have.been.calledWith('[T] DRS lookup datasetId=ds1: 1/3 available, 0 scraping, 2 not-found');
+    });
+
+    it('counts still-scraping URLs separately from not-found ones', async () => {
+      const log = { info: sandbox.stub(), warn: sandbox.stub() };
+      const drsClient = {
+        isConfigured: sandbox.stub().returns(true),
+        lookupScrapeResults: sandbox.stub().resolves({
+          results: [
+            { url: 'https://example.com/a', status: 'available' },
+            { url: 'https://example.com/b', status: 'scraping' },
+            { url: 'https://example.com/c', status: 'not_found' },
+          ],
+          summary: {
+            total: 3, available: 1, scraping: 1, not_found: 1,
+          },
+        }),
+      };
+
+      const result = await filterUrlsByDrsStatus(urls, ['ds1'], siteId, drsClient, log, '[T]');
+
+      expect(result.urls.map((u) => u.url)).to.deep.equal(['https://example.com/a']);
+      expect(result.counts).to.deep.equal({
+        total: 3, available: 1, scraping: 1, notFound: 1, determined: true,
+      });
+      expect(log.info).to.have.been.calledWith('[T] DRS availability filter: removed 2 URL(s) not yet scraped (1 scraping, 1 not-found), 1 remaining');
     });
 
     it('throws DrsNoContentAvailableError when DRS responded but no URLs are available', async () => {
@@ -178,9 +213,17 @@ describe('offsite-audit-utils', () => {
         }),
       };
 
-      await expect(
-        filterUrlsByDrsStatus(urls, datasetIds, siteId, drsClient, log, '[T]'),
-      ).to.be.rejectedWith(DrsNoContentAvailableError);
+      let thrown;
+      try {
+        await filterUrlsByDrsStatus(urls, datasetIds, siteId, drsClient, log, '[T]');
+      } catch (error) {
+        thrown = error;
+      }
+      expect(thrown).to.be.instanceOf(DrsNoContentAvailableError);
+      // The status breakdown is attached so callers can report why no content was available.
+      expect(thrown.counts).to.deep.equal({
+        total: 3, available: 0, scraping: 0, notFound: 3, determined: true,
+      });
     });
 
     it('falls back to full list when all lookups return null', async () => {
@@ -192,7 +235,8 @@ describe('offsite-audit-utils', () => {
 
       const result = await filterUrlsByDrsStatus(urls, ['ds1'], siteId, drsClient, log, '[T]');
 
-      expect(result).to.deep.equal(urls);
+      expect(result.urls).to.deep.equal(urls);
+      expect(result.counts.determined).to.equal(false);
       expect(log.warn).to.have.been.calledWithMatch(/DRS lookup returned null/);
       expect(log.warn).to.have.been.calledWithMatch(/All DRS lookups failed or returned null/);
     });
@@ -206,7 +250,8 @@ describe('offsite-audit-utils', () => {
 
       const result = await filterUrlsByDrsStatus(urls, ['ds1'], siteId, drsClient, log, '[T]');
 
-      expect(result).to.deep.equal(urls);
+      expect(result.urls).to.deep.equal(urls);
+      expect(result.counts.determined).to.equal(false);
       expect(log.warn).to.have.been.calledWithMatch(/DRS lookup failed for datasetId=ds1/);
       expect(log.warn).to.have.been.calledWithMatch(/All DRS lookups failed or returned null/);
     });
@@ -225,7 +270,10 @@ describe('offsite-audit-utils', () => {
 
       const result = await filterUrlsByDrsStatus(urls, ['ds1'], siteId, drsClient, log);
 
-      expect(result).to.deep.equal(urls);
+      expect(result.urls).to.deep.equal(urls);
+      expect(result.counts).to.deep.equal({
+        total: 3, available: 3, scraping: 0, notFound: 0, determined: true,
+      });
       expect(log.info).to.not.have.been.calledWithMatch(/DRS availability filter: removed/);
     });
 
@@ -242,8 +290,8 @@ describe('offsite-audit-utils', () => {
 
       const result = await filterUrlsByDrsStatus(urls, ['ds1'], siteId, drsClient);
 
-      expect(result).to.have.lengthOf(1);
-      expect(result[0].url).to.equal('https://example.com/a');
+      expect(result.urls).to.have.lengthOf(1);
+      expect(result.urls[0].url).to.equal('https://example.com/a');
     });
 
     it('falls back to rawUrls.length in summary log when response.summary is absent', async () => {
@@ -258,8 +306,89 @@ describe('offsite-audit-utils', () => {
       await filterUrlsByDrsStatus(urls, ['ds1'], siteId, drsClient, log, '[T]');
 
       expect(log.info).to.have.been.calledWith(
-        `[T] DRS lookup datasetId=ds1: 0/${urls.length} available`,
+        `[T] DRS lookup datasetId=ds1: 0/${urls.length} available, 0 scraping, 0 not-found`,
       );
+    });
+  });
+
+  describe('formatDrsExtras', () => {
+    it('returns empty string for undetermined counts', () => {
+      expect(formatDrsExtras({ determined: false })).to.equal('');
+    });
+
+    it('returns empty string when counts are missing', () => {
+      expect(formatDrsExtras(undefined)).to.equal('');
+    });
+
+    it('returns empty string when every URL is available', () => {
+      expect(formatDrsExtras({
+        available: 5, scraping: 0, notFound: 0, determined: true,
+      })).to.equal('');
+    });
+
+    it('reports scraping only', () => {
+      expect(formatDrsExtras({
+        available: 5, scraping: 3, notFound: 0, determined: true,
+      })).to.equal(' (3 still scraping — proceeding with 5 ready)');
+    });
+
+    it('reports not-found only', () => {
+      expect(formatDrsExtras({
+        available: 5, scraping: 0, notFound: 2, determined: true,
+      })).to.equal(' (2 not yet scraped — proceeding with 5 ready)');
+    });
+
+    it('reports both scraping and not-found', () => {
+      expect(formatDrsExtras({
+        available: 5, scraping: 3, notFound: 2, determined: true,
+      })).to.equal(' (3 still scraping, 2 not yet scraped — proceeding with 5 ready)');
+    });
+  });
+
+  describe('buildAnalysisScrapeStatusMessage', () => {
+    it('describes a fresh scrape that finished this cycle', () => {
+      const msg = buildAnalysisScrapeStatusMessage({
+        analysisName: 'reddit-analysis',
+        baseUrl: 'https://example.com',
+        urlCount: 12,
+        counts: {
+          available: 12, scraping: 0, notFound: 0, determined: true,
+        },
+        scrapedNow: true,
+      });
+      expect(msg).to.equal(
+        ':mag: *reddit-analysis* for *https://example.com* — DRS scrape finished; '
+        + '*12* scraped URL(s) ready. Sending to Mystique.',
+      );
+    });
+
+    it('describes reused prior content and appends the pending breakdown', () => {
+      const msg = buildAnalysisScrapeStatusMessage({
+        analysisName: 'cited-analysis',
+        baseUrl: 'https://example.com',
+        urlCount: 8,
+        counts: {
+          available: 8, scraping: 2, notFound: 1, determined: true,
+        },
+        scrapedNow: false,
+      });
+      expect(msg).to.equal(
+        ':mag: *cited-analysis* for *https://example.com* — reusing previously scraped DRS content '
+        + '(*8* URL(s) available (2 still scraping, 1 not yet scraped — proceeding with 8 ready)); '
+        + 'no new scrape needed. Sending to Mystique.',
+      );
+    });
+  });
+
+  describe('scrapedThisCycle', () => {
+    it('is true when both DRS timing anchors are present', () => {
+      expect(scrapedThisCycle({ timings: { drsStartedAt: 1, drsCompletedAt: 2 } })).to.equal(true);
+    });
+
+    it('is false when timing anchors are missing (reused prior content)', () => {
+      expect(scrapedThisCycle({ timings: { analysisStartedAt: 1 } })).to.equal(false);
+      expect(scrapedThisCycle({})).to.equal(false);
+      expect(scrapedThisCycle(undefined)).to.equal(false);
     });
   });
 
@@ -536,7 +665,7 @@ describe('offsite-audit-utils', () => {
 
     it('reports DRS as n/a when no scrape ran this cycle', () => {
       const lines = buildOffsiteTimingLines({ analysisStartedAt: now - 45_000 }, now);
-      expect(lines).to.include('• DRS scrape: already scraped (n/a)');
+      expect(lines).to.include('• DRS scrape: reused prior scrape (n/a)');
       expect(lines).to.include('• Suggestion generation (Mystique): 45s');
       expect(lines).to.include('• Total: 45s');
       expect(lines).to.not.include('DRS + Mystique');

--- a/test/utils/offsite-audit-utils.test.js
+++ b/test/utils/offsite-audit-utils.test.js
@@ -88,6 +88,15 @@ describe('offsite-audit-utils', () => {
       expect(error).to.be.instanceOf(Error);
       expect(error.name).to.equal('DrsNoContentAvailableError');
       expect(error.message).to.equal('nothing ready');
+      expect(error.counts).to.be.undefined;
+    });
+
+    it('exposes the DRS status breakdown passed to the constructor', () => {
+      const counts = {
+        total: 70, available: 0, scraping: 3, notFound: 67, determined: true,
+      };
+      const error = new DrsNoContentAvailableError('nothing ready', counts);
+      expect(error.counts).to.deep.equal(counts);
     });
   });
 


### PR DESCRIPTION
## Problem

The offsite-brand-presence flow (**URL Store → DRS scrape → Mystique**) posted Slack messages that contradicted each other within the same thread. Concretely, a single run looked like this:

- `3:29` ✅ *DRS jobs … job_id …* (a scrape **was** triggered)
- `3:40` 🔍 *DRS content already available … **no scrape job needed***
- `4:31` 🏁 *DRS jobs complete … DRS scraping elapsed: ~62m*
- `4:45` ✅ *audit finished … **DRS scrape: 62m 38s***

The `reddit`/`youtube`/`cited` analysis audits **always** printed *"DRS content already available … no scrape job needed"* whenever the URL store had content — even when a DRS scrape had just run this cycle and its duration was reported moments later. A scrape was very much needed and did run; the analysis audit just didn't *request* one itself. The blanket wording hid that distinction and read as self-contradictory.

## Scope

**Logging & messaging only — no change to what gets scraped or when.**

## Changes

- **Analysis audits** now key off the DRS phase-timing anchors (`auditContext.timings`) to describe exactly what happened:
  - Fresh scrape this cycle (poll-dispatched) → *"DRS scrape finished; N scraped URL(s) ready. Sending to Mystique."*
  - Reusing a prior scrape (direct/scheduled run) → *"reusing previously scraped DRS content (N URL(s) available); no new scrape needed. Sending to Mystique."*
- **`filterUrlsByDrsStatus`** now returns `{ urls, counts }` with an available / scraping / not-found breakdown (surfaced in logs and Slack) instead of collapsing `scraping` and `not_found` into one. The breakdown is attached to `DrsNoContentAvailableError` so the "requesting a scrape" path can explain *why* nothing was available.
- **`offsite-brand-presence`**: added a URL-Store step message (*"collected & stored N URL(s)…"*) and reworded the jobs message to *"DRS scraping started … running in the background"* so it no longer reads as complete.
- **DRS status poll**: header reworded to *"DRS scraping complete"*; added an *"Analysis dispatched to Mystique for: …"* footer.
- Added the previously-missing Slack messages for the *"stored but not scraped yet → starting scrape"* and *"no content after scraping"* analysis paths.
- New shared helpers (`buildAnalysisScrapeStatusMessage`, `formatDrsExtras`, `scrapedThisCycle`) keep the three analysis handlers consistent.

## Testing

- `npm test` — full suite green, **100% coverage** maintained on every changed source file.
- Added cases for the fresh-scrape branch, the status-count breakdown, and the new helpers across all six affected suites.