### PR TITLE
feat(gsc-search-analytics): tracking-only GSC before/after audit for fixed URLs

### DIFF
--- a/docs/specs/gsc-search-analytics.md
+++ b/docs/specs/gsc-search-analytics.md
@@ -35,9 +35,17 @@ Per-fix `status`:
 
 `delta` is populated **only** for `measured`, so a partial window can never masquerade as a complete change.
 
+## Timing
+
+A fix yields a `measured` delta only once its after-window has elapsed past GSC's ~3-day lag (roughly fix date + 87 days) **and** its before-window is still within the ~13-month retention horizon. So only fixes aged roughly **3-13 months** produce a delta; more recent fixes come back `incomplete` and need a later re-run once their after-window closes.
+
 ## Consumption
 
 Read the latest row via the `query-audits` skill (PostgREST, `audits`/`latest_audits`) filtered to the site and `audit_type = gsc-search-analytics`; the per-URL table is `audit_result.fixes`.
+
+Note: `latest_audits` holds a **snapshot, not a cumulative history** — each run replaces the prior `fixedUrls` set for the site. Consumers should treat one row as "the result of the most recent run for this exact URL list," not an accumulation across runs.
+
+URL matching assumes `www.` and apex are equivalent (see `match.js`). If a window returns rows but none of the fixed URLs match, the runner logs a host-mismatch warning rather than silently reporting `not_found`.
 
 ## Non-goals
 

