### PR TITLE
fix(preflight): stop form-accessibility identify/suggest racing on the shared S3 result key (SITES-49003)

### DIFF
--- a/src/preflight/form-accessibility.js
+++ b/src/preflight/form-accessibility.js
@@ -12,16 +12,22 @@
 
 import { createHash } from 'crypto';
 import { isNonEmptyArray } from '@adobe/spacecat-shared-utils';
-import { DeleteObjectsCommand } from '@aws-sdk/client-s3';
 import { load as cheerioLoad } from 'cheerio';
 
 import { saveIntermediateResults } from './utils.js';
 import { sleep } from '../support/utils.js';
-import { getObjectFromKey, getObjectKeysUsingPrefix } from '../utils/s3-utils.js';
+import { getObjectFromKey, getObjectMetadataUsingPrefix } from '../utils/s3-utils.js';
 import { generateAccessibilityFilename } from './accessibility.js';
 import { getDomElementSelector } from './utils/dom-selector.js';
 
 export const PREFLIGHT_FORM_ACCESSIBILITY = 'form-accessibility';
+
+// Only accept a Mystique-written result file whose S3 LastModified is at least this old
+// relative to the run start, to avoid reading a stale leftover file from a previous run on the
+// same site+URL+selector (the result key is not run-scoped, and we no longer delete after read).
+// Set far larger than plausible audit-worker↔S3 clock skew and far smaller than a typical
+// inter-run gap; missing LastModified fails open (accept) so it can never introduce a new hang.
+const CLOCK_SKEW_TOLERANCE_MS = 60 * 1000;
 
 /**
  * Generates a stable, unique filename for a single form's result file.
@@ -330,31 +336,13 @@ Form Accessibility audit completed in ${accessibilityElapsed} seconds`,
 
     await saveIntermediateResults(context, auditsResult, 'form accessibility audit');
 
-    // Clean up individual form accessibility files after processing
-    try {
-      const filesToDelete = resolvedFormEntries.map(({ form: url, formSource }) => {
-        const filename = generateFormAccessibilityFilename(url, formSource);
-        return `form-accessibility-preflight/${siteId}/${filename}`;
-      });
-
-      log.info(`[preflight-audit] Cleaning up ${filesToDelete.length} individual form accessibility files`);
-
-      const deleteCommand = new DeleteObjectsCommand({
-        Bucket: bucketName,
-        Delete: {
-          Objects: filesToDelete.map((Key) => ({ Key })),
-          Quiet: true,
-        },
-      });
-
-      await s3Client.send(deleteCommand);
-      log.info(`[preflight-audit] ${siteId} Successfully cleaned up ${filesToDelete.length} form accessibility files`);
-    } catch (cleanupError) {
-      log.warn(`[preflight-audit] ${siteId} Failed to clean up form accessibility files: ${cleanupError.message}`);
-      // Don't fail the entire audit if cleanup fails
-    }
+    // NOTE: individual form-accessibility result files are intentionally NOT deleted here.
+    // identify and suggest run concurrently and share this (non-run-scoped) result key; deleting
+    // after read starved whichever step read second, hanging the UI (SITES-49003). Files are
+    // overwritten in place on the next run for the same key; the poll's freshness gate prevents
+    // reading a stale leftover. Bulk lifecycle cleanup of the prefix is an infra follow-up.
   } catch (error) {
-    log.error(`[preflight-audit] ${siteId} not able to delete prefight files, site: ${site.getId()}, job: ${jobId}, step: ${step}. error ${error.message}`, error);
+    log.error(`[preflight-audit] ${siteId} error processing preflight form accessibility files, site: ${site.getId()}, job: ${jobId}, step: ${step}. error ${error.message}`, error);
   }
 }
 
@@ -414,8 +402,11 @@ export default async function formAccessibility(context, auditContext) {
     try {
       log.info(`[preflight-audit] Polling attempt - checking S3 bucket: ${bucketName}`);
 
-      // Check if form accessibility data files exist in S3 using helper function
-      const objectKeys = await getObjectKeysUsingPrefix(
+      // Check if form accessibility data files exist in S3 using helper function.
+      // We fetch LastModified so we only accept files freshly written by THIS run — the result
+      // key is not run-scoped and we no longer delete after read, so a stale leftover file from
+      // a previous run on the same site+URL+selector could otherwise be picked up.
+      const objects = await getObjectMetadataUsingPrefix(
         s3Client,
         bucketName,
         `form-accessibility-preflight/${siteId}/`,
@@ -424,15 +415,21 @@ export default async function formAccessibility(context, auditContext) {
         '.json',
       );
 
+      // Freshness gate: only accept a file written at/after this run started (minus a skew
+      // tolerance). Missing LastModified fails open (accept) so it can never add a new hang.
+      const freshnessThreshold = scrapeStartTime - CLOCK_SKEW_TOLERANCE_MS;
+
       // Check if we have the expected accessibility files
-      const foundFiles = objectKeys.filter((key) => {
+      const foundFiles = objects.filter(({ Key, LastModified }) => {
         // Extract filename from the S3 key
-        const pathParts = key.split('/');
+        const pathParts = Key.split('/');
         const filename = pathParts[pathParts.length - 1];
 
-        // Check if this is one of our expected files
-        return expectedFiles.includes(filename);
-      });
+        // Check if this is one of our expected files AND it is fresh for this run
+        const isExpected = expectedFiles.includes(filename);
+        const isFresh = !LastModified || new Date(LastModified).getTime() >= freshnessThreshold;
+        return isExpected && isFresh;
+      }).map(({ Key }) => Key);
 
       if (foundFiles && foundFiles.length >= expectedFiles.length) {
         log.info(`[preflight-audit] Found ${foundFiles.length} accessibility files out of ${expectedFiles.length} expected, form accessibility processing complete`);

--- a/src/utils/s3-utils.js
+++ b/src/utils/s3-utils.js
@@ -62,6 +62,70 @@ export async function getObjectKeysUsingPrefix(
 }
 
 /**
+ * Like {@link getObjectKeysUsingPrefix} but returns each object's key together with its
+ * `LastModified` timestamp, so callers can apply freshness checks (e.g. only accept a result
+ * file written after the current run started). Same signature, pagination, and validation as
+ * `getObjectKeysUsingPrefix`.
+ *
+ * @param {import('@aws-sdk/client-s3').S3Client} s3Client - an S3 client
+ * @param {string} bucketName - the name of the S3 bucket
+ * @param {string} prefix - the key prefix to list
+ * @param {import('@azure/logger').Logger} log - a logger instance
+ * @param {number} [maxKeys=1000] - max keys per page
+ * @param {string} [keyEndsWith='scrape.json'] - only include keys ending with this suffix
+ * @returns {Promise<Array<{ Key: string, LastModified: Date | undefined }>>}
+ */
+export async function getObjectMetadataUsingPrefix(
+  s3Client,
+  bucketName,
+  prefix,
+  log,
+  maxKeys = 1000,
+  keyEndsWith = 'scrape.json',
+) {
+  const objects = [];
+  let continuationToken = null;
+  if (!s3Client || !bucketName || !prefix) {
+    log.error(
+      `Invalid input parameters in getObjectMetadataUsingPrefix: ensure s3Client, bucketName:${bucketName}, and prefix:${prefix} are provided.`,
+    );
+    throw new Error(
+      'Invalid input parameters in getObjectMetadataUsingPrefix: ensure s3Client, bucketName, and prefix are provided.',
+    );
+  }
+  try {
+    const params = {
+      Bucket: bucketName,
+      Prefix: prefix,
+      MaxKeys: maxKeys,
+    };
+    do {
+      if (continuationToken) {
+        params.ContinuationToken = continuationToken;
+      }
+      // eslint-disable-next-line no-await-in-loop
+      const data = await s3Client.send(new ListObjectsV2Command(params));
+      data?.Contents?.forEach((obj) => {
+        if (obj.Key?.endsWith(keyEndsWith)) {
+          objects.push({ Key: obj.Key, LastModified: obj.LastModified });
+        }
+      });
+      continuationToken = data?.NextContinuationToken;
+    } while (continuationToken);
+    log.debug(
+      `Fetched ${objects.length} objects from S3 for bucket ${bucketName} and prefix ${prefix}`,
+    );
+  } catch (err) {
+    log.error(
+      `Error while fetching S3 object metadata using bucket ${bucketName} and prefix ${prefix}`,
+      err,
+    );
+    throw err;
+  }
+  return objects;
+}
+
+/**
  * Retrieves an object from S3 by its key and returns its JSON parsed content.
  * If the object is not JSON, returns the raw body.
  * If the object is not found, returns null.

--- a/test/audits/preflight-form-accessibility.test.js
+++ b/test/audits/preflight-form-accessibility.test.js
@@ -1168,21 +1168,21 @@ describe('Preflight Form Accessibility Audit', () => {
             sleep: sandbox.stub().resolves(),
           },
           '../../src/utils/s3-utils.js': {
-            getObjectKeysUsingPrefix: sinon.stub().callsFake(() => {
+            getObjectMetadataUsingPrefix: sinon.stub().callsFake(() => {
               pollCount += 1;
               if (pollCount === 1) {
                 // First call: Return files that don't match expected patterns
                 return Promise.resolve([
-                  'form-accessibility-preflight/site-123/wrong_file1.json',
-                  'form-accessibility-preflight/site-123/wrong_file2.json',
-                  'form-accessibility-preflight/site-123/other_file.json',
-                  'form-accessibility-preflight/site-123/', // Directory-like key
+                  { Key: 'form-accessibility-preflight/site-123/wrong_file1.json', LastModified: new Date() },
+                  { Key: 'form-accessibility-preflight/site-123/wrong_file2.json', LastModified: new Date() },
+                  { Key: 'form-accessibility-preflight/site-123/other_file.json', LastModified: new Date() },
+                  { Key: 'form-accessibility-preflight/site-123/', LastModified: new Date() }, // Directory-like key
                 ]);
               } else {
                 // Second call: Return proper files to exit the polling loop
                 return Promise.resolve([
-                  'form-accessibility-preflight/site-123/example_com_page1.json',
-                  'form-accessibility-preflight/site-123/example_com_page2.json',
+                  { Key: 'form-accessibility-preflight/site-123/example_com_page1.json', LastModified: new Date() },
+                  { Key: 'form-accessibility-preflight/site-123/example_com_page2.json', LastModified: new Date() },
                 ]);
               }
             }),
@@ -1223,7 +1223,7 @@ describe('Preflight Form Accessibility Audit', () => {
             sleep: sandbox.stub().resolves(),
           },
           '../../src/utils/s3-utils.js': {
-            getObjectKeysUsingPrefix: sinon.stub().resolves([]), // Always return empty array
+            getObjectMetadataUsingPrefix: sinon.stub().resolves([]), // Always return empty array
             getObjectFromKey: sinon.stub().resolves(null),
           },
         });
@@ -1237,6 +1237,49 @@ describe('Preflight Form Accessibility Audit', () => {
 
         // Restore the stub
         dateNowStub.restore();
+      });
+
+      it('does not accept a stale result file, then completes once a fresh one appears (freshness gate)', async () => {
+        let pollCount = 0;
+        const staleModified = new Date(Date.now() - 10 * 60 * 1000); // 10 min ago → before run start
+        const freshModified = new Date(); // now → after run start
+        const module = await esmock('../../src/preflight/form-accessibility.js', {
+          '../../src/support/utils.js': { sleep: sandbox.stub().resolves() },
+          '../../src/utils/s3-utils.js': {
+            getObjectMetadataUsingPrefix: sinon.stub().callsFake(() => {
+              pollCount += 1;
+              const LastModified = pollCount === 1 ? staleModified : freshModified;
+              return Promise.resolve([
+                { Key: 'form-accessibility-preflight/site-123/example_com_page1.json', LastModified },
+                { Key: 'form-accessibility-preflight/site-123/example_com_page2.json', LastModified },
+              ]);
+            }),
+            getObjectFromKey: sinon.stub().resolves({ a11yIssues: [] }),
+          },
+        });
+
+        await module.default(pollingContext, pollingAuditContext);
+
+        // Stale poll is rejected (0 fresh matches), so it keeps waiting; the fresh poll completes.
+        expect(pollingLog.info).to.have.been.calledWith('[preflight-audit] Found 0 out of 2 expected form accessibility files, continuing to wait...');
+        expect(pollingLog.info).to.have.been.calledWith('[preflight-audit] Found 2 accessibility files out of 2 expected, form accessibility processing complete');
+      });
+
+      it('accepts a result file with missing LastModified (fail-open)', async () => {
+        const module = await esmock('../../src/preflight/form-accessibility.js', {
+          '../../src/support/utils.js': { sleep: sandbox.stub().resolves() },
+          '../../src/utils/s3-utils.js': {
+            getObjectMetadataUsingPrefix: sinon.stub().resolves([
+              { Key: 'form-accessibility-preflight/site-123/example_com_page1.json', LastModified: undefined },
+              { Key: 'form-accessibility-preflight/site-123/example_com_page2.json', LastModified: undefined },
+            ]),
+            getObjectFromKey: sinon.stub().resolves({ a11yIssues: [] }),
+          },
+        });
+
+        await module.default(pollingContext, pollingAuditContext);
+
+        expect(pollingLog.info).to.have.been.calledWith('[preflight-audit] Found 2 accessibility files out of 2 expected, form accessibility processing complete');
       });
     });
 
@@ -1436,32 +1479,6 @@ describe('Preflight Form Accessibility Audit', () => {
       // The getObjectFromKey function returns null when S3 throws an error
       expect(log.warn).to.have.been.calledWith('[preflight-audit] site-123 No form accessibility data found for https://example.com/page1 at key: form-accessibility-preflight/site-123/example_com_page1.json');
       expect(log.warn).to.have.been.calledWith('[preflight-audit] site-123 No form accessibility data found for https://example.com/page2 at key: form-accessibility-preflight/site-123/example_com_page2.json');
-    });
-
-    it('should handle cleanup error in processFormAccessibilityOpportunities', async () => {
-      const { processFormAccessibilityOpportunities } = await import('../../src/preflight/form-accessibility.js');
-
-      // Mock S3 to succeed for GetObjectCommand but fail for DeleteObjectsCommand
-      s3Client.send.callsFake((command) => {
-        if (command.constructor.name === 'GetObjectCommand') {
-          return Promise.resolve({
-            Body: {
-              transformToString: sinon.stub().resolves(JSON.stringify({
-                a11yIssues: [],
-              })),
-            },
-          });
-        }
-        if (command.constructor.name === 'DeleteObjectsCommand') {
-          return Promise.reject(new Error('Cleanup failed'));
-        }
-        return Promise.resolve({});
-      });
-
-      await processFormAccessibilityOpportunities(context, auditContext);
-
-      // The cleanup error should be logged
-      expect(log.warn).to.have.been.calledWith('[preflight-audit] site-123 Failed to clean up form accessibility files: Cleanup failed');
     });
 
     it('should handle missing form accessibility audit in error handling', async () => {
@@ -2212,6 +2229,120 @@ describe('Preflight Form Accessibility Audit', () => {
       expect(a).to.not.equal(b);
       expect(a).to.equal(aAgain);
       expect(a).to.match(/^example_com_page1_[0-9a-f]{12}\.json$/);
+    });
+  });
+
+  describe('identify/suggest concurrency (SITES-49003 race #1)', () => {
+    let sandbox;
+    let raceModule;
+
+    beforeEach(async () => {
+      sandbox = sinon.createSandbox();
+      // Real s3-utils; only stub sleep so polling resolves fast.
+      raceModule = await esmock('../../src/preflight/form-accessibility.js', {
+        '../../src/support/utils.js': { sleep: sandbox.stub().resolves() },
+      });
+    });
+
+    afterEach(() => sandbox.restore());
+
+    // In-memory S3 backing store shared by both concurrent runs, so we exercise the real
+    // ListObjectsV2/GetObject path and can prove the destructive delete is gone.
+    const makeS3Fake = (store, tracker) => ({
+      send: async (command) => {
+        const name = command.constructor.name;
+        const input = command.input || {};
+        if (name === 'ListObjectsV2Command') {
+          return {
+            Contents: [...store.entries()]
+              .filter(([key]) => key.startsWith(input.Prefix))
+              .map(([Key, v]) => ({ Key, LastModified: v.lastModified })),
+          };
+        }
+        if (name === 'GetObjectCommand') {
+          const v = store.get(input.Key);
+          if (!v) {
+            const err = new Error('NoSuchKey');
+            err.name = 'NoSuchKey';
+            throw err;
+          }
+          return { Body: { transformToString: async () => v.body }, ContentType: 'application/json' };
+        }
+        if (name === 'DeleteObjectsCommand') {
+          tracker.deleteCalls += 1;
+          (input.Delete?.Objects || []).forEach(({ Key }) => store.delete(Key));
+          return {};
+        }
+        return {};
+      },
+    });
+
+    const makeContext = (store, tracker, step) => ({
+      site: {
+        getId: () => 'site-123',
+        getBaseURL: () => 'https://example.com',
+        getDeliveryType: () => 'aem_cs',
+      },
+      job: { getId: () => `job-${step}`, getMetadata: () => ({ payload: { enableAuthentication: true } }) },
+      env: { S3_SCRAPER_BUCKET_NAME: 'test-bucket', QUEUE_SPACECAT_TO_MYSTIQUE: 'q' },
+      s3Client: makeS3Fake(store, tracker),
+      // Simulate Mystique: when a step dispatches, write its result to the shared (non-run-scoped) key.
+      sqs: {
+        sendMessage: sinon.stub().callsFake(async (_q, msg) => {
+          (msg.data.a11y || []).forEach(({ form, formSource }) => {
+            const filename = raceModule.generateFormAccessibilityFilename(form, formSource);
+            store.set(`form-accessibility-preflight/site-123/${filename}`, {
+              body: JSON.stringify({
+                a11yIssues: [{
+                  wcagLevel: 'A',
+                  severity: 'critical',
+                  htmlWithIssues: ['<input name="x">'],
+                  failureSummary: 'needs a label',
+                  description: 'form control missing label',
+                  type: 'visible_label_missing',
+                }],
+              }),
+              lastModified: new Date(),
+            });
+          });
+        }),
+      },
+      log: {
+        info: sinon.stub(), warn: sinon.stub(), error: sinon.stub(), debug: sinon.stub(),
+      },
+    });
+
+    const makeAuditContext = (step) => ({
+      previewUrls: ['https://example.com/page1'],
+      step,
+      checks: ['form-accessibility'],
+      audits: new Map([
+        ['https://example.com/page1', { audits: [{ name: 'form-accessibility', type: 'form-a11y', opportunities: [] }] }],
+      ]),
+      auditsResult: [{ pageUrl: 'https://example.com/page1', audits: [] }],
+      timeExecutionBreakdown: [],
+    });
+
+    it('runs identify and suggest concurrently without one deleting the other\'s result (no starvation, no delete)', async () => {
+      const store = new Map();
+      const tracker = { deleteCalls: 0 };
+      const identifyAudit = makeAuditContext('identify');
+      const suggestAudit = makeAuditContext('suggest');
+
+      await Promise.all([
+        raceModule.default(makeContext(store, tracker, 'identify'), identifyAudit),
+        raceModule.default(makeContext(store, tracker, 'suggest'), suggestAudit),
+      ]);
+
+      // Both steps produced real form-accessibility opportunities (neither was starved).
+      const opps = (a) => a.audits.get('https://example.com/page1').audits
+        .find((x) => x.name === 'form-accessibility').opportunities;
+      expect(opps(identifyAudit)).to.have.lengthOf(1);
+      expect(opps(suggestAudit)).to.have.lengthOf(1);
+
+      // The destructive delete is gone: the shared result file was never deleted and survives.
+      expect(tracker.deleteCalls).to.equal(0);
+      expect(store.size).to.be.greaterThan(0);
     });
   });
 });

--- a/test/utils/s3-utils.test.js
+++ b/test/utils/s3-utils.test.js
@@ -13,7 +13,7 @@ import { expect, use } from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import { ListObjectsV2Command } from '@aws-sdk/client-s3';
-import { getObjectKeysUsingPrefix, getObjectFromKey } from '../../src/utils/s3-utils.js';
+import { getObjectKeysUsingPrefix, getObjectMetadataUsingPrefix, getObjectFromKey } from '../../src/utils/s3-utils.js';
 
 use(chaiAsPromised);
 
@@ -103,6 +103,94 @@ describe('S3 Utility Functions', () => {
 
       try {
         await getObjectKeysUsingPrefix(s3ClientMock, bucketName, prefix, logMock2);
+        throw new Error('Expected an error but none was thrown.');
+      } catch (error) {
+        expect(error).to.be.an('error');
+        expect(error.message).to.equal('S3 error');
+      }
+    });
+  });
+
+  describe('getObjectMetadataUsingPrefix', () => {
+    it('should throw if params are missing', async () => {
+      try {
+        await getObjectMetadataUsingPrefix(null, null, null, logMock);
+        throw new Error('Expected an error but none was thrown.');
+      } catch (error) {
+        expect(error).to.be.an('error');
+        expect(error.message).to.equal('Invalid input parameters in getObjectMetadataUsingPrefix: ensure s3Client, bucketName, and prefix are provided.');
+      }
+    });
+
+    it('should return keys with LastModified, paginating, filtered by keyEndsWith', async () => {
+      const bucketName = 'test-bucket';
+      const prefix = 'form-accessibility-preflight/site-id/';
+      const d1 = new Date('2026-07-31T14:00:00.000Z');
+      const d2 = new Date('2026-07-31T14:01:00.000Z');
+      const d3 = new Date('2026-07-31T14:02:00.000Z');
+
+      const s3ClientStub = { send: sinon.stub() };
+      s3ClientStub.send
+        .withArgs(sinon.match.instanceOf(ListObjectsV2Command).and(sinon.match.has('input', {
+          Bucket: bucketName,
+          Prefix: prefix,
+          MaxKeys: 100,
+        })))
+        .resolves({
+          NextContinuationToken: 'token',
+          Contents: [
+            { Key: `${prefix}page1.json`, LastModified: d1 },
+            { Key: `${prefix}ignore.txt`, LastModified: d2 }, // filtered out by keyEndsWith
+          ],
+        });
+      s3ClientStub.send
+        .withArgs(sinon.match.instanceOf(ListObjectsV2Command).and(sinon.match.has('input', {
+          Bucket: bucketName,
+          Prefix: prefix,
+          MaxKeys: 100,
+          ContinuationToken: 'token',
+        })))
+        .resolves({
+          Contents: [
+            { Key: `${prefix}page2.json`, LastModified: d3 },
+          ],
+        });
+
+      const objects = await getObjectMetadataUsingPrefix(
+        s3ClientStub,
+        bucketName,
+        prefix,
+        logMock,
+        100,
+        '.json',
+      );
+      expect(objects).to.deep.equal([
+        { Key: `${prefix}page1.json`, LastModified: d1 },
+        { Key: `${prefix}page2.json`, LastModified: d3 },
+      ]);
+    });
+
+    it('should return an empty list when S3 returns no data', async () => {
+      const s3ClientMock = { send: async () => ({ Contents: [] }) };
+      const objects = await getObjectMetadataUsingPrefix(s3ClientMock, 'b', 'p', logMock);
+      expect(objects).to.deep.equal([]);
+    });
+
+    it('should log an error and rethrow when the S3 call fails', async () => {
+      const bucketName = 'test-bucket';
+      const prefix = 'test-prefix';
+      const s3ClientMock = {
+        send: async () => { throw new Error('S3 error'); },
+      };
+      const logMock2 = {
+        debug: () => {},
+        error: (msg, err) => {
+          expect(msg).to.equal(`Error while fetching S3 object metadata using bucket ${bucketName} and prefix ${prefix}`);
+          expect(err.message).to.equal('S3 error');
+        },
+      };
+      try {
+        await getObjectMetadataUsingPrefix(s3ClientMock, bucketName, prefix, logMock2);
         throw new Error('Expected an error but none was thrown.');
       } catch (error) {
         expect(error).to.be.an('error');


### PR DESCRIPTION
## Problem (SITES-49003)
Preflight runs the `form-accessibility` check in **both** the `identify` and `suggest` steps, and the MFE submits those two steps concurrently. Both invocations poll the **same, non-run-scoped** S3 result key `form-accessibility-preflight/{siteId}/{filename}` and then unconditionally `DeleteObjectsCommand` it after reading. Whichever step reads first **deletes the shared file**, starving the other, which polls a now-missing key until its ~600s timeout — the UI's form-accessibility card hangs. Verified live in prod (identify stalled while suggest completed) and reproduced deterministically.

## Fix
- **Remove the destructive after-read delete** — the sole source of the starvation.
- **Freshness-gate the poll**: accept a result file only if its S3 `LastModified >= scrapeStartTime − 60s` (skew tolerance). Missing `LastModified` **fails open** (accept), so it can never introduce a new hang. This prevents reading a stale leftover now that we no longer delete.
- The result key is **overwritten in place** on the next run for the same site+URL+selector, so files don't grow unbounded (a prefix lifecycle rule is a nice-to-have infra follow-up).

## Blast radius (contained)
- `getObjectMetadataUsingPrefix` is **added** to `s3-utils.js`; `getObjectKeysUsingPrefix`/`getObjectFromKey` are untouched, so other audits that use them are unaffected.
- Only `preflight/handler.js` imports `form-accessibility.js`; the change is internal to that check and its own S3 prefix. Its outer try/catch is preserved (stays non-throwing in the sequential runner).

## Tests
- New deterministic **concurrency regression** test: two runs (identify + suggest) share an in-memory S3 store; both produce opportunities (no starvation) and **`DeleteObjectsCommand` is never sent** (fails on the old code).
- New **freshness-gate** tests: stale file rejected then fresh accepted; missing-`LastModified` fail-open.
- `getObjectMetadataUsingPrefix` unit tests. 100% line/branch/statement/function coverage on both changed source files; lint clean.

## Scope / follow-ups (not in this PR)
- `accessibility.js` has the identical latent race (never observed to hang — its result is written by the fast content-scraper, not the slow Mystique round-trip). Tracked separately.
- Mystique-side `opportunities/{siteId}/opportunity.json` last-writer-wins clobber (race #2) — Mystique-only; this PR greatly reduces failures but doesn't eliminate that mode.

## Verification after merge (deploys to prod)
Via the `run-preflight` skill, fire `--step identify` and `--step suggest` concurrently on a form page; confirm both steps COMPLETE (no ~600s hang) and Splunk shows both "processing complete" with no shared-file delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)