### PR TITLE
feat(offsite): log LLM cost at end of offsite audits

### DIFF
--- a/src/cited-analysis/guidance-handler.js
+++ b/src/cited-analysis/guidance-handler.js
@@ -20,7 +20,7 @@ import { createOpportunityData } from './opportunity-data-mapper.js';
 import { postMessageOptional, buildAnalysisVisibilityMessage } from '../utils/slack-utils.js';
 import { resolveBrandResultForSite, applyScopeToOpportunity } from '../utils/brand-resolver.js';
 import { fetchAnalysisFromPresignedUrl } from '../utils/analysis-fetch.js';
-import { buildOffsiteTimingLines } from '../utils/offsite-audit-utils.js';
+import { buildOffsiteTimingLines, logOffsiteLlmUsage } from '../utils/offsite-audit-utils.js';
 import {
   isValidOffsiteAnalysis,
   persistOffsiteOpportunity,
@@ -157,6 +157,7 @@ export default async function handler(message, context) {
     });
 
     log.info(`${LOG_PREFIX} Successfully processed cited analysis for site: ${siteId}, company: ${companyName}, ${suggestions.length} suggestions`);
+    logOffsiteLlmUsage(log, LOG_PREFIX, siteId, opportunityData.llmUsage);
 
     if (auditId) {
       const auditRecord = await AuditModel.findById(auditId);

--- a/src/reddit-analysis/guidance-handler.js
+++ b/src/reddit-analysis/guidance-handler.js
@@ -20,7 +20,7 @@ import { createOpportunityData } from './opportunity-data-mapper.js';
 import { postMessageOptional, buildAnalysisVisibilityMessage } from '../utils/slack-utils.js';
 import { resolveBrandResultForSite, applyScopeToOpportunity } from '../utils/brand-resolver.js';
 import { fetchAnalysisFromPresignedUrl } from '../utils/analysis-fetch.js';
-import { buildOffsiteTimingLines } from '../utils/offsite-audit-utils.js';
+import { buildOffsiteTimingLines, logOffsiteLlmUsage } from '../utils/offsite-audit-utils.js';
 import {
   isValidOffsiteAnalysis,
   persistOffsiteOpportunity,
@@ -157,6 +157,7 @@ export default async function handler(message, context) {
     });
 
     log.info(`${LOG_PREFIX} Successfully processed Reddit analysis for site: ${siteId}, company: ${companyName}, ${suggestions.length} suggestions`);
+    logOffsiteLlmUsage(log, LOG_PREFIX, siteId, opportunityData.llmUsage);
 
     if (auditId) {
       const auditRecord = await AuditModel.findById(auditId);

--- a/src/utils/offsite-audit-utils.js
+++ b/src/utils/offsite-audit-utils.js
@@ -120,6 +120,34 @@ export function buildOffsiteTimingLines(timings, nowMs = Date.now()) {
     + `• Total (DRS + Mystique): ${total}`;
 }
 
+/**
+ * Logs the LLM cost/usage Mystique reported for an offsite analysis, at the end of
+ * the run. Mystique stamps `opportunity.llmUsage`
+ * ({ totalLlmCalls, totalTokens, totalCostUsd }) into the BO JSON; this surfaces it
+ * as a structured, greppable log line alongside the timing lines.
+ *
+ * No-ops when `llmUsage` is absent or not an object (e.g. an analysis that doesn't
+ * track token usage, or a tracking-degraded run) so the caller never has to guard.
+ * Numeric fields are coerced defensively so a malformed payload can't throw.
+ *
+ * @param {object} log - Logger with an `info` method
+ * @param {string} logPrefix - Per-audit log prefix (e.g. '[Cited]')
+ * @param {string} siteId - The site the analysis ran for
+ * @param {object} [llmUsage] - { totalLlmCalls, totalTokens, totalCostUsd } from Mystique
+ */
+export function logOffsiteLlmUsage(log, logPrefix, siteId, llmUsage) {
+  if (!llmUsage || typeof llmUsage !== 'object') {
+    return;
+  }
+  const calls = Number(llmUsage.totalLlmCalls) || 0;
+  const tokens = Number(llmUsage.totalTokens) || 0;
+  const cost = Number(llmUsage.totalCostUsd) || 0;
+  log.info(
+    `${logPrefix} LLM usage for siteId: ${siteId}: ${calls} calls, `
+    + `${tokens} tokens, est. cost $${cost.toFixed(4)}`,
+  );
+}
+
 // Tokens shorter than this are dropped from brand-token matching: a 1-2 char
 // substring would match almost any host and turn the branded filter into a
 // blunt instrument.

--- a/src/youtube-analysis/guidance-handler.js
+++ b/src/youtube-analysis/guidance-handler.js
@@ -18,7 +18,7 @@ import { createOpportunityData } from './opportunity-data-mapper.js';
 import { postMessageOptional, buildAnalysisVisibilityMessage } from '../utils/slack-utils.js';
 import { resolveBrandResultForSite, applyScopeToOpportunity } from '../utils/brand-resolver.js';
 import { fetchAnalysisFromPresignedUrl } from '../utils/analysis-fetch.js';
-import { buildOffsiteTimingLines } from '../utils/offsite-audit-utils.js';
+import { buildOffsiteTimingLines, logOffsiteLlmUsage } from '../utils/offsite-audit-utils.js';
 import {
   isValidOffsiteAnalysis,
   persistOffsiteOpportunity,
@@ -155,6 +155,7 @@ export default async function handler(message, context) {
     });
 
     log.info(`${LOG_PREFIX} Successfully processed YouTube analysis for site: ${siteId}, company: ${companyName}, ${suggestions.length} suggestions`);
+    logOffsiteLlmUsage(log, LOG_PREFIX, siteId, opportunityData.llmUsage);
 
     if (auditId) {
       const audit = await AuditModel.findById(auditId);

--- a/test/audits/cited-analysis/guidance-handler.test.js
+++ b/test/audits/cited-analysis/guidance-handler.test.js
@@ -153,6 +153,30 @@ describe('Cited Analysis Guidance Handler', () => {
       expect(context.log.info).to.have.been.calledWith(sinon.match(/Successfully processed cited analysis/));
     });
 
+    it('logs the Mystique LLM cost when opportunity.llmUsage is present', async () => {
+      const message = {
+        siteId,
+        auditId,
+        data: {
+          companyName: 'Example Corp',
+          analysis: {
+            opportunity: {
+              llmUsage: { totalLlmCalls: 10, totalTokens: 326070, totalCostUsd: 1.468751 },
+            },
+            suggestions: [
+              { id: 'sug_1', priority: 'HIGH', title: 'T', description: 'D' },
+            ],
+          },
+        },
+      };
+
+      await handler.default(message, context);
+
+      expect(context.log.info).to.have.been.calledWith(
+        `[Cited] LLM usage for siteId: ${siteId}: 10 calls, 326070 tokens, est. cost $1.4688`,
+      );
+    });
+
     it('should pass opportunityData from BO JSON to persistOffsiteOpportunity', async () => {
       const opportunityData = {
         title: 'Cited URL Analysis',

--- a/test/utils/offsite-audit-utils.test.js
+++ b/test/utils/offsite-audit-utils.test.js
@@ -27,6 +27,7 @@ import {
   toApexHost,
   formatDuration,
   buildOffsiteTimingLines,
+  logOffsiteLlmUsage,
   formatDrsExtras,
   buildAnalysisScrapeStatusMessage,
   scrapedThisCycle,
@@ -683,6 +684,52 @@ describe('offsite-audit-utils', () => {
     it('returns empty string when the elapsed Mystique time is not computable', () => {
       // analysisStartedAt in the future → negative elapsed → no usable duration.
       expect(buildOffsiteTimingLines({ analysisStartedAt: now + 5_000 }, now)).to.equal('');
+    });
+  });
+
+  describe('logOffsiteLlmUsage', () => {
+    let log;
+
+    beforeEach(() => {
+      log = { info: sandbox.spy() };
+    });
+
+    it('logs calls, tokens, and 4-decimal cost when llmUsage is present', () => {
+      logOffsiteLlmUsage(log, '[Cited]', 'site-123', {
+        totalLlmCalls: 10,
+        totalTokens: 326070,
+        totalCostUsd: 1.468751,
+      });
+      expect(log.info).to.have.been.calledOnce;
+      expect(log.info.firstCall.args[0]).to.equal(
+        '[Cited] LLM usage for siteId: site-123: 10 calls, 326070 tokens, est. cost $1.4688',
+      );
+    });
+
+    it('logs nothing when llmUsage is undefined', () => {
+      logOffsiteLlmUsage(log, '[Cited]', 'site-123', undefined);
+      expect(log.info).to.not.have.been.called;
+    });
+
+    it('logs nothing when llmUsage is null', () => {
+      logOffsiteLlmUsage(log, '[Cited]', 'site-123', null);
+      expect(log.info).to.not.have.been.called;
+    });
+
+    it('logs nothing when llmUsage is not an object', () => {
+      logOffsiteLlmUsage(log, '[Cited]', 'site-123', 'oops');
+      expect(log.info).to.not.have.been.called;
+    });
+
+    it('coerces missing or malformed numeric fields to 0 without throwing', () => {
+      logOffsiteLlmUsage(log, '[YouTube]', 'site-999', {
+        totalLlmCalls: 'x',
+        totalCostUsd: undefined,
+      });
+      expect(log.info).to.have.been.calledOnce;
+      expect(log.info.firstCall.args[0]).to.equal(
+        '[YouTube] LLM usage for siteId: site-999: 0 calls, 0 tokens, est. cost $0.0000',
+      );
     });
   });
 });


### PR DESCRIPTION
## What

Log the LLM cost of each offsite audit when it finishes.

Mystique already tracks token spend per offsite analysis and stamps it into the BO JSON it returns as `opportunity.llmUsage`:

```json
"llmUsage": { "totalLlmCalls": 10, "totalTokens": 326070, "totalCostUsd": 1.468751 }
```

This surfaces that data as a structured, greppable log line at the end of the run, next to the existing timing lines.

## Changes

- **New helper** `logOffsiteLlmUsage(log, logPrefix, siteId, llmUsage)` in `src/utils/offsite-audit-utils.js` (alongside `buildOffsiteTimingLines`). Emits:
  ```
  [Cited] LLM usage for siteId: <id>: 10 calls, 326070 tokens, est. cost $1.4688
  ```
  No-ops when `llmUsage` is absent or malformed (never throws); numeric fields coerced defensively; cost formatted to 4 decimals to match Mystique's own summary line.
- Wired into the three offsite guidance handlers that receive `opportunity.llmUsage` from Mystique: **cited-analysis**, **youtube-analysis**, **reddit-analysis** — right after the "Successfully processed …" success log.

## Scope notes

- Only offsite audits produce `llmUsage` (that's the only place Mystique tracks token cost), so the change is scoped to those handlers.
- **wikipedia-analysis** is intentionally left out — Mystique does not currently emit `llmUsage` for it. Easy to add later once it does.

## Testing

- Unit tests for `logOffsiteLlmUsage`: present usage, missing/null/non-object usage, malformed numeric fields.
- Wiring test in the cited-analysis guidance handler asserting the cost line is logged when `opportunity.llmUsage` is present.
- Full suite + 100% coverage gate pass; lint clean.
