### PR TITLE
chore: bump @adobe/spacecat-shared-data-access to 4.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@adobe/mysticat-shared-seo-client": "1.8.0",
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
         "@adobe/spacecat-shared-athena-client": "1.11.0",
-        "@adobe/spacecat-shared-data-access": "4.11.0",
+        "@adobe/spacecat-shared-data-access": "4.15.1",
         "@adobe/spacecat-shared-drs-client": "1.13.0",
         "@adobe/spacecat-shared-google-client": "1.6.3",
         "@adobe/spacecat-shared-gpt-client": "1.7.1",
@@ -1372,9 +1372,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.11.0.tgz",
-      "integrity": "sha512-/Xi8wisTxX68Gy65QQIv2bnvSPPNT3UQw0GBMuMjv4E6tw/B5MXun4SohWFE5aDjZAZKl2ScLmLka6MdgkmFXQ==",
+      "version": "4.15.1",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.15.1.tgz",
+      "integrity": "sha512-PxrlbtxibRqTstqW4iszQDUz8R+v/jZmZu8hYkreGs8dUG2vg2VICYuaeUQSdx2MsU2JJ/4IhPuJHd/bmk5Gag==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@adobe/mysticat-shared-seo-client": "1.8.0",
     "@adobe/spacecat-helix-content-sdk": "1.4.33",
     "@adobe/spacecat-shared-athena-client": "1.11.0",
-    "@adobe/spacecat-shared-data-access": "4.11.0",
+    "@adobe/spacecat-shared-data-access": "4.15.1",
     "@adobe/spacecat-shared-drs-client": "1.13.0",
     "@adobe/spacecat-shared-google-client": "1.6.3",
     "@adobe/spacecat-shared-gpt-client": "1.7.1",


### PR DESCRIPTION
Bumps `@adobe/spacecat-shared-data-access` from 4.11.0 to 4.15.1.

Brings in the config-layer validation for CDN log filter keys (adobe/spacecat-shared#1851), keeping the write-time key allowlist aligned with the query-builder allowlist already in this repo (#2826).

Full test suite passes locally.

Ref: LLMO-6621