### PR TITLE
fix(deps): bump @adobe/spacecat-shared-data-access to 4.15.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@adobe/mysticat-shared-seo-client": "1.8.0",
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
         "@adobe/spacecat-shared-athena-client": "1.11.0",
-        "@adobe/spacecat-shared-data-access": "4.15.1",
+        "@adobe/spacecat-shared-data-access": "4.15.3",
         "@adobe/spacecat-shared-drs-client": "1.13.0",
         "@adobe/spacecat-shared-google-client": "1.6.3",
         "@adobe/spacecat-shared-gpt-client": "1.7.1",
@@ -1372,9 +1372,9 @@
       }
     },
     "node_modules/@adobe/spacecat-shared-data-access": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.15.1.tgz",
-      "integrity": "sha512-PxrlbtxibRqTstqW4iszQDUz8R+v/jZmZu8hYkreGs8dUG2vg2VICYuaeUQSdx2MsU2JJ/4IhPuJHd/bmk5Gag==",
+      "version": "4.15.3",
+      "resolved": "https://registry.npmjs.org/@adobe/spacecat-shared-data-access/-/spacecat-shared-data-access-4.15.3.tgz",
+      "integrity": "sha512-dylxr3Q6JzvCxyc8tVSXLMP7Gq7C2QVBUP0siAwrRMaqp6/8dLApF5dru+nXdVwKZ8tSl4b3Xpp3H3tVzH3WuQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "^4.2.3",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@adobe/mysticat-shared-seo-client": "1.8.0",
     "@adobe/spacecat-helix-content-sdk": "1.4.33",
     "@adobe/spacecat-shared-athena-client": "1.11.0",
-    "@adobe/spacecat-shared-data-access": "4.15.1",
+    "@adobe/spacecat-shared-data-access": "4.15.3",
     "@adobe/spacecat-shared-drs-client": "1.13.0",
     "@adobe/spacecat-shared-google-client": "1.6.3",
     "@adobe/spacecat-shared-gpt-client": "1.7.1",


### PR DESCRIPTION
## What
Bumps `@adobe/spacecat-shared-data-access` from `4.15.1` to `4.15.3` (exact pin, lockfile resynced). No other dependency changes.


## Testing
CI (unit + 100% coverage gate).