### PR TITLE
fix(cdn-analysis): make referral self-referral filter NULL-safe

### DIFF
--- a/src/cdn-analysis/sql/akamai/insert-aggregated-referral.sql
+++ b/src/cdn-analysis/sql/akamai/insert-aggregated-referral.sql
@@ -84,8 +84,9 @@ referrals_raw AS (
 
       -- case 3: IF cdn log contains external referrer (not one of first party hosts)
       OR (
+        -- NULL-safe: a NULL in the host set makes NOT IN drop ALL external referrals (SQL three-valued logic)
         referer_raw IS NOT NULL
-        AND try(url_extract_host(referer_raw)) NOT IN (SELECT host FROM hosts)
+        AND try(url_extract_host(referer_raw)) NOT IN (SELECT host FROM hosts WHERE host IS NOT NULL AND host <> '')
       )
     )
 

--- a/src/cdn-analysis/sql/cloudflare/insert-aggregated-referral.sql
+++ b/src/cdn-analysis/sql/cloudflare/insert-aggregated-referral.sql
@@ -73,8 +73,9 @@ referrals_raw AS (
 
       -- case 3: IF cdn log contains external referrer (not one of first party hosts)
       OR (
+        -- NULL-safe: a NULL in the host set makes NOT IN drop ALL external referrals (SQL three-valued logic)
         referer_raw IS NOT NULL
-        AND try(url_extract_host(referer_raw)) NOT IN (SELECT host FROM hosts)
+        AND try(url_extract_host(referer_raw)) NOT IN (SELECT host FROM hosts WHERE host IS NOT NULL AND host <> '')
       )
     )
 

--- a/src/cdn-analysis/sql/cloudfront/insert-aggregated-referral.sql
+++ b/src/cdn-analysis/sql/cloudfront/insert-aggregated-referral.sql
@@ -79,8 +79,9 @@ referrals_raw AS (
 
       -- case 3: IF cdn log contains external referrer (not one of first party hosts)
       OR (
+        -- NULL-safe: a NULL in the host set makes NOT IN drop ALL external referrals (SQL three-valued logic)
         referer_raw IS NOT NULL
-        AND try(url_extract_host(referer_raw)) NOT IN (SELECT host FROM hosts)
+        AND try(url_extract_host(referer_raw)) NOT IN (SELECT host FROM hosts WHERE host IS NOT NULL AND host <> '')
       )
     )
 

--- a/src/cdn-analysis/sql/fastly/insert-aggregated-referral.sql
+++ b/src/cdn-analysis/sql/fastly/insert-aggregated-referral.sql
@@ -68,7 +68,8 @@ referrals_raw AS (
 
       -- case 3: IF cdn log contains external referrer (not one of first party hosts)
       OR (
-        request_referer IS NOT NULL AND try(url_extract_host(request_referer)) NOT IN (SELECT host FROM hosts)
+        -- NULL-safe: a NULL in the host set makes NOT IN drop ALL external referrals (SQL three-valued logic)
+        request_referer IS NOT NULL AND try(url_extract_host(request_referer)) NOT IN (SELECT host FROM hosts WHERE host IS NOT NULL AND host <> '')
       )
     )
 

--- a/src/cdn-analysis/sql/frontdoor/insert-aggregated-referral.sql
+++ b/src/cdn-analysis/sql/frontdoor/insert-aggregated-referral.sql
@@ -67,7 +67,8 @@ referrals_raw AS (
 
       -- case 3: IF cdn log contains external referrer (not one of first party hosts)
       OR (
-        properties.referer IS NOT NULL AND try(url_extract_host(properties.referer)) NOT IN (SELECT host FROM hosts)
+        -- NULL-safe: a NULL in the host set makes NOT IN drop ALL external referrals (SQL three-valued logic)
+        properties.referer IS NOT NULL AND try(url_extract_host(properties.referer)) NOT IN (SELECT host FROM hosts WHERE host IS NOT NULL AND host <> '')
       )
     )
 

