### PR TITLE
perf(preflight): add rare pfauditmetric marker to structured log line for Splunk

### DIFF
--- a/docs/specs/preflight-structured-audit-logging.md
+++ b/docs/specs/preflight-structured-audit-logging.md
@@ -24,11 +24,16 @@ breakdown and top-error panels need dependable, queryable fields.
 ## Goals
 
 1. Emit one machine-parseable completion line per check with stable fields:
-   `audit=<name> status=<ok|fail> duration_ms=<n> [error="<message>"]`.
-2. Make the fields Splunk-auto-extractable (logfmt `key=value`) — no SPL-side `rex` needed.
-3. Attribute failures to the specific check for `canonical`/`links` (add local `try/catch` that
+   `pfauditmetric audit=<name> status=<ok|fail> duration_ms=<n> [error="<message>"]`.
+2. Make the fields cheaply queryable. **Correction (see note below): the sourcetype is
+   `KV_MODE=json`, so these `key=value` tokens live inside the JSON `message` string and are NOT
+   auto-extracted — the dashboard `rex`-extracts them.** The logfmt shape keeps that `rex` trivial.
+3. Lead the suffix with a rare, breaker-free marker token (`pfauditmetric`) so the dashboard can
+   anchor on a tiny postings list — without it, a wide-window search is unusably slow (see
+   "Query performance" below).
+4. Attribute failures to the specific check for `canonical`/`links` (add local `try/catch` that
    logs the structured line and rethrows — preserving today's fail-hard behavior).
-4. Ensure the lines are prod-visible (emit at `log.info`, not `debug`).
+5. Ensure the lines are prod-visible (emit at `log.info`, not `debug`).
 
 ## Non-Goals
 
@@ -51,8 +56,22 @@ A shared helper `formatStructuredAuditLog({ audit, status, durationMs, error })`
 existing completion message:
 
 ```
-[preflight-audit] site: <id>, job: <id>, step: <step>. Canonical audit completed in 0.12 seconds. audit=canonical status=ok duration_ms=120
+[preflight-audit] site: <id>, job: <id>, step: <step>. Canonical audit completed in 0.12 seconds. pfauditmetric audit=canonical status=ok duration_ms=120
 ```
+
+### Query performance — why the `pfauditmetric` marker exists
+
+The dashboard groups by `audit`/`status`/`duration_ms`, which are `rex`-extracted from `message`
+at search time, so Splunk's index cannot help with them — to *find* the lines it must use the
+search terms. Every otherwise-natural anchor (`audit`, `preflight`, `duration_ms`) is a **common**
+term in the `dx_aem_sites_spacecat_backend_*` sourcetype (it carries every SpaceCat Lambda/worker
+log; `api-service` alone emits `duration_ms` on nearly every request), so a wide-window search has
+to intersect enormous postings lists across a busy shared index — a 14-day search hangs, even a
+bare `count`. `pfauditmetric` is a made-up token that appears on **only** these completion lines,
+so it is a single rare indexed term (all lowercase, no Splunk breakers) with a tiny postings list.
+Anchoring the dashboard base search on it (`... "pfauditmetric" | rex ...`) makes the search cost
+proportional to preflight volume alone — fast at any window. For very high preflight volume or
+multi-month views, report acceleration / a summary index is the further step (needs Splunk perms).
 
 | Field | Meaning |
 |-------|---------|
@@ -98,17 +117,25 @@ imprecision documented here.
 
 ## Success Criteria
 
-- Every check above emits `audit=<name> status=<ok|fail> duration_ms=<n>` on completion, plus
-  `error="<message>"` on failure, at `log.info`.
+- Every check above emits `pfauditmetric audit=<name> status=<ok|fail> duration_ms=<n>` on
+  completion, plus `error="<message>"` on failure, at `log.info`.
 - `canonical`/`links` failures are attributable to the specific check, not just the job-level catch.
 - The `error=` value never contains a raw newline.
-- Splunk auto-extracts `audit`, `status`, `duration_ms`, `error` with no query-side regex.
+- The dashboard anchors on `pfauditmetric` and `rex`-extracts `audit`/`status`/`duration_ms`/`error`
+  from `message` (the sourcetype is `KV_MODE=json` — no auto-extraction), and a wide-window
+  (e.g. 14-day) query returns without hanging.
 - 100% unit-test coverage on all touched files, including a dedicated
-  `formatStructuredAuditLog` suite (happy path, newline/quote/backslash escaping, truncation,
-  fail-without-error).
+  `formatStructuredAuditLog` suite (marker prefix, happy path, newline/quote/backslash escaping,
+  truncation, fail-without-error).
 
 ## Downstream
 
-SITES-49489 builds the Splunk Dashboard Studio board on these fields:
-`index=dx_aem_engineering sourcetype=dx_aem_sites_spacecat_backend_prod "[preflight-audit]" audit=* | stats count by audit status`
-and a top-error panel keyed on `audit` + `error`.
+SITES-49489 builds the Splunk classic dashboard (`aso_preflight_status`) on these fields. Base
+search anchors on the marker and `rex`-extracts the fields from `message`:
+```
+index=dx_aem_engineering sourcetype=dx_aem_sites_spacecat_backend_prod "pfauditmetric"
+| rex field=message "audit=(?<audit>\S+)\s+status=(?<status>\S+)\s+duration_ms=(?<duration_ms>\d+)"
+| rex field=message "error=\"(?<error>.*)\""
+| stats count by audit status
+```
+plus a top-error panel keyed on `audit` + `error`.

--- a/src/preflight/utils.js
+++ b/src/preflight/utils.js
@@ -44,18 +44,31 @@ export function getPrefixedPageAuthToken(site, token, options) {
 }
 
 /**
- * Builds a logfmt-style `key=value` suffix for a per-audit completion log line, so Splunk's
- * automatic field extraction picks up `audit`/`status`/`duration_ms`/`error` without any
- * SPL-side regex. Appended to the existing `[preflight-audit] site: ..., job: ...` message,
- * never replacing it.
+ * Rare, breaker-free marker token that leads every structured completion suffix. Its whole job
+ * is Splunk query performance: `audit`/`status`/`duration_ms` are all common terms in the
+ * high-volume `dx_aem_sites_spacecat_backend_*` sourcetype, so a dashboard anchored on them has
+ * to intersect enormous postings lists across the whole time window (a 14-day search on that
+ * shared index hangs). `pfauditmetric` appears ONLY on these lines, so it is a single, rare
+ * indexed term (no Splunk breakers — all lowercase letters) with a tiny postings list; anchoring
+ * on it makes the search cost proportional to preflight volume alone, fast at any window.
+ * Keep it in sync with the SITES-49489 dashboard base search (`... "pfauditmetric" | rex ...`).
+ */
+export const PREFLIGHT_METRIC_MARKER = 'pfauditmetric';
+
+/**
+ * Builds the structured completion-log suffix: the `pfauditmetric` marker (query anchor) followed
+ * by logfmt-style `key=value` pairs (`audit`/`status`/`duration_ms`/`error`). Appended to the
+ * existing `[preflight-audit] site: ..., job: ...` message, never replacing it. The sourcetype is
+ * `KV_MODE=json`, so these live inside the JSON `message` string and are NOT auto-extracted — the
+ * dashboard `rex`-extracts them; the marker + logfmt shape is what makes that rex cheap and robust.
  * @param {{ audit: string, status: 'ok'|'fail', durationMs: number, error?: string }} params
  * @returns {string} A leading-space-prefixed suffix, e.g.
- *   ` audit=canonical status=ok duration_ms=120`
+ *   ` pfauditmetric audit=canonical status=ok duration_ms=120`
  */
 export function formatStructuredAuditLog({
   audit, status, durationMs, error,
 }) {
-  const parts = [`audit=${audit}`, `status=${status}`, `duration_ms=${durationMs}`];
+  const parts = [PREFLIGHT_METRIC_MARKER, `audit=${audit}`, `status=${status}`, `duration_ms=${durationMs}`];
   if (status === 'fail' && error) {
     // Collapse newlines/CRs to spaces BEFORE quoting: a raw newline inside the quoted value
     // would split the log entry into two lines and corrupt Splunk's per-line field extraction

--- a/test/preflight/utils.test.js
+++ b/test/preflight/utils.test.js
@@ -12,13 +12,20 @@
 
 import { expect } from 'chai';
 
-import { formatStructuredAuditLog } from '../../src/preflight/utils.js';
+import { formatStructuredAuditLog, PREFLIGHT_METRIC_MARKER } from '../../src/preflight/utils.js';
 
 describe('preflight/utils formatStructuredAuditLog', () => {
-  it('emits audit/status/duration on the happy path with a single leading space and no error token', () => {
+  it('leads with the rare pfauditmetric marker (the Splunk query anchor)', () => {
+    expect(PREFLIGHT_METRIC_MARKER).to.equal('pfauditmetric');
+    const out = formatStructuredAuditLog({ audit: 'canonical', status: 'ok', durationMs: 1 });
+    // Single leading space, then the marker as the first token, so the dashboard can anchor on it.
+    expect(out.startsWith(` ${PREFLIGHT_METRIC_MARKER} `)).to.be.true;
+  });
+
+  it('emits marker + audit/status/duration on the happy path with a single leading space and no error token', () => {
     const out = formatStructuredAuditLog({ audit: 'canonical', status: 'ok', durationMs: 120 });
 
-    expect(out).to.equal(' audit=canonical status=ok duration_ms=120');
+    expect(out).to.equal(' pfauditmetric audit=canonical status=ok duration_ms=120');
     // Leading space so it appends cleanly onto the existing message.
     expect(out.startsWith(' ')).to.be.true;
     expect(out).to.not.include('error=');
@@ -29,7 +36,7 @@ describe('preflight/utils formatStructuredAuditLog', () => {
       audit: 'links', status: 'ok', durationMs: 5, error: 'ignored',
     });
 
-    expect(out).to.equal(' audit=links status=ok duration_ms=5');
+    expect(out).to.equal(' pfauditmetric audit=links status=ok duration_ms=5');
   });
 
   it('includes a quoted error token on the failure path', () => {
@@ -37,7 +44,7 @@ describe('preflight/utils formatStructuredAuditLog', () => {
       audit: 'links', status: 'fail', durationMs: 340, error: 'Timeout fetching canonical tag',
     });
 
-    expect(out).to.equal(' audit=links status=fail duration_ms=340 error="Timeout fetching canonical tag"');
+    expect(out).to.equal(' pfauditmetric audit=links status=fail duration_ms=340 error="Timeout fetching canonical tag"');
   });
 
   it('collapses newlines and carriage returns so a multi-line error stays on one line', () => {
@@ -52,7 +59,7 @@ describe('preflight/utils formatStructuredAuditLog', () => {
 
     // A raw newline would split the Splunk event; assert none survive.
     expect(out).to.not.match(/[\r\n]/);
-    expect(out).to.equal(' audit=headings status=fail duration_ms=12 error="boom at Object.<anonymous> at next"');
+    expect(out).to.equal(' pfauditmetric audit=headings status=fail duration_ms=12 error="boom at Object.<anonymous> at next"');
   });
 
   it('escapes backslashes and double quotes inside the error value', () => {
@@ -63,7 +70,7 @@ describe('preflight/utils formatStructuredAuditLog', () => {
       error: 'bad path C:\\temp and "quoted"',
     });
 
-    expect(out).to.equal(' audit=metatags status=fail duration_ms=7 error="bad path C:\\\\temp and \\"quoted\\""');
+    expect(out).to.equal(' pfauditmetric audit=metatags status=fail duration_ms=7 error="bad path C:\\\\temp and \\"quoted\\""');
   });
 
   it('truncates the error value to 500 characters (after escaping)', () => {
@@ -80,7 +87,7 @@ describe('preflight/utils formatStructuredAuditLog', () => {
   it('omits the error token when status is fail but no error is provided', () => {
     const out = formatStructuredAuditLog({ audit: 'canonical', status: 'fail', durationMs: 3 });
 
-    expect(out).to.equal(' audit=canonical status=fail duration_ms=3');
+    expect(out).to.equal(' pfauditmetric audit=canonical status=fail duration_ms=3');
     expect(out).to.not.include('error=');
   });
 


### PR DESCRIPTION
## Summary
Follow-up to #2862. Makes the SITES-49489 preflight status dashboard actually usable over wide time windows.

The dashboard groups by `audit`/`status`/`duration_ms`, which are `rex`-extracted from the JSON `message` at search time (the sourcetype is `KV_MODE=json`), so Splunk's index can't help with them — it has to anchor on the *search terms*. Every available term (`audit`, `preflight`, `duration_ms`) is **common** in `dx_aem_sites_spacecat_backend_*` (it's every SpaceCat Lambda/worker log; `api-service` emits `duration_ms` on nearly every request). So a wide-window query intersects enormous postings lists across a busy shared index and a **14-day search hangs — even a bare `count`**.

Fix: lead each structured completion suffix with **`pfauditmetric`** — a made-up, breaker-free token that appears on **only** these lines. It's a single rare indexed term with a tiny postings list, so the dashboard anchors on it (`... "pfauditmetric" | rex ...`) and the search cost becomes proportional to preflight volume alone → fast at any window.

New line shape:
```
[preflight-audit] site: ..., job: ..., step: .... Canonical audit completed in 0.12 seconds. pfauditmetric audit=canonical status=ok duration_ms=120
```

Also **corrects the spec doc**: I originally claimed Splunk would auto-extract the fields with no SPL-side regex — that's wrong for this `KV_MODE=json` sourcetype (the `key=value` pairs sit inside the `message` string; the dashboard `rex`-extracts them). The logfmt shape keeps that `rex` trivial.

## Related Issues
- Part of SITES-49489 (Preflight status Splunk dashboard)
- Follows #2862 / SITES-49492

## Test plan
- [x] `npm test` — 9,480 passing, 100% coverage on all touched files
- [x] `npm run lint` clean
- [x] `formatStructuredAuditLog` unit suite updated: new test asserts the `pfauditmetric` marker leads; all exact-string expectations updated
- [ ] After deploy: re-anchor the dashboard on `pfauditmetric` and confirm a 14-day view returns quickly

## Checklist
- [x] Related issues linked
- [x] Issue reference (SITES-49489) in the commit body
- [x] N/A — no opportunity data sources changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```