### PR TITLE
fix(preflight): bounded network-idle settle for a11y scrape (SITES-49491)

### DIFF
--- a/src/preflight/accessibility.js
+++ b/src/preflight/accessibility.js
@@ -30,8 +30,11 @@ export const PREFLIGHT_ACCESSIBILITY = 'accessibility';
  * background traffic never reach that state, so page.goto aborts at the ~45s
  * nav timeout, the scrape fails, and the audit returns an empty (false-clean)
  * result. axe only needs the DOM built, not an idle network, so we navigate on
- * 'domcontentloaded' (which always fires) and add a short fixed settle for
- * late/SPA content.
+ * 'domcontentloaded' (which always fires), then wait for the network to go quiet
+ * (bounded by NETWORK_IDLE_MS) so async/lazy content (embeds, video, late XHR)
+ * renders before axe runs, plus a short fixed settle. The bounded network-idle
+ * wait fixes non-deterministic under-reporting seen with a fixed sleep alone
+ * (SITES-49491); it can't hang because the wait is capped and non-fatal.
  *
  * Scoped to Preflight only: ASO scheduled accessibility scans are sent from
  * src/accessibility/handler.js (config-driven scrapingParams) and are NOT
@@ -39,6 +42,7 @@ export const PREFLIGHT_ACCESSIBILITY = 'accessibility';
  */
 export const PREFLIGHT_A11Y_SCRAPE_WAIT_UNTIL = 'domcontentloaded';
 export const PREFLIGHT_A11Y_SCRAPE_SETTLE_MS = 3000;
+export const PREFLIGHT_A11Y_SCRAPE_NETWORK_IDLE_MS = 15000;
 
 /**
  * Generate normalized filename from URL
@@ -125,9 +129,11 @@ export async function scrapeAccessibilityData(context, auditContext) {
           enableAuthentication,
           a11yPreflight: true,
           // Loosen navigation so heavy pages don't 45s-timeout into empty
-          // results; Preflight-scoped, does not affect ASO scans (SITES-49365).
+          // results (SITES-49365), then wait (bounded) for async content so axe
+          // doesn't under-report (SITES-49491). Preflight-scoped; ASO unaffected.
           accessibilityScrapingParams: {
             waitUntil: PREFLIGHT_A11Y_SCRAPE_WAIT_UNTIL,
+            networkIdleTimeout: PREFLIGHT_A11Y_SCRAPE_NETWORK_IDLE_MS,
             additionalTimeout: PREFLIGHT_A11Y_SCRAPE_SETTLE_MS,
           },
           ...(context.promiseToken ? { promiseToken: context.promiseToken } : {}),
@@ -138,7 +144,8 @@ export async function scrapeAccessibilityData(context, auditContext) {
       // (the full-message log below is debug-only and not emitted in prod).
       log.info(`[preflight-audit] site: ${siteId}, job: ${jobId}, step: ${step}. `
         + `Accessibility scrape nav tuned: waitUntil=${PREFLIGHT_A11Y_SCRAPE_WAIT_UNTIL} `
-        + `settleMs=${PREFLIGHT_A11Y_SCRAPE_SETTLE_MS} (SITES-49365)`);
+        + `networkIdleMs=${PREFLIGHT_A11Y_SCRAPE_NETWORK_IDLE_MS} `
+        + `settleMs=${PREFLIGHT_A11Y_SCRAPE_SETTLE_MS} (SITES-49365, SITES-49491)`);
 
       log.debug(`[preflight-audit] Scrape message being sent: ${JSON.stringify(scrapeMessage, null, 2)}`);
       log.debug(`[preflight-audit] Processing type: ${scrapeMessage.processingType}`);

--- a/test/audits/preflight.test.js
+++ b/test/audits/preflight.test.js
@@ -2360,15 +2360,18 @@ describe('Preflight Audit', () => {
         });
 
         // Preflight-scoped nav tuning: loosen waitUntil so heavy pages don't
-        // 45s-timeout into empty results (SITES-49365). ASO scans are unaffected.
+        // 45s-timeout into empty results (SITES-49365), plus a bounded
+        // network-idle wait so axe doesn't under-report (SITES-49491). ASO
+        // scans are unaffected.
         expect(message.options.accessibilityScrapingParams).to.deep.equal({
           waitUntil: 'domcontentloaded',
+          networkIdleTimeout: 15000,
           additionalTimeout: 3000,
         });
 
         // Info-level marker must be emitted so prod Splunk can prove it is live.
         expect(log.info).to.have.been.calledWithMatch(
-          'Accessibility scrape nav tuned: waitUntil=domcontentloaded settleMs=3000',
+          'Accessibility scrape nav tuned: waitUntil=domcontentloaded networkIdleMs=15000 settleMs=3000',
         );
 
         expect(log.debug).to.have.been.calledWith(


### PR DESCRIPTION
## What

Follow-up to #2855 (SITES-49365). That fix set the Preflight accessibility scrape to `waitUntil: 'domcontentloaded'` plus a fixed 3s settle. `domcontentloaded` resolves **before** async/lazy content (embeds, video, late XHR) renders and the fixed sleep races it, so axe **intermittently under-reports** — the same Casio page returned **4** a11y issues in one run and **0** in another minutes apart.

## Change

Send `accessibilityScrapingParams.networkIdleTimeout: 15000` so the content-scraper accessibility handler waits (bounded) for the network to go quiet before running axe. Preflight-scoped; ASO scheduled scans are unaffected. The `[preflight-audit]` info marker now includes `networkIdleMs` for prod Splunk verification.

## Testing

`test/audits/preflight.test.js`: updated assertions for the new param + marker. 149 tests pass; `accessibility.js` at **100%** coverage; eslint clean.

## Coordination

Requires **adobe/spacecat-content-scraper#1009** (adds the bounded `waitForNetworkIdle` gated on `networkIdleTimeout`). Sending the param before that ships is inert/harmless — the current handler ignores the unknown key — so merge order is flexible; the fix takes effect once content-scraper deploys.

Fixes SITES-49491. Follow-up to #2855.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```