--- a/src/cdn-analysis/sql/imperva/insert-aggregated-referral.sql
+++ b/src/cdn-analysis/sql/imperva/insert-aggregated-referral.sql
@@ -77,8 +77,9 @@ referrals_raw AS (
 
       -- case 3: IF cdn log contains external referrer (not one of first party hosts)
       OR (
+        -- NULL-safe: a NULL in the host set makes NOT IN drop ALL external referrals (SQL three-valued logic)
         referer_raw IS NOT NULL
-        AND try(url_extract_host(referer_raw)) NOT IN (SELECT host FROM hosts)
+        AND try(url_extract_host(referer_raw)) NOT IN (SELECT host FROM hosts WHERE host IS NOT NULL AND host <> '')
       )
     )
 

--- a/src/cdn-analysis/sql/other/insert-aggregated-referral.sql
+++ b/src/cdn-analysis/sql/other/insert-aggregated-referral.sql
@@ -66,7 +66,8 @@ referrals_raw AS (
 
       -- case 3: IF cdn log contains external referrer (not one of first party hosts)
       OR (
-        request_referer IS NOT NULL AND try(url_extract_host(request_referer)) NOT IN (SELECT host FROM hosts)
+        -- NULL-safe: a NULL in the host set makes NOT IN drop ALL external referrals (SQL three-valued logic)
+        request_referer IS NOT NULL AND try(url_extract_host(request_referer)) NOT IN (SELECT host FROM hosts WHERE host IS NOT NULL AND host <> '')
       )
     )
 


### PR DESCRIPTION
## Problem

Customers on BYOCDN (e.g. MLB / mlb.com) report they **cannot see referral traffic** (LLM referrals in particular). The raw CDN logs contain the traffic, but it never reaches the `aggregated-referral` table, so the referral report is empty.

## Root cause: `NOT IN` + NULL in the self-referral filter

The referral aggregation builds a first-party host set and filters self-referrals / internal navigation with:

```sql
WITH hosts AS ( SELECT DISTINCT host FROM {{rawTable}} WHERE ... )   -- may include NULL
...
-- case 3: external referrer
OR ( referer IS NOT NULL AND url_extract_host(referer) NOT IN (SELECT host FROM hosts) )
```

When a partition contains **any** NULL/empty `host` value, the `hosts` set contains NULL. In SQL three-valued logic, `x NOT IN (a, b, NULL)` is never `TRUE` (it is `NULL`), so **case 3 matches zero rows** and every external-referrer pageview is silently dropped. Only `utm`/tracking-param referrals (cases 1 and 2, which do not touch the `hosts` subquery) survive.

LLM referrals almost always arrive as a plain external referrer (`referer: https://chatgpt.com/`) with no `utm_source`, so **100% of LLM referral traffic is dropped** whenever a partition has a NULL host.

NULL hosts are common and legitimate: Fastly logs health-checks and `forbidden`/`ERROR` responses that carry no Host header (valid JSON with `"host": null`), so this fires on essentially every partition.

## Fix

Filter NULL/empty out of the host subquery in all 7 provider queries (akamai, cloudflare, cloudfront, fastly, frontdoor, imperva, other):

```sql
... NOT IN (SELECT host FROM hosts WHERE host IS NOT NULL AND host <> '')
```

The `hosts` CTE is referenced only at this one predicate in each file, and the guard applies to the CTE's `host` output alias, so it is uniform and expression-agnostic (works for frontdoor's `COALESCE(NULLIF(...))` host expression too). NULL/empty were never legitimate first-party hosts, so removing them yields the correct set; genuine self-referrals still resolve against real hosts and stay excluded.

## Verification (MLB prod, Athena, full day 2026-07-29)

| | Total referral rows | LLM referral rows |
|---|---|---|
| Raw logs (source truth) | ~9.8M external + utm | 3,065 (text/html) |
| Aggregated table **before** | 177 | **0** |
| External-referrer filter **after fix** | (restored) | 2,961 chatgpt.com alone |

Self-referral safety confirmed: `host = www.mlb.com` (self + internal navigation, **1,418,734** rows) stays **excluded** after the fix (0 leak); only genuine external referrers (google, bing, chatgpt, perplexity, gemini, ...) are counted.

## Scope / rollout

- SQL-only change; `test/audits/cdn-analysis/handler.test.js` passes (54/54).
- No behavior change for partitions that never had NULL hosts.
- Affected customers need a **reprocess/backfill** (`cdn-logs-analysis` with `forceReprocess`) to repopulate historical `aggregated-referral` partitions once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