--- a/docs/specs/gsc-search-analytics.md
+++ b/docs/specs/gsc-search-analytics.md
@@ -1,0 +1,48 @@
+# Spec: `gsc-search-analytics` audit
+
+## Goal
+
+For each URL that ASO fixed, record that URL's Google Search Console (GSC) performance for the 84 days **before** and 84 days **after** its own fix date. This is the "Measured" layer of the outcome-proof framework: it **records raw figures only**. It makes **no causal claim, no attribution, and no dollar value** — any touched-vs-untouched or causal analysis is a separate workstream, out of scope here.
+
+## Why an audit
+
+The customer's GSC OAuth token lives only in the SpaceCat prod account's Secrets Manager. A laptop or a different service cannot read it; an audit runs in-account where `GoogleClient.createFrom` can. This audit reuses the existing `@adobe/spacecat-shared-google-client`.
+
+## Input contract
+
+The runner reads `auditContext.fixedUrls` (fallback `auditContext.messageData?.fixedUrls`): an array of `{ url, fixType, fixDate }`, `fixDate` as `YYYY-MM-DD`. Supplied manually for the pilot; may later be sourced from ASO's own FIXED-suggestion records.
+
+Guards (fail closed, recorded as a status, never a crash):
+- `missing_fixed_urls` — empty/absent list.
+- `too_many_fixed_urls` — more than 500 URLs.
+- `too_many_date_groups` — more than 30 distinct fix dates (each date = one sequential pair of window pulls; bounded to stay within the Lambda timeout).
+
+## Processing
+
+1. `GoogleClient.createFrom(context, finalUrl)`. Any failure is recorded as `status:'not_connected'` with a bounded `reason` (repo convention; never throws).
+2. Split invalid dates out as `status:'invalid_date'`. Group the rest by `fixDate` so URLs sharing a date share one pull pair.
+3. Per date-group: compute the two 84-day windows (`computeWindows`), assess completeness (`assessCompleteness` vs GSC's ~3-day freshness lag and ~16-month retention), fetch each window's page rows (`fetchWindow`, paginated, 50-page cap → `truncated` flag), and match each fixed URL client-side (`match.js`, normalized: lowercased host, no fragment, sorted query, trailing slash stripped).
+
+## Output (`audit_result`)
+
+`{ schemaVersion, interpretation, connected, status, fixCount, measuredCount, fixes[] }`. Each fix: `{ url, fixType, fixDate, status, windows, before, after, delta, found, dataQuality }`.
+
+Per-fix `status`:
+- `measured` — both windows found and fully elapsed/in-retention; `delta` = after minus before (for `position`, negative = moved up = better).
+- `not_found` — a window returned no row for the URL.
+- `incomplete` — a window is not fully elapsed or predates retention (`delta:null`; completeness is checked before presence).
+- `invalid_date` / `failed` — recorded with an error, never fetched / fetch failed.
+
+`delta` is populated **only** for `measured`, so a partial window can never masquerade as a complete change.
+
+## Consumption
+
+Read the latest row via the `query-audits` skill (PostgREST, `audits`/`latest_audits`) filtered to the site and `audit_type = gsc-search-analytics`; the per-URL table is `audit_result.fixes`.
+
+## Non-goals
+
+Causal attribution, touched-vs-untouched comparison, dollarization, cross-URL aggregation, automated apply, and sourcing the fixed-URL list from SpaceCat (pilot supplies it manually).
+
+## Related
+
+Implementation plan (private): `basecamp/projects/00_ASO-outcome-proof/docs/plans/2026-08-03-plan-gsc-search-analytics-audit.md`.

--- a/src/gsc-search-analytics/fetch.js
+++ b/src/gsc-search-analytics/fetch.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+const PAGE = 1000; // GSC returns at most 1000 rows per call
+const MAX_PAGES = 50; // safety cap: up to 50k rows per window
+
+/**
+ * Fetch all page-dimension rows for one window, paginating until Google returns
+ * fewer than a full page. Bounded by MAX_PAGES so a very large site cannot run away.
+ *
+ * @param {object} google - GoogleClient instance exposing getOrganicSearchData.
+ * @param {Date} startDate - window start.
+ * @param {Date} endDate - window end.
+ * @returns {Promise<Array<object>>} aggregated GSC rows (each keyed by page URL).
+ */
+export async function fetchWindow(google, startDate, endDate) {
+  const all = [];
+  let startRow = 0;
+  for (let i = 0; i < MAX_PAGES; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    const res = await google.getOrganicSearchData(startDate, endDate, ['page'], PAGE, startRow);
+    const rows = res?.data?.rows ?? [];
+    all.push(...rows);
+    if (rows.length < PAGE) {
+      break;
+    }
+    startRow += PAGE;
+  }
+  return all;
+}

--- a/src/gsc-search-analytics/fetch.js
+++ b/src/gsc-search-analytics/fetch.js
@@ -16,24 +16,26 @@ const MAX_PAGES = 50; // safety cap: up to 50k rows per window
 /**
  * Fetch all page-dimension rows for one window, paginating until Google returns
  * fewer than a full page. Bounded by MAX_PAGES so a very large site cannot run away.
+ * Reports `truncated: true` when the cap is hit (rows past the cap are not fetched),
+ * so callers can tell "URL genuinely absent" from "URL possibly beyond the cap".
  *
  * @param {object} google - GoogleClient instance exposing getOrganicSearchData.
  * @param {Date} startDate - window start.
  * @param {Date} endDate - window end.
- * @returns {Promise<Array<object>>} aggregated GSC rows (each keyed by page URL).
+ * @returns {Promise<{rows: Array<object>, truncated: boolean}>}
  */
 export async function fetchWindow(google, startDate, endDate) {
-  const all = [];
+  const rows = [];
   let startRow = 0;
   for (let i = 0; i < MAX_PAGES; i += 1) {
     // eslint-disable-next-line no-await-in-loop
     const res = await google.getOrganicSearchData(startDate, endDate, ['page'], PAGE, startRow);
-    const rows = res?.data?.rows ?? [];
-    all.push(...rows);
-    if (rows.length < PAGE) {
-      break;
+    const page = res?.data?.rows ?? [];
+    rows.push(...page);
+    if (page.length < PAGE) {
+      return { rows, truncated: false };
     }
     startRow += PAGE;
   }
-  return all;
+  return { rows, truncated: true };
 }

--- a/src/gsc-search-analytics/handler.js
+++ b/src/gsc-search-analytics/handler.js
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { AuditBuilder } from '../common/audit-builder.js';
+import { runGscSearchAnalytics } from './lib.js';
+
+export default new AuditBuilder()
+  .withUrlResolver((site) => site.getBaseURL())
+  .withRunner(runGscSearchAnalytics)
+  .build();

--- a/src/gsc-search-analytics/lib.js
+++ b/src/gsc-search-analytics/lib.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// Stub — replaced in Task 6 with the real runner.
+export async function runGscSearchAnalytics(finalUrl) {
+  return { auditResult: { stub: true }, fullAuditRef: finalUrl };
+}

--- a/src/gsc-search-analytics/lib.js
+++ b/src/gsc-search-analytics/lib.js
@@ -18,7 +18,11 @@ import { buildDelta } from './summarize.js';
 
 const SCHEMA_VERSION = 1;
 const MAX_FIXED_URLS = 500; // guard against an unbounded, Lambda-timeout-risking run
+// Each distinct fix date is one date-group = up to two paginated window pulls run
+// sequentially, so cap the number of groups to stay well inside the Lambda timeout.
+const MAX_DATE_GROUPS = 30;
 const toDate = (s) => new Date(`${s}T00:00:00Z`);
+const clip = (s) => String(s).slice(0, 300); // bound stored error text
 
 // A fix entry with the stable shape every consumer can rely on.
 function baseFix(f, status, extra) {
@@ -86,6 +90,18 @@ export async function runGscSearchAnalytics(finalUrl, context, site, auditContex
     }, finalUrl);
   }
 
+  // Each distinct valid fix date becomes one sequentially-processed date-group; bound the
+  // count so a spread-out list can't exhaust the Lambda timeout.
+  const distinctDateCount = new Set(
+    fixedUrls.filter((f) => isValidFixDate(f.fixDate)).map((f) => f.fixDate),
+  ).size;
+  if (distinctDateCount > MAX_DATE_GROUPS) {
+    log.warn(`gsc-search-analytics: ${distinctDateCount} distinct fix dates exceeds cap ${MAX_DATE_GROUPS} for ${finalUrl}`);
+    return envelope({
+      connected: null, status: 'too_many_date_groups', fixCount: 0, measuredCount: 0, fixes: [],
+    }, finalUrl);
+  }
+
   let google;
   try {
     google = await GoogleClient.createFrom(context, finalUrl);
@@ -94,7 +110,7 @@ export async function runGscSearchAnalytics(finalUrl, context, site, auditContex
     // any createFrom failure means the site is not connected to GSC. Record it, don't crash.
     log.info(`gsc-search-analytics: GSC not connected for ${finalUrl}: ${e.message}`);
     return envelope({
-      connected: false, status: 'not_connected', reason: e.message, fixCount: 0, measuredCount: 0, fixes: [],
+      connected: false, status: 'not_connected', reason: clip(e.message), fixCount: 0, measuredCount: 0, fixes: [],
     }, finalUrl);
   }
 
@@ -162,7 +178,7 @@ export async function runGscSearchAnalytics(finalUrl, context, site, auditContex
       // A failure on one date-group must not wipe the others; leave a diagnostic entry.
       log.error(`gsc-search-analytics: fetch failed for ${fixDate} / ${finalUrl}: ${e.message}`);
       for (const f of group) {
-        fixes.push(baseFix(f, 'failed', { windows, error: e.message }));
+        fixes.push(baseFix(f, 'failed', { windows, error: clip(e.message) }));
       }
     }
   }

--- a/src/gsc-search-analytics/lib.js
+++ b/src/gsc-search-analytics/lib.js
@@ -11,21 +11,48 @@
  */
 
 import GoogleClient from '@adobe/spacecat-shared-google-client';
-import { computeWindows } from './windows.js';
+import { computeWindows, assessCompleteness, isValidFixDate } from './windows.js';
 import { fetchWindow } from './fetch.js';
 import { indexRows, lookup } from './match.js';
 import { buildDelta } from './summarize.js';
 
-// Only a genuinely-absent GSC connection is an expected clean stop; anything
-// else (throttling, IAM, parse errors) is a real failure we must surface.
-const isNotConnected = (e) => /no secrets|not connected|no google|not onboarded/i.test(e.message || '');
+const SCHEMA_VERSION = 1;
+const MAX_FIXED_URLS = 500; // guard against an unbounded, Lambda-timeout-risking run
 const toDate = (s) => new Date(`${s}T00:00:00Z`);
+
+// A fix entry with the stable shape every consumer can rely on.
+function baseFix(f, status, extra) {
+  return {
+    url: f.url,
+    fixType: f.fixType,
+    fixDate: f.fixDate,
+    status,
+    before: null,
+    after: null,
+    delta: null,
+    found: { before: false, after: false },
+    ...extra,
+  };
+}
+
+function envelope(fields, finalUrl) {
+  return {
+    auditResult: { schemaVersion: SCHEMA_VERSION, ...fields },
+    fullAuditRef: finalUrl,
+  };
+}
 
 /**
  * Tracking-only audit: for each URL ASO fixed, record its GSC clicks/impressions/
  * ctr/position for the 84 days before and after the URL's own fix date. No causal
  * claim — this is the "Measured" layer. Input is a manually-supplied list of
  * { url, fixType, fixDate } in auditContext.fixedUrls.
+ *
+ * Result envelope (audit_result JSON): { schemaVersion, connected, status, fixCount,
+ * measuredCount, fixes[] }. Each fix carries a `status` of one of:
+ *   measured | not_found | incomplete | invalid_date | failed
+ * plus before/after/delta/found and a dataQuality marker so a later reader can tell a
+ * real signal from a data gap.
  *
  * @param {string} finalUrl - resolved site base URL.
  * @param {object} context - audit context ({ log, ... }).
@@ -36,69 +63,102 @@ const toDate = (s) => new Date(`${s}T00:00:00Z`);
 export async function runGscSearchAnalytics(finalUrl, context, site, auditContext = {}) {
   const { log } = context;
   const fixedUrls = auditContext.fixedUrls ?? auditContext.messageData?.fixedUrls;
+
   if (!Array.isArray(fixedUrls) || fixedUrls.length === 0) {
-    return { auditResult: { error: 'missing fixedUrls' }, fullAuditRef: finalUrl };
+    log.info(`gsc-search-analytics: no fixedUrls supplied for ${finalUrl}`);
+    return envelope({
+      connected: null, status: 'missing_fixed_urls', fixCount: 0, measuredCount: 0, fixes: [],
+    }, finalUrl);
+  }
+
+  if (fixedUrls.length > MAX_FIXED_URLS) {
+    log.warn(`gsc-search-analytics: ${fixedUrls.length} fixedUrls exceeds cap ${MAX_FIXED_URLS} for ${finalUrl}`);
+    return envelope({
+      connected: null, status: 'too_many_fixed_urls', fixCount: 0, measuredCount: 0, fixes: [],
+    }, finalUrl);
   }
 
   let google;
   try {
     google = await GoogleClient.createFrom(context, finalUrl);
   } catch (e) {
-    if (isNotConnected(e)) {
-      log.info(`GSC not connected for ${finalUrl}`);
-      return { auditResult: { connected: false }, fullAuditRef: finalUrl };
-    }
-    throw e; // surface real infra/auth failures loudly
+    // Repo convention (see structured-data/lib.js, opportunity-utils.checkGoogleConnection):
+    // any createFrom failure means the site is not connected to GSC. Record it, don't crash.
+    log.info(`gsc-search-analytics: GSC not connected for ${finalUrl}: ${e.message}`);
+    return envelope({
+      connected: false, status: 'not_connected', reason: e.message, fixCount: 0, measuredCount: 0, fixes: [],
+    }, finalUrl);
   }
 
-  // Group fixes by fixDate so URLs sharing a date share one pair of pulls.
-  const byDate = new Map();
-  for (const f of fixedUrls) {
-    if (!byDate.has(f.fixDate)) {
-      byDate.set(f.fixDate, []);
-    }
-    byDate.get(f.fixDate).push(f);
-  }
-
+  const now = new Date();
   const fixes = [];
+  const byDate = new Map();
+
+  // Split invalid dates out (recorded, never fetched); group the rest by fix date so
+  // URLs sharing a date share one pair of pulls.
+  for (const f of fixedUrls) {
+    if (!isValidFixDate(f.fixDate)) {
+      fixes.push(baseFix(f, 'invalid_date', { error: `Invalid fix date: ${f.fixDate}` }));
+    } else if (!byDate.has(f.fixDate)) {
+      byDate.set(f.fixDate, [f]);
+    } else {
+      byDate.get(f.fixDate).push(f);
+    }
+  }
+
   for (const [fixDate, group] of byDate) {
+    const windows = computeWindows(fixDate);
+    const completeness = assessCompleteness(windows, now);
     try {
-      const { before, after } = computeWindows(fixDate);
       /* eslint-disable no-await-in-loop */
-      const [beforeRows, afterRows] = await Promise.all([
-        fetchWindow(google, toDate(before.start), toDate(before.end)),
-        fetchWindow(google, toDate(after.start), toDate(after.end)),
+      const [beforeRes, afterRes] = await Promise.all([
+        fetchWindow(google, toDate(windows.before.start), toDate(windows.before.end)),
+        fetchWindow(google, toDate(windows.after.start), toDate(windows.after.end)),
       ]);
       /* eslint-enable no-await-in-loop */
-      const beforeMap = indexRows(beforeRows);
-      const afterMap = indexRows(afterRows);
+      const beforeMap = indexRows(beforeRes.rows);
+      const afterMap = indexRows(afterRes.rows);
+      const dataQuality = {
+        beforeComplete: completeness.beforeComplete,
+        afterComplete: completeness.afterComplete,
+        truncated: [beforeRes, afterRes].some((r) => r.truncated),
+      };
       for (const f of group) {
         const b = lookup(beforeMap, f.url);
         const a = lookup(afterMap, f.url);
+        const found = { before: !!b, after: !!a };
+        let status;
+        if (!found.before || !found.after) {
+          status = 'not_found';
+        } else if (!completeness.afterComplete || !completeness.beforeComplete) {
+          status = 'incomplete';
+        } else {
+          status = 'measured';
+        }
         fixes.push({
           url: f.url,
           fixType: f.fixType,
           fixDate,
-          windows: { before, after },
+          status,
+          windows,
           before: b,
           after: a,
-          delta: (b && a) ? buildDelta(b, a) : null,
-          found: { before: !!b, after: !!a },
+          delta: status === 'measured' ? buildDelta(b, a) : null,
+          found,
+          dataQuality,
         });
       }
     } catch (e) {
       // A failure on one date-group must not wipe the others; leave a diagnostic entry.
-      log.error(`GSC fetch failed for ${fixDate} / ${finalUrl}: ${e.message}`);
+      log.error(`gsc-search-analytics: fetch failed for ${fixDate} / ${finalUrl}: ${e.message}`);
       for (const f of group) {
-        fixes.push({
-          url: f.url, fixType: f.fixType, fixDate, failed: true, error: e.message,
-        });
+        fixes.push(baseFix(f, 'failed', { windows, error: e.message }));
       }
     }
   }
 
-  return {
-    auditResult: { connected: true, fixCount: fixes.length, fixes },
-    fullAuditRef: finalUrl,
-  };
+  const measuredCount = fixes.filter((f) => f.status === 'measured').length;
+  return envelope({
+    connected: true, status: 'ok', fixCount: fixes.length, measuredCount, fixes,
+  }, finalUrl);
 }

--- a/src/gsc-search-analytics/lib.js
+++ b/src/gsc-search-analytics/lib.js
@@ -27,10 +27,12 @@ function baseFix(f, status, extra) {
     fixType: f.fixType,
     fixDate: f.fixDate,
     status,
+    windows: null,
     before: null,
     after: null,
     delta: null,
     found: { before: false, after: false },
+    dataQuality: null,
     ...extra,
   };
 }
