### PR TITLE
fix(opportunity): reopen RESOLVED opportunity instead of creating duplicate

### DIFF
--- a/src/common/opportunity.js
+++ b/src/common/opportunity.js
@@ -51,6 +51,24 @@ export async function convertToOpportunity(auditUrl, auditData, context, createO
         }
         return false;
       });
+
+      if (!opportunity) {
+        // eslint-disable-next-line max-len
+        const resolvedOpportunities = await Opportunity.allBySiteIdAndStatus(auditData.siteId, Oppty.STATUSES.RESOLVED);
+        const resolvedOpportunity = resolvedOpportunities.find((oppty) => {
+          if (oppty.getType() === auditType) {
+            if (comparisonFn && typeof comparisonFn === 'function') {
+              return comparisonFn(oppty, opportunityInstance);
+            }
+            return true;
+          }
+          return false;
+        });
+        if (resolvedOpportunity) {
+          await resolvedOpportunity.setStatus(Oppty.STATUSES.NEW);
+          opportunity = resolvedOpportunity;
+        }
+      }
     } catch (e) {
       log.error(`Fetching opportunities for siteId ${auditData.siteId} failed with error: ${e.message}`);
       throw new Error(`Failed to fetch opportunities for siteId ${auditData.siteId}: ${e.message}`);

--- a/src/common/opportunity.js
+++ b/src/common/opportunity.js
@@ -55,15 +55,17 @@ export async function convertToOpportunity(auditUrl, auditData, context, createO
       if (!opportunity) {
         // eslint-disable-next-line max-len
         const resolvedOpportunities = await Opportunity.allBySiteIdAndStatus(auditData.siteId, Oppty.STATUSES.RESOLVED);
-        const resolvedOpportunity = resolvedOpportunities.find((oppty) => {
-          if (oppty.getType() === auditType) {
-            if (comparisonFn && typeof comparisonFn === 'function') {
-              return comparisonFn(oppty, opportunityInstance);
+        const resolvedOpportunity = [...resolvedOpportunities]
+          .sort((a, b) => new Date(b.getUpdatedAt()) - new Date(a.getUpdatedAt()))
+          .find((oppty) => {
+            if (oppty.getType() === auditType) {
+              if (comparisonFn && typeof comparisonFn === 'function') {
+                return comparisonFn(oppty, opportunityInstance);
+              }
+              return true;
             }
-            return true;
-          }
-          return false;
-        });
+            return false;
+          });
         if (resolvedOpportunity) {
           await resolvedOpportunity.setStatus(Oppty.STATUSES.NEW);
           opportunity = resolvedOpportunity;

--- a/src/common/opportunity.js
+++ b/src/common/opportunity.js
@@ -56,7 +56,7 @@ export async function convertToOpportunity(auditUrl, auditData, context, createO
         // eslint-disable-next-line max-len
         const resolvedOpportunities = await Opportunity.allBySiteIdAndStatus(auditData.siteId, Oppty.STATUSES.RESOLVED);
         const resolvedOpportunity = [...resolvedOpportunities]
-          .sort((a, b) => new Date(b.getUpdatedAt()) - new Date(a.getUpdatedAt()))
+          .sort((a, b) => new Date(b.getUpdatedAt?.() ?? 0) - new Date(a.getUpdatedAt?.() ?? 0))
           .find((oppty) => {
             if (oppty.getType() === auditType) {
               if (comparisonFn && typeof comparisonFn === 'function') {

--- a/test/common/opportunity.test.js
+++ b/test/common/opportunity.test.js
@@ -19,6 +19,165 @@ import chaiAsPromised from 'chai-as-promised';
 use(sinonChai);
 use(chaiAsPromised);
 
+describe('convertToOpportunity — RESOLVED fallback', () => {
+  let sandbox;
+  let convertToOpportunity;
+  let checkGoogleConnectionStub;
+
+  const siteId = 'site-id';
+  const auditId = 'audit-id';
+  const auditType = 'broken-backlinks';
+
+  const makeOpp = (type, updatedAt = '2024-01-01T00:00:00Z') => ({
+    getType: () => type,
+    getUpdatedAt: () => updatedAt,
+    setStatus: sandbox.stub().resolves(),
+    setAuditId: sandbox.stub(),
+    getData: sandbox.stub().returns({}),
+    setData: sandbox.stub(),
+    setUpdatedBy: sandbox.stub(),
+    save: sandbox.stub().resolves(),
+    getId: () => `opp-${updatedAt}`,
+  });
+
+  const makeContext = ({ newOpps = [], resolvedOpps = [], createStub } = {}) => {
+    const create = createStub ?? sandbox.stub().resolves(makeOpp(auditType));
+    return {
+      dataAccess: {
+        Opportunity: {
+          allBySiteIdAndStatus: sandbox.stub()
+            .onFirstCall().resolves(newOpps)
+            .onSecondCall()
+            .resolves(resolvedOpps),
+          create,
+        },
+      },
+      log: { error: sandbox.stub(), info: sandbox.stub(), debug: sandbox.stub() },
+    };
+  };
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    checkGoogleConnectionStub = sandbox.stub().resolves(true);
+    ({ convertToOpportunity } = await esmock('../../src/common/opportunity.js', {
+      '../../src/common/opportunity-utils.js': {
+        checkGoogleConnection: checkGoogleConnectionStub,
+      },
+    }));
+  });
+
+  afterEach(() => sandbox.restore());
+
+  it('reopens the matching RESOLVED opportunity and saves it without creating a new one', async () => {
+    const resolved = makeOpp(auditType);
+    const createStub = sandbox.stub();
+    const context = makeContext({ resolvedOpps: [resolved], createStub });
+
+    const result = await convertToOpportunity(
+      'https://example.com',
+      { siteId, id: auditId },
+      context,
+      () => ({ data: {} }),
+      auditType,
+    );
+
+    expect(resolved.setStatus).to.have.been.calledOnce;
+    expect(resolved.save).to.have.been.calledOnce;
+    expect(createStub).to.not.have.been.called;
+    expect(result.getId()).to.equal(resolved.getId());
+  });
+
+  it('picks the most recently updated RESOLVED opportunity when multiple match', async () => {
+    const older = makeOpp(auditType, '2023-01-01T00:00:00Z');
+    const newer = makeOpp(auditType, '2024-06-01T00:00:00Z');
+    const context = makeContext({ resolvedOpps: [older, newer] });
+
+    await convertToOpportunity(
+      'https://example.com',
+      { siteId, id: auditId },
+      context,
+      () => ({ data: {} }),
+      auditType,
+    );
+
+    expect(newer.setStatus).to.have.been.calledOnce;
+    expect(older.setStatus).to.not.have.been.called;
+  });
+
+  it('reopens a RESOLVED opportunity when comparisonFn returns true', async () => {
+    const resolved = makeOpp(auditType);
+    const createStub = sandbox.stub();
+    const context = makeContext({ resolvedOpps: [resolved], createStub });
+    const comparisonFn = sandbox.stub().returns(true);
+
+    await convertToOpportunity(
+      'https://example.com',
+      { siteId, id: auditId },
+      context,
+      () => ({ data: {} }),
+      auditType,
+      {},
+      comparisonFn,
+    );
+
+    expect(comparisonFn).to.have.been.called;
+    expect(resolved.setStatus).to.have.been.calledOnce;
+    expect(createStub).to.not.have.been.called;
+  });
+
+  it('does not reopen a RESOLVED opportunity when comparisonFn returns false', async () => {
+    const resolved = makeOpp(auditType);
+    const createStub = sandbox.stub().resolves(makeOpp(auditType));
+    const context = makeContext({ resolvedOpps: [resolved], createStub });
+    const comparisonFn = sandbox.stub().returns(false);
+
+    await convertToOpportunity(
+      'https://example.com',
+      { siteId, id: auditId },
+      context,
+      () => ({ data: {} }),
+      auditType,
+      {},
+      comparisonFn,
+    );
+
+    expect(resolved.setStatus).to.not.have.been.called;
+    expect(createStub).to.have.been.calledOnce;
+  });
+
+  it('creates a new opportunity when RESOLVED opportunities exist but none match the type', async () => {
+    const wrongType = makeOpp('other-audit-type');
+    const createStub = sandbox.stub().resolves(makeOpp(auditType));
+    const context = makeContext({ resolvedOpps: [wrongType], createStub });
+
+    await convertToOpportunity(
+      'https://example.com',
+      { siteId, id: auditId },
+      context,
+      () => ({ data: {} }),
+      auditType,
+    );
+
+    expect(wrongType.setStatus).to.not.have.been.called;
+    expect(createStub).to.have.been.calledOnce;
+  });
+
+  it('creates a new opportunity when no NEW or RESOLVED opportunities exist', async () => {
+    const createStub = sandbox.stub().resolves(makeOpp(auditType));
+    const context = makeContext({ createStub });
+
+    await convertToOpportunity(
+      'https://example.com',
+      { siteId, id: auditId },
+      context,
+      () => ({ data: {} }),
+      auditType,
+    );
+
+    expect(createStub).to.have.been.calledOnce;
+  });
+});
+
 describe('persistOffsiteOpportunity', () => {
   let sandbox;
   let persistOffsiteOpportunity;

--- a/test/common/opportunity.test.js
+++ b/test/common/opportunity.test.js
@@ -36,6 +36,8 @@ describe('convertToOpportunity — RESOLVED fallback', () => {
     getData: sandbox.stub().returns({}),
     setData: sandbox.stub(),
     setUpdatedBy: sandbox.stub(),
+    setScopeType: sandbox.stub(),
+    setScopeId: sandbox.stub(),
     save: sandbox.stub().resolves(),
     getId: () => `opp-${updatedAt}`,
   });


### PR DESCRIPTION
## Summary

- Adds a RESOLVED-status fallback in `convertToOpportunity`: when no NEW opportunity is found for a site/type, also checks RESOLVED opportunities and reopens the most recent matching one (sets it back to NEW) instead of creating a duplicate
- This prevents duplicate broken-backlinks opportunities from being created on sites whose original opportunity was resolved by the v2 audit's domain_score filter, and then found new broken backlinks on a subsequent audit run

## Root cause this addresses

`convertToOpportunity` only searched `STATUSES.NEW` when looking for an existing opportunity. If the original was RESOLVED (e.g. v2 returned 0 results due to domain_score >= 50 filtering), it missed it and created a new opportunity — leaving two active NEW opportunities for the same site and type.

## Relationship to PR #2850

PR #2850 (Abhinav's scope-type NULL fix) addresses the V1/V2 uniqueness gap at the DB index level. This change covers the separate case where the original opportunity is RESOLVED at the time of the audit — the unique index cannot prevent that scenario since RESOLVED rows are excluded from the partial index. The two changes are complementary and do not conflict. Consider folding together or reviewing side-by-side.

## Jira

Closes SITES-49355

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["@rpapani", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```