### PR TITLE
feat(offsite): source cited URLs from the Semrush URL-Inspector API

### DIFF
--- a/docs/decisions/002-offsite-cited-urls-semrush-source.md
+++ b/docs/decisions/002-offsite-cited-urls-semrush-source.md
@@ -19,13 +19,24 @@ involves several non-obvious trade-offs, so it warrants an ADR alongside the spe
    When `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED=true`, the runner tries the Semrush
    loader first; if it yields **no usable result** it falls back to the legacy
    `loadBrandPresenceData` (PostgREST → SharePoint). Flag off = legacy only.
-2. **"No usable result" = fall back (fail safe).** The loader returns `null` — and
-   the handler falls back — on: no org/brand, transient brand-resolution failure,
-   no date window, IMS-token failure, **or ANY upstream request failure**. A
-   partial Semrush result (e.g. YouTube succeeded, Reddit failed) is **not**
-   shipped, because it is indistinguishable from a genuine zero and would silently
-   drop a surface. Trade-off: one flaky engine/host forces a full-run fallback;
-   accepted because a silent partial is worse than a visible fallback.
+2. **"No usable result" = fall back, at the SURFACE granularity.** The loader
+   returns `null` — and the handler falls back — on: no org/brand, transient
+   brand-resolution failure, no date window, IMS-token failure, or when a **whole
+   surface (hostname) produced zero successful responses**. Rationale: a dropped
+   *surface* (all YouTube or all Reddit engines failed) is indistinguishable from a
+   genuine zero and must fall back; a **single failed engine is a partial count**,
+   not a dropped surface, and is tolerated (the successful engines still contribute).
+   This keeps the strictness aligned with the "don't drop a surface" goal rather than
+   over-firing on any one of ~12 requests. **Follow-up:** a bounded retry on
+   retriable statuses (`RETRIABLE_STATUSES`) — as the legacy path does — would
+   further reduce transient surface-level fallbacks; not in this PR.
+2b. **`dataSource` on the audit result.** `auditResult.dataSource` = `'semrush'` |
+   `'legacy'` (plus `fallbackReason` when a Semrush attempt fell back), so shadow-run
+   parity (LLMO-6711) can join on the source per run instead of grepping a log line.
+2c. **Scope + hygiene guards.** Off-host (`domain: null`) rows are dropped so nothing
+   leaks into the top-cited bucket / TOP_CITED scrape; citations are clamped
+   (`Math.max(0, …)`) and URLs with total count ≤ 0 are dropped so a negative/zero
+   value can't corrupt the citations-descending ranking.
 3. **Explicit multi-engine query, not an omitted `platform`.** Omitting `platform`
    on `domain-urls`/`cited-domains` does **not** aggregate across engines (the
    proxy resolves it to a single default engine). We query the full offsite provider
@@ -52,8 +63,9 @@ involves several non-obvious trade-offs, so it warrants an ADR alongside the spe
 ## Consequences
 
 - Enabling the flag can never silently zero out offsite (fallback), but the
-  fallback **masks** Semrush failures — parity validation (LLMO-6711) must watch
-  for the `using legacy fallback` warning to know when Semrush is not serving.
+  fallback **masks** Semrush failures — read `auditResult.dataSource` /
+  `fallbackReason` (and the `Service token rejected` / `No successful Semrush
+  response` logs) to know when Semrush is not actually serving.
 - `pageSize=100` assumes a server-side citations-descending sort (unconfirmed); the
   loader logs a truncation warning on a full page so an unsorted/capped response is
   visible rather than silently dropping high-citation URLs.
@@ -68,6 +80,32 @@ involves several non-obvious trade-offs, so it warrants an ADR alongside the spe
   (LLMO-6710) — must be closed before non-US parity can be claimed.
 - Generic "cited" (third-party) bucket — needs a `cited-domains` discovery hop
   (LLMO-6709 follow-up).
+
+## Enablement runbook (ordered gates before turning the flag on anywhere)
+
+The flag-off path is safe to merge now. Before `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED=true`
+in **any** environment, close these in order (LLMO-6709 → 6711):
+
+1. **Auth/authz verified (LLMO-6709).** Confirm the worker's **service** IMS token is
+   accepted by the Semrush proxy end-to-end (it is forwarded unchanged; the proxy is designed
+   around a *user* token). Confirm `tracingFetch` does **not** emit the `Authorization` header
+   into traces/spans (service-bearer leak). Confirm the token is org-scoped, or document that
+   tenant isolation is fully delegated to the proxy's per-caller org authz — the worker sends
+   `spaceCatId = site.getOrganizationId()` with a broad service token and asserts no boundary
+   itself (confused-deputy surface).
+2. **`dataSource` shipped** (this PR) — so parity can be measured.
+3. **Shadow-run parity on a canary site (LLMO-6711)** — top-70 overlap per surface vs legacy.
+4. **Fleet enable** per environment (the flag is environment-global).
+
+## Configuration / client-convention debt (to resolve before the 3rd caller)
+
+This loader reads `SPACECAT_API_URI` and mints an **IMS service bearer**; `brand-resolver.js`
+reads `SPACECAT_API_BASE_URL` and uses **`x-api-key`** — for the *same* spacecat-api-service.
+The IMS scheme is justified here (the Elements proxy must forward a bearer to Semrush), but
+**two base-URL env vars + two auth schemes** can drift (one caller repointed to stage/prod, the
+other not → IMS traffic to an untrusted issuer → 401 → silent legacy fallback). Documented as
+debt: pick one base-URL env var and one api-service client convention (a shared helper) **before
+the `cited-domains` follow-up adds a third caller** that copies whichever it finds first.
 
 ## Alternatives Considered
 

