### PR TITLE
docs(referral-traffic): spec for referral category generation from DRS sources (GA4/AA/CJA) | LLMO-6257

### DIFF
--- a/docs/specs/2026-07-26-referral-category-drs-generation.md
+++ b/docs/specs/2026-07-26-referral-category-drs-generation.md
@@ -35,6 +35,44 @@ DRS runs in a separate AWS account and cannot read the database directly, so:
 
 **Reuse (no new work):** the projector (already accepts `referral_url_classifications`), the data-service (the import RPC + tables), the api read RPCs, and the UI are all unchanged — they already handle this data for optel/cdn.
 
+### Architecture (with the chosen options)
+
+Two tracks: **Track 1** builds each site's rulebook (Fix A — the sweeper); **Track 2** applies it to DRS traffic (Fix B). Everything from the projector down is reused from Phase 1.
+
+```mermaid
+flowchart TB
+  subgraph TRACK1["Track 1 — Build the rulebook (Fix A: weekly sweeper)"]
+    direction TB
+    SCH["Scheduler (weekly)"] --> SW["audit-worker: sweeper job (new)"]
+    SW -->|"fetch top URLs"| CORP["rpc_referral_traffic_top_urls (corpus, all 5 sources)"]
+    SW -->|"no rules yet: LLM builds them"| RB["data-service: agentic_url_category_rules = THE RULEBOOK"]
+  end
+
+  subgraph TRACK2["Track 2 — Apply the rulebook (Fix B: DRS classifies in Python)"]
+    direction TB
+    DRS["DRS: imports GA4, AA, CJA"] -->|"1. GET rules"| EP["api-service: rules endpoint (new)"]
+    EP -->|"rules JSON"| DRS
+    DRS -->|"2. classify in Python, 3. write CSV"| PROJ["projector: single doorman (reused)"]
+    PROJ --> CLS["data-service: referral_url_classifications = THE TAGS (reused)"]
+    CLS --> API["api-service: referral read endpoints (reused)"]
+    API --> UI["UI: Category dropdown (reused)"]
+  end
+
+  EP -.->|"reads"| RB
+```
+
+**New vs reused:**
+
+| Piece | Status |
+|---|---|
+| Weekly **sweeper** (Track 1) | 🆕 new — re-triggers the existing `generateReferralCategoryRules` (create-if-missing) |
+| **Rules endpoint** (api-service) | 🆕 new — a small read endpoint |
+| **DRS Python classify** | 🆕 new — DRS team |
+| Corpus RPC + rulebook table | ♻️ reused (already shipped) |
+| projector → data-service → api → UI | ♻️ reused, untouched |
+
+*(This shows Option A. Under Option B only the "sweeper job" node becomes a "dedicated rule-gen audit"; the rest of the diagram is identical.)*
+
 ## 4. How it works (trace one GA4 URL end-to-end)
 
 1. DRS imports GA4 referral traffic for a site (as it does today).

--- a/docs/specs/2026-07-26-referral-category-drs-generation.md
+++ b/docs/specs/2026-07-26-referral-category-drs-generation.md
@@ -20,7 +20,7 @@ Result: DRS-only sites are stuck showing "All Categories." A prod scan on 2026-0
 
 - DRS-only sites (GA4/AA/CJA) get referral categories, matching the optel/cdn experience.
 - cdn-only sites — broken in prod today (0% categories) — also start getting categories.
-- The JS classifier (optel/cdn) and the Python classifier (DRS) stay in **parity**: identical `url_path` canonicalization and classification output.
+- The JS classifier (optel/cdn) and the Python classifier (DRS) stay in **classification parity**: given the same rulebook and `url_path`, both return the same category. `url_path` keys are **producer-native** — optel/cdn share the JS `canonicalizeUrlPath` form; DRS (ga4/aa/cja) emits its stored `url_path` verbatim, because its read-join is per-source and it classifies the exact path it wrote (see §3, §7.4).
 - No new load or risk on the reused downstream path (projector → data-service → api → UI).
 
 ## 3. Plan (technical design)
@@ -37,7 +37,7 @@ Today `generateReferralCategoryRules` only runs when the optel handler runs. Cha
 **Fix B — DRS classifies its own URLs write-time, in Python.**
 DRS runs in a separate AWS account and **cannot reach the data-service PostgREST** to read the rules directly. It *can*, however, reach the **api-service** (it already calls it), so:
 - **Reuse the existing api-service endpoint** `GET /sites/:siteId/agentic-categories`, which already returns a site's active category rules as `{ name, regex, sortOrder, ... }` (verified in `agentic-rules-factory.js` + `AgenticRuleDto`) and is gated by `site:read`. DRS already calls the api-service, so it just calls this — **no new endpoint needed.** The only remaining piece is **authorizing DRS** to call it (provision `site:read` / the S2S capability), an auth/provisioning task rather than endpoint code.
-- In DRS (Python), after it imports GA4/AA/CJA traffic, it fetches the rules via that endpoint, classifies each URL (mirroring the JS `classify.js` logic, including the same `url_path` canonicalization), writes the same category CSV, and drops it into the existing pipeline.
+- In DRS (Python), after it imports GA4/AA/CJA traffic, it fetches the rules via that endpoint, classifies each URL (mirroring the JS `classify.js` **matching semantics** — always case-insensitive, `sortOrder` precedence, ReDoS-shape rejection — against the `url_path` it stored **verbatim**, not the JS canonical form), writes the same category CSV, and drops it into the existing pipeline.
 
 **Reuse (no new work):** the projector (already accepts `referral_url_classifications`), the data-service (the import RPC + tables), the api read RPCs, and the UI are all unchanged — they already handle this data for optel/cdn.
 
@@ -85,7 +85,7 @@ The DRS→projector hand-off uses the **same transport as optel/cdn**: the produ
 
 1. DRS imports GA4 referral traffic for a site (as it does today).
 2. DRS calls the api-service **rules endpoint** → gets the site's category rulebook. *(rulebook exists because Fix A now generates rules for this site.)*
-3. DRS **classifies** each GA4 URL against the rulebook (Python, same canonicalization as JS) → produces `host, url_path, category_name` rows.
+3. DRS **classifies** each GA4 URL against the rulebook (Python, same matching semantics as JS, against the `url_path` DRS stored verbatim) → produces `host, url_path, category_name` rows.
 4. DRS writes a **category CSV** and hands it to the **projector** (same as optel/cdn do).
 5. Projector → **data-service** `wrpc_import_referral_url_classifications` writes it to `referral_url_classifications`.
 6. The **api-service** read RPCs surface the category; the **UI** shows it. Done.
@@ -122,25 +122,26 @@ Each decision lists the options weighed, the chosen one, and the reasoning. Thes
 - **Chosen: A + C.** Only invoke the LLM for sites with no rules (one-time per site), and cap how many sites a single sweep processes.
 - Why: makes the expensive LLM step one-time per site and prevents a single sweep from hammering the LLM.
 
-**7.4 — Canonicalization parity + where the fixtures live**
-- Options (source of truth): (A) the JS `canonicalizeUrlPath` is the reference and Python mirrors it; (B) a language-neutral spec both follow.
+**7.4 — url_path key form, classification parity + where the fixtures live**
+- Context: this reconciles the parity language with §3 — DRS classifies against the `url_path` it stored, so its read-join lines up by construction and it does not use the JS canonical form.
+- Options (DRS key form): (A) DRS canonicalizes **both** its traffic and classification `url_path` to the JS `canonicalizeUrlPath` form (byte-for-byte); (B) DRS uses **producer-native / verbatim** keys.
 - Options (fixtures location): (A) the same case-list committed in both repos; (B) one shared file both pull from.
