### PR TITLE
fix(offsite): v2 IMS getServiceAccessToken + hard-stop on enableSemrush:true failure

### DIFF
--- a/docs/decisions/002-offsite-cited-urls-semrush-source.md
+++ b/docs/decisions/002-offsite-cited-urls-semrush-source.md
@@ -15,12 +15,21 @@ involves several non-obvious trade-offs, so it warrants an ADR alongside the spe
 
 ## Decision
 
-1. **Source swap behind a flag, Semrush-first with automatic legacy fallback.**
-   When `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED=true`, the runner tries the Semrush
-   loader first; if it yields **no usable result** it falls back to the legacy
-   `loadBrandPresenceData` (PostgREST → SharePoint). Flag off = legacy only.
-2. **"No usable result" = fall back, at the SURFACE granularity.** The loader
-   returns `null` — and the handler falls back — on: no org/brand, transient
+1. **Source swap behind a flag, Semrush-first — failure handling depends on HOW it
+   was enabled.** When Semrush is enabled (env var
+   `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED=true`, or the per-run override in Decision 6),
+   the runner uses the Semrush loader. On a Semrush **failure** (loader returns `null`):
+   - **Env-enabled, or override `false`/absent →** fall back to the legacy
+     `loadBrandPresenceData` (PostgREST → SharePoint), so production is never silently
+     zeroed out.
+   - **Explicitly forced on via `enableSemrush:true` (Slack override) →** **hard stop**:
+     return `success:false` with `dataSource:'semrush'` + `fallbackReason`, and do **NOT**
+     run legacy. An operator testing Semrush on one run wants the failure **visible**, not
+     masked by legacy.
+   A genuinely-empty-but-successful result (Map size 0) is **not** a failure — it is used as
+   a normal zero-URL Semrush run in both modes. Flag off (no override) = legacy only.
+2. **What counts as a Semrush FAILURE (`null`), at the SURFACE granularity.** The loader
+   returns `null` on: no org/brand, transient
    brand-resolution failure, no date window, IMS-token failure, or when a **whole
    surface (hostname) produced zero successful responses**. Rationale: a dropped
    *surface* (all YouTube or all Reddit engines failed) is indistinguishable from a
@@ -53,11 +62,16 @@ involves several non-obvious trade-offs, so it warrants an ADR alongside the spe
    `search-gpt`, `microsoft-copilot`, `gemini-2.5-flash`, `google-ai-overview`,
    `perplexity`) — and **sum** citations per URL. Validating this map upstream is
    LLMO-6710.
