### PR TITLE
fix(preflight): run form-accessibility in the identify step only (SITES-49003)

### DIFF
--- a/src/preflight/handler.js
+++ b/src/preflight/handler.js
@@ -192,6 +192,20 @@ export const preflightAudit = async (context) => {
       }),
     )).filter(Boolean);
 
+    // form-accessibility is a Mystique round-trip that produces IDENTICAL output in both the
+    // identify and suggest steps (suggest adds GenVar suggestions only to other checks — never
+    // to form-a11y). The MFE submits both steps concurrently, so running it in both launches two
+    // concurrent Mystique detect crews that deadlock (both assemble issues, neither finalizes),
+    // hanging the UI's form-accessibility card to the ~600s timeout (SITES-49003). Run it in the
+    // identify step only: the MFE renders the form-a11y card purely from the identify result
+    // (a11yDetail reads the opportunity, no suggest-side slot), so nothing is lost. Excluding it
+    // here also drops it from the advertised `checks` metadata, so the MFE does not wait for a
+    // form-a11y result in the suggest step. (A suggest-only run — not the normal MFE flow — will
+    // therefore not produce form-a11y; identify covers it in every real preflight run.)
+    if (step === PREFLIGHT_STEP_SUGGEST) {
+      enabledChecks = enabledChecks.filter((audit) => audit !== AUDIT_FORM_ACCESSIBILITY);
+    }
+
     log.info(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. Enabled checks: ${JSON.stringify(enabledChecks)}`);
 
     const jobEntity = await AsyncJobEntity.findById(jobId);

--- a/test/audits/preflight.test.js
+++ b/test/audits/preflight.test.js
@@ -814,6 +814,52 @@ describe('Preflight Audit', () => {
       sandbox.restore();
     });
 
+    describe('form-accessibility step gating (SITES-49003)', () => {
+      const captureEnabledChecks = () => {
+        const captured = [];
+        context.dataAccess.AsyncJob.findById = sinon.stub().resolves({
+          getId: () => 'job-123',
+          getMetadata: () => ({ payload: {} }),
+          setResult: sinon.stub(),
+          setStatus: sinon.stub(),
+          setResultType: sinon.stub(),
+          setMetadata: sinon.stub().callsFake((m) => {
+            if (Array.isArray(m?.payload?.checks)) captured.push(m.payload.checks);
+          }),
+          setEndedAt: sinon.stub(),
+          setError: sinon.stub(),
+          save: sinon.stub().resolves(),
+        });
+        return captured;
+      };
+
+      it('advertises form-accessibility in the identify step', async () => {
+        configuration.isHandlerEnabledForSite.returns(true);
+        const captured = captureEnabledChecks();
+        job.getMetadata = () => ({
+          payload: { step: PREFLIGHT_STEP_IDENTIFY, urls: ['https://main--example--page.aem.page/page1'] },
+        });
+
+        await preflightAuditFunction(context);
+
+        expect(captured[0]).to.include('form-accessibility');
+      });
+
+      it('drops form-accessibility from the suggest step so it is not run concurrently with identify', async () => {
+        configuration.isHandlerEnabledForSite.returns(true);
+        const captured = captureEnabledChecks();
+        job.getMetadata = () => ({
+          payload: { step: PREFLIGHT_STEP_SUGGEST, urls: ['https://main--example--page.aem.page/page1'] },
+        });
+
+        await preflightAuditFunction(context);
+
+        expect(captured[0]).to.not.include('form-accessibility');
+        // sanity: other checks are still advertised in suggest
+        expect(captured[0]).to.include('metatags');
+      });
+    });
+
     it('completes successfully on the happy path for the suggest step', async () => {
       context.promiseToken = 'mock-promise-token';
       const head = '<head><a href="https://example.com/header-url"/></head>';


### PR DESCRIPTION
## Problem
The form-accessibility UI card hangs (spins to the ~600s timeout). Root cause, confirmed by a live overlapping run: the MFE submits the **identify** and **suggest** preflight steps as two concurrent jobs, and each job runs form-accessibility → two concurrent Mystique `detect:forms-a11y` crews **deadlock** (both assemble their issues, then neither finalizes — no `Completed crew`, no result-file write). De-colliding the shared `opportunity.json` per step (v1.511.10, Fix B) was necessary but did **not** clear the crew-level deadlock.

## Fix
Run form-accessibility in the **identify step only**. With no suggest-side message, only one detect crew runs per preflight → no concurrency → no deadlock (and half the Mystique crew cost).

**Verified lossless against the MFE renderer:** form-a11y is not suggestion-bearing — only `metatags/readability/headings/links` have slot-configs that consume the suggest step (`auditDetailRegistry` `CHECK_REGISTRY`). The form-a11y card is built by `a11yDetail.toSlots(audit, opportunity)` from the identify detection alone, so dropping it from `suggest` changes nothing the UI shows. Excluding it from `enabledChecks` also removes it from the advertised `checks` metadata, so the MFE does not wait for a form-a11y result in `suggest`.

**Certain Mystique won't run it:** Mystique's form-a11y detection is triggered *only* by the audit-worker's `detect:forms-a11y` SQS message, whose sole preflight sender is `form-accessibility.js` (reachable only via `handlersToRun`/`enabledChecks`). No message → no crew.

Audit-worker-only; no Mystique/MFE release required.

## Scope / residual
- Eliminates the concurrency that occurs on **every run** (identify + suggest of the same run).
- Does **not** cover two *separate* preflight runs on the same site overlapping (two tabs/users/rapid re-run) — that still needs the durable Mystique crew-concurrency fix. Fix A (no stale read on timeout) protects that case meanwhile.
- The separate scheduled (non-preflight) forms-a11y audit is a different flow and unaffected.

## Tests
Assert form-accessibility is advertised in `identify` and excluded from `suggest`. Full suite + 100% coverage gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)