### PR TITLE
fix(llm-error-pages): skip query when cdn-logs-analysis is disabled

### DIFF
--- a/src/llm-error-pages/handler.js
+++ b/src/llm-error-pages/handler.js
@@ -388,6 +388,17 @@ export async function runAuditAndSendToMystique(context) {
   log.info(`[LLM-ERROR-PAGES] Starting audit for ${url}`);
 
   try {
+    const configuration = await context.dataAccess.Configuration.findLatest();
+    if (configuration && !configuration.isHandlerEnabledForSite('cdn-logs-analysis', site)) {
+      log.info(`[LLM-ERROR-PAGES] Skipping ${url}; cdn-logs-analysis disabled for site ${site.getId()}`);
+      return {
+        type: 'audit-result',
+        siteId: site.getId(),
+        auditResult: [],
+        fullAuditRef: url,
+      };
+    }
+
     const awsRuntime = getCdnAwsRuntime(site, context);
     const athenaClient = awsRuntime.createAthenaClient(s3Config.getAthenaTempLocation());
 

--- a/test/audits/llm-error-pages/handler.test.js
+++ b/test/audits/llm-error-pages/handler.test.js
@@ -89,6 +89,11 @@ describe('LLM Error Pages Handler', function () {
         SiteTopPage: {
           allBySiteIdAndSourceAndGeo: sandbox.stub().resolves(topPages),
         },
+        Configuration: {
+          findLatest: sandbox.stub().resolves({
+            isHandlerEnabledForSite: sandbox.stub().returns(true),
+          }),
+        },
       },
     };
 
@@ -366,6 +371,31 @@ describe('LLM Error Pages Handler', function () {
       expect(context.log.info).to.have.been.calledWith(
         sinon.match(/\[LLM-ERROR-PAGES\] Sent.*consolidated 404 URLs to Mystique/),
       );
+    });
+
+    it('skips the query and returns an empty result when cdn-logs-analysis is disabled', async () => {
+      context.dataAccess.Configuration.findLatest.resolves({
+        isHandlerEnabledForSite: sandbox.stub().returns(false),
+      });
+
+      const result = await runAuditAndSendToMystique(context);
+
+      expect(result.type).to.equal('audit-result');
+      expect(result.siteId).to.equal('site-id-123');
+      expect(result.auditResult).to.deep.equal([]);
+      expect(result.fullAuditRef).to.equal('https://example.com');
+      expect(mockAthenaClient.query).to.not.have.been.called;
+      expect(context.sqs.sendMessage).to.not.have.been.called;
+    });
+
+    it('proceeds with the audit when no configuration record exists', async () => {
+      context.dataAccess.Configuration.findLatest.resolves(null);
+
+      const result = await runAuditAndSendToMystique(context);
+
+      expect(result.type).to.equal('audit-result');
+      expect(result.auditResult[0].success).to.be.true;
+      expect(mockAthenaClient.query).to.have.been.called;
     });
 
     it('logs a sample of malformed URLs filtered upstream in processErrorPagesResults', async () => {
@@ -1118,6 +1148,11 @@ describe('LLM Error Pages Handler - Athena/SEO fallback', function () {
         SiteTopPage: {
           allBySiteIdAndSourceAndGeo: sandbox.stub().resolves(topPages),
         },
+        Configuration: {
+          findLatest: sandbox.stub().resolves({
+            isHandlerEnabledForSite: sandbox.stub().returns(true),
+          }),
+        },
       },
     };
 
@@ -1183,6 +1218,11 @@ describe('LLM Error Pages Handler - Athena/SEO fallback', function () {
       dataAccess: {
         SiteTopPage: {
           allBySiteIdAndSourceAndGeo: sandbox.stub().resolves(topPages),
+        },
+        Configuration: {
+          findLatest: sandbox.stub().resolves({
+            isHandlerEnabledForSite: sandbox.stub().returns(true),
+          }),
         },
       },
     };
@@ -1296,6 +1336,11 @@ describe('LLM Error Pages Handler - Athena/SEO fallback', function () {
       audit: { getId: () => 'audit-123' },
       dataAccess: {
         SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([]) },
+        Configuration: {
+          findLatest: sandbox.stub().resolves({
+            isHandlerEnabledForSite: sandbox.stub().returns(true),
+          }),
+        },
       },
     };
 
@@ -1378,6 +1423,11 @@ describe('LLM Error Pages Handler - Athena/SEO fallback', function () {
       audit: { getId: () => 'audit-123' },
       dataAccess: {
         SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().resolves(topPages) },
+        Configuration: {
+          findLatest: sandbox.stub().resolves({
+            isHandlerEnabledForSite: sandbox.stub().returns(true),
+          }),
+        },
       },
     };
 
@@ -1724,6 +1774,11 @@ describe('LLM Error Pages Handler — DB dual-write', function () {
     audit: { getId: () => 'audit-1', getAuditResult: sandbox.stub() },
     dataAccess: {
       SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([]) },
+      Configuration: {
+        findLatest: sandbox.stub().resolves({
+          isHandlerEnabledForSite: sandbox.stub().returns(true),
+        }),
+      },
       Opportunity: {
         allBySiteIdAndStatus: sandbox.stub().resolves(overrides.existingOpportunities || []),
       },
@@ -2285,6 +2340,11 @@ describe('LLM Error Pages Handler — DB dual-write', function () {
       audit: { getId: () => 'audit-1', getAuditResult: sandbox.stub() },
       dataAccess: {
         SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([]) },
+        Configuration: {
+          findLatest: sandbox.stub().resolves({
+            isHandlerEnabledForSite: sandbox.stub().returns(true),
+          }),
+        },
         Opportunity: { allBySiteIdAndStatus: sandbox.stub().resolves([]) },
         Suggestion: { bulkUpdateStatus: sandbox.stub().resolves() },
       },


### PR DESCRIPTION
Skips the llm-error-pages Athena query and returns an empty result when cdn-logs-analysis is not enabled for the site, matching the existing agentic-urls guard. Missing configuration is treated as not-disabled (audit proceeds). Split out of #2843.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi", "Yaashi Madan"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```