### PR TITLE
fix: reject base URLs with userinfo when deriving CDN site key

### DIFF
--- a/src/utils/cdn-utils.js
+++ b/src/utils/cdn-utils.js
@@ -86,12 +86,14 @@ function normalizePathname(pathname, {
  * Extracts and sanitizes a site-specific key from the base URL.
  */
 export function extractSiteKeyFromBaseURL(site) {
-  const baseURL = site.getBaseURL();
   let url;
   try {
-    url = new URL(baseURL);
-  } catch {
-    throw new Error('Invalid base URL');
+    url = new URL(site.getBaseURL());
+  } catch (e) {
+    if (e instanceof TypeError) {
+      throw new Error('Invalid base URL');
+    }
+    throw e;
   }
   if (url.username || url.password) {
     throw new Error('Invalid base URL: userinfo is not permitted');

--- a/src/utils/cdn-utils.js
+++ b/src/utils/cdn-utils.js
@@ -86,7 +86,16 @@ function normalizePathname(pathname, {
  * Extracts and sanitizes a site-specific key from the base URL.
  */
 export function extractSiteKeyFromBaseURL(site) {
-  const { host, pathname } = new URL(site.getBaseURL());
+  let url;
+  try {
+    url = new URL(site.getBaseURL());
+  } catch {
+    throw new Error('Invalid base URL');
+  }
+  if (url.username || url.password) {
+    throw new Error('Invalid base URL: userinfo is not permitted');
+  }
+  const { host, pathname } = url;
   const cleanHost = host.startsWith('www.') ? host.substring(4) : host;
   const normalizedHost = cleanHost.replace(/[^a-zA-Z0-9]+/g, '_').toLowerCase();
   const normalizedPath = normalizePathname(pathname, {

--- a/src/utils/cdn-utils.js
+++ b/src/utils/cdn-utils.js
@@ -86,9 +86,10 @@ function normalizePathname(pathname, {
  * Extracts and sanitizes a site-specific key from the base URL.
  */
 export function extractSiteKeyFromBaseURL(site) {
+  const baseURL = site.getBaseURL();
   let url;
   try {
-    url = new URL(site.getBaseURL());
+    url = new URL(baseURL);
   } catch {
     throw new Error('Invalid base URL');
   }

--- a/test/utils/cdn-utils.test.js
+++ b/test/utils/cdn-utils.test.js
@@ -103,6 +103,15 @@ describe('CDN Utils', () => {
       const site = { getBaseURL: () => 'not a url' };
       expect(() => extractSiteKeyFromBaseURL(site)).to.throw('Invalid base URL');
     });
+
+    it('propagates non-URL errors from getBaseURL', () => {
+      const site = {
+        getBaseURL: () => {
+          throw new Error('boom');
+        },
+      };
+      expect(() => extractSiteKeyFromBaseURL(site)).to.throw('boom');
+    });
   });
 
   describe('resolveCdnBucketName', () => {

--- a/test/utils/cdn-utils.test.js
+++ b/test/utils/cdn-utils.test.js
@@ -88,6 +88,21 @@ describe('CDN Utils', () => {
       expect(extractSiteKeyFromBaseURL(hyphenatedSite)).to.equal('example_com_us_en');
       expect(extractSiteKeyFromBaseURL(nestedSite)).to.equal('example_com_us__en');
     });
+
+    it('throws for a base URL containing userinfo (collision guard)', () => {
+      const site = { getBaseURL: () => 'https://1122@www.interactivebrokers.com' };
+      expect(() => extractSiteKeyFromBaseURL(site)).to.throw('userinfo is not permitted');
+    });
+
+    it('throws for a base URL with only password userinfo', () => {
+      const site = { getBaseURL: () => 'https://:pass@example.com/abc' };
+      expect(() => extractSiteKeyFromBaseURL(site)).to.throw('userinfo is not permitted');
+    });
+
+    it('throws for an unparseable base URL', () => {
+      const site = { getBaseURL: () => 'not a url' };
+      expect(() => extractSiteKeyFromBaseURL(site)).to.throw('Invalid base URL');
+    });
   });
 
   describe('resolveCdnBucketName', () => {


### PR DESCRIPTION
`extractSiteKeyFromBaseURL`  S3 paths from a site's base URL. It previously called `new URL()` and used the host, silently discarding any userinfo (`https://@host`). This adds validation so a base URL containing userinfo (or an unparseable URL) is rejected up front, ensuring the derived site key reflects the actual base URL. Adds test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)