### PR TITLE
fix(llmo): populate previousConfigVersion in drs-prompt-generation handler

### DIFF
--- a/src/drs-prompt-generation/handler.js
+++ b/src/drs-prompt-generation/handler.js
@@ -11,6 +11,7 @@
  */
 
 import { ok } from '@adobe/spacecat-shared-http-utils';
+import { llmoConfig } from '@adobe/spacecat-shared-utils';
 import writeDrsPromptsToLlmoConfig from './drs-config-writer.js';
 import { postMessageSafe } from '../utils/slack-utils.js';
 
@@ -155,6 +156,23 @@ export default async function drsPromptGenerationHandler(message, context) {
 
   log.info(`DRS prompt generation completed for site ${siteId}, job ${drsJobId}, result: ${resultLocation}`);
 
+  // Capture the config version that existed *before* this job's write (below), so
+  // llmo-customer-analysis can tell a genuine first-time onboarding from a repeat one.
+  // Must be read before processDrsResult writes a new version, and is only needed
+  // for source=onboarding since that's the only case that reaches the SQS send below.
+  let previousConfigVersion;
+  if (source === 'onboarding') {
+    try {
+      const { s3Client, env } = context;
+      const prevConfig = await llmoConfig.readConfig(siteId, s3Client, {
+        s3Bucket: env.S3_IMPORTER_BUCKET_NAME,
+      });
+      previousConfigVersion = prevConfig.exists ? prevConfig.version : undefined;
+    } catch (error) {
+      log.warn(`Failed to read existing LLMO config version for site ${siteId}: ${error.message}`);
+    }
+  }
+
   let configVersion;
   const shouldWriteLegacyConfig = source !== 'onboarding' || onboardingMode !== 'v2';
 
@@ -191,6 +209,7 @@ export default async function drsPromptGenerationHandler(message, context) {
       drsJobId,
       resultLocation,
       ...(configVersion && { configVersion }),
+      ...(previousConfigVersion && { previousConfigVersion }),
       ...(onboardingMode && { onboardingMode }),
       ...(auditContext.imsOrgId && { imsOrgId: auditContext.imsOrgId }),
     },

--- a/test/drs-prompt-generation/handler.test.js
+++ b/test/drs-prompt-generation/handler.test.js
@@ -26,6 +26,7 @@ describe('DRS Prompt Generation Handler', () => {
   let drsPromptGenerationHandler;
   let mockPostMessageSafe;
   let mockWriteDrsPromptsToLlmoConfig;
+  let mockLlmoConfig;
 
   const AUDITS_QUEUE_URL = 'https://sqs.us-east-1.amazonaws.com/123456789/audits-queue';
   const PRESIGNED_URL = 'https://drs-bucket.s3.amazonaws.com/results/job-1/data.json?X-Amz-Signature=abc';
@@ -47,10 +48,12 @@ describe('DRS Prompt Generation Handler', () => {
   beforeEach(async () => {
     mockPostMessageSafe = sandbox.stub().resolves({ success: true });
     mockWriteDrsPromptsToLlmoConfig = sandbox.stub().resolves({ success: true, version: 'v1' });
+    mockLlmoConfig = { readConfig: sandbox.stub().resolves({ exists: false }) };
 
     const handler = await esmock('../../src/drs-prompt-generation/handler.js', {
       '../../src/utils/slack-utils.js': { postMessageSafe: mockPostMessageSafe },
       '../../src/drs-prompt-generation/drs-config-writer.js': { default: mockWriteDrsPromptsToLlmoConfig },
+      '@adobe/spacecat-shared-utils': { llmoConfig: mockLlmoConfig },
     });
     drsPromptGenerationHandler = handler.default;
 
@@ -201,6 +204,109 @@ describe('DRS Prompt Generation Handler', () => {
     expect(sentMessage.auditContext.configVersion).to.equal('v1');
     expect(sentMessage.auditContext).to.not.have.property('drsJsonKey');
     expect(sentMessage.auditContext).to.not.have.property('drsParquetKey');
+  });
+
+  it('includes previousConfigVersion when a prior LLMO config version exists', async () => {
+    mockLlmoConfig.readConfig.resolves({ exists: true, version: 'v0' });
+
+    const message = {
+      siteId: 'site-456',
+      auditContext: {
+        drsEventType: 'JOB_COMPLETED',
+        drsJobId: 'job-4',
+        resultLocation: PRESIGNED_URL,
+        source: 'onboarding',
+      },
+    };
+
+    await drsPromptGenerationHandler(message, context);
+
+    expect(mockLlmoConfig.readConfig).to.have.been.calledWith(
+      'site-456',
+      context.s3Client,
+      { s3Bucket: 'importer-bucket' },
+    );
+
+    const sentMessage = context.sqs.sendMessage.firstCall.args[1];
+    expect(sentMessage.auditContext.previousConfigVersion).to.equal('v0');
+    // The version written by *this* job stays distinct from the prior one.
+    expect(sentMessage.auditContext.configVersion).to.equal('v1');
+  });
+
+  it('omits previousConfigVersion for a genuine first-time onboarding (no prior config)', async () => {
+    mockLlmoConfig.readConfig.resolves({ exists: false });
+
+    const message = {
+      siteId: 'site-456',
+      auditContext: {
+        drsEventType: 'JOB_COMPLETED',
+        drsJobId: 'job-4',
+        resultLocation: PRESIGNED_URL,
+        source: 'onboarding',
+      },
+    };
+
+    await drsPromptGenerationHandler(message, context);
+
+    const sentMessage = context.sqs.sendMessage.firstCall.args[1];
+    expect(sentMessage.auditContext).to.not.have.property('previousConfigVersion');
+  });
+
+  it('includes imsOrgId in the audit context when present', async () => {
+    const message = {
+      siteId: 'site-456',
+      auditContext: {
+        drsEventType: 'JOB_COMPLETED',
+        drsJobId: 'job-4',
+        resultLocation: PRESIGNED_URL,
+        source: 'onboarding',
+        imsOrgId: 'IMS-ORG-123',
+      },
+    };
+
+    await drsPromptGenerationHandler(message, context);
+
+    const sentMessage = context.sqs.sendMessage.firstCall.args[1];
+    expect(sentMessage.auditContext.imsOrgId).to.equal('IMS-ORG-123');
+  });
+
+  it('does not read the LLMO config version for non-onboarding sources', async () => {
+    const message = {
+      siteId: 'site-456',
+      auditContext: {
+        drsEventType: 'JOB_COMPLETED',
+        drsJobId: 'job-4',
+        resultLocation: PRESIGNED_URL,
+        source: 'manual',
+      },
+    };
+
+    await drsPromptGenerationHandler(message, context);
+
+    expect(mockLlmoConfig.readConfig).to.not.have.been.called;
+  });
+
+  it('logs a warning and omits previousConfigVersion when reading the prior config fails', async () => {
+    mockLlmoConfig.readConfig.rejects(new Error('S3 unavailable'));
+
+    const message = {
+      siteId: 'site-456',
+      auditContext: {
+        drsEventType: 'JOB_COMPLETED',
+        drsJobId: 'job-4',
+        resultLocation: PRESIGNED_URL,
+        source: 'onboarding',
+      },
+    };
+
+    const result = await drsPromptGenerationHandler(message, context);
+
+    expect(result.status).to.equal(200);
+    expect(context.log.warn).to.have.been.calledWith(
+      'Failed to read existing LLMO config version for site site-456: S3 unavailable',
+    );
+    const sentMessage = context.sqs.sendMessage.firstCall.args[1];
+    expect(sentMessage.auditContext).to.not.have.property('previousConfigVersion');
   });
 
   it('skips v1 config write for v2 onboarding but still triggers llmo-customer-analysis', async () => {


### PR DESCRIPTION
## Summary
- The SQS message that re-triggers `llmo-customer-analysis` after a DRS prompt-generation job completes never set `previousConfigVersion`, so `isFirstTimeOnboarding` evaluated `true` on every completion regardless of actual onboarding history. This fired the "Onboarding Detected" Slack notification repeatedly for already-onboarded sites (observed dozens of times for the same sites in #llmo-onboarding-automation).
- Fix reads the existing LLMO config version before the legacy config write happens, same approach `updateLlmoConfig` already uses in spacecat-api-service, gated to `source=onboarding` since that's the only path that uses it. Non-fatal on read failure (logs a warning, falls back to omitting the field).

## Related Issues


## Test plan
- [x] Added tests covering: prior version present, no prior version (genuine first-time), read failure (non-fatal), and non-onboarding sources skip the read entirely
- [x] `npm test` passes with 100% coverage maintained
- [x] `npm run lint` clean