### PR TITLE
feat(preflight): add structured audit=/status=/duration_ms= logging to check handlers

### DIFF
--- a/docs/specs/preflight-structured-audit-logging.md
+++ b/docs/specs/preflight-structured-audit-logging.md
@@ -1,0 +1,114 @@
+# Spec: Preflight Per-Audit Structured Logging
+
+**PR:** [#2862](https://github.com/adobe/spacecat-audit-worker/pull/2862)
+**Jira:** SITES-49492 (blocks SITES-49489 — Preflight status Splunk dashboard)
+**Status:** Implemented
+**Last updated:** 2026-08-07
+
+---
+
+## Problem Statement
+
+Preflight runs a batch of per-page checks (`canonical`, `links`, `metatags`, `headings`,
+`body-size`, `lorem-ipsum`, `h1-count`, plus the Mystique-side `form-accessibility`). Each
+check logs a free-text completion line with no machine-parseable audit-name or status field,
+so answering "which audit is failing, how often, and with what error" requires regex-parsing
+prose. Two checks (`canonical`, `links`) had no local `try/catch` at all, so their failures
+surfaced only via the handler's single generic job-level catch — with no per-check attribution.
+Additionally, the completion lines were emitted at `log.debug`, which prod suppresses
+(`LOG_LEVEL=info`), so they never reached Splunk.
+
+This blocks a reliable "overall Preflight status" dashboard (SITES-49489), whose per-audit
+breakdown and top-error panels need dependable, queryable fields.
+
+## Goals
+
+1. Emit one machine-parseable completion line per check with stable fields:
+   `audit=<name> status=<ok|fail> duration_ms=<n> [error="<message>"]`.
+2. Make the fields Splunk-auto-extractable (logfmt `key=value`) — no SPL-side `rex` needed.
+3. Attribute failures to the specific check for `canonical`/`links` (add local `try/catch` that
+   logs the structured line and rethrows — preserving today's fail-hard behavior).
+4. Ensure the lines are prod-visible (emit at `log.info`, not `debug`).
+
+## Non-Goals
+
+- Restructuring the existing `[preflight-audit] site:/job:/step:` message prefix (append-only, so
+  existing log consumers are unaffected).
+- Changing control flow / error semantics of any check (every new `catch` rethrows).
+- Structured logging for the Mystique-side `form-accessibility` path (different service/repo;
+  the dashboard queries its free-text lines separately, per SITES-49489).
+- A `PreflightError`-style stable `code` for the `error=` value — it is free text for humans,
+  deliberately not a parsed contract.
+
+---
+
+## Technical Design
+
+### The contract
+
+A shared helper `formatStructuredAuditLog({ audit, status, durationMs, error })` in
+`src/preflight/utils.js` returns a leading-space-prefixed suffix appended to each check's
+existing completion message:
+
+```
+[preflight-audit] site: <id>, job: <id>, step: <step>. Canonical audit completed in 0.12 seconds. audit=canonical status=ok duration_ms=120
+```
+
+| Field | Meaning |
+|-------|---------|
+| `audit` | check name — one of the `AUDIT_*` constants in `handler.js` |
+| `status` | `ok` or `fail` |
+| `duration_ms` | integer wall-clock duration of the check |
+| `error` | (fail only) quoted, escaped, single-line, ≤500 chars |
+
+### Escaping (why it matters)
+
+The `error` value is quoted and sanitized in this order: backslash → double-quote → collapse
+`[\r\n]+` to a single space → truncate to 500 chars. Newline collapsing is essential: a raw
+newline inside the quoted value would split the log entry into two lines and corrupt Splunk's
+per-line field extraction (stack traces and multi-line assertion messages routinely contain
+newlines).
+
+### Log level
+
+All completion lines are emitted at `log.info`. Prod runs at `LOG_LEVEL=info`
+(`helix-universal-logger` default and set explicitly in CI's prod deploy), so a `debug` line
+would never reach Splunk and the dashboard would have no data for that check. This also makes
+the level consistent across all checks (previously the DOM-based block was `info` while the
+rest were `debug`).
+
+### DOM-based checks emit one line per check (by design)
+
+`body-size`, `lorem-ipsum`, and `h1-count` share a single pass over the scraped HTML, so they
+share one duration/status. They still emit **one structured line each** (same duration/status)
+rather than a single collapsed `audit=dom-checks` line, because the dashboard's per-audit
+breakdown needs each of the three as a distinct row. The shared duration is an accepted, minor
+imprecision documented here.
+
+### Files touched
+
+| File | Change |
+|------|--------|
+| `src/preflight/utils.js` | new `formatStructuredAuditLog` helper |
+| `src/preflight/canonical.js` | add `try/catch/finally`, structured line at info, rethrow on error |
+| `src/preflight/links.js` | add `try/catch/finally`, structured line at info, rethrow on error |
+| `src/preflight/metatags.js` | append structured suffix to existing catch + completion (info) |
+| `src/preflight/headings.js` | append structured suffix to existing catch + completion (info) |
+| `src/preflight/handler.js` | DOM-based block: `try/catch/finally`, one structured line per enabled check |
+
+## Success Criteria
+
+- Every check above emits `audit=<name> status=<ok|fail> duration_ms=<n>` on completion, plus
+  `error="<message>"` on failure, at `log.info`.
+- `canonical`/`links` failures are attributable to the specific check, not just the job-level catch.
+- The `error=` value never contains a raw newline.
+- Splunk auto-extracts `audit`, `status`, `duration_ms`, `error` with no query-side regex.
+- 100% unit-test coverage on all touched files, including a dedicated
+  `formatStructuredAuditLog` suite (happy path, newline/quote/backslash escaping, truncation,
+  fail-without-error).
+
+## Downstream
+
+SITES-49489 builds the Splunk Dashboard Studio board on these fields:
+`index=dx_aem_engineering sourcetype=dx_aem_sites_spacecat_backend_prod "[preflight-audit]" audit=* | stats count by audit status`
+and a top-error panel keyed on `audit` + `error`.

--- a/src/preflight/canonical.js
+++ b/src/preflight/canonical.js
@@ -231,7 +231,9 @@ export default async function canonical(context, auditContext) {
       audit: PREFLIGHT_CANONICAL, status, durationMs: endTime - startTime, error: errorMessage,
     });
 
-    log.debug(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Canonical audit completed in ${elapsed} seconds.${structured}`);
+    // info (not debug): prod runs at LOG_LEVEL=info, so a debug line never reaches Splunk and
+    // the per-audit dashboard would have no canonical data. Matches the DOM-based block's level.
+    log.info(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Canonical audit completed in ${elapsed} seconds.${structured}`);
 
     timeExecutionBreakdown.push({
       name: 'canonical',

--- a/src/preflight/canonical.js
+++ b/src/preflight/canonical.js
@@ -12,7 +12,7 @@
 
 import { stripTrailingSlash } from '@adobe/spacecat-shared-utils';
 import { load as cheerioLoad } from 'cheerio';
-import { saveIntermediateResults } from './utils.js';
+import { saveIntermediateResults, formatStructuredAuditLog } from './utils.js';
 import {
   validateCanonicalFormat,
   isSelfReferencing,
@@ -136,98 +136,110 @@ export default async function canonical(context, auditContext) {
 
   const startTime = Date.now();
   const startTimestamp = new Date().toISOString();
+  let status = 'ok';
+  let errorMessage;
 
-  previewUrls.forEach((url) => {
-    audits.get(url).audits.push({
-      name: PREFLIGHT_CANONICAL,
-      type: 'seo',
-      opportunities: [],
-    });
-  });
-
-  // Build URL → scraped data map
-  const scrapedByUrl = new Map();
-  scrapedObjects.forEach(({ data }) => {
-    if (data?.finalUrl) {
-      scrapedByUrl.set(stripTrailingSlash(data.finalUrl), data);
-    }
-  });
-
-  previewUrls.forEach((url) => {
-    const pageAudit = audits.get(url).audits.find((a) => a.name === PREFLIGHT_CANONICAL);
-    const scrapedData = scrapedByUrl.get(url);
-
-    if (!scrapedData) {
-      log.warn(`[preflight-canonical] No scraped data found for ${url}`);
-      return;
-    }
-
-    // Skip 4xx pages when statusCode is present (new scrapes); old scrapes have no statusCode
-    if (scrapedData.statusCode != null
-      && scrapedData.statusCode >= 400
-      && scrapedData.statusCode < 500) {
-      log.info(`[preflight-canonical] Skipping page with HTTP ${scrapedData.statusCode} for ${url}`);
-      return;
-    }
-
-    const { scrapeResult } = scrapedData;
-
-    // Prefer metadata injected by the scraper; fall back to HTML parsing when absent
-    const meta = scrapeResult?.canonical
-      ?? (scrapeResult?.rawBody ? extractCanonicalMetadataFromHtml(scrapeResult.rawBody) : null);
-
-    if (!meta) {
-      log.warn(`[preflight-canonical] No canonical metadata available for ${url}`);
-      pageAudit.opportunities.push({
-        check: CANONICAL_CHECKS.CANONICAL_TAG_MISSING.check,
-        issue: CANONICAL_CHECKS.CANONICAL_TAG_MISSING.explanation,
-        seoImpact: 'Moderate',
-        seoRecommendation: CANONICAL_CHECKS.CANONICAL_TAG_MISSING.suggestion,
-        suggestion: url,
-      });
-      return;
-    }
-
-    // Points findings at the actual <link rel="canonical"> tag(s) so authors can see which
-    // element triggered the finding, not just an issue description.
-    // Collected as a list because CANONICAL_TAG_MULTIPLE's whole point is "there is more than
-    // one" — surfacing only one tag there would hide the rest.
-    const canonicalSelectors = scrapeResult?.rawBody
-      ? cheerioLoad(scrapeResult.rawBody)('link[rel="canonical"]')
-        .toArray()
-        .map((el) => getDomElementSelector(el))
-        .filter(Boolean)
-      : [];
-    const hasHrefValue = Boolean(meta.href && meta.href.trim());
-    const { check: multipleTagsCheck } = CANONICAL_CHECKS.CANONICAL_TAG_MULTIPLE;
-
-    const failedChecks = runCanonicalChecks(url, meta, previewBaseURL, log);
-    failedChecks.forEach((checkConfig) => {
-      const isMultipleTagsCheck = checkConfig.check === multipleTagsCheck;
-      pageAudit.opportunities.push({
-        check: checkConfig.check,
-        issue: checkConfig.explanation,
-        seoImpact: 'Moderate',
-        seoRecommendation: checkConfig.suggestion,
-        ...(hasHrefValue ? { url: meta.href } : {}),
-        ...(CHECKS_SUGGESTING_OWN_URL.has(checkConfig.check) ? { suggestion: url } : {}),
-        ...toElementTargets(isMultipleTagsCheck ? canonicalSelectors : canonicalSelectors[0]),
+  try {
+    previewUrls.forEach((url) => {
+      audits.get(url).audits.push({
+        name: PREFLIGHT_CANONICAL,
+        type: 'seo',
+        opportunities: [],
       });
     });
-  });
 
-  const endTime = Date.now();
-  const endTimestamp = new Date().toISOString();
-  const elapsed = ((endTime - startTime) / 1000).toFixed(2);
+    // Build URL → scraped data map
+    const scrapedByUrl = new Map();
+    scrapedObjects.forEach(({ data }) => {
+      if (data?.finalUrl) {
+        scrapedByUrl.set(stripTrailingSlash(data.finalUrl), data);
+      }
+    });
 
-  log.debug(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Canonical audit completed in ${elapsed} seconds`);
+    previewUrls.forEach((url) => {
+      const pageAudit = audits.get(url).audits.find((a) => a.name === PREFLIGHT_CANONICAL);
+      const scrapedData = scrapedByUrl.get(url);
 
-  timeExecutionBreakdown.push({
-    name: 'canonical',
-    duration: `${elapsed} seconds`,
-    startTime: startTimestamp,
-    endTime: endTimestamp,
-  });
+      if (!scrapedData) {
+        log.warn(`[preflight-canonical] No scraped data found for ${url}`);
+        return;
+      }
+
+      // Skip 4xx pages when statusCode is present (new scrapes); old scrapes have no statusCode
+      if (scrapedData.statusCode != null
+        && scrapedData.statusCode >= 400
+        && scrapedData.statusCode < 500) {
+        log.info(`[preflight-canonical] Skipping page with HTTP ${scrapedData.statusCode} for ${url}`);
+        return;
+      }
+
+      const { scrapeResult } = scrapedData;
+
+      // Prefer metadata injected by the scraper; fall back to HTML parsing when absent
+      const meta = scrapeResult?.canonical
+        ?? (scrapeResult?.rawBody ? extractCanonicalMetadataFromHtml(scrapeResult.rawBody) : null);
+
+      if (!meta) {
+        log.warn(`[preflight-canonical] No canonical metadata available for ${url}`);
+        pageAudit.opportunities.push({
+          check: CANONICAL_CHECKS.CANONICAL_TAG_MISSING.check,
+          issue: CANONICAL_CHECKS.CANONICAL_TAG_MISSING.explanation,
+          seoImpact: 'Moderate',
+          seoRecommendation: CANONICAL_CHECKS.CANONICAL_TAG_MISSING.suggestion,
+          suggestion: url,
+        });
+        return;
+      }
+
+      // Points findings at the actual <link rel="canonical"> tag(s) so authors can see which
+      // element triggered the finding, not just an issue description.
+      // Collected as a list because CANONICAL_TAG_MULTIPLE's whole point is "there is more than
+      // one" — surfacing only one tag there would hide the rest.
+      const canonicalSelectors = scrapeResult?.rawBody
+        ? cheerioLoad(scrapeResult.rawBody)('link[rel="canonical"]')
+          .toArray()
+          .map((el) => getDomElementSelector(el))
+          .filter(Boolean)
+        : [];
+      const hasHrefValue = Boolean(meta.href && meta.href.trim());
+      const { check: multipleTagsCheck } = CANONICAL_CHECKS.CANONICAL_TAG_MULTIPLE;
+
+      const failedChecks = runCanonicalChecks(url, meta, previewBaseURL, log);
+      failedChecks.forEach((checkConfig) => {
+        const isMultipleTagsCheck = checkConfig.check === multipleTagsCheck;
+        pageAudit.opportunities.push({
+          check: checkConfig.check,
+          issue: checkConfig.explanation,
+          seoImpact: 'Moderate',
+          seoRecommendation: checkConfig.suggestion,
+          ...(hasHrefValue ? { url: meta.href } : {}),
+          ...(CHECKS_SUGGESTING_OWN_URL.has(checkConfig.check) ? { suggestion: url } : {}),
+          ...toElementTargets(isMultipleTagsCheck ? canonicalSelectors : canonicalSelectors[0]),
+        });
+      });
+    });
+  } catch (error) {
+    status = 'fail';
+    errorMessage = error.message;
+    log.error(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Canonical audit failed: ${error.message}`);
+    throw error;
+  } finally {
+    const endTime = Date.now();
+    const endTimestamp = new Date().toISOString();
+    const elapsed = ((endTime - startTime) / 1000).toFixed(2);
+    const structured = formatStructuredAuditLog({
+      audit: PREFLIGHT_CANONICAL, status, durationMs: endTime - startTime, error: errorMessage,
+    });
+
+    log.debug(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Canonical audit completed in ${elapsed} seconds.${structured}`);
+
+    timeExecutionBreakdown.push({
+      name: 'canonical',
+      duration: `${elapsed} seconds`,
+      startTime: startTimestamp,
+      endTime: endTimestamp,
+    });
+  }
 
   await saveIntermediateResults(context, auditsResult, 'canonical audit');
 }

--- a/src/preflight/handler.js
+++ b/src/preflight/handler.js
@@ -18,7 +18,7 @@ import { AuditBuilder } from '../common/audit-builder.js';
 import { isAuditEnabledForSite, noopPersister, noopUrlResolver } from '../common/index.js';
 import { getObjectKeysUsingPrefix, getObjectFromKey } from '../utils/s3-utils.js';
 import {
-  getPrefixedPageAuthToken, isValidUrls, saveIntermediateResults,
+  getPrefixedPageAuthToken, isValidUrls, saveIntermediateResults, formatStructuredAuditLog,
 } from './utils.js';
 import { getDomElementSelector, toElementTargets } from './utils/dom-selector.js';
 import { PreflightError } from './error-constants.js';
@@ -266,120 +266,148 @@ export const preflightAudit = async (context) => {
     if (bodySizeEnabled || loremIpsumEnabled || h1CountEnabled) {
       const domStartTime = Date.now();
       const domStartTimestamp = new Date().toISOString();
-      previewUrls.forEach((url) => {
-        const pageResult = audits.get(url);
-        if (bodySizeEnabled) {
-          pageResult.audits.push({ name: AUDIT_BODY_SIZE, type: 'seo', opportunities: [] });
-        }
-        if (loremIpsumEnabled) {
-          pageResult.audits.push({ name: AUDIT_LOREM_IPSUM, type: 'seo', opportunities: [] });
-        }
-        if (h1CountEnabled) {
-          pageResult.audits.push({ name: AUDIT_H1_COUNT, type: 'seo', opportunities: [] });
-        }
-      });
+      let domStatus = 'ok';
+      let domErrorMessage;
 
-      scrapedObjects.forEach(({ data }) => {
-        const { finalUrl, scrapeResult: { rawBody } } = data;
-        const pageResult = audits.get(stripTrailingSlash(finalUrl));
-        const $ = cheerioLoad(rawBody);
-
-        const auditsByName = Object.fromEntries(
-          pageResult.audits.map((auditEntry) => [auditEntry.name, auditEntry]),
-        );
-
-        const textContent = $('body').text().replace(/\n/g, '').trim();
-
-        if (bodySizeEnabled) {
-          if (textContent.length > 0 && textContent.length <= 100) {
-            auditsByName[AUDIT_BODY_SIZE].opportunities.push({
-              check: 'content-length',
-              issue: 'Body content length is below 100 characters',
-              seoImpact: 'Moderate',
-              seoRecommendation: 'Add more meaningful content to the page',
-              textContent,
-              ...toElementTargets(getDomElementSelector($('body').get(0))),
-            });
+      try {
+        previewUrls.forEach((url) => {
+          const pageResult = audits.get(url);
+          if (bodySizeEnabled) {
+            pageResult.audits.push({ name: AUDIT_BODY_SIZE, type: 'seo', opportunities: [] });
           }
-        }
+          if (loremIpsumEnabled) {
+            pageResult.audits.push({ name: AUDIT_LOREM_IPSUM, type: 'seo', opportunities: [] });
+          }
+          if (h1CountEnabled) {
+            pageResult.audits.push({ name: AUDIT_H1_COUNT, type: 'seo', opportunities: [] });
+          }
+        });
 
-        if (loremIpsumEnabled && /lorem ipsum/i.test(textContent)) {
-          const allLoremElements = $('p, div, span, li, section, article, h1, h2, h3, h4, h5, h6')
-            .toArray()
-            .filter((el) => /lorem ipsum/i.test($(el).text()));
-          // Keep only innermost matches — discard ancestors whose text matched
-          // solely because a descendant contains "Lorem ipsum".
-          const loremElements = allLoremElements.filter(
-            (el) => !allLoremElements.some((other) => {
-              if (other === el) {
-                return false;
-              }
-              let cursor = other.parent;
-              while (cursor) {
-                if (cursor === el) {
-                  return true;
-                }
-                cursor = cursor.parent;
-              }
-              return false;
-            }),
+        scrapedObjects.forEach(({ data }) => {
+          const { finalUrl, scrapeResult: { rawBody } } = data;
+          const pageResult = audits.get(stripTrailingSlash(finalUrl));
+          const $ = cheerioLoad(rawBody);
+
+          const auditsByName = Object.fromEntries(
+            pageResult.audits.map((auditEntry) => [auditEntry.name, auditEntry]),
           );
-          // Pair each element with its own text so multiple matches don't all show the first
-          // element's text once the MFE expands them into separate instances.
-          const loremPairs = loremElements
-            .map((el) => ({
-              selector: getDomElementSelector(el),
-              textContent: $(el).text().trim(),
-            }))
-            .filter((pair) => pair.selector);
-          auditsByName[AUDIT_LOREM_IPSUM].opportunities.push({
-            check: 'placeholder-text',
-            issue: 'Found Lorem ipsum placeholder text in the page content',
-            seoImpact: 'High',
-            seoRecommendation: 'Replace placeholder text with meaningful content',
-            ...toElementTargets(loremPairs),
-          });
-        }
 
-        if (h1CountEnabled) {
-          const headingCount = $('h1').length;
-          if (headingCount !== 1) {
-            const h1Elements = $('h1').toArray();
+          const textContent = $('body').text().replace(/\n/g, '').trim();
 
-            // Pair each H1 with its own text. When there are zero H1s, there is no
-            // offending element to point at, so no element is attached.
-            const h1Pairs = h1Elements
+          if (bodySizeEnabled) {
+            if (textContent.length > 0 && textContent.length <= 100) {
+              auditsByName[AUDIT_BODY_SIZE].opportunities.push({
+                check: 'content-length',
+                issue: 'Body content length is below 100 characters',
+                seoImpact: 'Moderate',
+                seoRecommendation: 'Add more meaningful content to the page',
+                textContent,
+                ...toElementTargets(getDomElementSelector($('body').get(0))),
+              });
+            }
+          }
+
+          if (loremIpsumEnabled && /lorem ipsum/i.test(textContent)) {
+            const allLoremElements = $('p, div, span, li, section, article, h1, h2, h3, h4, h5, h6')
+              .toArray()
+              .filter((el) => /lorem ipsum/i.test($(el).text()));
+            // Keep only innermost matches — discard ancestors whose text matched
+            // solely because a descendant contains "Lorem ipsum".
+            const loremElements = allLoremElements.filter(
+              (el) => !allLoremElements.some((other) => {
+                if (other === el) {
+                  return false;
+                }
+                let cursor = other.parent;
+                while (cursor) {
+                  if (cursor === el) {
+                    return true;
+                  }
+                  cursor = cursor.parent;
+                }
+                return false;
+              }),
+            );
+            // Pair each element with its own text so multiple matches don't all show the first
+            // element's text once the MFE expands them into separate instances.
+            const loremPairs = loremElements
               .map((el) => ({
                 selector: getDomElementSelector(el),
                 textContent: $(el).text().trim(),
               }))
               .filter((pair) => pair.selector);
+            auditsByName[AUDIT_LOREM_IPSUM].opportunities.push({
+              check: 'placeholder-text',
+              issue: 'Found Lorem ipsum placeholder text in the page content',
+              seoImpact: 'High',
+              seoRecommendation: 'Replace placeholder text with meaningful content',
+              ...toElementTargets(loremPairs),
+            });
+          }
 
-            auditsByName[AUDIT_H1_COUNT].opportunities.push({
-              check: headingCount > 1 ? 'multiple-h1' : 'missing-h1',
-              issue:
+          if (h1CountEnabled) {
+            const headingCount = $('h1').length;
+            if (headingCount !== 1) {
+              const h1Elements = $('h1').toArray();
+
+              // Pair each H1 with its own text. When there are zero H1s, there is no
+              // offending element to point at, so no element is attached.
+              const h1Pairs = h1Elements
+                .map((el) => ({
+                  selector: getDomElementSelector(el),
+                  textContent: $(el).text().trim(),
+                }))
+                .filter((pair) => pair.selector);
+
+              auditsByName[AUDIT_H1_COUNT].opportunities.push({
+                check: headingCount > 1 ? 'multiple-h1' : 'missing-h1',
+                issue:
                 headingCount > 1
                   ? `Found ${headingCount} H1 tags`
                   : 'No H1 tag found on the page',
-              seoImpact: 'High',
-              seoRecommendation:
+                seoImpact: 'High',
+                seoRecommendation:
                 'Use exactly one H1 tag per page for better SEO structure',
-              ...toElementTargets(h1Pairs),
-            });
+                ...toElementTargets(h1Pairs),
+              });
+            }
           }
-        }
-      });
-      const domEndTime = Date.now();
-      const domEndTimestamp = new Date().toISOString();
-      const domElapsed = ((domEndTime - domStartTime) / 1000).toFixed(2);
-      log.info(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. DOM-based audit completed in ${domElapsed} seconds`);
+        });
+      } catch (error) {
+        domStatus = 'fail';
+        domErrorMessage = error.message;
+        log.error(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. DOM-based audit failed: ${error.message}`);
+        throw error;
+      } finally {
+        const domEndTime = Date.now();
+        const domEndTimestamp = new Date().toISOString();
+        const domElapsed = ((domEndTime - domStartTime) / 1000).toFixed(2);
+        const domDurationMs = domEndTime - domStartTime;
 
-      timeExecutionBreakdown.push({
-        name: 'dom',
-        duration: `${domElapsed} seconds`,
-        startTime: domStartTimestamp,
-        endTime: domEndTimestamp,
-      });
+        // One structured line per enabled DOM-based check — they share a single pass over the
+        // scraped HTML (and therefore a single duration/status), so a failure here can't be
+        // attributed to just one of the three; every enabled check gets the same status/error.
+        [
+          [AUDIT_BODY_SIZE, bodySizeEnabled],
+          [AUDIT_LOREM_IPSUM, loremIpsumEnabled],
+          [AUDIT_H1_COUNT, h1CountEnabled],
+        ].forEach(([auditName, enabled]) => {
+          if (!enabled) {
+            return;
+          }
+          const structured = formatStructuredAuditLog({
+            audit: auditName, status: domStatus, durationMs: domDurationMs, error: domErrorMessage,
+          });
+          log.info(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. DOM-based audit (${auditName}) completed in ${domElapsed} seconds.${structured}`);
+        });
+
+        timeExecutionBreakdown.push({
+          name: 'dom',
+          duration: `${domElapsed} seconds`,
+          startTime: domStartTimestamp,
+          endTime: domEndTimestamp,
+        });
+      }
 
       await saveIntermediateResults(context, auditsResult, 'DOM-based audit');
     }

--- a/src/preflight/headings.js
+++ b/src/preflight/headings.js
@@ -314,7 +314,9 @@ export default async function headings(context, auditContext) {
     durationMs: headingsEndTime - headingsStartTime,
     error: errorMessage,
   });
-  log.debug(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Headings audit completed in ${headingsElapsed} seconds.${headingsStructured}`);
+  // info (not debug): prod runs at LOG_LEVEL=info, so a debug line never reaches Splunk and
+  // the per-audit dashboard would have no headings data. Matches the DOM-based block's level.
+  log.info(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Headings audit completed in ${headingsElapsed} seconds.${headingsStructured}`);
 
   timeExecutionBreakdown.push({
     name: 'headings',

--- a/src/preflight/headings.js
+++ b/src/preflight/headings.js
@@ -18,7 +18,7 @@ import {
   HEADINGS_CHECKS,
 } from '../headings/handler.js';
 import { getBrandGuidelines } from '../headings/shared-utils.js';
-import { saveIntermediateResults } from './utils.js';
+import { saveIntermediateResults, formatStructuredAuditLog } from './utils.js';
 import SeoChecks from '../metatags/seo-checks.js';
 import { getDomElementSelector, toElementTargets } from './utils/dom-selector.js';
 
@@ -195,6 +195,8 @@ export default async function headings(context, auditContext) {
 
   const headingsStartTime = Date.now();
   const headingsStartTimestamp = new Date().toISOString();
+  let status = 'ok';
+  let errorMessage;
 
   // Create headings audit entries for all pages
   previewUrls.forEach((url) => {
@@ -298,13 +300,21 @@ export default async function headings(context, auditContext) {
       });
     });
   } catch (error) {
+    status = 'fail';
+    errorMessage = error.message;
     log.error(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Headings audit failed: ${error.message}`);
   }
 
   const headingsEndTime = Date.now();
   const headingsEndTimestamp = new Date().toISOString();
   const headingsElapsed = ((headingsEndTime - headingsStartTime) / 1000).toFixed(2);
-  log.debug(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Headings audit completed in ${headingsElapsed} seconds`);
+  const headingsStructured = formatStructuredAuditLog({
+    audit: PREFLIGHT_HEADINGS,
+    status,
+    durationMs: headingsEndTime - headingsStartTime,
+    error: errorMessage,
+  });
+  log.debug(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Headings audit completed in ${headingsElapsed} seconds.${headingsStructured}`);
 
   timeExecutionBreakdown.push({
     name: 'headings',

--- a/src/preflight/links.js
+++ b/src/preflight/links.js
@@ -237,7 +237,6 @@ export default async function links(context, auditContext) {
         audit.opportunities.push({ check: 'bad-links', issue: insecureLinks });
       }
     });
-    // Check for insecure links in each scraped page
   } catch (error) {
     auditStatus = 'fail';
     auditErrorMessage = error.message;
@@ -254,7 +253,9 @@ export default async function links(context, auditContext) {
       error: auditErrorMessage,
     });
 
-    log.debug(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Links audit completed in ${linksElapsed} seconds.${structured}`);
+    // info (not debug): prod runs at LOG_LEVEL=info, so a debug line never reaches Splunk and
+    // the per-audit dashboard would have no links data. Matches the DOM-based block's level.
+    log.info(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Links audit completed in ${linksElapsed} seconds.${structured}`);
 
     timeExecutionBreakdown.push({
       name: 'links',

--- a/src/preflight/links.js
+++ b/src/preflight/links.js
@@ -11,7 +11,7 @@
  */
 import { isNonEmptyArray, stripTrailingSlash } from '@adobe/spacecat-shared-utils';
 import { load as cheerioLoad } from 'cheerio';
-import { saveIntermediateResults } from './utils.js';
+import { saveIntermediateResults, formatStructuredAuditLog } from './utils.js';
 import {
   runLinksChecks,
   filterExcludedElements,
@@ -92,160 +92,177 @@ export default async function links(context, auditContext) {
   // Link checks (both internal and external)
   const linksStartTime = Date.now();
   const linksStartTimestamp = new Date().toISOString();
-  const auditUrls = urls.map((url) => stripTrailingSlash(url));
-  const preflightHandlerConfig = site.getConfig?.()?.getHandlers?.()?.preflight?.config;
-  const excludedElementClasses = normalizeExcludedElementClasses(
-    preflightHandlerConfig?.excludedElementClasses,
-  );
-  const { auditResult } = await runLinksChecks(auditUrls, scrapedObjects, context, {
-    pageAuthToken,
-    excludedElementClasses,
-  });
+  let auditStatus = 'ok';
+  let auditErrorMessage;
 
-  const brokenInternalLinksByPage = new Map();
-  const brokenExternalLinksByPage = new Map();
+  try {
+    const auditUrls = urls.map((url) => stripTrailingSlash(url));
+    const preflightHandlerConfig = site.getConfig?.()?.getHandlers?.()?.preflight?.config;
+    const excludedElementClasses = normalizeExcludedElementClasses(
+      preflightHandlerConfig?.excludedElementClasses,
+    );
+    const { auditResult } = await runLinksChecks(auditUrls, scrapedObjects, context, {
+      pageAuthToken,
+      excludedElementClasses,
+    });
 
-  // Process internal links
-  if (isNonEmptyArray(auditResult.brokenInternalLinks)) {
-    const baseURLOrigin = new URL(previewBaseURL).origin;
-    if (step === 'suggest') {
-      const normalizeHref = (value) => stripTrailingSlash(value);
-      const normalizeUrlTo = (value) => stripTrailingSlash(
-        value.replace(new URL(value).origin, site.getBaseURL()),
-      );
-      const selectorKey = (hrefValue, urlValue) => `${normalizeHref(hrefValue)}|${normalizeUrlTo(urlValue)}`;
-      const selectorsByLink = new Map();
-      auditResult.brokenInternalLinks.forEach((link) => {
-        selectorsByLink.set(selectorKey(link.href, link.urlTo), link.elements);
-      });
-      const brokenLinks = auditResult.brokenInternalLinks.map((link) => ({
-        urlTo: normalizeUrlTo(link.urlTo),
-        href: normalizeHref(link.href),
-        status: link.status,
-      }));
-      log.debug(`[preflight-audit] Found ${JSON.stringify(brokenLinks)} broken internal links`);
-      const brokenInternalLinks = await
-      generateSuggestionData(previewBaseURL, brokenLinks, context, site);
-      log.debug(`[preflight-audit] Generated suggestions for broken internal links: ${JSON.stringify(brokenInternalLinks)}`);
-      brokenInternalLinks.forEach(({
-        urlTo, href, status, urlsSuggested, aiRationale,
-      }) => {
-        if (!brokenInternalLinksByPage.has(href)) {
-          brokenInternalLinksByPage.set(href, []);
-        }
-        const issue = createBrokenLinkIssue(
-          urlTo,
-          status,
-          baseURLOrigin,
-          urlsSuggested,
-          aiRationale,
-          selectorsByLink.get(selectorKey(href, urlTo)),
+    const brokenInternalLinksByPage = new Map();
+    const brokenExternalLinksByPage = new Map();
+
+    // Process internal links
+    if (isNonEmptyArray(auditResult.brokenInternalLinks)) {
+      const baseURLOrigin = new URL(previewBaseURL).origin;
+      if (step === 'suggest') {
+        const normalizeHref = (value) => stripTrailingSlash(value);
+        const normalizeUrlTo = (value) => stripTrailingSlash(
+          value.replace(new URL(value).origin, site.getBaseURL()),
         );
-        brokenInternalLinksByPage.get(href).push(issue);
-      });
-    } else {
-      auditResult.brokenInternalLinks.forEach(({
+        const selectorKey = (hrefValue, urlValue) => `${normalizeHref(hrefValue)}|${normalizeUrlTo(urlValue)}`;
+        const selectorsByLink = new Map();
+        auditResult.brokenInternalLinks.forEach((link) => {
+          selectorsByLink.set(selectorKey(link.href, link.urlTo), link.elements);
+        });
+        const brokenLinks = auditResult.brokenInternalLinks.map((link) => ({
+          urlTo: normalizeUrlTo(link.urlTo),
+          href: normalizeHref(link.href),
+          status: link.status,
+        }));
+        log.debug(`[preflight-audit] Found ${JSON.stringify(brokenLinks)} broken internal links`);
+        const brokenInternalLinks = await
+        generateSuggestionData(previewBaseURL, brokenLinks, context, site);
+        log.debug(`[preflight-audit] Generated suggestions for broken internal links: ${JSON.stringify(brokenInternalLinks)}`);
+        brokenInternalLinks.forEach(({
+          urlTo, href, status, urlsSuggested, aiRationale,
+        }) => {
+          if (!brokenInternalLinksByPage.has(href)) {
+            brokenInternalLinksByPage.set(href, []);
+          }
+          const issue = createBrokenLinkIssue(
+            urlTo,
+            status,
+            baseURLOrigin,
+            urlsSuggested,
+            aiRationale,
+            selectorsByLink.get(selectorKey(href, urlTo)),
+          );
+          brokenInternalLinksByPage.get(href).push(issue);
+        });
+      } else {
+        auditResult.brokenInternalLinks.forEach(({
+          urlTo, href, status, elements,
+        }) => {
+          if (!brokenInternalLinksByPage.has(href)) {
+            brokenInternalLinksByPage.set(href, []);
+          }
+          brokenInternalLinksByPage.get(href).push({
+            url: urlTo.replace(new URL(urlTo).origin, baseURLOrigin),
+            issue: `Status ${status}`,
+            seoImpact: 'High',
+            seoRecommendation: 'Fix or remove broken links to improve user experience and SEO',
+            elements,
+          });
+        });
+      }
+    }
+
+    // Process external links from the same audit auditsResult
+    if (isNonEmptyArray(auditResult.brokenExternalLinks)) {
+      auditResult.brokenExternalLinks.forEach(({
         urlTo, href, status, elements,
       }) => {
-        if (!brokenInternalLinksByPage.has(href)) {
-          brokenInternalLinksByPage.set(href, []);
+        if (!brokenExternalLinksByPage.has(href)) {
+          brokenExternalLinksByPage.set(href, []);
         }
-        brokenInternalLinksByPage.get(href).push({
-          url: urlTo.replace(new URL(urlTo).origin, baseURLOrigin),
+        brokenExternalLinksByPage.get(href).push({
+          url: urlTo,
           issue: `Status ${status}`,
           seoImpact: 'High',
-          seoRecommendation: 'Fix or remove broken links to improve user experience and SEO',
+          seoRecommendation: 'Fix or remove broken links to improve user experience',
           elements,
         });
       });
     }
-  }
 
-  // Process external links from the same audit auditsResult
-  if (isNonEmptyArray(auditResult.brokenExternalLinks)) {
-    auditResult.brokenExternalLinks.forEach(({
-      urlTo, href, status, elements,
-    }) => {
-      if (!brokenExternalLinksByPage.has(href)) {
-        brokenExternalLinksByPage.set(href, []);
+    brokenInternalLinksByPage.forEach((issues, href) => {
+      const audit = linksAuditMap.get(stripTrailingSlash(href));
+      if (audit && issues.length > 0) {
+        audit.opportunities.push({
+          check: 'broken-internal-links',
+          issue: issues,
+        });
       }
-      brokenExternalLinksByPage.get(href).push({
-        url: urlTo,
-        issue: `Status ${status}`,
-        seoImpact: 'High',
-        seoRecommendation: 'Fix or remove broken links to improve user experience',
-        elements,
-      });
+    });
+
+    brokenExternalLinksByPage.forEach((issues, href) => {
+      const audit = linksAuditMap.get(stripTrailingSlash(href));
+      if (audit && issues.length > 0) {
+        audit.opportunities.push({
+          check: 'broken-external-links',
+          issue: issues,
+        });
+      }
+    });
+
+    scrapedObjects.forEach(({ data }) => {
+      const { finalUrl, scrapeResult: { rawBody } } = data;
+      const $ = cheerioLoad(rawBody);
+      filterExcludedElements($, excludedElementClasses);
+      const auditUrl = stripTrailingSlash(finalUrl);
+      const audit = linksAuditMap.get(auditUrl);
+      const insecureLinks = $('a').map((i, anchor) => {
+        const href = $(anchor).attr('href');
+        if (href && href.startsWith('http://')) {
+          // Normalize URL using URL class to match jsdom behavior
+          let normalizedUrl;
+          try {
+            normalizedUrl = new URL(href).href;
+          } catch {
+            normalizedUrl = href;
+          }
+          const selector = getDomElementSelector(anchor);
+          const text = $(anchor).text().trim();
+          return {
+            url: normalizedUrl,
+            issue: 'Link using HTTP instead of HTTPS',
+            seoImpact: 'High',
+            seoRecommendation: 'Update all links to use HTTPS protocol',
+            ...(text ? { textContent: text } : {}),
+            ...toElementTargets(selector),
+          };
+        }
+        return null;
+      }).get().filter((link) => link !== null);
+
+      if (audit && insecureLinks.length > 0) {
+        audit.opportunities.push({ check: 'bad-links', issue: insecureLinks });
+      }
+    });
+    // Check for insecure links in each scraped page
+  } catch (error) {
+    auditStatus = 'fail';
+    auditErrorMessage = error.message;
+    log.error(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Links audit failed: ${error.message}`);
+    throw error;
+  } finally {
+    const linksEndTime = Date.now();
+    const linksEndTimestamp = new Date().toISOString();
+    const linksElapsed = ((linksEndTime - linksStartTime) / 1000).toFixed(2);
+    const structured = formatStructuredAuditLog({
+      audit: PREFLIGHT_LINKS,
+      status: auditStatus,
+      durationMs: linksEndTime - linksStartTime,
+      error: auditErrorMessage,
+    });
+
+    log.debug(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Links audit completed in ${linksElapsed} seconds.${structured}`);
+
+    timeExecutionBreakdown.push({
+      name: 'links',
+      duration: `${linksElapsed} seconds`,
+      startTime: linksStartTimestamp,
+      endTime: linksEndTimestamp,
     });
   }
-
-  brokenInternalLinksByPage.forEach((issues, href) => {
-    const audit = linksAuditMap.get(stripTrailingSlash(href));
-    if (audit && issues.length > 0) {
-      audit.opportunities.push({
-        check: 'broken-internal-links',
-        issue: issues,
-      });
-    }
-  });
-
-  brokenExternalLinksByPage.forEach((issues, href) => {
-    const audit = linksAuditMap.get(stripTrailingSlash(href));
-    if (audit && issues.length > 0) {
-      audit.opportunities.push({
-        check: 'broken-external-links',
-        issue: issues,
-      });
-    }
-  });
-
-  const linksEndTime = Date.now();
-  const linksEndTimestamp = new Date().toISOString();
-  const linksElapsed = ((linksEndTime - linksStartTime) / 1000).toFixed(2);
-  log.debug(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Links audit completed in ${linksElapsed} seconds`);
-
-  timeExecutionBreakdown.push({
-    name: 'links',
-    duration: `${linksElapsed} seconds`,
-    startTime: linksStartTimestamp,
-    endTime: linksEndTimestamp,
-  });
-
-  scrapedObjects.forEach(({ data }) => {
-    const { finalUrl, scrapeResult: { rawBody } } = data;
-    const $ = cheerioLoad(rawBody);
-    filterExcludedElements($, excludedElementClasses);
-    const auditUrl = stripTrailingSlash(finalUrl);
-    const audit = linksAuditMap.get(auditUrl);
-    const insecureLinks = $('a').map((i, anchor) => {
-      const href = $(anchor).attr('href');
-      if (href && href.startsWith('http://')) {
-        // Normalize URL using URL class to match jsdom behavior
-        let normalizedUrl;
-        try {
-          normalizedUrl = new URL(href).href;
-        } catch {
-          normalizedUrl = href;
-        }
-        const selector = getDomElementSelector(anchor);
-        const text = $(anchor).text().trim();
-        return {
-          url: normalizedUrl,
-          issue: 'Link using HTTP instead of HTTPS',
-          seoImpact: 'High',
-          seoRecommendation: 'Update all links to use HTTPS protocol',
-          ...(text ? { textContent: text } : {}),
-          ...toElementTargets(selector),
-        };
-      }
-      return null;
-    }).get().filter((link) => link !== null);
-
-    if (audit && insecureLinks.length > 0) {
-      audit.opportunities.push({ check: 'bad-links', issue: insecureLinks });
-    }
-  });
-  // Check for insecure links in each scraped page
 
   await saveIntermediateResults(context, auditsResult, 'links audit');
 }

--- a/src/preflight/metatags.js
+++ b/src/preflight/metatags.js
@@ -12,7 +12,7 @@
 
 import { stripTrailingSlash } from '@adobe/spacecat-shared-utils';
 import { load as cheerioLoad } from 'cheerio';
-import { saveIntermediateResults } from './utils.js';
+import { saveIntermediateResults, formatStructuredAuditLog } from './utils.js';
 import { metatagsAutoDetect } from '../metatags/handler.js';
 import metatagsAutoSuggest from '../metatags/metatags-auto-suggest.js';
 import { getDomElementSelector, toElementTargets } from './utils/dom-selector.js';
@@ -64,6 +64,8 @@ export default async function metatags(context, auditContext) {
 
   const metatagsStartTime = Date.now();
   const metatagsStartTimestamp = new Date().toISOString();
+  let status = 'ok';
+  let errorMessage;
   // Create metatags audit entries for all pages
   previewUrls.forEach((url) => {
     const pageResult = audits.get(url);
@@ -142,13 +144,21 @@ export default async function metatags(context, auditContext) {
       });
     });
   } catch (error) {
+    status = 'fail';
+    errorMessage = error.message;
     log.error(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Meta tags audit failed: ${error.message}`);
   }
 
   const metatagsEndTime = Date.now();
   const metatagsEndTimestamp = new Date().toISOString();
   const metatagsElapsed = ((metatagsEndTime - metatagsStartTime) / 1000).toFixed(2);
-  log.debug(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Meta tags audit completed in ${metatagsElapsed} seconds`);
+  const metatagsStructured = formatStructuredAuditLog({
+    audit: PREFLIGHT_METATAGS,
+    status,
+    durationMs: metatagsEndTime - metatagsStartTime,
+    error: errorMessage,
+  });
+  log.debug(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Meta tags audit completed in ${metatagsElapsed} seconds.${metatagsStructured}`);
 
   timeExecutionBreakdown.push({
     name: 'metatags',

--- a/src/preflight/metatags.js
+++ b/src/preflight/metatags.js
@@ -158,7 +158,9 @@ export default async function metatags(context, auditContext) {
     durationMs: metatagsEndTime - metatagsStartTime,
     error: errorMessage,
   });
-  log.debug(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Meta tags audit completed in ${metatagsElapsed} seconds.${metatagsStructured}`);
+  // info (not debug): prod runs at LOG_LEVEL=info, so a debug line never reaches Splunk and
+  // the per-audit dashboard would have no metatags data. Matches the DOM-based block's level.
+  log.info(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Meta tags audit completed in ${metatagsElapsed} seconds.${metatagsStructured}`);
 
   timeExecutionBreakdown.push({
     name: 'metatags',

--- a/src/preflight/utils.js
+++ b/src/preflight/utils.js
@@ -42,3 +42,23 @@ export function getPrefixedPageAuthToken(site, token, options) {
     return `token ${token}`;
   }
 }
+
+/**
+ * Builds a logfmt-style `key=value` suffix for a per-audit completion log line, so Splunk's
+ * automatic field extraction picks up `audit`/`status`/`duration_ms`/`error` without any
+ * SPL-side regex. Appended to the existing `[preflight-audit] site: ..., job: ...` message,
+ * never replacing it.
+ * @param {{ audit: string, status: 'ok'|'fail', durationMs: number, error?: string }} params
+ * @returns {string} A leading-space-prefixed suffix, e.g.
+ *   ` audit=canonical status=ok duration_ms=120`
+ */
+export function formatStructuredAuditLog({
+  audit, status, durationMs, error,
+}) {
+  const parts = [`audit=${audit}`, `status=${status}`, `duration_ms=${durationMs}`];
+  if (status === 'fail' && error) {
+    const escaped = String(error).replace(/\\/g, '\\\\').replace(/"/g, '\\"').slice(0, 500);
+    parts.push(`error="${escaped}"`);
+  }
+  return ` ${parts.join(' ')}`;
+}

--- a/src/preflight/utils.js
+++ b/src/preflight/utils.js
@@ -57,7 +57,14 @@ export function formatStructuredAuditLog({
 }) {
   const parts = [`audit=${audit}`, `status=${status}`, `duration_ms=${durationMs}`];
   if (status === 'fail' && error) {
-    const escaped = String(error).replace(/\\/g, '\\\\').replace(/"/g, '\\"').slice(0, 500);
+    // Collapse newlines/CRs to spaces BEFORE quoting: a raw newline inside the quoted value
+    // would split the log entry into two lines and corrupt Splunk's per-line field extraction
+    // (error messages from stack traces / multi-line assertions commonly contain them).
+    const escaped = String(error)
+      .replace(/\\/g, '\\\\')
+      .replace(/"/g, '\\"')
+      .replace(/[\r\n]+/g, ' ')
+      .slice(0, 500);
     parts.push(`error="${escaped}"`);
   }
   return ` ${parts.join(' ')}`;

--- a/test/audits/preflight-canonical.test.js
+++ b/test/audits/preflight-canonical.test.js
@@ -393,13 +393,29 @@ describe('Preflight Canonical Audit', () => {
       expect(ctx.log.error).to.have.been.calledOnce;
       expect(ctx.log.error.getCall(0).args[0]).to.include('Canonical audit failed');
 
-      const completionCall = ctx.log.debug.getCalls()
+      const completionCall = ctx.log.info.getCalls()
         .find((c) => c.args[0].includes('Canonical audit completed'));
       expect(completionCall).to.exist;
       expect(completionCall.args[0]).to.match(/audit=canonical status=fail duration_ms=\d+ error="/);
 
       const breakdown = auditCtx.timeExecutionBreakdown.find((e) => e.name === 'canonical');
       expect(breakdown).to.exist;
+    });
+
+    it('logs a structured status=ok line at info level on the happy path', async () => {
+      const ctx = buildContext();
+      const auditCtx = buildAuditContext([buildScrapedObject({
+        exists: true, count: 1, href: PAGE_URL, inHead: true,
+      })]);
+
+      await canonicalHandler(ctx, auditCtx);
+
+      const completionCall = ctx.log.info.getCalls()
+        .find((c) => c.args[0].includes('Canonical audit completed'));
+      expect(completionCall).to.exist;
+      expect(completionCall.args[0]).to.match(/audit=canonical status=ok duration_ms=\d+/);
+      // No error= token on the success path.
+      expect(completionCall.args[0]).to.not.include('error=');
     });
   });
 });

--- a/test/audits/preflight-canonical.test.js
+++ b/test/audits/preflight-canonical.test.js
@@ -380,4 +380,26 @@ describe('Preflight Canonical Audit', () => {
       expect(ctx.dataAccess.AsyncJob.findById).to.have.been.calledWith('job-123');
     });
   });
+
+  describe('error handling', () => {
+    it('logs a structured failure line, still records timing, and rethrows', async () => {
+      const ctx = buildContext();
+      // Empty audits map: `audits.get(url)` resolves to undefined, so `.audits.push(...)`
+      // throws inside the try block — exercises the catch/finally without invasive mocking.
+      const auditCtx = buildAuditContext([], { audits: new Map() });
+
+      await expect(canonicalHandler(ctx, auditCtx)).to.be.rejected;
+
+      expect(ctx.log.error).to.have.been.calledOnce;
+      expect(ctx.log.error.getCall(0).args[0]).to.include('Canonical audit failed');
+
+      const completionCall = ctx.log.debug.getCalls()
+        .find((c) => c.args[0].includes('Canonical audit completed'));
+      expect(completionCall).to.exist;
+      expect(completionCall.args[0]).to.match(/audit=canonical status=fail duration_ms=\d+ error="/);
+
+      const breakdown = auditCtx.timeExecutionBreakdown.find((e) => e.name === 'canonical');
+      expect(breakdown).to.exist;
+    });
+  });
 });

--- a/test/audits/preflight.test.js
+++ b/test/audits/preflight.test.js
@@ -5049,5 +5049,71 @@ describe('Preflight Audit', () => {
       expect(metadataArg.payload.checks).to.deep.equal([AUDIT_BODY_SIZE]);
       expect(jobEntity.save).to.have.been.called;
     });
+
+    it('logs a structured failure line and rethrows when the DOM-based block throws', async () => {
+      configuration.isHandlerEnabledForSite.withArgs(`${AUDIT_BODY_SIZE}-preflight`, site).returns(true);
+      configuration.isHandlerEnabledForSite.returns(false);
+
+      // Scrape object is missing `scrapeResult` entirely, so destructuring `rawBody` from it
+      // inside the DOM-based block throws — exercises the catch/finally without extra mocking.
+      s3Client.send.callsFake((command) => {
+        if (command.input?.Prefix) {
+          return Promise.resolve({
+            Contents: [{ Key: 'scrapes/site-123/page1/scrape.json' }],
+            IsTruncated: false,
+          });
+        }
+        return Promise.resolve({
+          ContentType: 'application/json',
+          Body: {
+            transformToString: sinon.stub().resolves(JSON.stringify({
+              finalUrl: 'https://main--example--page.aem.page/page1',
+            })),
+          },
+        });
+      });
+
+      const jobEntity = {
+        getMetadata: sinon.stub().returns(job.getMetadata()),
+        setMetadata: sinon.stub(),
+        setStatus: sinon.stub(),
+        setResultType: sinon.stub(),
+        setResult: sinon.stub(),
+        setEndedAt: sinon.stub(),
+        setError: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+
+      const context = new MockContextBuilder()
+        .withSandbox(sinon.createSandbox())
+        .withOverrides({
+          job,
+          site,
+          s3Client,
+          func: { version: 'test' },
+        })
+        .build();
+
+      context.env.S3_SCRAPER_BUCKET_NAME = 'test-bucket';
+      context.dataAccess.Configuration.findLatest.resolves(configuration);
+      context.dataAccess.AsyncJob.findById = sinon.stub().resolves(jobEntity);
+
+      let thrown;
+      try {
+        await preflightAuditFunction(context);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).to.exist;
+
+      const failCall = context.log.error.getCalls()
+        .find((c) => c.args[0].includes('DOM-based audit failed'));
+      expect(failCall).to.exist;
+
+      const completionCall = context.log.info.getCalls()
+        .find((c) => c.args[0].includes('DOM-based audit (body-size) completed'));
+      expect(completionCall).to.exist;
+      expect(completionCall.args[0]).to.match(/audit=body-size status=fail duration_ms=\d+ error="/);
+    });
   });
 });

--- a/test/preflight/links.test.js
+++ b/test/preflight/links.test.js
@@ -222,13 +222,26 @@ describe('preflight/links - default runner: excludedElementClasses plumbing', ()
       expect(context.log.error).to.have.been.calledOnce;
       expect(context.log.error.firstCall.args[0]).to.include('Links audit failed');
 
-      const completionCall = context.log.debug.getCalls()
+      const completionCall = context.log.info.getCalls()
         .find((c) => c.args[0].includes('Links audit completed'));
       expect(completionCall).to.exist;
       expect(completionCall.args[0]).to.match(/audit=links status=fail duration_ms=\d+ error="links-checks boom"/);
 
       const breakdown = auditCtx.timeExecutionBreakdown.find((e) => e.name === 'links');
       expect(breakdown).to.exist;
+    });
+
+    it('logs a structured status=ok line at info level on the happy path', async () => {
+      const context = buildContext({ getHandlers: () => ({}) });
+      const auditCtx = buildAuditContext();
+
+      await linksRunner(context, auditCtx);
+
+      const completionCall = context.log.info.getCalls()
+        .find((c) => c.args[0].includes('Links audit completed'));
+      expect(completionCall).to.exist;
+      expect(completionCall.args[0]).to.match(/audit=links status=ok duration_ms=\d+/);
+      expect(completionCall.args[0]).to.not.include('error=');
     });
   });
 });

--- a/test/preflight/links.test.js
+++ b/test/preflight/links.test.js
@@ -203,4 +203,32 @@ describe('preflight/links - default runner: excludedElementClasses plumbing', ()
       ]);
     });
   });
+
+  describe('error handling', () => {
+    it('logs a structured failure line, still records timing, and rethrows', async () => {
+      runLinksChecksStub.rejects(new Error('links-checks boom'));
+      const context = buildContext({ getHandlers: () => ({}) });
+      const auditCtx = buildAuditContext();
+
+      let thrown;
+      try {
+        await linksRunner(context, auditCtx);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).to.exist;
+      expect(thrown.message).to.equal('links-checks boom');
+
+      expect(context.log.error).to.have.been.calledOnce;
+      expect(context.log.error.firstCall.args[0]).to.include('Links audit failed');
+
+      const completionCall = context.log.debug.getCalls()
+        .find((c) => c.args[0].includes('Links audit completed'));
+      expect(completionCall).to.exist;
+      expect(completionCall.args[0]).to.match(/audit=links status=fail duration_ms=\d+ error="links-checks boom"/);
+
+      const breakdown = auditCtx.timeExecutionBreakdown.find((e) => e.name === 'links');
+      expect(breakdown).to.exist;
+    });
+  });
 });

--- a/test/preflight/utils.test.js
+++ b/test/preflight/utils.test.js
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+
+import { formatStructuredAuditLog } from '../../src/preflight/utils.js';
+
+describe('preflight/utils formatStructuredAuditLog', () => {
+  it('emits audit/status/duration on the happy path with a single leading space and no error token', () => {
+    const out = formatStructuredAuditLog({ audit: 'canonical', status: 'ok', durationMs: 120 });
+
+    expect(out).to.equal(' audit=canonical status=ok duration_ms=120');
+    // Leading space so it appends cleanly onto the existing message.
+    expect(out.startsWith(' ')).to.be.true;
+    expect(out).to.not.include('error=');
+  });
+
+  it('omits the error token when status is ok even if an error string is passed', () => {
+    const out = formatStructuredAuditLog({
+      audit: 'links', status: 'ok', durationMs: 5, error: 'ignored',
+    });
+
+    expect(out).to.equal(' audit=links status=ok duration_ms=5');
+  });
+
+  it('includes a quoted error token on the failure path', () => {
+    const out = formatStructuredAuditLog({
+      audit: 'links', status: 'fail', durationMs: 340, error: 'Timeout fetching canonical tag',
+    });
+
+    expect(out).to.equal(' audit=links status=fail duration_ms=340 error="Timeout fetching canonical tag"');
+  });
+
+  it('collapses newlines and carriage returns so a multi-line error stays on one line', () => {
+    const out = formatStructuredAuditLog({
+      audit: 'headings',
+      status: 'fail',
+      durationMs: 12,
+      // Consecutive \r\n collapse to a single space; only newlines are touched (literal spaces
+      // elsewhere are preserved verbatim), which is the behavior we depend on for Splunk.
+      error: 'boom\nat Object.<anonymous>\r\nat next',
+    });
+
+    // A raw newline would split the Splunk event; assert none survive.
+    expect(out).to.not.match(/[\r\n]/);
+    expect(out).to.equal(' audit=headings status=fail duration_ms=12 error="boom at Object.<anonymous> at next"');
+  });
+
+  it('escapes backslashes and double quotes inside the error value', () => {
+    const out = formatStructuredAuditLog({
+      audit: 'metatags',
+      status: 'fail',
+      durationMs: 7,
+      error: 'bad path C:\\temp and "quoted"',
+    });
+
+    expect(out).to.equal(' audit=metatags status=fail duration_ms=7 error="bad path C:\\\\temp and \\"quoted\\""');
+  });
+
+  it('truncates the error value to 500 characters (after escaping)', () => {
+    const longError = 'x'.repeat(1000);
+    const out = formatStructuredAuditLog({
+      audit: 'canonical', status: 'fail', durationMs: 1, error: longError,
+    });
+
+    const match = out.match(/error="(.*)"$/);
+    expect(match).to.not.be.null;
+    expect(match[1]).to.have.lengthOf(500);
+  });
+
+  it('omits the error token when status is fail but no error is provided', () => {
+    const out = formatStructuredAuditLog({ audit: 'canonical', status: 'fail', durationMs: 3 });
+
+    expect(out).to.equal(' audit=canonical status=fail duration_ms=3');
+    expect(out).to.not.include('error=');
+  });
+
+  it('coerces a non-string error (e.g. an Error object) via String()', () => {
+    const out = formatStructuredAuditLog({
+      audit: 'links', status: 'fail', durationMs: 2, error: new Error('kaboom'),
+    });
+
+    expect(out).to.include('error="Error: kaboom"');
+  });
+});


### PR DESCRIPTION
## Summary
- Preflight per-check logs (canonical, links, metatags, headings, body-size/lorem-ipsum/h1-count) were free text with no `audit`/`status` field — building a reliable per-audit dashboard or alert meant regex-parsing prose, and `canonical`/`links` didn't log their own failures at all (errors only surfaced via the generic job-level catch, with no check name attached).
- Appends a logfmt-style suffix to each check's existing completion log line: `audit=<name> status=<ok|fail> duration_ms=<n> [error="<message>"]`. Splunk auto-extracts these as fields with no SPL-side regex.
- `canonical`/`links`/the DOM-based block (body-size, lorem-ipsum, h1-count) now catch their own errors, log the structured line, and rethrow — preserving today's fail-hard behavior for those checks exactly (verified by new tests asserting the original error still propagates unchanged).
- `metatags`/`headings` already had try/catch (fail-soft) — no control-flow change there, just the added log content.

Companion/prerequisite for the Preflight status Splunk dashboard (SITES-49489).

## Related Issues
- Resolves SITES-49492
- Blocks SITES-49489

## Test plan
- [x] `npm test` — 9,469 passing, 100% line/branch/statement coverage on every touched file
- [x] `npm run lint` clean
- [x] New tests force each new catch/finally path (canonical, links, DOM block) and assert the structured fields, timing entry, and that the original error still propagates unchanged
- [ ] Confirm structured fields render correctly in Splunk once deployed

## Checklist
- [x] Related issues linked above
- [x] Issue reference (SITES-49492) visible in the commit body for release notes
- [x] N/A — no opportunity data sources added/changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```