### PR TITLE
feat(referral-traffic): rule-gen sweeper audit for all referral sites (llmo-referral-category-rules) | LLMO-6257

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,6 +79,7 @@ import readabilityOpportunities from './readability/opportunities/handler.js';
 import unifiedReadabilityGuidance from './readability/shared/unified-guidance-handler.js';
 import llmoReferralTraffic from './llmo-referral-traffic/handler.js';
 import llmoReferralTrafficDaily from './llmo-referral-traffic-daily/handler.js';
+import llmoReferralCategoryRules from './llmo-referral-category-rules/handler.js';
 import llmErrorPages from './llm-error-pages/handler.js';
 import llmErrorPagesGuidance from './llm-error-pages/guidance-handler.js';
 import paidTrafficAnalysis from './paid-traffic-analysis/handler.js';
@@ -190,6 +191,7 @@ const HANDLERS = {
   'page-intent': pageIntent,
   'llmo-referral-traffic': llmoReferralTraffic,
   'llmo-referral-traffic-daily': llmoReferralTrafficDaily,
+  'llmo-referral-category-rules': llmoReferralCategoryRules,
   'llm-error-pages': llmErrorPages,
   'guidance:llm-error-pages': llmErrorPagesGuidance,
   'optimization-report-callback': optimizationReportCallback,

--- a/src/llmo-referral-category-rules/handler.js
+++ b/src/llmo-referral-category-rules/handler.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { AuditBuilder } from '../common/audit-builder.js';
+import { noopUrlResolver } from '../common/index.js';
+import { generateReferralCategoryRules } from '../cdn-logs-report/patterns/patterns-uploader.js';
+
+/**
+ * Standalone per-site audit that (re)generates a site's shared referral category
+ * rules when it has none yet (create-if-missing). It runs off the DB corpus
+ * (`rpc_referral_traffic_top_urls`, which unions all referral sources), so it covers
+ * every site with referral traffic — not just optel. Scheduled to fan out weekly
+ * across referral sites, this is the "sweeper" that closes the rule-gen gap for
+ * cdn-only and DRS-only sites (LLMO-6257 P2, Fix A).
+ *
+ * @param {string} auditUrl - resolved site URL (noop-resolved; unused by rule-gen).
+ * @param {object} context - audit context (log, dataAccess, env, ...).
+ * @param {object} site - the site being processed.
+ * @returns {Promise<{auditResult: object, fullAuditRef: string}>}
+ */
+export async function referralCategoryRulesRunner(auditUrl, context, site) {
+  const { log } = context;
+  const siteId = site.getId();
+
+  try {
+    const generated = await generateReferralCategoryRules({ site, context });
+    log.info(`[llmo-referral-category-rules] site ${siteId}: rule generation ran, generated=${generated}`);
+    return { auditResult: { generated }, fullAuditRef: auditUrl };
+  } catch (err) {
+    // Return (don't throw) so a per-site failure doesn't trigger SQS retries that
+    // would re-invoke the LLM; the outcome is recorded on the audit and logged.
+    log.warn(`[llmo-referral-category-rules] rule generation failed for site ${siteId}: ${err.message}`);
+    return { auditResult: { generated: false, error: err.message }, fullAuditRef: auditUrl };
+  }
+}
+
+export default new AuditBuilder()
+  .withRunner(referralCategoryRulesRunner)
+  .withUrlResolver(noopUrlResolver)
+  .build();

--- a/test/audits/llmo-referral-category-rules/handler.test.js
+++ b/test/audits/llmo-referral-category-rules/handler.test.js
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+/* eslint-env mocha */
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import esmock from 'esmock';
+import { MockContextBuilder } from '../../shared.js';
+
+use(sinonChai);
+
+describe('llmo-referral-category-rules handler', function () {
+  this.timeout(10000);
+
+  const sandbox = sinon.createSandbox();
+  const AUDIT_URL = 'https://example.com';
+  let context;
+  let site;
+  let mockGenerateReferralCategoryRules;
+  let handlerModule;
+
+  beforeEach(async () => {
+    mockGenerateReferralCategoryRules = sandbox.stub().resolves(true);
+
+    site = {
+      getId: sandbox.stub().returns('site-123'),
+    };
+
+    context = new MockContextBuilder()
+      .withSandbox(sandbox)
+      .withOverrides({})
+      .build();
+
+    handlerModule = await esmock('../../../src/llmo-referral-category-rules/handler.js', {
+      '../../../src/cdn-logs-report/patterns/patterns-uploader.js': {
+        generateReferralCategoryRules: mockGenerateReferralCategoryRules,
+      },
+    });
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('exports a built audit as the default export', () => {
+    expect(handlerModule.default).to.exist;
+  });
+
+  it('generates rules and returns generated=true when fresh rules are created', async () => {
+    mockGenerateReferralCategoryRules.resolves(true);
+
+    const result = await handlerModule.referralCategoryRulesRunner(AUDIT_URL, context, site);
+
+    expect(mockGenerateReferralCategoryRules).to.have.been.calledOnce;
+    const arg = mockGenerateReferralCategoryRules.firstCall.args[0];
+    expect(arg.site).to.equal(site);
+    expect(arg.context).to.equal(context);
+    expect(result).to.deep.equal({
+      auditResult: { generated: true },
+      fullAuditRef: AUDIT_URL,
+    });
+    expect(context.log.info).to.have.been.calledOnce;
+  });
+
+  it('returns generated=false when the site already has rules (no-op)', async () => {
+    mockGenerateReferralCategoryRules.resolves(false);
+
+    const result = await handlerModule.referralCategoryRulesRunner(AUDIT_URL, context, site);
+
+    expect(result).to.deep.equal({
+      auditResult: { generated: false },
+      fullAuditRef: AUDIT_URL,
+    });
+  });
+
+  it('records the error and does not throw when rule generation fails', async () => {
+    mockGenerateReferralCategoryRules.rejects(new Error('boom'));
+
+    const result = await handlerModule.referralCategoryRulesRunner(AUDIT_URL, context, site);
+
+    expect(result).to.deep.equal({
+      auditResult: { generated: false, error: 'boom' },
+      fullAuditRef: AUDIT_URL,
+    });
+    expect(context.log.warn).to.have.been.calledOnce;
+  });
+});


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## Abstract
Adds a new per-site audit, `llmo-referral-category-rules`, that (re)generates a site's shared referral category rules when it has none yet. This is Fix A of the LLMO-6257 Phase-2 DRS work — decoupling rule generation from the optel audit so every site with referral traffic can get a rulebook.

## Reasoning
Referral category rules are only generated inside the optel daily audit today, so sites without optel — cdn-only sites, and (once built) DRS-only sites — never get a rulebook, and therefore never get categories. A prod scan on 2026-07-26 confirmed this: categories appear only on sites that have optel; every non-optel source (including 142 cdn-only sites) is at 0%. This audit gives the system a source-agnostic way to generate rules for any referral site, which fixes the cdn-only gap in prod today and unblocks the DRS work.

## Overview
A small `RunnerAudit` whose runner calls the existing `generateReferralCategoryRules({ site, context })` for one site and records the outcome. That function is already source-agnostic (its corpus unions all referral sources) and create-if-missing (idempotent), so this change only gives it a new trigger — it does not change how rules are generated, and it moves nothing into the database. On a per-site failure the runner records the error and returns rather than throwing, so a single site's failure can't trigger retries that would re-invoke the LLM. Registered as audit type `llmo-referral-category-rules` in the handler map; no existing audit is modified.

This handler is ready but does not run on its own yet — turning it on is a follow-up configuration step (register it as a scheduled job at the chosen cadence and enable it for referral sites in the Configuration), which lands after this deploys.

## Links
- Jira: LLMO-6257 (parent LLMO-5440)
- Design spec: adobe/spacecat-audit-worker#2817

## Affected projects
Change is confined to spacecat-audit-worker. It relies at runtime on the existing data-service corpus/rules RPCs (unchanged) and, once scheduled, on the jobs-dispatcher Configuration (a follow-up). The DRS Python classifier that will consume these rules is separate (DRS team).

## Test plan
Unit tests cover the runner's three outcomes: fresh rules generated, no-op when the site already has rules, and a generation failure being recorded without throwing. After deploy, the sweep is switched on via the scheduling/enablement configuration and verified by confirming categories begin appearing for cdn-only (and later DRS-only) sites through the referral `filter-dimensions` API — the same check used to confirm the optel/cdn path in prod.

## Deployment order
Independent and safe to ship on its own — it registers a new audit but nothing dispatches it yet, so there is no behavior change until the follow-up scheduling config is applied. Ship this first; the scheduling/enablement config follows once it is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
