### PR TITLE
fix(prerender): restore unrestricted top-pages fallback when baseURL is empty

### DIFF
--- a/src/prerender/handler.js
+++ b/src/prerender/handler.js
@@ -59,6 +59,14 @@ function rebaseUrl(url, preferredBase, log) {
   }
 }
 
+// Sites with no configured baseURL have no scope to restrict to, so nothing should be
+// filtered out. filterBySiteScope's own empty-siteBaseUrl handling is fail-closed (it
+// rejects everything), which is the right default for a scope check but not what
+// prerender wants here: an unconfigured baseURL should fall back to unfiltered top pages.
+function scopeToBaseUrl(urls, siteBaseUrl) {
+  return siteBaseUrl ? filterBySiteScope(urls, siteBaseUrl) : urls;
+}
+
 const LOG_PREFIX = 'Prerender -';
 const AUDIT_TYPE = Audit.AUDIT_TYPES.PRERENDER;
 const { AUDIT_STEP_DESTINATIONS } = Audit;
@@ -557,7 +565,7 @@ export async function submitForScraping(context) {
       rebasedCsvUrls,
       { includeQueryParams: true },
     );
-    const explicitUrls = filterBySiteScope(mergedCsvUrls, siteBaseUrl);
+    const explicitUrls = scopeToBaseUrl(mergedCsvUrls, siteBaseUrl);
     const scopeFilteredCount = mergedCsvUrls.length - explicitUrls.length;
 
     log.info(`
@@ -631,7 +639,7 @@ export async function submitForScraping(context) {
       { includeQueryParams: true },
     );
     // Single site-scope filter on the merged candidate set (scoped here, not per-source).
-    finalUrls = filterBySiteScope(crossSlackDeduped, siteBaseUrl);
+    finalUrls = scopeToBaseUrl(crossSlackDeduped, siteBaseUrl);
     scopeFilteredCount = crossSlackDeduped.length - finalUrls.length;
     filteredCount = organicSlackFiltered + includedSlackFiltered;
     currentOrganic = organicSlackDeduped.length;
@@ -680,7 +688,7 @@ export async function submitForScraping(context) {
     );
     // Single site-scope filter on the merged candidate set, applied before the daily-batch
     // slice so out-of-scope URLs don't consume batch slots and starve in-scope ones.
-    const scopedUrls = filterBySiteScope(crossDeduped, siteBaseUrl);
+    const scopedUrls = scopeToBaseUrl(crossDeduped, siteBaseUrl);
     scopeFilteredCount = crossDeduped.length - scopedUrls.length;
     const batchedUrls = scopedUrls.slice(0, DAILY_BATCH_SIZE);
 


### PR DESCRIPTION
## Problem

`@adobe/spacecat-shared-utils` 1.124.1 (picked up on `main` via the recent `fix(deps): update adobe fixes` Renovate PR) changed `isWithinSiteScope`'s handling of an empty `siteBaseUrl` from `return true` (unrestricted) to `return false` (fail closed). That's the right default for a scope *check*, but it broke `src/prerender/handler.js`'s `submitForScraping`: sites with no configured baseURL now get **zero** scraping URLs from `filterBySiteScope` instead of falling back to the unfiltered top-pages list — a real behavior regression, not just a test artifact, since all three `filterBySiteScope` call sites in this file share the same `siteBaseUrl`.

This is currently failing on `main` (`test/audits/prerender/handler.test.js` — "should fall back to top pages when baseUrl is empty"), blocking `semantic-release`/deploy for everything merged since.

## Fix

Added a local `scopeToBaseUrl(urls, siteBaseUrl)` wrapper that skips `filterBySiteScope` entirely when there's no baseURL to scope to, restoring the previous, intended behavior explicitly at the call site rather than relying on the shared library's default. Replaced all three `filterBySiteScope` call sites in `src/prerender/handler.js` with it.

## Testing

- `test/audits/prerender/handler.test.js`: 291 passing (was 290 passing / 1 failing)
- `eslint src/prerender/handler.js`: clean

## Related Issues

None yet — this is a live production-blocking regression discovered while verifying an unrelated fix's deploy status, not pre-planned work. Happy to file a Jira ticket for tracking if the team wants one; flagging here in the meantime so it isn't lost.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```