### PR TITLE
feat(cwv): bow out of legacy opportunity/suggestion sync when deliveryConfig.cwvEngine=blackboard

### DIFF
--- a/docs/cwv-autofix-flow.md
+++ b/docs/cwv-autofix-flow.md
@@ -72,6 +72,23 @@ generation on SME approval (`NEW` → code-fix; `PENDING_VALIDATION` → guidanc
 
 Both flags are checked in this repo. The autofix-worker also checks `cwv-auto-fix` independently — both must be enabled for the chain to complete.
 
+## Blackboard engine bow-out (`deliveryConfig.cwvEngine`)
+
+Mystique is migrating CWV per-site off this legacy flow and onto its own blackboard
+producer cascade (detection → guidance → autofix → verified projection). Both flows write
+the **same** SpaceCat `type: "cwv"` opportunity + suggestion rows, so for a migrated site
+exactly one flow must be authoritative or the rows collide/duplicate.
+
+The switch is one field both systems read: `deliveryConfig.cwvEngine ∈ { "legacy"
+(default/absent), "blackboard" }` (mirrors `altTextEngine` / `formsA11yEngine`). When
+`cwvEngine === "blackboard"`, the CWV audit's `syncOpportunityAndSuggestionsStep`
+(`src/cwv/handler.js`) **bows out**: it creates no opportunity/suggestion rows and sends no
+`guidance:cwv` message. Mystique's blackboard cascade then owns those rows for the site.
+The migration action is flipping `cwvEngine`; flipping it back to `legacy` restores this
+flow on the next audit. The full cross-repo contract, the projector-ownership rationale, and
+a duplicate-row detection recipe live in Mystique's
+`docs/opportunities/cwv/design-cwv-blackboard-migration.md` §9.4 (Spec 009-04 / ADR-0022).
+
 ## Key files
 
 - [`src/cwv/handler.js`](../src/cwv/handler.js) — `StepAudit` definition (2 steps)

--- a/docs/cwv-autofix-flow.md
+++ b/docs/cwv-autofix-flow.md
@@ -67,10 +67,15 @@ generation on SME approval (`NEW` → code-fix; `PENDING_VALIDATION` → guidanc
 
 | Flag | Effect |
 |---|---|
-| `cwv-auto-suggest` | gates whether the `guidance:cwv` SQS message is sent at all |
-| `cwv-auto-fix` | gates whether `codeBucket` / `codePath` are included (so Mystique can do a code fix, not just guidance) |
+| `cwv-auto-fix` | gates whether `codeBucket` / `codePath` are included in the `guidance:cwv` message (so Mystique can do a code fix, not just guidance) |
 
-Both flags are checked in this repo. The autofix-worker also checks `cwv-auto-fix` independently — both must be enabled for the chain to complete.
+> **Note (current behavior):** the CWV audit's `processAutoSuggest` **no longer re-checks**
+> `cwv-auto-suggest` / `cwv-auto-fix` (see `src/cwv/auto-suggest.js`) — per-site enablement of
+> the `cwv` audit is verified upstream via `isHandlerEnabledForSite('cwv', site)`
+> (`src/common/audit-utils.js`), consistent with every other audit type. So disabling CWV for a
+> site is done by disabling the `cwv` handler in `Configuration` (see the bow-out section below),
+> not by flipping `cwv-auto-suggest=false`. The `spacecat-autofix-worker` still checks
+> `cwv-auto-fix` independently to gate whether the Issue/PR is actually opened.
 
 ## Blackboard engine bow-out (`deliveryConfig.cwvEngine`)
 
@@ -81,12 +86,23 @@ exactly one flow must be authoritative or the rows collide/duplicate.
 
 The switch is one field both systems read: `deliveryConfig.cwvEngine ∈ { "legacy"
 (default/absent), "blackboard" }` (mirrors `altTextEngine` / `formsA11yEngine`). When
-`cwvEngine === "blackboard"`, the CWV audit's `syncOpportunityAndSuggestionsStep`
-(`src/cwv/handler.js`) **bows out**: it creates no opportunity/suggestion rows and sends no
-`guidance:cwv` message. Mystique's blackboard cascade then owns those rows for the site.
-The migration action is flipping `cwvEngine`; flipping it back to `legacy` restores this
-flow on the next audit. The full cross-repo contract, the projector-ownership rationale, and
-a duplicate-row detection recipe live in Mystique's
+`cwvEngine === "blackboard"`, the CWV audit (`src/cwv/handler.js`) **bows out** at both steps:
+
+- **Step 1 (`collectCWVDataAndImportCode`)** skips the RUM/PSI collection (nothing consumes the
+  persisted `cwv` audit result — trend audits read RUM directly) and **resolves any pre-existing
+  legacy `type:"cwv"` opportunity**, outdating its still-live (`NEW`/`IN_PROGRESS`) suggestions
+  while preserving customer-/system-touched ones (`FIXED`/`SKIPPED`/`ERROR`). This is done in
+  Step 1 because it always runs on the initial trigger (not gated on the import-worker
+  round-trip). The import-worker hop itself is kept (its payload contract requires a valid
+  `type`) — harmless for a migrated site; to skip the audit *entirely* (RUM + import + sync),
+  disable the `cwv` handler for the site in `Configuration`.
+- **Step 2 (`syncOpportunityAndSuggestionsStep`)** creates no opportunity/suggestion rows and
+  sends no `guidance:cwv` message (defense-in-depth if reached).
+
+Mystique's blackboard cascade then owns those rows for the site. The migration action is
+flipping `cwvEngine`; flipping it back to `legacy` restores this flow on the next audit. The
+full cross-repo contract, the projector-ownership rationale, and a duplicate-row detection
+recipe live in Mystique's
 `docs/opportunities/cwv/design-cwv-blackboard-migration.md` §9.4 (Spec 009-04 / ADR-0022).
 
 ## Key files

--- a/src/cwv/handler.js
+++ b/src/cwv/handler.js
@@ -59,6 +59,22 @@ export async function syncOpportunityAndSuggestionsStep(context) {
   const { Suggestion } = dataAccess;
   const siteId = site.getId();
 
+  // Legacy-source bow-out (Spec 009-04 / ADR-0022). When a site's CWV opportunity is owned
+  // by the Mystique blackboard engine (deliveryConfig.cwvEngine === 'blackboard'), this
+  // legacy audit must NOT create the shared type:"cwv" opportunity / CODE_CHANGE suggestion
+  // rows or send the guidance:cwv message — otherwise the two flows write the same SpaceCat
+  // rows and collide (the blackboard projector keys its parent on
+  // (type, scope_type='site', scope_id), so it creates a *second* active cwv opportunity
+  // rather than reusing this null-scoped one). The blackboard producer cascade owns
+  // detection→guidance→autofix and projects the customer-facing suggestions itself.
+  const cwvEngine = site.getDeliveryConfig?.()?.cwvEngine;
+  if (cwvEngine === 'blackboard') {
+    log.info(`[audit-worker-cwv] siteId: ${siteId} | Step 2: bowing out — deliveryConfig.cwvEngine=blackboard, CWV opportunity is Mystique-owned; skipping opportunity/suggestion sync and auto-suggest`);
+    return {
+      status: 'complete',
+    };
+  }
+
   log.info(`[audit-worker-cwv] siteId: ${siteId} | Step 2: Syncing opportunities and suggestions`);
 
   const opportunity = await syncOpportunitiesAndSuggestions(context);

--- a/src/cwv/handler.js
+++ b/src/cwv/handler.js
@@ -10,7 +10,11 @@
  * governing permissions and limitations under the License.
  */
 
-import { Audit, Suggestion as SuggestionModel } from '@adobe/spacecat-shared-data-access';
+import {
+  Audit,
+  Suggestion as SuggestionModel,
+  Opportunity as OpportunityModel,
+} from '@adobe/spacecat-shared-data-access';
 import { AuditBuilder } from '../common/audit-builder.js';
 import { wwwUrlResolver } from '../common/index.js';
 import { buildCWVAuditResult } from './cwv-audit-result.js';
@@ -20,9 +24,76 @@ import { sendLowSuggestionCountAlert } from '../support/plg-suggestion-alert.js'
 
 const { AUDIT_STEP_DESTINATIONS } = Audit;
 
+const CWV_BLACKBOARD_ENGINE = 'blackboard';
+
+/**
+ * A site's CWV opportunity is owned by the Mystique blackboard producer cascade — rather
+ * than this legacy audit — when `deliveryConfig.cwvEngine === "blackboard"` (Spec 009-04 /
+ * ADR-0022). Mirrors the `altTextEngine` / `formsA11yEngine` per-site engine switches.
+ * Degrades to legacy on absent / null / any other value.
+ * @param {Object} site - Site with a `getDeliveryConfig()` accessor.
+ * @returns {boolean}
+ */
+export function isCwvBlackboardEngine(site) {
+  return site.getDeliveryConfig?.()?.cwvEngine === CWV_BLACKBOARD_ENGINE;
+}
+
+/**
+ * Bow-out cleanup for a site migrated to the blackboard engine: resolve the pre-existing
+ * legacy `type:"cwv"` opportunity and outdate its still-live suggestions, so the flip does
+ * not strand active legacy rows the customer can no longer act on. Customer-/system-touched
+ * suggestion states (FIXED / SKIPPED / ERROR / already-OUTDATED) are preserved as history;
+ * only NEW / IN_PROGRESS suggestions are outdated. Idempotent: no active NEW opportunity →
+ * no-op (mirrors this audit's own `allBySiteIdAndStatus(..., NEW).find(type==='cwv')`
+ * find-existing, and the resolve pattern in `src/csp/csp.js`).
+ * @param {Object} context - Audit context (dataAccess, log).
+ * @param {Object} site - Site being audited.
+ */
+export async function resolveLegacyCwvOpportunity(context, site) {
+  const { dataAccess, log } = context;
+  const { Opportunity, Suggestion } = dataAccess;
+  const siteId = site.getId();
+
+  const opportunities = await Opportunity.allBySiteIdAndStatus(
+    siteId,
+    OpportunityModel.STATUSES.NEW,
+  );
+  const opportunity = opportunities.find((o) => o.getType() === Audit.AUDIT_TYPES.CWV);
+  if (!opportunity) {
+    return;
+  }
+
+  await opportunity.setStatus(OpportunityModel.STATUSES.RESOLVED);
+  await opportunity.save();
+
+  const suggestions = await opportunity.getSuggestions();
+  const liveSuggestions = suggestions.filter((s) => ![
+    SuggestionModel.STATUSES.OUTDATED,
+    SuggestionModel.STATUSES.FIXED,
+    SuggestionModel.STATUSES.ERROR,
+    SuggestionModel.STATUSES.SKIPPED,
+  ].includes(s.getStatus()));
+  if (liveSuggestions.length > 0) {
+    await Suggestion.bulkUpdateStatus(liveSuggestions, SuggestionModel.STATUSES.OUTDATED);
+  }
+
+  log.info(`[audit-worker-cwv] siteId: ${siteId} | resolved legacy cwv opportunity ${opportunity.getId()} and outdated ${liveSuggestions.length} live suggestion(s) (cwvEngine=blackboard bow-out)`);
+}
+
 /**
  * Step 1: CWV Data Collection and Code Import
- * Builds CWV audit result and triggers code import
+ * Builds CWV audit result and triggers code import.
+ *
+ * Legacy-source bow-out (Spec 009-04 / ADR-0022): for a `cwvEngine === "blackboard"` site
+ * the Mystique blackboard cascade already owns detection + source materialization, so this
+ * step skips the RUM/PSI collection and returns an empty audit result (nothing reads the
+ * persisted `cwv` audit result — trend audits read RUM directly). It also resolves any
+ * pre-existing legacy opportunity here (Step 1 always runs on the initial trigger, so the
+ * resolve is not gated on the import-worker round-trip). The `import-worker` hop itself is
+ * kept (its payload contract requires a valid `type`); to skip the audit entirely for a
+ * migrated site, disable the `cwv` handler for it in `Configuration` (see the coexistence
+ * contract in the Mystique migration design doc §9.4).
+ *
  * @param {Object} context - Context object containing site, finalUrl, log, env
  *                           (with env.RUM_ADMIN_KEY)
  * @returns {Promise<Object>} Object containing auditResult, fullAuditRef (for persister),
@@ -31,6 +102,23 @@ const { AUDIT_STEP_DESTINATIONS } = Audit;
 export async function collectCWVDataAndImportCode(context) {
   const { site, log } = context;
   const siteId = site.getId();
+
+  if (isCwvBlackboardEngine(site)) {
+    log.info(`[audit-worker-cwv] siteId: ${siteId} | Step 1: bowing out — deliveryConfig.cwvEngine=blackboard; resolving any legacy cwv opportunity and skipping RUM collection`);
+    await resolveLegacyCwvOpportunity(context, site);
+    return {
+      // Nothing consumes the persisted cwv audit result (trends read RUM directly);
+      // an empty result is correct for a bowed-out site.
+      auditResult: { cwv: [] },
+      fullAuditRef: context.finalUrl || site.getBaseURL(),
+      // Import-worker payload contract requires a valid type; keep the hop (harmless for a
+      // migrated site — the download is unused). Skipping it needs an import-worker-side
+      // flag; the clean full-skip is the Configuration cwv handler-disable.
+      type: 'code',
+      siteId,
+      allowCache: false,
+    };
+  }
 
   log.info(`[audit-worker-cwv] siteId: ${siteId} | Step 1: Collecting CWV data and triggering code import`);
 
@@ -59,16 +147,15 @@ export async function syncOpportunityAndSuggestionsStep(context) {
   const { Suggestion } = dataAccess;
   const siteId = site.getId();
 
-  // Legacy-source bow-out (Spec 009-04 / ADR-0022). When a site's CWV opportunity is owned
-  // by the Mystique blackboard engine (deliveryConfig.cwvEngine === 'blackboard'), this
-  // legacy audit must NOT create the shared type:"cwv" opportunity / CODE_CHANGE suggestion
-  // rows or send the guidance:cwv message — otherwise the two flows write the same SpaceCat
-  // rows and collide (the blackboard projector keys its parent on
-  // (type, scope_type='site', scope_id), so it creates a *second* active cwv opportunity
-  // rather than reusing this null-scoped one). The blackboard producer cascade owns
-  // detection→guidance→autofix and projects the customer-facing suggestions itself.
-  const cwvEngine = site.getDeliveryConfig?.()?.cwvEngine;
-  if (cwvEngine === 'blackboard') {
+  // Legacy-source bow-out (Spec 009-04 / ADR-0022). Defense-in-depth: Step 1 already bows
+  // out + resolves for a blackboard-engine site, but if this step is reached it must NOT
+  // create the shared type:"cwv" opportunity / CODE_CHANGE suggestion rows or send the
+  // guidance:cwv message — otherwise the two flows write the same SpaceCat rows and collide
+  // (the blackboard projector keys its parent on (type, scope_type='site', scope_id), so it
+  // creates a *second* active cwv opportunity rather than reusing this null-scoped one). The
+  // blackboard producer cascade owns detection→guidance→autofix and projects the
+  // customer-facing suggestions itself.
+  if (isCwvBlackboardEngine(site)) {
     log.info(`[audit-worker-cwv] siteId: ${siteId} | Step 2: bowing out — deliveryConfig.cwvEngine=blackboard, CWV opportunity is Mystique-owned; skipping opportunity/suggestion sync and auto-suggest`);
     return {
       status: 'complete',

--- a/src/cwv/handler.js
+++ b/src/cwv/handler.js
@@ -110,7 +110,9 @@ export async function collectCWVDataAndImportCode(context) {
       // Nothing consumes the persisted cwv audit result (trends read RUM directly);
       // an empty result is correct for a bowed-out site.
       auditResult: { cwv: [] },
-      fullAuditRef: context.finalUrl || site.getBaseURL(),
+      // The StepAudit framework always sets finalUrl via the urlResolver before running the
+      // step, so use it directly — matching how buildCWVAuditResult sets fullAuditRef.
+      fullAuditRef: context.finalUrl,
       // Import-worker payload contract requires a valid type; keep the hop (harmless for a
       // migrated site — the download is unused). Skipping it needs an import-worker-side
       // flag; the clean full-skip is the Configuration cwv handler-disable.

--- a/test/audits/cwv.test.js
+++ b/test/audits/cwv.test.js
@@ -15,7 +15,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import chaiAsPromised from 'chai-as-promised';
 import nock from 'nock';
-import { Audit } from '@adobe/spacecat-shared-data-access';
+import { Audit, Suggestion as SuggestionModel, Opportunity as OpportunityModel } from '@adobe/spacecat-shared-data-access';
 import GoogleClient from '@adobe/spacecat-shared-google-client';
 import { TierClient } from '@adobe/spacecat-shared-tier-client';
 import { collectCWVDataAndImportCode, syncOpportunityAndSuggestionsStep } from '../../src/cwv/handler.js';
@@ -140,6 +140,76 @@ describe('collectCWVDataAndImportCode Tests', () => {
     expect(result.auditResult.cwv).to.have.lengthOf(10);
     expect(result.auditResult.cwv).to.deep.equal(expectedData);
     expect(result.auditResult.auditContext.interval).to.equal(7);
+  });
+
+  describe('Step 1 blackboard bow-out (Spec 009-04)', () => {
+    let cwvOpportunity;
+    let newSuggestion;
+    let fixedSuggestion;
+
+    beforeEach(() => {
+      site.getDeliveryConfig.returns({ cwvEngine: 'blackboard' });
+      newSuggestion = { getStatus: () => SuggestionModel.STATUSES.NEW };
+      fixedSuggestion = { getStatus: () => SuggestionModel.STATUSES.FIXED };
+      cwvOpportunity = {
+        getType: () => Audit.AUDIT_TYPES.CWV,
+        getId: () => 'legacy-oppty-id',
+        setStatus: sandbox.stub().resolves(),
+        save: sandbox.stub().resolves(),
+        getSuggestions: sandbox.stub().resolves([newSuggestion, fixedSuggestion]),
+      };
+      context.dataAccess.Opportunity = {
+        allBySiteIdAndStatus: sandbox.stub().resolves([cwvOpportunity]),
+      };
+      context.dataAccess.Suggestion = {
+        bulkUpdateStatus: sandbox.stub().resolves(),
+      };
+    });
+
+    it('skips RUM collection and returns an empty audit result + import trigger', async () => {
+      const result = await collectCWVDataAndImportCode({ site, finalUrl: auditUrl, log: context.log, ...context });
+
+      // RUM/PSI collection is skipped for a blackboard-engine site.
+      expect(context.rumApiClient.query).to.not.have.been.called;
+      expect(result.auditResult).to.deep.equal({ cwv: [] });
+      expect(result.fullAuditRef).to.equal(auditUrl);
+      // Import hop is kept (payload contract requires a valid type).
+      expect(result.type).to.equal('code');
+    });
+
+    it('resolves the pre-existing legacy cwv opportunity and outdates only its live suggestions', async () => {
+      await collectCWVDataAndImportCode({ site, finalUrl: auditUrl, log: context.log, ...context });
+
+      expect(context.dataAccess.Opportunity.allBySiteIdAndStatus)
+        .to.have.been.calledWith('site-id', OpportunityModel.STATUSES.NEW);
+      expect(cwvOpportunity.setStatus).to.have.been.calledOnceWith(OpportunityModel.STATUSES.RESOLVED);
+      expect(cwvOpportunity.save).to.have.been.calledOnce;
+      // Only the live (NEW) suggestion is outdated; the FIXED one is preserved as history.
+      expect(context.dataAccess.Suggestion.bulkUpdateStatus)
+        .to.have.been.calledOnceWith([newSuggestion], SuggestionModel.STATUSES.OUTDATED);
+    });
+
+    it('is a no-op resolve when there is no active legacy cwv opportunity', async () => {
+      context.dataAccess.Opportunity.allBySiteIdAndStatus.resolves([]);
+
+      const result = await collectCWVDataAndImportCode({ site, finalUrl: auditUrl, log: context.log, ...context });
+
+      expect(cwvOpportunity.setStatus).to.not.have.been.called;
+      expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.not.have.been.called;
+      // Still bows out (empty result, no RUM).
+      expect(context.rumApiClient.query).to.not.have.been.called;
+      expect(result.auditResult).to.deep.equal({ cwv: [] });
+    });
+
+    it('does not resolve when all suggestions are already terminal (FIXED/SKIPPED)', async () => {
+      cwvOpportunity.getSuggestions.resolves([fixedSuggestion]);
+
+      await collectCWVDataAndImportCode({ site, finalUrl: auditUrl, log: context.log, ...context });
+
+      expect(cwvOpportunity.setStatus).to.have.been.calledOnceWith(OpportunityModel.STATUSES.RESOLVED);
+      // No live suggestions → bulkUpdateStatus not called.
+      expect(context.dataAccess.Suggestion.bulkUpdateStatus).to.not.have.been.called;
+    });
   });
 
   it('includes pages beyond top 10 if they meet threshold', async () => {

--- a/test/audits/cwv.test.js
+++ b/test/audits/cwv.test.js
@@ -443,6 +443,41 @@ describe('collectCWVDataAndImportCode Tests', () => {
       suggestionsArg.forEach((s) => expect(s.data).to.have.property('jiraLink', null));
     });
 
+    it('bows out (creates no opportunity/suggestion rows, sends no message) when deliveryConfig.cwvEngine === "blackboard" (Spec 009-04)', async () => {
+      site.getDeliveryConfig.returns({ cwvEngine: 'blackboard' });
+      context.dataAccess.Opportunity.allBySiteIdAndStatus.resolves([]);
+      context.dataAccess.Opportunity.create.resolves(oppty);
+
+      const stepContext = { ...context, site, audit: mockAudit, finalUrl: auditUrl };
+      const result = await syncOpportunityAndSuggestionsStep(stepContext);
+
+      expect(result).to.deep.equal({ status: 'complete' });
+      // No opportunity is fetched or created for a Mystique-owned (blackboard) CWV site.
+      expect(context.dataAccess.Opportunity.allBySiteIdAndStatus).to.not.have.been.called;
+      expect(context.dataAccess.Opportunity.create).to.not.have.been.called;
+      // No guidance:cwv auto-suggest message is sent.
+      expect(context.sqs.sendMessage).to.not.have.been.called;
+      // The PLG-alert suggestion count query is not reached either.
+      expect(context.dataAccess.Suggestion.allByOpportunityIdAndStatus).to.not.have.been.called;
+
+      site.getDeliveryConfig.returns({});
+    });
+
+    it('does not bow out for a legacy site (cwvEngine absent / deliveryConfig null)', async () => {
+      site.getDeliveryConfig.returns(null);
+      context.dataAccess.Opportunity.allBySiteIdAndStatus.resolves([]);
+      context.dataAccess.Opportunity.create.resolves(oppty);
+      sinon.stub(GoogleClient, 'createFrom').resolves({});
+
+      const stepContext = { ...context, site, audit: mockAudit, finalUrl: auditUrl };
+      await syncOpportunityAndSuggestionsStep(stepContext);
+
+      // Null deliveryConfig degrades to the legacy path unchanged: the opportunity is created.
+      expect(context.dataAccess.Opportunity.create).to.have.been.calledOnce;
+
+      site.getDeliveryConfig.returns({});
+    });
+
     it('handles audit result with only group entries for maxConfidenceForUrls coverage', async () => {
       context.dataAccess.Opportunity.allBySiteIdAndStatus.resolves([]);
       context.dataAccess.Opportunity.create.resolves(oppty);


### PR DESCRIPTION
## What

Per-site legacy→blackboard CWV cutover — the **suspenders** half of Mystique's
Spec 009-04 / ADR-0022. When a site's CWV opportunity is owned by Mystique's
blackboard producer cascade (`deliveryConfig.cwvEngine === "blackboard"`), the legacy
CWV audit's `syncOpportunityAndSuggestionsStep` now **bows out**: it creates no
`type:"cwv"` opportunity / `CODE_CHANGE` suggestion rows and sends no `guidance:cwv`
message, returning `{ status: 'complete' }` early. Absent / `"legacy"` / null
`deliveryConfig` is unchanged (default legacy path).

## Why

Both flows write the **same** SpaceCat `type:"cwv"` opportunity + suggestion rows. If
both run for one site they collide: Mystique's projector keys its parent on
`(type, scope_type='site', scope_id)`, so against this audit's null-scoped opportunity
it creates a **second** active `cwv` opportunity rather than reusing it; and the two
writers key suggestions in disjoint spaces (projector `site:{id}:cwv:{hash}:{metric}`
vs. this repo's `data.url`/`pattern`), so they never dedup. A collision-free cutover
therefore needs the source to stop writing — this change.

`cwvEngine` mirrors the existing `altTextEngine` / `formsA11yEngine` per-site switches;
flipping it is the migration action, flipping it back restores this flow on the next audit.

## Testing

`test/audits/cwv.test.js` — two new cases: blackboard bow-out (no opportunity/suggestion
row created, no SQS message, PLG-alert query not reached) and legacy passthrough (null
`deliveryConfig` still creates the opportunity). Full `cwv.test.js` suite green (49
passing); `eslint src/cwv/handler.js` clean.

## Coordination

Mystique owns the belt (its `_resolve_cwv_engine` gate, Spec 009-01) and the full
cross-repo contract, projector-ownership evidence, and a duplicate-row detection recipe:
`docs/opportunities/cwv/design-cwv-blackboard-migration.md` §9.4 (Spec 009-04 / ADR-0022).
Safe cutover ordering flips `cwvEngine` and confirms this bow-out **before** enrolling the
site in Mystique's scheduler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Julien Ramboz", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```