### PR TITLE
fix(prerender): strip tracking query params from RCV dedup keys

### DIFF
--- a/src/prerender/utils/utils.js
+++ b/src/prerender/utils/utils.js
@@ -67,8 +67,84 @@ export function toPathname(url) {
 }
 
 /**
+ * Tracking/marketing query parameter patterns that should not cause two otherwise-identical
+ * URLs to be treated as distinct pages (e.g. in RCV suggestion/opportunity dedup keys).
+ * Mirrors TRACKING_PARAM_PATTERNS in tokowaka-worker's src/utils/request-utils.js so the audit
+ * and the edge worker agree on which query params are tracking-only noise.
+ */
+const TRACKING_PARAM_PATTERNS = [
+  // Google Ads
+  /^gad_source$/, // Google Ads click source identifier
+  /^gad_campaignid$/, // Google Ads campaign ID (auto-tagging)
+  /^gbraid$/, // Google Ads app-to-web attribution (iOS)
+  /^wbraid$/, // Google Ads web-to-app attribution (iOS)
+  /^gclid$/, // Google Ads click identifier
+  /^gclsrc$/, // Google Ads click source type (e.g. aw.ds for Search Ads 360)
+  /^dclid$/, // Google Display & Video 360 (DoubleClick) click identifier
+  /^srsltid$/, // Google Shopping / Merchant Center result identifier
+
+  // Google Analytics
+  /^_gl$/, // Google Analytics cross-domain linker parameter
+
+  // Microsoft Advertising (Bing Ads)
+  /^msclkid$/, // Microsoft Advertising click identifier
+
+  // Meta (Facebook / Instagram)
+  /^fbclid$/, // Meta (Facebook) click identifier
+
+  // Zanox / Awin (affiliate network)
+  /^zanpid$/, // Zanox/Awin affiliate partner click identifier
+
+  // Klaviyo (email marketing)
+  /^_kx$/, // Klaviyo email tracking identifier
+
+  // Mailchimp (email marketing)
+  /^mc_[a-z]+$/, // Mailchimp campaign tracking params (mc_cid, mc_eid, etc.)
+
+  // Bronto / Oracle (email marketing)
+  /^_bta_[a-z]+$/, // Bronto/Oracle email tracking params (_bta_tid, _bta_c, etc.)
+
+  // Cross-platform (Urchin / Google Analytics standard)
+  /^utm_[a-z]+$/, // UTM campaign tracking params (utm_source, utm_medium, utm_campaign, etc.)
+
+  // Cache busters (jQuery/AJAX timestamps)
+  /^_$/, // jQuery cache-buster param (e.g. ?_=1780463035675)
+
+  // Microsoft Bing session
+  /^msockid$/, // Bing/Copilot session identifier (companion to msclkid)
+
+  // Criteo (retargeting ads)
+  /^cto_pld$/, // Criteo click payload (read by Criteo OneTag client-side; doesn't affect HTML)
+];
+
+/**
+ * Removes tracking/marketing query parameters from a URL search string.
+ * Returns the search string untouched (including param order) when it contains no tracking
+ * params, so non-tracking dedup keys (e.g. CSV-provided `?filter=a` vs `?filter=b`) are
+ * never altered.
+ * @param {string} search - A URL search string, with or without the leading '?' ('' allowed).
+ * @returns {string} The cleaned search string (with leading '?' if any params remain), or ''.
+ */
+function stripTrackingParams(search) {
+  if (!search) {
+    return '';
+  }
+  const params = new URLSearchParams(search);
+  const trackingKeys = [...params.keys()]
+    .filter((key) => TRACKING_PARAM_PATTERNS.some((pattern) => pattern.test(key)));
+  if (trackingKeys.length === 0) {
+    return search;
+  }
+  trackingKeys.forEach((key) => params.delete(key));
+  const cleaned = params.toString();
+  return cleaned ? `?${cleaned}` : '';
+}
+
+/**
  * Normalizes a URL to its pathname + search string.
  * Trailing slashes on the pathname are removed (except for the root path).
+ * Tracking/marketing query parameters (see TRACKING_PARAM_PATTERNS) are stripped so that URLs
+ * differing only by tracking params resolve to the same identity/dedup key.
  * Falls back to the raw string when the URL is not parseable.
  * @param {string} url
  * @returns {string} pathname+search, or the original string on parse failure
@@ -77,7 +153,8 @@ export function normalizePathnameWithQuery(url) {
   try {
     const { pathname, search } = new URL(url);
     const normalized = (pathname.length > 1 ? pathname.replace(/\/+$/, '') : pathname).toLowerCase();
-    return search ? `${normalized}${search}` : normalized;
+    const cleanedSearch = stripTrackingParams(search);
+    return cleanedSearch ? `${normalized}${cleanedSearch}` : normalized;
   } catch {
     return url.toLowerCase();
   }
@@ -103,7 +180,9 @@ export function buildSuggestionKey(data) {
  * Merges multiple URL arrays, ensures uniqueness, and filters out non-HTML URLs.
  * By default, deduplicates by pathname only (handles www vs non-www differences).
  * When includeQueryParams is true, query parameters are included in the uniqueness
- * key so that URLs like /page?a=1 and /page?b=2 are treated as distinct.
+ * key so that URLs like /page?a=1 and /page?b=2 are treated as distinct — except for
+ * tracking/marketing params (see TRACKING_PARAM_PATTERNS), which are stripped from the key
+ * so URLs differing only by those (e.g. ?utm_source=a vs ?utm_source=b) still collapse.
  * @param {Array<string>} urlArrays - URL arrays to merge (spread or single array)
  * @param {Object} [options] - Options object (must be last argument)
  * @param {boolean} [options.includeQueryParams=false] - Include query params in dedup key
@@ -139,10 +218,11 @@ export function mergeAndGetUniqueHtmlUrls(...args) {
         dedupKey = dedupKey.replace(/\/+$/, ''); // Remove all trailing slashes
       }
 
-      // Include the raw query string in the dedup key when requested,
-      // so the user gets exactly what they passed in the CSV.
+      // Include the query string in the dedup key when requested, so the user gets exactly
+      // what they passed in the CSV. Tracking/marketing params are stripped first so that
+      // e.g. ?utm_source=a vs ?utm_source=b still collapse to the same page.
       if (includeQueryParams && urlObj.search) {
-        dedupKey += urlObj.search;
+        dedupKey += stripTrackingParams(urlObj.search);
       }
 
       // Only add URL if we haven't seen this key before

--- a/test/audits/prerender/utils.test.js
+++ b/test/audits/prerender/utils.test.js
@@ -310,6 +310,31 @@ describe('Prerender Utils', () => {
       expect(result.urls).to.have.lengthOf(3);
     });
 
+    it('should collapse URLs that differ only by tracking params when includeQueryParams is true', () => {
+      const urls = [
+        'https://example.com/page?utm_source=newsletter&utm_campaign=spring',
+        'https://example.com/page?utm_source=social&utm_campaign=summer',
+        'https://example.com/page?gclid=abc123',
+      ];
+
+      const result = utils.mergeAndGetUniqueHtmlUrls(urls, { includeQueryParams: true });
+
+      expect(result.urls).to.have.lengthOf(1);
+      expect(result.urls[0]).to.equal(urls[0]);
+    });
+
+    it('should still keep non-tracking query-param variants distinct when includeQueryParams is true', () => {
+      const urls = [
+        'https://example.com/page?filter=iphone&utm_source=newsletter',
+        'https://example.com/page?filter=mac&utm_source=social',
+      ];
+
+      const result = utils.mergeAndGetUniqueHtmlUrls(urls, { includeQueryParams: true });
+
+      expect(result.urls).to.have.lengthOf(2);
+      expect(result.urls).to.deep.equal(urls);
+    });
+
     it('should handle URLs with hash fragments', () => {
       const urls1 = ['https://example.com/page#section1'];
       const urls2 = ['https://example.com/page#section2'];
@@ -502,6 +527,29 @@ describe('Prerender Utils', () => {
 
     it('should preserve percent-encoding and lowercase hex digits (%41BC/Page → %41bc/page)', () => {
       expect(normalizePathnameWithQuery('https://example.com/%41BC/Page')).to.equal('/%41bc/page');
+    });
+
+    it('should strip a single tracking param and drop the "?" when it was the only param', () => {
+      expect(normalizePathnameWithQuery('https://adobe.com/test?utm_source=newsletter')).to.equal('/test');
+    });
+
+    it('should strip multiple tracking params from different vendors', () => {
+      expect(normalizePathnameWithQuery('https://adobe.com/test?gclid=abc&fbclid=def&msclkid=ghi')).to.equal('/test');
+    });
+
+    it('should strip tracking params while preserving non-tracking params', () => {
+      expect(normalizePathnameWithQuery('https://adobe.com/test?utm_source=newsletter&foo=bar')).to.equal('/test?foo=bar');
+    });
+
+    it('should treat URLs differing only by tracking params as identical', () => {
+      const a = normalizePathnameWithQuery('https://adobe.com/test?utm_source=a&utm_campaign=spring');
+      const b = normalizePathnameWithQuery('https://adobe.com/test?utm_source=b&utm_campaign=summer');
+      expect(a).to.equal(b);
+      expect(a).to.equal('/test');
+    });
+
+    it('should not touch non-tracking query strings (order preserved)', () => {
+      expect(normalizePathnameWithQuery('https://adobe.com/test?b=2&a=1')).to.equal('/test?b=2&a=1');
     });
   });
 


### PR DESCRIPTION
## Summary
- Fixes duplicate entries in the RCV (Recover Content Visibility) opportunity caused by tracking/marketing query parameters (`utm_*`, `gclid`, `gbraid`, `wbraid`, `fbclid`, `msclkid`, `_gl`, `srsltid`, Mailchimp/Klaviyo/Bronto params, cache-busters, etc.) being treated as part of a page's identity when building suggestion/opportunity dedup keys.
- Adds `TRACKING_PARAM_PATTERNS` + a `stripTrackingParams()` helper to `src/prerender/utils/utils.js`, mirroring [`TRACKING_PARAM_PATTERNS` in tokowaka-worker](https://github.com/adobe-rnd/tokowaka-worker/blob/main/src/utils/request-utils.js#L220) so the audit worker and the edge worker agree on which query params are tracking-only noise.
- Wires the stripping into `normalizePathnameWithQuery` (used by `buildSuggestionKey`, `syncSuggestions` matching, and scraped-URL-set lookups) and into `mergeAndGetUniqueHtmlUrls`'s `includeQueryParams` path (CSV/included-URL and cross-source dedup), so two URLs differing only by tracking params now resolve to the same suggestion/opportunity, while non-tracking query-param variants (e.g. `?filter=iphone` vs `?filter=mac`) are still kept distinct as before.

## Root cause
- Organic/agentic top-page URL lists already dedup by pathname only (all query params dropped), but "included"/CSV URL lists and the cross-source merge intentionally preserve query params so legitimate variants aren't collapsed. Tracking params riding along on included/CSV URLs (or URLs reaching the audit from real traffic with ad/campaign params attached) fell into that "preserved" bucket and produced separate suggestions/opportunity rows for what was actually the same page.
- `normalizePathnameWithQuery`, the canonical identity key used across suggestion sync and scrape lookups, also included the full raw query string, so the same issue surfaced there independent of which URL source was used.

## Test plan
- [x] Added unit tests in `test/audits/prerender/utils.test.js` covering: single/multiple tracking params stripped, tracking params stripped while non-tracking params preserved, URLs differing only by tracking params normalize to the same key, and non-tracking query strings are left untouched (order preserved).
- [x] `npx mocha --recursive test/audits/prerender/` — 643 passing
- [x] `npm run lint` — clean
- [x] `npx c8 --include='src/prerender/utils/utils.js' mocha --recursive test/audits/prerender/` — 100% lines/branches/functions

Jira: LLMO-5897

🤖 Generated with [Claude Code](https://claude.com/claude-code)