### PR TITLE
feat(offsite): show capped URL count and LLM cost in analysis Slack messages

### DIFF
--- a/src/cited-analysis/guidance-handler.js
+++ b/src/cited-analysis/guidance-handler.js
@@ -20,7 +20,7 @@ import { createOpportunityData } from './opportunity-data-mapper.js';
 import { postMessageOptional, buildAnalysisVisibilityMessage } from '../utils/slack-utils.js';
 import { resolveBrandResultForSite, applyScopeToOpportunity } from '../utils/brand-resolver.js';
 import { fetchAnalysisFromPresignedUrl } from '../utils/analysis-fetch.js';
-import { buildOffsiteTimingLines, logOffsiteLlmUsage } from '../utils/offsite-audit-utils.js';
+import { buildOffsiteTimingLines, logOffsiteLlmUsage, buildOffsiteLlmUsageLine } from '../utils/offsite-audit-utils.js';
 import {
   isValidOffsiteAnalysis,
   persistOffsiteOpportunity,
@@ -178,9 +178,14 @@ export default async function handler(message, context) {
           verdict: opportunityData.qaVerdict,
         });
 
-        // Append DRS / Mystique / total phase timings (from anchors on the audit result).
+        // Append DRS / Mystique / total phase timings and the LLM cost Mystique reported.
+        // Each is omitted when its data is absent (no timing anchors / no llmUsage stamp).
         const timingLines = buildOffsiteTimingLines(auditResultData?.timings);
-        const fullMessage = timingLines ? `${slackMessage}\n${timingLines}` : slackMessage;
+        const llmUsageLine = buildOffsiteLlmUsageLine(opportunityData.llmUsage);
+        const extraLines = [timingLines, llmUsageLine].filter(Boolean);
+        const fullMessage = extraLines.length
+          ? `${slackMessage}\n${extraLines.join('\n')}`
+          : slackMessage;
 
         await postMessageOptional(context, channelId, fullMessage, { threadTs });
       }

--- a/src/cited-analysis/handler.js
+++ b/src/cited-analysis/handler.js
@@ -304,6 +304,7 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
         analysisName: 'cited-analysis',
         baseUrl: site.getBaseURL(),
         urlCount: storeData.urls.length,
+        urlLimit,
         counts: storeData.drsCounts,
         scrapedNow,
       }),

--- a/src/reddit-analysis/guidance-handler.js
+++ b/src/reddit-analysis/guidance-handler.js
@@ -20,7 +20,7 @@ import { createOpportunityData } from './opportunity-data-mapper.js';
 import { postMessageOptional, buildAnalysisVisibilityMessage } from '../utils/slack-utils.js';
 import { resolveBrandResultForSite, applyScopeToOpportunity } from '../utils/brand-resolver.js';
 import { fetchAnalysisFromPresignedUrl } from '../utils/analysis-fetch.js';
-import { buildOffsiteTimingLines, logOffsiteLlmUsage } from '../utils/offsite-audit-utils.js';
+import { buildOffsiteTimingLines, logOffsiteLlmUsage, buildOffsiteLlmUsageLine } from '../utils/offsite-audit-utils.js';
 import {
   isValidOffsiteAnalysis,
   persistOffsiteOpportunity,
@@ -176,9 +176,14 @@ export default async function handler(message, context) {
           verdict: opportunityData.qaVerdict,
         });
 
-        // Append DRS / Mystique / total phase timings (from anchors on the audit result).
+        // Append DRS / Mystique / total phase timings and the LLM cost Mystique reported.
+        // Each is omitted when its data is absent (no timing anchors / no llmUsage stamp).
         const timingLines = buildOffsiteTimingLines(auditResultData?.timings);
-        const fullMessage = timingLines ? `${slackMessage}\n${timingLines}` : slackMessage;
+        const llmUsageLine = buildOffsiteLlmUsageLine(opportunityData.llmUsage);
+        const extraLines = [timingLines, llmUsageLine].filter(Boolean);
+        const fullMessage = extraLines.length
+          ? `${slackMessage}\n${extraLines.join('\n')}`
+          : slackMessage;
 
         await postMessageOptional(context, channelId, fullMessage, { threadTs });
       }

--- a/src/reddit-analysis/handler.js
+++ b/src/reddit-analysis/handler.js
@@ -190,6 +190,7 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
         analysisName: 'reddit-analysis',
         baseUrl: site.getBaseURL(),
         urlCount: storeData.urls.length,
+        urlLimit,
         counts: storeData.drsCounts,
         scrapedNow,
       }),