@@ -128,10 +130,12 @@ export async function runGscSearchAnalytics(finalUrl, context, site, auditContex
         const a = lookup(afterMap, f.url);
         const found = { before: !!b, after: !!a };
         let status;
-        if (!found.before || !found.after) {
-          status = 'not_found';
-        } else if (!completeness.afterComplete || !completeness.beforeComplete) {
+        // Completeness is checked FIRST: a not-yet-elapsed after-window legitimately
+        // returns no rows, which must read as 'incomplete', not 'not_found'.
+        if (!completeness.afterComplete || !completeness.beforeComplete) {
           status = 'incomplete';
+        } else if (!found.before || !found.after) {
+          status = 'not_found';
         } else {
           status = 'measured';
         }

--- a/src/gsc-search-analytics/lib.js
+++ b/src/gsc-search-analytics/lib.js
@@ -39,7 +39,13 @@ function baseFix(f, status, extra) {
 
 function envelope(fields, finalUrl) {
   return {
-    auditResult: { schemaVersion: SCHEMA_VERSION, ...fields },
+    auditResult: {
+      schemaVersion: SCHEMA_VERSION,
+      // Self-describing guard for anyone reading the raw row via PostgREST: these are
+      // raw recorded figures, NOT a causal or attributed claim about the fix.
+      interpretation: 'raw before/after GSC figures per fixed URL; not a causal or attributed measurement',
+      ...fields,
+    },
     fullAuditRef: finalUrl,
   };
 }

--- a/src/gsc-search-analytics/lib.js
+++ b/src/gsc-search-analytics/lib.js
@@ -10,7 +10,95 @@
  * governing permissions and limitations under the License.
  */
 
-// Stub — replaced in Task 6 with the real runner.
-export async function runGscSearchAnalytics(finalUrl) {
-  return { auditResult: { stub: true }, fullAuditRef: finalUrl };
+import GoogleClient from '@adobe/spacecat-shared-google-client';
+import { computeWindows } from './windows.js';
+import { fetchWindow } from './fetch.js';
+import { indexRows, lookup } from './match.js';
+import { buildDelta } from './summarize.js';
+
+// Only a genuinely-absent GSC connection is an expected clean stop; anything
+// else (throttling, IAM, parse errors) is a real failure we must surface.
+const isNotConnected = (e) => /no secrets|not connected|no google|not onboarded/i.test(e.message || '');
+const toDate = (s) => new Date(`${s}T00:00:00Z`);
+
+/**
+ * Tracking-only audit: for each URL ASO fixed, record its GSC clicks/impressions/
+ * ctr/position for the 84 days before and after the URL's own fix date. No causal
+ * claim — this is the "Measured" layer. Input is a manually-supplied list of
+ * { url, fixType, fixDate } in auditContext.fixedUrls.
+ *
+ * @param {string} finalUrl - resolved site base URL.
+ * @param {object} context - audit context ({ log, ... }).
+ * @param {object} site - the site under audit.
+ * @param {object} auditContext - carries fixedUrls (or messageData.fixedUrls).
+ * @returns {Promise<{auditResult: object, fullAuditRef: string}>}
+ */
+export async function runGscSearchAnalytics(finalUrl, context, site, auditContext = {}) {
+  const { log } = context;
+  const fixedUrls = auditContext.fixedUrls ?? auditContext.messageData?.fixedUrls;
+  if (!Array.isArray(fixedUrls) || fixedUrls.length === 0) {
+    return { auditResult: { error: 'missing fixedUrls' }, fullAuditRef: finalUrl };
+  }
+
+  let google;
+  try {
+    google = await GoogleClient.createFrom(context, finalUrl);
+  } catch (e) {
+    if (isNotConnected(e)) {
+      log.info(`GSC not connected for ${finalUrl}`);
+      return { auditResult: { connected: false }, fullAuditRef: finalUrl };
+    }
+    throw e; // surface real infra/auth failures loudly
+  }
+
+  // Group fixes by fixDate so URLs sharing a date share one pair of pulls.
+  const byDate = new Map();
+  for (const f of fixedUrls) {
+    if (!byDate.has(f.fixDate)) {
+      byDate.set(f.fixDate, []);
+    }
+    byDate.get(f.fixDate).push(f);
+  }
+
+  const fixes = [];
+  for (const [fixDate, group] of byDate) {
+    try {
+      const { before, after } = computeWindows(fixDate);
+      /* eslint-disable no-await-in-loop */
+      const [beforeRows, afterRows] = await Promise.all([
+        fetchWindow(google, toDate(before.start), toDate(before.end)),
+        fetchWindow(google, toDate(after.start), toDate(after.end)),
+      ]);
+      /* eslint-enable no-await-in-loop */
+      const beforeMap = indexRows(beforeRows);
+      const afterMap = indexRows(afterRows);
+      for (const f of group) {
+        const b = lookup(beforeMap, f.url);
+        const a = lookup(afterMap, f.url);
+        fixes.push({
+          url: f.url,
+          fixType: f.fixType,
+          fixDate,
+          windows: { before, after },
+          before: b,
+          after: a,
+          delta: (b && a) ? buildDelta(b, a) : null,
+          found: { before: !!b, after: !!a },
+        });
+      }
+    } catch (e) {
+      // A failure on one date-group must not wipe the others; leave a diagnostic entry.
+      log.error(`GSC fetch failed for ${fixDate} / ${finalUrl}: ${e.message}`);
+      for (const f of group) {
+        fixes.push({
+          url: f.url, fixType: f.fixType, fixDate, failed: true, error: e.message,
+        });
+      }
+    }
+  }
+
+  return {
+    auditResult: { connected: true, fixCount: fixes.length, fixes },
+    fullAuditRef: finalUrl,
+  };
 }

--- a/src/gsc-search-analytics/lib.js
+++ b/src/gsc-search-analytics/lib.js
@@ -147,10 +147,14 @@ export async function runGscSearchAnalytics(finalUrl, context, site, auditContex
         afterComplete: completeness.afterComplete,
         truncated: [beforeRes, afterRes].some((r) => r.truncated),
       };
+      let matchedAny = false;
       for (const f of group) {
         const b = lookup(beforeMap, f.url);
         const a = lookup(afterMap, f.url);
         const found = { before: !!b, after: !!a };
+        if (found.before || found.after) {
+          matchedAny = true;
+        }
         let status;
         // Completeness is checked FIRST: a not-yet-elapsed after-window legitimately
         // returns no rows, which must read as 'incomplete', not 'not_found'.
@@ -173,6 +177,13 @@ export async function runGscSearchAnalytics(finalUrl, context, site, auditContex
           found,
           dataQuality,
         });
+      }
+      // Rows came back but none of this group's fixed URLs matched -> almost always a
+      // host mismatch (www/apex, or fixedUrls built from a different host than the GSC
+      // property). Surface it instead of silently reporting not_found.
+      const rowsSeen = beforeMap.size + afterMap.size > 0;
+      if (!matchedAny && rowsSeen) {
+        log.warn(`gsc-search-analytics: ${fixDate} returned rows but no fixed URL matched for ${finalUrl} - likely host mismatch (www/apex or GSC property host)`);
       }
     } catch (e) {
       // A failure on one date-group must not wipe the others; leave a diagnostic entry.

--- a/src/gsc-search-analytics/match.js
+++ b/src/gsc-search-analytics/match.js
@@ -38,11 +38,13 @@ export function normalizeUrl(u) {
 export function indexRows(rows) {
   const map = new Map();
   for (const r of rows) {
+    // Use ?? (not ||) so a legitimate zero is preserved and only absent metrics
+    // default. Real GSC rows always populate all four fields.
     map.set(normalizeUrl(r.keys?.[0] ?? ''), {
-      clicks: r.clicks || 0,
-      impressions: r.impressions || 0,
-      ctr: r.ctr || 0,
-      position: r.position || 0,
+      clicks: r.clicks ?? 0,
+      impressions: r.impressions ?? 0,
+      ctr: r.ctr ?? 0,
+      position: r.position ?? 0,
     });
   }
   return map;

--- a/src/gsc-search-analytics/match.js
+++ b/src/gsc-search-analytics/match.js
@@ -10,10 +10,18 @@
  * governing permissions and limitations under the License.
  */
 
+import { stripWWW } from '@adobe/spacecat-shared-utils';
+
 /**
  * Normalize a URL so a supplied fixed URL lines up with how Google reports it:
- * lowercase host, drop the fragment, and strip a trailing slash (except root).
- * Returns the input unchanged if it is not a parseable URL.
+ * lowercase host, strip a leading `www.`, drop the fragment, sort the query, and
+ * strip a trailing slash (except root). Returns the input unchanged if unparseable.
+ *
+ * The `www.`/apex reconciliation matters because GSC page rows carry the site's GSC
+ * *property* host while fixedUrls are built from the site's registered base-URL host;
+ * these commonly differ only by `www.`. A run queries a single property, so collapsing
+ * `www.` cannot collide across properties. Assumes `www.` and apex serve the same
+ * content (true for essentially every real site).
  *
  * @param {string} u - a URL string.
  * @returns {string} normalized URL, or the original string if unparseable.
@@ -23,8 +31,9 @@ export function normalizeUrl(u) {
     const url = new URL(u);
     url.hash = '';
     url.searchParams.sort(); // stable query order so reordered params still match
+    const host = stripWWW(url.host.toLowerCase());
     const path = url.pathname.replace(/\/+$/, '') || '/';
-    return `${url.protocol}//${url.host.toLowerCase()}${path}${url.search}`;
+    return `${url.protocol}//${host}${path}${url.search}`;
   } catch {
     return u;
   }

--- a/src/gsc-search-analytics/match.js
+++ b/src/gsc-search-analytics/match.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Normalize a URL so a supplied fixed URL lines up with how Google reports it:
+ * lowercase host, drop the fragment, and strip a trailing slash (except root).
+ * Returns the input unchanged if it is not a parseable URL.
+ *
+ * @param {string} u - a URL string.
+ * @returns {string} normalized URL, or the original string if unparseable.
+ */
+export function normalizeUrl(u) {
+  try {
+    const url = new URL(u);
+    url.hash = '';
+    const path = url.pathname.replace(/\/+$/, '') || '/';
+    return `${url.protocol}//${url.host.toLowerCase()}${path}${url.search}`;
+  } catch {
+    return u;
+  }
+}
+
+/**
+ * Build a lookup map of normalized URL -> metrics from GSC page rows.
+ *
+ * @param {Array<object>} rows - GSC rows (each with keys[0] = page URL).
+ * @returns {Map<string, {clicks:number, impressions:number, ctr:number, position:number}>}
+ */
+export function indexRows(rows) {
+  const map = new Map();
+  for (const r of rows) {
+    map.set(normalizeUrl(r.keys?.[0] ?? ''), {
+      clicks: r.clicks || 0,
+      impressions: r.impressions || 0,
+      ctr: r.ctr || 0,
+      position: r.position || 0,
+    });
+  }
+  return map;
+}
+
+/**
+ * Look up one URL's metrics in an indexed map, normalizing first.
+ *
+ * @param {Map} map - map from indexRows.
+ * @param {string} url - the URL to find.
+ * @returns {object|null} metrics, or null if the URL is not present.
+ */
+export function lookup(map, url) {
+  return map.get(normalizeUrl(url)) ?? null;
+}

--- a/src/gsc-search-analytics/match.js
+++ b/src/gsc-search-analytics/match.js
@@ -22,6 +22,7 @@ export function normalizeUrl(u) {
   try {
     const url = new URL(u);
     url.hash = '';
+    url.searchParams.sort(); // stable query order so reordered params still match
     const path = url.pathname.replace(/\/+$/, '') || '/';
     return `${url.protocol}//${url.host.toLowerCase()}${path}${url.search}`;
   } catch {

--- a/src/gsc-search-analytics/summarize.js
+++ b/src/gsc-search-analytics/summarize.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Compute the after-minus-before change for one URL's metrics.
+ * A negative position delta means the URL moved up in results (better).
+ *
+ * @param {{clicks:number, impressions:number, ctr:number, position:number}} before
+ * @param {{clicks:number, impressions:number, ctr:number, position:number}} after
+ * @returns {{clicks:number, impressions:number, ctr:number, position:number}}
+ */
+export function buildDelta(before, after) {
+  return {
+    clicks: after.clicks - before.clicks,
+    impressions: after.impressions - before.impressions,
+    ctr: after.ctr - before.ctr,
+    position: after.position - before.position,
+  };
+}

--- a/src/gsc-search-analytics/windows.js
+++ b/src/gsc-search-analytics/windows.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+const DAYS = 84; // 12 weeks
+const iso = (d) => d.toISOString().split('T')[0];
+const addDays = (d, n) => new Date(d.getTime() + n * 86400000);
+
+/**
+ * Compute the 12-week before/after windows around a fix date.
+ * before = the 84 days ending the day before the fix.
+ * after  = the 84 days starting the day after the fix.
+ *
+ * @param {string} fixDate - ISO date (YYYY-MM-DD) when the URL was fixed.
+ * @returns {{before: {start: string, end: string}, after: {start: string, end: string}}}
+ */
+export function computeWindows(fixDate) {
+  const fix = new Date(`${fixDate}T00:00:00Z`);
+  if (Number.isNaN(fix.getTime())) {
+    throw new Error(`Invalid fix date: ${fixDate}`);
+  }
+  const beforeEnd = addDays(fix, -1);
+  const afterStart = addDays(fix, 1);
+  return {
+    before: { start: iso(addDays(beforeEnd, -(DAYS - 1))), end: iso(beforeEnd) },
+    after: { start: iso(afterStart), end: iso(addDays(afterStart, DAYS - 1)) },
+  };
+}

--- a/src/gsc-search-analytics/windows.js
+++ b/src/gsc-search-analytics/windows.js
@@ -11,8 +11,24 @@
  */
 
 const DAYS = 84; // 12 weeks
+// GSC finalizes data with a ~2-3 day lag; treat the trailing 3 days as not yet available.
+export const GSC_LAG_DAYS = 3;
+// GSC retains ~16 months of history; older data falls off and returns empty.
+export const RETENTION_DAYS = 480;
+
 const iso = (d) => d.toISOString().split('T')[0];
 const addDays = (d, n) => new Date(d.getTime() + n * 86400000);
+const toUtc = (s) => new Date(`${s}T00:00:00Z`);
+
+/**
+ * True when the string parses to a valid calendar date (YYYY-MM-DD).
+ *
+ * @param {*} fixDate - candidate date value.
+ * @returns {boolean}
+ */
+export function isValidFixDate(fixDate) {
+  return !Number.isNaN(toUtc(fixDate).getTime());
+}
 
 /**
  * Compute the 12-week before/after windows around a fix date.
@@ -23,7 +39,7 @@ const addDays = (d, n) => new Date(d.getTime() + n * 86400000);
  * @returns {{before: {start: string, end: string}, after: {start: string, end: string}}}
  */
 export function computeWindows(fixDate) {
-  const fix = new Date(`${fixDate}T00:00:00Z`);
+  const fix = toUtc(fixDate);
   if (Number.isNaN(fix.getTime())) {
     throw new Error(`Invalid fix date: ${fixDate}`);
   }
@@ -32,5 +48,23 @@ export function computeWindows(fixDate) {
   return {
     before: { start: iso(addDays(beforeEnd, -(DAYS - 1))), end: iso(beforeEnd) },
     after: { start: iso(afterStart), end: iso(addDays(afterStart, DAYS - 1)) },
+  };
+}
+
+/**
+ * Assess whether GSC data is fully available for each window as of `now`:
+ * - afterComplete: the after window has fully elapsed past GSC's freshness lag.
+ * - beforeComplete: the before window's start is still within GSC's retention horizon.
+ *
+ * @param {{before:{start:string,end:string}, after:{start:string,end:string}}} windows
+ * @param {Date} now - reference "current" time.
+ * @returns {{beforeComplete: boolean, afterComplete: boolean}}
+ */
+export function assessCompleteness(windows, now) {
+  const lagHorizon = addDays(now, -GSC_LAG_DAYS);
+  const retentionHorizon = addDays(now, -RETENTION_DAYS);
+  return {
+    afterComplete: toUtc(windows.after.end) <= lagHorizon,
+    beforeComplete: toUtc(windows.before.start) >= retentionHorizon,
   };
 }

--- a/src/gsc-search-analytics/windows.js
+++ b/src/gsc-search-analytics/windows.js
@@ -21,13 +21,19 @@ const addDays = (d, n) => new Date(d.getTime() + n * 86400000);
 const toUtc = (s) => new Date(`${s}T00:00:00Z`);
 
 /**
- * True when the string parses to a valid calendar date (YYYY-MM-DD).
+ * True when the value is a strict YYYY-MM-DD string denoting a real calendar day.
+ * Rejects non-strings and values that JS Date silently rolls over (e.g. 2026-02-30
+ * → Mar 2), which would otherwise anchor the windows to the wrong date.
  *
  * @param {*} fixDate - candidate date value.
  * @returns {boolean}
  */
 export function isValidFixDate(fixDate) {
-  return !Number.isNaN(toUtc(fixDate).getTime());
+  if (typeof fixDate !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(fixDate)) {
+    return false;
+  }
+  const d = toUtc(fixDate);
+  return !Number.isNaN(d.getTime()) && iso(d) === fixDate;
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,7 @@ import formsOpportunities from './forms-opportunities/handler.js';
 import metaTags from './metatags/handler.js';
 import structuredData from './structured-data/handler.js';
 import structuredDataGuidance from './structured-data/guidance-handler.js';
+import gscSearchAnalytics from './gsc-search-analytics/handler.js';
 import siteDetection from './site-detection/handler.js';
 import detectCdn from './detect-cdn/handler.js';
 import deliveryConfigWriter from './delivery-config-writer/handler.js';
@@ -155,6 +156,7 @@ const HANDLERS = {
   'detect-cdn': detectCdn,
   'delivery-config-writer': deliveryConfigWriter,
   'structured-data': structuredData,
+  'gsc-search-analytics': gscSearchAnalytics,
   'llm-blocked': llmBlocked,
   'forms-opportunities': formsOpportunities,
   'site-detection': siteDetection,

--- a/test/audits/gsc-search-analytics/fetch.test.js
+++ b/test/audits/gsc-search-analytics/fetch.test.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { fetchWindow } from '../../../src/gsc-search-analytics/fetch.js';
+
+describe('fetchWindow', () => {
+  it('aggregates paginated page rows', async () => {
+    const google = { getOrganicSearchData: sinon.stub() };
+    google.getOrganicSearchData.onCall(0).resolves({
+      data: {
+        rows: Array.from({ length: 1000 }, (_, i) => ({
+          keys: [`https://s/p${i}`], clicks: 1, impressions: 10, ctr: 0.1, position: 5,
+        })),
+      },
+    });
+    google.getOrganicSearchData.onCall(1).resolves({
+      data: { rows: [{ keys: ['https://s/last'], clicks: 2, impressions: 20, ctr: 0.1, position: 4 }] },
+    });
+
+    const rows = await fetchWindow(
+      google,
+      new Date('2026-03-02T00:00:00Z'),
+      new Date('2026-05-24T00:00:00Z'),
+    );
+
+    expect(rows).to.have.length(1001);
+    expect(google.getOrganicSearchData.callCount).to.equal(2);
+  });
+
+  it('stops on an empty/short page and tolerates a missing rows field', async () => {
+    const google = { getOrganicSearchData: sinon.stub().resolves({ data: {} }) };
+    const rows = await fetchWindow(
+      google,
+      new Date('2026-03-02T00:00:00Z'),
+      new Date('2026-05-24T00:00:00Z'),
+    );
+    expect(rows).to.have.length(0);
+    expect(google.getOrganicSearchData.callCount).to.equal(1);
+  });
+});

--- a/test/audits/gsc-search-analytics/fetch.test.js
+++ b/test/audits/gsc-search-analytics/fetch.test.js
@@ -14,38 +14,44 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { fetchWindow } from '../../../src/gsc-search-analytics/fetch.js';
 
+const fullPage = () => ({
+  data: {
+    rows: Array.from({ length: 1000 }, (_, i) => ({
+      keys: [`https://s/p${i}`], clicks: 1, impressions: 10, ctr: 0.1, position: 5,
+    })),
+  },
+});
+
 describe('fetchWindow', () => {
-  it('aggregates paginated page rows', async () => {
+  const start = new Date('2026-03-02T00:00:00Z');
+  const end = new Date('2026-05-24T00:00:00Z');
+
+  it('aggregates paginated page rows and reports not truncated', async () => {
     const google = { getOrganicSearchData: sinon.stub() };
-    google.getOrganicSearchData.onCall(0).resolves({
-      data: {
-        rows: Array.from({ length: 1000 }, (_, i) => ({
-          keys: [`https://s/p${i}`], clicks: 1, impressions: 10, ctr: 0.1, position: 5,
-        })),
-      },
-    });
+    google.getOrganicSearchData.onCall(0).resolves(fullPage());
     google.getOrganicSearchData.onCall(1).resolves({
       data: { rows: [{ keys: ['https://s/last'], clicks: 2, impressions: 20, ctr: 0.1, position: 4 }] },
     });
 
-    const rows = await fetchWindow(
-      google,
-      new Date('2026-03-02T00:00:00Z'),
-      new Date('2026-05-24T00:00:00Z'),
-    );
-
+    const { rows, truncated } = await fetchWindow(google, start, end);
     expect(rows).to.have.length(1001);
+    expect(truncated).to.equal(false);
     expect(google.getOrganicSearchData.callCount).to.equal(2);
   });
 
   it('stops on an empty/short page and tolerates a missing rows field', async () => {
     const google = { getOrganicSearchData: sinon.stub().resolves({ data: {} }) };
-    const rows = await fetchWindow(
-      google,
-      new Date('2026-03-02T00:00:00Z'),
-      new Date('2026-05-24T00:00:00Z'),
-    );
+    const { rows, truncated } = await fetchWindow(google, start, end);
     expect(rows).to.have.length(0);
+    expect(truncated).to.equal(false);
     expect(google.getOrganicSearchData.callCount).to.equal(1);
+  });
+
+  it('reports truncated when the page cap is hit with full pages throughout', async () => {
+    const google = { getOrganicSearchData: sinon.stub().resolves(fullPage()) };
+    const { rows, truncated } = await fetchWindow(google, start, end);
+    expect(truncated).to.equal(true);
+    expect(rows).to.have.length(50000);
+    expect(google.getOrganicSearchData.callCount).to.equal(50);
   });
 });

--- a/test/audits/gsc-search-analytics/handler.test.js
+++ b/test/audits/gsc-search-analytics/handler.test.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import handler from '../../../src/gsc-search-analytics/handler.js';
+
+describe('gsc-search-analytics handler', () => {
+  it('exports a built audit with a run method', () => {
+    expect(handler).to.be.an('object');
+    expect(handler.run).to.be.a('function');
+  });
+});

--- a/test/audits/gsc-search-analytics/lib.test.js
+++ b/test/audits/gsc-search-analytics/lib.test.js
@@ -15,99 +15,156 @@ import sinon from 'sinon';
 import GoogleClient from '@adobe/spacecat-shared-google-client';
 import { runGscSearchAnalytics } from '../../../src/gsc-search-analytics/lib.js';
 
+const iso = (offsetDays) => new Date(Date.now() + offsetDays * 86400000).toISOString().split('T')[0];
+const rowFor = (url) => ({
+  data: {
+    rows: [{
+      keys: [url], clicks: 5, impressions: 50, ctr: 0.1, position: 4,
+    }],
+  },
+});
+const emptyRows = () => ({ data: { rows: [] } });
+
 describe('runGscSearchAnalytics', () => {
   const finalUrl = 'https://krisshop.com';
   const site = { getBaseURL: () => finalUrl };
-  const context = { log: { info() {}, error() {} } };
-  const fixedUrls = [
-    { url: 'https://krisshop.com/products/x', fixType: 'meta-tags', fixDate: '2026-03-01' },
-  ];
+  const context = { log: { info() {}, warn() {}, error() {} } };
+  const url = 'https://krisshop.com/products/x';
 
   afterEach(() => sinon.restore());
 
-  it('returns a per-url before/after result when GSC is connected', async () => {
-    const google = {
-      getOrganicSearchData: sinon.stub().resolves({
-        data: {
-          rows: [{
-            keys: ['https://krisshop.com/products/x'], clicks: 5, impressions: 50, ctr: 0.1, position: 4,
-          }],
-        },
-      }),
-    };
+  it('measures a URL when both windows are present and fully elapsed', async () => {
+    const google = { getOrganicSearchData: sinon.stub().resolves(rowFor(url)) };
     sinon.stub(GoogleClient, 'createFrom').resolves(google);
+    const fixedUrls = [{ url, fixType: 'meta-tags', fixDate: '2026-03-01' }];
 
     const { auditResult, fullAuditRef } = await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
     expect(fullAuditRef).to.equal(finalUrl);
-    expect(auditResult.connected).to.equal(true);
+    expect(auditResult).to.include({ schemaVersion: 1, connected: true, status: 'ok' });
     expect(auditResult.fixCount).to.equal(1);
-    expect(auditResult.fixes[0]).to.include({ url: 'https://krisshop.com/products/x', fixType: 'meta-tags' });
-    expect(auditResult.fixes[0].found).to.deep.equal({ before: true, after: true });
-    expect(auditResult.fixes[0]).to.have.nested.property('delta.clicks');
+    expect(auditResult.measuredCount).to.equal(1);
+    const fix = auditResult.fixes[0];
+    expect(fix.status).to.equal('measured');
+    expect(fix.found).to.deep.equal({ before: true, after: true });
+    expect(fix).to.have.nested.property('delta.clicks');
+    expect(fix.dataQuality).to.include({ beforeComplete: true, afterComplete: true, truncated: false });
+  });
+
+  it('marks not_found when the URL is absent in a window (partial)', async () => {
+    const google = { getOrganicSearchData: sinon.stub() };
+    google.getOrganicSearchData.onCall(0).resolves(rowFor(url)); // before pull
+    google.getOrganicSearchData.onCall(1).resolves(emptyRows()); // after pull
+    sinon.stub(GoogleClient, 'createFrom').resolves(google);
+    const fixedUrls = [{ url, fixType: 'meta-tags', fixDate: '2026-03-01' }];
+
+    const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
+    const fix = auditResult.fixes[0];
+    expect(fix.status).to.equal('not_found');
+    expect(fix.found).to.deep.equal({ before: true, after: false });
+    expect(fix.delta).to.equal(null);
+    expect(auditResult.measuredCount).to.equal(0);
+  });
+
+  it('marks incomplete when the after window has not fully elapsed', async () => {
+    const google = { getOrganicSearchData: sinon.stub().resolves(rowFor(url)) };
+    sinon.stub(GoogleClient, 'createFrom').resolves(google);
+    const fixedUrls = [{ url, fixType: 'meta-tags', fixDate: iso(-5) }]; // fixed 5 days ago
+
+    const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
+    const fix = auditResult.fixes[0];
+    expect(fix.status).to.equal('incomplete');
+    expect(fix.dataQuality.afterComplete).to.equal(false);
+    expect(fix.delta).to.equal(null);
+  });
+
+  it('marks incomplete when the before window predates retention', async () => {
+    const google = { getOrganicSearchData: sinon.stub().resolves(rowFor(url)) };
+    sinon.stub(GoogleClient, 'createFrom').resolves(google);
+    const fixedUrls = [{ url, fixType: 'meta-tags', fixDate: iso(-520) }]; // ~17 months ago
+
+    const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
+    const fix = auditResult.fixes[0];
+    expect(fix.status).to.equal('incomplete');
+    expect(fix.dataQuality).to.include({ beforeComplete: false, afterComplete: true });
   });
 
   it('groups URLs sharing a fix date into one pair of pulls', async () => {
-    const google = { getOrganicSearchData: sinon.stub().resolves({ data: { rows: [] } }) };
+    const google = { getOrganicSearchData: sinon.stub().resolves(emptyRows()) };
     sinon.stub(GoogleClient, 'createFrom').resolves(google);
-    const twoSameDate = [
+    const fixedUrls = [
       { url: 'https://krisshop.com/a', fixType: 'meta-tags', fixDate: '2026-03-01' },
       { url: 'https://krisshop.com/b', fixType: 'alt-text', fixDate: '2026-03-01' },
     ];
-    const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls: twoSameDate });
-    expect(auditResult.fixCount).to.equal(2);
-    // one before pull + one after pull for the shared date
-    expect(google.getOrganicSearchData.callCount).to.equal(2);
-    expect(auditResult.fixes[0].found).to.deep.equal({ before: false, after: false });
-    expect(auditResult.fixes[0].delta).to.equal(null);
-  });
-
-  it('records connected:false when GSC is not onboarded', async () => {
-    sinon.stub(GoogleClient, 'createFrom').rejects(new Error('No secrets found for site'));
     const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
-    expect(auditResult.connected).to.equal(false);
+    expect(auditResult.fixCount).to.equal(2);
+    expect(google.getOrganicSearchData.callCount).to.equal(2);
+    expect(auditResult.fixes[0].status).to.equal('not_found');
   });
 
-  it('re-raises a real infra failure instead of masking it as not-connected', async () => {
-    sinon.stub(GoogleClient, 'createFrom').rejects(new Error('AccessDenied: throttled'));
-    let threw = false;
-    try {
-      await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
-    } catch {
-      threw = true;
-    }
-    expect(threw).to.equal(true);
+  it('issues separate pulls for distinct fix dates', async () => {
+    const google = { getOrganicSearchData: sinon.stub().resolves(emptyRows()) };
+    sinon.stub(GoogleClient, 'createFrom').resolves(google);
+    const fixedUrls = [
+      { url: 'https://krisshop.com/a', fixType: 'meta-tags', fixDate: '2026-03-01' },
+      { url: 'https://krisshop.com/b', fixType: 'meta-tags', fixDate: '2026-04-01' },
+    ];
+    const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
+    expect(auditResult.fixCount).to.equal(2);
+    expect(google.getOrganicSearchData.callCount).to.equal(4);
   });
 
-  it('re-raises an error that has no message (falsy message path)', async () => {
-    sinon.stub(GoogleClient, 'createFrom').rejects(new Error());
-    let threw = false;
-    try {
-      await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
-    } catch {
-      threw = true;
-    }
-    expect(threw).to.equal(true);
+  it('records invalid_date without fetching', async () => {
+    const google = { getOrganicSearchData: sinon.stub().resolves(emptyRows()) };
+    sinon.stub(GoogleClient, 'createFrom').resolves(google);
+    const fixedUrls = [{ url, fixType: 'meta-tags', fixDate: 'nope' }];
+    const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
+    expect(auditResult.connected).to.equal(true);
+    expect(auditResult.fixes[0].status).to.equal('invalid_date');
+    expect(auditResult.fixes[0].error).to.match(/Invalid fix date/);
+    expect(google.getOrganicSearchData.callCount).to.equal(0);
   });
 
   it('records a per-group failure without wiping other groups', async () => {
     const google = { getOrganicSearchData: sinon.stub().rejects(new Error('GSC 500')) };
     sinon.stub(GoogleClient, 'createFrom').resolves(google);
+    const fixedUrls = [{ url, fixType: 'meta-tags', fixDate: '2026-03-01' }];
     const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
     expect(auditResult.connected).to.equal(true);
-    expect(auditResult.fixes[0]).to.include({ failed: true });
-    expect(auditResult.fixes[0].error).to.equal('GSC 500');
+    const fix = auditResult.fixes[0];
+    expect(fix.status).to.equal('failed');
+    expect(fix.error).to.equal('GSC 500');
+    expect(fix.found).to.deep.equal({ before: false, after: false });
+  });
+
+  it('records not_connected (and does not throw) when createFrom fails', async () => {
+    sinon.stub(GoogleClient, 'createFrom').rejects(new Error('ResourceNotFoundException: no secret'));
+    const fixedUrls = [{ url, fixType: 'meta-tags', fixDate: '2026-03-01' }];
+    const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
+    expect(auditResult.connected).to.equal(false);
+    expect(auditResult.status).to.equal('not_connected');
+    expect(auditResult.reason).to.match(/ResourceNotFound/);
   });
 
   it('reads fixedUrls from messageData as a fallback', async () => {
-    const google = { getOrganicSearchData: sinon.stub().resolves({ data: { rows: [] } }) };
+    const google = { getOrganicSearchData: sinon.stub().resolves(emptyRows()) };
     sinon.stub(GoogleClient, 'createFrom').resolves(google);
+    const fixedUrls = [{ url, fixType: 'meta-tags', fixDate: '2026-03-01' }];
     const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site, { messageData: { fixedUrls } });
     expect(auditResult.connected).to.equal(true);
     expect(auditResult.fixCount).to.equal(1);
   });
 
-  it('errors cleanly when no fixedUrls are supplied', async () => {
-    const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site, {});
-    expect(auditResult.error).to.equal('missing fixedUrls');
+  it('returns missing_fixed_urls when none are supplied (default auditContext)', async () => {
+    const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site);
+    expect(auditResult.status).to.equal('missing_fixed_urls');
+    expect(auditResult.connected).to.equal(null);
+  });
+
+  it('returns too_many_fixed_urls above the cap', async () => {
+    const fixedUrls = Array.from({ length: 501 }, (_, i) => ({
+      url: `https://krisshop.com/p${i}`, fixType: 'meta-tags', fixDate: '2026-03-01',
+    }));
+    const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
+    expect(auditResult.status).to.equal('too_many_fixed_urls');
   });
 });

--- a/test/audits/gsc-search-analytics/lib.test.js
+++ b/test/audits/gsc-search-analytics/lib.test.js
@@ -211,4 +211,15 @@ describe('runGscSearchAnalytics', () => {
     const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
     expect(auditResult.status).to.equal('too_many_fixed_urls');
   });
+
+  it('returns too_many_date_groups above the distinct-date cap', async () => {
+    // 31 distinct fix dates (> MAX_DATE_GROUPS of 30); stays under the 500-URL cap.
+    const fixedUrls = Array.from({ length: 31 }, (_, i) => ({
+      url: `https://krisshop.com/p${i}`,
+      fixType: 'meta-tags',
+      fixDate: `2026-03-${String(i + 1).padStart(2, '0')}`,
+    }));
+    const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
+    expect(auditResult.status).to.equal('too_many_date_groups');
+  });
 });

--- a/test/audits/gsc-search-analytics/lib.test.js
+++ b/test/audits/gsc-search-analytics/lib.test.js
@@ -165,6 +165,23 @@ describe('runGscSearchAnalytics', () => {
     expect(failFix.found).to.deep.equal({ before: false, after: false });
   });
 
+  it('warns on a host mismatch: rows returned but no fixed URL matched', async () => {
+    const warn = sinon.spy();
+    const ctx = { log: { info() {}, warn, error() {} } };
+    // GSC rows are on a different host than the supplied fixed URL -> nothing matches.
+    const google = {
+      getOrganicSearchData: sinon.stub().resolves({
+        data: { rows: [{ keys: ['https://othersite.com/x'], clicks: 5, impressions: 50, ctr: 0.1, position: 4 }] },
+      }),
+    };
+    sinon.stub(GoogleClient, 'createFrom').resolves(google);
+    const fixedUrls = [{ url, fixType: 'meta-tags', fixDate: '2026-03-01' }];
+    const { auditResult } = await runGscSearchAnalytics(finalUrl, ctx, site, { fixedUrls });
+    expect(auditResult.fixes[0].status).to.equal('not_found');
+    expect(warn.calledOnce).to.equal(true);
+    expect(warn.firstCall.args[0]).to.match(/host mismatch/);
+  });
+
   it('flags truncation and reads not_found when the URL is past the page cap', async () => {
     const targetAfterMs = afterStartMs('2026-03-01');
     const google = {

--- a/test/audits/gsc-search-analytics/lib.test.js
+++ b/test/audits/gsc-search-analytics/lib.test.js
@@ -50,6 +50,7 @@ describe('runGscSearchAnalytics', () => {
     const { auditResult, fullAuditRef } = await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
     expect(fullAuditRef).to.equal(finalUrl);
     expect(auditResult).to.include({ schemaVersion: 1, connected: true, status: 'ok' });
+    expect(auditResult.interpretation).to.match(/not a causal or attributed/);
     expect(auditResult.fixCount).to.equal(1);
     expect(auditResult.measuredCount).to.equal(1);
     const fix = auditResult.fixes[0];

--- a/test/audits/gsc-search-analytics/lib.test.js
+++ b/test/audits/gsc-search-analytics/lib.test.js
@@ -78,6 +78,17 @@ describe('runGscSearchAnalytics', () => {
     expect(threw).to.equal(true);
   });
 
+  it('re-raises an error that has no message (falsy message path)', async () => {
+    sinon.stub(GoogleClient, 'createFrom').rejects(new Error());
+    let threw = false;
+    try {
+      await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
+    } catch {
+      threw = true;
+    }
+    expect(threw).to.equal(true);
+  });
+
   it('records a per-group failure without wiping other groups', async () => {
     const google = { getOrganicSearchData: sinon.stub().rejects(new Error('GSC 500')) };
     sinon.stub(GoogleClient, 'createFrom').resolves(google);

--- a/test/audits/gsc-search-analytics/lib.test.js
+++ b/test/audits/gsc-search-analytics/lib.test.js
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import GoogleClient from '@adobe/spacecat-shared-google-client';
+import { runGscSearchAnalytics } from '../../../src/gsc-search-analytics/lib.js';
+
+describe('runGscSearchAnalytics', () => {
+  const finalUrl = 'https://krisshop.com';
+  const site = { getBaseURL: () => finalUrl };
+  const context = { log: { info() {}, error() {} } };
+  const fixedUrls = [
+    { url: 'https://krisshop.com/products/x', fixType: 'meta-tags', fixDate: '2026-03-01' },
+  ];
+
+  afterEach(() => sinon.restore());
+
+  it('returns a per-url before/after result when GSC is connected', async () => {
+    const google = {
+      getOrganicSearchData: sinon.stub().resolves({
+        data: {
+          rows: [{
+            keys: ['https://krisshop.com/products/x'], clicks: 5, impressions: 50, ctr: 0.1, position: 4,
+          }],
+        },
+      }),
+    };
+    sinon.stub(GoogleClient, 'createFrom').resolves(google);
+
+    const { auditResult, fullAuditRef } = await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
+    expect(fullAuditRef).to.equal(finalUrl);
+    expect(auditResult.connected).to.equal(true);
+    expect(auditResult.fixCount).to.equal(1);
+    expect(auditResult.fixes[0]).to.include({ url: 'https://krisshop.com/products/x', fixType: 'meta-tags' });
+    expect(auditResult.fixes[0].found).to.deep.equal({ before: true, after: true });
+    expect(auditResult.fixes[0]).to.have.nested.property('delta.clicks');
+  });
+
+  it('groups URLs sharing a fix date into one pair of pulls', async () => {
+    const google = { getOrganicSearchData: sinon.stub().resolves({ data: { rows: [] } }) };
+    sinon.stub(GoogleClient, 'createFrom').resolves(google);
+    const twoSameDate = [
+      { url: 'https://krisshop.com/a', fixType: 'meta-tags', fixDate: '2026-03-01' },
+      { url: 'https://krisshop.com/b', fixType: 'alt-text', fixDate: '2026-03-01' },
+    ];
+    const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls: twoSameDate });
+    expect(auditResult.fixCount).to.equal(2);
+    // one before pull + one after pull for the shared date
+    expect(google.getOrganicSearchData.callCount).to.equal(2);
+    expect(auditResult.fixes[0].found).to.deep.equal({ before: false, after: false });
+    expect(auditResult.fixes[0].delta).to.equal(null);
+  });
+
+  it('records connected:false when GSC is not onboarded', async () => {
+    sinon.stub(GoogleClient, 'createFrom').rejects(new Error('No secrets found for site'));
+    const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
+    expect(auditResult.connected).to.equal(false);
+  });
+
+  it('re-raises a real infra failure instead of masking it as not-connected', async () => {
+    sinon.stub(GoogleClient, 'createFrom').rejects(new Error('AccessDenied: throttled'));
+    let threw = false;
+    try {
+      await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
+    } catch {
+      threw = true;
+    }
+    expect(threw).to.equal(true);
+  });
+
+  it('records a per-group failure without wiping other groups', async () => {
+    const google = { getOrganicSearchData: sinon.stub().rejects(new Error('GSC 500')) };
+    sinon.stub(GoogleClient, 'createFrom').resolves(google);
+    const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
+    expect(auditResult.connected).to.equal(true);
+    expect(auditResult.fixes[0]).to.include({ failed: true });
+    expect(auditResult.fixes[0].error).to.equal('GSC 500');
+  });
+
+  it('reads fixedUrls from messageData as a fallback', async () => {
+    const google = { getOrganicSearchData: sinon.stub().resolves({ data: { rows: [] } }) };
+    sinon.stub(GoogleClient, 'createFrom').resolves(google);
+    const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site, { messageData: { fixedUrls } });
+    expect(auditResult.connected).to.equal(true);
+    expect(auditResult.fixCount).to.equal(1);
+  });
+
+  it('errors cleanly when no fixedUrls are supplied', async () => {
+    const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site, {});
+    expect(auditResult.error).to.equal('missing fixedUrls');
+  });
+});

--- a/test/audits/gsc-search-analytics/lib.test.js
+++ b/test/audits/gsc-search-analytics/lib.test.js
@@ -14,6 +14,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import GoogleClient from '@adobe/spacecat-shared-google-client';
 import { runGscSearchAnalytics } from '../../../src/gsc-search-analytics/lib.js';
+import { computeWindows } from '../../../src/gsc-search-analytics/windows.js';
 
 const iso = (offsetDays) => new Date(Date.now() + offsetDays * 86400000).toISOString().split('T')[0];
 const rowFor = (url) => ({
@@ -24,6 +25,14 @@ const rowFor = (url) => ({
   },
 });
 const emptyRows = () => ({ data: { rows: [] } });
+const fullPage = () => ({
+  data: {
+    rows: Array.from({ length: 1000 }, (_, i) => ({
+      keys: [`https://krisshop.com/other${i}`], clicks: 1, impressions: 10, ctr: 0.1, position: 5,
+    })),
+  },
+});
+const afterStartMs = (fixDate) => new Date(`${computeWindows(fixDate).after.start}T00:00:00Z`).getTime();
 
 describe('runGscSearchAnalytics', () => {
   const finalUrl = 'https://krisshop.com';
@@ -65,8 +74,10 @@ describe('runGscSearchAnalytics', () => {
     expect(auditResult.measuredCount).to.equal(0);
   });
 
-  it('marks incomplete when the after window has not fully elapsed', async () => {
-    const google = { getOrganicSearchData: sinon.stub().resolves(rowFor(url)) };
+  it('marks incomplete (not not_found) when the after window has not elapsed, even with no rows', async () => {
+    // Precedence check: a not-yet-elapsed window legitimately returns no rows; it must
+    // read as 'incomplete', never 'not_found'.
+    const google = { getOrganicSearchData: sinon.stub().resolves(emptyRows()) };
     sinon.stub(GoogleClient, 'createFrom').resolves(google);
     const fixedUrls = [{ url, fixType: 'meta-tags', fixDate: iso(-5) }]; // fixed 5 days ago
 
@@ -124,16 +135,48 @@ describe('runGscSearchAnalytics', () => {
     expect(google.getOrganicSearchData.callCount).to.equal(0);
   });
 
-  it('records a per-group failure without wiping other groups', async () => {
-    const google = { getOrganicSearchData: sinon.stub().rejects(new Error('GSC 500')) };
+  it('isolates a per-group failure: the failing date fails, other dates still measure', async () => {
+    const okUrl = 'https://krisshop.com/ok';
+    const failDateAfterMs = afterStartMs('2026-04-01');
+    const failBeforeMs = new Date(`${computeWindows('2026-04-01').before.start}T00:00:00Z`).getTime();
+    const google = {
+      getOrganicSearchData: sinon.stub().callsFake((start) => {
+        const t = start.getTime();
+        if (t === failDateAfterMs || t === failBeforeMs) {
+          return Promise.reject(new Error('GSC 500'));
+        }
+        return Promise.resolve(rowFor(okUrl));
+      }),
+    };
+    sinon.stub(GoogleClient, 'createFrom').resolves(google);
+    const fixedUrls = [
+      { url: okUrl, fixType: 'meta-tags', fixDate: '2026-03-01' },
+      { url: 'https://krisshop.com/fail', fixType: 'meta-tags', fixDate: '2026-04-01' },
+    ];
+    const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
+    expect(auditResult.connected).to.equal(true);
+    expect(auditResult.measuredCount).to.equal(1);
+    const okFix = auditResult.fixes.find((f) => f.url === okUrl);
+    const failFix = auditResult.fixes.find((f) => f.url === 'https://krisshop.com/fail');
+    expect(okFix.status).to.equal('measured');
+    expect(failFix.status).to.equal('failed');
+    expect(failFix.error).to.equal('GSC 500');
+    expect(failFix.found).to.deep.equal({ before: false, after: false });
+  });
+
+  it('flags truncation and reads not_found when the URL is past the page cap', async () => {
+    const targetAfterMs = afterStartMs('2026-03-01');
+    const google = {
+      getOrganicSearchData: sinon.stub().callsFake((start) => (
+        start.getTime() === targetAfterMs ? Promise.resolve(fullPage()) : Promise.resolve(emptyRows())
+      )),
+    };
     sinon.stub(GoogleClient, 'createFrom').resolves(google);
     const fixedUrls = [{ url, fixType: 'meta-tags', fixDate: '2026-03-01' }];
     const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
-    expect(auditResult.connected).to.equal(true);
     const fix = auditResult.fixes[0];
-    expect(fix.status).to.equal('failed');
-    expect(fix.error).to.equal('GSC 500');
-    expect(fix.found).to.deep.equal({ before: false, after: false });
+    expect(fix.dataQuality.truncated).to.equal(true);
+    expect(fix.status).to.equal('not_found');
   });
 
   it('records not_connected (and does not throw) when createFrom fails', async () => {

--- a/test/audits/gsc-search-analytics/match.test.js
+++ b/test/audits/gsc-search-analytics/match.test.js
@@ -34,6 +34,17 @@ describe('match', () => {
     expect(normalizeUrl('https://krisshop.com/x?b=2&a=1')).to.equal('https://krisshop.com/x?a=1&b=2');
   });
 
+  it('strips a leading www so apex and www reconcile', () => {
+    expect(normalizeUrl('https://www.krisshop.com/x/')).to.equal('https://krisshop.com/x');
+  });
+
+  it('matches a www-host GSC row against an apex fixed URL', () => {
+    const map = indexRows([{
+      keys: ['https://www.krisshop.com/x'], clicks: 3, impressions: 30, ctr: 0.1, position: 6,
+    }]);
+    expect(lookup(map, 'https://krisshop.com/x')).to.include({ clicks: 3 });
+  });
+
   it('returns the input unchanged when it is not a valid URL', () => {
     expect(normalizeUrl('not a url')).to.equal('not a url');
   });

--- a/test/audits/gsc-search-analytics/match.test.js
+++ b/test/audits/gsc-search-analytics/match.test.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { normalizeUrl, indexRows, lookup } from '../../../src/gsc-search-analytics/match.js';
+
+describe('match', () => {
+  it('normalizes trailing slash and host case', () => {
+    expect(normalizeUrl('https://KrisShop.com/products/x/')).to.equal('https://krisshop.com/products/x');
+  });
+
+  it('keeps the root path as "/"', () => {
+    expect(normalizeUrl('https://krisshop.com/')).to.equal('https://krisshop.com/');
+  });
+
+  it('returns the input unchanged when it is not a valid URL', () => {
+    expect(normalizeUrl('not a url')).to.equal('not a url');
+  });
+
+  it('indexes rows and looks a url up regardless of trailing slash', () => {
+    const map = indexRows([
+      { keys: ['https://krisshop.com/products/x'], clicks: 5, impressions: 50, ctr: 0.1, position: 4 },
+      { keys: [], clicks: 1, impressions: 1 }, // missing key -> tolerated
+    ]);
+    expect(lookup(map, 'https://krisshop.com/products/x/')).to.include({ clicks: 5 });
+    expect(lookup(map, 'https://krisshop.com/missing')).to.equal(null);
+  });
+});

--- a/test/audits/gsc-search-analytics/match.test.js
+++ b/test/audits/gsc-search-analytics/match.test.js
@@ -30,6 +30,10 @@ describe('match', () => {
     expect(normalizeUrl('https://krisshop.com/x?id=7')).to.equal('https://krisshop.com/x?id=7');
   });
 
+  it('sorts query params so reordered params still match', () => {
+    expect(normalizeUrl('https://krisshop.com/x?b=2&a=1')).to.equal('https://krisshop.com/x?a=1&b=2');
+  });
+
   it('returns the input unchanged when it is not a valid URL', () => {
     expect(normalizeUrl('not a url')).to.equal('not a url');
   });

--- a/test/audits/gsc-search-analytics/match.test.js
+++ b/test/audits/gsc-search-analytics/match.test.js
@@ -30,8 +30,12 @@ describe('match', () => {
     const map = indexRows([
       { keys: ['https://krisshop.com/products/x'], clicks: 5, impressions: 50, ctr: 0.1, position: 4 },
       { keys: [], clicks: 1, impressions: 1 }, // missing key -> tolerated
+      { keys: ['https://krisshop.com/z'] }, // no metric fields -> default to 0
     ]);
     expect(lookup(map, 'https://krisshop.com/products/x/')).to.include({ clicks: 5 });
+    expect(lookup(map, 'https://krisshop.com/z')).to.deep.equal({
+      clicks: 0, impressions: 0, ctr: 0, position: 0,
+    });
     expect(lookup(map, 'https://krisshop.com/missing')).to.equal(null);
   });
 });

--- a/test/audits/gsc-search-analytics/match.test.js
+++ b/test/audits/gsc-search-analytics/match.test.js
@@ -22,6 +22,14 @@ describe('match', () => {
     expect(normalizeUrl('https://krisshop.com/')).to.equal('https://krisshop.com/');
   });
 
+  it('drops the fragment', () => {
+    expect(normalizeUrl('https://krisshop.com/x#section')).to.equal('https://krisshop.com/x');
+  });
+
+  it('preserves the query string (canonical URLs may be query-distinct)', () => {
+    expect(normalizeUrl('https://krisshop.com/x?id=7')).to.equal('https://krisshop.com/x?id=7');
+  });
+
   it('returns the input unchanged when it is not a valid URL', () => {
     expect(normalizeUrl('not a url')).to.equal('not a url');
   });

--- a/test/audits/gsc-search-analytics/summarize.test.js
+++ b/test/audits/gsc-search-analytics/summarize.test.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { buildDelta } from '../../../src/gsc-search-analytics/summarize.js';
+
+describe('buildDelta', () => {
+  it('builds after-minus-before', () => {
+    const d = buildDelta(
+      {
+        clicks: 3200, impressions: 80000, ctr: 0.040, position: 9.1,
+      },
+      {
+        clicks: 4100, impressions: 85000, ctr: 0.048, position: 7.2,
+      },
+    );
+    expect(d.clicks).to.equal(900);
+    expect(d.impressions).to.equal(5000);
+    expect(d.ctr).to.be.closeTo(0.008, 1e-9);
+    expect(d.position).to.be.closeTo(-1.9, 1e-9); // negative = moved up
+  });
+});

--- a/test/audits/gsc-search-analytics/windows.test.js
+++ b/test/audits/gsc-search-analytics/windows.test.js
@@ -11,7 +11,7 @@
  */
 
 import { expect } from 'chai';
-import { computeWindows } from '../../../src/gsc-search-analytics/windows.js';
+import { computeWindows, assessCompleteness, isValidFixDate } from '../../../src/gsc-search-analytics/windows.js';
 
 describe('computeWindows', () => {
   it('returns 84-day before/after windows around the fix date', () => {
@@ -24,5 +24,38 @@ describe('computeWindows', () => {
 
   it('throws on an invalid date', () => {
     expect(() => computeWindows('not-a-date')).to.throw('Invalid fix date');
+  });
+});
+
+describe('isValidFixDate', () => {
+  it('accepts a valid ISO date', () => {
+    expect(isValidFixDate('2026-03-01')).to.equal(true);
+  });
+  it('rejects a malformed date', () => {
+    expect(isValidFixDate('not-a-date')).to.equal(false);
+  });
+  it('rejects undefined', () => {
+    expect(isValidFixDate(undefined)).to.equal(false);
+  });
+});
+
+describe('assessCompleteness', () => {
+  const now = new Date('2026-08-05T00:00:00Z');
+
+  it('marks a long-past window fully complete', () => {
+    const windows = computeWindows('2026-03-01'); // after.end 2026-05-24, well past lag
+    expect(assessCompleteness(windows, now)).to.deep.equal({ beforeComplete: true, afterComplete: true });
+  });
+
+  it('marks the after window incomplete when it has not fully elapsed', () => {
+    const windows = { before: { start: '2026-05-01', end: '2026-07-25' }, after: { start: '2026-07-27', end: '2026-10-18' } };
+    const c = assessCompleteness(windows, now);
+    expect(c.afterComplete).to.equal(false);
+  });
+
+  it('marks the before window incomplete when it predates retention', () => {
+    const windows = { before: { start: '2023-01-01', end: '2023-03-25' }, after: { start: '2023-03-27', end: '2023-06-18' } };
+    const c = assessCompleteness(windows, now);
+    expect(c.beforeComplete).to.equal(false);
   });
 });

--- a/test/audits/gsc-search-analytics/windows.test.js
+++ b/test/audits/gsc-search-analytics/windows.test.js
@@ -37,6 +37,12 @@ describe('isValidFixDate', () => {
   it('rejects undefined', () => {
     expect(isValidFixDate(undefined)).to.equal(false);
   });
+  it('rejects a rolled-over impossible date (2026-02-30)', () => {
+    expect(isValidFixDate('2026-02-30')).to.equal(false);
+  });
+  it('rejects an out-of-range month/day (2026-13-45)', () => {
+    expect(isValidFixDate('2026-13-45')).to.equal(false);
+  });
 });
 
 describe('assessCompleteness', () => {

--- a/test/audits/gsc-search-analytics/windows.test.js
+++ b/test/audits/gsc-search-analytics/windows.test.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { computeWindows } from '../../../src/gsc-search-analytics/windows.js';
+
+describe('computeWindows', () => {
+  it('returns 84-day before/after windows around the fix date', () => {
+    const { before, after } = computeWindows('2026-03-01');
+    expect(before.start).to.equal('2025-12-07');
+    expect(before.end).to.equal('2026-02-28');
+    expect(after.start).to.equal('2026-03-02');
+    expect(after.end).to.equal('2026-05-24'); // 84 inclusive days, NOT 05-25
+  });
+
+  it('throws on an invalid date', () => {
+    expect(() => computeWindows('not-a-date')).to.throw('Invalid fix date');
+  });
+});


### PR DESCRIPTION
## What this change intends

Adds a new **tracking-only** SpaceCat audit, `gsc-search-analytics`. For each URL that ASO fixed (supplied as `auditContext.fixedUrls = [{ url, fixType, fixDate }]`), it records that URL's Google Search Console clicks / impressions / CTR / position for the 84 days **before** and **after** its own fix date, and stores one row in the `audits` table.

This is the "Measured" layer of an outcome-proof effort: it **records raw before/after figures only**. It makes **no causal claim, no attribution, no dollar value** — the stored row carries an explicit `interpretation` label saying so.

## How it works

- Runner audit via `AuditBuilder`; registered in `src/index.js` `HANDLERS` as `gsc-search-analytics`.
- Reuses the existing `@adobe/spacecat-shared-google-client` `getOrganicSearchData` (page dimension), paginated with a 50-page safety cap.
- URLs sharing a fix date share one pair of window pulls; fixed URLs are matched client-side (normalized) against the site's per-page rows.
- Result envelope: `{ schemaVersion, interpretation, connected, status, fixCount, measuredCount, fixes[] }`. Each fix has a `status` of `measured | not_found | incomplete | invalid_date | failed`, plus a `dataQuality` marker.
- **Data-integrity gating:** a delta is stored only when both windows are fully elapsed (GSC ~3-day freshness lag) and within retention (~16 months); otherwise `status: incomplete`, `delta: null`. Completeness is checked before presence, so a not-yet-elapsed window reads `incomplete`, not `not_found`.

## What it changes / breaks

- Additive only: one new handler package + one `HANDLERS` entry. No existing behavior changed.
- `spacecat-shared` is **not** touched — plain-string audit type, no shared release needed.

## Testing

- 34 unit tests for the new module; **100% coverage** (lines / branches / statements) on `src/gsc-search-analytics/**`.
- Full local suite green: 9,424 passing, 0 failing; repo coverage gate met.
- Went through multiple code-review rounds plus a plan/scope conformance review.

## Two decisions to confirm before enabling

1. **Failure handling:** any `GoogleClient.createFrom` failure is recorded as `status: not_connected` with the raw `reason` (matches repo convention, never crashes the run). A transient throttle/5xx therefore reads as "not connected" — confirm that's acceptable.
2. **Oversized list:** `> 500` fixedUrls fails closed (`too_many_fixed_urls`) rather than processing the first 500. Fine for the manual pilot; revisit if the fixed-URL feed is automated.

## Spec

`docs/specs/gsc-search-analytics.md` (in this PR). Implementation plan lives in a private basecamp repo.

> Do not merge yet — pending review + prod registration for the pilot.

Issue: _none (tracking-only pilot audit)_

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Daniel Huser", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```