### PR TITLE
fix(preflight): scope form-accessibility opportunityId per step + gate stale result reads (SITES-49003)

### DIFF
--- a/src/preflight/form-accessibility.js
+++ b/src/preflight/form-accessibility.js
@@ -183,7 +183,16 @@ export async function detectFormAccessibility(context, auditContext) {
         time: new Date().toISOString(),
         data: {
           url: previewUrls[0], // M expects url in the data object for forms opportunity
-          opportunityId: siteId,
+          // Scope the opportunity to THIS preflight step+run, not the site. Mystique keys
+          // its shared `opportunities/{opportunityId}/opportunity.json` on this value
+          // (read-modify-written during detection). The MFE submits the identify and
+          // suggest steps concurrently as two separate jobs; when both sent
+          // opportunityId=siteId they collided on that one file (last-writer-wins), and a
+          // detection task could stall past the ~600s poll — SITES-49003 (race #2). The
+          // per-step jobId is unique per run, so each step gets its own opportunity file.
+          // The S3 result key we poll is unaffected (it is keyed on siteId+URL+formSource,
+          // not opportunityId), so this needs no Mystique change.
+          opportunityId: jobId,
           a11y: urlsToDetect,
         },
         options: {
@@ -218,7 +227,12 @@ export async function detectFormAccessibility(context, auditContext) {
 /**
  * Step 2: Process detected form accessibility issues and create opportunities
  */
-export async function processFormAccessibilityOpportunities(context, auditContext, formEntries) {
+export async function processFormAccessibilityOpportunities(
+  context,
+  auditContext,
+  formEntries,
+  freshnessThreshold,
+) {
   const {
     site, job, log, env, s3Client,
   } = context;
@@ -251,6 +265,30 @@ export async function processFormAccessibilityOpportunities(context, auditContex
     || previewUrls.map((url) => ({ form: url, formSource: 'form' }));
 
   try {
+    // When invoked from the main runner we get the freshness threshold the poll used.
+    // Build the set of result files that are fresh for THIS run, so that after a poll
+    // timeout we never read a stale leftover from a previous run: we no longer delete
+    // result files, and the key is not run-scoped, so a same-key file from an earlier
+    // run on the same site+URL+selector can otherwise linger and be served as if fresh
+    // (SITES-49003). Missing LastModified fails open (accept), consistent with the poll.
+    let freshKeys = null;
+    if (freshnessThreshold != null) {
+      const objects = await getObjectMetadataUsingPrefix(
+        s3Client,
+        bucketName,
+        `form-accessibility-preflight/${siteId}/`,
+        log,
+        100,
+        '.json',
+      );
+      freshKeys = new Set(
+        objects
+          .filter(({ LastModified }) => !LastModified
+            || new Date(LastModified).getTime() >= freshnessThreshold)
+          .map(({ Key }) => Key),
+      );
+    }
+
     // Process each detected form's accessibility result file (a page can have
     // more than one entry when it has multiple forms)
     for (const { form: url, formSource } of resolvedFormEntries) {
@@ -261,9 +299,15 @@ export async function processFormAccessibilityOpportunities(context, auditContex
         const fileKey = `form-accessibility-preflight/${siteId}/${filename}`;
         log.info(`[preflight-audit] ${siteId}  Processing form accessibility file: ${fileKey}`);
 
-        // Get the accessibility result file from S3 using existing utility
-        // eslint-disable-next-line no-await-in-loop
-        const accessibilityData = await getObjectFromKey(s3Client, bucketName, fileKey, log);
+        // Only read a result file this run actually produced. On a poll timeout with no
+        // fresh file, skip rather than serve a previous run's stale result (SITES-49003).
+        let accessibilityData = null;
+        if (freshKeys && !freshKeys.has(fileKey)) {
+          log.warn(`[preflight-audit] ${siteId} Skipping stale/missing form accessibility file for ${url} at key: ${fileKey} (not written by this run)`);
+        } else {
+          // eslint-disable-next-line no-await-in-loop
+          accessibilityData = await getObjectFromKey(s3Client, bucketName, fileKey, log);
+        }
 
         if (!accessibilityData) {
           log.warn(`[preflight-audit] ${siteId} No form accessibility data found for ${url} at key: ${fileKey}`);
@@ -477,5 +521,10 @@ export default async function formAccessibility(context, auditContext) {
   log.info(`[preflight-audit] ${siteId} Polling completed, proceeding to process form accessibility data`);
 
   // Step 2: Process scraped data and create opportunities
-  await processFormAccessibilityOpportunities(context, auditContext, formEntries);
+  await processFormAccessibilityOpportunities(
+    context,
+    auditContext,
+    formEntries,
+    scrapeStartTime - CLOCK_SKEW_TOLERANCE_MS,
+  );
 }

--- a/test/audits/preflight-form-accessibility.test.js
+++ b/test/audits/preflight-form-accessibility.test.js
@@ -127,6 +127,11 @@ describe('Preflight Form Accessibility Audit', () => {
 
         expect(message.data.url).to.equal('https://example.com/page1');
 
+        // opportunityId must be the per-step jobId, NOT the siteId — otherwise the
+        // concurrent identify + suggest steps collide on the same shared Mystique
+        // opportunity.json and one stalls (SITES-49003 race #2).
+        expect(message.data.opportunityId).to.equal('job-123');
+
         expect(message.data.a11y).to.deep.equal([
           { form: 'https://example.com/page1', formSource: 'form' },
           { form: 'https://example.com/page2', formSource: 'form' },
@@ -584,6 +589,47 @@ describe('Preflight Form Accessibility Audit', () => {
         expect(log.warn).to.have.been.calledWith(
           '[preflight-audit] site-123 No form accessibility data found for https://example.com/page1 at key: form-accessibility-preflight/site-123/example_com_page1.json',
         );
+      });
+
+      it('skips a stale result file (freshness gate) instead of serving previous-run data (SITES-49003)', async () => {
+        const { processFormAccessibilityOpportunities } = await import('../../src/preflight/form-accessibility.js');
+
+        // A result file left on the shared key by an earlier run (we no longer delete),
+        // written before THIS run started. With a freshnessThreshold set, it must be
+        // rejected and never read — otherwise a poll timeout would serve stale results.
+        const runStartThreshold = Date.now();
+        const staleModified = new Date(runStartThreshold - 10 * 60 * 1000); // 10 min ago
+        let getObjectCalled = false;
+
+        s3Client.send.callsFake((command) => {
+          if (command.constructor.name === 'ListObjectsV2Command') {
+            return Promise.resolve({
+              Contents: [
+                { Key: 'form-accessibility-preflight/site-123/example_com_page1.json', LastModified: staleModified },
+                { Key: 'form-accessibility-preflight/site-123/example_com_page2.json', LastModified: staleModified },
+              ],
+            });
+          }
+          if (command.constructor.name === 'GetObjectCommand') {
+            getObjectCalled = true;
+            return Promise.resolve({
+              Body: { transformToString: sinon.stub().resolves(JSON.stringify({ a11yIssues: [] })) },
+            });
+          }
+          return Promise.resolve({});
+        });
+
+        await processFormAccessibilityOpportunities(context, auditContext, undefined, runStartThreshold);
+
+        expect(log.warn).to.have.been.calledWith(
+          '[preflight-audit] site-123 Skipping stale/missing form accessibility file for https://example.com/page1 at key: form-accessibility-preflight/site-123/example_com_page1.json (not written by this run)',
+        );
+        // The stale file is never read, and no opportunities are produced from it.
+        expect(getObjectCalled).to.be.false;
+        const page1 = auditContext.audits
+          .get('https://example.com/page1').audits
+          .find((a) => a.name === 'form-accessibility');
+        expect(page1.opportunities).to.have.lengthOf(0);
       });
 
       it('should add timing information to execution breakdown', async () => {
@@ -1936,8 +1982,9 @@ describe('Preflight Form Accessibility Audit', () => {
       // Verify that polling continued and eventually succeeded
       expect(log.info).to.have.been.calledWith('[preflight-audit] Found 2 accessibility files out of 2 expected, form accessibility processing complete');
       expect(log.info).to.have.been.calledWith('[preflight-audit] site-123 Polling completed, proceeding to process form accessibility data');
-      // Verify that both polling attempts were made
-      expect(pollCallCount).to.equal(2);
+      // Two polling attempts (error then success) + one processor-side freshness re-check
+      // (getObjectMetadataUsingPrefix) before reading the result files — SITES-49003.
+      expect(pollCallCount).to.equal(3);
     });
 
     it('should handle foundFiles', async () => {
@@ -1983,8 +2030,9 @@ describe('Preflight Form Accessibility Audit', () => {
       // Verify that polling continued and eventually succeeded
       expect(log.info).to.have.been.calledWith('[preflight-audit] Found 2 accessibility files out of 2 expected, form accessibility processing complete');
       expect(log.info).to.have.been.calledWith('[preflight-audit] site-123 Polling completed, proceeding to process form accessibility data');
-      // Verify that both polling attempts were made
-      expect(pollCallCount).to.equal(2);
+      // Two polling attempts (empty then success) + one processor-side freshness re-check
+      // (getObjectMetadataUsingPrefix) before reading the result files — SITES-49003.
+      expect(pollCallCount).to.equal(3);
     });
   });
 


### PR DESCRIPTION
## Problem (SITES-49003, race #2 + a stale-read gap)
The MFE submits the form-accessibility **identify** and **suggest** steps concurrently as two separate AsyncJobs. Both sent `opportunityId: siteId` to Mystique, which keys its shared `opportunities/{opportunityId}/opportunity.json` on that value and read-modify-writes it during detection. When the two runs' detection windows overlap — reliably in the **UI** (they land ~seconds apart); only *intermittently* from the CLI (where the two Mystique writes happened to land 20–30 s apart) — they clobber that one file (last-writer-wins, a hazard the Mystique code itself documents), and a detection task can **stall past the ~600 s poll**. Result: no fresh result file is written and the UI's form-accessibility card hangs.

Prod evidence (UI trace `e6ecd5a3…`): both Mystique tasks registered `opportunityId == siteId`, both assembled issues, **neither** reached `Detect opportunity for…`/result-write/SQS-delete, both SQS messages **redelivered at ~600 s**, and the audit-worker poll timed out (`completed in 600.99 s`).

## Fix B — root cause, audit-worker-only (no Mystique release)
Send `opportunityId: jobId` (the per-step AsyncJob id, already unique per run) instead of `siteId`, so identify and suggest no longer share `opportunity.json`. Verified safe end-to-end:
- Mystique reads `opportunityId` **from the SQS message** (`Using opportunity ID from SQS message data`), so this is entirely audit-worker-controlled.
- The S3 **result key** is keyed on `siteId + URL + formSource` (**not** `opportunityId`) on both sides and must match byte-for-byte — **unchanged**, so no Mystique change and no filename coordination.
- Mystique's opportunity store is **S3-only** (`opportunities/{id}/opportunity.json`) — a unique id just isolates that file: no SpaceCat DB writes, no orphans; `get_opportunity` now reads each step's own file.

## Fix A — correctness (stale-read gap from race #1's no-delete)
Since we no longer delete result files, a stale leftover lingers on the shared key. The poll already freshness-gated, but the **post-poll processor read did not** — so a timeout could serve a previous run's file as if fresh (invisible on an unchanged page; wrong data if the form changed). The processor now only reads files written at/after this run started; a timeout yields **empty**, never stale.

## Tests
- Assert `opportunityId === jobId` in the Mystique message (contract for Fix B).
- New freshness-gate test: a stale result file is **skipped** — never read, no opportunities produced.
- Full suite green (9364 passing); **100% line/branch/statement coverage** on `form-accessibility.js`; lint clean.

## Verification after deploy (the meaningful check)
A green CLI run is **necessary but not sufficient** — it can pass by timing luck. Reproduce a real **overlap** (UI/bookmarklet, or several forced concurrent CLI pairs) and confirm in Splunk that both Mystique tasks use **distinct** `opportunities/{jobId}/opportunity.json`, both reach `Detect opportunity for…` → result write → SQS delete, and there is **no 600 s redelivery/stall**.

## Scope / residuals (not in this PR)
- If the stall has a *second* cause inside Mystique (CrewAI flow / worker-pool contention), it could persist even with unique ids — the overlap test settles this; Fix A still prevents stale data meanwhile.
- The result file is still shared across concurrent runs (benign for identical content; run-scoped result key would need Mystique).
- form-a11y detection tasks still lack an SQS visibility heartbeat (robustness follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)