### PR TITLE
fix: restrict CDN log filter keys to a column allowlist

### DIFF
--- a/src/utils/cdn-utils.js
+++ b/src/utils/cdn-utils.js
@@ -499,6 +499,23 @@ export async function shouldRecreateTable(
   }
 }
 
+// Columns present on the aggregated/raw CDN log tables that filters are allowed to
+// target. `key` comes straight from customer-controlled site config (cdnlogsFilter),
+// so it must never be interpolated into the query without being checked against this
+// allowlist (see VULN-37491 - SQL injection via cdnlogsFilter[].key).
+const ALLOWED_FILTER_KEYS = new Set([
+  'url',
+  'host',
+  'x_forwarded_host',
+  'user_agent',
+  'referer',
+  'cdn_provider',
+]);
+
+function escapeSqlLiteral(value) {
+  return String(value).replace(/'/g, "''");
+}
+
 export function buildSiteFilters(filters, site) {
   if (!filters || filters.length === 0) {
     const baseURL = site.getBaseURL();
@@ -516,11 +533,17 @@ export function buildSiteFilters(filters, site) {
   }
 
   const clauses = filters.map(({ key, value, type }) => {
-    const regexPattern = value.join('|');
-    if (type === 'exclude') {
-      return `NOT REGEXP_LIKE(${key}, '(?i)(${regexPattern})')`;
+    // Athena folds column identifiers to lowercase, so normalize before the
+    // allowlist check (e.g. a stored 'X_forwarded_host' is the same column).
+    const normalizedKey = String(key).toLowerCase();
+    if (!ALLOWED_FILTER_KEYS.has(normalizedKey)) {
+      throw new Error(`Invalid CDN log filter key: ${key}`);
     }
-    return `REGEXP_LIKE(${key}, '(?i)(${regexPattern})')`;
+    const regexPattern = value.map(escapeSqlLiteral).join('|');
+    if (type === 'exclude') {
+      return `NOT REGEXP_LIKE(${normalizedKey}, '(?i)(${regexPattern})')`;
+    }
+    return `REGEXP_LIKE(${normalizedKey}, '(?i)(${regexPattern})')`;
   });
 
   const filterConditions = clauses.length > 1 ? clauses.join(' AND ') : clauses[0];

--- a/test/utils/cdn-utils.test.js
+++ b/test/utils/cdn-utils.test.js
@@ -558,6 +558,35 @@ describe('CDN Utils', () => {
       expect(result).to.include('AND');
     });
 
+    it('rejects a key that is not on the allowlist (VULN-37491)', () => {
+      const maliciousKey = "url, '(?i)(x)')) UNION ALL SELECT CONCAT('https://example.com?schema=', CAST(current_schema AS VARCHAR)), CAST(1 AS BIGINT) -- ";
+      expect(() => buildSiteFilters([
+        { key: maliciousKey, value: ['x'], type: 'include' },
+      ])).to.throw('Invalid CDN log filter key');
+    });
+
+    it('accepts every column on the allowlist', () => {
+      const allowedKeys = ['url', 'host', 'x_forwarded_host', 'user_agent', 'referer', 'cdn_provider'];
+      allowedKeys.forEach((key) => {
+        const result = buildSiteFilters([{ key, value: ['test'], type: 'include' }]);
+        expect(result).to.include(`REGEXP_LIKE(${key}, '(?i)(test)')`);
+      });
+    });
+
+    it('normalizes uppercase column keys to lowercase (Athena is case-insensitive)', () => {
+      const result = buildSiteFilters([
+        { key: 'X_forwarded_host', value: ['example.com'], type: 'include' },
+      ]);
+      expect(result).to.include("REGEXP_LIKE(x_forwarded_host, '(?i)(example.com)')");
+    });
+
+    it('escapes single quotes in filter values to prevent literal breakout', () => {
+      const result = buildSiteFilters([
+        { key: 'url', value: ["x') OR REGEXP_LIKE(url, '(?i)(y"], type: 'include' },
+      ]);
+      expect(result).to.include("REGEXP_LIKE(url, '(?i)(x'') OR REGEXP_LIKE(url, ''(?i)(y)')");
+    });
+
     it('falls back to baseURL when filters are empty', () => {
       const mockSite = {
         getBaseURL: () => 'https://adobe.com',


### PR DESCRIPTION
## Problem
`buildSiteFilters()` builds Athena filter clauses from the customer-configurable `cdnlogsFilter` entries. The `key` of each entry was used directly when composing the SQL, with no constraint on its contents, and filter `value` strings were not escaped. An unexpected or malformed `key` could therefore produce a query that does not match the intended, well-formed shape.

## Change
- Validate each filter `key` against an allowlist of the known CDN log columns (`url`, `host`, `x_forwarded_host`, `user_agent`, `referer`, `cdn_provider`). Anything else throws early.
- Match case-insensitively, since Athena folds column identifiers to lowercase (e.g. a stored `X_forwarded_host` resolves to the same column).
- Escape single quotes in filter `value` strings.

## Tests
- Added coverage for allowlist rejection, all allowed columns, case normalization, and value escaping.
- Full suite passes; `cdn-utils.js` at 100% coverage; lint clean.

Ref: LLMO-6621