--- a/src/utils/offsite-audit-utils.js
+++ b/src/utils/offsite-audit-utils.js
@@ -384,7 +384,7 @@ export function buildAnalysisScrapeStatusMessage({
   // so show both counts; otherwise the plain store count is exactly what gets sent.
   const capped = Number.isFinite(urlLimit) && urlCount > urlLimit;
   const countPhrase = capped
-    ? `Sending *${urlLimit}* of *${urlCount}* available URL(s) (capped at *${urlLimit}*)`
+    ? `Sending *${urlLimit}* of *${urlCount}* available URL(s)`
     : `Sending *${urlCount}* available URL(s)`;
   return `:mag: *${analysisName}* for *${baseUrl}* — ${leadIn} `
     + `${countPhrase} from the URL store to Mystique for analysis${extras}.`;

--- a/src/utils/offsite-audit-utils.js
+++ b/src/utils/offsite-audit-utils.js
@@ -148,6 +148,28 @@ export function logOffsiteLlmUsage(log, logPrefix, siteId, llmUsage) {
   );
 }
 
+/**
+ * Builds the Slack bullet line reporting the LLM cost/usage Mystique stamped onto
+ * `opportunity.llmUsage`, for the "audit finished" summary. Mirrors {@link logOffsiteLlmUsage}
+ * so the Slack line and the CloudWatch log line stay in sync: same fields, same 4-decimal cost.
+ *
+ * Returns an empty string when `llmUsage` is absent or not an object (e.g. an analysis that
+ * doesn't track token usage, or a tracking-degraded run) so callers can append it
+ * unconditionally. Numeric fields are coerced defensively so a malformed payload can't throw.
+ *
+ * @param {object} [llmUsage] - { totalLlmCalls, totalTokens, totalCostUsd } from Mystique
+ * @returns {string} A Slack bullet line, or '' when there is nothing to report
+ */
+export function buildOffsiteLlmUsageLine(llmUsage) {
+  if (!llmUsage || typeof llmUsage !== 'object') {
+    return '';
+  }
+  const calls = Number(llmUsage.totalLlmCalls) || 0;
+  const tokens = Number(llmUsage.totalTokens) || 0;
+  const cost = Number(llmUsage.totalCostUsd) || 0;
+  return `• :moneybag: LLM usage: ${calls} calls, ${tokens} tokens, est. cost $${cost.toFixed(4)}`;
+}
+
 // Tokens shorter than this are dropped from brand-token matching: a 1-2 char
 // substring would match almost any host and turn the branded filter into a
 // blunt instrument.
@@ -331,6 +353,10 @@ export function formatDrsExtras(counts) {
  *     this audit type (accumulated across runs), not this run's freshly-selected scrape batch.
  *     That is why it can exceed the "selected N to scrape this run" number the offsite run
  *     reports (e.g. 156 to Mystique vs. 70 selected this run).
+ *  3. Cap — the post-processor caps the payload at `urlLimit` (MYSTIQUE_URLS_LIMIT, or a Slack
+ *     override) before sending. When the store exceeds the cap, report BOTH the sent count and
+ *     the store total (e.g. "50 of 68") so the line matches what Mystique actually receives
+ *     rather than overstating it as the full store size.
  *
  * The lead-in is conditioned on whether a DRS scrape actually ran *this cycle*:
  *  - `scrapedNow` true  → "DRS scrape finished." (the offsite run scraped this cycle and the
@@ -341,20 +367,27 @@ export function formatDrsExtras(counts) {
  * @param {object} params
  * @param {string} params.analysisName - e.g. 'reddit-analysis'
  * @param {string} params.baseUrl
- * @param {number} params.urlCount - available URLs from the full store being sent to Mystique
+ * @param {number} params.urlCount - available URLs from the full store
+ * @param {number} [params.urlLimit] - cap the post-processor applies before sending to Mystique
  * @param {object} [params.counts] - DRS status breakdown from {@link filterUrlsByDrsStatus}
  * @param {boolean} params.scrapedNow - whether a DRS scrape ran during this cycle
  * @returns {string}
  */
 export function buildAnalysisScrapeStatusMessage({
-  analysisName, baseUrl, urlCount, counts, scrapedNow,
+  analysisName, baseUrl, urlCount, urlLimit, counts, scrapedNow,
 }) {
   const extras = formatDrsExtras(counts);
   const leadIn = scrapedNow
     ? 'DRS scrape finished.'
     : 'reusing previously scraped DRS content (no new scrape needed).';
+  // When the store holds more than the cap, the post-processor only sends `urlLimit` of them,
+  // so show both counts; otherwise the plain store count is exactly what gets sent.
+  const capped = Number.isFinite(urlLimit) && urlCount > urlLimit;
+  const countPhrase = capped
+    ? `Sending *${urlLimit}* of *${urlCount}* available URL(s) (capped at *${urlLimit}*)`
+    : `Sending *${urlCount}* available URL(s)`;
   return `:mag: *${analysisName}* for *${baseUrl}* — ${leadIn} `
-    + `Sending *${urlCount}* available URL(s) from the URL store to Mystique for analysis${extras}.`;
+    + `${countPhrase} from the URL store to Mystique for analysis${extras}.`;
 }
 
 /**

--- a/src/youtube-analysis/guidance-handler.js
+++ b/src/youtube-analysis/guidance-handler.js
@@ -18,7 +18,7 @@ import { createOpportunityData } from './opportunity-data-mapper.js';
 import { postMessageOptional, buildAnalysisVisibilityMessage } from '../utils/slack-utils.js';
 import { resolveBrandResultForSite, applyScopeToOpportunity } from '../utils/brand-resolver.js';
 import { fetchAnalysisFromPresignedUrl } from '../utils/analysis-fetch.js';
-import { buildOffsiteTimingLines, logOffsiteLlmUsage } from '../utils/offsite-audit-utils.js';
+import { buildOffsiteTimingLines, logOffsiteLlmUsage, buildOffsiteLlmUsageLine } from '../utils/offsite-audit-utils.js';
 import {
   isValidOffsiteAnalysis,
   persistOffsiteOpportunity,
@@ -174,9 +174,14 @@ export default async function handler(message, context) {
           verdict: opportunityData.qaVerdict,
         });
 
-        // Append DRS / Mystique / total phase timings (from anchors on the audit result).
+        // Append DRS / Mystique / total phase timings and the LLM cost Mystique reported.
+        // Each is omitted when its data is absent (no timing anchors / no llmUsage stamp).
         const timingLines = buildOffsiteTimingLines(auditResultData?.timings);
-        const fullMessage = timingLines ? `${slackMessage}\n${timingLines}` : slackMessage;
+        const llmUsageLine = buildOffsiteLlmUsageLine(opportunityData.llmUsage);
+        const extraLines = [timingLines, llmUsageLine].filter(Boolean);
+        const fullMessage = extraLines.length
+          ? `${slackMessage}\n${extraLines.join('\n')}`
+          : slackMessage;
 
         await postMessageOptional(context, channelId, fullMessage, { threadTs });
       }

--- a/src/youtube-analysis/handler.js
+++ b/src/youtube-analysis/handler.js
@@ -190,6 +190,7 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
         analysisName: 'youtube-analysis',
         baseUrl: site.getBaseURL(),
         urlCount: storeData.urls.length,
+        urlLimit,
         counts: storeData.drsCounts,
         scrapedNow,
       }),

--- a/test/utils/offsite-audit-utils.test.js
+++ b/test/utils/offsite-audit-utils.test.js
@@ -403,7 +403,7 @@ describe('offsite-audit-utils', () => {
       });
       expect(msg).to.equal(
         ':mag: *cited-analysis* for *https://lilly.com* — reusing previously scraped DRS content '
-        + '(no new scrape needed). Sending *50* of *68* available URL(s) (capped at *50*) '
+        + '(no new scrape needed). Sending *50* of *68* available URL(s) '
         + 'from the URL store to Mystique for analysis (2 not yet scraped).',
       );
     });

--- a/test/utils/offsite-audit-utils.test.js
+++ b/test/utils/offsite-audit-utils.test.js
@@ -28,6 +28,7 @@ import {
   formatDuration,
   buildOffsiteTimingLines,
   logOffsiteLlmUsage,
+  buildOffsiteLlmUsageLine,
   formatDrsExtras,
   buildAnalysisScrapeStatusMessage,
   scrapedThisCycle,
@@ -388,6 +389,41 @@ describe('offsite-audit-utils', () => {
         + 'for analysis (2 still scraping, 1 not yet scraped).',
       );
     });
+
+    it('reports both sent and store counts when the store exceeds the cap', () => {
+      const msg = buildAnalysisScrapeStatusMessage({
+        analysisName: 'cited-analysis',
+        baseUrl: 'https://lilly.com',
+        urlCount: 68,
+        urlLimit: 50,
+        counts: {
+          available: 68, scraping: 0, notFound: 2, determined: true,
+        },
+        scrapedNow: false,
+      });
+      expect(msg).to.equal(
+        ':mag: *cited-analysis* for *https://lilly.com* — reusing previously scraped DRS content '
+        + '(no new scrape needed). Sending *50* of *68* available URL(s) (capped at *50*) '
+        + 'from the URL store to Mystique for analysis (2 not yet scraped).',
+      );
+    });
+
+    it('reports the plain store count when it is within the cap', () => {
+      const msg = buildAnalysisScrapeStatusMessage({
+        analysisName: 'reddit-analysis',
+        baseUrl: 'https://example.com',
+        urlCount: 12,
+        urlLimit: 50,
+        counts: {
+          available: 12, scraping: 0, notFound: 0, determined: true,
+        },
+        scrapedNow: true,
+      });
+      expect(msg).to.equal(
+        ':mag: *reddit-analysis* for *https://example.com* — DRS scrape finished. '
+        + 'Sending *12* available URL(s) from the URL store to Mystique for analysis.',
+      );
+    });
   });
 
   describe('scrapedThisCycle', () => {
@@ -730,6 +766,29 @@ describe('offsite-audit-utils', () => {
       expect(log.info.firstCall.args[0]).to.equal(
         '[YouTube] LLM usage for siteId: site-999: 0 calls, 0 tokens, est. cost $0.0000',
       );
+    });
+  });
+
+  describe('buildOffsiteLlmUsageLine', () => {
+    it('builds a bullet line with calls, tokens, and 4-decimal cost when present', () => {
+      expect(buildOffsiteLlmUsageLine({
+        totalLlmCalls: 10,
+        totalTokens: 326070,
+        totalCostUsd: 1.468751,
+      })).to.equal('• :moneybag: LLM usage: 10 calls, 326070 tokens, est. cost $1.4688');
+    });
+
+    it('returns an empty string when llmUsage is absent or not an object', () => {
+      expect(buildOffsiteLlmUsageLine(undefined)).to.equal('');
+      expect(buildOffsiteLlmUsageLine(null)).to.equal('');
+      expect(buildOffsiteLlmUsageLine('oops')).to.equal('');
+    });
+
+    it('coerces missing or malformed numeric fields to 0 without throwing', () => {
+      expect(buildOffsiteLlmUsageLine({
+        totalLlmCalls: 'x',
+        totalCostUsd: undefined,
+      })).to.equal('• :moneybag: LLM usage: 0 calls, 0 tokens, est. cost $0.0000');
     });
   });
 });


### PR DESCRIPTION
## What

Two Slack-messaging fixes for the offsite analysis audits (cited / reddit / youtube).

### 1. Capped URL count in the pre-send message

The pre-send Slack line reported the **full URL store size** even though the post-processor caps the payload at `urlLimit` (default `MYSTIQUE_URLS_LIMIT` = 50) before sending. So a run with a 100-URL store (or lilly.com's 68) announced *"Sending 100 available URL(s) ... to Mystique"* while Mystique actually received 50 — the payload was always correct; only the message overstated it.

`buildAnalysisScrapeStatusMessage` now takes `urlLimit` and, when the store exceeds the cap, reports **both** counts:

> `Sending *50* of *68* available URL(s) (capped at *50*) from the URL store to Mystique for analysis (2 not yet scraped).`

Wording is unchanged when the store is within the cap.

### 2. LLM cost in the "audit finished" summary

PR #2822 added `logOffsiteLlmUsage`, which surfaces Mystique's `opportunity.llmUsage` **to CloudWatch logs only** — so the cost never appeared in the Slack thread. This adds a matching `buildOffsiteLlmUsageLine` (kept in sync with the log line: same fields, same 4-decimal cost) and appends it to the completion message:

> `• :moneybag: LLM usage: 10 calls, 326070 tokens, est. cost $1.4688`

Omitted gracefully when Mystique reports no `llmUsage` (e.g. wikipedia-analysis, or a tracking-degraded run).

## Changes

- `src/utils/offsite-audit-utils.js` — `buildAnalysisScrapeStatusMessage` gains a `urlLimit` param + capped "N of M" phrasing; new `buildOffsiteLlmUsageLine` helper.
- `src/{cited,reddit,youtube}-analysis/handler.js` — pass `urlLimit` into the pre-send message.
- `src/{cited,reddit,youtube}-analysis/guidance-handler.js` — append the LLM cost line to the completion message.
- Tests for the capped/within-cap message paths and `buildOffsiteLlmUsageLine` (present / absent / malformed).

## Testing

- Full `npm test` green with the strict 100% line/branch/statement coverage gate.
- Lint clean.