### PR TITLE
fix(cwv): suppress redundant guidance re-dispatch for unchanged failing metrics

### DIFF
--- a/src/cwv/auto-suggest.js
+++ b/src/cwv/auto-suggest.js
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import { deepEqual, isObject } from '@adobe/spacecat-shared-utils';
 import { getCodeInfo } from '../accessibility/utils/data-processing.js';
 import { METRICS, THRESHOLDS } from './kpi-metrics.js';
 
@@ -41,6 +42,24 @@ function getFailingMetricInfo(allMetrics) {
   };
 }
 
+/**
+ * Deterministic "dispatch fingerprint" describing the inputs that justify (re)sending a
+ * CWV suggestion to Mystique. Stamped on the suggestion after a NEW dispatch and compared
+ * on the next weekly audit so we only re-dispatch when a relevant input changed:
+ * - the set of failing metrics grew/changed (e.g. CLS newly goes bad), or
+ * - site code became available (`hadCodeInfo` false -> true) so a code patch that couldn't
+ *   be generated before might now succeed.
+ * Both the guard (read) and `processAutoSuggest` (stamp) build it identically so a stamped
+ * marker re-compares exactly next run. Mirrors the V2/blackboard `idea_fingerprint` idea.
+ *
+ * @param {string[]} failingMetrics - metrics failing this run (lcp/cls/inp)
+ * @param {boolean} hasCodeInfo - whether a code repo/path is available for this site
+ * @returns {{ failingMetrics: string[], hadCodeInfo: boolean }}
+ */
+function buildDispatchFingerprint(failingMetrics, hasCodeInfo) {
+  return { failingMetrics: [...failingMetrics].sort(), hadCodeInfo: !!hasCodeInfo };
+}
+
 const CWV_AUTO_SUGGEST_MESSAGE_TYPE = 'guidance:cwv';
 
 /**
@@ -69,10 +88,17 @@ const CWV_AUTO_SUGGEST_MESSAGE_TYPE = 'guidance:cwv';
  * is nothing for the SME to review and the suggestion can never be approved.
  *
  * For NEW, we dispatch whenever no code patch has been produced yet
- * (`data.isCodeChangeAvailable !== true`). We deliberately ignore
- * `issues[*].value` here — text guidance being present is not proof that a code
- * patch ran successfully, and `mergeCwvData` preserves that field across every
- * re-audit, which used to silently block retries forever.
+ * (`data.isCodeChangeAvailable !== true`) AND a relevant input has changed since the
+ * last dispatch. Cost control (same flagged metric week after week shouldn't pay for
+ * fresh guidance every audit): we SUPPRESS the re-dispatch when the currently-failing
+ * metric set is already fully covered by existing guidance (`data.issues[*].type`) AND
+ * the dispatch fingerprint is unchanged from the last stamped one
+ * (`data.autoSuggestDispatch`). We still re-dispatch when a new bad metric appears or
+ * when site code becomes available (both flip the fingerprint), and — crucially — when
+ * guidance never actually arrived for a still-failing metric (`allFailingGuided` false),
+ * so a slow/failed Mystique run is still retried. We deliberately ignore
+ * `issues[*].value` (its mere presence is not proof a code patch ran) — the retry is
+ * bounded by the fingerprint + code-patch availability, not by guidance text existing.
  *
  * For PENDING_VALIDATION, re-dispatch is gated on the existing guidance being
  * missing or in the legacy aggregated format (no per-issue `source_index`), so a
@@ -82,9 +108,11 @@ const CWV_AUTO_SUGGEST_MESSAGE_TYPE = 'guidance:cwv';
  * Group filtering and "page is all-green" filtering happen in `processAutoSuggest`.
  *
  * @param {Object} suggestion - Suggestion object
+ * @param {boolean} [hasCodeInfo=false] - whether site code is available this run; part of
+ *   the dispatch fingerprint so a NEW page re-dispatches once when code first appears.
  * @returns {boolean} True if suggestion should receive auto-suggest
  */