-- **Chosen: JS is the reference (A); an identical case-list committed in both repos (A).** Sync is **verified during the DRS classify PR review** — the reviewer diffs the two case-lists as an explicit checklist item — rather than relying on an as-yet-unbuilt cross-repo check. A mechanical guard (audit-worker CI fetches the DRS fixture file and fails if the two hashes differ) is a possible follow-up, but is not required for the first cut and no one owns it yet.
-- Why: JS shipped first (Phase 1), so it is the natural source of truth; a duplicated case-list is the simplest way to guarantee byte-for-byte parity, and naming a concrete review-time owner keeps the sync honest without a speculative CI mechanism.
+- **Chosen: producer-native keys for DRS (B); an identical classification case-list committed in both repos (A).** The referral read-RPC joins **per-source** on `(site_id, url_path)`, and each producer emits a classification for every `url_path` it wrote to its own traffic table, so the join lines up within a producer with no cross-language canonicalization. optel/cdn still share the JS `canonicalizeUrlPath` form (they share traffic-table rows); DRS does not need it. What must match across engines is the **classification result**, so the shared fixture is `(rulebook, url_path) → expected category` and the two classifiers are aligned on matching semantics (both always case-insensitive, `sortOrder` precedence, ReDoS-shape rejection). Sync is **verified during PR review** — the reviewer diffs the two case-lists — with a hash-check follow-up possible later.
+- Why: Option A would mean maintaining a byte-identical `canonicalizeUrlPath` in two languages **and** migrating DRS's existing traffic `url_path` form (a backfill) — high, permanent fragility to buy cross-source *path* unification the per-source read join never uses. Producer-native keys make the feature work today with far less surface; if a future consumer ever needs cross-source path unification, canonicalizing DRS on both sides becomes the follow-up.
 
 **7.5 — Rules endpoint (shape + auth)**
 - Options (shape): (A) build a new dedicated rules endpoint; (B) **reuse the existing** `GET /sites/:siteId/agentic-categories`.
 - Options (auth): (A) reuse the access path DRS already uses; (B) a new auth mechanism.
 - **Chosen: B (reuse endpoint) + A (reuse auth).** The existing `GET /sites/:siteId/agentic-categories` already returns each active rule as `{ name, regex, sortOrder }` (verified against `agentic-rules-factory.js` + `AgenticRuleDto`) and is gated by `site:read`, so **no new endpoint is needed**. Remaining: provision DRS with `site:read` (auth/provisioning, not endpoint code).
 - Why: the endpoint already exists and returns exactly what DRS needs; building a new one would duplicate it.