-4. **Auth = service IMS bearer, forwarded unchanged to Semrush.** No
-   `x-promise-token` for a service caller (that header is the non-IMS/browser path).
-   **Open risk:** the proxy forwards the token unchanged and is designed around a
-   real *user* IMS token; whether Semrush accepts the worker's *service* token is
-   unverified — the flag stays off until confirmed end-to-end (LLMO-6709).
+4. **Auth = IMS service bearer via v2 `getServiceAccessToken()` (`authorization_code`
+   grant), default IMS client.** This is the same S2S path `commerce-product-enrichments`,
+   `vulnerabilities` and `permissions` use. v3 `getServiceAccessTokenV3()`
+   (`client_credentials`) was tried first but returns IMS **`400 unauthorized_client`** —
+   the worker's default IMS client is only provisioned for `authorization_code`; only a
+   dedicated integration (content-ai's `CONTENTAI_*`) is registered for `client_credentials`.
+   The token is forwarded unchanged to Semrush; no `x-promise-token` for a service caller.
+   **Open risk (LLMO-6709):** the proxy is designed around a real *user* IMS token, so whether
+   Semrush accepts the worker's *service* token is unverified — the flag stays off until
+   confirmed end-to-end (use `enableSemrush:true` on one canary run, per Decision 6, to test).
 5. **Format parity.** The loader re-applies `YOUTUBE_URL_REGEX` / `REDDIT_URL_REGEX`
    (matching the legacy `handler.js` classify) so non-thread Reddit and lookalike
    YouTube hosts are dropped identically.
@@ -65,9 +79,9 @@ involves several non-obvious trade-offs, so it warrants an ADR alongside the spe
    `enableSemrush` (`auditContext.messageData.enableSemrush`, resolved by
    `resolveEnableSemrush`) lets a single Slack-triggered `offsite-brand-presence` /
    `cited-analysis` / `youtube-analysis` / `reddit-analysis` run override the env var —
-   `true` forces the Semrush attempt on for that run, `false` forces legacy even when the
-   env var is on, anything else (absent, empty, invalid) falls through to the env var
-   unchanged. This is the intended mechanism for verifying LLMO-6709 against the real
+   `true` forces the Semrush attempt on for that run **and makes a failure a hard stop with
+   no legacy fallback** (Decision 1), `false` forces legacy even when the env var is on,
+   anything else (absent, empty, invalid) falls through to the env var unchanged. This is the intended mechanism for verifying LLMO-6709 against the real
    Semrush proxy on one site at a time, before `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED`
    is flipped fleet-wide. Same tri-state mechanism as the existing `enableBrandProfile`
    override. It is a **per-run** override only (one Slack invocation), not the persistent

--- a/docs/specs/2026-08-05-offsite-cited-urls-semrush-source.md
+++ b/docs/specs/2026-08-05-offsite-cited-urls-semrush-source.md
@@ -54,12 +54,16 @@ request carries a 10s timeout; requests run concurrently.
 
 ### 3.2 Auth
 
-The loader mints a **service IMS token** (`ImsClient.getServiceAccessTokenV3`) and sends
-`Authorization: Bearer`. The proxy's `requireImsBearer` forwards it **unchanged** to Semrush
+The loader mints a **service IMS token** via **v2 `ImsClient.getServiceAccessToken()`**
+(`authorization_code` grant, default IMS client — the same S2S path commerce/vulnerabilities/
+permissions use) and sends `Authorization: Bearer`. (v3 `getServiceAccessTokenV3()` /
+`client_credentials` returned IMS `400 unauthorized_client` — the default client isn't
+provisioned for that grant; only a dedicated integration like `CONTENTAI_*` is.) The proxy's
+`requireImsBearer` forwards it **unchanged** to Semrush
 (`docs/elements/semrush-elements-api-reference.md` §Authentication) — no `x-promise-token`
 needed for a service caller. **Open risk (LLMO-6709):** the wrapper is designed around a real
 user's IMS token, so the worker's service token must be authorized upstream by Semrush; the
-flag stays off until verified.
+flag stays off until verified (test one canary run via the `enableSemrush:true` Slack override).
 
 ### 3.3 Flow (`src/utils/offsite-brand-presence-semrush.js`)
 
@@ -124,7 +128,9 @@ added.
 - Flag off ⇒ byte-for-byte today's behavior (no regression).
 - Flag on ⇒ YouTube/Reddit cited URLs come from Semrush with exact citation counts; strict
   format filtering matches the legacy path.
-- Flag on + Semrush unavailable ⇒ automatic fallback to the legacy PostgREST → SharePoint
+- Env-enabled + Semrush fails ⇒ automatic fallback to the legacy PostgREST → SharePoint
   source (no offsite gap).
+- `enableSemrush:true` (Slack override) + Semrush fails ⇒ **hard stop** (`success:false`,
+  `dataSource:'semrush'`, no fallback) so the failure is visible during LLMO-6709 testing.
 - Shadow-run (LLMO-6711) shows acceptable top-70 overlap per surface vs the legacy source.
 - 100% test coverage on the new module; full suite green.

--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -900,15 +900,21 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
 
   const allUrls = new Map();
   let usedSemrush = false;
-  // Recorded on auditResult.dataSource so shadow-run parity (LLMO-6711) can join
-  // on which source served each run instead of grepping a log string.
-  let fallbackReason;
   let semrushDiagnostics;
+  // Recorded on auditResult.dataSource / fallbackReason so shadow-run parity
+  // (LLMO-6711) can join on which source served each run.
+  let fallbackReason;
   // Per-run Slack override (resolveEnableSemrush) takes precedence over the env flag.
   // This is the mechanism for testing the Semrush path live on one site/run before
   // flipping OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED fleet-wide (see the ADR).
   const semrushEnabled = enableSemrushOverride
     ?? (context.env?.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED === 'true');
+  // Hard stop (NO legacy fallback) applies ONLY when a run EXPLICITLY opted into
+  // Semrush via the Slack override `enableSemrush:true` — a failure there must be
+  // visible, not masked by legacy. When Semrush was enabled by the env var (or the
+  // override is false/absent), a failure falls back to legacy so production can
+  // never be silently zeroed out.
+  const hardStopOnFailure = enableSemrushOverride === true;
   // Logged unconditionally (including the off case) so a Splunk search on siteId
   // alone shows whether this run even attempted Semrush and, if so, which knob
   // decided that (Slack per-run override vs the env var) — the two can disagree.
@@ -918,14 +924,10 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
     decidedBy: enableSemrushOverride !== undefined ? 'slack-override' : 'env-var',
   });
   if (semrushEnabled) {
-    // Semrush-first: the loader returns the same allUrls shape, with
-    // count = exact citations. Everything downstream (selectTopUrls -> DRS)
-    // is unchanged. If Semrush yields no usable URLs (auth failure, no brand,
-    // outage, empty result) we fall back to the legacy PostgREST/SharePoint
-    // source below so a Semrush problem can never silently zero out offsite.
-    // onProgress mirrors the Semrush attempt into the Slack thread (when one
-    // exists — postMessageOptional no-ops otherwise) as an alternative to Splunk
-    // for the manual per-run testing this override was built for.
+    // Semrush is the source when enabled. The loader returns the same allUrls
+    // shape (count = exact citations); everything downstream (selectTopUrls ->
+    // DRS) is unchanged. onProgress mirrors the attempt into the Slack thread
+    // (when one exists — postMessageOptional no-ops otherwise) for per-run testing.
     semrushDiagnostics = {};
     const semrushUrls = await loadCitedUrlsFromSemrush({
       site,
@@ -940,7 +942,40 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
         { threadTs },
       ),
     });
