### PR TITLE
fix(cdn-logs): source cdn bucket config from provisioning-owned values

### DIFF
--- a/src/llmo-customer-analysis/cdn-config-handler.js
+++ b/src/llmo-customer-analysis/cdn-config-handler.js
@@ -154,23 +154,14 @@ async function handleAdobeFastly(
 
 async function handleBucketConfiguration(
   siteId,
-  bucketName,
   pathId,
-  region,
+  cdnProvider,
   { dataAccess: { Site } },
 ) {
   const site = await Site.findById(siteId);
   const config = site.getConfig();
 
-  if (!bucketName && !pathId && !region) {
-    config.updateLlmoCdnBucketConfig({});
-  } else {
-    config.updateLlmoCdnBucketConfig({
-      ...(bucketName && { bucketName }),
-      ...(pathId && { orgId: pathId }),
-      ...(region && { region }),
-    });
-  }
+  config.updateLlmoCdnBucketConfig(pathId ? { orgId: pathId, cdnProvider } : {});
 
   site.setConfig(Config.toDynamoItem(config));
   await site.save();
@@ -182,13 +173,8 @@ async function handleBucketConfiguration(
 export async function handleCdnBucketConfigChanges(context, data) {
   /* c8 ignore next */
   const { siteId } = context.params || {};
-  const {
-    cdnProvider,
-    allowedPaths,
-    bucketName,
-    region,
-  } = data;
-  const { dataAccess: { Configuration }, log } = context;
+  const { cdnProvider } = data;
+  const { dataAccess: { Configuration, Organization }, log } = context;
 
   if (!siteId) {
     throw new Error('Site ID is required for CDN configuration');
@@ -209,7 +195,7 @@ export async function handleCdnBucketConfigChanges(context, data) {
       before: previousConfig,
     });
     // if no cdn provider is provided, remove the bucket configuration
-    await handleBucketConfiguration(siteId, null, null, null, context);
+    await handleBucketConfiguration(siteId, null, null, context);
     // disable CDN-derived audits when the CDN configuration is removed
     const configuration = await Configuration.findLatest();
     configuration.disableHandlerForSite('cdn-logs-analysis', site);
@@ -221,30 +207,20 @@ export async function handleCdnBucketConfigChanges(context, data) {
 
   let pathId;
 
-  if (allowedPaths && allowedPaths.length > 0) {
-    const [firstPath] = allowedPaths;
-    [pathId] = firstPath.split('/');
-  }
-
   if (cdnProvider === SERVICE_PROVIDER_TYPES.COMMERCE_FASTLY) {
     const service = await fetchCommerceFastlyService(site.getBaseURL(), context);
     if (service) {
       pathId = service.serviceName;
     }
-  }
-
-  if (cdnProvider.includes('ams')) {
-    if (cdnProvider === SERVICE_PROVIDER_TYPES.AMS_CLOUDFRONT) {
-      const imsOrgId = await getImsOrgId(site, context.dataAccess, log);
-      if (imsOrgId) {
-        pathId = imsOrgId.replace('@', ''); // Remove @ for filesystem-safe path
-      }
+  } else if (cdnProvider === SERVICE_PROVIDER_TYPES.AMS_CLOUDFRONT) {
+    const imsOrgId = await getImsOrgId(site, context.dataAccess, log);
+    if (imsOrgId) {
+      pathId = imsOrgId.replace('@', '');
     }
   }
 
-  // Set bucket configuration
-  if (bucketName || pathId || region) {
-    await handleBucketConfiguration(siteId, bucketName, pathId, region, context);
+  if (pathId) {
+    await handleBucketConfiguration(siteId, pathId, cdnProvider, context);
   }
 
   log.info('CDN_CONFIG_CHANGED: CDN bucket configuration updated', {
@@ -252,17 +228,16 @@ export async function handleCdnBucketConfigChanges(context, data) {
     baseURL,
     cdnProvider,
     before: previousConfig,
-    after: {
-      ...(bucketName && { bucketName }),
-      ...(pathId && { orgId: pathId }),
-      ...(region && { region }),
-    },
+    after: pathId ? { orgId: pathId, cdnProvider } : previousConfig,
   });
 
-  // enable CDN-derived audits once the site has a valid CDN configuration
   const configuration = await Configuration.findLatest();
-  configuration.enableHandlerForSite('cdn-logs-analysis', site);
-  configuration.enableHandlerForSite('cdn-logs-report', site);
+  const organization = await Organization.findById(site.getOrganizationId());
+  for (const handlerType of ['cdn-logs-analysis', 'cdn-logs-report']) {
+    if (!(organization && configuration.isHandlerDisabledForOrg(handlerType, organization))) {
+      configuration.enableHandlerForSite(handlerType, site);
+    }
+  }
   await configuration.save();
 
   // Run analysis and reporting for Adobe-managed Fastly customers

--- a/src/llmo-customer-analysis/cdn-config-handler.js
+++ b/src/llmo-customer-analysis/cdn-config-handler.js
@@ -254,8 +254,9 @@ export async function handleCdnBucketConfigChanges(context, data) {
     after: pathId ? { orgId: pathId, cdnProvider } : previousConfig,
   });
 
-  cdnHandlers.forEach((h) => configuration.enableHandlerForSite(h, site));
-  await configuration.save();
+  const latestConfiguration = await Configuration.findLatest();
+  cdnHandlers.forEach((h) => latestConfiguration.enableHandlerForSite(h, site));
+  await latestConfiguration.save();
 
   // Run analysis and reporting for Adobe-managed Fastly customers
   if (

--- a/src/llmo-customer-analysis/cdn-config-handler.js
+++ b/src/llmo-customer-analysis/cdn-config-handler.js
@@ -188,21 +188,27 @@ export async function handleCdnBucketConfigChanges(context, data) {
   const baseURL = site.getBaseURL();
   const previousConfig = site.getConfig()?.getLlmoCdnBucketConfig() ?? {};
 
-  if (!cdnProvider) {
-    log.warn('CDN_CONFIG_DELETED: CDN provider removed — this will break CDN log reporting', {
-      siteId,
-      baseURL,
-      before: previousConfig,
-    });
-    // if no cdn provider is provided, remove the bucket configuration
+  const configuration = await Configuration.findLatest();
+  const organization = await Organization.findById(site.getOrganizationId());
+  const cdnHandlers = ['cdn-logs-analysis', 'cdn-logs-report'];
+  const orgDisabled = organization
+    && cdnHandlers.some((h) => configuration.isHandlerDisabledForOrg(h, organization));
+
+  if (!cdnProvider || orgDisabled) {
+    if (!cdnProvider) {
+      log.warn('CDN_CONFIG_DELETED: CDN provider removed — this will break CDN log reporting', {
+        siteId,
+        baseURL,
+        before: previousConfig,
+      });
+    }
     await handleBucketConfiguration(siteId, null, null, context);
-    // disable CDN-derived audits when the CDN configuration is removed
-    const configuration = await Configuration.findLatest();
-    configuration.disableHandlerForSite('cdn-logs-analysis', site);
-    configuration.disableHandlerForSite('cdn-logs-report', site);
-    configuration.disableHandlerForSite('page-citability', site);
+    cdnHandlers.forEach((h) => configuration.disableHandlerForSite(h, site));
     await configuration.save();
-    throw new Error('CDN provider is required for CDN configuration');
+    if (!cdnProvider) {
+      throw new Error('CDN provider is required for CDN configuration');
+    }
+    return;
   }
 
   let pathId;
@@ -231,13 +237,7 @@ export async function handleCdnBucketConfigChanges(context, data) {
     after: pathId ? { orgId: pathId, cdnProvider } : previousConfig,
   });
 
-  const configuration = await Configuration.findLatest();
-  const organization = await Organization.findById(site.getOrganizationId());
-  for (const handlerType of ['cdn-logs-analysis', 'cdn-logs-report']) {
-    if (!(organization && configuration.isHandlerDisabledForOrg(handlerType, organization))) {
-      configuration.enableHandlerForSite(handlerType, site);
-    }
-  }
+  cdnHandlers.forEach((h) => configuration.enableHandlerForSite(h, site));
   await configuration.save();
 
   // Run analysis and reporting for Adobe-managed Fastly customers

--- a/src/llmo-customer-analysis/cdn-config-handler.js
+++ b/src/llmo-customer-analysis/cdn-config-handler.js
@@ -154,14 +154,24 @@ async function handleAdobeFastly(
 
 async function handleBucketConfiguration(
   siteId,
-  pathId,
+  bucketName,
+  orgId,
+  region,
   cdnProvider,
   { dataAccess: { Site } },
 ) {
   const site = await Site.findById(siteId);
   const config = site.getConfig();
 
-  config.updateLlmoCdnBucketConfig(pathId ? { orgId: pathId, cdnProvider } : {});
+  const cdnBucketConfig = Object.fromEntries(
+    Object.entries({
+      bucketName,
+      orgId,
+      region,
+      cdnProvider,
+    }).filter(([, value]) => value),
+  );
+  config.updateLlmoCdnBucketConfig(cdnBucketConfig);
 
   site.setConfig(Config.toDynamoItem(config));
   await site.save();
@@ -202,7 +212,7 @@ export async function handleCdnBucketConfigChanges(context, data) {
         before: previousConfig,
       });
     }
-    await handleBucketConfiguration(siteId, null, null, context);
+    await handleBucketConfiguration(siteId, null, null, null, null, context);
     cdnHandlers.forEach((h) => configuration.disableHandlerForSite(h, site));
     await configuration.save();
     if (!cdnProvider) {
@@ -226,7 +236,7 @@ export async function handleCdnBucketConfigChanges(context, data) {
   }
 
   if (pathId) {
-    await handleBucketConfiguration(siteId, pathId, cdnProvider, context);
+    await handleBucketConfiguration(siteId, null, pathId, null, cdnProvider, context);
   }
 
   log.info('CDN_CONFIG_CHANGED: CDN bucket configuration updated', {
@@ -237,8 +247,9 @@ export async function handleCdnBucketConfigChanges(context, data) {
     after: pathId ? { orgId: pathId, cdnProvider } : previousConfig,
   });
 
-  cdnHandlers.forEach((h) => configuration.enableHandlerForSite(h, site));
-  await configuration.save();
+  const latestConfiguration = await Configuration.findLatest();
+  cdnHandlers.forEach((h) => latestConfiguration.enableHandlerForSite(h, site));
+  await latestConfiguration.save();
 
   // Run analysis and reporting for Adobe-managed Fastly customers
   if (

--- a/src/llmo-customer-analysis/cdn-config-handler.js
+++ b/src/llmo-customer-analysis/cdn-config-handler.js
@@ -254,9 +254,8 @@ export async function handleCdnBucketConfigChanges(context, data) {
     after: pathId ? { orgId: pathId, cdnProvider } : previousConfig,
   });
 
-  const latestConfiguration = await Configuration.findLatest();
-  cdnHandlers.forEach((h) => latestConfiguration.enableHandlerForSite(h, site));
-  await latestConfiguration.save();
+  cdnHandlers.forEach((h) => configuration.enableHandlerForSite(h, site));
+  await configuration.save();
 
   // Run analysis and reporting for Adobe-managed Fastly customers
   if (

--- a/src/llmo-customer-analysis/cdn-config-handler.js
+++ b/src/llmo-customer-analysis/cdn-config-handler.js
@@ -211,6 +211,13 @@ export async function handleCdnBucketConfigChanges(context, data) {
         baseURL,
         before: previousConfig,
       });
+    } else {
+      log.info('CDN_CONFIG_ORG_DISABLED: CDN handlers disabled for a disabled organization', {
+        siteId,
+        baseURL,
+        cdnProvider,
+        before: previousConfig,
+      });
     }
     await handleBucketConfiguration(siteId, null, null, null, null, context);
     cdnHandlers.forEach((h) => configuration.disableHandlerForSite(h, site));

--- a/test/audits/llmo-customer-analysis-cdn-config.test.js
+++ b/test/audits/llmo-customer-analysis-cdn-config.test.js
@@ -313,6 +313,7 @@ describe('CDN Config Handler', () => {
 
       mockConfiguration = {
         enableHandlerForSite: sandbox.stub(),
+        disableHandlerForSite: sandbox.stub(),
         isHandlerEnabledForSite: sandbox.stub().returns(false),
         isHandlerDisabledForOrg: sandbox.stub().returns(false),
         save: sandbox.stub().resolves(),
@@ -350,7 +351,6 @@ describe('CDN Config Handler', () => {
       expect(mockSite.save).to.have.been.called;
       expect(mockConfiguration.disableHandlerForSite).to.have.been.calledWith('cdn-logs-analysis', mockSite);
       expect(mockConfiguration.disableHandlerForSite).to.have.been.calledWith('cdn-logs-report', mockSite);
-      expect(mockConfiguration.disableHandlerForSite).to.have.been.calledWith('page-citability', mockSite);
       expect(mockConfiguration.save).to.have.been.called;
       expect(context.log.warn).to.have.been.calledWith(
         'CDN_CONFIG_DELETED: CDN provider removed — this will break CDN log reporting',
@@ -461,7 +461,6 @@ describe('CDN Config Handler', () => {
       expect(mockSite.save).to.have.been.called;
       expect(mockConfiguration.enableHandlerForSite).to.have.been.calledWith('cdn-logs-analysis', mockSite);
       expect(mockConfiguration.enableHandlerForSite).to.have.been.calledWith('cdn-logs-report', mockSite);
-      expect(mockConfiguration.enableHandlerForSite).to.not.have.been.calledWith('page-citability', mockSite);
       expect(context.log.info).to.have.been.calledWith(
         'CDN_CONFIG_CHANGED: CDN bucket configuration updated',
         sinon.match({
@@ -497,17 +496,21 @@ describe('CDN Config Handler', () => {
       );
     });
 
-    it('should not enable handlers when the org is disabled at org level', async () => {
+    it('should disable handlers and return early when the org is disabled at org level', async () => {
       const mockOrganization = { getId: sandbox.stub().returns('org-123') };
       context.dataAccess.Organization.findById.resolves(mockOrganization);
       mockConfiguration.isHandlerDisabledForOrg.returns(true);
 
-      const data = { cdnProvider: 'byocdn-fastly' };
+      const data = { cdnProvider: 'commerce-fastly' };
 
       await cdnConfigHandler.handleCdnBucketConfigChanges(context, data);
 
       expect(mockConfiguration.isHandlerDisabledForOrg).to.have.been.calledWith('cdn-logs-analysis', mockOrganization);
+      expect(mockSiteConfig.updateLlmoCdnBucketConfig).to.have.been.calledWith({});
+      expect(mockConfiguration.disableHandlerForSite).to.have.been.calledWith('cdn-logs-analysis', mockSite);
+      expect(mockConfiguration.disableHandlerForSite).to.have.been.calledWith('cdn-logs-report', mockSite);
       expect(mockConfiguration.enableHandlerForSite).to.not.have.been.called;
+      expect(context.sqs.sendMessage).to.not.have.been.called;
       expect(mockConfiguration.save).to.have.been.called;
     });
 

--- a/test/audits/llmo-customer-analysis-cdn-config.test.js
+++ b/test/audits/llmo-customer-analysis-cdn-config.test.js
@@ -314,6 +314,7 @@ describe('CDN Config Handler', () => {
       mockConfiguration = {
         enableHandlerForSite: sandbox.stub(),
         isHandlerEnabledForSite: sandbox.stub().returns(false),
+        isHandlerDisabledForOrg: sandbox.stub().returns(false),
         save: sandbox.stub().resolves(),
         getQueues: sandbox.stub().returns({
           audits: 'audit-queue-url',
@@ -385,7 +386,7 @@ describe('CDN Config Handler', () => {
 
       await cdnConfigHandler.handleCdnBucketConfigChanges(context, data);
 
-      expect(mockSiteConfig.updateLlmoCdnBucketConfig).to.have.been.calledWith({ orgId: 'commerce-org' });
+      expect(mockSiteConfig.updateLlmoCdnBucketConfig).to.have.been.calledWith({ orgId: 'commerce-org', cdnProvider: 'commerce-fastly' });
     });
 
     it('should run Fastly analysis and reporting for commerce-fastly provider', async () => {
@@ -436,16 +437,27 @@ describe('CDN Config Handler', () => {
       expect(context.sqs.sendMessage).to.not.have.been.called;
     });
 
-    it('should handle bucket configuration when bucketName provided', async () => {
+    it('should ignore customer-supplied bucketName/allowedPaths/region for commerce-fastly', async () => {
       nock('https://main--project-elmo-ui-data--adobe.aem.live')
         .get('/adobe-managed-domains/commerce-fastly-domains.json?limit=10000')
-        .reply(200, { data: [] });
+        .reply(200, {
+          data: [{
+            ServiceName: 'commerce-org',
+            ServiceID: 'service-123',
+            domains: 'example.com,www.example.com',
+          }],
+        });
 
-      const data = { bucketName: 'test-bucket', cdnProvider: 'commerce-fastly' };
+      const data = {
+        bucketName: 'attacker-bucket',
+        allowedPaths: ['victim-org/raw/byocdn-fastly/'],
+        region: 'eu-west-1',
+        cdnProvider: 'commerce-fastly',
+      };
 
       await cdnConfigHandler.handleCdnBucketConfigChanges(context, data);
 
-      expect(mockSiteConfig.updateLlmoCdnBucketConfig).to.have.been.calledWith({ bucketName: 'test-bucket' });
+      expect(mockSiteConfig.updateLlmoCdnBucketConfig).to.have.been.calledOnceWithExactly({ orgId: 'commerce-org', cdnProvider: 'commerce-fastly' });
       expect(mockSite.save).to.have.been.called;
       expect(mockConfiguration.enableHandlerForSite).to.have.been.calledWith('cdn-logs-analysis', mockSite);
       expect(mockConfiguration.enableHandlerForSite).to.have.been.calledWith('cdn-logs-report', mockSite);
@@ -457,54 +469,46 @@ describe('CDN Config Handler', () => {
           baseURL: 'https://example.com',
           cdnProvider: 'commerce-fastly',
           before: { bucketName: 'old-bucket', orgId: 'old-org' },
-          after: { bucketName: 'test-bucket' },
+          after: { orgId: 'commerce-org', cdnProvider: 'commerce-fastly' },
         }),
       );
     });
 
-    it('should handle bucket configuration when allowedPaths provided', async () => {
-      nock('https://main--project-elmo-ui-data--adobe.aem.live')
-        .get('/adobe-managed-domains/commerce-fastly-domains.json?limit=10000')
-        .reply(200, { data: [] });
-
-      const data = { allowedPaths: ['test-org/path1', 'test-org/path2'], cdnProvider: 'commerce-fastly' };
-
-      await cdnConfigHandler.handleCdnBucketConfigChanges(context, data);
-
-      expect(mockSiteConfig.updateLlmoCdnBucketConfig).to.have.been.calledWith({ orgId: 'test-org' });
-      expect(mockSite.save).to.have.been.called;
-    });
-
-    it('should handle bucket configuration when both bucketName and allowedPaths provided', async () => {
-      nock('https://main--project-elmo-ui-data--adobe.aem.live')
-        .get('/adobe-managed-domains/commerce-fastly-domains.json?limit=10000')
-        .reply(200, { data: [] });
-
-      const data = { bucketName: 'test-bucket', allowedPaths: ['test-org/path1'], cdnProvider: 'commerce-fastly' };
-
-      await cdnConfigHandler.handleCdnBucketConfigChanges(context, data);
-
-      expect(mockSiteConfig.updateLlmoCdnBucketConfig).to.have.been.calledWith({
-        bucketName: 'test-bucket',
-        orgId: 'test-org',
-      });
-      expect(mockSite.save).to.have.been.called;
-    });
-
-    it('should persist region in bucket configuration when provided', async () => {
-      nock('https://main--project-elmo-ui-data--adobe.aem.live')
-        .get('/adobe-managed-domains/commerce-fastly-domains.json?limit=10000')
-        .reply(200, { data: [] });
-
-      const data = { bucketName: 'test-bucket', region: 'eu-west-1', cdnProvider: 'commerce-fastly' };
-
-      await cdnConfigHandler.handleCdnBucketConfigChanges(context, data);
-
-      expect(mockSiteConfig.updateLlmoCdnBucketConfig).to.have.been.calledWith({
-        bucketName: 'test-bucket',
+    it('should not write bucket config for byocdn providers but still enable handlers', async () => {
+      const data = {
+        bucketName: 'attacker-bucket',
+        allowedPaths: ['victim-org/raw/byocdn-fastly/'],
         region: 'eu-west-1',
-      });
-      expect(mockSite.save).to.have.been.called;
+        cdnProvider: 'byocdn-fastly',
+      };
+
+      await cdnConfigHandler.handleCdnBucketConfigChanges(context, data);
+
+      expect(mockSiteConfig.updateLlmoCdnBucketConfig).to.not.have.been.called;
+      expect(mockSite.save).to.not.have.been.called;
+      expect(mockConfiguration.enableHandlerForSite).to.have.been.calledWith('cdn-logs-analysis', mockSite);
+      expect(mockConfiguration.enableHandlerForSite).to.have.been.calledWith('cdn-logs-report', mockSite);
+      expect(context.log.info).to.have.been.calledWith(
+        'CDN_CONFIG_CHANGED: CDN bucket configuration updated',
+        sinon.match({
+          cdnProvider: 'byocdn-fastly',
+          after: { bucketName: 'old-bucket', orgId: 'old-org' },
+        }),
+      );
+    });
+
+    it('should not enable handlers when the org is disabled at org level', async () => {
+      const mockOrganization = { getId: sandbox.stub().returns('org-123') };
+      context.dataAccess.Organization.findById.resolves(mockOrganization);
+      mockConfiguration.isHandlerDisabledForOrg.returns(true);
+
+      const data = { cdnProvider: 'byocdn-fastly' };
+
+      await cdnConfigHandler.handleCdnBucketConfigChanges(context, data);
+
+      expect(mockConfiguration.isHandlerDisabledForOrg).to.have.been.calledWith('cdn-logs-analysis', mockOrganization);
+      expect(mockConfiguration.enableHandlerForSite).to.not.have.been.called;
+      expect(mockConfiguration.save).to.have.been.called;
     });
 
     it('should handle aem-cs-fastly provider', async () => {
@@ -672,8 +676,9 @@ describe('CDN Config Handler', () => {
         await cdnConfigHandler.handleCdnBucketConfigChanges(context, data);
 
         expect(context.dataAccess.Organization.findById).to.have.been.calledWith(mockSite.getOrganizationId());
-        expect(mockSiteConfig.updateLlmoCdnBucketConfig).to.have.been.calledWith({ 
-          orgId: 'TestOrg123AdobeOrg' 
+        expect(mockSiteConfig.updateLlmoCdnBucketConfig).to.have.been.calledWith({
+          orgId: 'TestOrg123AdobeOrg',
+          cdnProvider: 'ams-cloudfront',
         });
       });
     });

--- a/test/audits/llmo-customer-analysis-cdn-config.test.js
+++ b/test/audits/llmo-customer-analysis-cdn-config.test.js
@@ -435,6 +435,9 @@ describe('CDN Config Handler', () => {
       await cdnConfigHandler.handleCdnBucketConfigChanges(context, data);
 
       expect(context.sqs.sendMessage).to.not.have.been.called;
+      expect(mockSiteConfig.updateLlmoCdnBucketConfig).to.not.have.been.called;
+      expect(mockConfiguration.enableHandlerForSite).to.have.been.calledWith('cdn-logs-analysis', mockSite);
+      expect(mockConfiguration.enableHandlerForSite).to.have.been.calledWith('cdn-logs-report', mockSite);
     });
 
     it('should ignore customer-supplied bucketName/allowedPaths/region for commerce-fastly', async () => {
@@ -511,6 +514,10 @@ describe('CDN Config Handler', () => {
       expect(mockConfiguration.disableHandlerForSite).to.have.been.calledWith('cdn-logs-report', mockSite);
       expect(mockConfiguration.enableHandlerForSite).to.not.have.been.called;
       expect(context.sqs.sendMessage).to.not.have.been.called;
+      expect(context.log.info).to.have.been.calledWith(
+        'CDN_CONFIG_ORG_DISABLED: CDN handlers disabled for a disabled organization',
+        sinon.match({ siteId: 'site-123', cdnProvider: 'commerce-fastly' }),
+      );
       expect(mockConfiguration.save).to.have.been.called;
     });
 


### PR DESCRIPTION
## What
Streamlines how the `llmo-customer-analysis` CDN config sync persists the site's `cdnBucketConfig`:

- For **commerce-fastly** and **ams-cloudfront**, persist only the server-resolved `orgId` (service name / IMS org) plus `cdnProvider`; the bucket resolves from the standard shared bucket at read time.
- Empty the bucket config and disable the CDN handlers in a single branch when the CDN provider is absent or the site's organization is disabled.
- Drop toggling of the deprecated `page-citability` handler.

## Why
Keeps the persisted CDN bucket config a product of  provisioning-owned values rather than re-derived from synced input, and removes redundant handling.

## Deploy note
Depends on the companion `spacecat-auth-service` change (which now owns the BYOCDN config write) landing and deploying **first**.

## Testing
- `test/audits/llmo-customer-analysis-cdn-config.test.js` updated.
- Full suite: 9357 passing, 100% coverage.