-- **Size bound:** the endpoint is unpaginated, and rule-gen is LLM-driven, so a rulebook could in principle grow large. Rather than bolt pagination onto a reused endpoint, the DRS consumer caps the rules it ingests (`MAX_CATEGORY_RULES = 200`, truncating with a warning) before attaching them to the referral-traffic event — this keeps the event under the Step Functions / Lambda 256KB transport limit and is well above any realistic per-site category count. If rulebooks ever legitimately exceed that, pagination on the endpoint becomes the follow-up.
+- **Size bound:** the endpoint is unpaginated, and rule-gen is LLM-driven, so a rulebook could in principle grow large. Rather than bolt pagination onto a reused endpoint, the DRS consumer **projects each rule to just `{name, regex, sortOrder}`** (dropping the DTO's `sampleUrls` et al.) and caps the ingested rules by **both** count (`MAX_CATEGORY_RULES = 200`) **and serialized bytes** before attaching them to the referral-traffic event — keeping it under the Step Functions / Lambda 256KB transport limit regardless of how large individual rule DTOs are. If rulebooks ever legitimately exceed that, pagination on the endpoint becomes the follow-up.
 
 **7.6 — Ownership**
 - Options: (A) split — Omair owns the JS pieces, the DRS team owns the Python classify; (B) a single owner for everything.
 - **Chosen: A — Omair owns the JS pieces (the rule-gen sweeper + confirming/provisioning DRS's auth on the existing rules endpoint); the DRS team owns the Python classify.** (Subject to confirmation.)
 - Why: keeps the JS work where the code and familiarity are, and Python-in-DRS with its owners.
 
-**How the choices fit together:** a weekly JS sweeper builds each site's rulebook once (cheap, capped); DRS pulls that rulebook via the existing api-service endpoint and classifies in Python against the JS-defined canonical form. Every referral source — optel, cdn, or DRS-only — gets categories the same way.
+**How the choices fit together:** a weekly JS sweeper builds each site's rulebook once (cheap, capped); DRS pulls that rulebook via the existing api-service endpoint and classifies in Python against the `url_path` it stored (producer-native), matching the JS **classification** semantics. Every referral source — optel, cdn, or DRS-only — gets categories the same way.
 
 **Known limitation (accepted for now):** rules are generated once and do **not** auto-refresh. If a site later adds many new URL types, its rulebook can go stale until a forced regeneration. Rule refresh/evolution is deferred to a later phase.
 
@@ -148,11 +149,11 @@ Each decision lists the options weighed, the chosen one, and the reasoning. Thes
 
 - Category coverage goes from **0% → >0%** for DRS-only sites (verified the same way as the 2026-07-26 prod scan: sample DRS-only sites via the api `filter-dimensions` endpoint, bucketed by `availableSources`). ">0%" is the floor — the meaningful bar is that **≥ ~50% of a sampled set of DRS-only sites show at least one category within a week of the sweep running** (a week covers the weekly sweep cadence from §7.2). A site legitimately shows no category only when none of its URLs match any generated rule.
 - cdn-only sites likewise clear the same bar (0% → the ~50%-of-sampled target).
-- **Parity fixtures pass in CI**: the JS and Python classifiers produce identical canonicalization + classification for the shared case set.
+- **Parity fixtures pass in CI**: given the same rulebook and `url_path`, the JS and Python classifiers return the **same category** for every case in the shared set.
 
 ## 9. Test plan
 
-- **Parity fixtures**: a shared list of `input url → expected canonical url_path` (and `url → expected category`) cases, run against **both** the JS and Python classifiers, proving identical output.
+- **Parity fixtures**: a shared `(rulebook, url_path) → expected category` case list (`referral_category_parity_cases.json`), committed in both repos and run against **both** the JS and Python classifiers, proving identical classification. (`url_path` canonicalization is producer-native and out of scope for the fixture — see §7.4.)
 - **Fix A**: unit test that rule generation now fires for a site with only cdn/DRS referral traffic (no optel).
 - **DRS classify**: unit tests on the Python classifier (match / no-match / bad-rule handling), mirroring the existing `classify.test.js` cases.
 - **End-to-end in a lower env**: pick a DRS-only site, run the flow, confirm categories appear via the api (`filter-dimensions`) — the same check we did in prod for optel/cdn.

--- a/docs/specs/2026-07-26-referral-category-drs-generation.md
+++ b/docs/specs/2026-07-26-referral-category-drs-generation.md
@@ -1,0 +1,58 @@
+# Referral Category Generation for DRS sources (GA4 / Adobe Analytics / CJA)
+
+**Status:** Draft · **Author:** Omair Temurian · **Date:** 2026-07-26
+**Parent:** LLMO-5440 (Referral Category feature) · **Follows:** LLMO-6257 Phase 1 (optel + cdn, shipped to prod)
+
+## 1. Problem
+
+Referral traffic from the DRS sources — **GA4, Adobe Analytics (AA), and CJA (Customer Journey Analytics)** — shows **no category** on the Referral Traffic dashboard. Two reasons:
+
+1. **No classifier** — nothing goes through those URLs and tags them with a category. DRS imports the traffic, but classification never happens for it.
+2. **No rulebook** — sites whose *only* referral data comes from DRS never get category **rules** generated at all. Rule generation runs *only* inside the optel audit (`llmo-referral-traffic-daily/handler.js:299` calls `generateReferralCategoryRules`); a DRS-only site has no optel run, so no rules exist to classify against.
+
+Result: DRS-only sites are stuck showing "All Categories." (A prod scan on 2026-07-26 confirmed this shape: categories appear **only** on sites that have optel; every source combination without optel — including 142 cdn-only sites — is at 0% categories.)
+
+## 2. Plan
+
+Two gaps → two fixes, both reusing the Phase-1 pipeline.
+
+**Fix A — decouple rule generation from the optel audit.**
+Today `generateReferralCategoryRules` only runs when the optel handler runs. Change the trigger so it runs for **any site that has referral traffic**, regardless of source. The function is already source-agnostic — it builds its corpus from `rpc_referral_traffic_top_urls`, which unions all 5 source tables, and it is create-if-missing (idempotent). So this is a change to *where it's triggered from*, not a rewrite. **Bonus: this also fixes the cdn-only sites that are broken in prod today.**
+
+> Note: Fix A is new to this spec and concerns **rule generation** (building the rulebook) — which is distinct from *classification* (applying it). It keeps rule-gen exactly where it lives today (the audit-worker) and only broadens which sites trigger it; it does not move anything into the database.
+
+**Fix B — DRS classifies its own URLs write-time, in Python.**
+DRS runs in a separate AWS account and cannot read the database directly, so:
+- Add a small **read endpoint on the api-service** that returns a site's active category rules (the "rules proxy"). DRS already calls the api-service, so this is the natural bridge.
+- In DRS (Python), after it imports GA4/AA/CJA traffic, it fetches the rules via that endpoint, classifies each URL (mirroring the JS `classify.js` logic, including the same `url_path` canonicalization), writes the same category CSV, and drops it into the existing pipeline.
+
+**Reuse (no new work):** the projector (already accepts `referral_url_classifications`), the data-service (the import RPC + tables), the api read RPCs, and the UI are all unchanged — they already handle this data for optel/cdn.
+
+## 3. How it works (trace one GA4 URL end-to-end)
+
+1. DRS imports GA4 referral traffic for a site (as it does today).
+2. DRS calls the api-service **rules endpoint** → gets the site's category rulebook. *(rulebook exists because Fix A now generates rules for this site.)*
+3. DRS **classifies** each GA4 URL against the rulebook (Python, same canonicalization as JS) → produces `host, url_path, category_name` rows.
+4. DRS writes a **category CSV** and hands it to the **projector** (same as optel/cdn do).
+5. Projector → **data-service** `wrpc_import_referral_url_classifications` writes it to `referral_url_classifications`.
+6. The **api-service** read RPCs surface the category; the **UI** shows it. Done.
+
+## 4. Open questions (to resolve in review)
+
+1. **Ownership / scope.** Which of these pieces is Omair's vs DRS-team's? (Fix A + the api endpoint are JS; the DRS Python classify is DRS-side.)
+2. **Where does the decoupled rule-gen run?** A scheduled job that loops sites with referral traffic, or a new audit type, or extend an existing daily run? And **how often** (rules don't need daily regeneration — once per site? weekly? on first referral data?).
+3. **LLM cost gating** — rule-gen calls an LLM; running it for many more sites has a cost. What's the budget/guard?
+4. **Canonicalization parity** — the exact `url_path` cleanup rules the Python side must match the JS side byte-for-byte (query/fragment stripping, leading slash, collapse `//`, trailing-slash handling). Where do the shared **parity fixtures** live?
+5. **Rules endpoint shape + auth** — exact request/response, and how DRS authenticates to the api-service.
+
+## 5. Test plan
+
+- **Parity fixtures**: a shared list of `input url → expected canonical url_path` (and `url → expected category`) cases, run against **both** the JS and Python classifiers, proving identical output.
+- **Fix A**: unit test that rule generation now fires for a site with only cdn/DRS referral traffic (no optel).
+- **DRS classify**: unit tests on the Python classifier (match / no-match / bad-rule handling), mirroring the existing `classify.test.js` cases.
+- **End-to-end in a lower env**: pick a DRS-only site, run the flow, confirm categories appear via the api (`filter-dimensions`) — the same check we did in prod for optel/cdn.
+
+## Non-goals
+
+- No changes to the projector, data-service tables/RPCs, api read RPCs, or UI (all reused from Phase 1).
+- No re-classification/backfill of historical DRS traffic beyond what the normal daily flow covers (matches the Phase-1 "self-healing, no backfill" decision).

--- a/docs/specs/2026-07-26-referral-category-drs-generation.md
+++ b/docs/specs/2026-07-26-referral-category-drs-generation.md
@@ -52,7 +52,7 @@ flowchart TB
     direction TB
     DRS["DRS: imports GA4, AA, CJA"] -->|"1. GET rules"| EP["api-service: rules endpoint (new)"]
     EP -->|"rules JSON"| DRS
-    DRS -->|"2. classify in Python, 3. write CSV"| PROJ["projector: single doorman (reused)"]
+    DRS -->|"2. classify (Python)  3. write CSV to S3"| PROJ["projector: routes the S3 drop, calls import RPC (reused)"]
     PROJ --> CLS["data-service: referral_url_classifications = THE TAGS (reused)"]
     CLS --> API["api-service: referral read endpoints (reused)"]
     API --> UI["UI: Category dropdown (reused)"]
@@ -60,6 +60,8 @@ flowchart TB
 
   EP -.->|"reads"| RB
 ```
+
+The DRS→projector hand-off uses the **same transport as optel/cdn**: the producer drops the classification CSV in **S3**, and the projector imports it via `wrpc_import_referral_url_classifications`. So "write CSV" in the diagram means the S3 drop, not a direct DB write.
 
 **New vs reused:**
 

--- a/docs/specs/2026-07-26-referral-category-drs-generation.md
+++ b/docs/specs/2026-07-26-referral-category-drs-generation.md
@@ -30,7 +30,7 @@ Today `generateReferralCategoryRules` only runs when the optel handler runs. Cha
 
 **Fix B — DRS classifies its own URLs write-time, in Python.**
 DRS runs in a separate AWS account and cannot read the database directly, so:
-- Add a small **read endpoint on the api-service** that returns a site's active category rules (the "rules proxy"). DRS already calls the api-service, so this is the natural bridge.
+- **Reuse the existing api-service endpoint** `GET /sites/:siteId/agentic-categories`, which already returns a site's active category rules as `{ name, regex, sortOrder, ... }` (verified in `agentic-rules-factory.js` + `AgenticRuleDto`) and is gated by `site:read`. DRS already calls the api-service, so it just calls this — **no new endpoint needed.** The only remaining piece is **authorizing DRS** to call it (provision `site:read` / the S2S capability), an auth/provisioning task rather than endpoint code.
 - In DRS (Python), after it imports GA4/AA/CJA traffic, it fetches the rules via that endpoint, classifies each URL (mirroring the JS `classify.js` logic, including the same `url_path` canonicalization), writes the same category CSV, and drops it into the existing pipeline.
 
 **Reuse (no new work):** the projector (already accepts `referral_url_classifications`), the data-service (the import RPC + tables), the api read RPCs, and the UI are all unchanged — they already handle this data for optel/cdn.
@@ -50,7 +50,7 @@ flowchart TB
 
   subgraph TRACK2["Track 2 — Apply the rulebook (Fix B: DRS classifies in Python)"]
     direction TB
-    DRS["DRS: imports GA4, AA, CJA"] -->|"1. GET rules"| EP["api-service: rules endpoint (new)"]
+    DRS["DRS: imports GA4, AA, CJA"] -->|"1. GET rules"| EP["api-service: GET /sites/{siteId}/agentic-categories (existing)"]
     EP -->|"rules JSON"| DRS
     DRS -->|"2. classify (Python)  3. write CSV to S3"| PROJ["projector: routes the S3 drop, calls import RPC (reused)"]
     PROJ --> CLS["data-service: referral_url_classifications = THE TAGS (reused)"]
@@ -68,7 +68,7 @@ The DRS→projector hand-off uses the **same transport as optel/cdn**: the produ
 | Piece | Status |
 |---|---|
 | Weekly **sweeper** (Track 1) | 🆕 new — re-triggers the existing `generateReferralCategoryRules` (create-if-missing) |
-| **Rules endpoint** (api-service) | 🆕 new — a small read endpoint |
+| **Rules endpoint** (api-service) | ♻️ reused — existing `GET /sites/{siteId}/agentic-categories` (returns name/regex/sortOrder, `site:read`); only DRS auth to provision |
 | **DRS Python classify** | 🆕 new — DRS team |
 | Corpus RPC + rulebook table | ♻️ reused (already shipped) |
 | projector → data-service → api → UI | ♻️ reused, untouched |
@@ -123,14 +123,14 @@ Each decision lists the options weighed, the chosen one, and the reasoning. Thes
 - Why: JS shipped first (Phase 1), so it is the natural source of truth; a duplicated case-list is the simplest way to guarantee byte-for-byte parity.
 
 **7.5 — Rules endpoint (shape + auth)**
-- Options (shape): (A) a new dedicated GET rules endpoint; (B) extend an existing referral endpoint.
-- Options (auth): (A) reuse the cross-account path DRS already uses to call the api-service; (B) a new auth mechanism.
-- **Chosen: a new GET rules endpoint (A); reuse DRS's existing auth (A).**
-- Why: mirrors the existing referral read endpoints and avoids inventing new auth.
+- Options (shape): (A) build a new dedicated rules endpoint; (B) **reuse the existing** `GET /sites/:siteId/agentic-categories`.
+- Options (auth): (A) reuse the access path DRS already uses; (B) a new auth mechanism.
+- **Chosen: B (reuse endpoint) + A (reuse auth).** The existing `GET /sites/:siteId/agentic-categories` already returns each active rule as `{ name, regex, sortOrder }` (verified against `agentic-rules-factory.js` + `AgenticRuleDto`) and is gated by `site:read`, so **no new endpoint is needed**. Remaining: provision DRS with `site:read` (auth/provisioning, not endpoint code).
+- Why: the endpoint already exists and returns exactly what DRS needs; building a new one would duplicate it.
 
 **7.6 — Ownership**
 - Options: (A) split — Omair owns the JS pieces, the DRS team owns the Python classify; (B) a single owner for everything.
-- **Chosen: A — Omair owns the JS pieces (sweeper + api endpoint); the DRS team owns the Python classify.** (Subject to confirmation.)
+- **Chosen: A — Omair owns the JS pieces (the rule-gen sweeper + confirming/provisioning DRS's auth on the existing rules endpoint); the DRS team owns the Python classify.** (Subject to confirmation.)
 - Why: keeps the JS work where the code and familiarity are, and Python-in-DRS with its owners.
 
 **How the choices fit together:** a weekly JS sweeper builds each site's rulebook once (cheap, capped); DRS pulls that rulebook via a simple new endpoint and classifies in Python against the JS-defined canonical form. Every referral source — optel, cdn, or DRS-only — gets categories the same way.

--- a/docs/specs/2026-07-26-referral-category-drs-generation.md
+++ b/docs/specs/2026-07-26-referral-category-drs-generation.md
@@ -110,7 +110,7 @@ Each decision lists the options weighed, the chosen one, and the reasoning. Thes
 **7.1 — Where the decoupled rule-gen runs**
 - Options: (A) a scheduled "sweeper" job that walks every site with referral traffic; (B) rule-gen as its own audit type; (C) bolt rule-gen onto each source's existing job.
 - **Chosen: A — scheduled sweeper.** A timer job walks every referral site and ensures each has a rulebook (create-if-missing).
-- Why: covers every referral site uniformly, including DRS-only, and keeps rule-gen in one JS place. Option C breaks for DRS-only sites — DRS is Python in a separate account and cannot call the JS rule-gen.
+- Why: covers every referral site uniformly, including DRS-only, and keeps rule-gen in one JS place. Option C breaks for DRS-only sites — DRS is Python in a separate account and cannot call the JS rule-gen. (Option A sidesteps that constraint because the sweeper runs *in* the audit-worker in JS and works off `rpc_referral_traffic_top_urls`, independent of which source produced the traffic — so a DRS-only site's rules still get built by JS.)
 
 **7.2 — Sweep cadence**
 - Options: (A) once per site; (B) weekly; (C) daily.
@@ -125,14 +125,15 @@ Each decision lists the options weighed, the chosen one, and the reasoning. Thes
 **7.4 — Canonicalization parity + where the fixtures live**
 - Options (source of truth): (A) the JS `canonicalizeUrlPath` is the reference and Python mirrors it; (B) a language-neutral spec both follow.
 - Options (fixtures location): (A) the same case-list committed in both repos; (B) one shared file both pull from.
-- **Chosen: JS is the reference (A); an identical case-list committed in both repos (A), kept in sync (a CI check can flag drift).**
-- Why: JS shipped first (Phase 1), so it is the natural source of truth; a duplicated case-list is the simplest way to guarantee byte-for-byte parity.
+- **Chosen: JS is the reference (A); an identical case-list committed in both repos (A).** Sync is **verified during the DRS classify PR review** — the reviewer diffs the two case-lists as an explicit checklist item — rather than relying on an as-yet-unbuilt cross-repo check. A mechanical guard (audit-worker CI fetches the DRS fixture file and fails if the two hashes differ) is a possible follow-up, but is not required for the first cut and no one owns it yet.
+- Why: JS shipped first (Phase 1), so it is the natural source of truth; a duplicated case-list is the simplest way to guarantee byte-for-byte parity, and naming a concrete review-time owner keeps the sync honest without a speculative CI mechanism.
 
 **7.5 — Rules endpoint (shape + auth)**
 - Options (shape): (A) build a new dedicated rules endpoint; (B) **reuse the existing** `GET /sites/:siteId/agentic-categories`.
 - Options (auth): (A) reuse the access path DRS already uses; (B) a new auth mechanism.
 - **Chosen: B (reuse endpoint) + A (reuse auth).** The existing `GET /sites/:siteId/agentic-categories` already returns each active rule as `{ name, regex, sortOrder }` (verified against `agentic-rules-factory.js` + `AgenticRuleDto`) and is gated by `site:read`, so **no new endpoint is needed**. Remaining: provision DRS with `site:read` (auth/provisioning, not endpoint code).
 - Why: the endpoint already exists and returns exactly what DRS needs; building a new one would duplicate it.
+- **Size bound:** the endpoint is unpaginated, and rule-gen is LLM-driven, so a rulebook could in principle grow large. Rather than bolt pagination onto a reused endpoint, the DRS consumer caps the rules it ingests (`MAX_CATEGORY_RULES = 200`, truncating with a warning) before attaching them to the referral-traffic event — this keeps the event under the Step Functions / Lambda 256KB transport limit and is well above any realistic per-site category count. If rulebooks ever legitimately exceed that, pagination on the endpoint becomes the follow-up.
 
 **7.6 — Ownership**
 - Options: (A) split — Omair owns the JS pieces, the DRS team owns the Python classify; (B) a single owner for everything.
@@ -145,8 +146,8 @@ Each decision lists the options weighed, the chosen one, and the reasoning. Thes
 
 ## 8. Success criteria
 
-- Category coverage goes from **0% → >0%** for DRS-only sites (verified the same way as the 2026-07-26 prod scan: sample DRS-only sites via the api `filter-dimensions` endpoint, bucketed by `availableSources`).
-- cdn-only sites likewise go from **0% → >0%**.
+- Category coverage goes from **0% → >0%** for DRS-only sites (verified the same way as the 2026-07-26 prod scan: sample DRS-only sites via the api `filter-dimensions` endpoint, bucketed by `availableSources`). ">0%" is the floor — the meaningful bar is that **≥ ~50% of a sampled set of DRS-only sites show at least one category within a week of the sweep running** (a week covers the weekly sweep cadence from §7.2). A site legitimately shows no category only when none of its URLs match any generated rule.
+- cdn-only sites likewise clear the same bar (0% → the ~50%-of-sampled target).
 - **Parity fixtures pass in CI**: the JS and Python classifiers produce identical canonicalization + classification for the shared case set.
 
 ## 9. Test plan

--- a/docs/specs/2026-07-26-referral-category-drs-generation.md
+++ b/docs/specs/2026-07-26-referral-category-drs-generation.md
@@ -57,13 +57,45 @@ DRS runs in a separate AWS account and cannot read the database directly, so:
 - **A single shared classify library vs mirrored JS + Python** — chose mirrored implementations kept honest by **parity fixtures**, because DRS is Python in a separate AWS account and there is no clean way to share the JS code.
 - **Push rules to DRS vs DRS pulls them** — chose DRS **pulls** via the new api-service endpoint, since DRS already calls the api-service and cannot read the database directly.
 
-## 7. Open questions (to resolve in review)
+## 7. Decisions (options considered → chosen)
 
-1. **Ownership / scope.** Which pieces are Omair's vs DRS-team's? (Fix A + the api endpoint are JS; the DRS Python classify is DRS-side.)
-2. **Where does the decoupled rule-gen run?** A scheduled job that loops sites with referral traffic, or a new audit type, or extend an existing daily run? And **how often** (rules don't need daily regeneration — once per site? weekly? on first referral data?).
-3. **LLM cost gating** — rule-gen calls an LLM; running it for many more sites has a cost. What's the budget/guard?
-4. **Canonicalization parity** — the exact `url_path` cleanup rules the Python side must match the JS side byte-for-byte. Where do the shared **parity fixtures** live?
-5. **Rules endpoint shape + auth** — exact request/response, and how DRS authenticates to the api-service.
+Each decision lists the options weighed, the chosen one, and the reasoning. These are proposals for review.
+
+**7.1 — Where the decoupled rule-gen runs**
+- Options: (A) a scheduled "sweeper" job that walks every site with referral traffic; (B) rule-gen as its own audit type; (C) bolt rule-gen onto each source's existing job.
+- **Chosen: A — scheduled sweeper.** A timer job walks every referral site and ensures each has a rulebook (create-if-missing).
+- Why: covers every referral site uniformly, including DRS-only, and keeps rule-gen in one JS place. Option C breaks for DRS-only sites — DRS is Python in a separate account and cannot call the JS rule-gen.
+
+**7.2 — How often rules regenerate**
+- Options: (A) once per site; (B) weekly; (C) daily.
+- **Chosen: a weekly sweep that generates once per site.** The weekly sweep picks up new sites within a week; because generation is create-if-missing, sites that already have rules are cheap no-ops.
+- Why: a site's URL structure barely changes, so daily is wasteful; weekly balances coverage against cost.
+
+**7.3 — LLM cost gating**
+- Options: (A) only call the LLM when a site has no rules yet; (B) regenerate every cycle; (C) cap the number of sites per run.
+- **Chosen: A + C.** Only invoke the LLM for sites with no rules (one-time per site), and cap how many sites a single sweep processes.
+- Why: makes the expensive LLM step one-time per site and prevents a single sweep from hammering the LLM.
+
+**7.4 — Canonicalization parity + where the fixtures live**
+- Options (source of truth): (A) the JS `canonicalizeUrlPath` is the reference and Python mirrors it; (B) a language-neutral spec both follow.
+- Options (fixtures location): (A) the same case-list committed in both repos; (B) one shared file both pull from.
+- **Chosen: JS is the reference (A); an identical case-list committed in both repos (A), kept in sync (a CI check can flag drift).**
+- Why: JS shipped first (Phase 1), so it is the natural source of truth; a duplicated case-list is the simplest way to guarantee byte-for-byte parity.
+
+**7.5 — Rules endpoint (shape + auth)**
+- Options (shape): (A) a new dedicated GET rules endpoint; (B) extend an existing referral endpoint.
+- Options (auth): (A) reuse the cross-account path DRS already uses to call the api-service; (B) a new auth mechanism.
+- **Chosen: a new GET rules endpoint (A); reuse DRS's existing auth (A).**
+- Why: mirrors the existing referral read endpoints and avoids inventing new auth.
+
+**7.6 — Ownership**
+- Options: (A) split — Omair owns the JS pieces, the DRS team owns the Python classify; (B) a single owner for everything.
+- **Chosen: A — Omair owns the JS pieces (sweeper + api endpoint); the DRS team owns the Python classify.** (Subject to confirmation.)
+- Why: keeps the JS work where the code and familiarity are, and Python-in-DRS with its owners.
+
+**How the choices fit together:** a weekly JS sweeper builds each site's rulebook once (cheap, capped); DRS pulls that rulebook via a simple new endpoint and classifies in Python against the JS-defined canonical form. Every referral source — optel, cdn, or DRS-only — gets categories the same way.
+
+**Known limitation (accepted for now):** rules are generated once and do **not** auto-refresh. If a site later adds many new URL types, its rulebook can go stale until a forced regeneration. Rule refresh/evolution is deferred to a later phase.
 
 ## 8. Success criteria
 
@@ -82,3 +114,4 @@ DRS runs in a separate AWS account and cannot read the database directly, so:
 
 - No changes to the projector, data-service tables/RPCs, api read RPCs, or UI (all reused from Phase 1).
 - No re-classification/backfill of historical DRS traffic beyond what the normal daily flow covers (matches the Phase-1 "self-healing, no backfill" decision).
+- No automatic rule refresh/evolution — rules are generated once per site; refreshing stale rulebooks is deferred to a later phase (see §7.2 / the limitation in §7).

--- a/docs/specs/2026-07-26-referral-category-drs-generation.md
+++ b/docs/specs/2026-07-26-referral-category-drs-generation.md
@@ -8,18 +8,25 @@
 Referral traffic from the DRS sources — **GA4, Adobe Analytics (AA), and CJA (Customer Journey Analytics)** — shows **no category** on the Referral Traffic dashboard. Two reasons:
 
 1. **No classifier** — nothing goes through those URLs and tags them with a category. DRS imports the traffic, but classification never happens for it.
-2. **No rulebook** — sites whose *only* referral data comes from DRS never get category **rules** generated at all. Rule generation runs *only* inside the optel audit (`llmo-referral-traffic-daily/handler.js:299` calls `generateReferralCategoryRules`); a DRS-only site has no optel run, so no rules exist to classify against.
+2. **No rulebook** — sites whose *only* referral data comes from DRS never get category **rules** generated at all. Rule generation runs *only* inside the optel audit (the optel handler calls `generateReferralCategoryRules`, defined in `patterns-uploader.js`); a DRS-only site has no optel run, so no rules exist to classify against.
 
-Result: DRS-only sites are stuck showing "All Categories." (A prod scan on 2026-07-26 confirmed this shape: categories appear **only** on sites that have optel; every source combination without optel — including 142 cdn-only sites — is at 0% categories.)
+Result: DRS-only sites are stuck showing "All Categories." A prod scan on 2026-07-26 confirmed this shape — categories appear **only** on sites that have optel data; every source combination without optel, including 142 cdn-only sites, is at 0%. (Measured by querying each site's `referral-traffic/filter-dimensions` on the SpaceCat API and bucketing by `availableSources`.)
 
-## 2. Plan
+## 2. Goals
+
+- DRS-only sites (GA4/AA/CJA) get referral categories, matching the optel/cdn experience.
+- cdn-only sites — broken in prod today (0% categories) — also start getting categories.
+- The JS classifier (optel/cdn) and the Python classifier (DRS) stay in **parity**: identical `url_path` canonicalization and classification output.
+- No new load or risk on the reused downstream path (projector → data-service → api → UI).
+
+## 3. Plan (technical design)
 
 Two gaps → two fixes, both reusing the Phase-1 pipeline.
 
 **Fix A — decouple rule generation from the optel audit.**
-Today `generateReferralCategoryRules` only runs when the optel handler runs. Change the trigger so it runs for **any site that has referral traffic**, regardless of source. The function is already source-agnostic — it builds its corpus from `rpc_referral_traffic_top_urls`, which unions all 5 source tables, and it is create-if-missing (idempotent). So this is a change to *where it's triggered from*, not a rewrite. **Bonus: this also fixes the cdn-only sites that are broken in prod today.**
+Today `generateReferralCategoryRules` only runs when the optel handler runs. Change the trigger so it runs for **any site that has referral traffic**, regardless of source. The function is already source-agnostic — it builds its corpus from `rpc_referral_traffic_top_urls`, which unions all 5 source tables, and it is create-if-missing (idempotent). So this is a change to *where it's triggered from*, not a rewrite. **Bonus: this also fixes the cdn-only sites broken in prod today.**
 
-> Note: Fix A is new to this spec and concerns **rule generation** (building the rulebook) — which is distinct from *classification* (applying it). It keeps rule-gen exactly where it lives today (the audit-worker) and only broadens which sites trigger it; it does not move anything into the database.
+> Note: Fix A concerns **rule generation** (building the rulebook) — distinct from *classification* (applying it). It keeps rule-gen exactly where it lives today (the audit-worker) and only broadens which sites trigger it; it does not move anything into the database.
 
 **Fix B — DRS classifies its own URLs write-time, in Python.**
 DRS runs in a separate AWS account and cannot read the database directly, so:
@@ -28,7 +35,7 @@ DRS runs in a separate AWS account and cannot read the database directly, so:
 
 **Reuse (no new work):** the projector (already accepts `referral_url_classifications`), the data-service (the import RPC + tables), the api read RPCs, and the UI are all unchanged — they already handle this data for optel/cdn.
 
-## 3. How it works (trace one GA4 URL end-to-end)
+## 4. How it works (trace one GA4 URL end-to-end)
 
 1. DRS imports GA4 referral traffic for a site (as it does today).
 2. DRS calls the api-service **rules endpoint** → gets the site's category rulebook. *(rulebook exists because Fix A now generates rules for this site.)*
@@ -37,15 +44,34 @@ DRS runs in a separate AWS account and cannot read the database directly, so:
 5. Projector → **data-service** `wrpc_import_referral_url_classifications` writes it to `referral_url_classifications`.
 6. The **api-service** read RPCs surface the category; the **UI** shows it. Done.
 
-## 4. Open questions (to resolve in review)
+## 5. Sequencing & failure modes
 
-1. **Ownership / scope.** Which of these pieces is Omair's vs DRS-team's? (Fix A + the api endpoint are JS; the DRS Python classify is DRS-side.)
+- **Ordering:** Fix A must be deployed **and must have run for a site** before Fix B can produce categories for that site — Fix B classifies against the rulebook Fix A creates. So Fix A lands first.
+- **Empty / missing rulebook:** if DRS calls the rules endpoint and gets no rules (the site's rules aren't generated yet, a brand-new site, or the endpoint is unavailable), DRS **skips classification and imports the traffic uncategorized** — matching today's behavior — and **self-heals** on a later run once rules exist. No blocking, no data loss (consistent with the Phase-1 "self-healing, no backfill" decision). Repeated empty responses can be surfaced for alerting.
+
+## 6. Alternatives considered
+
+- **Classify in the projector** — rejected: the projector's only job is routing/writing (single-writer). It has neither the rules nor the classify logic, and adding them overloads it.
+- **Audit-worker does a second-pass classify of DRS data** (read DRS traffic back from the DB and classify it) — rejected: that's a batch re-classification of already-stored data — the same shape as the previously-rejected chunk-5 in-DB approach — not write-time in the producing service.
+- **DRS generates its own rules in Python** — rejected: duplicates the rule-generation (LLM) logic in a second language and risks a site ending up with two divergent rulebooks. Chosen instead: generate rules in **one** place (Fix A) and have DRS only classify.
+- **A single shared classify library vs mirrored JS + Python** — chose mirrored implementations kept honest by **parity fixtures**, because DRS is Python in a separate AWS account and there is no clean way to share the JS code.
+- **Push rules to DRS vs DRS pulls them** — chose DRS **pulls** via the new api-service endpoint, since DRS already calls the api-service and cannot read the database directly.
+
+## 7. Open questions (to resolve in review)
+
+1. **Ownership / scope.** Which pieces are Omair's vs DRS-team's? (Fix A + the api endpoint are JS; the DRS Python classify is DRS-side.)
 2. **Where does the decoupled rule-gen run?** A scheduled job that loops sites with referral traffic, or a new audit type, or extend an existing daily run? And **how often** (rules don't need daily regeneration — once per site? weekly? on first referral data?).
 3. **LLM cost gating** — rule-gen calls an LLM; running it for many more sites has a cost. What's the budget/guard?
-4. **Canonicalization parity** — the exact `url_path` cleanup rules the Python side must match the JS side byte-for-byte (query/fragment stripping, leading slash, collapse `//`, trailing-slash handling). Where do the shared **parity fixtures** live?
+4. **Canonicalization parity** — the exact `url_path` cleanup rules the Python side must match the JS side byte-for-byte. Where do the shared **parity fixtures** live?
 5. **Rules endpoint shape + auth** — exact request/response, and how DRS authenticates to the api-service.
 
-## 5. Test plan
+## 8. Success criteria
+
+- Category coverage goes from **0% → >0%** for DRS-only sites (verified the same way as the 2026-07-26 prod scan: sample DRS-only sites via the api `filter-dimensions` endpoint, bucketed by `availableSources`).
+- cdn-only sites likewise go from **0% → >0%**.
+- **Parity fixtures pass in CI**: the JS and Python classifiers produce identical canonicalization + classification for the shared case set.
+
+## 9. Test plan
 
 - **Parity fixtures**: a shared list of `input url → expected canonical url_path` (and `url → expected category`) cases, run against **both** the JS and Python classifiers, proving identical output.
 - **Fix A**: unit test that rule generation now fires for a site with only cdn/DRS referral traffic (no optel).

--- a/docs/specs/2026-07-26-referral-category-drs-generation.md
+++ b/docs/specs/2026-07-26-referral-category-drs-generation.md
@@ -3,6 +3,10 @@
 **Status:** Draft · **Author:** Omair Temurian · **Date:** 2026-07-26
 **Parent:** LLMO-5440 (Referral Category feature) · **Follows:** LLMO-6257 Phase 1 (optel + cdn, shipped to prod)
 
+> **Supersedes / correction — re: Phase-1 spec (`docs/specs/2026-07-21-referral-category-generation-p2.md`).**
+> Phase-1's "as-built" revision claims DRS *already* classifies its URLs **in-DB** via `wrpc_apply_referral_categories` (invoked by `wrpc_import_referral_traffic`), and that this replaced the planned same-idiom-in-Python path. **That in-DB path was never built** — no `wrpc_apply_referral_categories` exists in `mysticat-data-service` (only `wrpc_backfill_referral_categories`, CDN-only, and `wrpc_import_referral_url_classifications`). This spec returns DRS to the **write-time-in-service (Python)** model specified by the data-service design-of-record (`docs/plans/2026-07-17-llmo-6257-referral-category-generation.md`, which Phase-1 itself names as authoritative), and is the authoritative spec for DRS-source classification going forward.
+> Phase-1's claim that DRS "cannot reach PostgREST to read the rules" **still holds**: DRS cannot reach the **data-service PostgREST**. Fix B (§3) does not contradict it — DRS pulls rules from the **api-service** `GET /sites/:siteId/agentic-categories`, a *different* surface that DRS already calls.
+
 ## 1. Problem
 
 Referral traffic from the DRS sources — **GA4, Adobe Analytics (AA), and CJA (Customer Journey Analytics)** — shows **no category** on the Referral Traffic dashboard. Two reasons:
@@ -26,10 +30,12 @@ Two gaps → two fixes, both reusing the Phase-1 pipeline.
 **Fix A — decouple rule generation from the optel audit.**
 Today `generateReferralCategoryRules` only runs when the optel handler runs. Change the trigger so it runs for **any site that has referral traffic**, regardless of source. The function is already source-agnostic — it builds its corpus from `rpc_referral_traffic_top_urls`, which unions all 5 source tables, and it is create-if-missing (idempotent). So this is a change to *where it's triggered from*, not a rewrite. **Bonus: this also fixes the cdn-only sites broken in prod today.**
 
+> **Status (Fix A): partially shipped.** The per-site rule-gen sweeper audit (`llmo-referral-category-rules`) merged in PR #2821 (2026-07-28). Still pending: the **weekly fan-out** (scheduling the sweep across all referral sites) and the **enablement config**.
+
 > Note: Fix A concerns **rule generation** (building the rulebook) — distinct from *classification* (applying it). It keeps rule-gen exactly where it lives today (the audit-worker) and only broadens which sites trigger it; it does not move anything into the database.
 
 **Fix B — DRS classifies its own URLs write-time, in Python.**
-DRS runs in a separate AWS account and cannot read the database directly, so:
+DRS runs in a separate AWS account and **cannot reach the data-service PostgREST** to read the rules directly. It *can*, however, reach the **api-service** (it already calls it), so:
 - **Reuse the existing api-service endpoint** `GET /sites/:siteId/agentic-categories`, which already returns a site's active category rules as `{ name, regex, sortOrder, ... }` (verified in `agentic-rules-factory.js` + `AgenticRuleDto`) and is gated by `site:read`. DRS already calls the api-service, so it just calls this — **no new endpoint needed.** The only remaining piece is **authorizing DRS** to call it (provision `site:read` / the S2S capability), an auth/provisioning task rather than endpoint code.
 - In DRS (Python), after it imports GA4/AA/CJA traffic, it fetches the rules via that endpoint, classifies each URL (mirroring the JS `classify.js` logic, including the same `url_path` canonicalization), writes the same category CSV, and drops it into the existing pipeline.
 
@@ -67,7 +73,7 @@ The DRS→projector hand-off uses the **same transport as optel/cdn**: the produ
 
 | Piece | Status |
 |---|---|
-| Weekly **sweeper** (Track 1) | 🆕 new — re-triggers the existing `generateReferralCategoryRules` (create-if-missing) |
+| Weekly **sweeper** (Track 1) | 🟡 partially shipped — per-site sweeper audit merged in PR #2821; weekly fan-out + enablement config still pending |
 | **Rules endpoint** (api-service) | ♻️ reused — existing `GET /sites/{siteId}/agentic-categories` (returns name/regex/sortOrder, `site:read`); only DRS auth to provision |
 | **DRS Python classify** | 🆕 new — DRS team |
 | Corpus RPC + rulebook table | ♻️ reused (already shipped) |
@@ -95,7 +101,7 @@ The DRS→projector hand-off uses the **same transport as optel/cdn**: the produ
 - **Audit-worker does a second-pass classify of DRS data** (read DRS traffic back from the DB and classify it) — rejected: that's a batch re-classification of already-stored data — the same shape as the previously-rejected chunk-5 in-DB approach — not write-time in the producing service.
 - **DRS generates its own rules in Python** — rejected: duplicates the rule-generation (LLM) logic in a second language and risks a site ending up with two divergent rulebooks. Chosen instead: generate rules in **one** place (Fix A) and have DRS only classify.
 - **A single shared classify library vs mirrored JS + Python** — chose mirrored implementations kept honest by **parity fixtures**, because DRS is Python in a separate AWS account and there is no clean way to share the JS code.
-- **Push rules to DRS vs DRS pulls them** — chose DRS **pulls** via the new api-service endpoint, since DRS already calls the api-service and cannot read the database directly.
+- **Push rules to DRS vs DRS pulls them** — chose DRS **pulls** via the existing api-service endpoint, since DRS already calls the api-service and cannot reach the data-service PostgREST directly.
 
 ## 7. Decisions (options considered → chosen)
 
@@ -106,7 +112,7 @@ Each decision lists the options weighed, the chosen one, and the reasoning. Thes
 - **Chosen: A — scheduled sweeper.** A timer job walks every referral site and ensures each has a rulebook (create-if-missing).
 - Why: covers every referral site uniformly, including DRS-only, and keeps rule-gen in one JS place. Option C breaks for DRS-only sites — DRS is Python in a separate account and cannot call the JS rule-gen.
 
-**7.2 — How often rules regenerate**
+**7.2 — Sweep cadence**
 - Options: (A) once per site; (B) weekly; (C) daily.
 - **Chosen: a weekly sweep that generates once per site.** The weekly sweep picks up new sites within a week; because generation is create-if-missing, sites that already have rules are cheap no-ops.
 - Why: a site's URL structure barely changes, so daily is wasteful; weekly balances coverage against cost.
@@ -133,7 +139,7 @@ Each decision lists the options weighed, the chosen one, and the reasoning. Thes
 - **Chosen: A — Omair owns the JS pieces (the rule-gen sweeper + confirming/provisioning DRS's auth on the existing rules endpoint); the DRS team owns the Python classify.** (Subject to confirmation.)
 - Why: keeps the JS work where the code and familiarity are, and Python-in-DRS with its owners.
 
-**How the choices fit together:** a weekly JS sweeper builds each site's rulebook once (cheap, capped); DRS pulls that rulebook via a simple new endpoint and classifies in Python against the JS-defined canonical form. Every referral source — optel, cdn, or DRS-only — gets categories the same way.
+**How the choices fit together:** a weekly JS sweeper builds each site's rulebook once (cheap, capped); DRS pulls that rulebook via the existing api-service endpoint and classifies in Python against the JS-defined canonical form. Every referral source — optel, cdn, or DRS-only — gets categories the same way.
 
 **Known limitation (accepted for now):** rules are generated once and do **not** auto-refresh. If a site later adds many new URL types, its rulebook can go stale until a forced regeneration. Rule refresh/evolution is deferred to a later phase.
 

--- a/src/llmo-referral-traffic-daily/classify.js
+++ b/src/llmo-referral-traffic-daily/classify.js
@@ -60,8 +60,9 @@ function compileRuleRegex(regex) {
 // across sources. Canonical form: host-stripped (a full URL collapses to its
 // pathname), query- and fragment-stripped, duplicate slashes collapsed, exactly one
 // leading slash, and no trailing slash except the root '/'. DRS (ga4/aa/cja) does not
-// use this — it classifies in-DB against the same url_path it stored, so its join
-// lines up by construction (spec §3).
+// use this — it classifies write-time in its own service (Python), emitting a CSV via
+// the projector, against the same url_path it stored, so its join lines up by
+// construction (see the DRS classification spec under docs/specs/).
 export function canonicalizeUrlPath(path) {
   if (typeof path !== 'string' || path === '') {
     return '/';

--- a/test/audits/llmo-referral-traffic-daily/classify.test.js
+++ b/test/audits/llmo-referral-traffic-daily/classify.test.js
@@ -11,6 +11,7 @@
  */
 /* eslint-env mocha */
 import { expect } from 'chai';
+import { readFileSync } from 'fs';
 import {
   classifyUrlPath, buildClassificationRows, serializeClassificationCsv, canonicalizeUrlPath,
   isCatastrophicQuantifier,
@@ -189,6 +190,28 @@ describe('referral URL classification', () => {
       ]);
       const [, row] = csv.split('\r\n');
       expect(row).to.equal('example.com,"/a,b","has ""quote""",');
+    });
+  });
+
+  describe('classifier parity (shared JS/Python fixture)', () => {
+    // This fixture is mirrored verbatim in llmo-data-retrieval-service
+    // (tests/common/utils/fixtures/referral_category_parity_cases.json); given the
+    // same rulebook + url_path, the JS and Python classifiers must return the same
+    // category. Rules arrive pre-sorted by sortOrder (the fetch layer sorts).
+    const parityCases = JSON.parse(
+      readFileSync(
+        new URL(
+          '../../fixtures/llmo-referral-traffic-daily/referral_category_parity_cases.json',
+          import.meta.url,
+        ),
+        'utf8',
+      ),
+    ).cases;
+
+    parityCases.forEach((parityCase) => {
+      it(`matches the shared contract: ${parityCase.name}`, () => {
+        expect(classifyUrlPath(parityCase.rules, parityCase.urlPath)).to.equal(parityCase.expected);
+      });
     });
   });
 });

--- a/test/fixtures/llmo-referral-traffic-daily/referral_category_parity_cases.json
+++ b/test/fixtures/llmo-referral-traffic-daily/referral_category_parity_cases.json
@@ -1,0 +1,12 @@
+{
+  "_comment": "Shared JS/Python classifier parity fixture (LLMO-6257). The same rulebook + url_path MUST yield the same category in the audit-worker JS classifyUrlPath and the DRS Python classify_url_path. This file is mirrored verbatim in llmo-data-retrieval-service (tests/common/utils/fixtures/) so both engines assert the identical contract. Rules use the agentic-categories DTO shape {name, regex, sortOrder} and arrive pre-sorted by sortOrder (the fetch layer sorts; the JS classifier does not); expected is the category name or null for no-match.",
+  "cases": [
+    {"name": "simple match", "rules": [{"name": "Blog", "regex": "^/blog", "sortOrder": 10}], "urlPath": "/blog/post-1", "expected": "Blog"},
+    {"name": "no match returns null", "rules": [{"name": "Blog", "regex": "^/blog", "sortOrder": 10}], "urlPath": "/about", "expected": null},
+    {"name": "first matching rule wins (rules arrive pre-sorted by sortOrder)", "rules": [{"name": "Blog", "regex": "^/blog", "sortOrder": 10}, {"name": "Broad", "regex": "^/", "sortOrder": 100}], "urlPath": "/blog/x", "expected": "Blog"},
+    {"name": "case-insensitive without inline flag", "rules": [{"name": "Blog", "regex": "^/BLOG", "sortOrder": 10}], "urlPath": "/blog/x", "expected": "Blog"},
+    {"name": "redundant inline (?i) still matches", "rules": [{"name": "Blog", "regex": "(?i)^/BLOG", "sortOrder": 10}], "urlPath": "/blog/x", "expected": "Blog"},
+    {"name": "query string retained (verbatim producer-native key)", "rules": [{"name": "Search", "regex": "^/search", "sortOrder": 10}], "urlPath": "/search/results?q=agentic", "expected": "Search"},
+    {"name": "ReDoS-shaped rule is skipped, no match", "rules": [{"name": "Redos", "regex": "(a+)+$", "sortOrder": 10}], "urlPath": "/aaaa", "expected": null}
+  ]
+}


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## Abstract
Adds a design spec for generating referral-traffic categories for the DRS analytics sources — GA4, Adobe Analytics, and CJA. This is the Phase-2 follow-up to LLMO-6257 Phase 1 (optel + cdn), which shipped to prod.

## Reasoning
Referral traffic from the DRS sources currently shows no category on the dashboard. A prod scan on 2026-07-26 confirmed the shape: categories appear only on sites that have optel data — every source combination without optel, including 142 cdn-only sites, is at 0%. This spec proposes how to close that gap so DRS-only (and cdn-only) sites get categories.

## Overview
Documentation only — adds `docs/specs/2026-07-26-referral-category-drs-generation.md`; no code or behavior changes. The spec identifies two gaps and proposes a fix for each:
- **Rule generation** is coupled to the optel audit, so sites without optel never get a rulebook. Fix A decouples it so rule-gen runs for any site with referral traffic (this also fixes the cdn-only sites broken in prod today). It only broadens the trigger — rule-gen stays in the audit-worker, nothing moves into the database. The per-site sweeper audit already merged in PR #2821; weekly fan-out + enablement config are still pending.
- **Classification** does not happen for DRS sources. Fix B has DRS classify its own URLs write-time in Python (mirroring the existing JS classifier), reading rules via the **existing** api-service endpoint `GET /sites/:siteId/agentic-categories` (no new endpoint — only DRS auth to provision) and emitting the same classification CSV into the existing pipeline.

The downstream path (projector → data-service → api → UI) is reused unchanged.

## Links
- Jira: LLMO-6257 (parent LLMO-5440)
- Follows the Phase-1 spec: `docs/specs/2026-07-21-referral-category-generation-p2.md`

## Affected projects
Documentation lands in spacecat-audit-worker. The proposed work would span: **spacecat-audit-worker** (decouple the rule-gen trigger — sweeper merged in PR #2821), **llmo-data-retrieval-service** (DRS Python classify), and **spacecat-api-service** (reuse the existing `GET /sites/:siteId/agentic-categories` — only provision DRS `site:read` auth, no new endpoint). Reused unchanged downstream: mysticat-projector-service, mysticat-data-service, project-elmo-ui.

## Test plan
This PR adds a document; there is no runtime change to verify. The spec itself defines the test approach for the eventual implementation: shared parity fixtures proving the JS and Python classifiers produce identical output, a test that rule-generation fires for a non-optel site, and an end-to-end category check on a DRS-only site in a lower environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