-    if (semrushUrls && semrushUrls.size > 0) {
+    // A `null` return means the Semrush source FAILED (auth / no-brand /
+    // no-date-window / outage / whole-surface-zero — see the loader's
+    // diagnostics.fallbackReason). A genuinely-empty-but-successful result (Map
+    // with size 0) is NOT a failure and continues as a normal zero-URL run.
+    if (semrushUrls === null) {
+      const reason = semrushDiagnostics.fallbackReason ?? 'semrush-failed';
+      if (hardStopOnFailure) {
+        // enableSemrush:true forced this run — surface the failure, no fallback.
+        log.error(`${LOG_PREFIX} Semrush source failed (${reason}); hard stop — no legacy fallback (enableSemrush:true)`, {
+          siteId, fallbackReason: reason,
+        });
+        await postMessageOptional(
+          context,
+          channelId,
+          `:x: *offsite-brand-presence* for *${baseURL}* — Semrush source failed (${reason}); stopping (enableSemrush:true, no fallback).`,
+          { threadTs },
+        );
+        return {
+          auditResult: {
+            success: false,
+            error: `Semrush source failed (${reason}); hard stop (enableSemrush:true)`,
+            dataSource: 'semrush',
+            fallbackReason: reason,
+          },
+          fullAuditRef: finalUrl,
+        };
+      }
+      // Enabled by the env var (or override not forced) — fall back to legacy so a
+      // Semrush problem never silently zeroes out offsite.
+      fallbackReason = reason;
+      log.warn(`${LOG_PREFIX} Semrush source failed (${reason}); falling back to PostgREST/SharePoint`, {
+        siteId, fallbackReason: reason,
+      });
+    } else {
       for (const [url, info] of semrushUrls) {
         allUrls.set(url, info);
       }
@@ -956,18 +991,15 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
           engineFailureCount: semrushDiagnostics.engineFailureCount,
         });
       }
-    } else {
-      fallbackReason = semrushDiagnostics.fallbackReason ?? 'semrush-no-usable-urls';
-      log.warn(`${LOG_PREFIX} Semrush source returned no URLs; falling back to PostgREST/SharePoint`, {
-        siteId, fallbackReason,
-      });
     }
   }
   const dataSource = usedSemrush ? 'semrush' : 'legacy';
   const semrushDegraded = usedSemrush && (semrushDiagnostics?.engineFailureCount ?? 0) > 0;
 
