### PR TITLE
fix(preflight): loosen accessibility scrape nav wait to avoid 45s timeout (SITES-49365)

### DIFF
--- a/src/preflight/accessibility.js
+++ b/src/preflight/accessibility.js
@@ -21,6 +21,25 @@ import { formatWcagRule } from '../accessibility/utils/generate-individual-oppor
 
 export const PREFLIGHT_ACCESSIBILITY = 'accessibility';
 
+/*
+ * Navigation tuning for the Preflight accessibility scrape.
+ *
+ * The content-scraper accessibility handler defaults to
+ * waitUntil ['networkidle2', 'load'], which requires the network to fully
+ * settle before axe runs. Heavy author/marketing pages with persistent
+ * background traffic never reach that state, so page.goto aborts at the ~45s
+ * nav timeout, the scrape fails, and the audit returns an empty (false-clean)
+ * result. axe only needs the DOM built, not an idle network, so we navigate on
+ * 'domcontentloaded' (which always fires) and add a short fixed settle for
+ * late/SPA content.
+ *
+ * Scoped to Preflight only: ASO scheduled accessibility scans are sent from
+ * src/accessibility/handler.js (config-driven scrapingParams) and are NOT
+ * affected by this. See SITES-49365.
+ */
+export const PREFLIGHT_A11Y_SCRAPE_WAIT_UNTIL = 'domcontentloaded';
+export const PREFLIGHT_A11Y_SCRAPE_SETTLE_MS = 3000;
+
 /**
  * Generate normalized filename from URL
  */
@@ -105,9 +124,21 @@ export async function scrapeAccessibilityData(context, auditContext) {
         options: {
           enableAuthentication,
           a11yPreflight: true,
+          // Loosen navigation so heavy pages don't 45s-timeout into empty
+          // results; Preflight-scoped, does not affect ASO scans (SITES-49365).
+          accessibilityScrapingParams: {
+            waitUntil: PREFLIGHT_A11Y_SCRAPE_WAIT_UNTIL,
+            additionalTimeout: PREFLIGHT_A11Y_SCRAPE_SETTLE_MS,
+          },
           ...(context.promiseToken ? { promiseToken: context.promiseToken } : {}),
         },
       };
+
+      // Info-level marker so prod Splunk can confirm the nav tuning is live
+      // (the full-message log below is debug-only and not emitted in prod).
+      log.info(`[preflight-audit] site: ${siteId}, job: ${jobId}, step: ${step}. `
+        + `Accessibility scrape nav tuned: waitUntil=${PREFLIGHT_A11Y_SCRAPE_WAIT_UNTIL} `
+        + `settleMs=${PREFLIGHT_A11Y_SCRAPE_SETTLE_MS} (SITES-49365)`);
 
       log.debug(`[preflight-audit] Scrape message being sent: ${JSON.stringify(scrapeMessage, null, 2)}`);
       log.debug(`[preflight-audit] Processing type: ${scrapeMessage.processingType}`);

--- a/test/audits/preflight.test.js
+++ b/test/audits/preflight.test.js
@@ -2359,6 +2359,18 @@ describe('Preflight Audit', () => {
           promiseToken: 'test-token',
         });
 
+        // Preflight-scoped nav tuning: loosen waitUntil so heavy pages don't
+        // 45s-timeout into empty results (SITES-49365). ASO scans are unaffected.
+        expect(message.options.accessibilityScrapingParams).to.deep.equal({
+          waitUntil: 'domcontentloaded',
+          additionalTimeout: 3000,
+        });
+
+        // Info-level marker must be emitted so prod Splunk can prove it is live.
+        expect(log.info).to.have.been.calledWithMatch(
+          'Accessibility scrape nav tuned: waitUntil=domcontentloaded settleMs=3000',
+        );
+
         expect(log.debug).to.have.been.calledWith(
           '[preflight-audit] Sent accessibility scraping request to content scraper for 2 URLs',
         );


### PR DESCRIPTION
## What

Preflight's accessibility check scrapes via the content-scraper accessibility handler, which navigates with `waitUntil: ['networkidle2', 'load']` (both events required). On heavy author/marketing pages whose network never goes idle, `page.goto` aborts at the ~45s nav timeout, the scrape fails, and the audit polls ~10 min and returns an **empty (false-clean)** result.

This sets `accessibilityScrapingParams: { waitUntil: 'domcontentloaded', additionalTimeout: 3000 }` on the Preflight accessibility scrape message so navigation completes reliably (axe needs the DOM built, not an idle network), with a short fixed settle for late/SPA content.

## Scope — Preflight only

- The `accessibilityScrapingParams.waitUntil` / `additionalTimeout` hook **already exists** in the content-scraper accessibility handler, so **no content-scraper change** is needed.
- ASO scheduled accessibility scans are sent from a **different** file (`src/accessibility/handler.js`, config-driven `scrapingParams`) and are **unaffected**. The fleet-wide ASO timeout is tracked separately in **SITES-49369**.

## Provability

Adds an info-level `[preflight-audit]` marker so prod Splunk can confirm the tuning is live (the existing full-message log is debug-only). The query plus the two content-scraper signals are documented in SITES-49365.

## Testing

- Extended `test/audits/preflight.test.js` to assert the scrape message carries `waitUntil: 'domcontentloaded'` + `additionalTimeout: 3000` and that the info marker is emitted.
- `preflight.test.js`: 149 passing; eslint clean.

Fixes SITES-49365. Sibling: SITES-49369 (ASO). Related: SITES-49360 (error surfacing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Guy Pelletier", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```