-export function shouldSendAutoSuggestForSuggestion(suggestion) {
+export function shouldSendAutoSuggestForSuggestion(suggestion, hasCodeInfo = false) {
   const status = suggestion.getStatus();
   if (status !== 'NEW' && status !== 'PENDING_VALIDATION') {
     return false;
@@ -98,6 +126,23 @@ export function shouldSendAutoSuggestForSuggestion(suggestion) {
     const hasGranularGuidance = Array.isArray(issues) && issues.length > 0
       && issues.some((i) => Number.isInteger(i.source_index));
     return !hasGranularGuidance;
+  }
+
+  // status === 'NEW': suppress the weekly re-dispatch unless an input changed.
+  const { failingMetrics } = getFailingMetricInfo(data.metrics || []);
+  if (failingMetrics.length === 0) {
+    // All-green: dispatch decision defers to processAutoSuggest, which owns the skip+log.
+    return true;
+  }
+  const guidedMetrics = new Set(
+    (Array.isArray(data.issues) ? data.issues : []).map((i) => i.type),
+  );
+  const allFailingGuided = failingMetrics.every((m) => guidedMetrics.has(m));
+  const stored = data.autoSuggestDispatch;
+  const fingerprintUnchanged = isObject(stored)
+    && deepEqual(stored, buildDispatchFingerprint(failingMetrics, hasCodeInfo));
+  if (allFailingGuided && fingerprintUnchanged) {
+    return false;
   }
   return true;
 }
@@ -124,8 +169,9 @@ export function shouldSendAutoSuggestForSuggestion(suggestion) {
  */
 export async function processAutoSuggest(context, opportunity, site) {
   const {
-    log, sqs, env,
+    log, sqs, env, dataAccess,
   } = context;
+  const Suggestion = dataAccess?.Suggestion;
 
   try {
     const siteId = opportunity.getSiteId();
@@ -138,10 +184,15 @@ export async function processAutoSuggest(context, opportunity, site) {
     const codeInfo = site ? await getCodeInfo(site, 'cwv', context) : null;
     const hasCodeInfo = codeInfo && codeInfo.codeBucket && codeInfo.codePath && String(codeInfo.codePath).trim() !== '';
 
+    // NEW suggestions we dispatched this run, stamped with a fresh dispatch fingerprint so
+    // the next weekly audit can suppress an identical re-dispatch. Persisted in one batched
+    // saveMany (never per-item save — see the repo N+1 guidance).
+    const dispatchedNew = [];
+
     // Send one SQS message per suggestion that needs auto-suggest
     for (const suggestion of suggestions) {
       // Skip suggestions that don't need auto-suggest
-      if (!shouldSendAutoSuggestForSuggestion(suggestion)) {
+      if (!shouldSendAutoSuggestForSuggestion(suggestion, hasCodeInfo)) {
         // eslint-disable-next-line no-continue
         continue;
       }
@@ -205,6 +256,22 @@ export async function processAutoSuggest(context, opportunity, site) {
       // eslint-disable-next-line no-await-in-loop
       await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, sqsMessage);
       log.info(`[audit-worker-cwv] siteId: ${siteId} | CWV suggestion message sent to Mystique (opportunityId: ${opportunityId}, suggestionId: ${suggestionId}, url: ${url}), message: \n${JSON.stringify(sqsMessage, null, 2)}`);
+
+      // Stamp the dispatch fingerprint on NEW suggestions so an unchanged re-audit next
+      // week is suppressed. NEW only: a leftover PENDING_VALIDATION-era fingerprint must
+      // not suppress the first post-SME-approval NEW dispatch (that dispatch is what
+      // authorizes Mystique code-fix generation via suggestionStatus).
+      if (Suggestion && suggestion.getStatus() === 'NEW') {
+        suggestion.setData({
+          ...suggestionData,
+          autoSuggestDispatch: buildDispatchFingerprint(failingMetrics, hasCodeInfo),
+        });
+        dispatchedNew.push(suggestion);
+      }
+    }
+
+    if (dispatchedNew.length > 0) {
+      await Suggestion.saveMany(dispatchedNew);
     }
 
     log.info(`[audit-worker-cwv] siteId: ${siteId} | Completed sending CWV auto-suggest messages, opportunityId: ${opportunityId}`);

--- a/src/cwv/auto-suggest.js
+++ b/src/cwv/auto-suggest.js
@@ -96,9 +96,19 @@ const CWV_AUTO_SUGGEST_MESSAGE_TYPE = 'guidance:cwv';
  * (`data.autoSuggestDispatch`). We still re-dispatch when a new bad metric appears or
  * when site code becomes available (both flip the fingerprint), and — crucially — when
  * guidance never actually arrived for a still-failing metric (`allFailingGuided` false),
- * so a slow/failed Mystique run is still retried. We deliberately ignore
+ * so a slow/failed Mystique *guidance* run is still retried. We deliberately ignore
  * `issues[*].value` (its mere presence is not proof a code patch ran) — the retry is
  * bounded by the fingerprint + code-patch availability, not by guidance text existing.
+ *
+ * Bounded limitation: if code was already available at the first dispatch (so
+ * `hadCodeInfo` is already `true` and never flips), guidance succeeded for every failing
+ * metric, but Mystique's *code-fix* generation transiently failed and no patch landed
+ * (`isCodeChangeAvailable` stays `false`), the fingerprint is unchanged and re-dispatch is
+ * suppressed until the failing-metric set changes. The `hadCodeInfo false→true` escape only
+ * covers newly-available code, not a failed generation on already-available code. This is
+ * an accepted trade-off: reintroducing a blanket weekly retry for this case is exactly the
+ * cost this guard removes, and it assumes code-fix generation is reliable whenever guidance
+ * succeeds and code is present.
  *
  * For PENDING_VALIDATION, re-dispatch is gated on the existing guidance being
  * missing or in the legacy aggregated format (no per-issue `source_index`), so a
@@ -271,7 +281,15 @@ export async function processAutoSuggest(context, opportunity, site) {
     }
 
     if (dispatchedNew.length > 0) {
-      await Suggestion.saveMany(dispatchedNew);
+      // Best-effort persistence: every SQS message already went out above, so a failure
+      // here must not fail the audit step. If the stamp doesn't persist, next week's
+      // audit simply re-dispatches (the fingerprint guard sees no stored fingerprint) —
+      // the fail-safe direction. Log a warning instead of propagating to the outer catch.
+      try {
+        await Suggestion.saveMany(dispatchedNew);
+      } catch (stampError) {
+        log.warn(`[audit-worker-cwv] siteId: ${siteId} | Failed to persist dispatch fingerprint for ${dispatchedNew.length} suggestion(s); messages were already sent, will re-dispatch next audit. error: ${stampError.message}`);
+      }
     }
 
     log.info(`[audit-worker-cwv] siteId: ${siteId} | Completed sending CWV auto-suggest messages, opportunityId: ${opportunityId}`);

--- a/test/audits/cwv.test.js
+++ b/test/audits/cwv.test.js
@@ -535,7 +535,10 @@ describe('collectCWVDataAndImportCode Tests', () => {
       // make sure that 1 existing suggestion is updated
       expect(existingSuggestions[1].setData).to.have.been.calledOnce;
       expect(existingSuggestions[1].setData.firstCall.args[0]).to.deep.equal(suggestions[1].data);
-      expect(context.dataAccess.Suggestion.saveMany).to.have.been.calledOnce;
+      // Two batched saveMany calls: syncSuggestions persists the changed suggestion, then
+      // processAutoSuggest persists the dispatch-fingerprint stamp on the NEW suggestion it
+      // re-dispatched to Mystique (both single batched upserts, not N+1).
+      expect(context.dataAccess.Suggestion.saveMany).to.have.been.calledTwice;
 
       // make sure that 1 new suggestion is created (/docs/ — the only new failing-metric page)
       expect(oppty.addSuggestions).to.have.been.calledOnce;
@@ -665,8 +668,8 @@ describe('collectCWVDataAndImportCode Tests', () => {
       // on each so the auto-suggest skip ("no failing CWV metrics") doesn't drop them.
       const failingMetrics = [{ deviceType: 'mobile', lcp: 3500, cls: 0.05, inp: 100 }];
       const mockSuggestions = [
-        { getId: () => 'sugg-1', getData: () => ({ type: 'url', url: 'test1', issues: [], metrics: failingMetrics }), getStatus: () => 'NEW' },
-        { getId: () => 'sugg-2', getData: () => ({ type: 'url', url: 'test2', issues: [], metrics: failingMetrics }), getStatus: () => 'NEW' }
+        { getId: () => 'sugg-1', getData: () => ({ type: 'url', url: 'test1', issues: [], metrics: failingMetrics }), getStatus: () => 'NEW', setData: sinon.stub() },
+        { getId: () => 'sugg-2', getData: () => ({ type: 'url', url: 'test2', issues: [], metrics: failingMetrics }), getStatus: () => 'NEW', setData: sinon.stub() }
       ];
       
       // Setup opportunity with mock suggestions before the function call
@@ -794,7 +797,8 @@ describe('collectCWVDataAndImportCode Tests', () => {
             ],
             metrics: failingMetrics,
           }),
-          getStatus: () => 'NEW'
+          getStatus: () => 'NEW',
+          setData: sinon.stub(),
         },
         {
           getId: () => 'sugg-2',
@@ -805,7 +809,8 @@ describe('collectCWVDataAndImportCode Tests', () => {
             issues: [],
             metrics: failingMetrics,
           }),
-          getStatus: () => 'NEW'
+          getStatus: () => 'NEW',
+          setData: sinon.stub(),
         }
       ];
 

--- a/test/audits/cwv/auto-suggest.test.js
+++ b/test/audits/cwv/auto-suggest.test.js
@@ -827,4 +827,188 @@ describe('CWV Auto-Suggest', () => {
       expect(result).to.be.false;
     });
   });
+
+  describe('shouldSendAutoSuggestForSuggestion — suppress unless inputs changed (NEW)', () => {
+    const newSuggestion = (data) => ({ getStatus: () => 'NEW', getData: () => data });
+
+    it('suppresses re-dispatch when failing metrics are unchanged and already guided', () => {
+      const suggestion = newSuggestion({
+        metrics: [{ deviceType: 'mobile', lcp: 3500, cls: 0.05, inp: 100 }],
+        issues: [{ type: 'lcp', value: 'x' }],
+        autoSuggestDispatch: { failingMetrics: ['lcp'], hadCodeInfo: false },
+      });
+      expect(shouldSendAutoSuggestForSuggestion(suggestion, false)).to.be.false;
+    });
+
+    it('dispatches when there is no stored dispatch fingerprint yet (first run / legacy)', () => {
+      const suggestion = newSuggestion({
+        metrics: [{ deviceType: 'mobile', lcp: 3500, cls: 0.05, inp: 100 }],
+        issues: [{ type: 'lcp', value: 'x' }],
+      });
+      expect(shouldSendAutoSuggestForSuggestion(suggestion, false)).to.be.true;
+    });
+
+    it('dispatches when guidance has not arrived for the failing metric (empty issues)', () => {
+      const suggestion = newSuggestion({
+        metrics: [{ deviceType: 'mobile', lcp: 3500, cls: 0.05, inp: 100 }],
+        issues: [],
+        autoSuggestDispatch: { failingMetrics: ['lcp'], hadCodeInfo: false },
+      });
+      expect(shouldSendAutoSuggestForSuggestion(suggestion, false)).to.be.true;
+    });
+
+    it('dispatches when issues is not an array', () => {
+      const suggestion = newSuggestion({
+        metrics: [{ deviceType: 'mobile', lcp: 3500, cls: 0.05, inp: 100 }],
+        autoSuggestDispatch: { failingMetrics: ['lcp'], hadCodeInfo: false },
+      });
+      expect(shouldSendAutoSuggestForSuggestion(suggestion, false)).to.be.true;
+    });
+
+    it('dispatches when a new bad metric appears that is not yet guided', () => {
+      const suggestion = newSuggestion({
+        metrics: [{ deviceType: 'mobile', lcp: 3500, cls: 0.05, inp: 300 }], // lcp + inp
+        issues: [{ type: 'lcp', value: 'x' }],
+        autoSuggestDispatch: { failingMetrics: ['lcp'], hadCodeInfo: false },
+      });
+      expect(shouldSendAutoSuggestForSuggestion(suggestion, false)).to.be.true;
+    });
+
+    it('dispatches once when site code becomes available (fingerprint hadCodeInfo flips)', () => {
+      const suggestion = newSuggestion({
+        metrics: [{ deviceType: 'mobile', lcp: 3500, cls: 0.05, inp: 100 }],
+        issues: [{ type: 'lcp', value: 'x' }],
+        autoSuggestDispatch: { failingMetrics: ['lcp'], hadCodeInfo: false },
+      });
+      expect(shouldSendAutoSuggestForSuggestion(suggestion, true)).to.be.true;
+    });
+
+    it('dispatches when the stored failing-metric set differs from the current one', () => {
+      const suggestion = newSuggestion({
+        metrics: [{ deviceType: 'mobile', lcp: 3500, cls: 0.05, inp: 100 }],
+        issues: [{ type: 'lcp', value: 'x' }],
+        autoSuggestDispatch: { failingMetrics: ['cls'], hadCodeInfo: false },
+      });
+      expect(shouldSendAutoSuggestForSuggestion(suggestion, false)).to.be.true;
+    });
+  });
+
+  describe('processAutoSuggest — dispatch fingerprint stamping', () => {
+    let saveManyStub;
+    let daContext;
+
+    const makeOpp = (suggestions) => ({
+      getSiteId: () => 'site-123',
+      getAuditId: () => 'audit-456',
+      getId: () => 'oppty-789',
+      getType: () => 'cwv',
+      getSuggestions: () => Promise.resolve(suggestions),
+    });
+
+    beforeEach(() => {
+      saveManyStub = sandbox.stub().resolves();
+      daContext = { ...context, dataAccess: { Suggestion: { saveMany: saveManyStub } } };
+    });
+
+    it('stamps a dispatch fingerprint and batch-saves NEW dispatches', async () => {
+      const setDataStub = sandbox.stub();
+      const suggestion = {
+        getId: () => 'sugg-001',
+        getStatus: () => 'NEW',
+        getData: () => ({
+          type: 'url',
+          url: 'https://example.com/page1',
+          metrics: [{ deviceType: 'mobile', lcp: 3500, cls: 0.05, inp: 100 }],
+          issues: [],
+        }),
+        setData: setDataStub,
+      };
+
+      await processAutoSuggest(daContext, makeOpp([suggestion]), null);
+
+      expect(sqsStub.calledOnce).to.be.true;
+      expect(setDataStub).to.have.been.calledOnceWithExactly(sinon.match({
+        autoSuggestDispatch: { failingMetrics: ['lcp'], hadCodeInfo: false },
+      }));
+      expect(saveManyStub).to.have.been.calledOnceWithExactly([suggestion]);
+    });
+
+    it('suppresses an unchanged, already-guided re-dispatch (no SQS, no save)', async () => {
+      const suggestion = {
+        getId: () => 'sugg-001',
+        getStatus: () => 'NEW',
+        getData: () => ({
+          type: 'url',
+          url: 'https://example.com/page1',
+          metrics: [{ deviceType: 'mobile', lcp: 3500, cls: 0.05, inp: 100 }],
+          issues: [{ type: 'lcp', value: 'x' }],
+          autoSuggestDispatch: { failingMetrics: ['lcp'], hadCodeInfo: false },
+        }),
+        setData: sandbox.stub(),
+      };
+
+      await processAutoSuggest(daContext, makeOpp([suggestion]), null);
+
+      expect(sqsStub.called).to.be.false;
+      expect(saveManyStub.called).to.be.false;
+    });
+
+    it('does not stamp PENDING_VALIDATION dispatches', async () => {
+      const suggestion = {
+        getId: () => 'sugg-001',
+        getStatus: () => 'PENDING_VALIDATION',
+        getData: () => ({
+          type: 'url',
+          url: 'https://example.com/page1',
+          metrics: [{ deviceType: 'mobile', lcp: 3500 }],
+          issues: [],
+        }),
+        setData: sandbox.stub(),
+      };
+
+      await processAutoSuggest(daContext, makeOpp([suggestion]), null);
+
+      expect(sqsStub.calledOnce).to.be.true;
+      expect(saveManyStub.called).to.be.false;
+    });
+
+    it('re-dispatches and re-stamps hadCodeInfo:true when site code becomes available', async () => {
+      const getCodeInfoStub = sandbox.stub().resolves({
+        codeBucket: 'test-bucket',
+        codePath: 'code/site/repo.zip',
+      });
+      const { processAutoSuggest: processWithCode } = await esmock('../../../src/cwv/auto-suggest.js', {
+        '../../../src/accessibility/utils/data-processing.js': { getCodeInfo: getCodeInfoStub },
+      });
+      const setDataStub = sandbox.stub();
+      const suggestion = {
+        getId: () => 'sugg-001',
+        getStatus: () => 'NEW',
+        getData: () => ({
+          type: 'url',
+          url: 'https://example.com/page1',
+          metrics: [{ deviceType: 'mobile', lcp: 3500, cls: 0.05, inp: 100 }],
+          issues: [{ type: 'lcp', value: 'x' }],
+          autoSuggestDispatch: { failingMetrics: ['lcp'], hadCodeInfo: false },
+        }),
+        setData: setDataStub,
+      };
+      const siteWithCode = {
+        getId: () => 'test-site-id',
+        getBaseURL: sandbox.stub().returns('https://example.com'),
+        getDeliveryType: sandbox.stub().returns('aem_cs'),
+        getCode: sandbox.stub().returns({
+          source: 'github', owner: 'o', repo: 'r', ref: 'main',
+        }),
+      };
+
+      await processWithCode(daContext, makeOpp([suggestion]), siteWithCode);
+
+      expect(sqsStub.calledOnce).to.be.true;
+      expect(setDataStub).to.have.been.calledOnceWithExactly(sinon.match({
+        autoSuggestDispatch: { failingMetrics: ['lcp'], hadCodeInfo: true },
+      }));
+      expect(saveManyStub).to.have.been.calledOnce;
+    });
+  });
 });

--- a/test/audits/cwv/auto-suggest.test.js
+++ b/test/audits/cwv/auto-suggest.test.js
@@ -933,6 +933,29 @@ describe('CWV Auto-Suggest', () => {
       expect(saveManyStub).to.have.been.calledOnceWithExactly([suggestion]);
     });
 
+    it('does not fail the audit when the stamp saveMany throws (best-effort persistence)', async () => {
+      saveManyStub.rejects(new Error('dynamo throttled'));
+      const suggestion = {
+        getId: () => 'sugg-001',
+        getStatus: () => 'NEW',
+        getData: () => ({
+          type: 'url',
+          url: 'https://example.com/page1',
+          metrics: [{ deviceType: 'mobile', lcp: 3500, cls: 0.05, inp: 100 }],
+          issues: [],
+        }),
+        setData: sandbox.stub(),
+      };
+
+      await processAutoSuggest(daContext, makeOpp([suggestion]), null);
+
+      // Message was already sent; the failed stamp persistence must not propagate.
+      expect(sqsStub.calledOnce).to.be.true;
+      expect(saveManyStub.calledOnce).to.be.true;
+      expect(daContext.log.warn).to.have.been.calledOnce;
+      expect(daContext.log.error).to.not.have.been.called;
+    });
+
     it('suppresses an unchanged, already-guided re-dispatch (no SQS, no save)', async () => {
       const suggestion = {
         getId: () => 'sugg-001',


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/SITES-48889

## Problem

Every weekly CWV audit re-sends a `guidance:cwv` message to Mystique for each `NEW` suggestion without a code patch — even when the identical metric (e.g. bad LCP) was already flagged and already has guidance. A page failing LCP in week *n* is re-guided in weeks *n+1*, *n+2*, … paying for fresh guidance/code-fix generation with **no new signal**. Bad LCP this week almost certainly means bad LCP next week; there is no reason to re-run the expensive downstream work unless the flagged metric set actually changes.

The suggestion DB sync already deep-equal-skips unchanged rows, so the waste is purely in the Mystique dispatch.

## Change

`shouldSendAutoSuggestForSuggestion` now stamps a **dispatch fingerprint** on `NEW` dispatches:

```js
data.autoSuggestDispatch = { failingMetrics: [...sorted], hadCodeInfo }
```

and suppresses the next re-dispatch when the failing-metric set is unchanged **AND** every failing metric is already covered by existing guidance (`data.issues[*].type`).

**It still re-dispatches (no functionality lost) when:**
- a new bad metric appears (e.g. CLS newly goes bad) — the fingerprint set changes;
- site code becomes available (`hadCodeInfo` flips `false -> true`) so a code patch that could not be generated before might now succeed;
- guidance never actually arrived for a still-failing metric (slow/failed Mystique run) — preserving the deliberate code-fix retry loop.

The stamp is persisted via a single batched `Suggestion.saveMany` (not N+1), stamped **NEW-only** (so a leftover `PENDING_VALIDATION`-era fingerprint cannot suppress the first post-approval dispatch that authorizes code-fix generation), and preserved across re-audits by `mergeCwvData`'s shallow spread (so it never trips the sync deep-equal skip).

## Goal

Cost reduction — stop paying for redundant weekly guidance/code-fix generation on pages whose flagged CWV metrics have not changed — **with essentially no loss of functionality**.

One bounded case is deliberately narrowed: if code was already available at the first dispatch (so `hadCodeInfo` is already `true` and never flips), guidance succeeded for every failing metric, but Mystique's *code-fix* generation transiently failed and no patch landed (`isCodeChangeAvailable` stays `false`), the fingerprint is unchanged and re-dispatch is suppressed until the failing-metric set changes. This is an accepted trade-off — restoring a blanket weekly retry for it is exactly the cost this guard removes — and it assumes code-fix generation is reliable whenever guidance succeeds and code is present. Guidance failures (the common failure mode) are still retried via the `allFailingGuided` gate.

## Testing

- `auto-suggest.js` at **100%** line/branch/statement/function coverage.
- 12 new unit + e2e tests (suppression branches, first-run/legacy dispatch, new-metric dispatch, code-available re-dispatch, PENDING not stamped, batched save, best-effort stamp-persist failure).
- Full suite: **9300 passing**, lines/branches/statements 100%.

## Note

A follow-up (tracked separately) will address the equivalent gap on the V2/blackboard path, where the 168h TTL on `a_cwv_guidance`/`a_cwv_autofix`/`a_cwv_autofix_verified` sits exactly on the weekly cadence and re-runs the full Opus chain for unchanged metrics; `idea_fingerprint` there only dedupes stored results, it never gates the agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