-  // Legacy source: runs when the flag is off, OR when Semrush was tried but
-  // produced nothing (fallback). Flag off = today's behavior, unchanged.
+  // Legacy source: runs when the flag is off, OR when Semrush was env-enabled but
+  // failed (fallback). An enableSemrush:true run that failed already hard-stopped
+  // above — there is
+  // no legacy fallback on the Semrush path.
   if (!usedSemrush) {
     const brandPresenceData = await loadBrandPresenceData({
       siteId, site, previousWeeks, context,

--- a/src/utils/offsite-brand-presence-semrush.js
+++ b/src/utils/offsite-brand-presence-semrush.js
@@ -84,9 +84,17 @@ export function getSemrushPlatforms(env) {
 }
 
 /**
- * Mints an IMS service access token as an Authorization header value. The scheme
- * is normalised to `Bearer` (the token endpoint may return `token_type: "bearer"`
- * lowercase, which a strict `startsWith('Bearer ')` parser upstream would reject).
+ * Mints an IMS service access token as an Authorization header value.
+ *
+ * Uses the v2 `getServiceAccessToken()` (`authorization_code` grant) with the
+ * worker's default IMS client — the same S2S path `commerce-product-enrichments`,
+ * `vulnerabilities` and `permissions` use. The default client is provisioned for
+ * `authorization_code`, NOT the `client_credentials` grant that
+ * `getServiceAccessTokenV3()` requests (which returns IMS `400 unauthorized_client`
+ * unless a dedicated client_credentials integration is configured, e.g. content-ai's
+ * `CONTENTAI_*`). The scheme is normalised to `Bearer` (the endpoint may return
+ * `token_type: "bearer"` lowercase, which a strict `startsWith('Bearer ')` parser
+ * upstream would reject).
  *
  * @param {object} context - Lambda context (env + log).
  * @returns {Promise<string>} e.g. "Bearer eyJ...".
@@ -94,7 +102,7 @@ export function getSemrushPlatforms(env) {
  */
 async function getAuthorizationHeader(context) {
   const imsClient = ImsClient.createFrom(context);
-  const token = await imsClient.getServiceAccessTokenV3();
+  const token = await imsClient.getServiceAccessToken();
   if (!token?.access_token) {
     throw new Error('IMS service token response missing access_token');
   }

--- a/test/audits/offsite-brand-presence.test.js
+++ b/test/audits/offsite-brand-presence.test.js
@@ -321,8 +321,25 @@ describe('Offsite Brand Presence Handler', () => {
       );
     });
 
-    it('falls back to the legacy PostgREST/SharePoint source when Semrush yields null', async () => {
-      context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
+    it('hard-stops (success:false, no legacy) when an enableSemrush:true run fails', async () => {
+      // Forced on via the Slack override — a failure must be visible, not masked.
+      mockLoadCitedUrlsFromSemrush.resolves(null); // null = Semrush FAILED
+      stubBrandPresenceData(['https://www.youtube.com/watch?v=legacy']); // must NOT be used
+
+      const result = await offsiteBrandPresenceRunner(
+        FINAL_URL, context, site, { messageData: { enableSemrush: true } },
+      );
+
+      expect(result.auditResult.success).to.be.false;
+      expect(result.auditResult.dataSource).to.equal('semrush');
+      expect(result.auditResult.fallbackReason).to.equal('semrush-failed');
+      expect(result.auditResult.error).to.match(/hard stop/);
+      expect(mockLoadCitedUrlsFromSemrush).to.have.been.calledOnce;
+      expect(mockLoadBrandPresenceData).to.not.have.been.called; // no legacy fallback
+    });
+
+    it('falls back to legacy when an ENV-enabled Semrush run fails (no hard stop)', async () => {
+      context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true'; // env, not the override
       mockLoadCitedUrlsFromSemrush.resolves(null);
       stubBrandPresenceData(['https://www.youtube.com/watch?v=legacy']);
 
@@ -330,25 +347,23 @@ describe('Offsite Brand Presence Handler', () => {
 
       expect(result.auditResult.success).to.be.true;
       expect(result.auditResult.dataSource).to.equal('legacy');
-      expect(result.auditResult.fallbackReason).to.equal('semrush-no-usable-urls');
-      expect(mockLoadCitedUrlsFromSemrush).to.have.been.calledOnce;
+      expect(result.auditResult.fallbackReason).to.equal('semrush-failed');
       expect(mockLoadBrandPresenceData).to.have.been.calledOnce;
       expect(result.auditResult.urlCounts['youtube.com']).to.equal(1);
-      expect(log.warn).to.have.been.called;
     });
 
-    it('falls back to the legacy source when Semrush yields an empty map', async () => {
+    it('treats a genuinely-empty Semrush result as a zero-URL semrush run (no legacy)', async () => {
       context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
-      mockLoadCitedUrlsFromSemrush.resolves(new Map());
-      stubBrandPresenceData(['https://www.reddit.com/r/test/comments/1/thread']);
+      mockLoadCitedUrlsFromSemrush.resolves(new Map()); // success, 0 URLs (not a failure)
+      stubBrandPresenceData(['https://www.reddit.com/r/test/comments/1/thread']); // must NOT be used
 
       const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
 
-      expect(mockLoadCitedUrlsFromSemrush).to.have.been.calledOnce;
-      expect(mockLoadBrandPresenceData).to.have.been.calledOnce;
-      expect(result.auditResult.urlCounts['reddit.com']).to.equal(1);
-      expect(result.auditResult.dataSource).to.equal('legacy');
-      expect(result.auditResult.fallbackReason).to.equal('semrush-no-usable-urls');
+      expect(result.auditResult.success).to.be.true;
+      expect(result.auditResult.dataSource).to.equal('semrush');
+      expect(result.auditResult.urlCounts['reddit.com']).to.equal(0);
+      expect(result.auditResult).to.not.have.property('fallbackReason');
+      expect(mockLoadBrandPresenceData).to.not.have.been.called; // no legacy fallback
     });
 
     it('a Slack-requested enableSemrush:true override invokes the Semrush loader even when the env var is off', async () => {
@@ -403,7 +418,7 @@ describe('Offsite Brand Presence Handler', () => {
       expect(log.warn).to.have.been.calledWithMatch(/Invalid enableSemrush/);
     });
 
-    it('surfaces dataSource + fallbackReason even when the legacy fallback also yields nothing', async () => {
+    it('env-enabled fallback surfaces dataSource+fallbackReason even when legacy also yields nothing', async () => {
       context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
       mockLoadCitedUrlsFromSemrush.resolves(null);
       mockLoadBrandPresenceData.resolves(null); // legacy empty too
@@ -412,8 +427,26 @@ describe('Offsite Brand Presence Handler', () => {
 
       expect(result.auditResult.success).to.be.true;
       expect(result.auditResult.dataSource).to.equal('legacy');
-      expect(result.auditResult.fallbackReason).to.equal('semrush-no-usable-urls');
+      expect(result.auditResult.fallbackReason).to.equal('semrush-failed');
       expect(result.auditResult.urlCounts['youtube.com']).to.equal(0);
+    });
+
+    it('surfaces the loader diagnostics fallbackReason code on hard stop', async () => {
+      mockLoadCitedUrlsFromSemrush.callsFake(async ({ diagnostics }) => {
+        if (diagnostics) {
+          diagnostics.fallbackReason = 'ims-token-failed';
+        }
+        return null;
+      });
+
+      const result = await offsiteBrandPresenceRunner(
+        FINAL_URL, context, site, { messageData: { enableSemrush: true } },
+      );
+
+      expect(result.auditResult.success).to.be.false;
+      expect(result.auditResult.dataSource).to.equal('semrush');
+      expect(result.auditResult.fallbackReason).to.equal('ims-token-failed');
+      expect(mockLoadBrandPresenceData).to.not.have.been.called;
     });
   });
 
@@ -1858,7 +1891,11 @@ describe('Offsite Brand Presence Handler', () => {
     });
 
     it('forwards the Semrush override to the poll message auditContext when set on Slack', async () => {
-      stubBrandPresenceData(['https://youtube.com/shorts/v1']);
+      // enableSemrush:true hard-stops on failure, so give Semrush a usable result
+      // to let the run proceed to DRS poll scheduling.
+      mockLoadCitedUrlsFromSemrush.resolves(new Map([
+        ['https://youtu.be/v1', { count: 5, domain: 'youtube.com' }],
+      ]));
       const auditContext = {
         slackContext: { channelId: 'C123', threadTs: '111.222' },
         messageData: { enableSemrush: true },

--- a/test/utils/offsite-brand-presence-semrush.test.js
+++ b/test/utils/offsite-brand-presence-semrush.test.js
@@ -42,7 +42,7 @@ describe('offsite-brand-presence-semrush', function () {
   let log;
   let fetchStub;
   let resolveBrandResultForSite;
-  let getServiceAccessTokenV3;
+  let getServiceAccessToken;
   let imsCreateFrom;
   let mod;
 
@@ -84,8 +84,8 @@ describe('offsite-brand-presence-semrush', function () {
     fetchStub = sandbox.stub();
     resolveBrandResultForSite = sandbox.stub()
       .resolves({ brand: { brandId: BRAND_ID }, resolved: true });
-    getServiceAccessTokenV3 = sandbox.stub().resolves({ token_type: 'Bearer', access_token: 'tok' });
-    imsCreateFrom = sandbox.stub().returns({ getServiceAccessTokenV3 });
+    getServiceAccessToken = sandbox.stub().resolves({ token_type: 'Bearer', access_token: 'tok' });
+    imsCreateFrom = sandbox.stub().returns({ getServiceAccessToken });
     mod = await loadModule();
   });
 
@@ -129,7 +129,7 @@ describe('offsite-brand-presence-semrush', function () {
   });
 
   it('normalizes a lowercase token_type to Bearer', async () => {
-    getServiceAccessTokenV3.resolves({ token_type: 'bearer', access_token: 'tok' });
+    getServiceAccessToken.resolves({ token_type: 'bearer', access_token: 'tok' });
     fetchStub.resolves(okJson({ urls: [] }));
     await run();
     expect(fetchStub.firstCall.args[1].headers.Authorization).to.equal('Bearer tok');
@@ -392,13 +392,13 @@ describe('offsite-brand-presence-semrush', function () {
   });
 
   it('returns null when the IMS service token cannot be minted', async () => {
-    getServiceAccessTokenV3.rejects(new Error('ims down'));
+    getServiceAccessToken.rejects(new Error('ims down'));
     expect(await run()).to.equal(null);
     expect(log.error).to.have.been.called;
   });
 
   it('returns null when the IMS token response has no access_token', async () => {
-    getServiceAccessTokenV3.resolves({ token_type: 'Bearer' });
+    getServiceAccessToken.resolves({ token_type: 'Bearer' });
     expect(await run()).to.equal(null);
     expect(erroredWith(/access_token/)).to.equal(true);
   });


### PR DESCRIPTION
## What

Follow-up to #2847. Fixes the runtime `IMS getServiceAccessTokenV3 request failed with status: 400 - unauthorized_client`.

## 1. Auth: v3 → v2 IMS token

The loader minted the service token with **v3 `getServiceAccessTokenV3()`** = `client_credentials` grant, using the worker's **default IMS client**. That client is only provisioned for the **`authorization_code`** grant → IMS returns `400 unauthorized_client`.

Switched to **v2 `getServiceAccessToken()`** (`authorization_code`, default `IMS_*` creds) — the exact S2S path `commerce-product-enrichments`, `vulnerabilities` and `permissions` already use successfully. (v3/`client_credentials` needs a *dedicated* integration, like content-ai's `CONTENTAI_*`; that isn't provisioned for LLMO/Semrush.)

## 2. Hard-stop vs fallback, by how Semrush was enabled

| Enabled by | Semrush **fails** (loader `null`) | Semrush returns 0 URLs (success) |
|---|---|---|
| `enableSemrush:true` (Slack override) | **HARD STOP** — `success:false`, `dataSource:'semrush'`, `fallbackReason`, **no legacy** | zero-URL semrush run |
| env var (or override `false`/absent) | **fall back** to legacy PostgREST → SharePoint | zero-URL semrush run |
| flag off | — (legacy only) | — |

Rationale: an operator explicitly testing Semrush on one run (`enableSemrush:true`) wants a failure **visible**, not masked by legacy; but an **env-enabled** production run must never be silently zeroed out, so it keeps the fallback.

## Auth still gated (LLMO-6709)

This makes the **token mint** succeed. Whether Semrush accepts the worker's *service* identity (the proxy forwards it unchanged and is built around *user* tokens) is still the open gate — verify with one canary run via `enableSemrush:true` and read `auditResult.dataSource` / the `Service token rejected` log.

## Testing
- v2 stub; hard-stop (override) vs env-fallback vs genuinely-empty; diagnostics `fallbackReason` on hard stop; fixed the poll-forwarding test (an `enableSemrush:true` run now hard-stops on the default null mock, so it seeds a success).
- Loader/constants **100% coverage**; full suite **9460 passing**.
- Flag off = unchanged; safe to merge.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi", "TB ADBE"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```