--- a/docs/decisions/002-offsite-cited-urls-semrush-source.md
+++ b/docs/decisions/002-offsite-cited-urls-semrush-source.md
@@ -1,0 +1,70 @@
+# 002 — Off-Site Cited-URL Source: Semrush URL-Inspector with Legacy Fallback
+
+- **Status:** Proposed
+- **Date:** 2026-08-05
+- **Related:** spec `docs/specs/2026-08-05-offsite-cited-urls-semrush-source.md` · plan `docs/plans/2026-07-17-offsite-cited-urls-semrush-migration.md` · [LLMO-6488](https://jira.corp.adobe.com/browse/LLMO-6488) / [LLMO-6709](https://jira.corp.adobe.com/browse/LLMO-6709) / [LLMO-6710](https://jira.corp.adobe.com/browse/LLMO-6710)
+
+## Context
+
+The `offsite-brand-presence` audit selects the cited URLs it feeds to DRS
+(YouTube, Reddit, cited web) from internal Brand-Presence data (PostgREST for
+brandalf orgs, SharePoint Excel fallback). We are moving that sourcing to the
+Semrush-backed Serenity URL-Inspector data, served by the spacecat-api-service
+Elements proxy. This swaps the **primary data source of a production audit** and
+involves several non-obvious trade-offs, so it warrants an ADR alongside the spec.
+
+## Decision
+
+1. **Source swap behind a flag, Semrush-first with automatic legacy fallback.**
+   When `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED=true`, the runner tries the Semrush
+   loader first; if it yields **no usable result** it falls back to the legacy
+   `loadBrandPresenceData` (PostgREST → SharePoint). Flag off = legacy only.
+2. **"No usable result" = fall back (fail safe).** The loader returns `null` — and
+   the handler falls back — on: no org/brand, transient brand-resolution failure,
+   no date window, IMS-token failure, **or ANY upstream request failure**. A
+   partial Semrush result (e.g. YouTube succeeded, Reddit failed) is **not**
+   shipped, because it is indistinguishable from a genuine zero and would silently
+   drop a surface. Trade-off: one flaky engine/host forces a full-run fallback;
+   accepted because a silent partial is worse than a visible fallback.
+3. **Explicit multi-engine query, not an omitted `platform`.** Omitting `platform`
+   on `domain-urls`/`cited-domains` does **not** aggregate across engines (the
+   proxy resolves it to a single default engine). We query the full offsite provider
+   set mapped to serenity models — `SEMRUSH_PLATFORM_BY_PROVIDER` (`google-ai-mode`,
+   `search-gpt`, `microsoft-copilot`, `gemini-2.5-flash`, `google-ai-overview`,
+   `perplexity`) — and **sum** citations per URL. Validating this map upstream is
+   LLMO-6710.
+4. **Auth = service IMS bearer, forwarded unchanged to Semrush.** No
+   `x-promise-token` for a service caller (that header is the non-IMS/browser path).
+   **Open risk:** the proxy forwards the token unchanged and is designed around a
+   real *user* IMS token; whether Semrush accepts the worker's *service* token is
+   unverified — the flag stays off until confirmed end-to-end (LLMO-6709).
+5. **Format parity.** The loader re-applies `YOUTUBE_URL_REGEX` / `REDDIT_URL_REGEX`
+   (matching the legacy `handler.js` classify) so non-thread Reddit and lookalike
+   YouTube hosts are dropped identically.
+
+## Consequences
+
+- Enabling the flag can never silently zero out offsite (fallback), but the
+  fallback **masks** Semrush failures — parity validation (LLMO-6711) must watch
+  for the `using legacy fallback` warning to know when Semrush is not serving.
+- `pageSize=100` assumes a server-side citations-descending sort (unconfirmed); the
+  loader logs a truncation warning on a full page so an unsorted/capped response is
+  visible rather than silently dropping high-citation URLs.
+- The flag is **environment-global** (not per-site); per-site cutover is LLMO-6711.
+
+## Known gaps / non-goals (tracked)
+
+- **Region scoping** is not implemented; the legacy path spans `ACCEPTED_REGIONS`
+  (six markets) while this loader sends no region. Documented as a follow-up
+  (LLMO-6710) — must be closed before non-US parity can be claimed.
+- Generic "cited" (third-party) bucket — needs a `cited-domains` discovery hop
+  (LLMO-6709 follow-up).
+
+## Alternatives Considered
+
+- **No fallback (Semrush-only when on).** Rejected: a Semrush outage would zero out
+  offsite for every audited site with no safety net.
+- **Per-domain fallback** (fall back only for the failed surface). Deferred: more
+  complex; the full-run fallback is simpler and strictly safe.
+- **Omit `platform` and rely on server-side aggregation.** Rejected: not how these
+  two endpoints resolve an absent platform (single-engine narrowing).

--- a/docs/decisions/002-offsite-cited-urls-semrush-source.md
+++ b/docs/decisions/002-offsite-cited-urls-semrush-source.md
@@ -19,16 +19,6 @@ involves several non-obvious trade-offs, so it warrants an ADR alongside the spe
    When `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED=true`, the runner tries the Semrush
    loader first; if it yields **no usable result** it falls back to the legacy
    `loadBrandPresenceData` (PostgREST → SharePoint). Flag off = legacy only.
-1b. **Gate 1 is enforced in code, not just documented.** Neither this flag nor the
-   per-run Slack override (Decision 6) has any effect unless
-   `OFFSITE_SEMRUSH_GATE1_VERIFIED=true` in that environment — a second,
-   deploy-controlled flag flipped only once LLMO-6709 (auth verified end-to-end, no
-   token leakage into trace spans, org-scoping confirmed) actually closes there. A
-   request that is blocked by this gate is logged and (when a Slack thread exists)
-   posted to it, naming which knob requested Semrush, rather than silently honored.
-   This exists because Slack-trigger access is a much larger population than
-   deploy access, and a markdown sentence cannot stop a Slack command from setting
-   a boolean at runtime.
 2. **"No usable result" = fall back, at the SURFACE granularity.** The loader
    returns `null` — and the handler falls back — on: no org/brand, transient
    brand-resolution failure, no date window, IMS-token failure, or when a **whole
@@ -71,11 +61,15 @@ involves several non-obvious trade-offs, so it warrants an ADR alongside the spe
 5. **Format parity.** The loader re-applies `YOUTUBE_URL_REGEX` / `REDDIT_URL_REGEX`
    (matching the legacy `handler.js` classify) so non-thread Reddit and lookalike
    YouTube hosts are dropped identically.
-6. **Per-run override via Slack custom arg.** `enableSemrush` (`auditContext.messageData.enableSemrush`,
-   resolved by `resolveEnableSemrush`) lets a single Slack-triggered `offsite-brand-presence` /
+6. **Per-run override via Slack custom arg — how the first live runs get tested.**
+   `enableSemrush` (`auditContext.messageData.enableSemrush`, resolved by
+   `resolveEnableSemrush`) lets a single Slack-triggered `offsite-brand-presence` /
    `cited-analysis` / `youtube-analysis` / `reddit-analysis` run override the env var —
    `true` forces the Semrush attempt on for that run, `false` forces legacy even when the
-   env var is on. This is the same tri-state mechanism as the existing `enableBrandProfile`
+   env var is on, anything else (absent, empty, invalid) falls through to the env var
+   unchanged. This is the intended mechanism for verifying LLMO-6709 against the real
+   Semrush proxy on one site at a time, before `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED`
+   is flipped fleet-wide. Same tri-state mechanism as the existing `enableBrandProfile`
    override. It is a **per-run** override only (one Slack invocation), not the persistent
    **per-site** cutover tracked under LLMO-6711.
 
@@ -103,11 +97,10 @@ involves several non-obvious trade-offs, so it warrants an ADR alongside the spe
 ## Enablement runbook (ordered gates before turning the flag on anywhere)
 
 The flag-off path is safe to merge now. Before `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED=true`
-in **any** environment, close these in order (LLMO-6709 → 6711). The per-run Slack override
-(`enableSemrush`, Decision 6) exercises this identical code path and is code-gated behind the
-same gate 1 precondition below (Decision 1b, `OFFSITE_SEMRUSH_GATE1_VERIFIED`) — it is a
-controlled, single-run instrument for verifying LLMO-6709 on one site once that flag is set,
-not a way to light up the unverified path in production ahead of sign-off.
+fleet-wide in any environment, close these in order (LLMO-6709 → 6711). The per-run Slack
+override (`enableSemrush`, Decision 6) is the intended tool for step 1 below: use it to run a
+single live request against the real Semrush proxy on one site and confirm the auth path
+works end-to-end, before flipping the env var for the whole fleet.
 
 1. **Auth/authz verified (LLMO-6709).** Confirm the worker's **service** IMS token is
    accepted by the Semrush proxy end-to-end (it is forwarded unchanged; the proxy is designed
@@ -115,9 +108,7 @@ not a way to light up the unverified path in production ahead of sign-off.
    into traces/spans (service-bearer leak). Confirm the token is org-scoped, or document that
    tenant isolation is fully delegated to the proxy's per-caller org authz — the worker sends
    `spaceCatId = site.getOrganizationId()` with a broad service token and asserts no boundary
-   itself (confused-deputy surface). Once confirmed, set `OFFSITE_SEMRUSH_GATE1_VERIFIED=true`
-   in that environment — this is the actual code-level switch gating both the fleet flag and
-   the per-run Slack override (Decision 1b); nothing before this step can produce real traffic.
+   itself (confused-deputy surface).
 2. **`dataSource` shipped** (this PR) — so parity can be measured.
 3. **Shadow-run parity on a canary site (LLMO-6711)** — top-70 overlap per surface vs legacy.
 4. **Fleet enable** per environment (the flag is environment-global) — **US markets only**
@@ -132,8 +123,8 @@ The IMS scheme is justified here (the Elements proxy must forward a bearer to Se
 **two base-URL env vars + two auth schemes** can drift (one caller repointed to stage/prod, the
 other not → IMS traffic to an untrusted issuer → 401 → silent legacy fallback). Documented as
 debt: pick one base-URL env var and one api-service client convention (a shared helper) **before
-the `cited-domains` follow-up adds a third caller** that copies whichever it finds first.
-Tracked under a follow-up ticket (TBD) rather than left as an unticketed prose condition.
+the `cited-domains` follow-up adds a third caller** that copies whichever it finds first. A
+tracking ticket will be filed before this debt is resolved; not required to close this PR.
 
 ## Alternatives Considered
 

--- a/docs/decisions/002-offsite-cited-urls-semrush-source.md
+++ b/docs/decisions/002-offsite-cited-urls-semrush-source.md
@@ -41,6 +41,13 @@ involves several non-obvious trade-offs, so it warrants an ADR alongside the spe
 5. **Format parity.** The loader re-applies `YOUTUBE_URL_REGEX` / `REDDIT_URL_REGEX`
    (matching the legacy `handler.js` classify) so non-thread Reddit and lookalike
    YouTube hosts are dropped identically.
+6. **Per-run override via Slack custom arg.** `enableSemrush` (`auditContext.messageData.enableSemrush`,
+   resolved by `resolveEnableSemrush`) lets a single Slack-triggered `offsite-brand-presence` /
+   `cited-analysis` / `youtube-analysis` / `reddit-analysis` run override the env var —
+   `true` forces the Semrush attempt on for that run, `false` forces legacy even when the
+   env var is on. This is the same tri-state mechanism as the existing `enableBrandProfile`
+   override. It is a **per-run** override only (one Slack invocation), not the persistent
+   **per-site** cutover tracked under LLMO-6711.
 
 ## Consequences
 
@@ -51,6 +58,8 @@ involves several non-obvious trade-offs, so it warrants an ADR alongside the spe
   loader logs a truncation warning on a full page so an unsorted/capped response is
   visible rather than silently dropping high-citation URLs.
 - The flag is **environment-global** (not per-site); per-site cutover is LLMO-6711.
+  A per-run Slack override (`enableSemrush`, see Decision 6) exists for ad-hoc testing
+  of one run, but does not persist across runs or substitute for the per-site cutover.
 
 ## Known gaps / non-goals (tracked)
 

--- a/docs/decisions/002-offsite-cited-urls-semrush-source.md
+++ b/docs/decisions/002-offsite-cited-urls-semrush-source.md
@@ -84,7 +84,10 @@ involves several non-obvious trade-offs, so it warrants an ADR alongside the spe
 ## Enablement runbook (ordered gates before turning the flag on anywhere)
 
 The flag-off path is safe to merge now. Before `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED=true`
-in **any** environment, close these in order (LLMO-6709 → 6711):
+in **any** environment, close these in order (LLMO-6709 → 6711). The per-run Slack override
+(`enableSemrush`, Decision 6) exercises this identical code path and is subject to the same
+gate 1 precondition below — it is a controlled, single-run instrument for verifying LLMO-6709
+on one site, not a way to light up the unverified path in production ahead of sign-off:
 
 1. **Auth/authz verified (LLMO-6709).** Confirm the worker's **service** IMS token is
    accepted by the Semrush proxy end-to-end (it is forwarded unchanged; the proxy is designed
@@ -95,7 +98,9 @@ in **any** environment, close these in order (LLMO-6709 → 6711):
    itself (confused-deputy surface).
 2. **`dataSource` shipped** (this PR) — so parity can be measured.
 3. **Shadow-run parity on a canary site (LLMO-6711)** — top-70 overlap per surface vs legacy.
-4. **Fleet enable** per environment (the flag is environment-global).
+4. **Fleet enable** per environment (the flag is environment-global) — **US markets only**
+   until region scoping (LLMO-6710, see Known gaps below) closes; non-US parity cannot be
+   claimed before then.
 
 ## Configuration / client-convention debt (to resolve before the 3rd caller)
 
@@ -106,6 +111,7 @@ The IMS scheme is justified here (the Elements proxy must forward a bearer to Se
 other not → IMS traffic to an untrusted issuer → 401 → silent legacy fallback). Documented as
 debt: pick one base-URL env var and one api-service client convention (a shared helper) **before
 the `cited-domains` follow-up adds a third caller** that copies whichever it finds first.
+Tracked under a follow-up ticket (TBD) rather than left as an unticketed prose condition.
 
 ## Alternatives Considered
 

--- a/docs/decisions/002-offsite-cited-urls-semrush-source.md
+++ b/docs/decisions/002-offsite-cited-urls-semrush-source.md
@@ -19,6 +19,16 @@ involves several non-obvious trade-offs, so it warrants an ADR alongside the spe
    When `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED=true`, the runner tries the Semrush
    loader first; if it yields **no usable result** it falls back to the legacy
    `loadBrandPresenceData` (PostgREST → SharePoint). Flag off = legacy only.
+1b. **Gate 1 is enforced in code, not just documented.** Neither this flag nor the
+   per-run Slack override (Decision 6) has any effect unless
+   `OFFSITE_SEMRUSH_GATE1_VERIFIED=true` in that environment — a second,
+   deploy-controlled flag flipped only once LLMO-6709 (auth verified end-to-end, no
+   token leakage into trace spans, org-scoping confirmed) actually closes there. A
+   request that is blocked by this gate is logged and (when a Slack thread exists)
+   posted to it, naming which knob requested Semrush, rather than silently honored.
+   This exists because Slack-trigger access is a much larger population than
+   deploy access, and a markdown sentence cannot stop a Slack command from setting
+   a boolean at runtime.
 2. **"No usable result" = fall back, at the SURFACE granularity.** The loader
    returns `null` — and the handler falls back — on: no org/brand, transient
    brand-resolution failure, no date window, IMS-token failure, or when a **whole
@@ -31,8 +41,17 @@ involves several non-obvious trade-offs, so it warrants an ADR alongside the spe
    retriable statuses (`RETRIABLE_STATUSES`) — as the legacy path does — would
    further reduce transient surface-level fallbacks; not in this PR.
 2b. **`dataSource` on the audit result.** `auditResult.dataSource` = `'semrush'` |
-   `'legacy'` (plus `fallbackReason` when a Semrush attempt fell back), so shadow-run
-   parity (LLMO-6711) can join on the source per run instead of grepping a log line.
+   `'legacy'`, plus one of two structured signals depending on outcome: a fully-failed
+   attempt sets `fallbackReason` to a specific code (`no-organization-id`,
+   `no-active-brand`, `brand-resolution-failed`, `no-date-window`, `ims-token-failed`,
+   or `surface-failed:<hostname>`) instead of one generic string; a *succeeded* attempt
+   that still tolerated partial engine/auth failures (Decision 2 above) sets
+   `semrushEngineFailureCount` / `semrushDegradedHosts` so that degradation is visible
+   without going back to logs — `dataSource: 'semrush'` alone does not distinguish a
+   clean run from one where some engines failed. Any 401/403 among the tolerated
+   failures is also logged as a distinct WARN even on overall success, since an
+   intermittent auth rejection is the signal to watch for during the pre-LLMO-6709
+   window. All of this feeds shadow-run parity (LLMO-6711) without grepping logs.
 2c. **Scope + hygiene guards.** Off-host (`domain: null`) rows are dropped so nothing
    leaks into the top-cited bucket / TOP_CITED scrape; citations are clamped
    (`Math.max(0, …)`) and URLs with total count ≤ 0 are dropped so a negative/zero
@@ -85,9 +104,10 @@ involves several non-obvious trade-offs, so it warrants an ADR alongside the spe
 
 The flag-off path is safe to merge now. Before `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED=true`
 in **any** environment, close these in order (LLMO-6709 → 6711). The per-run Slack override
-(`enableSemrush`, Decision 6) exercises this identical code path and is subject to the same
-gate 1 precondition below — it is a controlled, single-run instrument for verifying LLMO-6709
-on one site, not a way to light up the unverified path in production ahead of sign-off:
+(`enableSemrush`, Decision 6) exercises this identical code path and is code-gated behind the
+same gate 1 precondition below (Decision 1b, `OFFSITE_SEMRUSH_GATE1_VERIFIED`) — it is a
+controlled, single-run instrument for verifying LLMO-6709 on one site once that flag is set,
+not a way to light up the unverified path in production ahead of sign-off.
 
 1. **Auth/authz verified (LLMO-6709).** Confirm the worker's **service** IMS token is
    accepted by the Semrush proxy end-to-end (it is forwarded unchanged; the proxy is designed
@@ -95,7 +115,9 @@ on one site, not a way to light up the unverified path in production ahead of si
    into traces/spans (service-bearer leak). Confirm the token is org-scoped, or document that
    tenant isolation is fully delegated to the proxy's per-caller org authz — the worker sends
    `spaceCatId = site.getOrganizationId()` with a broad service token and asserts no boundary
-   itself (confused-deputy surface).
+   itself (confused-deputy surface). Once confirmed, set `OFFSITE_SEMRUSH_GATE1_VERIFIED=true`
+   in that environment — this is the actual code-level switch gating both the fleet flag and
+   the per-run Slack override (Decision 1b); nothing before this step can produce real traffic.
 2. **`dataSource` shipped** (this PR) — so parity can be measured.
 3. **Shadow-run parity on a canary site (LLMO-6711)** — top-70 overlap per surface vs legacy.
 4. **Fleet enable** per environment (the flag is environment-global) — **US markets only**

--- a/docs/specs/2026-08-05-offsite-cited-urls-semrush-source.md
+++ b/docs/specs/2026-08-05-offsite-cited-urls-semrush-source.md
@@ -12,7 +12,7 @@
 
 The `offsite-brand-presence` audit selects the cited URLs it feeds to DRS (YouTube, Reddit,
 and top third-party "cited" sources) from **internal Brand-Presence execution data** —
-PostgREST for brandalf-enabled orgs, with an S3 / SharePoint Excel fallback
+PostgREST for brandalf-enabled orgs, with a SharePoint Excel fallback
 (`loadBrandPresenceData`). We want those same URLs — ranked by citation volume — sourced from
 the **Semrush URL-Inspector API** instead, without changing anything downstream of URL
 selection.
@@ -36,7 +36,7 @@ selection.
 
 ### 3.1 Endpoint (spacecat-api-service wrapper)
 
-`GET {SPACECAT_API_URI}/v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/domain-urls?hostname={host}&startDate=&endDate=&pageSize=1000`
+`GET {SPACECAT_API_URI}/v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/domain-urls?hostname={host}&startDate=&endDate=&pageSize=100`
 
 Served by the api-service **Elements proxy** (`src/controllers/elements.js` →
 `listDomainUrls`, Semrush element `STATS_PER_URL`). Response: `{ urls: [{ url, citations,
@@ -63,8 +63,11 @@ flag stays off until verified.
    - **enforce `YOUTUBE_URL_REGEX` / `REDDIT_URL_REGEX`** (parity with `handler.js:199-204`) so
      non-thread Reddit URLs and lookalike YouTube hosts are dropped, matching the legacy path;
    - `count = row.citations` (exact); sum across platforms for the same URL.
-3. Handler branch (`OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED === 'true'`) uses this map; else the
-   legacy `loadBrandPresenceData` + `extractUrlsAndTopics`. `selectTopUrls` onward is unchanged.
+3. Handler branch: when `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED === 'true'` it tries Semrush
+   **first**; if the loader yields no usable URLs (auth failure, no brand, outage, empty result)
+   it **falls back** to the legacy `loadBrandPresenceData` (PostgREST → SharePoint) +
+   `extractUrlsAndTopics`, so a Semrush problem can never silently zero out offsite. Flag off =
+   legacy only. `selectTopUrls` onward is unchanged in every case.
 
 ### 3.4 Platform aggregation
 
@@ -101,5 +104,7 @@ added.
 - Flag off ⇒ byte-for-byte today's behavior (no regression).
 - Flag on ⇒ YouTube/Reddit cited URLs come from Semrush with exact citation counts; strict
   format filtering matches the legacy path.
+- Flag on + Semrush unavailable ⇒ automatic fallback to the legacy PostgREST → SharePoint
+  source (no offsite gap).
 - Shadow-run (LLMO-6711) shows acceptable top-70 overlap per surface vs the legacy source.
 - 100% test coverage on the new module; full suite green.

--- a/docs/specs/2026-08-05-offsite-cited-urls-semrush-source.md
+++ b/docs/specs/2026-08-05-offsite-cited-urls-semrush-source.md
@@ -4,7 +4,7 @@
 **Author:** Andrei Paraschiv
 **Date:** 2026-08-05
 **Epic:** [LLMO-6488](https://jira.corp.adobe.com/browse/LLMO-6488) · **Story:** [LLMO-6709](https://jira.corp.adobe.com/browse/LLMO-6709)
-**Related:** migration plan `docs/plans/2026-07-17-offsite-cited-urls-semrush-migration.md` · PR #2847
+**Related:** ADR `docs/decisions/002-offsite-cited-urls-semrush-source.md` · migration plan `docs/plans/2026-07-17-offsite-cited-urls-semrush-migration.md` · PR #2847
 
 ---
 
@@ -26,9 +26,13 @@ selection.
   citations) and the DRS scrape / poll / analysis path are **unchanged**.
 - Behavioral parity with the legacy path for the URL set it produces.
 
-**Non-goals**
+**Non-goals (known gaps, tracked)**
 - The generic "cited" (top third-party) bucket — needs a `cited-domains` discovery hop;
   tracked as a follow-up under LLMO-6709. This spec covers **YouTube + Reddit** only.
+- **Region scoping.** The legacy path spans `ACCEPTED_REGIONS` (six markets) while this loader
+  sends **no region param**. If the endpoint defaults to a single region, non-US orgs will
+  diverge from legacy. Deferred to LLMO-6710 (region + platform mapping) — must be closed
+  before non-US parity is claimed.
 - Changing ranking, bucketing, DRS, or the analysis audits.
 - Per-URL prompt attribution (LLMO-6712) and topic/category enrichment (LLMO-6708).
 
@@ -41,7 +45,12 @@ selection.
 Served by the api-service **Elements proxy** (`src/controllers/elements.js` →
 `listDomainUrls`, Semrush element `STATS_PER_URL`). Response: `{ urls: [{ url, citations,
 promptsCited, categories, regions, contentType, urlId }] }`. `llmo.experiencecloud.live/api/v1`
-is an edge alias for the same service.
+is an edge alias for the same service. Path segments (`spaceCatId`, `brandId`) are URL-encoded.
+
+`pageSize=100` covers the per-surface top-70 in one page. A server-side citations-descending
+sort is **assumed but not confirmed**; the loader logs a truncation warning on a full page so a
+capped/unsorted response is visible rather than silently dropping high-citation URLs. Each
+request carries a 10s timeout; requests run concurrently.
 
 ### 3.2 Auth
 
@@ -71,8 +80,12 @@ flag stays off until verified.
 
 ### 3.4 Platform aggregation
 
-`platform` is omitted by default so the proxy aggregates across engines; the surface is
-multi-engine (`search-gpt` and `google-ai-mode` both return data). `OFFSITE_SEMRUSH_PLATFORMS`
+Omitting `platform` does **not** aggregate across engines on `domain-urls`/`cited-domains` —
+the proxy resolves an absent value to a single default engine. So the loader queries an
+**explicit engine list** — the full offsite provider set mapped to serenity models via
+`SEMRUSH_PLATFORM_BY_PROVIDER` (offsite `constants.js`): `google-ai-mode`, `search-gpt`,
+`microsoft-copilot`, `gemini-2.5-flash`, `google-ai-overview`, `perplexity` — and **sums**
+citations per URL, mirroring the legacy multi-engine mix. `OFFSITE_SEMRUSH_PLATFORMS`
 (comma-separated) queries each engine and **sums citations per URL**. (LLMO-6710.)
 
 ### 3.5 Config
@@ -81,7 +94,7 @@ multi-engine (`search-gpt` and `google-ai-mode` both return data). `OFFSITE_SEMR
 |---|---|---|
 | `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED` | (off) | `"true"` switches source to Semrush |
 | `SPACECAT_API_URI` | `https://spacecat.experiencecloud.live/api/v1` | api-service base |
-| `OFFSITE_SEMRUSH_PLATFORMS` | (omit) | engines to query + sum |
+| `OFFSITE_SEMRUSH_PLATFORMS` | full provider set (`SEMRUSH_PLATFORM_BY_PROVIDER`) | override: engines to query + sum |
 
 ## 4. Alternatives considered
 

--- a/docs/specs/2026-08-05-offsite-cited-urls-semrush-source.md
+++ b/docs/specs/2026-08-05-offsite-cited-urls-semrush-source.md
@@ -1,0 +1,105 @@
+# Spec: Offsite cited-URL source from the Semrush URL-Inspector API
+
+**Status:** Proposed
+**Author:** Andrei Paraschiv
+**Date:** 2026-08-05
+**Epic:** [LLMO-6488](https://jira.corp.adobe.com/browse/LLMO-6488) · **Story:** [LLMO-6709](https://jira.corp.adobe.com/browse/LLMO-6709)
+**Related:** migration plan `docs/plans/2026-07-17-offsite-cited-urls-semrush-migration.md` · PR #2847
+
+---
+
+## 1. Problem statement
+
+The `offsite-brand-presence` audit selects the cited URLs it feeds to DRS (YouTube, Reddit,
+and top third-party "cited" sources) from **internal Brand-Presence execution data** —
+PostgREST for brandalf-enabled orgs, with an S3 / SharePoint Excel fallback
+(`loadBrandPresenceData`). We want those same URLs — ranked by citation volume — sourced from
+the **Semrush URL-Inspector API** instead, without changing anything downstream of URL
+selection.
+
+## 2. Goals / non-goals
+
+**Goals**
+- Add a flag-gated data source that returns the exact `allUrls: Map<url, { count, domain }>`
+  contract the existing pipeline consumes, with `count = exact Semrush citations`.
+- Preserve today's selection semantics: `selectTopUrls` (per-surface top-70, ranked by
+  citations) and the DRS scrape / poll / analysis path are **unchanged**.
+- Behavioral parity with the legacy path for the URL set it produces.
+
+**Non-goals**
+- The generic "cited" (top third-party) bucket — needs a `cited-domains` discovery hop;
+  tracked as a follow-up under LLMO-6709. This spec covers **YouTube + Reddit** only.
+- Changing ranking, bucketing, DRS, or the analysis audits.
+- Per-URL prompt attribution (LLMO-6712) and topic/category enrichment (LLMO-6708).
+
+## 3. Technical design
+
+### 3.1 Endpoint (spacecat-api-service wrapper)
+
+`GET {SPACECAT_API_URI}/v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/domain-urls?hostname={host}&startDate=&endDate=&pageSize=1000`
+
+Served by the api-service **Elements proxy** (`src/controllers/elements.js` →
+`listDomainUrls`, Semrush element `STATS_PER_URL`). Response: `{ urls: [{ url, citations,
+promptsCited, categories, regions, contentType, urlId }] }`. `llmo.experiencecloud.live/api/v1`
+is an edge alias for the same service.
+
+### 3.2 Auth
+
+The loader mints a **service IMS token** (`ImsClient.getServiceAccessTokenV3`) and sends
+`Authorization: Bearer`. The proxy's `requireImsBearer` forwards it **unchanged** to Semrush
+(`docs/elements/semrush-elements-api-reference.md` §Authentication) — no `x-promise-token`
+needed for a service caller. **Open risk (LLMO-6709):** the wrapper is designed around a real
+user's IMS token, so the worker's service token must be authorized upstream by Semrush; the
+flag stays off until verified.
+
+### 3.3 Flow (`src/utils/offsite-brand-presence-semrush.js`)
+
+1. Resolve `spaceCatId = site.getOrganizationId()`, `brandId = resolveBrandForSite(...)`,
+   `{ startDate, endDate } = getDateWindowForPreviousWeeks(previousWeeks)`.
+2. For each `OFFSITE_DOMAINS` hostname (`youtube.com`, `reddit.com`) × each configured platform,
+   call `domain-urls` and fold rows into `allUrls`:
+   - normalize + classify via the shared `classifyAndNormalize` (owned-URL filtering, youtu.be
+     canonicalization, domain assignment);
+   - **enforce `YOUTUBE_URL_REGEX` / `REDDIT_URL_REGEX`** (parity with `handler.js:199-204`) so
+     non-thread Reddit URLs and lookalike YouTube hosts are dropped, matching the legacy path;
+   - `count = row.citations` (exact); sum across platforms for the same URL.
+3. Handler branch (`OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED === 'true'`) uses this map; else the
+   legacy `loadBrandPresenceData` + `extractUrlsAndTopics`. `selectTopUrls` onward is unchanged.
+
+### 3.4 Platform aggregation
+
+`platform` is omitted by default so the proxy aggregates across engines; the surface is
+multi-engine (`search-gpt` and `google-ai-mode` both return data). `OFFSITE_SEMRUSH_PLATFORMS`
+(comma-separated) queries each engine and **sums citations per URL**. (LLMO-6710.)
+
+### 3.5 Config
+
+| Env | Default | Purpose |
+|---|---|---|
+| `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED` | (off) | `"true"` switches source to Semrush |
+| `SPACECAT_API_URI` | `https://spacecat.experiencecloud.live/api/v1` | api-service base |
+| `OFFSITE_SEMRUSH_PLATFORMS` | (omit) | engines to query + sum |
+
+## 4. Alternatives considered
+
+- **Build a new SR AI-Visibility endpoint** / **direct v4-raw Semrush client** (Options 1 & 2 in
+  the migration plan) — superseded: the api-service wrapper already exists and is UI-validated.
+- **Route Semrush rows through the existing `extractUrlsAndTopics`** — rejected: it recounts by
+  repetition and would discard the exact citation numbers.
+
+## 5. Behavioral-parity note (reviewer follow-up)
+
+There are two `classifyAndNormalize` functions: the enrichment one (hostname match +
+normalization) and the stricter `handler.js` one (adds `YOUTUBE_URL_REGEX` / `REDDIT_URL_REGEX`
++ `isExcludedCitedHost`). The loader normalizes with the former and **re-applies the two
+regexes** to match the legacy filter for its YouTube/Reddit scope. `isExcludedCitedHost` /
+brand-token filtering only affect the top-cited bucket and will be applied when that bucket is
+added.
+
+## 6. Success criteria
+
+- Flag off ⇒ byte-for-byte today's behavior (no regression).
+- Flag on ⇒ YouTube/Reddit cited URLs come from Semrush with exact citation counts; strict
+  format filtering matches the legacy path.
+- Shadow-run (LLMO-6711) shows acceptable top-70 overlap per surface vs the legacy source.
+- 100% test coverage on the new module; full suite green.

--- a/docs/specs/2026-08-05-offsite-cited-urls-semrush-source.md
+++ b/docs/specs/2026-08-05-offsite-cited-urls-semrush-source.md
@@ -77,6 +77,12 @@ flag stays off until verified.
    it **falls back** to the legacy `loadBrandPresenceData` (PostgREST → SharePoint) +
    `extractUrlsAndTopics`, so a Semrush problem can never silently zero out offsite. Flag off =
    legacy only. `selectTopUrls` onward is unchanged in every case.
+   A Slack-triggered `offsite-brand-presence`/`cited-analysis`/`youtube-analysis`/`reddit-analysis`
+   run can override this env var for that single run via the `enableSemrush` custom arg
+   (`auditContext.messageData.enableSemrush`, resolved by `resolveEnableSemrush` — same
+   tri-state mechanism as `enableBrandProfile`); `cited-analysis`/`youtube-analysis`/
+   `reddit-analysis` forward it through `requestOffsiteScrape` so the override survives when
+   they trigger a scoped `offsite-brand-presence` re-scrape. See ADR-002 decision 6.
 
 ### 3.4 Platform aggregation
 
@@ -95,6 +101,7 @@ citations per URL, mirroring the legacy multi-engine mix. `OFFSITE_SEMRUSH_PLATF
 | `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED` | (off) | `"true"` switches source to Semrush |
 | `SPACECAT_API_URI` | `https://spacecat.experiencecloud.live/api/v1` | api-service base |
 | `OFFSITE_SEMRUSH_PLATFORMS` | full provider set (`SEMRUSH_PLATFORM_BY_PROVIDER`) | override: engines to query + sum |
+| `enableSemrush` (Slack custom arg, not an env var) | (unset — env var applies) | per-run override of `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED` |
 
 ## 4. Alternatives considered
 

--- a/src/cited-analysis/handler.js
+++ b/src/cited-analysis/handler.js
@@ -23,6 +23,7 @@ import {
   resolveMystiqueUrlLimit,
   resolveForwardedUrlLimit,
   resolveEnableBrandProfile,
+  resolveEnableSemrush,
   requestOffsiteScrape,
   computeBrandTokens,
   isExcludedCitedHost,
@@ -241,7 +242,7 @@ async function fetchStoreData(siteId, context, site) {
  * @param {Object} context - The audit context
  * @param {Object} site - The site being audited
  * @param {Object} [auditContext] - SQS audit context; optional `messageData` from `message.data`
- *   (e.g. urlLimit, enableBrandProfile from Slack)
+ *   (e.g. urlLimit, enableBrandProfile, enableSemrush from Slack)
  * @returns {Promise<Object>} Audit result
  */
 async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
@@ -257,6 +258,7 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
 
   const enableBrandProfile = resolveEnableBrandProfile(auditContext, log, LOG_PREFIX);
   const forwardedUrlLimit = resolveForwardedUrlLimit(auditContext, log, LOG_PREFIX);
+  const enableSemrush = resolveEnableSemrush(auditContext, log, LOG_PREFIX);
 
   try {
     const citedConfig = getCitedConfig(site);
@@ -365,6 +367,7 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
         slackContext,
         enableBrandProfile,
         forwardedUrlLimit,
+        enableSemrush,
       );
       return {
         auditResult: { success: false, status: 'pending_scrape', error: error.message },
@@ -404,6 +407,7 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
         slackContext,
         enableBrandProfile,
         forwardedUrlLimit,
+        enableSemrush,
       );
       return {
         auditResult: { success: false, status: 'pending_scrape', error: error.message },

--- a/src/offsite-brand-presence/constants.js
+++ b/src/offsite-brand-presence/constants.js
@@ -24,6 +24,22 @@ export const PROVIDERS = Object.freeze([
 ]);
 
 export const PROVIDERS_SET = new Set(PROVIDERS);
+
+// Serenity/Semrush `platform` (model) value per offsite audit provider. Values
+// are the SerenityModel enum (see project-elmo-ui `src/api/serenityApi.ts`).
+// 'all' (chatgpt-paid) has no distinct serenity model — 'search-gpt' covers it —
+// so it is intentionally omitted. Used by the Semrush URL-Inspector loader to
+// query each engine explicitly (omitting `platform` narrows to one engine, it
+// does NOT aggregate). Completing/validating this map is LLMO-6710.
+export const SEMRUSH_PLATFORM_BY_PROVIDER = Object.freeze({
+  'ai-mode': 'google-ai-mode',
+  chatgpt: 'search-gpt',
+  copilot: 'microsoft-copilot',
+  gemini: 'gemini-2.5-flash',
+  'google-ai-overviews': 'google-ai-overview',
+  perplexity: 'perplexity',
+});
+
 export const BRAND_PRESENCE_REGEX = /brandpresence-(.+?)-w(\d{1,2})-(\d{4})(?:-.*)?$/;
 
 // Region codes whose brand-presence rows are processed. Limited to English-speaking markets.

--- a/src/offsite-brand-presence/drs-status-handler.js
+++ b/src/offsite-brand-presence/drs-status-handler.js
@@ -146,6 +146,10 @@ function computeReadyAuditTypes(statuses, deadlineReached, alreadyTriggered) {
  * @param {number} [urlLimit] - Forwarded from the originating Slack request (see
  *   offsite-brand-presence/handler.js) so the re-triggered analysis audit resolves the same
  *   urlLimit, instead of losing it across the scrape round-trip.
+ * @param {boolean} [enableSemrush] - Forwarded from the originating Slack request (see
+ *   offsite-brand-presence/handler.js) so the re-triggered analysis audit's own scoped
+ *   re-scrape (if it needs one) honors the same per-run Semrush override, instead of
+ *   silently reverting to the env var across the scrape round-trip.
  * @returns {Promise<string[]>} Audit types that were dispatched or intentionally skipped
  */
 async function triggerAnalysisAudits(
@@ -156,6 +160,7 @@ async function triggerAnalysisAudits(
   drsStartedAt,
   enableBrandProfile,
   urlLimit,
+  enableSemrush,
 ) {
   const { sqs, dataAccess, log } = context;
 
@@ -181,6 +186,7 @@ async function triggerAnalysisAudits(
       const messageData = {
         ...(enableBrandProfile != null && { enableBrandProfile }),
         ...(urlLimit != null && { urlLimit }),
+        ...(enableSemrush != null && { enableSemrush }),
       };
       // eslint-disable-next-line no-await-in-loop
       await sqs.sendMessage(queueUrl, {
@@ -256,7 +262,7 @@ function buildSummary(baseURL, statuses, drsStartedAt, triggeredAuditTypes = [])
  *
  * @param {object} message - SQS message with auditContext { baseURL, slackContext?,
  *   jobs: [{domain, datasetId, jobId}], deadline, triggeredAuditTypes?, enableBrandProfile?,
- *   urlLimit? }
+ *   urlLimit?, enableSemrush? }
  * @param {object} context - Universal context (log, sqs, dataAccess, env)
  * @returns {Promise<Response>}
  */
@@ -266,7 +272,7 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
   const { siteId, auditContext = {} } = message;
   const {
     baseURL, slackContext = {}, jobs = [], deadline, triggeredAuditTypes = [], drsStartedAt,
-    enableBrandProfile, urlLimit,
+    enableBrandProfile, urlLimit, enableSemrush,
   } = auditContext;
   const { channelId, threadTs } = slackContext;
 
@@ -312,6 +318,7 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
       drsStartedAt,
       enableBrandProfile,
       urlLimit,
+      enableSemrush,
     );
   } catch (err) {
     log.warn(`${LOG_PREFIX} Failed to trigger analysis audits for ${baseURL}: ${err.message}`);

--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -894,6 +894,10 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
 
   const allUrls = new Map();
   let usedSemrush = false;
+  // Recorded on auditResult.dataSource so shadow-run parity (LLMO-6711) can join
+  // on which source served each run instead of grepping a log string.
+  let fallbackReason;
+  // Per-run Slack override (resolveEnableSemrush) takes precedence over the env flag.
   const semrushEnabled = enableSemrushOverride
     ?? (context.env?.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED === 'true');
   if (semrushEnabled) {
@@ -911,9 +915,11 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
       }
       usedSemrush = true;
     } else {
+      fallbackReason = 'semrush-no-usable-urls';
       log.warn(`${LOG_PREFIX} Semrush source returned no URLs; falling back to PostgREST/SharePoint`);
     }
   }
+  const dataSource = usedSemrush ? 'semrush' : 'legacy';
 
   // Legacy source: runs when the flag is off, OR when Semrush was tried but
   // produced nothing (fallback). Flag off = today's behavior, unchanged.
@@ -953,6 +959,8 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
         success: true,
         urlCounts,
         weeks: previousWeeks,
+        dataSource,
+        ...(fallbackReason ? { fallbackReason } : {}),
       },
       fullAuditRef: finalUrl,
     };
@@ -1018,6 +1026,8 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
       urlCounts,
       drsJobs: drsResults,
       weeks: previousWeeks,
+      dataSource,
+      ...(fallbackReason ? { fallbackReason } : {}),
     },
     fullAuditRef: finalUrl,
   };

--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -891,19 +891,29 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
   const brandTokens = computeBrandTokens(siteHostname, brandKeywords);
 
   const allUrls = new Map();
+  let usedSemrush = false;
   if (context.env?.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED === 'true') {
-    // Semrush source: the loader returns the same allUrls shape, with
+    // Semrush-first: the loader returns the same allUrls shape, with
     // count = exact citations. Everything downstream (selectTopUrls -> DRS)
-    // is unchanged. Flag off = today's SharePoint/PostgREST path.
+    // is unchanged. If Semrush yields no usable URLs (auth failure, no brand,
+    // outage, empty result) we fall back to the legacy PostgREST/SharePoint
+    // source below so a Semrush problem can never silently zero out offsite.
     const semrushUrls = await loadCitedUrlsFromSemrush({
       site, previousWeeks, context, siteHostname,
     });
-    if (semrushUrls) {
+    if (semrushUrls && semrushUrls.size > 0) {
       for (const [url, info] of semrushUrls) {
         allUrls.set(url, info);
       }
+      usedSemrush = true;
+    } else {
+      log.warn(`${LOG_PREFIX} Semrush source returned no URLs; falling back to PostgREST/SharePoint`);
     }
-  } else {
+  }
+
+  // Legacy source: runs when the flag is off, OR when Semrush was tried but
+  // produced nothing (fallback). Flag off = today's behavior, unchanged.
+  if (!usedSemrush) {
     const brandPresenceData = await loadBrandPresenceData({
       siteId, site, previousWeeks, context,
     });

--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -900,6 +900,14 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
   // Per-run Slack override (resolveEnableSemrush) takes precedence over the env flag.
   const semrushEnabled = enableSemrushOverride
     ?? (context.env?.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED === 'true');
+  // Logged unconditionally (including the off case) so a Splunk search on siteId
+  // alone shows whether this run even attempted Semrush and, if so, which knob
+  // decided that (Slack per-run override vs the env var) — the two can disagree.
+  log.info(`${LOG_PREFIX} Semrush source ${semrushEnabled ? 'enabled' : 'disabled'} for this run`, {
+    siteId,
+    semrushEnabled,
+    decidedBy: enableSemrushOverride !== undefined ? 'slack-override' : 'env-var',
+  });
   if (semrushEnabled) {
     // Semrush-first: the loader returns the same allUrls shape, with
     // count = exact citations. Everything downstream (selectTopUrls -> DRS)
@@ -916,7 +924,9 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
       usedSemrush = true;
     } else {
       fallbackReason = 'semrush-no-usable-urls';
-      log.warn(`${LOG_PREFIX} Semrush source returned no URLs; falling back to PostgREST/SharePoint`);
+      log.warn(`${LOG_PREFIX} Semrush source returned no URLs; falling back to PostgREST/SharePoint`, {
+        siteId, fallbackReason,
+      });
     }
   }
   const dataSource = usedSemrush ? 'semrush' : 'legacy';

--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -914,8 +914,20 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
     // is unchanged. If Semrush yields no usable URLs (auth failure, no brand,
     // outage, empty result) we fall back to the legacy PostgREST/SharePoint
     // source below so a Semrush problem can never silently zero out offsite.
+    // onProgress mirrors the Semrush attempt into the Slack thread (when one
+    // exists — postMessageOptional no-ops otherwise) as an alternative to Splunk
+    // for the manual per-run testing this override was built for.
     const semrushUrls = await loadCitedUrlsFromSemrush({
-      site, previousWeeks, context, siteHostname,
+      site,
+      previousWeeks,
+      context,
+      siteHostname,
+      onProgress: (text) => postMessageOptional(
+        context,
+        channelId,
+        `*offsite-brand-presence* for *${baseURL}* — ${text}`,
+        { threadTs },
+      ),
     });
     if (semrushUrls && semrushUrls.size > 0) {
       for (const [url, info] of semrushUrls) {

--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -784,6 +784,10 @@ async function notifyDrsResults(drsResults, baseURL, context, channelId, threadT
  * @param {number} [urlLimit] - Forwarded so the analysis audits triggered once DRS scraping
  *   completes (see drs-status-handler.js) still resolve the urlLimit originally requested
  *   on Slack, instead of losing it across the scrape round-trip.
+ * @param {boolean} [enableSemrush] - Forwarded so the analysis audits triggered once DRS
+ *   scraping completes (see drs-status-handler.js) still honor the same per-run Semrush
+ *   override originally requested on Slack, instead of silently reverting to the env var
+ *   across the scrape round-trip — mirrors enableBrandProfile/urlLimit exactly.
  */
 async function scheduleDrsStatusPoll(
   drsResults,
@@ -795,6 +799,7 @@ async function scheduleDrsStatusPoll(
   drsStartedAt,
   enableBrandProfile,
   urlLimit,
+  enableSemrush,
 ) {
   const { sqs, dataAccess, log } = context;
 
@@ -821,6 +826,7 @@ async function scheduleDrsStatusPoll(
       drsStartedAt,
       ...(enableBrandProfile != null && { enableBrandProfile }),
       ...(urlLimit != null && { urlLimit }),
+      ...(enableSemrush != null && { enableSemrush }),
     },
   }, null, pollIntervalSeconds);
 
@@ -897,17 +903,37 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
   // Recorded on auditResult.dataSource so shadow-run parity (LLMO-6711) can join
   // on which source served each run instead of grepping a log string.
   let fallbackReason;
+  let semrushDiagnostics;
   // Per-run Slack override (resolveEnableSemrush) takes precedence over the env flag.
-  const semrushEnabled = enableSemrushOverride
+  const semrushRequested = enableSemrushOverride
     ?? (context.env?.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED === 'true');
+  const decidedBy = enableSemrushOverride !== undefined ? 'slack-override' : 'env-var';
+  // Gate 1 (LLMO-6709: the worker's service IMS token verified end-to-end against the
+  // real Semrush proxy, no token leakage into trace spans, org-scoping confirmed) must
+  // close in an environment before ANY Semrush attempt runs there — enforced here in
+  // code, not just documented in the ADR. Without this, the per-run Slack override
+  // (`enableSemrush`) could force a real, unverified request against production the
+  // moment someone with Slack access sets it — a much larger population than the
+  // deploy access that controls OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED itself.
+  const gate1Verified = context.env?.OFFSITE_SEMRUSH_GATE1_VERIFIED === 'true';
+  const semrushEnabled = semrushRequested && gate1Verified;
   // Logged unconditionally (including the off case) so a Splunk search on siteId
   // alone shows whether this run even attempted Semrush and, if so, which knob
   // decided that (Slack per-run override vs the env var) — the two can disagree.
   log.info(`${LOG_PREFIX} Semrush source ${semrushEnabled ? 'enabled' : 'disabled'} for this run`, {
-    siteId,
-    semrushEnabled,
-    decidedBy: enableSemrushOverride !== undefined ? 'slack-override' : 'env-var',
+    siteId, semrushRequested, gate1Verified, semrushEnabled, decidedBy,
   });
+  if (semrushRequested && !gate1Verified) {
+    log.warn(`${LOG_PREFIX} Semrush requested (${decidedBy}) but gate 1 (LLMO-6709) is not marked verified via OFFSITE_SEMRUSH_GATE1_VERIFIED in this environment — using the legacy source`, {
+      siteId, decidedBy,
+    });
+    await postMessageOptional(
+      context,
+      channelId,
+      `*offsite-brand-presence* for *${baseURL}* — :no_entry: Semrush was requested (${decidedBy}) but is gated off in this environment until LLMO-6709 (auth verification) closes. Using the legacy source.`,
+      { threadTs },
+    );
+  }
   if (semrushEnabled) {
     // Semrush-first: the loader returns the same allUrls shape, with
     // count = exact citations. Everything downstream (selectTopUrls -> DRS)
@@ -917,11 +943,13 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
     // onProgress mirrors the Semrush attempt into the Slack thread (when one
     // exists — postMessageOptional no-ops otherwise) as an alternative to Splunk
     // for the manual per-run testing this override was built for.
+    semrushDiagnostics = {};
     const semrushUrls = await loadCitedUrlsFromSemrush({
       site,
       previousWeeks,
       context,
       siteHostname,
+      diagnostics: semrushDiagnostics,
       onProgress: (text) => postMessageOptional(
         context,
         channelId,
@@ -934,14 +962,26 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
         allUrls.set(url, info);
       }
       usedSemrush = true;
+      // Surfaced even on success: a run that tolerated partial engine/auth failures
+      // reports the same dataSource: 'semrush' as a clean run otherwise, which is
+      // exactly the signal LLMO-6711's shadow-run parity work needs to avoid grepping
+      // logs, and the one auth-rejection signal that matters most pre-LLMO-6709.
+      if (semrushDiagnostics.authFailureDetected) {
+        log.warn(`${LOG_PREFIX} Semrush succeeded but at least one engine request returned 401/403 — possible auth/token issue during the pre-LLMO-6709 verification window`, {
+          siteId,
+          degradedHosts: semrushDiagnostics.degradedHosts,
+          engineFailureCount: semrushDiagnostics.engineFailureCount,
+        });
+      }
     } else {
-      fallbackReason = 'semrush-no-usable-urls';
+      fallbackReason = semrushDiagnostics.fallbackReason ?? 'semrush-no-usable-urls';
       log.warn(`${LOG_PREFIX} Semrush source returned no URLs; falling back to PostgREST/SharePoint`, {
         siteId, fallbackReason,
       });
     }
   }
   const dataSource = usedSemrush ? 'semrush' : 'legacy';
+  const semrushDegraded = usedSemrush && (semrushDiagnostics?.engineFailureCount ?? 0) > 0;
 
   // Legacy source: runs when the flag is off, OR when Semrush was tried but
   // produced nothing (fallback). Flag off = today's behavior, unchanged.
@@ -1029,6 +1069,7 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
         drsStartedAt,
         enableBrandProfile,
         urlLimit,
+        enableSemrushOverride,
       );
     } catch (err) {
       log.warn(`${LOG_PREFIX} Failed to schedule DRS status poll: ${err.message}`);
@@ -1050,6 +1091,10 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
       weeks: previousWeeks,
       dataSource,
       ...(fallbackReason ? { fallbackReason } : {}),
+      ...(semrushDegraded ? {
+        semrushEngineFailureCount: semrushDiagnostics.engineFailureCount,
+        semrushDegradedHosts: semrushDiagnostics.degradedHosts,
+      } : {}),
     },
     fullAuditRef: finalUrl,
   };

--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -24,6 +24,7 @@ import {
   isExcludedCitedHost,
   resolveDrsPollIntervalSeconds,
   resolveEnableBrandProfile,
+  resolveEnableSemrush,
   resolveForwardedUrlLimit,
 } from '../utils/offsite-audit-utils.js';
 import {
@@ -855,6 +856,7 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
   // scraping completes, so a Slack-requested flag survives the scrape round-trip.
   const enableBrandProfile = resolveEnableBrandProfile(auditContext, log, LOG_PREFIX);
   const urlLimit = resolveForwardedUrlLimit(auditContext, log, LOG_PREFIX);
+  const enableSemrushOverride = resolveEnableSemrush(auditContext, log, LOG_PREFIX);
   const { channelId, threadTs } = slackContext || {};
   const siteId = site.getId();
   const baseURL = site.getBaseURL();
@@ -892,7 +894,9 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
 
   const allUrls = new Map();
   let usedSemrush = false;
-  if (context.env?.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED === 'true') {
+  const semrushEnabled = enableSemrushOverride
+    ?? (context.env?.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED === 'true');
+  if (semrushEnabled) {
     // Semrush-first: the loader returns the same allUrls shape, with
     // count = exact citations. Everything downstream (selectTopUrls -> DRS)
     // is unchanged. If Semrush yields no usable URLs (auth failure, no brand,

--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -17,6 +17,7 @@ import DrsClient, {
 import { AuditBuilder } from '../common/audit-builder.js';
 import { noopUrlResolver } from '../common/index.js';
 import { getPreviousWeeks, loadBrandPresenceData } from '../utils/offsite-brand-presence-enrichment.js';
+import { loadCitedUrlsFromSemrush } from '../utils/offsite-brand-presence-semrush.js';
 import { postMessageOptional } from '../utils/slack-utils.js';
 import {
   computeBrandTokens,
@@ -889,14 +890,27 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
   const brandKeywords = site.getConfig?.()?.getBrandKeywords?.() || [];
   const brandTokens = computeBrandTokens(siteHostname, brandKeywords);
 
-  const brandPresenceData = await loadBrandPresenceData({
-    siteId, site, previousWeeks, context,
-  });
-
   const allUrls = new Map();
-  if (brandPresenceData) {
-    const topicMap = new Map();
-    extractUrlsAndTopics(brandPresenceData, allUrls, topicMap, log, siteHostname, brandTokens);
+  if (context.env?.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED === 'true') {
+    // Semrush source: the loader returns the same allUrls shape, with
+    // count = exact citations. Everything downstream (selectTopUrls -> DRS)
+    // is unchanged. Flag off = today's SharePoint/PostgREST path.
+    const semrushUrls = await loadCitedUrlsFromSemrush({
+      site, previousWeeks, context, siteHostname,
+    });
+    if (semrushUrls) {
+      for (const [url, info] of semrushUrls) {
+        allUrls.set(url, info);
+      }
+    }
+  } else {
+    const brandPresenceData = await loadBrandPresenceData({
+      siteId, site, previousWeeks, context,
+    });
+    if (brandPresenceData) {
+      const topicMap = new Map();
+      extractUrlsAndTopics(brandPresenceData, allUrls, topicMap, log, siteHostname, brandTokens);
+    }
   }
 
   log.info(`${LOG_PREFIX} Total unique source URLs found: ${allUrls.size}`);

--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -905,35 +905,18 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
   let fallbackReason;
   let semrushDiagnostics;
   // Per-run Slack override (resolveEnableSemrush) takes precedence over the env flag.
-  const semrushRequested = enableSemrushOverride
+  // This is the mechanism for testing the Semrush path live on one site/run before
+  // flipping OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED fleet-wide (see the ADR).
+  const semrushEnabled = enableSemrushOverride
     ?? (context.env?.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED === 'true');
-  const decidedBy = enableSemrushOverride !== undefined ? 'slack-override' : 'env-var';
-  // Gate 1 (LLMO-6709: the worker's service IMS token verified end-to-end against the
-  // real Semrush proxy, no token leakage into trace spans, org-scoping confirmed) must
-  // close in an environment before ANY Semrush attempt runs there — enforced here in
-  // code, not just documented in the ADR. Without this, the per-run Slack override
-  // (`enableSemrush`) could force a real, unverified request against production the
-  // moment someone with Slack access sets it — a much larger population than the
-  // deploy access that controls OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED itself.
-  const gate1Verified = context.env?.OFFSITE_SEMRUSH_GATE1_VERIFIED === 'true';
-  const semrushEnabled = semrushRequested && gate1Verified;
   // Logged unconditionally (including the off case) so a Splunk search on siteId
   // alone shows whether this run even attempted Semrush and, if so, which knob
   // decided that (Slack per-run override vs the env var) — the two can disagree.
   log.info(`${LOG_PREFIX} Semrush source ${semrushEnabled ? 'enabled' : 'disabled'} for this run`, {
-    siteId, semrushRequested, gate1Verified, semrushEnabled, decidedBy,
+    siteId,
+    semrushEnabled,
+    decidedBy: enableSemrushOverride !== undefined ? 'slack-override' : 'env-var',
   });
-  if (semrushRequested && !gate1Verified) {
-    log.warn(`${LOG_PREFIX} Semrush requested (${decidedBy}) but gate 1 (LLMO-6709) is not marked verified via OFFSITE_SEMRUSH_GATE1_VERIFIED in this environment — using the legacy source`, {
-      siteId, decidedBy,
-    });
-    await postMessageOptional(
-      context,
-      channelId,
-      `*offsite-brand-presence* for *${baseURL}* — :no_entry: Semrush was requested (${decidedBy}) but is gated off in this environment until LLMO-6709 (auth verification) closes. Using the legacy source.`,
-      { threadTs },
-    );
-  }
   if (semrushEnabled) {
     // Semrush-first: the loader returns the same allUrls shape, with
     // count = exact citations. Everything downstream (selectTopUrls -> DRS)

--- a/src/reddit-analysis/handler.js
+++ b/src/reddit-analysis/handler.js
@@ -23,6 +23,7 @@ import {
   resolveMystiqueUrlLimit,
   resolveForwardedUrlLimit,
   resolveEnableBrandProfile,
+  resolveEnableSemrush,
   requestOffsiteScrape,
   buildAnalysisScrapeStatusMessage,
   formatDrsExtras,
@@ -133,7 +134,7 @@ async function fetchStoreData(siteId, context, site) {
  * @param {Object} context - The audit context
  * @param {Object} site - The site being audited
  * @param {Object} [auditContext] - SQS audit context; optional `messageData` from `message.data`
- *   (e.g. urlLimit, enableBrandProfile from Slack)
+ *   (e.g. urlLimit, enableBrandProfile, enableSemrush from Slack)
  * @returns {Promise<Object>} Audit result
  */
 async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
@@ -149,6 +150,7 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
 
   const enableBrandProfile = resolveEnableBrandProfile(auditContext, log, LOG_PREFIX);
   const forwardedUrlLimit = resolveForwardedUrlLimit(auditContext, log, LOG_PREFIX);
+  const enableSemrush = resolveEnableSemrush(auditContext, log, LOG_PREFIX);
 
   try {
     const redditConfig = getRedditConfig(site);
@@ -251,6 +253,7 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
         slackContext,
         enableBrandProfile,
         forwardedUrlLimit,
+        enableSemrush,
       );
       return {
         auditResult: { success: false, status: 'pending_scrape', error: error.message },
@@ -290,6 +293,7 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
         slackContext,
         enableBrandProfile,
         forwardedUrlLimit,
+        enableSemrush,
       );
       return {
         auditResult: { success: false, status: 'pending_scrape', error: error.message },

--- a/src/utils/offsite-audit-utils.js
+++ b/src/utils/offsite-audit-utils.js
@@ -593,6 +593,7 @@ export function resolveEnableSemrush(auditContext, log, logPrefix) {
   }
   log?.warn(
     `${prefix} Invalid enableSemrush in auditContext (${JSON.stringify(raw).slice(0, 100)}), omitting`,
+    { raw },
   );
   return undefined;
 }
@@ -651,6 +652,13 @@ export async function requestOffsiteScrape(
   enableSemrush,
 ) {
   const { sqs, dataAccess, log } = context;
+  // enableSemrush is included so a Splunk search on siteId shows whether a per-run
+  // Semrush override survives this scrape round-trip, or gets lost/swallowed here.
+  const overrides = {
+    ...(enableBrandProfile != null && { enableBrandProfile }),
+    ...(urlLimit != null && { urlLimit }),
+    ...(enableSemrush != null && { enableSemrush }),
+  };
   try {
     const configuration = await dataAccess.Configuration.findLatest();
     await sqs.sendMessage(configuration.getQueues().audits, {
@@ -658,16 +666,13 @@ export async function requestOffsiteScrape(
       siteId,
       auditContext: {
         ...(slackContext && { slackContext }),
-        messageData: {
-          domainScope,
-          ...(enableBrandProfile != null && { enableBrandProfile }),
-          ...(urlLimit != null && { urlLimit }),
-          ...(enableSemrush != null && { enableSemrush }),
-        },
+        messageData: { domainScope, ...overrides },
       },
     });
-    log?.info(`Requested DRS scrape for '${domainScope}' (site ${siteId})`);
+    log?.info(`Requested DRS scrape for '${domainScope}' (site ${siteId})`, { siteId, domainScope, ...overrides });
   } catch (error) {
-    log?.warn(`Failed to request DRS scrape for '${domainScope}' (site ${siteId}): ${error.message}`);
+    log?.warn(`Failed to request DRS scrape for '${domainScope}' (site ${siteId}): ${error.message}`, {
+      siteId, domainScope, error: error.message, ...overrides,
+    });
   }
 }

--- a/src/utils/offsite-audit-utils.js
+++ b/src/utils/offsite-audit-utils.js
@@ -524,16 +524,47 @@ export function resolveMystiqueUrlLimit(auditContext, log, logPrefix) {
 }
 
 /**
- * Optional `enableBrandProfile` flag from `auditContext.messageData.enableBrandProfile`
- * (RunnerAudit), same Slack-originated mechanism as {@link resolveMystiqueUrlLimit}.
- * Runners merge the resolved value into `auditResult.config.enableBrandProfile` for
- * post-processors, which forward it to Mystique on `data.enableBrandProfile`.
+ * Builds a tri-state resolver for a single boolean flag delivered via
+ * `auditContext.messageData[fieldName]` from a Slack custom arg — the shared shape
+ * behind {@link resolveEnableBrandProfile} and {@link resolveEnableSemrush} (and any
+ * future per-run override), so a third copy-paste doesn't drift from the first two.
  *
- * Tri-state by design: an explicit `true`/`false` overrides Mystique's own default
- * logic for this flag, while `undefined` (absent, empty, or invalid input) means the
- * flag is omitted entirely from the outgoing message so Mystique's default applies.
- * Slack delivers keyword values as strings, so only the strings 'true'/'false' or real
- * booleans are accepted as explicit values; anything else resolves to `undefined`.
+ * Tri-state by design: an explicit `true`/`false` (or the strings `'true'`/`'false'`)
+ * overrides the caller's own default for this run only; `undefined` (absent, empty, or
+ * invalid input) means the caller's default applies unchanged. Slack delivers keyword
+ * values as strings, so only those two string forms or real booleans are accepted as
+ * explicit values; anything else is invalid and resolves to `undefined` with a warning.
+ *
+ * @param {string} fieldName - Key read from `auditContext.messageData`.
+ * @returns {function(object, object, string): boolean|undefined}
+ */
+function makeResolveOverride(fieldName) {
+  return function resolveOverride(auditContext, log, logPrefix) {
+    const prefix = logPrefix ?? '';
+    const ctx = auditContext ?? {};
+    const raw = ctx.messageData?.[fieldName];
+    if (raw === true || raw === 'true') {
+      return true;
+    }
+    if (raw === false || raw === 'false') {
+      return false;
+    }
+    if (raw === undefined || raw === null || raw === '') {
+      return undefined;
+    }
+    log?.warn(
+      `${prefix} Invalid ${fieldName} in auditContext (${JSON.stringify(raw).slice(0, 100)}), omitting`,
+      { raw },
+    );
+    return undefined;
+  };
+}
+
+/**
+ * Optional `enableBrandProfile` flag from `auditContext.messageData.enableBrandProfile`
+ * (RunnerAudit). Runners merge the resolved value into `auditResult.config.enableBrandProfile`
+ * for post-processors, which forward it to Mystique on `data.enableBrandProfile`; `undefined`
+ * omits the flag entirely from the outgoing message so Mystique's own default applies.
  *
  * @param {object} [auditContext]
  * @param {boolean|string} [auditContext.messageData.enableBrandProfile]
@@ -541,36 +572,14 @@ export function resolveMystiqueUrlLimit(auditContext, log, logPrefix) {
  * @param {string} [logPrefix]
  * @returns {boolean|undefined}
  */
-export function resolveEnableBrandProfile(auditContext, log, logPrefix) {
-  const prefix = logPrefix ?? '';
-  const ctx = auditContext ?? {};
-  const raw = ctx.messageData?.enableBrandProfile;
-  if (raw === true || raw === 'true') {
-    return true;
-  }
-  if (raw === false || raw === 'false') {
-    return false;
-  }
-  if (raw === undefined || raw === null || raw === '') {
-    return undefined;
-  }
-  log?.warn(
-    `${prefix} Invalid enableBrandProfile in auditContext (${JSON.stringify(raw).slice(0, 100)}), omitting`,
-  );
-  return undefined;
-}
+export const resolveEnableBrandProfile = makeResolveOverride('enableBrandProfile');
 
 /**
- * Optional `enableSemrush` flag from `auditContext.messageData.enableSemrush`, same
- * Slack-originated mechanism as {@link resolveEnableBrandProfile}. Lets a Slack-triggered
- * run override the global `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED` env var for that single
- * run — e.g. to test the Semrush URL-Inspector source ahead of a fleet-wide env var flip, or
- * to force the legacy source for one run while the env var is on.
- *
- * Tri-state by design: an explicit `true`/`false` overrides the env var for this run only,
- * while `undefined` (absent, empty, or invalid input) means the env var's value applies
- * unchanged. Slack delivers keyword values as strings, so only the strings 'true'/'false' or
- * real booleans are accepted as explicit values; anything else resolves to `undefined`.
+ * Optional `enableSemrush` flag from `auditContext.messageData.enableSemrush`. Lets a
+ * Slack-triggered run override the global `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED` env
+ * var for that single run — e.g. to test the Semrush URL-Inspector source ahead of a
+ * fleet-wide env var flip, or to force the legacy source for one run while the env var is
+ * on. `undefined` means the env var's value applies unchanged.
  *
  * @param {object} [auditContext]
  * @param {boolean|string} [auditContext.messageData.enableSemrush]
@@ -578,25 +587,7 @@ export function resolveEnableBrandProfile(auditContext, log, logPrefix) {
  * @param {string} [logPrefix]
  * @returns {boolean|undefined}
  */
-export function resolveEnableSemrush(auditContext, log, logPrefix) {
-  const prefix = logPrefix ?? '';
-  const ctx = auditContext ?? {};
-  const raw = ctx.messageData?.enableSemrush;
-  if (raw === true || raw === 'true') {
-    return true;
-  }
-  if (raw === false || raw === 'false') {
-    return false;
-  }
-  if (raw === undefined || raw === null || raw === '') {
-    return undefined;
-  }
-  log?.warn(
-    `${prefix} Invalid enableSemrush in auditContext (${JSON.stringify(raw).slice(0, 100)}), omitting`,
-    { raw },
-  );
-  return undefined;
-}
+export const resolveEnableSemrush = makeResolveOverride('enableSemrush');
 
 /**
  * Same validation/cap as {@link resolveMystiqueUrlLimit}, but returns `undefined` when

--- a/src/utils/offsite-audit-utils.js
+++ b/src/utils/offsite-audit-utils.js
@@ -561,6 +561,43 @@ export function resolveEnableBrandProfile(auditContext, log, logPrefix) {
 }
 
 /**
+ * Optional `enableSemrush` flag from `auditContext.messageData.enableSemrush`, same
+ * Slack-originated mechanism as {@link resolveEnableBrandProfile}. Lets a Slack-triggered
+ * run override the global `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED` env var for that single
+ * run — e.g. to test the Semrush URL-Inspector source ahead of a fleet-wide env var flip, or
+ * to force the legacy source for one run while the env var is on.
+ *
+ * Tri-state by design: an explicit `true`/`false` overrides the env var for this run only,
+ * while `undefined` (absent, empty, or invalid input) means the env var's value applies
+ * unchanged. Slack delivers keyword values as strings, so only the strings 'true'/'false' or
+ * real booleans are accepted as explicit values; anything else resolves to `undefined`.
+ *
+ * @param {object} [auditContext]
+ * @param {boolean|string} [auditContext.messageData.enableSemrush]
+ * @param {object} [log]
+ * @param {string} [logPrefix]
+ * @returns {boolean|undefined}
+ */
+export function resolveEnableSemrush(auditContext, log, logPrefix) {
+  const prefix = logPrefix ?? '';
+  const ctx = auditContext ?? {};
+  const raw = ctx.messageData?.enableSemrush;
+  if (raw === true || raw === 'true') {
+    return true;
+  }
+  if (raw === false || raw === 'false') {
+    return false;
+  }
+  if (raw === undefined || raw === null || raw === '') {
+    return undefined;
+  }
+  log?.warn(
+    `${prefix} Invalid enableSemrush in auditContext (${JSON.stringify(raw).slice(0, 100)}), omitting`,
+  );
+  return undefined;
+}
+
+/**
  * Same validation/cap as {@link resolveMystiqueUrlLimit}, but returns `undefined` when
  * `urlLimit` is absent instead of defaulting to `MYSTIQUE_URLS_LIMIT`. Used by
  * offsite-brand-presence to forward an explicitly-requested urlLimit through the DRS
@@ -596,6 +633,9 @@ export function resolveForwardedUrlLimit(auditContext, log, logPrefix) {
  *   originally requested on Slack, instead of losing it across the scrape round-trip.
  * @param {number} [urlLimit] - Forwarded so the re-triggered analysis audit still resolves the
  *   urlLimit originally requested on Slack, instead of losing it across the scrape round-trip.
+ * @param {boolean} [enableSemrush] - Forwarded so this scoped offsite-brand-presence run honors
+ *   the same `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED` override originally requested on Slack for
+ *   the analysis audit that triggered it, instead of falling back to the plain env var.
  *
  * Best-effort: a transient Configuration/SQS failure is logged and swallowed rather than
  * thrown, so the analysis audit degrades to its pending_scrape result instead of failing
@@ -608,6 +648,7 @@ export async function requestOffsiteScrape(
   slackContext,
   enableBrandProfile,
   urlLimit,
+  enableSemrush,
 ) {
   const { sqs, dataAccess, log } = context;
   try {
@@ -621,6 +662,7 @@ export async function requestOffsiteScrape(
           domainScope,
           ...(enableBrandProfile != null && { enableBrandProfile }),
           ...(urlLimit != null && { urlLimit }),
+          ...(enableSemrush != null && { enableSemrush }),
         },
       },
     });

--- a/src/utils/offsite-brand-presence-enrichment.js
+++ b/src/utils/offsite-brand-presence-enrichment.js
@@ -246,7 +246,7 @@ function normalizeUrl(parsed, domain) {
  *   matching this hostname or any subdomain of it are excluded
  * @returns {{ url: string, domain: string|null } | null} Normalized URL with domain, or null
  */
-function classifyAndNormalize(rawUrl, siteHostname) {
+export function classifyAndNormalize(rawUrl, siteHostname) {
   let parsed;
   try {
     parsed = new URL(rawUrl);

--- a/src/utils/offsite-brand-presence-semrush.js
+++ b/src/utils/offsite-brand-presence-semrush.js
@@ -11,13 +11,15 @@
  */
 
 import { ImsClient } from '@adobe/spacecat-shared-ims-client';
-import { resolveBrandForSite } from './brand-resolver.js';
+import { tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
+import { resolveBrandResultForSite } from './brand-resolver.js';
 import { getDateWindowForPreviousWeeks } from './offsite-brand-presence-postgrest.js';
 import { classifyAndNormalize } from './offsite-brand-presence-enrichment.js';
 import {
   OFFSITE_DOMAINS,
   YOUTUBE_URL_REGEX,
   REDDIT_URL_REGEX,
+  SEMRUSH_PLATFORM_BY_PROVIDER,
 } from '../offsite-brand-presence/constants.js';
 
 const LOG_PREFIX = '[offsite-brand-presence][semrush]';
@@ -27,43 +29,56 @@ const LOG_PREFIX = '[offsite-brand-presence][semrush]';
  * (`src/controllers/elements.js`) serves the Semrush-backed Serenity
  * URL-Inspector endpoints at
  * `/v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/*`.
- * Overridable per-environment with `SPACECAT_API_URI` (the standard worker
- * override, e.g. used by paid-cookie-consent).
+ * Overridable per-environment with `SPACECAT_API_URI`.
  */
 export const SPACECAT_API_DEFAULT_BASE_URL = 'https://spacecat.experiencecloud.live/api/v1';
 
 /**
- * Page size requested from the url-inspector endpoints. 100 comfortably covers
- * the per-surface top-70 (`DRS_URLS_LIMIT`) that `selectTopUrls` keeps, in a
- * single page (the proxy paginates client-side).
+ * Rows requested per url-inspector page — covers the per-surface top-70
+ * (`DRS_URLS_LIMIT`) in a single page. NOTE: a server-side citations-descending
+ * sort is *assumed but not confirmed* for `domain-urls`; `fetchRows` logs a
+ * truncation warning when a full page comes back so a capped/unsorted response
+ * is visible in logs rather than silently dropping high-citation URLs.
  */
 const PAGE_SIZE = 100;
 
 /**
- * Resolves which AI-engine platform values to query.
+ * Per-request timeout. A hung upstream must never stall the audit, or the whole
+ * Semrush attempt (and therefore the legacy fallback in the handler) would never
+ * resolve and the Lambda would run to its own timeout — worse than legacy-only.
+ */
+const FETCH_TIMEOUT_MS = 10_000;
+
+/**
+ * Default engine (serenity `platform`) values to query — the full offsite
+ * provider set mapped to serenity models (`SEMRUSH_PLATFORM_BY_PROVIDER`).
  *
- * Default: a single call with NO `platform` param, so the gateway aggregates
- * citations across every engine it has (mirroring the legacy all-providers
- * behaviour). Set `OFFSITE_SEMRUSH_PLATFORMS` (comma-separated, e.g.
- * `"search-gpt,google-ai-mode"`) to query each engine explicitly and sum the
- * citations per URL — use this if the gateway does not aggregate on an absent
- * `platform`. See LLMO-6710.
+ * IMPORTANT: omitting `platform` does NOT aggregate across engines on the
+ * `domain-urls` / `cited-domains` endpoints — the proxy resolves an absent value
+ * to a single default engine. To mirror the legacy multi-engine mix we query each
+ * engine explicitly and SUM citations per URL.
+ */
+export const DEFAULT_SEMRUSH_PLATFORMS = Object.freeze(
+  Object.values(SEMRUSH_PLATFORM_BY_PROVIDER),
+);
+
+/**
+ * Resolves which engine platform values to query. `OFFSITE_SEMRUSH_PLATFORMS`
+ * (comma-separated) overrides the default list.
  *
  * @param {object} env - Lambda env.
- * @returns {Array<string|undefined>} platform values (`[undefined]` = omit param).
+ * @returns {string[]} platform values (always at least one).
  */
 export function getSemrushPlatforms(env) {
   const raw = env?.OFFSITE_SEMRUSH_PLATFORMS;
   if (typeof raw === 'string' && raw.trim()) {
     return raw.split(',').map((p) => p.trim()).filter(Boolean);
   }
-  return [undefined];
+  return [...DEFAULT_SEMRUSH_PLATFORMS];
 }
 
 /**
- * Mints an IMS service access token and returns it as an Authorization header value.
- * Reuses the standard IMS_* env the worker already configures for other
- * service-to-service calls.
+ * Mints an IMS service access token as an Authorization header value.
  *
  * @param {object} context - Lambda context (env + log).
  * @returns {Promise<string>} e.g. "Bearer eyJ...".
@@ -75,8 +90,9 @@ async function getAuthorizationHeader(context) {
 }
 
 /**
- * Builds a url-inspector `domain-urls` request URL for one hostname (and optional
- * platform).
+ * Builds a url-inspector `domain-urls` request URL. Path segments are
+ * URL-encoded (matching `brand-resolver.js`), and `platform` is included only
+ * when provided.
  *
  * @returns {string}
  */
@@ -92,33 +108,30 @@ export function buildDomainUrlsUrl({
   if (platform) {
     params.set('platform', platform);
   }
-  return `${baseUrl}/v2/orgs/${spaceCatId}/brands/${brandId}`
+  return `${baseUrl}/v2/orgs/${encodeURIComponent(spaceCatId)}/brands/${encodeURIComponent(brandId)}`
     + `/serenity/brand-presence/url-inspector/domain-urls?${params.toString()}`;
 }
 
 /**
- * Fetches the cited URLs for a single (hostname, platform) request and folds them
- * into `allUrls`. `count` is the exact Semrush citation number (never recounted by
- * repetition) and is SUMMED across platforms; `url` + `domain` come from the shared
- * `classifyAndNormalize` so normalisation, owned-URL filtering and domain bucketing
- * match the legacy path exactly.
+ * Fetches one (hostname, platform) page.
  *
- * @returns {Promise<void>}
+ * @returns {Promise<{ hostname: string, rows: object[], ok: boolean }>} `ok` is
+ *   false on network error / timeout / non-2xx / unparseable body. The caller
+ *   treats ANY failed request as reason to discard the whole Semrush attempt and
+ *   fall back to legacy, so a partial result can never masquerade as success.
  */
-async function collectRequest({
-  hostname, url, headers, allUrls, siteHostname, log,
-}) {
+async function fetchRows({ hostname, url }, headers, log) {
   let response;
   try {
-    response = await fetch(url, { headers });
+    response = await fetch(url, { headers, timeout: FETCH_TIMEOUT_MS });
   } catch (error) {
     log.error(`${LOG_PREFIX} Fetch failed for ${hostname}: ${error.message}`);
-    return;
+    return { hostname, rows: [], ok: false };
   }
 
   if (!response.ok) {
     log.error(`${LOG_PREFIX} ${hostname} returned HTTP ${response.status}`);
-    return;
+    return { hostname, rows: [], ok: false };
   }
 
   let body;
@@ -126,56 +139,29 @@ async function collectRequest({
     body = await response.json();
   } catch (error) {
     log.error(`${LOG_PREFIX} Could not parse ${hostname} response: ${error.message}`);
-    return;
+    return { hostname, rows: [], ok: false };
   }
 
   const rows = Array.isArray(body?.urls) ? body.urls : [];
-  let added = 0;
-  for (const row of rows) {
-    const classified = row?.url ? classifyAndNormalize(row.url, siteHostname) : null;
-    if (!classified) {
-      // eslint-disable-next-line no-continue
-      continue;
-    }
-    // Parity with the legacy handler path (handler.js:199-204): drop URLs that
-    // fail the strict offsite formats so the Semrush path never feeds DRS a
-    // non-thread Reddit URL (e.g. /settings, subreddit landing) or a
-    // lookalike YouTube host (e.g. music.youtube.com) that the legacy path
-    // filters. (isExcludedCitedHost / brand-token filtering only affects the
-    // top-cited bucket, which this loader does not fetch yet — LLMO-6709.)
-    if (classified.domain === 'youtube.com' && !YOUTUBE_URL_REGEX.test(row.url)) {
-      // eslint-disable-next-line no-continue
-      continue;
-    }
-    if (classified.domain === 'reddit.com' && !REDDIT_URL_REGEX.test(row.url)) {
-      // eslint-disable-next-line no-continue
-      continue;
-    }
-    const citations = Number(row.citations) || 0;
-    const existing = allUrls.get(classified.url);
-    if (existing) {
-      // Same URL seen under another platform — sum the citations so ranking
-      // reflects total cross-engine citation volume.
-      existing.count += citations;
-    } else {
-      allUrls.set(classified.url, { count: citations, domain: classified.domain });
-    }
-    added += 1;
+  if (rows.length >= PAGE_SIZE) {
+    log.warn(`${LOG_PREFIX} ${hostname} returned a full page (${rows.length} >= ${PAGE_SIZE}); response may be truncated — top URLs by citations could be missing`);
   }
-  log.info(`${LOG_PREFIX} ${hostname}: ${added} cited URLs`);
+  return { hostname, rows, ok: true };
 }
 
 /**
- * Loads the offsite cited URLs from the live Semrush-backed Serenity URL-Inspector
- * endpoints, producing the exact `allUrls: Map<url, { count, domain }>` shape that
- * the existing `selectTopUrls` -> DRS pipeline consumes. Ranking is preserved
- * (`count` = citation volume), so `selectTopUrls` still takes the top
- * `DRS_URLS_LIMIT` per surface, unchanged.
+ * Loads the offsite cited URLs from the Semrush-backed Serenity URL-Inspector
+ * endpoints (via the spacecat-api-service Elements proxy), producing the exact
+ * `allUrls: Map<url, { count, domain }>` shape the existing `selectTopUrls` -> DRS
+ * pipeline consumes. `count` = exact citation volume (summed across engines).
  *
- * Scope: `youtube.com` + `reddit.com` (fixed hostnames — one `domain-urls` call
- * each, per platform). The generic "cited" bucket needs a `cited-domains`
- * discovery hop and is a follow-up (LLMO-6709). Gated by the caller behind
- * `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED`.
+ * Returns `null` whenever a usable result cannot be produced — no org/brand,
+ * transient brand-resolution failure, no date window, auth failure, or ANY
+ * upstream request failure — so the handler falls back to the legacy source
+ * rather than shipping a partial result.
+ *
+ * Scope: youtube.com + reddit.com. Region scoping and the generic cited bucket
+ * are follow-ups (LLMO-6709 / LLMO-6710).
  *
  * @param {object} params
  * @param {object} params.site - Site model (`getOrganizationId()`).
@@ -183,8 +169,6 @@ async function collectRequest({
  * @param {object} params.context - Lambda context (env, log, dataAccess).
  * @param {string} [params.siteHostname] - www-stripped site hostname for owned-URL filtering.
  * @returns {Promise<Map<string, {count:number, domain:string|null}> | null>}
- *   The URL map, or `null` when the source cannot be queried (caller falls back
- *   to an empty run).
  */
 export async function loadCitedUrlsFromSemrush({
   site, previousWeeks, context, siteHostname,
@@ -198,9 +182,15 @@ export async function loadCitedUrlsFromSemrush({
     return null;
   }
 
-  const brand = await resolveBrandForSite(context, site);
+  // Distinguish "confirmed no brand" from "resolution failed" (transient), so a
+  // PostgREST blip doesn't read like a permanently-unconfigured brand in logs.
+  const { brand, resolved } = await resolveBrandResultForSite(context, site);
   if (!brand?.brandId) {
-    log.warn(`${LOG_PREFIX} No active brand for org ${spaceCatId}; skipping Semrush source`);
+    if (resolved) {
+      log.info(`${LOG_PREFIX} No active brand for org ${spaceCatId}; skipping Semrush source`);
+    } else {
+      log.warn(`${LOG_PREFIX} Brand resolution failed (transient) for org ${spaceCatId}; using legacy fallback`);
+    }
     return null;
   }
 
@@ -223,24 +213,60 @@ export async function loadCitedUrlsFromSemrush({
     Authorization: authorization,
     'Content-Type': 'application/json',
     // The api-service Elements proxy authenticates IMS callers directly and
-    // forwards this Bearer token to Semrush (resolveElementsImsToken's fallback
-    // path), so a promise token is NOT required for a service caller. Forward
-    // one only if the platform later threads it onto the context (non-IMS callers).
+    // forwards this Bearer to Semrush (resolveElementsImsToken fallback), so a
+    // promise token is not required for a service caller. Forward one only if
+    // the platform later threads it onto the context (non-IMS callers).
     ...(context.promiseToken ? { 'x-promise-token': context.promiseToken } : {}),
   };
 
   const platforms = getSemrushPlatforms(env);
-  const allUrls = new Map();
-
+  const requests = [];
   for (const hostname of Object.keys(OFFSITE_DOMAINS)) {
     for (const platform of platforms) {
-      const requestUrl = buildDomainUrlsUrl({
-        baseUrl, spaceCatId, brandId: brand.brandId, hostname, startDate, endDate, platform,
+      requests.push({
+        hostname,
+        url: buildDomainUrlsUrl({
+          baseUrl, spaceCatId, brandId: brand.brandId, hostname, startDate, endDate, platform,
+        }),
       });
-      // eslint-disable-next-line no-await-in-loop
-      await collectRequest({
-        hostname, url: requestUrl, headers, allUrls, siteHostname, log,
-      });
+    }
+  }
+
+  // Concurrent (each with its own timeout). ANY failure -> null, so the handler
+  // falls back to the FULL legacy source instead of shipping a partial Semrush
+  // result (e.g. youtube-only when the reddit request failed).
+  const results = await Promise.all(requests.map((r) => fetchRows(r, headers, log)));
+  if (results.some((r) => !r.ok)) {
+    log.warn(`${LOG_PREFIX} One or more Semrush requests failed; using legacy fallback`);
+    return null;
+  }
+
+  const allUrls = new Map();
+  for (const { rows } of results) {
+    for (const row of rows) {
+      const classified = row?.url ? classifyAndNormalize(row.url, siteHostname) : null;
+      if (!classified) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      // Parity with the legacy handler path (handler.js:199-204): drop URLs that
+      // fail the strict offsite formats (non-thread Reddit, lookalike YouTube host).
+      if (classified.domain === 'youtube.com' && !YOUTUBE_URL_REGEX.test(row.url)) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      if (classified.domain === 'reddit.com' && !REDDIT_URL_REGEX.test(row.url)) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      const citations = Number(row.citations) || 0;
+      const existing = allUrls.get(classified.url);
+      if (existing) {
+        // Same URL under another engine — sum so ranking reflects total volume.
+        existing.count += citations;
+      } else {
+        allUrls.set(classified.url, { count: citations, domain: classified.domain });
+      }
     }
   }
 

--- a/src/utils/offsite-brand-presence-semrush.js
+++ b/src/utils/offsite-brand-presence-semrush.js
@@ -37,8 +37,8 @@ export const SPACECAT_API_DEFAULT_BASE_URL = 'https://spacecat.experiencecloud.l
  * Rows requested per url-inspector page — covers the per-surface top-70
  * (`DRS_URLS_LIMIT`) in a single page. NOTE: a server-side citations-descending
  * sort is *assumed but not confirmed* for `domain-urls`; `fetchRows` logs a
- * truncation warning when a full page comes back so a capped/unsorted response
- * is visible in logs rather than silently dropping high-citation URLs.
+ * truncation warning when a full page comes back and hard-caps the array at
+ * `PAGE_SIZE` as defence against a malfunctioning upstream.
  */
 const PAGE_SIZE = 100;
 
@@ -46,6 +46,8 @@ const PAGE_SIZE = 100;
  * Per-request timeout. A hung upstream must never stall the audit, or the whole
  * Semrush attempt (and therefore the legacy fallback in the handler) would never
  * resolve and the Lambda would run to its own timeout — worse than legacy-only.
+ * (Unit tests stub the fetch; actual abort behaviour is a shadow-run integration
+ * concern, not covered here.)
  */
 const FETCH_TIMEOUT_MS = 10_000;
 
@@ -64,7 +66,8 @@ export const DEFAULT_SEMRUSH_PLATFORMS = Object.freeze(
 
 /**
  * Resolves which engine platform values to query. `OFFSITE_SEMRUSH_PLATFORMS`
- * (comma-separated) overrides the default list.
+ * (comma-separated) overrides the default list; a blank / separators-only value
+ * falls back to the default rather than disabling all requests.
  *
  * @param {object} env - Lambda env.
  * @returns {string[]} platform values (always at least one).
@@ -72,27 +75,36 @@ export const DEFAULT_SEMRUSH_PLATFORMS = Object.freeze(
 export function getSemrushPlatforms(env) {
   const raw = env?.OFFSITE_SEMRUSH_PLATFORMS;
   if (typeof raw === 'string' && raw.trim()) {
-    return raw.split(',').map((p) => p.trim()).filter(Boolean);
+    const parsed = raw.split(',').map((p) => p.trim()).filter(Boolean);
+    if (parsed.length > 0) {
+      return parsed;
+    }
   }
   return [...DEFAULT_SEMRUSH_PLATFORMS];
 }
 
 /**
- * Mints an IMS service access token as an Authorization header value.
+ * Mints an IMS service access token as an Authorization header value. The scheme
+ * is normalised to `Bearer` (the token endpoint may return `token_type: "bearer"`
+ * lowercase, which a strict `startsWith('Bearer ')` parser upstream would reject).
  *
  * @param {object} context - Lambda context (env + log).
  * @returns {Promise<string>} e.g. "Bearer eyJ...".
+ * @throws {Error} when the token response has no access_token.
  */
 async function getAuthorizationHeader(context) {
   const imsClient = ImsClient.createFrom(context);
   const token = await imsClient.getServiceAccessTokenV3();
-  return `${token.token_type} ${token.access_token}`;
+  if (!token?.access_token) {
+    throw new Error('IMS service token response missing access_token');
+  }
+  return `Bearer ${token.access_token}`;
 }
 
 /**
  * Builds a url-inspector `domain-urls` request URL. Path segments are
- * URL-encoded (matching `brand-resolver.js`), and `platform` is included only
- * when provided.
+ * URL-encoded (matching `brand-resolver.js`); `platform` is included only when
+ * provided.
  *
  * @returns {string}
  */
@@ -116,9 +128,8 @@ export function buildDomainUrlsUrl({
  * Fetches one (hostname, platform) page.
  *
  * @returns {Promise<{ hostname: string, rows: object[], ok: boolean }>} `ok` is
- *   false on network error / timeout / non-2xx / unparseable body. The caller
- *   treats ANY failed request as reason to discard the whole Semrush attempt and
- *   fall back to legacy, so a partial result can never masquerade as success.
+ *   false on network error / timeout / non-2xx / unparseable body. The array is
+ *   hard-capped at `PAGE_SIZE`.
  */
 async function fetchRows({ hostname, url }, headers, log) {
   let response;
@@ -130,7 +141,13 @@ async function fetchRows({ hostname, url }, headers, log) {
   }
 
   if (!response.ok) {
-    log.error(`${LOG_PREFIX} ${hostname} returned HTTP ${response.status}`);
+    if (response.status === 401 || response.status === 403) {
+      // Distinct branch so a rejected service token is visible instead of being
+      // masked as "Semrush returned nothing" (LLMO-6709 verification).
+      log.error(`${LOG_PREFIX} Service token rejected for ${hostname} (HTTP ${response.status}) — verify the IMS service token is authorized by the Semrush proxy (LLMO-6709)`);
+    } else {
+      log.error(`${LOG_PREFIX} ${hostname} returned HTTP ${response.status}`);
+    }
     return { hostname, rows: [], ok: false };
   }
 
@@ -142,11 +159,11 @@ async function fetchRows({ hostname, url }, headers, log) {
     return { hostname, rows: [], ok: false };
   }
 
-  const rows = Array.isArray(body?.urls) ? body.urls : [];
-  if (rows.length >= PAGE_SIZE) {
-    log.warn(`${LOG_PREFIX} ${hostname} returned a full page (${rows.length} >= ${PAGE_SIZE}); response may be truncated — top URLs by citations could be missing`);
+  const raw = Array.isArray(body?.urls) ? body.urls : [];
+  if (raw.length >= PAGE_SIZE) {
+    log.warn(`${LOG_PREFIX} ${hostname} returned a full page (${raw.length} >= ${PAGE_SIZE}); response may be truncated — top URLs by citations could be missing`);
   }
-  return { hostname, rows, ok: true };
+  return { hostname, rows: raw.slice(0, PAGE_SIZE), ok: true };
 }
 
 /**
@@ -155,12 +172,13 @@ async function fetchRows({ hostname, url }, headers, log) {
  * `allUrls: Map<url, { count, domain }>` shape the existing `selectTopUrls` -> DRS
  * pipeline consumes. `count` = exact citation volume (summed across engines).
  *
- * Returns `null` whenever a usable result cannot be produced — no org/brand,
- * transient brand-resolution failure, no date window, auth failure, or ANY
- * upstream request failure — so the handler falls back to the legacy source
- * rather than shipping a partial result.
+ * Returns `null` (so the handler falls back to the legacy source) when a usable
+ * result cannot be produced: no org/brand, transient brand-resolution failure,
+ * no date window, auth failure, or when a whole surface (hostname) produced zero
+ * successful responses. A single failed engine is tolerated as a partial count.
  *
- * Scope: youtube.com + reddit.com. Region scoping and the generic cited bucket
+ * Scope: youtube.com + reddit.com only — off-host rows are dropped so nothing
+ * leaks into the top-cited bucket. Region scoping and the generic cited bucket
  * are follow-ups (LLMO-6709 / LLMO-6710).
  *
  * @param {object} params
@@ -211,7 +229,9 @@ export async function loadCitedUrlsFromSemrush({
 
   const headers = {
     Authorization: authorization,
-    'Content-Type': 'application/json',
+    // GET has no body — advertise the desired representation with Accept rather
+    // than Content-Type (some proxies buffer/reject a Content-Type on a bodyless GET).
+    Accept: 'application/json',
     // The api-service Elements proxy authenticates IMS callers directly and
     // forwards this Bearer to Semrush (resolveElementsImsToken fallback), so a
     // promise token is not required for a service caller. Forward one only if
@@ -232,25 +252,47 @@ export async function loadCitedUrlsFromSemrush({
     }
   }
 
-  // Concurrent (each with its own timeout). ANY failure -> null, so the handler
-  // falls back to the FULL legacy source instead of shipping a partial Semrush
-  // result (e.g. youtube-only when the reddit request failed).
   const results = await Promise.all(requests.map((r) => fetchRows(r, headers, log)));
-  if (results.some((r) => !r.ok)) {
-    log.warn(`${LOG_PREFIX} One or more Semrush requests failed; using legacy fallback`);
-    return null;
+
+  // Group by surface (hostname). Fall back to legacy only when a whole surface
+  // produced ZERO successful responses (that surface would be dropped) — a single
+  // failed engine is a partial count, not a dropped surface, and is tolerated.
+  const byHost = new Map();
+  for (const hostname of Object.keys(OFFSITE_DOMAINS)) {
+    byHost.set(hostname, { anyOk: false, rows: [] });
+  }
+  for (const result of results) {
+    const entry = byHost.get(result.hostname);
+    if (result.ok) {
+      entry.anyOk = true;
+      entry.rows.push(...result.rows);
+    }
+  }
+  for (const [hostname, entry] of byHost) {
+    if (!entry.anyOk) {
+      log.warn(`${LOG_PREFIX} No successful Semrush response for ${hostname}; using legacy fallback`);
+      return null;
+    }
   }
 
   const allUrls = new Map();
-  for (const { rows } of results) {
-    for (const row of rows) {
+  for (const [, entry] of byHost) {
+    for (const row of entry.rows) {
       const classified = row?.url ? classifyAndNormalize(row.url, siteHostname) : null;
       if (!classified) {
         // eslint-disable-next-line no-continue
         continue;
       }
-      // Parity with the legacy handler path (handler.js:199-204): drop URLs that
-      // fail the strict offsite formats (non-thread Reddit, lookalike YouTube host).
+      // Enforce the youtube/reddit-only scope on the OUTPUT. A `domain: null`
+      // (off-host) row would otherwise pass both regex guards below and reach
+      // selectTopUrls' top-cited bucket -> live TOP_CITED scrape, bypassing the
+      // legacy isExcludedCitedHost / brand-token filtering this PR scopes out.
+      if (classified.domain !== 'youtube.com' && classified.domain !== 'reddit.com') {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      // Strict-format parity with the legacy handler path (non-thread Reddit,
+      // lookalike YouTube host).
       if (classified.domain === 'youtube.com' && !YOUTUBE_URL_REGEX.test(row.url)) {
         // eslint-disable-next-line no-continue
         continue;
@@ -259,14 +301,23 @@ export async function loadCitedUrlsFromSemrush({
         // eslint-disable-next-line no-continue
         continue;
       }
-      const citations = Number(row.citations) || 0;
+      // Clamp: a negative value would subtract when summed and corrupt the
+      // citations-descending ranking; NaN / non-numeric -> 0.
+      const citations = Math.max(0, Number(row.citations) || 0);
       const existing = allUrls.get(classified.url);
       if (existing) {
-        // Same URL under another engine — sum so ranking reflects total volume.
         existing.count += citations;
       } else {
         allUrls.set(classified.url, { count: citations, domain: classified.domain });
       }
+    }
+  }
+
+  // Drop URLs whose total citation volume is <= 0 (malformed / all-zero rows): a
+  // zero-citation URL is not a real cited source and must not be scraped.
+  for (const [url, info] of allUrls) {
+    if (info.count <= 0) {
+      allUrls.delete(url);
     }
   }
 

--- a/src/utils/offsite-brand-presence-semrush.js
+++ b/src/utils/offsite-brand-presence-semrush.js
@@ -201,10 +201,15 @@ async function fetchRows({ hostname, platform, url }, headers, log, siteId) {
  * @param {Array<{week:number, year:number}>} params.previousWeeks
  * @param {object} params.context - Lambda context (env, log, dataAccess).
  * @param {string} [params.siteHostname] - www-stripped site hostname for owned-URL filtering.
+ * @param {function(string): Promise<*>} [params.onProgress] - Optional best-effort progress
+ *   callback (e.g. a Slack thread reply), invoked with a short human-readable status string at
+ *   each stage of the attempt. Kept generic (not a Slack import) so this module stays testable
+ *   without a Slack dependency; a failure here is logged and swallowed, never thrown — a Slack
+ *   outage must not affect the Semrush attempt itself.
  * @returns {Promise<Map<string, {count:number, domain:string|null}> | null>}
  */
 export async function loadCitedUrlsFromSemrush({
-  site, previousWeeks, context, siteHostname,
+  site, previousWeeks, context, siteHostname, onProgress,
 }) {
   const { log, env } = context;
   const startedAt = Date.now();
@@ -212,13 +217,26 @@ export async function loadCitedUrlsFromSemrush({
   const elapsed = () => Date.now() - startedAt;
   const baseUrl = env?.SPACECAT_API_URI || SPACECAT_API_DEFAULT_BASE_URL;
 
+  const notify = async (text) => {
+    if (typeof onProgress !== 'function') {
+      return;
+    }
+    try {
+      await onProgress(text);
+    } catch (error) {
+      log.warn(`${LOG_PREFIX} Failed to post Semrush progress update: ${error.message}`, { siteId });
+    }
+  };
+
   log.info(`${LOG_PREFIX} Starting Semrush source attempt`, { siteId, baseUrl });
+  await notify(':mag: Starting Semrush URL-Inspector lookup...');
 
   const spaceCatId = site?.getOrganizationId?.();
   if (!spaceCatId) {
     log.warn(`${LOG_PREFIX} Site has no organization id; skipping Semrush source`, {
       siteId, durationMs: elapsed(),
     });
+    await notify(':warning: Site has no organization id — falling back to the legacy source.');
     return null;
   }
 
@@ -230,10 +248,12 @@ export async function loadCitedUrlsFromSemrush({
       log.info(`${LOG_PREFIX} No active brand for org ${spaceCatId}; skipping Semrush source`, {
         siteId, orgId: spaceCatId, durationMs: elapsed(),
       });
+      await notify(':information_source: No active brand configured for this org — falling back to the legacy source.');
     } else {
       log.warn(`${LOG_PREFIX} Brand resolution failed (transient) for org ${spaceCatId}; using legacy fallback`, {
         siteId, orgId: spaceCatId, durationMs: elapsed(),
       });
+      await notify(':warning: Brand resolution failed (transient) — falling back to the legacy source.');
     }
     return null;
   }
@@ -243,6 +263,7 @@ export async function loadCitedUrlsFromSemrush({
     log.warn(`${LOG_PREFIX} Could not derive a date window; skipping Semrush source`, {
       siteId, orgId: spaceCatId, brandId: brand.brandId, durationMs: elapsed(),
     });
+    await notify(':warning: Could not derive a date window — falling back to the legacy source.');
     return null;
   }
   const { startDate, endDate } = dateWindow;
@@ -258,6 +279,7 @@ export async function loadCitedUrlsFromSemrush({
       error: error.message,
       durationMs: elapsed(),
     });
+    await notify(`:x: Failed to obtain an IMS service token (\`${error.message}\`) — falling back to the legacy source.`);
     return null;
   }
 
@@ -290,6 +312,7 @@ export async function loadCitedUrlsFromSemrush({
   log.info(`${LOG_PREFIX} Querying ${hostnames.length} hostnames x ${platforms.length} platforms (${requests.length} requests)`, {
     siteId, orgId: spaceCatId, brandId: brand.brandId, hostnames, platforms,
   });
+  await notify(`:satellite: Querying ${hostnames.length} surface(s) x ${platforms.length} engine(s) (${requests.length} requests)...`);
 
   const results = await Promise.all(requests.map((r) => fetchRows(r, headers, log, siteId)));
 
@@ -322,8 +345,14 @@ export async function loadCitedUrlsFromSemrush({
       log.warn(`${LOG_PREFIX} No successful Semrush response for ${hostname}; using legacy fallback`, {
         siteId, orgId: spaceCatId, hostname, platformsQueried: platforms, durationMs: elapsed(),
       });
+      // Sequential, not Promise.all: these post to a Slack thread where message
+      // order is the whole point (a readable narrative), not a perf-sensitive loop.
+      // eslint-disable-next-line no-await-in-loop
+      await notify(`:x: \`${hostname}\`: 0/${entry.okCount + entry.failCount} engine requests succeeded — falling back to the legacy source.`);
       return null;
     }
+    // eslint-disable-next-line no-await-in-loop
+    await notify(`:white_check_mark: \`${hostname}\`: ${entry.okCount}/${entry.okCount + entry.failCount} engine requests succeeded.`);
   }
 
   const allUrls = new Map();
@@ -372,6 +401,20 @@ export async function loadCitedUrlsFromSemrush({
     }
   }
 
+  // Loaded-per-surface counts, for the "loaded N results from <hostname>" progress
+  // update — distinct from the engine-success-ratio message above, since a surface can
+  // have every engine succeed yet contribute zero URLs (e.g. all filtered as off-format).
+  const loadedByHostname = new Map(hostnames.map((hostname) => [hostname, 0]));
+  for (const [, info] of allUrls) {
+    // info.domain is always youtube.com/reddit.com here — the earlier scope guard
+    // already dropped any other domain, so loadedByHostname always has this key.
+    loadedByHostname.set(info.domain, loadedByHostname.get(info.domain) + 1);
+  }
+  for (const [hostname, count] of loadedByHostname) {
+    // eslint-disable-next-line no-await-in-loop
+    await notify(`:package: Loaded ${count} URL(s) from \`${hostname}\`.`);
+  }
+
   log.info(`${LOG_PREFIX} Collected ${allUrls.size} cited URLs from Semrush`, {
     siteId,
     orgId: spaceCatId,
@@ -379,5 +422,6 @@ export async function loadCitedUrlsFromSemrush({
     urlCount: allUrls.size,
     durationMs: elapsed(),
   });
+  await notify(`:tada: Semrush source succeeded — *${allUrls.size}* total cited URL(s) in ${elapsed()}ms.`);
   return allUrls;
 }

--- a/src/utils/offsite-brand-presence-semrush.js
+++ b/src/utils/offsite-brand-presence-semrush.js
@@ -33,11 +33,11 @@ const LOG_PREFIX = '[offsite-brand-presence][semrush]';
 export const SPACECAT_API_DEFAULT_BASE_URL = 'https://spacecat.experiencecloud.live/api/v1';
 
 /**
- * Page size accepted by the url-inspector endpoints. The proxy paginates
- * client-side, so a single large page avoids a fetch loop for the bounded
- * youtube/reddit sets.
+ * Page size requested from the url-inspector endpoints. 100 comfortably covers
+ * the per-surface top-70 (`DRS_URLS_LIMIT`) that `selectTopUrls` keeps, in a
+ * single page (the proxy paginates client-side).
  */
-const PAGE_SIZE = 1000;
+const PAGE_SIZE = 100;
 
 /**
  * Resolves which AI-engine platform values to query.

--- a/src/utils/offsite-brand-presence-semrush.js
+++ b/src/utils/offsite-brand-presence-semrush.js
@@ -125,18 +125,25 @@ export function buildDomainUrlsUrl({
 }
 
 /**
- * Fetches one (hostname, platform) page.
+ * Fetches one (hostname, platform) page. Every log call carries `siteId`/`hostname`/
+ * `platform` as structured fields (in addition to the human-readable message) so a
+ * Splunk query can isolate which site/surface/engine combination failed and why,
+ * without parsing the message string.
  *
  * @returns {Promise<{ hostname: string, rows: object[], ok: boolean }>} `ok` is
  *   false on network error / timeout / non-2xx / unparseable body. The array is
  *   hard-capped at `PAGE_SIZE`.
  */
-async function fetchRows({ hostname, url }, headers, log) {
+async function fetchRows({ hostname, platform, url }, headers, log, siteId) {
+  const ctx = { siteId, hostname, platform };
   let response;
+  const startedAt = Date.now();
   try {
     response = await fetch(url, { headers, timeout: FETCH_TIMEOUT_MS });
   } catch (error) {
-    log.error(`${LOG_PREFIX} Fetch failed for ${hostname}: ${error.message}`);
+    log.error(`${LOG_PREFIX} Fetch failed for ${hostname}: ${error.message}`, {
+      ...ctx, error: error.message, durationMs: Date.now() - startedAt,
+    });
     return { hostname, rows: [], ok: false };
   }
 
@@ -144,9 +151,13 @@ async function fetchRows({ hostname, url }, headers, log) {
     if (response.status === 401 || response.status === 403) {
       // Distinct branch so a rejected service token is visible instead of being
       // masked as "Semrush returned nothing" (LLMO-6709 verification).
-      log.error(`${LOG_PREFIX} Service token rejected for ${hostname} (HTTP ${response.status}) — verify the IMS service token is authorized by the Semrush proxy (LLMO-6709)`);
+      log.error(`${LOG_PREFIX} Service token rejected for ${hostname} (HTTP ${response.status}) — verify the IMS service token is authorized by the Semrush proxy (LLMO-6709)`, {
+        ...ctx, status: response.status, durationMs: Date.now() - startedAt,
+      });
     } else {
-      log.error(`${LOG_PREFIX} ${hostname} returned HTTP ${response.status}`);
+      log.error(`${LOG_PREFIX} ${hostname} returned HTTP ${response.status}`, {
+        ...ctx, status: response.status, durationMs: Date.now() - startedAt,
+      });
     }
     return { hostname, rows: [], ok: false };
   }
@@ -155,13 +166,17 @@ async function fetchRows({ hostname, url }, headers, log) {
   try {
     body = await response.json();
   } catch (error) {
-    log.error(`${LOG_PREFIX} Could not parse ${hostname} response: ${error.message}`);
+    log.error(`${LOG_PREFIX} Could not parse ${hostname} response: ${error.message}`, {
+      ...ctx, error: error.message, durationMs: Date.now() - startedAt,
+    });
     return { hostname, rows: [], ok: false };
   }
 
   const raw = Array.isArray(body?.urls) ? body.urls : [];
   if (raw.length >= PAGE_SIZE) {
-    log.warn(`${LOG_PREFIX} ${hostname} returned a full page (${raw.length} >= ${PAGE_SIZE}); response may be truncated — top URLs by citations could be missing`);
+    log.warn(`${LOG_PREFIX} ${hostname} returned a full page (${raw.length} >= ${PAGE_SIZE}); response may be truncated — top URLs by citations could be missing`, {
+      ...ctx, rowCount: raw.length, pageSize: PAGE_SIZE,
+    });
   }
   return { hostname, rows: raw.slice(0, PAGE_SIZE), ok: true };
 }
@@ -192,11 +207,18 @@ export async function loadCitedUrlsFromSemrush({
   site, previousWeeks, context, siteHostname,
 }) {
   const { log, env } = context;
+  const startedAt = Date.now();
+  const siteId = site?.getId?.();
+  const elapsed = () => Date.now() - startedAt;
   const baseUrl = env?.SPACECAT_API_URI || SPACECAT_API_DEFAULT_BASE_URL;
+
+  log.info(`${LOG_PREFIX} Starting Semrush source attempt`, { siteId, baseUrl });
 
   const spaceCatId = site?.getOrganizationId?.();
   if (!spaceCatId) {
-    log.warn(`${LOG_PREFIX} Site has no organization id; skipping Semrush source`);
+    log.warn(`${LOG_PREFIX} Site has no organization id; skipping Semrush source`, {
+      siteId, durationMs: elapsed(),
+    });
     return null;
   }
 
@@ -205,16 +227,22 @@ export async function loadCitedUrlsFromSemrush({
   const { brand, resolved } = await resolveBrandResultForSite(context, site);
   if (!brand?.brandId) {
     if (resolved) {
-      log.info(`${LOG_PREFIX} No active brand for org ${spaceCatId}; skipping Semrush source`);
+      log.info(`${LOG_PREFIX} No active brand for org ${spaceCatId}; skipping Semrush source`, {
+        siteId, orgId: spaceCatId, durationMs: elapsed(),
+      });
     } else {
-      log.warn(`${LOG_PREFIX} Brand resolution failed (transient) for org ${spaceCatId}; using legacy fallback`);
+      log.warn(`${LOG_PREFIX} Brand resolution failed (transient) for org ${spaceCatId}; using legacy fallback`, {
+        siteId, orgId: spaceCatId, durationMs: elapsed(),
+      });
     }
     return null;
   }
 
   const dateWindow = getDateWindowForPreviousWeeks(previousWeeks);
   if (!dateWindow) {
-    log.warn(`${LOG_PREFIX} Could not derive a date window; skipping Semrush source`);
+    log.warn(`${LOG_PREFIX} Could not derive a date window; skipping Semrush source`, {
+      siteId, orgId: spaceCatId, brandId: brand.brandId, durationMs: elapsed(),
+    });
     return null;
   }
   const { startDate, endDate } = dateWindow;
@@ -223,7 +251,13 @@ export async function loadCitedUrlsFromSemrush({
   try {
     authorization = await getAuthorizationHeader(context);
   } catch (error) {
-    log.error(`${LOG_PREFIX} Failed to obtain IMS service token: ${error.message}`);
+    log.error(`${LOG_PREFIX} Failed to obtain IMS service token: ${error.message}`, {
+      siteId,
+      orgId: spaceCatId,
+      brandId: brand.brandId,
+      error: error.message,
+      durationMs: elapsed(),
+    });
     return null;
   }
 
@@ -245,32 +279,49 @@ export async function loadCitedUrlsFromSemrush({
     for (const platform of platforms) {
       requests.push({
         hostname,
+        platform,
         url: buildDomainUrlsUrl({
           baseUrl, spaceCatId, brandId: brand.brandId, hostname, startDate, endDate, platform,
         }),
       });
     }
   }
+  const hostnames = Object.keys(OFFSITE_DOMAINS);
+  log.info(`${LOG_PREFIX} Querying ${hostnames.length} hostnames x ${platforms.length} platforms (${requests.length} requests)`, {
+    siteId, orgId: spaceCatId, brandId: brand.brandId, hostnames, platforms,
+  });
 
-  const results = await Promise.all(requests.map((r) => fetchRows(r, headers, log)));
+  const results = await Promise.all(requests.map((r) => fetchRows(r, headers, log, siteId)));
 
   // Group by surface (hostname). Fall back to legacy only when a whole surface
   // produced ZERO successful responses (that surface would be dropped) — a single
   // failed engine is a partial count, not a dropped surface, and is tolerated.
   const byHost = new Map();
   for (const hostname of Object.keys(OFFSITE_DOMAINS)) {
-    byHost.set(hostname, { anyOk: false, rows: [] });
+    byHost.set(hostname, {
+      anyOk: false, okCount: 0, failCount: 0, rows: [],
+    });
   }
   for (const result of results) {
     const entry = byHost.get(result.hostname);
     if (result.ok) {
       entry.anyOk = true;
+      entry.okCount += 1;
       entry.rows.push(...result.rows);
+    } else {
+      entry.failCount += 1;
     }
   }
   for (const [hostname, entry] of byHost) {
+    // One summary line per hostname (not per-request) — enough to see partial engine
+    // degradation in Splunk without a log line per one of the ~12 concurrent requests.
+    log.info(`${LOG_PREFIX} ${hostname}: ${entry.okCount}/${entry.okCount + entry.failCount} engine requests succeeded`, {
+      siteId, hostname, okCount: entry.okCount, failCount: entry.failCount,
+    });
     if (!entry.anyOk) {
-      log.warn(`${LOG_PREFIX} No successful Semrush response for ${hostname}; using legacy fallback`);
+      log.warn(`${LOG_PREFIX} No successful Semrush response for ${hostname}; using legacy fallback`, {
+        siteId, orgId: spaceCatId, hostname, platformsQueried: platforms, durationMs: elapsed(),
+      });
       return null;
     }
   }
@@ -321,6 +372,12 @@ export async function loadCitedUrlsFromSemrush({
     }
   }
 
-  log.info(`${LOG_PREFIX} Collected ${allUrls.size} cited URLs from Semrush`);
+  log.info(`${LOG_PREFIX} Collected ${allUrls.size} cited URLs from Semrush`, {
+    siteId,
+    orgId: spaceCatId,
+    brandId: brand.brandId,
+    urlCount: allUrls.size,
+    durationMs: elapsed(),
+  });
   return allUrls;
 }

--- a/src/utils/offsite-brand-presence-semrush.js
+++ b/src/utils/offsite-brand-presence-semrush.js
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { ImsClient } from '@adobe/spacecat-shared-ims-client';
+import { resolveBrandForSite } from './brand-resolver.js';
+import { getDateWindowForPreviousWeeks } from './offsite-brand-presence-postgrest.js';
+import { classifyAndNormalize } from './offsite-brand-presence-enrichment.js';
+import { OFFSITE_DOMAINS } from '../offsite-brand-presence/constants.js';
+
+const LOG_PREFIX = '[offsite-brand-presence][semrush]';
+
+/**
+ * Default spacecat-api-service base URL. Its Elements proxy
+ * (`src/controllers/elements.js`) serves the Semrush-backed Serenity
+ * URL-Inspector endpoints at
+ * `/v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/*`.
+ * Overridable per-environment with `SPACECAT_API_URI` (the standard worker
+ * override, e.g. used by paid-cookie-consent).
+ */
+export const SPACECAT_API_DEFAULT_BASE_URL = 'https://spacecat.experiencecloud.live/api/v1';
+
+/**
+ * Page size accepted by the url-inspector endpoints. The proxy paginates
+ * client-side, so a single large page avoids a fetch loop for the bounded
+ * youtube/reddit sets.
+ */
+const PAGE_SIZE = 1000;
+
+/**
+ * Resolves which AI-engine platform values to query.
+ *
+ * Default: a single call with NO `platform` param, so the gateway aggregates
+ * citations across every engine it has (mirroring the legacy all-providers
+ * behaviour). Set `OFFSITE_SEMRUSH_PLATFORMS` (comma-separated, e.g.
+ * `"search-gpt,google-ai-mode"`) to query each engine explicitly and sum the
+ * citations per URL — use this if the gateway does not aggregate on an absent
+ * `platform`. See LLMO-6710.
+ *
+ * @param {object} env - Lambda env.
+ * @returns {Array<string|undefined>} platform values (`[undefined]` = omit param).
+ */
+export function getSemrushPlatforms(env) {
+  const raw = env?.OFFSITE_SEMRUSH_PLATFORMS;
+  if (typeof raw === 'string' && raw.trim()) {
+    return raw.split(',').map((p) => p.trim()).filter(Boolean);
+  }
+  return [undefined];
+}
+
+/**
+ * Mints an IMS service access token and returns it as an Authorization header value.
+ * Reuses the standard IMS_* env the worker already configures for other
+ * service-to-service calls.
+ *
+ * @param {object} context - Lambda context (env + log).
+ * @returns {Promise<string>} e.g. "Bearer eyJ...".
+ */
+async function getAuthorizationHeader(context) {
+  const imsClient = ImsClient.createFrom(context);
+  const token = await imsClient.getServiceAccessTokenV3();
+  return `${token.token_type} ${token.access_token}`;
+}
+
+/**
+ * Builds a url-inspector `domain-urls` request URL for one hostname (and optional
+ * platform).
+ *
+ * @returns {string}
+ */
+export function buildDomainUrlsUrl({
+  baseUrl, spaceCatId, brandId, hostname, startDate, endDate, platform,
+}) {
+  const params = new URLSearchParams({
+    startDate,
+    endDate,
+    hostname,
+    pageSize: String(PAGE_SIZE),
+  });
+  if (platform) {
+    params.set('platform', platform);
+  }
+  return `${baseUrl}/v2/orgs/${spaceCatId}/brands/${brandId}`
+    + `/serenity/brand-presence/url-inspector/domain-urls?${params.toString()}`;
+}
+
+/**
+ * Fetches the cited URLs for a single (hostname, platform) request and folds them
+ * into `allUrls`. `count` is the exact Semrush citation number (never recounted by
+ * repetition) and is SUMMED across platforms; `url` + `domain` come from the shared
+ * `classifyAndNormalize` so normalisation, owned-URL filtering and domain bucketing
+ * match the legacy path exactly.
+ *
+ * @returns {Promise<void>}
+ */
+async function collectRequest({
+  hostname, url, headers, allUrls, siteHostname, log,
+}) {
+  let response;
+  try {
+    response = await fetch(url, { headers });
+  } catch (error) {
+    log.error(`${LOG_PREFIX} Fetch failed for ${hostname}: ${error.message}`);
+    return;
+  }
+
+  if (!response.ok) {
+    log.error(`${LOG_PREFIX} ${hostname} returned HTTP ${response.status}`);
+    return;
+  }
+
+  let body;
+  try {
+    body = await response.json();
+  } catch (error) {
+    log.error(`${LOG_PREFIX} Could not parse ${hostname} response: ${error.message}`);
+    return;
+  }
+
+  const rows = Array.isArray(body?.urls) ? body.urls : [];
+  let added = 0;
+  for (const row of rows) {
+    const classified = row?.url ? classifyAndNormalize(row.url, siteHostname) : null;
+    if (!classified) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    const citations = Number(row.citations) || 0;
+    const existing = allUrls.get(classified.url);
+    if (existing) {
+      // Same URL seen under another platform — sum the citations so ranking
+      // reflects total cross-engine citation volume.
+      existing.count += citations;
+    } else {
+      allUrls.set(classified.url, { count: citations, domain: classified.domain });
+    }
+    added += 1;
+  }
+  log.info(`${LOG_PREFIX} ${hostname}: ${added} cited URLs`);
+}
+
+/**
+ * Loads the offsite cited URLs from the live Semrush-backed Serenity URL-Inspector
+ * endpoints, producing the exact `allUrls: Map<url, { count, domain }>` shape that
+ * the existing `selectTopUrls` -> DRS pipeline consumes. Ranking is preserved
+ * (`count` = citation volume), so `selectTopUrls` still takes the top
+ * `DRS_URLS_LIMIT` per surface, unchanged.
+ *
+ * Scope: `youtube.com` + `reddit.com` (fixed hostnames — one `domain-urls` call
+ * each, per platform). The generic "cited" bucket needs a `cited-domains`
+ * discovery hop and is a follow-up (LLMO-6709). Gated by the caller behind
+ * `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED`.
+ *
+ * @param {object} params
+ * @param {object} params.site - Site model (`getOrganizationId()`).
+ * @param {Array<{week:number, year:number}>} params.previousWeeks
+ * @param {object} params.context - Lambda context (env, log, dataAccess).
+ * @param {string} [params.siteHostname] - www-stripped site hostname for owned-URL filtering.
+ * @returns {Promise<Map<string, {count:number, domain:string|null}> | null>}
+ *   The URL map, or `null` when the source cannot be queried (caller falls back
+ *   to an empty run).
+ */
+export async function loadCitedUrlsFromSemrush({
+  site, previousWeeks, context, siteHostname,
+}) {
+  const { log, env } = context;
+  const baseUrl = env?.SPACECAT_API_URI || SPACECAT_API_DEFAULT_BASE_URL;
+
+  const spaceCatId = site?.getOrganizationId?.();
+  if (!spaceCatId) {
+    log.warn(`${LOG_PREFIX} Site has no organization id; skipping Semrush source`);
+    return null;
+  }
+
+  const brand = await resolveBrandForSite(context, site);
+  if (!brand?.brandId) {
+    log.warn(`${LOG_PREFIX} No active brand for org ${spaceCatId}; skipping Semrush source`);
+    return null;
+  }
+
+  const dateWindow = getDateWindowForPreviousWeeks(previousWeeks);
+  if (!dateWindow) {
+    log.warn(`${LOG_PREFIX} Could not derive a date window; skipping Semrush source`);
+    return null;
+  }
+  const { startDate, endDate } = dateWindow;
+
+  let authorization;
+  try {
+    authorization = await getAuthorizationHeader(context);
+  } catch (error) {
+    log.error(`${LOG_PREFIX} Failed to obtain IMS service token: ${error.message}`);
+    return null;
+  }
+
+  const headers = {
+    Authorization: authorization,
+    'Content-Type': 'application/json',
+    // The api-service Elements proxy authenticates IMS callers directly and
+    // forwards this Bearer token to Semrush (resolveElementsImsToken's fallback
+    // path), so a promise token is NOT required for a service caller. Forward
+    // one only if the platform later threads it onto the context (non-IMS callers).
+    ...(context.promiseToken ? { 'x-promise-token': context.promiseToken } : {}),
+  };
+
+  const platforms = getSemrushPlatforms(env);
+  const allUrls = new Map();
+
+  for (const hostname of Object.keys(OFFSITE_DOMAINS)) {
+    for (const platform of platforms) {
+      const requestUrl = buildDomainUrlsUrl({
+        baseUrl, spaceCatId, brandId: brand.brandId, hostname, startDate, endDate, platform,
+      });
+      // eslint-disable-next-line no-await-in-loop
+      await collectRequest({
+        hostname, url: requestUrl, headers, allUrls, siteHostname, log,
+      });
+    }
+  }
+
+  log.info(`${LOG_PREFIX} Collected ${allUrls.size} cited URLs from Semrush`);
+  return allUrls;
+}

--- a/src/utils/offsite-brand-presence-semrush.js
+++ b/src/utils/offsite-brand-presence-semrush.js
@@ -14,7 +14,11 @@ import { ImsClient } from '@adobe/spacecat-shared-ims-client';
 import { resolveBrandForSite } from './brand-resolver.js';
 import { getDateWindowForPreviousWeeks } from './offsite-brand-presence-postgrest.js';
 import { classifyAndNormalize } from './offsite-brand-presence-enrichment.js';
-import { OFFSITE_DOMAINS } from '../offsite-brand-presence/constants.js';
+import {
+  OFFSITE_DOMAINS,
+  YOUTUBE_URL_REGEX,
+  REDDIT_URL_REGEX,
+} from '../offsite-brand-presence/constants.js';
 
 const LOG_PREFIX = '[offsite-brand-presence][semrush]';
 
@@ -130,6 +134,20 @@ async function collectRequest({
   for (const row of rows) {
     const classified = row?.url ? classifyAndNormalize(row.url, siteHostname) : null;
     if (!classified) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    // Parity with the legacy handler path (handler.js:199-204): drop URLs that
+    // fail the strict offsite formats so the Semrush path never feeds DRS a
+    // non-thread Reddit URL (e.g. /settings, subreddit landing) or a
+    // lookalike YouTube host (e.g. music.youtube.com) that the legacy path
+    // filters. (isExcludedCitedHost / brand-token filtering only affects the
+    // top-cited bucket, which this loader does not fetch yet — LLMO-6709.)
+    if (classified.domain === 'youtube.com' && !YOUTUBE_URL_REGEX.test(row.url)) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    if (classified.domain === 'reddit.com' && !REDDIT_URL_REGEX.test(row.url)) {
       // eslint-disable-next-line no-continue
       continue;
     }

--- a/src/utils/offsite-brand-presence-semrush.js
+++ b/src/utils/offsite-brand-presence-semrush.js
@@ -130,8 +130,11 @@ export function buildDomainUrlsUrl({
  * Splunk query can isolate which site/surface/engine combination failed and why,
  * without parsing the message string.
  *
- * @returns {Promise<{ hostname: string, rows: object[], ok: boolean }>} `ok` is
- *   false on network error / timeout / non-2xx / unparseable body. The array is
+ * @returns {Promise<{ hostname: string, rows: object[], ok: boolean, authFailure: boolean }>}
+ *   `ok` is false on network error / timeout / non-2xx / unparseable body. `authFailure` is
+ *   true specifically for a 401/403 (distinct from other failure causes, since an
+ *   intermittent auth/token rejection is the signal to watch during the pre-LLMO-6709
+ *   verification window even when tolerated as a partial engine failure). The rows array is
  *   hard-capped at `PAGE_SIZE`.
  */
 async function fetchRows({ hostname, platform, url }, headers, log, siteId) {
@@ -144,11 +147,14 @@ async function fetchRows({ hostname, platform, url }, headers, log, siteId) {
     log.error(`${LOG_PREFIX} Fetch failed for ${hostname}: ${error.message}`, {
       ...ctx, error: error.message, durationMs: Date.now() - startedAt,
     });
-    return { hostname, rows: [], ok: false };
+    return {
+      hostname, rows: [], ok: false, authFailure: false,
+    };
   }
 
   if (!response.ok) {
-    if (response.status === 401 || response.status === 403) {
+    const authFailure = response.status === 401 || response.status === 403;
+    if (authFailure) {
       // Distinct branch so a rejected service token is visible instead of being
       // masked as "Semrush returned nothing" (LLMO-6709 verification).
       log.error(`${LOG_PREFIX} Service token rejected for ${hostname} (HTTP ${response.status}) — verify the IMS service token is authorized by the Semrush proxy (LLMO-6709)`, {
@@ -159,7 +165,9 @@ async function fetchRows({ hostname, platform, url }, headers, log, siteId) {
         ...ctx, status: response.status, durationMs: Date.now() - startedAt,
       });
     }
-    return { hostname, rows: [], ok: false };
+    return {
+      hostname, rows: [], ok: false, authFailure,
+    };
   }
 
   let body;
@@ -169,7 +177,9 @@ async function fetchRows({ hostname, platform, url }, headers, log, siteId) {
     log.error(`${LOG_PREFIX} Could not parse ${hostname} response: ${error.message}`, {
       ...ctx, error: error.message, durationMs: Date.now() - startedAt,
     });
-    return { hostname, rows: [], ok: false };
+    return {
+      hostname, rows: [], ok: false, authFailure: false,
+    };
   }
 
   const raw = Array.isArray(body?.urls) ? body.urls : [];
@@ -178,7 +188,9 @@ async function fetchRows({ hostname, platform, url }, headers, log, siteId) {
       ...ctx, rowCount: raw.length, pageSize: PAGE_SIZE,
     });
   }
-  return { hostname, rows: raw.slice(0, PAGE_SIZE), ok: true };
+  return {
+    hostname, rows: raw.slice(0, PAGE_SIZE), ok: true, authFailure: false,
+  };
 }
 
 /**
@@ -206,10 +218,18 @@ async function fetchRows({ hostname, platform, url }, headers, log, siteId) {
  *   each stage of the attempt. Kept generic (not a Slack import) so this module stays testable
  *   without a Slack dependency; a failure here is logged and swallowed, never thrown — a Slack
  *   outage must not affect the Semrush attempt itself.
+ * @param {object} [params.diagnostics] - Optional out-param, mutated in place. On a null return,
+ *   set to `{ fallbackReason }` with a specific code (`no-organization-id`, `no-active-brand`,
+ *   `brand-resolution-failed`, `no-date-window`, `ims-token-failed`, or `surface-failed:<host>`)
+ *   instead of the single generic reason the handler used to report for every case. On a
+ *   successful (non-null) return, set to
+ *   `{ engineFailureCount, degradedHosts, authFailureDetected }` so a surface that tolerated
+ *   partial engine failures is distinguishable from a clean run — both `dataSource` and
+ *   `fallbackReason` alone report success/fail but not degradation.
  * @returns {Promise<Map<string, {count:number, domain:string|null}> | null>}
  */
 export async function loadCitedUrlsFromSemrush({
-  site, previousWeeks, context, siteHostname, onProgress,
+  site, previousWeeks, context, siteHostname, onProgress, diagnostics,
 }) {
   const { log, env } = context;
   const startedAt = Date.now();
@@ -227,6 +247,11 @@ export async function loadCitedUrlsFromSemrush({
       log.warn(`${LOG_PREFIX} Failed to post Semrush progress update: ${error.message}`, { siteId });
     }
   };
+  const setDiagnostics = (patch) => {
+    if (diagnostics && typeof diagnostics === 'object') {
+      Object.assign(diagnostics, patch);
+    }
+  };
 
   log.info(`${LOG_PREFIX} Starting Semrush source attempt`, { siteId, baseUrl });
   await notify(':mag: Starting Semrush URL-Inspector lookup...');
@@ -237,6 +262,7 @@ export async function loadCitedUrlsFromSemrush({
       siteId, durationMs: elapsed(),
     });
     await notify(':warning: Site has no organization id — falling back to the legacy source.');
+    setDiagnostics({ fallbackReason: 'no-organization-id' });
     return null;
   }
 
@@ -249,11 +275,13 @@ export async function loadCitedUrlsFromSemrush({
         siteId, orgId: spaceCatId, durationMs: elapsed(),
       });
       await notify(':information_source: No active brand configured for this org — falling back to the legacy source.');
+      setDiagnostics({ fallbackReason: 'no-active-brand' });
     } else {
       log.warn(`${LOG_PREFIX} Brand resolution failed (transient) for org ${spaceCatId}; using legacy fallback`, {
         siteId, orgId: spaceCatId, durationMs: elapsed(),
       });
       await notify(':warning: Brand resolution failed (transient) — falling back to the legacy source.');
+      setDiagnostics({ fallbackReason: 'brand-resolution-failed' });
     }
     return null;
   }
@@ -264,6 +292,7 @@ export async function loadCitedUrlsFromSemrush({
       siteId, orgId: spaceCatId, brandId: brand.brandId, durationMs: elapsed(),
     });
     await notify(':warning: Could not derive a date window — falling back to the legacy source.');
+    setDiagnostics({ fallbackReason: 'no-date-window' });
     return null;
   }
   const { startDate, endDate } = dateWindow;
@@ -280,6 +309,7 @@ export async function loadCitedUrlsFromSemrush({
       durationMs: elapsed(),
     });
     await notify(`:x: Failed to obtain an IMS service token (\`${error.message}\`) — falling back to the legacy source.`);
+    setDiagnostics({ fallbackReason: 'ims-token-failed' });
     return null;
   }
 
@@ -322,7 +352,7 @@ export async function loadCitedUrlsFromSemrush({
   const byHost = new Map();
   for (const hostname of Object.keys(OFFSITE_DOMAINS)) {
     byHost.set(hostname, {
-      anyOk: false, okCount: 0, failCount: 0, rows: [],
+      anyOk: false, okCount: 0, failCount: 0, authFailureCount: 0, rows: [],
     });
   }
   for (const result of results) {
@@ -333,6 +363,9 @@ export async function loadCitedUrlsFromSemrush({
       entry.rows.push(...result.rows);
     } else {
       entry.failCount += 1;
+      if (result.authFailure) {
+        entry.authFailureCount += 1;
+      }
     }
   }
   for (const [hostname, entry] of byHost) {
@@ -349,11 +382,25 @@ export async function loadCitedUrlsFromSemrush({
       // order is the whole point (a readable narrative), not a perf-sensitive loop.
       // eslint-disable-next-line no-await-in-loop
       await notify(`:x: \`${hostname}\`: 0/${entry.okCount + entry.failCount} engine requests succeeded — falling back to the legacy source.`);
+      setDiagnostics({ fallbackReason: `surface-failed:${hostname}` });
       return null;
     }
     // eslint-disable-next-line no-await-in-loop
     await notify(`:white_check_mark: \`${hostname}\`: ${entry.okCount}/${entry.okCount + entry.failCount} engine requests succeeded.`);
   }
+
+  // Partial-degradation signal for LLMO-6711 shadow-run parity: a surface that
+  // tolerated failed engines (see above) still reports dataSource: 'semrush' below
+  // with no fallbackReason, so this is the only structured way to tell "clean run"
+  // from "succeeded, but N engine requests failed" without going back to logs. Any
+  // 401/403 is called out distinctly since an intermittent auth rejection is the
+  // signal to watch for during the pre-LLMO-6709 verification window specifically.
+  const engineFailureCount = [...byHost.values()].reduce((sum, entry) => sum + entry.failCount, 0);
+  const degradedHosts = [...byHost.entries()]
+    .filter(([, entry]) => entry.failCount > 0)
+    .map(([hostname]) => hostname);
+  const authFailureDetected = [...byHost.values()].some((entry) => entry.authFailureCount > 0);
+  setDiagnostics({ engineFailureCount, degradedHosts, authFailureDetected });
 
   const allUrls = new Map();
   for (const [, entry] of byHost) {
@@ -393,10 +440,12 @@ export async function loadCitedUrlsFromSemrush({
     }
   }
 
-  // Drop URLs whose total citation volume is <= 0 (malformed / all-zero rows): a
-  // zero-citation URL is not a real cited source and must not be scraped.
+  // Drop URLs whose total citation volume is zero (malformed / all-zero rows): a
+  // zero-citation URL is not a real cited source and must not be scraped. count can
+  // never go negative here — each contribution is Math.max(0, ...)-clamped above, so
+  // a sum of non-negative values is always >= 0; the check is `=== 0`, not `<= 0`.
   for (const [url, info] of allUrls) {
-    if (info.count <= 0) {
+    if (info.count === 0) {
       allUrls.delete(url);
     }
   }

--- a/src/youtube-analysis/handler.js
+++ b/src/youtube-analysis/handler.js
@@ -23,6 +23,7 @@ import {
   resolveMystiqueUrlLimit,
   resolveForwardedUrlLimit,
   resolveEnableBrandProfile,
+  resolveEnableSemrush,
   requestOffsiteScrape,
   buildAnalysisScrapeStatusMessage,
   formatDrsExtras,
@@ -133,7 +134,7 @@ async function fetchStoreData(siteId, context, site) {
  * @param {Object} context - The audit context
  * @param {Object} site - The site being audited
  * @param {Object} [auditContext] - SQS audit context; optional `messageData` from `message.data`
- *   (e.g. urlLimit, enableBrandProfile from Slack)
+ *   (e.g. urlLimit, enableBrandProfile, enableSemrush from Slack)
  * @returns {Promise<Object>} Audit result
  */
 async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
@@ -149,6 +150,7 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
 
   const enableBrandProfile = resolveEnableBrandProfile(auditContext, log, LOG_PREFIX);
   const forwardedUrlLimit = resolveForwardedUrlLimit(auditContext, log, LOG_PREFIX);
+  const enableSemrush = resolveEnableSemrush(auditContext, log, LOG_PREFIX);
 
   try {
     const youtubeConfig = getYouTubeConfig(site);
@@ -251,6 +253,7 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
         slackContext,
         enableBrandProfile,
         forwardedUrlLimit,
+        enableSemrush,
       );
       return {
         auditResult: { success: false, status: 'pending_scrape', error: error.message },
@@ -290,6 +293,7 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
         slackContext,
         enableBrandProfile,
         forwardedUrlLimit,
+        enableSemrush,
       );
       return {
         auditResult: { success: false, status: 'pending_scrape', error: error.message },

--- a/test/audits/cited-analysis/handler.test.js
+++ b/test/audits/cited-analysis/handler.test.js
@@ -339,6 +339,20 @@ describe('Cited Analysis Handler', function () {
       expect(msg.auditContext.messageData).to.deep.equal({ domainScope: 'top-cited', enableBrandProfile: true });
     });
 
+    it('forwards enableSemrush on the scoped scrape request when DRS has no available content yet', async () => {
+      mockFilterUrlsByDrsStatus.rejects(new DrsNoContentAvailableError('no content'));
+
+      await citedAnalysisHandler.default.runner(
+        baseURL,
+        context,
+        mockSite,
+        { messageData: { enableSemrush: 'false' } },
+      );
+
+      const msg = context.sqs.sendMessage.firstCall.args[1];
+      expect(msg.auditContext.messageData).to.deep.equal({ domainScope: 'top-cited', enableSemrush: false });
+    });
+
     it('returns error without re-scraping when scrape was already requested', async () => {
       mockFilterUrlsByDrsStatus.rejects(new DrsNoContentAvailableError('no content'));
 

--- a/test/audits/offsite-brand-presence-drs-status.test.js
+++ b/test/audits/offsite-brand-presence-drs-status.test.js
@@ -363,6 +363,48 @@ describe('offsite-brand-presence DRS status handler', () => {
       });
     });
 
+    it('forwards enableSemrush as messageData on every triggered analysis audit when set', async () => {
+      mockGetJob.withArgs('job-1').resolves({ status: 'COMPLETED' });
+      mockGetJob.withArgs('job-2').resolves({ status: 'COMPLETED' });
+
+      await handler.default(buildMessage({ enableSemrush: true }), context);
+
+      const calls = context.sqs.sendMessage.getCalls();
+      const reddit = calls.find((c) => c.args[1].type === 'reddit-analysis');
+      const youtube = calls.find((c) => c.args[1].type === 'youtube-analysis');
+      expect(reddit.args[1].auditContext.messageData).to.deep.equal({ enableSemrush: true });
+      expect(youtube.args[1].auditContext.messageData).to.deep.equal({ enableSemrush: true });
+    });
+
+    it('forwards explicit enableSemrush:false as messageData (distinct from absent)', async () => {
+      mockGetJob.withArgs('job-1').resolves({ status: 'COMPLETED' });
+      mockGetJob.withArgs('job-2').resolves({ status: 'COMPLETED' });
+
+      await handler.default(buildMessage({ enableSemrush: false }), context);
+
+      const reddit = context.sqs.sendMessage.getCalls()
+        .find((c) => c.args[1].type === 'reddit-analysis');
+      expect(reddit.args[1].auditContext.messageData).to.deep.equal({ enableSemrush: false });
+    });
+
+    it('forwards enableBrandProfile, urlLimit, and enableSemrush together as messageData', async () => {
+      mockGetJob.withArgs('job-1').resolves({ status: 'COMPLETED' });
+      mockGetJob.withArgs('job-2').resolves({ status: 'COMPLETED' });
+
+      await handler.default(
+        buildMessage({ enableBrandProfile: true, urlLimit: 20, enableSemrush: true }),
+        context,
+      );
+
+      const reddit = context.sqs.sendMessage.getCalls()
+        .find((c) => c.args[1].type === 'reddit-analysis');
+      expect(reddit.args[1].auditContext.messageData).to.deep.equal({
+        enableBrandProfile: true,
+        urlLimit: 20,
+        enableSemrush: true,
+      });
+    });
+
     it('maps top-cited to cited-analysis and does not trigger wikipedia-analysis', async () => {
       mockGetJob.withArgs('job-c').resolves({ status: 'COMPLETED' });
       mockGetJob.withArgs('job-w').resolves({ status: 'COMPLETED' });

--- a/test/audits/offsite-brand-presence.test.js
+++ b/test/audits/offsite-brand-presence.test.js
@@ -214,8 +214,20 @@ describe('Offsite Brand Presence Handler', () => {
       const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
 
       expect(result.auditResult.success).to.be.true;
+      expect(result.auditResult.dataSource).to.equal('legacy');
+      expect(result.auditResult).to.not.have.property('fallbackReason');
       expect(mockLoadCitedUrlsFromSemrush).to.not.have.been.called;
       expect(mockLoadBrandPresenceData).to.have.been.calledOnce;
+    });
+
+    it('treats a non-"true" flag value as off (strict === true)', async () => {
+      context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'TRUE';
+      stubBrandPresenceData(['https://www.youtube.com/watch?v=x']);
+
+      const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
+
+      expect(result.auditResult.dataSource).to.equal('legacy');
+      expect(mockLoadCitedUrlsFromSemrush).to.not.have.been.called;
     });
 
     it('uses the Semrush loader (with the expected args) and skips the legacy source when it yields URLs', async () => {
@@ -228,6 +240,8 @@ describe('Offsite Brand Presence Handler', () => {
       const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
 
       expect(result.auditResult.success).to.be.true;
+      expect(result.auditResult.dataSource).to.equal('semrush');
+      expect(result.auditResult).to.not.have.property('fallbackReason');
       expect(result.auditResult.urlCounts['youtube.com']).to.equal(1);
       expect(result.auditResult.urlCounts['reddit.com']).to.equal(1);
       expect(mockLoadCitedUrlsFromSemrush).to.have.been.calledOnce;
@@ -237,7 +251,10 @@ describe('Offsite Brand Presence Handler', () => {
       expect(args.site).to.equal(site);
       expect(args.siteHostname).to.equal('example.com');
       expect(args.context).to.equal(context);
-      expect(args.previousWeeks).to.be.an('array');
+      expect(args.previousWeeks).to.deep.equal([
+        { week: DEFAULT_WEEK, year: DEFAULT_YEAR },
+        { week: DEFAULT_WEEK_2, year: DEFAULT_YEAR },
+      ]);
       expect(mockLoadBrandPresenceData).to.not.have.been.called;
     });
 
@@ -249,6 +266,8 @@ describe('Offsite Brand Presence Handler', () => {
       const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
 
       expect(result.auditResult.success).to.be.true;
+      expect(result.auditResult.dataSource).to.equal('legacy');
+      expect(result.auditResult.fallbackReason).to.equal('semrush-no-usable-urls');
       expect(mockLoadCitedUrlsFromSemrush).to.have.been.calledOnce;
       expect(mockLoadBrandPresenceData).to.have.been.calledOnce;
       expect(result.auditResult.urlCounts['youtube.com']).to.equal(1);
@@ -317,6 +336,19 @@ describe('Offsite Brand Presence Handler', () => {
       expect(result.auditResult.success).to.be.true;
       expect(mockLoadCitedUrlsFromSemrush).to.have.been.calledOnce;
       expect(log.warn).to.have.been.calledWithMatch(/Invalid enableSemrush/);
+    });
+
+    it('surfaces dataSource + fallbackReason even when the legacy fallback also yields nothing', async () => {
+      context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
+      mockLoadCitedUrlsFromSemrush.resolves(null);
+      mockLoadBrandPresenceData.resolves(null); // legacy empty too
+
+      const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
+
+      expect(result.auditResult.success).to.be.true;
+      expect(result.auditResult.dataSource).to.equal('legacy');
+      expect(result.auditResult.fallbackReason).to.equal('semrush-no-usable-urls');
+      expect(result.auditResult.urlCounts['youtube.com']).to.equal(0);
     });
   });
 

--- a/test/audits/offsite-brand-presence.test.js
+++ b/test/audits/offsite-brand-presence.test.js
@@ -266,6 +266,58 @@ describe('Offsite Brand Presence Handler', () => {
       expect(mockLoadBrandPresenceData).to.have.been.calledOnce;
       expect(result.auditResult.urlCounts['reddit.com']).to.equal(1);
     });
+
+    it('a Slack-requested enableSemrush:true override invokes the Semrush loader even when the env var is off', async () => {
+      // flag unset in env
+      mockLoadCitedUrlsFromSemrush.resolves(new Map([
+        ['https://youtu.be/abc', { count: 5, domain: 'youtube.com' }],
+      ]));
+
+      const result = await offsiteBrandPresenceRunner(
+        FINAL_URL,
+        context,
+        site,
+        { messageData: { enableSemrush: true } },
+      );
+
+      expect(result.auditResult.success).to.be.true;
+      expect(mockLoadCitedUrlsFromSemrush).to.have.been.calledOnce;
+      expect(mockLoadBrandPresenceData).to.not.have.been.called;
+    });
+
+    it('a Slack-requested enableSemrush:false override skips the Semrush loader even when the env var is on', async () => {
+      context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
+      stubBrandPresenceData(['https://www.youtube.com/watch?v=legacy']);
+
+      const result = await offsiteBrandPresenceRunner(
+        FINAL_URL,
+        context,
+        site,
+        { messageData: { enableSemrush: false } },
+      );
+
+      expect(result.auditResult.success).to.be.true;
+      expect(mockLoadCitedUrlsFromSemrush).to.not.have.been.called;
+      expect(mockLoadBrandPresenceData).to.have.been.calledOnce;
+    });
+
+    it('an invalid enableSemrush override is ignored and the env var value applies, with a warning logged', async () => {
+      context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
+      mockLoadCitedUrlsFromSemrush.resolves(new Map([
+        ['https://youtu.be/abc', { count: 5, domain: 'youtube.com' }],
+      ]));
+
+      const result = await offsiteBrandPresenceRunner(
+        FINAL_URL,
+        context,
+        site,
+        { messageData: { enableSemrush: 'maybe' } },
+      );
+
+      expect(result.auditResult.success).to.be.true;
+      expect(mockLoadCitedUrlsFromSemrush).to.have.been.calledOnce;
+      expect(log.warn).to.have.been.calledWithMatch(/Invalid enableSemrush/);
+    });
   });
 
   describe('URL Extraction', () => {

--- a/test/audits/offsite-brand-presence.test.js
+++ b/test/audits/offsite-brand-presence.test.js
@@ -207,7 +207,7 @@ describe('Offsite Brand Presence Handler', () => {
   });
 
   describe('Semrush source (OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED)', () => {
-    it('uses the Semrush loader instead of loadBrandPresenceData when the flag is on', async () => {
+    it('uses the Semrush loader and skips the legacy source when it yields URLs', async () => {
       context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
       mockLoadCitedUrlsFromSemrush.resolves(new Map([
         ['https://youtu.be/abc', { count: 5, domain: 'youtube.com' }],
@@ -223,16 +223,30 @@ describe('Offsite Brand Presence Handler', () => {
       expect(mockLoadBrandPresenceData).to.not.have.been.called;
     });
 
-    it('returns an empty result when the Semrush loader yields null', async () => {
+    it('falls back to the legacy PostgREST/SharePoint source when Semrush yields null', async () => {
       context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
       mockLoadCitedUrlsFromSemrush.resolves(null);
+      stubBrandPresenceData(['https://www.youtube.com/watch?v=legacy']);
 
       const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
 
       expect(result.auditResult.success).to.be.true;
-      expect(result.auditResult.urlCounts['youtube.com']).to.equal(0);
-      expect(result.auditResult.urlCounts['reddit.com']).to.equal(0);
-      expect(mockLoadBrandPresenceData).to.not.have.been.called;
+      expect(mockLoadCitedUrlsFromSemrush).to.have.been.calledOnce;
+      expect(mockLoadBrandPresenceData).to.have.been.calledOnce;
+      expect(result.auditResult.urlCounts['youtube.com']).to.equal(1);
+      expect(log.warn).to.have.been.called;
+    });
+
+    it('falls back to the legacy source when Semrush yields an empty map', async () => {
+      context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
+      mockLoadCitedUrlsFromSemrush.resolves(new Map());
+      stubBrandPresenceData(['https://www.reddit.com/r/test/comments/1/thread']);
+
+      const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
+
+      expect(mockLoadCitedUrlsFromSemrush).to.have.been.calledOnce;
+      expect(mockLoadBrandPresenceData).to.have.been.calledOnce;
+      expect(result.auditResult.urlCounts['reddit.com']).to.equal(1);
     });
   });
 

--- a/test/audits/offsite-brand-presence.test.js
+++ b/test/audits/offsite-brand-presence.test.js
@@ -207,7 +207,18 @@ describe('Offsite Brand Presence Handler', () => {
   });
 
   describe('Semrush source (OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED)', () => {
-    it('uses the Semrush loader and skips the legacy source when it yields URLs', async () => {
+    it('does not invoke the Semrush loader when the flag is off (regression)', async () => {
+      // flag unset in env
+      stubBrandPresenceData(['https://www.youtube.com/watch?v=x']);
+
+      const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
+
+      expect(result.auditResult.success).to.be.true;
+      expect(mockLoadCitedUrlsFromSemrush).to.not.have.been.called;
+      expect(mockLoadBrandPresenceData).to.have.been.calledOnce;
+    });
+
+    it('uses the Semrush loader (with the expected args) and skips the legacy source when it yields URLs', async () => {
       context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
       mockLoadCitedUrlsFromSemrush.resolves(new Map([
         ['https://youtu.be/abc', { count: 5, domain: 'youtube.com' }],
@@ -220,6 +231,13 @@ describe('Offsite Brand Presence Handler', () => {
       expect(result.auditResult.urlCounts['youtube.com']).to.equal(1);
       expect(result.auditResult.urlCounts['reddit.com']).to.equal(1);
       expect(mockLoadCitedUrlsFromSemrush).to.have.been.calledOnce;
+      // Assert the integration seam wires the right args through (site + the
+      // www-stripped siteHostname that owned-URL filtering depends on).
+      const args = mockLoadCitedUrlsFromSemrush.firstCall.args[0];
+      expect(args.site).to.equal(site);
+      expect(args.siteHostname).to.equal('example.com');
+      expect(args.context).to.equal(context);
+      expect(args.previousWeeks).to.be.an('array');
       expect(mockLoadBrandPresenceData).to.not.have.been.called;
     });
 

--- a/test/audits/offsite-brand-presence.test.js
+++ b/test/audits/offsite-brand-presence.test.js
@@ -230,6 +230,16 @@ describe('Offsite Brand Presence Handler', () => {
       expect(mockLoadCitedUrlsFromSemrush).to.not.have.been.called;
     });
 
+    it('treats "1" as off, not a truthy flag value (strict === true)', async () => {
+      context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = '1';
+      stubBrandPresenceData(['https://www.youtube.com/watch?v=x']);
+
+      const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
+
+      expect(result.auditResult.dataSource).to.equal('legacy');
+      expect(mockLoadCitedUrlsFromSemrush).to.not.have.been.called;
+    });
+
     it('uses the Semrush loader (with the expected args) and skips the legacy source when it yields URLs', async () => {
       context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
       mockLoadCitedUrlsFromSemrush.resolves(new Map([

--- a/test/audits/offsite-brand-presence.test.js
+++ b/test/audits/offsite-brand-presence.test.js
@@ -30,6 +30,7 @@ const DEFAULT_YEAR = 2026;
 describe('Offsite Brand Presence Handler', () => {
   let sandbox;
   let mockLoadBrandPresenceData;
+  let mockLoadCitedUrlsFromSemrush;
   let mockGetPreviousWeeks;
   let mockSubmitScrapeJob;
   let mockDrsIsConfigured;
@@ -52,6 +53,7 @@ describe('Offsite Brand Presence Handler', () => {
     sandbox = sinon.createSandbox();
 
     mockLoadBrandPresenceData = sandbox.stub();
+    mockLoadCitedUrlsFromSemrush = sandbox.stub().resolves(null);
     mockGetPreviousWeeks = sandbox.stub().returns([
       { week: DEFAULT_WEEK, year: DEFAULT_YEAR },
       { week: DEFAULT_WEEK_2, year: DEFAULT_YEAR },
@@ -64,6 +66,9 @@ describe('Offsite Brand Presence Handler', () => {
       '../../src/utils/offsite-brand-presence-enrichment.js': {
         getPreviousWeeks: mockGetPreviousWeeks,
         loadBrandPresenceData: mockLoadBrandPresenceData,
+      },
+      '../../src/utils/offsite-brand-presence-semrush.js': {
+        loadCitedUrlsFromSemrush: mockLoadCitedUrlsFromSemrush,
       },
       '@adobe/spacecat-shared-drs-client': {
         default: {
@@ -198,6 +203,36 @@ describe('Offsite Brand Presence Handler', () => {
       expect(result.auditResult.success).to.be.true;
       expect(result.auditResult.urlCounts['youtube.com']).to.equal(0);
       expect(result.auditResult.urlCounts['reddit.com']).to.equal(0);
+    });
+  });
+
+  describe('Semrush source (OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED)', () => {
+    it('uses the Semrush loader instead of loadBrandPresenceData when the flag is on', async () => {
+      context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
+      mockLoadCitedUrlsFromSemrush.resolves(new Map([
+        ['https://youtu.be/abc', { count: 5, domain: 'youtube.com' }],
+        ['https://www.reddit.com/r/test/comments/1/p', { count: 3, domain: 'reddit.com' }],
+      ]));
+
+      const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
+
+      expect(result.auditResult.success).to.be.true;
+      expect(result.auditResult.urlCounts['youtube.com']).to.equal(1);
+      expect(result.auditResult.urlCounts['reddit.com']).to.equal(1);
+      expect(mockLoadCitedUrlsFromSemrush).to.have.been.calledOnce;
+      expect(mockLoadBrandPresenceData).to.not.have.been.called;
+    });
+
+    it('returns an empty result when the Semrush loader yields null', async () => {
+      context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
+      mockLoadCitedUrlsFromSemrush.resolves(null);
+
+      const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
+
+      expect(result.auditResult.success).to.be.true;
+      expect(result.auditResult.urlCounts['youtube.com']).to.equal(0);
+      expect(result.auditResult.urlCounts['reddit.com']).to.equal(0);
+      expect(mockLoadBrandPresenceData).to.not.have.been.called;
     });
   });
 

--- a/test/audits/offsite-brand-presence.test.js
+++ b/test/audits/offsite-brand-presence.test.js
@@ -268,6 +268,28 @@ describe('Offsite Brand Presence Handler', () => {
       expect(mockLoadBrandPresenceData).to.not.have.been.called;
     });
 
+    it('wires onProgress to post Semrush progress updates into the Slack thread', async () => {
+      context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
+      mockLoadCitedUrlsFromSemrush.resolves(new Map([
+        ['https://youtu.be/abc', { count: 5, domain: 'youtube.com' }],
+      ]));
+      const slackContext = { channelId: 'C-semrush', threadTs: '111.222' };
+
+      await offsiteBrandPresenceRunner(FINAL_URL, context, site, { slackContext });
+
+      const args = mockLoadCitedUrlsFromSemrush.firstCall.args[0];
+      expect(args.onProgress).to.be.a('function');
+
+      await args.onProgress(':mag: test update');
+
+      expect(mockPostMessageOptional).to.have.been.calledWithMatch(
+        context,
+        'C-semrush',
+        `*offsite-brand-presence* for *${BASE_URL}* — :mag: test update`,
+        { threadTs: '111.222' },
+      );
+    });
+
     it('falls back to the legacy PostgREST/SharePoint source when Semrush yields null', async () => {
       context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
       mockLoadCitedUrlsFromSemrush.resolves(null);

--- a/test/audits/offsite-brand-presence.test.js
+++ b/test/audits/offsite-brand-presence.test.js
@@ -207,6 +207,13 @@ describe('Offsite Brand Presence Handler', () => {
   });
 
   describe('Semrush source (OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED)', () => {
+    beforeEach(() => {
+      // Gate 1 (LLMO-6709) defaults to verified in this describe block so the existing
+      // env-var/override tests below exercise the flag logic itself; the dedicated
+      // "Gate 1 (OFFSITE_SEMRUSH_GATE1_VERIFIED)" block below covers the gate independently.
+      context.env.OFFSITE_SEMRUSH_GATE1_VERIFIED = 'true';
+    });
+
     it('does not invoke the Semrush loader when the flag is off (regression)', async () => {
       // flag unset in env
       stubBrandPresenceData(['https://www.youtube.com/watch?v=x']);
@@ -268,6 +275,37 @@ describe('Offsite Brand Presence Handler', () => {
       expect(mockLoadBrandPresenceData).to.not.have.been.called;
     });
 
+    it('surfaces semrushEngineFailureCount/semrushDegradedHosts and warns when the loader reports degradation', async () => {
+      context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
+      mockLoadCitedUrlsFromSemrush.callsFake(async (args) => {
+        Object.assign(args.diagnostics, {
+          engineFailureCount: 1,
+          degradedHosts: ['youtube.com'],
+          authFailureDetected: true,
+        });
+        return new Map([['https://youtu.be/abc', { count: 5, domain: 'youtube.com' }]]);
+      });
+
+      const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
+
+      expect(result.auditResult.dataSource).to.equal('semrush');
+      expect(result.auditResult.semrushEngineFailureCount).to.equal(1);
+      expect(result.auditResult.semrushDegradedHosts).to.deep.equal(['youtube.com']);
+      expect(log.warn).to.have.been.calledWithMatch(/possible auth\/token issue/);
+    });
+
+    it('does not surface degradation fields on a clean Semrush success', async () => {
+      context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
+      mockLoadCitedUrlsFromSemrush.resolves(new Map([
+        ['https://youtu.be/abc', { count: 5, domain: 'youtube.com' }],
+      ]));
+
+      const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
+
+      expect(result.auditResult).to.not.have.property('semrushEngineFailureCount');
+      expect(result.auditResult).to.not.have.property('semrushDegradedHosts');
+    });
+
     it('wires onProgress to post Semrush progress updates into the Slack thread', async () => {
       context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
       mockLoadCitedUrlsFromSemrush.resolves(new Map([
@@ -316,6 +354,8 @@ describe('Offsite Brand Presence Handler', () => {
       expect(mockLoadCitedUrlsFromSemrush).to.have.been.calledOnce;
       expect(mockLoadBrandPresenceData).to.have.been.calledOnce;
       expect(result.auditResult.urlCounts['reddit.com']).to.equal(1);
+      expect(result.auditResult.dataSource).to.equal('legacy');
+      expect(result.auditResult.fallbackReason).to.equal('semrush-no-usable-urls');
     });
 
     it('a Slack-requested enableSemrush:true override invokes the Semrush loader even when the env var is off', async () => {
@@ -381,6 +421,77 @@ describe('Offsite Brand Presence Handler', () => {
       expect(result.auditResult.dataSource).to.equal('legacy');
       expect(result.auditResult.fallbackReason).to.equal('semrush-no-usable-urls');
       expect(result.auditResult.urlCounts['youtube.com']).to.equal(0);
+    });
+  });
+
+  describe('Gate 1 (OFFSITE_SEMRUSH_GATE1_VERIFIED)', () => {
+    // Gate 1 is unset/false by default here (no beforeEach override), matching the real
+    // default in every environment until LLMO-6709 closes.
+
+    it('blocks the env-var flag when gate 1 is not verified', async () => {
+      context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
+      stubBrandPresenceData(['https://www.youtube.com/watch?v=x']);
+
+      const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
+
+      expect(result.auditResult.dataSource).to.equal('legacy');
+      expect(mockLoadCitedUrlsFromSemrush).to.not.have.been.called;
+      expect(log.warn).to.have.been.calledWithMatch(/gate 1/);
+    });
+
+    it('blocks the Slack per-run override when gate 1 is not verified', async () => {
+      stubBrandPresenceData(['https://www.youtube.com/watch?v=x']);
+
+      const result = await offsiteBrandPresenceRunner(
+        FINAL_URL,
+        context,
+        site,
+        { messageData: { enableSemrush: true } },
+      );
+
+      expect(result.auditResult.dataSource).to.equal('legacy');
+      expect(mockLoadCitedUrlsFromSemrush).to.not.have.been.called;
+      expect(log.warn).to.have.been.calledWithMatch(/gate 1/);
+    });
+
+    it('posts a Slack notice explaining the gate block when a thread exists', async () => {
+      stubBrandPresenceData(['https://www.youtube.com/watch?v=x']);
+      const slackContext = { channelId: 'C-gate', threadTs: '999.111' };
+
+      await offsiteBrandPresenceRunner(
+        FINAL_URL,
+        context,
+        site,
+        { slackContext, messageData: { enableSemrush: true } },
+      );
+
+      expect(mockPostMessageOptional).to.have.been.calledWithMatch(
+        context,
+        'C-gate',
+        sinon.match(/gated off/),
+        { threadTs: '999.111' },
+      );
+    });
+
+    it('does not warn or notify when Semrush was never requested (flag off, no override)', async () => {
+      stubBrandPresenceData(['https://www.youtube.com/watch?v=x']);
+
+      await offsiteBrandPresenceRunner(FINAL_URL, context, site);
+
+      expect(log.warn.getCalls().some((c) => /gate 1/.test(c.args[0]))).to.equal(false);
+    });
+
+    it('allows Semrush through once gate 1 is verified, mirroring the env var behavior', async () => {
+      context.env.OFFSITE_SEMRUSH_GATE1_VERIFIED = 'true';
+      context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
+      mockLoadCitedUrlsFromSemrush.resolves(new Map([
+        ['https://youtu.be/abc', { count: 5, domain: 'youtube.com' }],
+      ]));
+
+      const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
+
+      expect(result.auditResult.dataSource).to.equal('semrush');
+      expect(mockLoadCitedUrlsFromSemrush).to.have.been.calledOnce;
     });
   });
 
@@ -1822,6 +1933,29 @@ describe('Offsite Brand Presence Handler', () => {
 
       const msg = context.sqs.sendMessage.firstCall.args[1];
       expect(msg.auditContext.urlLimit).to.be.undefined;
+    });
+
+    it('forwards the Semrush override to the poll message auditContext when set on Slack', async () => {
+      stubBrandPresenceData(['https://youtube.com/shorts/v1']);
+      const auditContext = {
+        slackContext: { channelId: 'C123', threadTs: '111.222' },
+        messageData: { enableSemrush: true },
+      };
+
+      await offsiteBrandPresenceRunner(FINAL_URL, context, site, auditContext);
+
+      const msg = context.sqs.sendMessage.firstCall.args[1];
+      expect(msg.auditContext.enableSemrush).to.equal(true);
+    });
+
+    it('omits enableSemrush from the poll message auditContext when absent on Slack', async () => {
+      stubBrandPresenceData(['https://youtube.com/shorts/v1']);
+      const auditContext = { slackContext: { channelId: 'C123', threadTs: '111.222' } };
+
+      await offsiteBrandPresenceRunner(FINAL_URL, context, site, auditContext);
+
+      const msg = context.sqs.sendMessage.firstCall.args[1];
+      expect(msg.auditContext.enableSemrush).to.be.undefined;
     });
   });
 

--- a/test/audits/offsite-brand-presence.test.js
+++ b/test/audits/offsite-brand-presence.test.js
@@ -207,13 +207,6 @@ describe('Offsite Brand Presence Handler', () => {
   });
 
   describe('Semrush source (OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED)', () => {
-    beforeEach(() => {
-      // Gate 1 (LLMO-6709) defaults to verified in this describe block so the existing
-      // env-var/override tests below exercise the flag logic itself; the dedicated
-      // "Gate 1 (OFFSITE_SEMRUSH_GATE1_VERIFIED)" block below covers the gate independently.
-      context.env.OFFSITE_SEMRUSH_GATE1_VERIFIED = 'true';
-    });
-
     it('does not invoke the Semrush loader when the flag is off (regression)', async () => {
       // flag unset in env
       stubBrandPresenceData(['https://www.youtube.com/watch?v=x']);
@@ -421,77 +414,6 @@ describe('Offsite Brand Presence Handler', () => {
       expect(result.auditResult.dataSource).to.equal('legacy');
       expect(result.auditResult.fallbackReason).to.equal('semrush-no-usable-urls');
       expect(result.auditResult.urlCounts['youtube.com']).to.equal(0);
-    });
-  });
-
-  describe('Gate 1 (OFFSITE_SEMRUSH_GATE1_VERIFIED)', () => {
-    // Gate 1 is unset/false by default here (no beforeEach override), matching the real
-    // default in every environment until LLMO-6709 closes.
-
-    it('blocks the env-var flag when gate 1 is not verified', async () => {
-      context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
-      stubBrandPresenceData(['https://www.youtube.com/watch?v=x']);
-
-      const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
-
-      expect(result.auditResult.dataSource).to.equal('legacy');
-      expect(mockLoadCitedUrlsFromSemrush).to.not.have.been.called;
-      expect(log.warn).to.have.been.calledWithMatch(/gate 1/);
-    });
-
-    it('blocks the Slack per-run override when gate 1 is not verified', async () => {
-      stubBrandPresenceData(['https://www.youtube.com/watch?v=x']);
-
-      const result = await offsiteBrandPresenceRunner(
-        FINAL_URL,
-        context,
-        site,
-        { messageData: { enableSemrush: true } },
-      );
-
-      expect(result.auditResult.dataSource).to.equal('legacy');
-      expect(mockLoadCitedUrlsFromSemrush).to.not.have.been.called;
-      expect(log.warn).to.have.been.calledWithMatch(/gate 1/);
-    });
-
-    it('posts a Slack notice explaining the gate block when a thread exists', async () => {
-      stubBrandPresenceData(['https://www.youtube.com/watch?v=x']);
-      const slackContext = { channelId: 'C-gate', threadTs: '999.111' };
-
-      await offsiteBrandPresenceRunner(
-        FINAL_URL,
-        context,
-        site,
-        { slackContext, messageData: { enableSemrush: true } },
-      );
-
-      expect(mockPostMessageOptional).to.have.been.calledWithMatch(
-        context,
-        'C-gate',
-        sinon.match(/gated off/),
-        { threadTs: '999.111' },
-      );
-    });
-
-    it('does not warn or notify when Semrush was never requested (flag off, no override)', async () => {
-      stubBrandPresenceData(['https://www.youtube.com/watch?v=x']);
-
-      await offsiteBrandPresenceRunner(FINAL_URL, context, site);
-
-      expect(log.warn.getCalls().some((c) => /gate 1/.test(c.args[0]))).to.equal(false);
-    });
-
-    it('allows Semrush through once gate 1 is verified, mirroring the env var behavior', async () => {
-      context.env.OFFSITE_SEMRUSH_GATE1_VERIFIED = 'true';
-      context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
-      mockLoadCitedUrlsFromSemrush.resolves(new Map([
-        ['https://youtu.be/abc', { count: 5, domain: 'youtube.com' }],
-      ]));
-
-      const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
-
-      expect(result.auditResult.dataSource).to.equal('semrush');
-      expect(mockLoadCitedUrlsFromSemrush).to.have.been.calledOnce;
     });
   });
 

--- a/test/audits/reddit-analysis/handler.test.js
+++ b/test/audits/reddit-analysis/handler.test.js
@@ -310,6 +310,20 @@ describe('Reddit Analysis Handler', function () {
       expect(msg.auditContext.messageData).to.deep.equal({ domainScope: 'reddit.com', enableBrandProfile: true });
     });
 
+    it('forwards enableSemrush on the scoped scrape request when DRS has no available content yet', async () => {
+      mockFilterUrlsByDrsStatus.rejects(new DrsNoContentAvailableError('no content'));
+
+      await redditAnalysisHandler.default.runner(
+        baseURL,
+        context,
+        mockSite,
+        { messageData: { enableSemrush: 'false' } },
+      );
+
+      const msg = context.sqs.sendMessage.firstCall.args[1];
+      expect(msg.auditContext.messageData).to.deep.equal({ domainScope: 'reddit.com', enableSemrush: false });
+    });
+
     it('returns error without re-scraping when scrape was already requested', async () => {
       mockFilterUrlsByDrsStatus.rejects(new DrsNoContentAvailableError('no content'));
 

--- a/test/audits/youtube-analysis/handler.test.js
+++ b/test/audits/youtube-analysis/handler.test.js
@@ -311,6 +311,20 @@ describe('YouTube Analysis Handler', function () {
       expect(msg.auditContext.messageData).to.deep.equal({ domainScope: 'youtube.com', enableBrandProfile: true });
     });
 
+    it('forwards enableSemrush on the scoped scrape request when DRS has no available content yet', async () => {
+      mockFilterUrlsByDrsStatus.rejects(new DrsNoContentAvailableError('no content'));
+
+      await youtubeAnalysisHandler.default.runner(
+        baseURL,
+        context,
+        mockSite,
+        { messageData: { enableSemrush: 'false' } },
+      );
+
+      const msg = context.sqs.sendMessage.firstCall.args[1];
+      expect(msg.auditContext.messageData).to.deep.equal({ domainScope: 'youtube.com', enableSemrush: false });
+    });
+
     it('returns error without re-scraping when scrape was already requested', async () => {
       mockFilterUrlsByDrsStatus.rejects(new DrsNoContentAvailableError('no content'));
 

--- a/test/utils/offsite-audit-utils.test.js
+++ b/test/utils/offsite-audit-utils.test.js
@@ -22,6 +22,7 @@ import {
   resolveForwardedUrlLimit,
   resolveDrsPollIntervalSeconds,
   resolveEnableBrandProfile,
+  resolveEnableSemrush,
   requestOffsiteScrape,
   computeBrandTokens,
   isExcludedCitedHost,
@@ -533,6 +534,46 @@ describe('offsite-audit-utils', () => {
     });
   });
 
+  describe('resolveEnableSemrush', () => {
+    it('returns undefined when auditContext or messageData is absent, so the env var applies', () => {
+      expect(resolveEnableSemrush({})).to.be.undefined;
+      expect(resolveEnableSemrush(undefined)).to.be.undefined;
+      expect(resolveEnableSemrush(null)).to.be.undefined;
+      expect(resolveEnableSemrush({ messageData: { enableSemrush: '' } })).to.be.undefined;
+    });
+
+    it('returns true for boolean true or the string "true"', () => {
+      expect(resolveEnableSemrush(
+        { messageData: { enableSemrush: true } },
+      )).to.equal(true);
+      expect(resolveEnableSemrush(
+        { messageData: { enableSemrush: 'true' } },
+      )).to.equal(true);
+    });
+
+    it('returns false for boolean false or the string "false"', () => {
+      expect(resolveEnableSemrush(
+        { messageData: { enableSemrush: false } },
+      )).to.equal(false);
+      expect(resolveEnableSemrush(
+        { messageData: { enableSemrush: 'false' } },
+      )).to.equal(false);
+    });
+
+    it('returns undefined and warns when enableSemrush is invalid', () => {
+      const log = { warn: sandbox.stub() };
+      expect(resolveEnableSemrush({ messageData: { enableSemrush: 'yes' } }, log, '[T]')).to.be.undefined;
+      expect(log.warn).to.have.been.calledOnce;
+    });
+
+    it('returns undefined and warns for numeric values (e.g. 0), same as any other invalid input', () => {
+      const log = { warn: sandbox.stub() };
+      expect(resolveEnableSemrush({ messageData: { enableSemrush: 0 } }, log, '[T]')).to.be.undefined;
+      expect(resolveEnableSemrush({ messageData: { enableSemrush: 1 } }, log, '[T]')).to.be.undefined;
+      expect(log.warn).to.have.been.calledTwice;
+    });
+  });
+
   describe('requestOffsiteScrape', () => {
     let context;
 
@@ -597,6 +638,25 @@ describe('offsite-audit-utils', () => {
 
       const msg = context.sqs.sendMessage.firstCall.args[1];
       expect(msg.auditContext.messageData).to.deep.equal({ domainScope: 'top-cited', urlLimit: 15 });
+    });
+
+    it('forwards enableSemrush in messageData alongside enableBrandProfile and urlLimit', async () => {
+      await requestOffsiteScrape(context, 'site-1', 'reddit.com', undefined, true, 20, true);
+
+      const msg = context.sqs.sendMessage.firstCall.args[1];
+      expect(msg.auditContext.messageData).to.deep.equal({
+        domainScope: 'reddit.com',
+        enableBrandProfile: true,
+        urlLimit: 20,
+        enableSemrush: true,
+      });
+    });
+
+    it('forwards explicit enableSemrush:false (distinct from absent)', async () => {
+      await requestOffsiteScrape(context, 'site-1', 'top-cited', undefined, undefined, undefined, false);
+
+      const msg = context.sqs.sendMessage.firstCall.args[1];
+      expect(msg.auditContext.messageData).to.deep.equal({ domainScope: 'top-cited', enableSemrush: false });
     });
 
     it('swallows and logs a warning when the send fails', async () => {

--- a/test/utils/offsite-brand-presence-semrush.test.js
+++ b/test/utils/offsite-brand-presence-semrush.test.js
@@ -46,7 +46,8 @@ describe('offsite-brand-presence-semrush', function () {
   let imsCreateFrom;
   let mod;
 
-  const site = { getOrganizationId: () => ORG_ID };
+  const SITE_ID = '5b0d4d6e-3d2e-4a5b-8e2a-9b6f7c9c1e2a';
+  const site = { getOrganizationId: () => ORG_ID, getId: () => SITE_ID };
   const makeContext = (env = {}, extra = {}) => ({ log, env, ...extra });
   const warnedWith = (re) => log.warn.getCalls().some((c) => re.test(c.args[0]));
   const erroredWith = (re) => log.error.getCalls().some((c) => re.test(c.args[0]));

--- a/test/utils/offsite-brand-presence-semrush.test.js
+++ b/test/utils/offsite-brand-presence-semrush.test.js
@@ -168,6 +168,34 @@ describe('offsite-brand-presence-semrush', function () {
     expect(allUrls.size).to.equal(1);
   });
 
+  it('drops URLs failing the strict youtube/reddit formats (parity with the legacy path)', async () => {
+    fetchStub.callsFake(async (url) => {
+      const hostname = new URL(url).searchParams.get('hostname');
+      if (hostname === 'youtube.com') {
+        return okJson({
+          urls: [
+            { url: YT_URL, citations: 10 }, // valid watch URL -> kept
+            { url: 'https://music.youtube.com/watch?v=zzz', citations: 99 }, // lookalike host -> dropped
+          ],
+        });
+      }
+      return okJson({
+        urls: [
+          { url: RD_URL, citations: 7 }, // valid /r/.../comments/ thread -> kept
+          { url: 'https://www.reddit.com/settings', citations: 99 }, // non-thread -> dropped
+        ],
+      });
+    });
+
+    const allUrls = await mod.loadCitedUrlsFromSemrush({
+      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
+    });
+
+    expect([...allUrls.keys()].sort()).to.deep.equal(['https://youtu.be/abc', RD_URL].sort());
+    expect(allUrls.has('https://music.youtube.com/watch?v=zzz')).to.equal(false);
+    expect(allUrls.has('https://www.reddit.com/settings')).to.equal(false);
+  });
+
   it('treats a non-array urls body as empty', async () => {
     fetchStub.resolves(okJson({ notUrls: true }));
     const allUrls = await mod.loadCitedUrlsFromSemrush({

--- a/test/utils/offsite-brand-presence-semrush.test.js
+++ b/test/utils/offsite-brand-presence-semrush.test.js
@@ -1,0 +1,296 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import esmock from 'esmock';
+
+use(sinonChai);
+
+const ORG_ID = 'e07a0aae-b794-41f6-9622-a602203c5a3e';
+const BRAND_ID = 'cb84e91a-f7e9-488b-8220-e0d031941cd7';
+const PREVIOUS_WEEKS = [{ week: 29, year: 2026 }, { week: 28, year: 2026 }];
+
+const YT_URL = 'https://www.youtube.com/watch?v=abc';
+const RD_URL = 'https://www.reddit.com/r/Lovesac/comments/1/pros_cons';
+
+const okJson = (body) => ({ ok: true, status: 200, json: async () => body });
+
+describe('offsite-brand-presence-semrush', function () {
+  this.timeout(10000);
+
+  let sandbox;
+  let log;
+  let fetchStub;
+  let resolveBrandForSite;
+  let getServiceAccessTokenV3;
+  let imsCreateFrom;
+  let mod;
+
+  const site = { getOrganizationId: () => ORG_ID };
+
+  const makeContext = (env = {}, extra = {}) => ({ log, env, ...extra });
+
+  async function loadModule() {
+    return esmock('../../src/utils/offsite-brand-presence-semrush.js', {
+      '@adobe/spacecat-shared-ims-client': {
+        ImsClient: { createFrom: imsCreateFrom },
+      },
+      '../../src/utils/brand-resolver.js': { resolveBrandForSite },
+    });
+  }
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    log = {
+      info: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub(), debug: sandbox.stub(),
+    };
+    fetchStub = sandbox.stub(global, 'fetch');
+    resolveBrandForSite = sandbox.stub().resolves({ brandId: BRAND_ID });
+    getServiceAccessTokenV3 = sandbox.stub().resolves({ token_type: 'Bearer', access_token: 'tok' });
+    imsCreateFrom = sandbox.stub().returns({ getServiceAccessTokenV3 });
+    mod = await loadModule();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  // --- happy path -----------------------------------------------------------
+
+  it('loads youtube + reddit cited URLs and maps count=citations, domain', async () => {
+    fetchStub.callsFake(async (url) => {
+      const hostname = new URL(url).searchParams.get('hostname');
+      return hostname === 'youtube.com'
+        ? okJson({ urls: [{ url: YT_URL, citations: 10 }] })
+        : okJson({ urls: [{ url: RD_URL, citations: 7 }] });
+    });
+
+    const allUrls = await mod.loadCitedUrlsFromSemrush({
+      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
+    });
+
+    expect(fetchStub).to.have.been.calledTwice;
+    // youtube watch?v=abc is normalized to the youtu.be canonical form
+    expect(allUrls.get('https://youtu.be/abc')).to.deep.equal({ count: 10, domain: 'youtube.com' });
+    expect(allUrls.get(RD_URL)).to.deep.equal({ count: 7, domain: 'reddit.com' });
+  });
+
+  it('sends Authorization but no platform param by default, and no x-promise-token', async () => {
+    fetchStub.resolves(okJson({ urls: [] }));
+
+    await mod.loadCitedUrlsFromSemrush({
+      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
+    });
+
+    const [url, opts] = fetchStub.firstCall.args;
+    expect(new URL(url).searchParams.has('platform')).to.equal(false);
+    expect(url).to.contain(`${mod.SPACECAT_API_DEFAULT_BASE_URL}/v2/orgs/${ORG_ID}/brands/${BRAND_ID}`);
+    expect(opts.headers.Authorization).to.equal('Bearer tok');
+    expect(opts.headers).to.not.have.property('x-promise-token');
+  });
+
+  it('forwards x-promise-token when present on the context', async () => {
+    fetchStub.resolves(okJson({ urls: [] }));
+
+    await mod.loadCitedUrlsFromSemrush({
+      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext({}, { promiseToken: 'ptok' }),
+    });
+
+    expect(fetchStub.firstCall.args[1].headers['x-promise-token']).to.equal('ptok');
+  });
+
+  it('honours the SPACECAT_API_URI override', async () => {
+    fetchStub.resolves(okJson({ urls: [] }));
+
+    await mod.loadCitedUrlsFromSemrush({
+      site,
+      previousWeeks: PREVIOUS_WEEKS,
+      context: makeContext({ SPACECAT_API_URI: 'https://stage.example/api' }),
+    });
+
+    expect(fetchStub.firstCall.args[0]).to.contain('https://stage.example/api/v2/orgs/');
+  });
+
+  it('queries per platform and SUMS citations across engines', async () => {
+    fetchStub.callsFake(async (url) => {
+      const params = new URL(url).searchParams;
+      const hostname = params.get('hostname');
+      const platform = params.get('platform');
+      if (hostname === 'youtube.com') {
+        return okJson({ urls: [{ url: YT_URL, citations: platform === 'google-ai-mode' ? 5 : 10 }] });
+      }
+      return okJson({ urls: [{ url: RD_URL, citations: 7 }] });
+    });
+
+    const allUrls = await mod.loadCitedUrlsFromSemrush({
+      site,
+      previousWeeks: PREVIOUS_WEEKS,
+      context: makeContext({ OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt, google-ai-mode' }),
+    });
+
+    // 2 hostnames x 2 platforms
+    expect(fetchStub.callCount).to.equal(4);
+    expect(allUrls.get('https://youtu.be/abc').count).to.equal(15); // 10 + 5
+    expect(allUrls.get(RD_URL).count).to.equal(14); // 7 + 7
+  });
+
+  it('filters owned URLs (siteHostname) and rows without a url; defaults missing citations to 0', async () => {
+    fetchStub.callsFake(async (url) => {
+      const hostname = new URL(url).searchParams.get('hostname');
+      if (hostname === 'youtube.com') {
+        return okJson({
+          urls: [
+            { url: YT_URL }, // missing citations -> 0
+            { citations: 3 }, // no url -> skipped
+          ],
+        });
+      }
+      return okJson({ urls: [{ url: 'https://www.lovesac.com/owned', citations: 99 }] });
+    });
+
+    const allUrls = await mod.loadCitedUrlsFromSemrush({
+      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(), siteHostname: 'lovesac.com',
+    });
+
+    expect(allUrls.get('https://youtu.be/abc')).to.deep.equal({ count: 0, domain: 'youtube.com' });
+    expect([...allUrls.keys()]).to.not.include('https://www.lovesac.com/owned');
+    expect(allUrls.size).to.equal(1);
+  });
+
+  it('treats a non-array urls body as empty', async () => {
+    fetchStub.resolves(okJson({ notUrls: true }));
+    const allUrls = await mod.loadCitedUrlsFromSemrush({
+      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
+    });
+    expect(allUrls.size).to.equal(0);
+  });
+
+  // --- per-request error handling ------------------------------------------
+
+  it('skips a hostname whose fetch rejects, keeping the other', async () => {
+    fetchStub.callsFake(async (url) => {
+      const hostname = new URL(url).searchParams.get('hostname');
+      if (hostname === 'youtube.com') {
+        throw new Error('network down');
+      }
+      return okJson({ urls: [{ url: RD_URL, citations: 7 }] });
+    });
+
+    const allUrls = await mod.loadCitedUrlsFromSemrush({
+      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
+    });
+
+    expect(allUrls.get(RD_URL)).to.deep.equal({ count: 7, domain: 'reddit.com' });
+    expect(log.error).to.have.been.called;
+  });
+
+  it('skips a non-2xx response', async () => {
+    fetchStub.resolves({ ok: false, status: 500 });
+    const allUrls = await mod.loadCitedUrlsFromSemrush({
+      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
+    });
+    expect(allUrls.size).to.equal(0);
+    expect(log.error).to.have.been.called;
+  });
+
+  it('skips a response whose body fails to parse', async () => {
+    const throwingJson = async () => {
+      throw new Error('bad json');
+    };
+    fetchStub.resolves({ ok: true, status: 200, json: throwingJson });
+    const allUrls = await mod.loadCitedUrlsFromSemrush({
+      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
+    });
+    expect(allUrls.size).to.equal(0);
+    expect(log.error).to.have.been.called;
+  });
+
+  // --- precondition guards (return null) -----------------------------------
+
+  it('returns null when the site has no organization id', async () => {
+    const result = await mod.loadCitedUrlsFromSemrush({
+      site: { getOrganizationId: () => null },
+      previousWeeks: PREVIOUS_WEEKS,
+      context: makeContext(),
+    });
+    expect(result).to.equal(null);
+    expect(fetchStub).to.not.have.been.called;
+  });
+
+  it('returns null when no active brand resolves', async () => {
+    resolveBrandForSite.resolves(null);
+    const result = await mod.loadCitedUrlsFromSemrush({
+      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
+    });
+    expect(result).to.equal(null);
+  });
+
+  it('returns null when the brand has no brandId', async () => {
+    resolveBrandForSite.resolves({});
+    const result = await mod.loadCitedUrlsFromSemrush({
+      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
+    });
+    expect(result).to.equal(null);
+  });
+
+  it('returns null when no date window can be derived', async () => {
+    const result = await mod.loadCitedUrlsFromSemrush({
+      site, previousWeeks: [], context: makeContext(),
+    });
+    expect(result).to.equal(null);
+  });
+
+  it('returns null when the IMS service token cannot be minted', async () => {
+    getServiceAccessTokenV3.rejects(new Error('ims down'));
+    const result = await mod.loadCitedUrlsFromSemrush({
+      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
+    });
+    expect(result).to.equal(null);
+    expect(log.error).to.have.been.called;
+  });
+
+  // --- pure helpers ---------------------------------------------------------
+
+  describe('getSemrushPlatforms', () => {
+    it('defaults to a single omitted platform', () => {
+      expect(mod.getSemrushPlatforms(undefined)).to.deep.equal([undefined]);
+      expect(mod.getSemrushPlatforms({})).to.deep.equal([undefined]);
+      expect(mod.getSemrushPlatforms({ OFFSITE_SEMRUSH_PLATFORMS: '   ' }))
+        .to.deep.equal([undefined]);
+    });
+
+    it('parses a comma-separated list, trimming and dropping empties', () => {
+      expect(mod.getSemrushPlatforms({ OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt, ,google-ai-mode ' }))
+        .to.deep.equal(['search-gpt', 'google-ai-mode']);
+    });
+  });
+
+  describe('buildDomainUrlsUrl', () => {
+    const baseArgs = {
+      baseUrl: 'https://h/api', spaceCatId: 'o', brandId: 'b', hostname: 'reddit.com', startDate: '2026-07-06', endDate: '2026-08-02',
+    };
+
+    it('omits platform when not provided', () => {
+      const url = mod.buildDomainUrlsUrl(baseArgs);
+      expect(url).to.contain('/v2/orgs/o/brands/b/serenity/brand-presence/url-inspector/domain-urls?');
+      expect(new URL(url).searchParams.has('platform')).to.equal(false);
+      expect(new URL(url).searchParams.get('hostname')).to.equal('reddit.com');
+    });
+
+    it('includes platform when provided', () => {
+      const url = mod.buildDomainUrlsUrl({ ...baseArgs, platform: 'search-gpt' });
+      expect(new URL(url).searchParams.get('platform')).to.equal('search-gpt');
+    });
+  });
+});

--- a/test/utils/offsite-brand-presence-semrush.test.js
+++ b/test/utils/offsite-brand-presence-semrush.test.js
@@ -67,9 +67,14 @@ describe('offsite-brand-presence-semrush', function () {
     });
   }
 
-  const run = (env = {}, extra = {}, onProgress = undefined) => mod.loadCitedUrlsFromSemrush({
-    site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(env, extra), onProgress,
-  });
+  const run = (env = {}, extra = {}, onProgress = undefined, diagnostics = undefined) => mod
+    .loadCitedUrlsFromSemrush({
+      site,
+      previousWeeks: PREVIOUS_WEEKS,
+      context: makeContext(env, extra),
+      onProgress,
+      diagnostics,
+    });
 
   beforeEach(async () => {
     sandbox = sinon.createSandbox();
@@ -275,9 +280,18 @@ describe('offsite-brand-presence-semrush', function () {
     expect(await run(ONE_ENGINE)).to.equal(null);
   });
 
-  it('logs a distinct rejection and falls back on a 401/403 surface', async () => {
+  it('logs a distinct rejection and falls back on a 401 surface', async () => {
     stubByHostname((hostname) => (hostname === 'reddit.com'
       ? { ok: false, status: 401 }
+      : okJson({ urls: [{ url: YT_URL, citations: 10 }] })));
+    const result = await run(ONE_ENGINE);
+    expect(result).to.equal(null);
+    expect(erroredWith(/Service token rejected/)).to.equal(true);
+  });
+
+  it('logs a distinct rejection and falls back on a 403 surface', async () => {
+    stubByHostname((hostname) => (hostname === 'reddit.com'
+      ? { ok: false, status: 403 }
       : okJson({ urls: [{ url: YT_URL, citations: 10 }] })));
     const result = await run(ONE_ENGINE);
     expect(result).to.equal(null);
@@ -306,16 +320,56 @@ describe('offsite-brand-presence-semrush', function () {
     expect(allUrls.get(RD_URL).count).to.equal(14); // reddit ok on both engines
   });
 
+  // --- diagnostics out-param --------------------------------------------------
+
+  it('reports a specific fallbackReason for a fully-failed surface, distinct from other null causes', async () => {
+    stubByHostname((hostname) => (hostname === 'reddit.com'
+      ? Promise.reject(new Error('network down'))
+      : okJson({ urls: [{ url: YT_URL, citations: 10 }] })));
+    const diagnostics = {};
+    expect(await run(ONE_ENGINE, {}, undefined, diagnostics)).to.equal(null);
+    expect(diagnostics.fallbackReason).to.equal('surface-failed:reddit.com');
+  });
+
+  it('reports engineFailureCount/degradedHosts/authFailureDetected on a successful but degraded run', async () => {
+    stubByHostname((hostname, platform) => {
+      if (hostname === 'youtube.com' && platform === 'search-gpt') {
+        return { ok: false, status: 401 };
+      }
+      return hostname === 'youtube.com'
+        ? okJson({ urls: [{ url: YT_URL, citations: 5 }] })
+        : okJson({ urls: [{ url: RD_URL, citations: 7 }] });
+    });
+    const diagnostics = {};
+    const allUrls = await run(TWO_ENGINES, {}, undefined, diagnostics);
+    expect(allUrls).to.not.equal(null);
+    expect(diagnostics.engineFailureCount).to.equal(1);
+    expect(diagnostics.degradedHosts).to.deep.equal(['youtube.com']);
+    expect(diagnostics.authFailureDetected).to.equal(true);
+  });
+
+  it('reports no degradation on a fully clean run', async () => {
+    fetchStub.resolves(okJson({ urls: [] }));
+    const diagnostics = {};
+    await run(ONE_ENGINE, {}, undefined, diagnostics);
+    expect(diagnostics.engineFailureCount).to.equal(0);
+    expect(diagnostics.degradedHosts).to.deep.equal([]);
+    expect(diagnostics.authFailureDetected).to.equal(false);
+  });
+
   // --- precondition guards (return null) -----------------------------------
 
   it('returns null when the site has no organization id', async () => {
+    const diagnostics = {};
     const result = await mod.loadCitedUrlsFromSemrush({
       site: { getOrganizationId: () => null },
       previousWeeks: PREVIOUS_WEEKS,
       context: makeContext(),
+      diagnostics,
     });
     expect(result).to.equal(null);
     expect(fetchStub).to.not.have.been.called;
+    expect(diagnostics.fallbackReason).to.equal('no-organization-id');
   });
 
   it('returns null and logs info when the brand is confirmed absent (resolved=true)', async () => {

--- a/test/utils/offsite-brand-presence-semrush.test.js
+++ b/test/utils/offsite-brand-presence-semrush.test.js
@@ -14,6 +14,7 @@ import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import esmock from 'esmock';
+import * as spacecatSharedUtils from '@adobe/spacecat-shared-utils';
 
 use(sinonChai);
 
@@ -26,13 +27,19 @@ const RD_URL = 'https://www.reddit.com/r/Lovesac/comments/1/pros_cons';
 
 const okJson = (body) => ({ ok: true, status: 200, json: async () => body });
 
+// Default engines queried when OFFSITE_SEMRUSH_PLATFORMS is unset — the full
+// offsite provider set mapped to serenity models (SEMRUSH_PLATFORM_BY_PROVIDER).
+const DEFAULT_PLATFORMS = [
+  'google-ai-mode', 'search-gpt', 'microsoft-copilot', 'gemini-2.5-flash', 'google-ai-overview', 'perplexity',
+];
+
 describe('offsite-brand-presence-semrush', function () {
   this.timeout(10000);
 
   let sandbox;
   let log;
   let fetchStub;
-  let resolveBrandForSite;
+  let resolveBrandResultForSite;
   let getServiceAccessTokenV3;
   let imsCreateFrom;
   let mod;
@@ -43,10 +50,17 @@ describe('offsite-brand-presence-semrush', function () {
 
   async function loadModule() {
     return esmock('../../src/utils/offsite-brand-presence-semrush.js', {
-      '@adobe/spacecat-shared-ims-client': {
-        ImsClient: { createFrom: imsCreateFrom },
-      },
-      '../../src/utils/brand-resolver.js': { resolveBrandForSite },
+      '@adobe/spacecat-shared-ims-client': { ImsClient: { createFrom: imsCreateFrom } },
+      '../../src/utils/brand-resolver.js': { resolveBrandResultForSite },
+      '@adobe/spacecat-shared-utils': { ...spacecatSharedUtils, tracingFetch: fetchStub },
+    });
+  }
+
+  // Returns rows keyed by hostname; platform can vary the payload.
+  function stubByHostname(fn) {
+    fetchStub.callsFake(async (url) => {
+      const params = new URL(url).searchParams;
+      return fn(params.get('hostname'), params.get('platform'));
     });
   }
 
@@ -55,8 +69,9 @@ describe('offsite-brand-presence-semrush', function () {
     log = {
       info: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub(), debug: sandbox.stub(),
     };
-    fetchStub = sandbox.stub(global, 'fetch');
-    resolveBrandForSite = sandbox.stub().resolves({ brandId: BRAND_ID });
+    fetchStub = sandbox.stub();
+    resolveBrandResultForSite = sandbox.stub()
+      .resolves({ brand: { brandId: BRAND_ID }, resolved: true });
     getServiceAccessTokenV3 = sandbox.stub().resolves({ token_type: 'Bearer', access_token: 'tok' });
     imsCreateFrom = sandbox.stub().returns({ getServiceAccessTokenV3 });
     mod = await loadModule();
@@ -68,25 +83,35 @@ describe('offsite-brand-presence-semrush', function () {
 
   // --- happy path -----------------------------------------------------------
 
-  it('loads youtube + reddit cited URLs and maps count=citations, domain', async () => {
-    fetchStub.callsFake(async (url) => {
-      const hostname = new URL(url).searchParams.get('hostname');
-      return hostname === 'youtube.com'
-        ? okJson({ urls: [{ url: YT_URL, citations: 10 }] })
-        : okJson({ urls: [{ url: RD_URL, citations: 7 }] });
-    });
+  it('queries each engine per hostname and SUMS citations per URL', async () => {
+    stubByHostname((hostname, platform) => (hostname === 'youtube.com'
+      ? okJson({ urls: [{ url: YT_URL, citations: platform === 'google-ai-mode' ? 5 : 10 }] })
+      : okJson({ urls: [{ url: RD_URL, citations: platform === 'google-ai-mode' ? 4 : 7 }] })));
 
     const allUrls = await mod.loadCitedUrlsFromSemrush({
+      site,
+      previousWeeks: PREVIOUS_WEEKS,
+      context: makeContext({ OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt, google-ai-mode' }),
+    });
+
+    // 2 hostnames x 2 engines
+    expect(fetchStub.callCount).to.equal(4);
+    expect(allUrls.get('https://youtu.be/abc')).to.deep.equal({ count: 15, domain: 'youtube.com' }); // 10 + 5
+    expect(allUrls.get(RD_URL)).to.deep.equal({ count: 11, domain: 'reddit.com' }); // 7 + 4
+  });
+
+  it('defaults to the full provider engine set (one request per engine per hostname)', async () => {
+    fetchStub.resolves(okJson({ urls: [] }));
+
+    await mod.loadCitedUrlsFromSemrush({
       site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
     });
 
-    expect(fetchStub).to.have.been.calledTwice;
-    // youtube watch?v=abc is normalized to the youtu.be canonical form
-    expect(allUrls.get('https://youtu.be/abc')).to.deep.equal({ count: 10, domain: 'youtube.com' });
-    expect(allUrls.get(RD_URL)).to.deep.equal({ count: 7, domain: 'reddit.com' });
+    expect(mod.getSemrushPlatforms(undefined)).to.have.lengthOf(6);
+    expect(fetchStub.callCount).to.equal(12); // 2 hostnames x 6 engines
   });
 
-  it('sends Authorization but no platform param by default, and no x-promise-token', async () => {
+  it('sends Authorization + timeout, no platform-less request, and no x-promise-token by default', async () => {
     fetchStub.resolves(okJson({ urls: [] }));
 
     await mod.loadCitedUrlsFromSemrush({
@@ -94,9 +119,10 @@ describe('offsite-brand-presence-semrush', function () {
     });
 
     const [url, opts] = fetchStub.firstCall.args;
-    expect(new URL(url).searchParams.has('platform')).to.equal(false);
     expect(url).to.contain(`${mod.SPACECAT_API_DEFAULT_BASE_URL}/v2/orgs/${ORG_ID}/brands/${BRAND_ID}`);
+    expect(new URL(url).searchParams.get('platform')).to.be.oneOf(DEFAULT_PLATFORMS);
     expect(opts.headers.Authorization).to.equal('Bearer tok');
+    expect(opts.timeout).to.be.a('number');
     expect(opts.headers).to.not.have.property('x-promise-token');
   });
 
@@ -122,78 +148,59 @@ describe('offsite-brand-presence-semrush', function () {
     expect(fetchStub.firstCall.args[0]).to.contain('https://stage.example/api/v2/orgs/');
   });
 
-  it('queries per platform and SUMS citations across engines', async () => {
-    fetchStub.callsFake(async (url) => {
-      const params = new URL(url).searchParams;
-      const hostname = params.get('hostname');
-      const platform = params.get('platform');
-      if (hostname === 'youtube.com') {
-        return okJson({ urls: [{ url: YT_URL, citations: platform === 'google-ai-mode' ? 5 : 10 }] });
-      }
-      return okJson({ urls: [{ url: RD_URL, citations: 7 }] });
+  it('honours OFFSITE_SEMRUSH_PLATFORMS override (fewer engines)', async () => {
+    fetchStub.resolves(okJson({ urls: [] }));
+
+    await mod.loadCitedUrlsFromSemrush({
+      site,
+      previousWeeks: PREVIOUS_WEEKS,
+      context: makeContext({ OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt' }),
     });
+
+    // 2 hostnames x 1 engine
+    expect(fetchStub.callCount).to.equal(2);
+    fetchStub.getCalls().forEach((c) => {
+      expect(new URL(c.args[0]).searchParams.get('platform')).to.equal('search-gpt');
+    });
+  });
+
+  it('drops URLs failing the strict youtube/reddit formats (parity with the legacy path)', async () => {
+    stubByHostname((hostname) => (hostname === 'youtube.com'
+      ? okJson({
+        urls: [
+          { url: YT_URL, citations: 10 },
+          { url: 'https://music.youtube.com/watch?v=zzz', citations: 99 }, // lookalike host -> dropped
+        ],
+      })
+      : okJson({
+        urls: [
+          { url: RD_URL, citations: 7 },
+          { url: 'https://www.reddit.com/settings', citations: 99 }, // non-thread -> dropped
+        ],
+      })));
+
+    const allUrls = await mod.loadCitedUrlsFromSemrush({
+      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext({ OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt' }),
+    });
+
+    expect([...allUrls.keys()].sort()).to.deep.equal(['https://youtu.be/abc', RD_URL].sort());
+  });
+
+  it('filters owned URLs, rows without a url, and defaults missing citations to 0', async () => {
+    stubByHostname((hostname) => (hostname === 'youtube.com'
+      // first row: missing citations -> 0; second row: no url -> skipped
+      ? okJson({ urls: [{ url: YT_URL }, { citations: 3 }] })
+      : okJson({ urls: [{ url: 'https://www.lovesac.com/owned', citations: 99 }] }))); // owned -> dropped
 
     const allUrls = await mod.loadCitedUrlsFromSemrush({
       site,
       previousWeeks: PREVIOUS_WEEKS,
-      context: makeContext({ OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt, google-ai-mode' }),
-    });
-
-    // 2 hostnames x 2 platforms
-    expect(fetchStub.callCount).to.equal(4);
-    expect(allUrls.get('https://youtu.be/abc').count).to.equal(15); // 10 + 5
-    expect(allUrls.get(RD_URL).count).to.equal(14); // 7 + 7
-  });
-
-  it('filters owned URLs (siteHostname) and rows without a url; defaults missing citations to 0', async () => {
-    fetchStub.callsFake(async (url) => {
-      const hostname = new URL(url).searchParams.get('hostname');
-      if (hostname === 'youtube.com') {
-        return okJson({
-          urls: [
-            { url: YT_URL }, // missing citations -> 0
-            { citations: 3 }, // no url -> skipped
-          ],
-        });
-      }
-      return okJson({ urls: [{ url: 'https://www.lovesac.com/owned', citations: 99 }] });
-    });
-
-    const allUrls = await mod.loadCitedUrlsFromSemrush({
-      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(), siteHostname: 'lovesac.com',
+      context: makeContext({ OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt' }),
+      siteHostname: 'lovesac.com',
     });
 
     expect(allUrls.get('https://youtu.be/abc')).to.deep.equal({ count: 0, domain: 'youtube.com' });
-    expect([...allUrls.keys()]).to.not.include('https://www.lovesac.com/owned');
     expect(allUrls.size).to.equal(1);
-  });
-
-  it('drops URLs failing the strict youtube/reddit formats (parity with the legacy path)', async () => {
-    fetchStub.callsFake(async (url) => {
-      const hostname = new URL(url).searchParams.get('hostname');
-      if (hostname === 'youtube.com') {
-        return okJson({
-          urls: [
-            { url: YT_URL, citations: 10 }, // valid watch URL -> kept
-            { url: 'https://music.youtube.com/watch?v=zzz', citations: 99 }, // lookalike host -> dropped
-          ],
-        });
-      }
-      return okJson({
-        urls: [
-          { url: RD_URL, citations: 7 }, // valid /r/.../comments/ thread -> kept
-          { url: 'https://www.reddit.com/settings', citations: 99 }, // non-thread -> dropped
-        ],
-      });
-    });
-
-    const allUrls = await mod.loadCitedUrlsFromSemrush({
-      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
-    });
-
-    expect([...allUrls.keys()].sort()).to.deep.equal(['https://youtu.be/abc', RD_URL].sort());
-    expect(allUrls.has('https://music.youtube.com/watch?v=zzz')).to.equal(false);
-    expect(allUrls.has('https://www.reddit.com/settings')).to.equal(false);
   });
 
   it('treats a non-array urls body as empty', async () => {
@@ -204,44 +211,55 @@ describe('offsite-brand-presence-semrush', function () {
     expect(allUrls.size).to.equal(0);
   });
 
-  // --- per-request error handling ------------------------------------------
+  it('warns when a full page is returned (possible truncation)', async () => {
+    const rows = Array.from({ length: 100 }, (_, i) => ({ url: `${YT_URL}${i}`, citations: 1 }));
+    fetchStub.resolves(okJson({ urls: rows }));
 
-  it('skips a hostname whose fetch rejects, keeping the other', async () => {
-    fetchStub.callsFake(async (url) => {
-      const hostname = new URL(url).searchParams.get('hostname');
-      if (hostname === 'youtube.com') {
-        throw new Error('network down');
+    await mod.loadCitedUrlsFromSemrush({
+      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext({ OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt' }),
+    });
+
+    expect(log.warn.getCalls().some((c) => /full page/.test(c.args[0]))).to.equal(true);
+  });
+
+  // --- ANY request failure => null (full legacy fallback) -------------------
+
+  it('returns null when a single request rejects (partial result never masquerades as success)', async () => {
+    stubByHostname((hostname) => {
+      if (hostname === 'reddit.com') {
+        return Promise.reject(new Error('network down'));
       }
-      return okJson({ urls: [{ url: RD_URL, citations: 7 }] });
+      return okJson({ urls: [{ url: YT_URL, citations: 10 }] });
     });
 
-    const allUrls = await mod.loadCitedUrlsFromSemrush({
-      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
+    const result = await mod.loadCitedUrlsFromSemrush({
+      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext({ OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt' }),
     });
 
-    expect(allUrls.get(RD_URL)).to.deep.equal({ count: 7, domain: 'reddit.com' });
-    expect(log.error).to.have.been.called;
+    expect(result).to.equal(null);
+    expect(log.warn.getCalls().some((c) => /using legacy fallback/.test(c.args[0]))).to.equal(true);
   });
 
-  it('skips a non-2xx response', async () => {
-    fetchStub.resolves({ ok: false, status: 500 });
-    const allUrls = await mod.loadCitedUrlsFromSemrush({
-      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
+  it('returns null when any request is non-2xx', async () => {
+    stubByHostname((hostname) => (hostname === 'reddit.com'
+      ? { ok: false, status: 500 }
+      : okJson({ urls: [{ url: YT_URL, citations: 10 }] })));
+
+    const result = await mod.loadCitedUrlsFromSemrush({
+      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext({ OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt' }),
     });
-    expect(allUrls.size).to.equal(0);
-    expect(log.error).to.have.been.called;
+    expect(result).to.equal(null);
   });
 
-  it('skips a response whose body fails to parse', async () => {
-    const throwingJson = async () => {
-      throw new Error('bad json');
-    };
-    fetchStub.resolves({ ok: true, status: 200, json: throwingJson });
-    const allUrls = await mod.loadCitedUrlsFromSemrush({
-      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
+  it('returns null when any response body fails to parse', async () => {
+    stubByHostname((hostname) => (hostname === 'reddit.com'
+      ? { ok: true, status: 200, json: async () => { throw new Error('bad json'); } }
+      : okJson({ urls: [{ url: YT_URL, citations: 10 }] })));
+
+    const result = await mod.loadCitedUrlsFromSemrush({
+      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext({ OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt' }),
     });
-    expect(allUrls.size).to.equal(0);
-    expect(log.error).to.have.been.called;
+    expect(result).to.equal(null);
   });
 
   // --- precondition guards (return null) -----------------------------------
@@ -256,20 +274,22 @@ describe('offsite-brand-presence-semrush', function () {
     expect(fetchStub).to.not.have.been.called;
   });
 
-  it('returns null when no active brand resolves', async () => {
-    resolveBrandForSite.resolves(null);
+  it('returns null and logs info when the brand is confirmed absent (resolved=true)', async () => {
+    resolveBrandResultForSite.resolves({ brand: null, resolved: true });
     const result = await mod.loadCitedUrlsFromSemrush({
       site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
     });
     expect(result).to.equal(null);
+    expect(log.info).to.have.been.called;
   });
 
-  it('returns null when the brand has no brandId', async () => {
-    resolveBrandForSite.resolves({});
+  it('returns null and logs a transient warning when brand resolution failed (resolved=false)', async () => {
+    resolveBrandResultForSite.resolves({ brand: null, resolved: false });
     const result = await mod.loadCitedUrlsFromSemrush({
       site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
     });
     expect(result).to.equal(null);
+    expect(log.warn.getCalls().some((c) => /transient/.test(c.args[0]))).to.equal(true);
   });
 
   it('returns null when no date window can be derived', async () => {
@@ -291,14 +311,13 @@ describe('offsite-brand-presence-semrush', function () {
   // --- pure helpers ---------------------------------------------------------
 
   describe('getSemrushPlatforms', () => {
-    it('defaults to a single omitted platform', () => {
-      expect(mod.getSemrushPlatforms(undefined)).to.deep.equal([undefined]);
-      expect(mod.getSemrushPlatforms({})).to.deep.equal([undefined]);
-      expect(mod.getSemrushPlatforms({ OFFSITE_SEMRUSH_PLATFORMS: '   ' }))
-        .to.deep.equal([undefined]);
+    it('defaults to the confirmed engine list', () => {
+      expect(mod.getSemrushPlatforms(undefined)).to.deep.equal(DEFAULT_PLATFORMS);
+      expect(mod.getSemrushPlatforms({})).to.deep.equal(DEFAULT_PLATFORMS);
+      expect(mod.getSemrushPlatforms({ OFFSITE_SEMRUSH_PLATFORMS: '   ' })).to.deep.equal(DEFAULT_PLATFORMS);
     });
 
-    it('parses a comma-separated list, trimming and dropping empties', () => {
+    it('parses a comma-separated override, trimming and dropping empties', () => {
       expect(mod.getSemrushPlatforms({ OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt, ,google-ai-mode ' }))
         .to.deep.equal(['search-gpt', 'google-ai-mode']);
     });
@@ -309,9 +328,9 @@ describe('offsite-brand-presence-semrush', function () {
       baseUrl: 'https://h/api', spaceCatId: 'o', brandId: 'b', hostname: 'reddit.com', startDate: '2026-07-06', endDate: '2026-08-02',
     };
 
-    it('omits platform when not provided', () => {
-      const url = mod.buildDomainUrlsUrl(baseArgs);
-      expect(url).to.contain('/v2/orgs/o/brands/b/serenity/brand-presence/url-inspector/domain-urls?');
+    it('omits platform when not provided and encodes path segments', () => {
+      const url = mod.buildDomainUrlsUrl({ ...baseArgs, spaceCatId: 'o/x', brandId: 'b?y' });
+      expect(url).to.contain('/v2/orgs/o%2Fx/brands/b%3Fy/serenity/brand-presence/url-inspector/domain-urls?');
       expect(new URL(url).searchParams.has('platform')).to.equal(false);
       expect(new URL(url).searchParams.get('hostname')).to.equal('reddit.com');
     });

--- a/test/utils/offsite-brand-presence-semrush.test.js
+++ b/test/utils/offsite-brand-presence-semrush.test.js
@@ -67,8 +67,8 @@ describe('offsite-brand-presence-semrush', function () {
     });
   }
 
-  const run = (env = {}, extra = {}) => mod.loadCitedUrlsFromSemrush({
-    site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(env, extra),
+  const run = (env = {}, extra = {}, onProgress = undefined) => mod.loadCitedUrlsFromSemrush({
+    site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(env, extra), onProgress,
   });
 
   beforeEach(async () => {
@@ -347,6 +347,50 @@ describe('offsite-brand-presence-semrush', function () {
     getServiceAccessTokenV3.resolves({ token_type: 'Bearer' });
     expect(await run()).to.equal(null);
     expect(erroredWith(/access_token/)).to.equal(true);
+  });
+
+  // --- progress notifications (onProgress) -----------------------------------
+
+  it('invokes onProgress at each stage of a successful attempt', async () => {
+    stubByHostname((hostname) => (hostname === 'youtube.com'
+      ? okJson({ urls: [{ url: YT_URL, citations: 10 }] })
+      : okJson({ urls: [{ url: RD_URL, citations: 7 }] })));
+    const onProgress = sandbox.stub().resolves();
+
+    const allUrls = await run(ONE_ENGINE, {}, onProgress);
+
+    expect(allUrls.size).to.equal(2);
+    expect(onProgress).to.have.been.called;
+    const messages = onProgress.getCalls().map((c) => c.args[0]);
+    expect(messages.some((m) => /Starting Semrush/.test(m))).to.equal(true);
+    expect(messages.some((m) => /Querying/.test(m))).to.equal(true);
+    expect(messages.some((m) => /youtube\.com.*engine requests succeeded/.test(m))).to.equal(true);
+    expect(messages.some((m) => /reddit\.com.*engine requests succeeded/.test(m))).to.equal(true);
+    expect(messages.some((m) => /Loaded 1 URL\(s\) from `youtube\.com`/.test(m))).to.equal(true);
+    expect(messages.some((m) => /Loaded 1 URL\(s\) from `reddit\.com`/.test(m))).to.equal(true);
+    expect(messages.some((m) => /total cited URL/.test(m))).to.equal(true);
+  });
+
+  it('invokes onProgress with a failure notice on the surface that triggers fallback', async () => {
+    stubByHostname((hostname) => (hostname === 'youtube.com'
+      ? okJson({ urls: [{ url: YT_URL, citations: 10 }] })
+      : { ok: false, status: 500, json: async () => ({}) }));
+    const onProgress = sandbox.stub().resolves();
+
+    expect(await run(ONE_ENGINE, {}, onProgress)).to.equal(null);
+
+    const messages = onProgress.getCalls().map((c) => c.args[0]);
+    expect(messages.some((m) => /reddit\.com.*0\/1 engine requests succeeded/.test(m))).to.equal(true);
+  });
+
+  it('logs a warning and does not throw when onProgress rejects', async () => {
+    fetchStub.resolves(okJson({ urls: [] }));
+    const onProgress = sandbox.stub().rejects(new Error('slack down'));
+
+    const allUrls = await run(ONE_ENGINE, {}, onProgress);
+
+    expect(allUrls).to.not.equal(null);
+    expect(warnedWith(/Failed to post Semrush progress update/)).to.equal(true);
   });
 
   // --- pure helpers ---------------------------------------------------------

--- a/test/utils/offsite-brand-presence-semrush.test.js
+++ b/test/utils/offsite-brand-presence-semrush.test.js
@@ -244,6 +244,15 @@ describe('offsite-brand-presence-semrush', function () {
     expect(warnedWith(/full page/)).to.equal(false);
   });
 
+  it('warns on an exactly-PAGE_SIZE (100-row) page (>= boundary, not >)', async () => {
+    const rows = Array.from({ length: 100 }, (_, i) => ({ url: `${YT_URL}${i}`, citations: 1 }));
+    stubByHostname((hostname) => (hostname === 'youtube.com'
+      ? okJson({ urls: rows })
+      : okJson({ urls: [{ url: RD_URL, citations: 1 }] })));
+    await run(ONE_ENGINE);
+    expect(warnedWith(/full page/)).to.equal(true);
+  });
+
   // --- surface-level fallback (returns null) --------------------------------
 
   it('falls back (null) when a whole hostname has no successful response — reject', async () => {

--- a/test/utils/offsite-brand-presence-semrush.test.js
+++ b/test/utils/offsite-brand-presence-semrush.test.js
@@ -23,15 +23,17 @@ const BRAND_ID = 'cb84e91a-f7e9-488b-8220-e0d031941cd7';
 const PREVIOUS_WEEKS = [{ week: 29, year: 2026 }, { week: 28, year: 2026 }];
 
 const YT_URL = 'https://www.youtube.com/watch?v=abc';
+const YT_NORM = 'https://youtu.be/abc';
 const RD_URL = 'https://www.reddit.com/r/Lovesac/comments/1/pros_cons';
 
-const okJson = (body) => ({ ok: true, status: 200, json: async () => body });
-
-// Default engines queried when OFFSITE_SEMRUSH_PLATFORMS is unset — the full
-// offsite provider set mapped to serenity models (SEMRUSH_PLATFORM_BY_PROVIDER).
+// Full provider engine set (SEMRUSH_PLATFORM_BY_PROVIDER values), the default.
 const DEFAULT_PLATFORMS = [
   'google-ai-mode', 'search-gpt', 'microsoft-copilot', 'gemini-2.5-flash', 'google-ai-overview', 'perplexity',
 ];
+
+const okJson = (body) => ({ ok: true, status: 200, json: async () => body });
+const ONE_ENGINE = { OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt' };
+const TWO_ENGINES = { OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt, google-ai-mode' };
 
 describe('offsite-brand-presence-semrush', function () {
   this.timeout(10000);
@@ -45,8 +47,9 @@ describe('offsite-brand-presence-semrush', function () {
   let mod;
 
   const site = { getOrganizationId: () => ORG_ID };
-
   const makeContext = (env = {}, extra = {}) => ({ log, env, ...extra });
+  const warnedWith = (re) => log.warn.getCalls().some((c) => re.test(c.args[0]));
+  const erroredWith = (re) => log.error.getCalls().some((c) => re.test(c.args[0]));
 
   async function loadModule() {
     return esmock('../../src/utils/offsite-brand-presence-semrush.js', {
@@ -56,13 +59,16 @@ describe('offsite-brand-presence-semrush', function () {
     });
   }
 
-  // Returns rows keyed by hostname; platform can vary the payload.
   function stubByHostname(fn) {
     fetchStub.callsFake(async (url) => {
       const params = new URL(url).searchParams;
       return fn(params.get('hostname'), params.get('platform'));
     });
   }
+
+  const run = (env = {}, extra = {}) => mod.loadCitedUrlsFromSemrush({
+    site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(env, extra),
+  });
 
   beforeEach(async () => {
     sandbox = sinon.createSandbox();
@@ -88,178 +94,206 @@ describe('offsite-brand-presence-semrush', function () {
       ? okJson({ urls: [{ url: YT_URL, citations: platform === 'google-ai-mode' ? 5 : 10 }] })
       : okJson({ urls: [{ url: RD_URL, citations: platform === 'google-ai-mode' ? 4 : 7 }] })));
 
-    const allUrls = await mod.loadCitedUrlsFromSemrush({
-      site,
-      previousWeeks: PREVIOUS_WEEKS,
-      context: makeContext({ OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt, google-ai-mode' }),
-    });
+    const allUrls = await run(TWO_ENGINES);
 
-    // 2 hostnames x 2 engines
-    expect(fetchStub.callCount).to.equal(4);
-    expect(allUrls.get('https://youtu.be/abc')).to.deep.equal({ count: 15, domain: 'youtube.com' }); // 10 + 5
+    expect(fetchStub.callCount).to.equal(4); // 2 hosts x 2 engines
+    expect(allUrls.get(YT_NORM)).to.deep.equal({ count: 15, domain: 'youtube.com' }); // 10 + 5
     expect(allUrls.get(RD_URL)).to.deep.equal({ count: 11, domain: 'reddit.com' }); // 7 + 4
   });
 
   it('defaults to the full provider engine set (one request per engine per hostname)', async () => {
     fetchStub.resolves(okJson({ urls: [] }));
-
-    await mod.loadCitedUrlsFromSemrush({
-      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
-    });
-
+    await run();
     expect(mod.getSemrushPlatforms(undefined)).to.have.lengthOf(6);
-    expect(fetchStub.callCount).to.equal(12); // 2 hostnames x 6 engines
+    expect(fetchStub.callCount).to.equal(12); // 2 hosts x 6 engines
   });
 
-  it('sends Authorization + timeout, no platform-less request, and no x-promise-token by default', async () => {
+  it('sends Authorization+Accept+timeout, no Content-Type, no x-promise-token by default', async () => {
     fetchStub.resolves(okJson({ urls: [] }));
-
-    await mod.loadCitedUrlsFromSemrush({
-      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
-    });
+    await run();
 
     const [url, opts] = fetchStub.firstCall.args;
     expect(url).to.contain(`${mod.SPACECAT_API_DEFAULT_BASE_URL}/v2/orgs/${ORG_ID}/brands/${BRAND_ID}`);
     expect(new URL(url).searchParams.get('platform')).to.be.oneOf(DEFAULT_PLATFORMS);
     expect(opts.headers.Authorization).to.equal('Bearer tok');
-    expect(opts.timeout).to.be.a('number');
+    expect(opts.headers.Accept).to.equal('application/json');
+    expect(opts.headers).to.not.have.property('Content-Type');
     expect(opts.headers).to.not.have.property('x-promise-token');
+    expect(opts.timeout).to.equal(10000);
+  });
+
+  it('normalizes a lowercase token_type to Bearer', async () => {
+    getServiceAccessTokenV3.resolves({ token_type: 'bearer', access_token: 'tok' });
+    fetchStub.resolves(okJson({ urls: [] }));
+    await run();
+    expect(fetchStub.firstCall.args[1].headers.Authorization).to.equal('Bearer tok');
   });
 
   it('forwards x-promise-token when present on the context', async () => {
     fetchStub.resolves(okJson({ urls: [] }));
-
-    await mod.loadCitedUrlsFromSemrush({
-      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext({}, { promiseToken: 'ptok' }),
-    });
-
+    await run({}, { promiseToken: 'ptok' });
     expect(fetchStub.firstCall.args[1].headers['x-promise-token']).to.equal('ptok');
   });
 
   it('honours the SPACECAT_API_URI override', async () => {
     fetchStub.resolves(okJson({ urls: [] }));
-
-    await mod.loadCitedUrlsFromSemrush({
-      site,
-      previousWeeks: PREVIOUS_WEEKS,
-      context: makeContext({ SPACECAT_API_URI: 'https://stage.example/api' }),
-    });
-
+    await run({ SPACECAT_API_URI: 'https://stage.example/api' });
     expect(fetchStub.firstCall.args[0]).to.contain('https://stage.example/api/v2/orgs/');
   });
 
-  it('honours OFFSITE_SEMRUSH_PLATFORMS override (fewer engines)', async () => {
+  it('honours an OFFSITE_SEMRUSH_PLATFORMS override', async () => {
     fetchStub.resolves(okJson({ urls: [] }));
-
-    await mod.loadCitedUrlsFromSemrush({
-      site,
-      previousWeeks: PREVIOUS_WEEKS,
-      context: makeContext({ OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt' }),
-    });
-
-    // 2 hostnames x 1 engine
-    expect(fetchStub.callCount).to.equal(2);
+    await run(ONE_ENGINE);
+    expect(fetchStub.callCount).to.equal(2); // 2 hosts x 1 engine
     fetchStub.getCalls().forEach((c) => {
       expect(new URL(c.args[0]).searchParams.get('platform')).to.equal('search-gpt');
     });
   });
 
-  it('drops URLs failing the strict youtube/reddit formats (parity with the legacy path)', async () => {
+  // --- filtering / scope ----------------------------------------------------
+
+  it('drops URLs failing the strict youtube/reddit formats', async () => {
     stubByHostname((hostname) => (hostname === 'youtube.com'
-      ? okJson({
-        urls: [
-          { url: YT_URL, citations: 10 },
-          { url: 'https://music.youtube.com/watch?v=zzz', citations: 99 }, // lookalike host -> dropped
-        ],
-      })
-      : okJson({
-        urls: [
-          { url: RD_URL, citations: 7 },
-          { url: 'https://www.reddit.com/settings', citations: 99 }, // non-thread -> dropped
-        ],
-      })));
+      ? okJson({ urls: [{ url: YT_URL, citations: 10 }, { url: 'https://music.youtube.com/watch?v=z', citations: 99 }] })
+      : okJson({ urls: [{ url: RD_URL, citations: 7 }, { url: 'https://www.reddit.com/settings', citations: 99 }] })));
 
-    const allUrls = await mod.loadCitedUrlsFromSemrush({
-      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext({ OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt' }),
-    });
-
-    expect([...allUrls.keys()].sort()).to.deep.equal(['https://youtu.be/abc', RD_URL].sort());
+    const allUrls = await run(ONE_ENGINE);
+    expect([...allUrls.keys()].sort()).to.deep.equal([YT_NORM, RD_URL].sort());
   });
 
-  it('filters owned URLs, rows without a url, and defaults missing citations to 0', async () => {
+  it('drops off-host (domain: null) rows so nothing leaks into top-cited', async () => {
     stubByHostname((hostname) => (hostname === 'youtube.com'
-      // first row: missing citations -> 0; second row: no url -> skipped
-      ? okJson({ urls: [{ url: YT_URL }, { citations: 3 }] })
-      : okJson({ urls: [{ url: 'https://www.lovesac.com/owned', citations: 99 }] }))); // owned -> dropped
+      ? okJson({ urls: [{ url: YT_URL, citations: 10 }, { url: 'https://example.org/page', citations: 99 }] })
+      : okJson({ urls: [{ url: RD_URL, citations: 7 }] })));
 
-    const allUrls = await mod.loadCitedUrlsFromSemrush({
-      site,
-      previousWeeks: PREVIOUS_WEEKS,
-      context: makeContext({ OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt' }),
-      siteHostname: 'lovesac.com',
-    });
-
-    expect(allUrls.get('https://youtu.be/abc')).to.deep.equal({ count: 0, domain: 'youtube.com' });
-    expect(allUrls.size).to.equal(1);
+    const allUrls = await run(ONE_ENGINE);
+    expect([...allUrls.keys()]).to.not.include('https://example.org/page');
+    expect(allUrls.has(YT_NORM)).to.equal(true);
   });
 
-  it('treats a non-array urls body as empty', async () => {
-    fetchStub.resolves(okJson({ notUrls: true }));
+  it('filters owned URLs (siteHostname) and rows without a url', async () => {
+    stubByHostname((hostname) => (hostname === 'youtube.com'
+      ? okJson({ urls: [{ url: YT_URL, citations: 10 }, { citations: 3 }] }) // 2nd: no url
+      : okJson({ urls: [{ url: 'https://www.lovesac.com/owned', citations: 99 }] }))); // owned
+
     const allUrls = await mod.loadCitedUrlsFromSemrush({
-      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
+      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(ONE_ENGINE), siteHostname: 'lovesac.com',
     });
+    expect([...allUrls.keys()]).to.deep.equal([YT_NORM]);
+  });
+
+  // --- citation clamping ----------------------------------------------------
+
+  it('drops a URL whose citations are negative (clamped to 0 -> dropped)', async () => {
+    stubByHostname((hostname) => (hostname === 'youtube.com'
+      ? okJson({ urls: [{ url: YT_URL, citations: -5 }] })
+      : okJson({ urls: [{ url: RD_URL, citations: 7 }] })));
+    const allUrls = await run(ONE_ENGINE);
+    expect(allUrls.has(YT_NORM)).to.equal(false);
+    expect(allUrls.get(RD_URL).count).to.equal(7);
+  });
+
+  it('drops a URL whose citations are non-numeric or missing (0 -> dropped)', async () => {
+    stubByHostname((hostname) => (hostname === 'youtube.com'
+      ? okJson({ urls: [{ url: YT_URL, citations: 'abc' }] }) // NaN -> 0
+      : okJson({ urls: [{ url: RD_URL }] }))); // missing -> 0
+    const allUrls = await run(ONE_ENGINE);
     expect(allUrls.size).to.equal(0);
   });
 
-  it('warns when a full page is returned (possible truncation)', async () => {
-    const rows = Array.from({ length: 100 }, (_, i) => ({ url: `${YT_URL}${i}`, citations: 1 }));
-    fetchStub.resolves(okJson({ urls: rows }));
-
-    await mod.loadCitedUrlsFromSemrush({
-      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext({ OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt' }),
-    });
-
-    expect(log.warn.getCalls().some((c) => /full page/.test(c.args[0]))).to.equal(true);
+  it('keeps a URL when one engine reports 0 but another reports a positive count', async () => {
+    stubByHostname((hostname, platform) => (hostname === 'youtube.com'
+      ? okJson({ urls: [{ url: YT_URL, citations: platform === 'google-ai-mode' ? 5 : 0 }] })
+      : okJson({ urls: [{ url: RD_URL, citations: 7 }] })));
+    const allUrls = await run(TWO_ENGINES);
+    expect(allUrls.get(YT_NORM)).to.deep.equal({ count: 5, domain: 'youtube.com' });
   });
 
-  // --- ANY request failure => null (full legacy fallback) -------------------
+  it('sums duplicate URLs within a single page', async () => {
+    stubByHostname((hostname) => (hostname === 'youtube.com'
+      ? okJson({ urls: [{ url: YT_URL, citations: 3 }, { url: YT_URL, citations: 4 }] })
+      : okJson({ urls: [{ url: RD_URL, citations: 1 }] })));
+    const allUrls = await run(ONE_ENGINE);
+    expect(allUrls.get(YT_NORM).count).to.equal(7);
+  });
 
-  it('returns null when a single request rejects (partial result never masquerades as success)', async () => {
+  // --- body / truncation ----------------------------------------------------
+
+  it('treats a non-array urls body as empty (no fallback)', async () => {
+    fetchStub.resolves(okJson({ notUrls: true }));
+    const allUrls = await run();
+    expect(allUrls.size).to.equal(0);
+  });
+
+  it('warns and hard-caps at PAGE_SIZE when a full page is returned', async () => {
+    const rows = Array.from({ length: 101 }, (_, i) => ({ url: `${YT_URL}${i}`, citations: 1 }));
+    stubByHostname((hostname) => (hostname === 'youtube.com'
+      ? okJson({ urls: rows })
+      : okJson({ urls: [{ url: RD_URL, citations: 1 }] })));
+    const allUrls = await run(ONE_ENGINE);
+    expect(warnedWith(/full page/)).to.equal(true);
+    expect([...allUrls.keys()].filter((k) => k.startsWith('https://youtu.be/')).length).to.equal(100);
+  });
+
+  it('does not warn on a 99-row page (truncation off-by-one)', async () => {
+    const rows = Array.from({ length: 99 }, (_, i) => ({ url: `${YT_URL}${i}`, citations: 1 }));
+    stubByHostname((hostname) => (hostname === 'youtube.com'
+      ? okJson({ urls: rows })
+      : okJson({ urls: [{ url: RD_URL, citations: 1 }] })));
+    await run(ONE_ENGINE);
+    expect(warnedWith(/full page/)).to.equal(false);
+  });
+
+  // --- surface-level fallback (returns null) --------------------------------
+
+  it('falls back (null) when a whole hostname has no successful response — reject', async () => {
     stubByHostname((hostname) => {
       if (hostname === 'reddit.com') {
         return Promise.reject(new Error('network down'));
       }
       return okJson({ urls: [{ url: YT_URL, citations: 10 }] });
     });
-
-    const result = await mod.loadCitedUrlsFromSemrush({
-      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext({ OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt' }),
-    });
-
+    const result = await run(ONE_ENGINE);
     expect(result).to.equal(null);
-    expect(log.warn.getCalls().some((c) => /using legacy fallback/.test(c.args[0]))).to.equal(true);
+    expect(warnedWith(/No successful Semrush response for reddit\.com/)).to.equal(true);
   });
 
-  it('returns null when any request is non-2xx', async () => {
+  it('falls back (null) on a non-2xx surface', async () => {
     stubByHostname((hostname) => (hostname === 'reddit.com'
       ? { ok: false, status: 500 }
       : okJson({ urls: [{ url: YT_URL, citations: 10 }] })));
-
-    const result = await mod.loadCitedUrlsFromSemrush({
-      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext({ OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt' }),
-    });
-    expect(result).to.equal(null);
+    expect(await run(ONE_ENGINE)).to.equal(null);
   });
 
-  it('returns null when any response body fails to parse', async () => {
+  it('logs a distinct rejection and falls back on a 401/403 surface', async () => {
+    stubByHostname((hostname) => (hostname === 'reddit.com'
+      ? { ok: false, status: 401 }
+      : okJson({ urls: [{ url: YT_URL, citations: 10 }] })));
+    const result = await run(ONE_ENGINE);
+    expect(result).to.equal(null);
+    expect(erroredWith(/Service token rejected/)).to.equal(true);
+  });
+
+  it('falls back (null) when a surface body fails to parse', async () => {
     stubByHostname((hostname) => (hostname === 'reddit.com'
       ? { ok: true, status: 200, json: async () => { throw new Error('bad json'); } }
       : okJson({ urls: [{ url: YT_URL, citations: 10 }] })));
+    expect(await run(ONE_ENGINE)).to.equal(null);
+  });
 
-    const result = await mod.loadCitedUrlsFromSemrush({
-      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext({ OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt' }),
+  it('tolerates a single failed engine when the surface still has a successful response', async () => {
+    stubByHostname((hostname, platform) => {
+      if (hostname === 'youtube.com' && platform === 'search-gpt') {
+        return Promise.reject(new Error('flaky engine'));
+      }
+      return hostname === 'youtube.com'
+        ? okJson({ urls: [{ url: YT_URL, citations: 5 }] })
+        : okJson({ urls: [{ url: RD_URL, citations: 7 }] });
     });
-    expect(result).to.equal(null);
+    const allUrls = await run(TWO_ENGINES);
+    expect(allUrls).to.not.equal(null);
+    expect(allUrls.get(YT_NORM).count).to.equal(5);
+    expect(allUrls.get(RD_URL).count).to.equal(14); // reddit ok on both engines
   });
 
   // --- precondition guards (return null) -----------------------------------
@@ -276,20 +310,14 @@ describe('offsite-brand-presence-semrush', function () {
 
   it('returns null and logs info when the brand is confirmed absent (resolved=true)', async () => {
     resolveBrandResultForSite.resolves({ brand: null, resolved: true });
-    const result = await mod.loadCitedUrlsFromSemrush({
-      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
-    });
-    expect(result).to.equal(null);
+    expect(await run()).to.equal(null);
     expect(log.info).to.have.been.called;
   });
 
-  it('returns null and logs a transient warning when brand resolution failed (resolved=false)', async () => {
+  it('returns null and warns when brand resolution failed (resolved=false)', async () => {
     resolveBrandResultForSite.resolves({ brand: null, resolved: false });
-    const result = await mod.loadCitedUrlsFromSemrush({
-      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
-    });
-    expect(result).to.equal(null);
-    expect(log.warn.getCalls().some((c) => /transient/.test(c.args[0]))).to.equal(true);
+    expect(await run()).to.equal(null);
+    expect(warnedWith(/transient/)).to.equal(true);
   });
 
   it('returns null when no date window can be derived', async () => {
@@ -301,11 +329,14 @@ describe('offsite-brand-presence-semrush', function () {
 
   it('returns null when the IMS service token cannot be minted', async () => {
     getServiceAccessTokenV3.rejects(new Error('ims down'));
-    const result = await mod.loadCitedUrlsFromSemrush({
-      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
-    });
-    expect(result).to.equal(null);
+    expect(await run()).to.equal(null);
     expect(log.error).to.have.been.called;
+  });
+
+  it('returns null when the IMS token response has no access_token', async () => {
+    getServiceAccessTokenV3.resolves({ token_type: 'Bearer' });
+    expect(await run()).to.equal(null);
+    expect(erroredWith(/access_token/)).to.equal(true);
   });
 
   // --- pure helpers ---------------------------------------------------------
@@ -315,6 +346,8 @@ describe('offsite-brand-presence-semrush', function () {
       expect(mod.getSemrushPlatforms(undefined)).to.deep.equal(DEFAULT_PLATFORMS);
       expect(mod.getSemrushPlatforms({})).to.deep.equal(DEFAULT_PLATFORMS);
       expect(mod.getSemrushPlatforms({ OFFSITE_SEMRUSH_PLATFORMS: '   ' })).to.deep.equal(DEFAULT_PLATFORMS);
+      // separators-only must NOT disable all requests
+      expect(mod.getSemrushPlatforms({ OFFSITE_SEMRUSH_PLATFORMS: ' , , ' })).to.deep.equal(DEFAULT_PLATFORMS);
     });
 
     it('parses a comma-separated override, trimming and dropping empties', () => {


### PR DESCRIPTION
## What

Adds a **flag-gated** data source that fetches the offsite cited URLs (YouTube, Reddit) from the **Semrush-backed Serenity URL-Inspector** endpoints exposed by **spacecat-api-service** (the Elements proxy, `src/controllers/elements.js`) and feeds them into the existing offsite pipeline **unchanged**.

Epic: [LLMO-6488](https://jira.corp.adobe.com/browse/LLMO-6488) · Story: [LLMO-6709](https://jira.corp.adobe.com/browse/LLMO-6709) · Plan: #2779

**Spec (PR template §4):** `docs/specs/2026-08-05-offsite-cited-urls-semrush-source.md` · **ADR:** `docs/decisions/002-offsite-cited-urls-semrush-source.md` (both added in this PR).

## Why a loader

The downstream pipeline (`selectTopUrls` → `addUrlsToUrlStore` → DRS → cited/youtube/reddit-analysis) only understands one input contract: `allUrls: Map<url, { count, domain }>`. The Semrush API returns a shape-incompatible response (structured JSON, per-hostname, requires auth + brand/org resolution + week→date mapping, carries exact citation counts). The loader is the single, isolated adapter that turns that into the exact map the pipeline already consumes — so **everything downstream is reused untouched**.

## How

- **New** `src/utils/offsite-brand-presence-semrush.js` → `loadCitedUrlsFromSemrush()`:
  - Calls `GET {SPACECAT_API_URI}/v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/domain-urls?hostname=…` for each offsite hostname (`youtube.com`, `reddit.com`).
  - Builds `allUrls` with **`count = row.citations`** (exact; not recounted by repetition), reusing the existing `classifyAndNormalize` for URL normalization, owned-URL filtering and domain bucketing → **the same map shape** as today.
  - `spaceCatId` from `site.getOrganizationId()`, `brandId` via `resolveBrandForSite`, date window via `getDateWindowForPreviousWeeks`.
- **Handler** (`offsite-brand-presence/handler.js`): gated by `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED`. Flag **off** = today's PostgREST → SharePoint path (no behavior change). Flag **on** = **Semrush-first with automatic fallback**: if the loader yields no usable URLs (auth failure, no brand, outage, empty), it falls back to the legacy `loadBrandPresenceData` so a Semrush problem can never silently zero out offsite. `selectTopUrls` (per-surface top-70, ranked by citations) is **unchanged** in every case.
- `domain-urls` requested with `pageSize=100` (covers the per-surface top-70 in one page).
- **`export classifyAndNormalize`** from the enrichment module for reuse.

## Endpoint & auth — via spacecat-api-service, not a raw gateway

These are first-class api-service routes (`elementsController.listDomainUrls`, `listCitedDomains`, …). The loader calls **api-service** — the same host the worker already targets via `SPACECAT_API_URI` — rather than hardcoding the `llmo.experiencecloud.live` edge.

Auth is simple: the loader mints a **service IMS token** via the existing `ImsClient` and sends `Authorization: Bearer`. The Elements proxy's `resolveElementsImsToken` authenticates IMS callers directly and **forwards the token to Semrush** (its fallback path — see `requireImsBearer`), so **no `x-promise-token` is required** for a service caller. (A promise token is forwarded only if the platform later threads one onto the context, for non-IMS callers.)

> Remaining validation (not a code blocker): confirm the worker's **service** IMS token is authorized by the upstream Semrush gateway. Flag stays off until verified end-to-end.

## Platform coverage

Omitting `platform` does **not** aggregate across engines (the proxy resolves an absent value to a single default engine). The loader queries the **full offsite provider set** mapped to serenity models via `SEMRUSH_PLATFORM_BY_PROVIDER` (`google-ai-mode`, `search-gpt`, `microsoft-copilot`, `gemini-2.5-flash`, `google-ai-overview`, `perplexity`) and **sums citations per URL**. Override with `OFFSITE_SEMRUSH_PLATFORMS`. Validating the map upstream is [LLMO-6710](https://jira.corp.adobe.com/browse/LLMO-6710).

## Reliability

- **Per-request timeout (10s) + concurrent requests** (`tracingFetch`), so a hung/slow upstream can't stall the audit past the timeout or serialize behind other calls.
- **Any per-request failure → loader returns `null` → full legacy fallback.** A partial Semrush result (e.g. YouTube ok, Reddit failed) is never shipped as success.
- **Truncation warning** when a full page (`>= PAGE_SIZE`) is returned (server-side citations sort is assumed, not confirmed).
- Path segments URL-encoded; brand resolution uses `resolveBrandResultForSite` to log "confirmed no brand" vs "transient failure" distinctly.

## Behavioral parity with the legacy path

There are two `classifyAndNormalize` functions: the enrichment one (hostname match + normalization) and the stricter `handler.js:170` one (adds `YOUTUBE_URL_REGEX` / `REDDIT_URL_REGEX` + `isExcludedCitedHost`). The loader normalizes with the former and **re-applies both regexes** (`handler.js:199-204`) so the Semrush path drops non-thread Reddit URLs (e.g. `/settings`) and lookalike YouTube hosts (e.g. `music.youtube.com`) exactly like the legacy path. A test asserts this. `isExcludedCitedHost` only affects the top-cited bucket and will be applied when that bucket is added.

## Scope / follow-ups

- ✅ **YouTube + Reddit** (fixed hostnames, one `domain-urls` call each).
- ⬜ **Generic "cited" bucket** — needs a `cited-domains` discovery hop; follow-up under LLMO-6709.
- ⬜ **Region scoping** — loader sends no region; legacy spans `ACCEPTED_REGIONS` (6 markets). Documented as a known gap (LLMO-6710); must close before non-US parity.

## Config

| Env | Default | Purpose |
|---|---|---|
| `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED` | (off) | `"true"` switches the source to Semrush |
| `SPACECAT_API_URI` | `https://spacecat.experiencecloud.live/api/v1` | api-service base (standard worker override) |
| `OFFSITE_SEMRUSH_PLATFORMS` | full provider set (`SEMRUSH_PLATFORM_BY_PROVIDER`) | override: comma-sep engines to query + sum |

## Testing

- New `test/utils/offsite-brand-presence-semrush.test.js` — **100% coverage** on the loader (happy path, per-platform sum, owned-URL filtering, all precondition guards, per-request error handling).
- Extended the handler test with flag-on cases (map + null).
- Full suite green: **9411 passing**, coverage gate (100% lines/branches/functions/statements) satisfied.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["@amitruluimadalina", "Dominique Jäggi", "TB ADBE"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```