### PR TITLE
perf(preflight): emit pfauditmetric marker for accessibility, form-accessibility, readability

### DIFF
--- a/src/preflight/accessibility.js
+++ b/src/preflight/accessibility.js
@@ -13,7 +13,7 @@
 import { isNonEmptyArray } from '@adobe/spacecat-shared-utils';
 import { DeleteObjectsCommand } from '@aws-sdk/client-s3';
 
-import { saveIntermediateResults } from './utils.js';
+import { saveIntermediateResults, formatStructuredAuditLog } from './utils.js';
 import { sleep } from '../support/utils.js';
 import { accessibilityOpportunitiesMap } from '../accessibility/utils/constants.js';
 import { getObjectFromKey, getObjectKeysUsingPrefix } from '../utils/s3-utils.js';
@@ -198,6 +198,12 @@ export async function processAccessibilityOpportunities(context, auditContext) {
 
   log.debug(`[preflight-audit] Processing individual accessibility result files for ${site.getBaseURL()}`);
 
+  // Track outcome so the structured completion line can report ok/fail: a preflight scrape that
+  // times out (SITES-49365/49491) leaves some/all result files missing, and per-page processing
+  // can throw - both mean the audit did not fully succeed.
+  let pagesWithData = 0;
+  let pageErrors = 0;
+
   for (const url of previewUrls) {
     try {
       // Generate the expected filename for this URL
@@ -214,6 +220,7 @@ export async function processAccessibilityOpportunities(context, auditContext) {
         log.warn(`[preflight-audit] No accessibility data found for ${url} at key: ${fileKey}`);
         // Skip to next URL if no data found
       } else {
+        pagesWithData += 1;
         log.debug(`[preflight-audit] Successfully loaded accessibility data for ${url}`);
 
         // Get the page result for this URL
@@ -279,6 +286,7 @@ export async function processAccessibilityOpportunities(context, auditContext) {
         }
       }
     } catch (error) {
+      pageErrors += 1;
       log.error(`[preflight-audit] Error processing accessibility file for ${url}: ${error.message}`, error);
 
       // Add error opportunity to the audit
@@ -303,10 +311,19 @@ export async function processAccessibilityOpportunities(context, auditContext) {
   const accessibilityElapsed = ((accessibilityEndTime - accessibilityStartTime) / 1000)
     .toFixed(2);
 
-  log.debug(
-    `[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}.
-Accessibility audit completed in ${accessibilityElapsed} seconds`,
-  );
+  // Structured completion line (info, so it reaches prod Splunk) with the pfauditmetric marker,
+  // so the SITES-49489 dashboard picks up accessibility alongside the other checks. fail =
+  // some/all pages returned no data (scrape timeout/partial) or a page threw during processing.
+  const failed = pageErrors > 0 || pagesWithData < previewUrls.length;
+  const structured = formatStructuredAuditLog({
+    audit: PREFLIGHT_ACCESSIBILITY,
+    status: failed ? 'fail' : 'ok',
+    durationMs: accessibilityEndTime - accessibilityStartTime,
+    error: failed
+      ? `${pagesWithData}/${previewUrls.length} pages returned data, ${pageErrors} processing error(s)`
+      : undefined,
+  });
+  log.info(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. Accessibility audit completed in ${accessibilityElapsed} seconds.${structured}`);
 
   timeExecutionBreakdown.push({
     name: 'accessibility-processing',

--- a/src/preflight/form-accessibility.js
+++ b/src/preflight/form-accessibility.js
@@ -14,7 +14,7 @@ import { createHash } from 'crypto';
 import { isNonEmptyArray } from '@adobe/spacecat-shared-utils';
 import { load as cheerioLoad } from 'cheerio';
 
-import { saveIntermediateResults } from './utils.js';
+import { saveIntermediateResults, formatStructuredAuditLog } from './utils.js';
 import { sleep } from '../support/utils.js';
 import { getObjectFromKey, getObjectMetadataUsingPrefix } from '../utils/s3-utils.js';
 import { generateAccessibilityFilename } from './accessibility.js';
@@ -289,6 +289,12 @@ export async function processFormAccessibilityOpportunities(
       );
     }
 
+    // Track outcome for the structured completion line: a Mystique round-trip that times out
+    // (SITES-49003) leaves the fresh result file(s) missing, and per-form processing can throw -
+    // both mean the audit did not fully succeed.
+    let formsWithData = 0;
+    let formErrors = 0;
+
     // Process each detected form's accessibility result file (a page can have
     // more than one entry when it has multiple forms)
     for (const { form: url, formSource } of resolvedFormEntries) {
@@ -313,6 +319,7 @@ export async function processFormAccessibilityOpportunities(
           log.warn(`[preflight-audit] ${siteId} No form accessibility data found for ${url} at key: ${fileKey}`);
           // Skip to next URL if no data found
         } else {
+          formsWithData += 1;
           log.info(`[preflight-audit] ${siteId} Successfully loaded form accessibility data for ${url}`);
 
           // Get the page result for this URL
@@ -342,6 +349,7 @@ export async function processFormAccessibilityOpportunities(
           }
         }
       } catch (error) {
+        formErrors += 1;
         log.error(`[preflight-audit] Error processing accessibility file for ${url}: ${error.message}`, error);
 
         // Add error opportunity to the audit
@@ -366,10 +374,19 @@ export async function processFormAccessibilityOpportunities(
     const accessibilityElapsed = ((accessibilityEndTime - accessibilityStartTime) / 1000)
       .toFixed(2);
 
-    log.info(
-      `[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}.
-Form Accessibility audit completed in ${accessibilityElapsed} seconds`,
-    );
+    // Structured completion line with the pfauditmetric marker so the SITES-49489 dashboard picks
+    // up form-accessibility. fail = the Mystique round-trip timed out (fresh result file(s)
+    // missing - the SITES-49003 signature) or a form threw during processing.
+    const failed = formErrors > 0 || formsWithData < resolvedFormEntries.length;
+    const structured = formatStructuredAuditLog({
+      audit: PREFLIGHT_FORM_ACCESSIBILITY,
+      status: failed ? 'fail' : 'ok',
+      durationMs: accessibilityEndTime - accessibilityStartTime,
+      error: failed
+        ? `${formsWithData}/${resolvedFormEntries.length} forms returned data, ${formErrors} processing error(s)`
+        : undefined,
+    });
+    log.info(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. Form Accessibility audit completed in ${accessibilityElapsed} seconds.${structured}`);
 
     timeExecutionBreakdown.push({
       name: 'form-accessibility-processing',

--- a/src/readability/preflight/handler.js
+++ b/src/readability/preflight/handler.js
@@ -157,8 +157,13 @@ export default async function readability(context, auditContext) {
     site, job, log,
   } = context;
   let isProcessing = false;
-  // Tracks whether the suggest-step Mystique dispatch threw, so the structured completion line
-  // can report status=fail (the readability audit's one hard failure mode).
+  // Failure signals for the structured completion line. Unlike accessibility/form-accessibility
+  // (which poll S3 for an expected set of result files, so they compare found-vs-expected),
+  // readability scores in-process from the scrapedObjects it is handed - there is no "expected
+  // files/pages" count to fall short of. Its degradation modes are therefore: a per-element
+  // scoring error (scoringErrors), or the suggest-step Mystique dispatch throwing
+  // (suggestSendFailed).
+  let scoringErrors = 0;
   let suggestSendFailed = false;
   const {
     previewUrls,
@@ -205,6 +210,10 @@ export default async function readability(context, auditContext) {
 
     let processedElements = 0;
     let poorReadabilityCount = 0;
+    // Per-page scoring-error tally; rolled up into the function-level scoringErrors after this
+    // page's analyses settle. Kept page-local so the in-loop analyzeReadability closure only
+    // mutates loop-scoped state (avoids no-loop-func on the shared counter).
+    let pageScoringErrors = 0;
     const detectedLanguages = new Set(); // Track languages actually detected
 
     // Helper function to detect if text is in a supported language
@@ -264,6 +273,7 @@ export default async function readability(context, auditContext) {
           });
         }
       } catch (error) {
+        pageScoringErrors += 1;
         const errorContext = `element with index ${elementIndex}`;
         log.error(
           `[readability-suggest handler] readability: Error calculating readability for ${errorContext} `
@@ -352,6 +362,10 @@ export default async function readability(context, auditContext) {
     // Execute all readability analyses in parallel
     // eslint-disable-next-line no-await-in-loop
     await Promise.all(readabilityPromises);
+
+    // Roll this page's scoring errors into the run-level total (mutated here in the loop body,
+    // not inside the in-loop analyze closure, to satisfy no-loop-func).
+    scoringErrors += pageScoringErrors;
 
     const detectedLanguagesList = detectedLanguages.size > 0
       ? Array.from(detectedLanguages).join(', ')
@@ -470,18 +484,17 @@ export default async function readability(context, auditContext) {
   const readabilityElapsed = ((readabilityEndTime - readabilityStartTime) / 1000).toFixed(2);
   const auditStepName = step === 'suggest' ? 'readability-suggestions' : 'readability';
 
-  log.debug(
-    `[readability-suggest handler] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. `
-    + `Readability audit completed in ${readabilityElapsed} seconds`,
-  );
-
-  // Structured completion line (info + [preflight-audit] prefix + pfauditmetric marker) so the
-  // SITES-49489 dashboard picks up readability. fail = the suggest-step Mystique dispatch threw.
+  // Single structured completion line (info + [preflight-audit] prefix + pfauditmetric marker) so
+  // the SITES-49489 dashboard picks up readability, consistent with the other two handlers. fail =
+  // any per-element scoring error, or the suggest-step Mystique dispatch threw.
+  const failed = scoringErrors > 0 || suggestSendFailed;
   const structured = formatStructuredAuditLog({
     audit: PREFLIGHT_READABILITY,
-    status: suggestSendFailed ? 'fail' : 'ok',
+    status: failed ? 'fail' : 'ok',
     durationMs: readabilityEndTime - readabilityStartTime,
-    error: suggestSendFailed ? 'Mystique readability suggestion dispatch failed' : undefined,
+    error: failed
+      ? `readability degraded (scoring errors: ${scoringErrors}, suggestion dispatch failed: ${suggestSendFailed})`
+      : undefined,
   });
   log.info(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Readability audit completed in ${readabilityElapsed} seconds.${structured}`);
 

--- a/src/readability/preflight/handler.js
+++ b/src/readability/preflight/handler.js
@@ -13,7 +13,7 @@
 import rs from 'text-readability';
 import { load as cheerioLoad } from 'cheerio';
 import { franc } from 'franc-min';
-import { saveIntermediateResults } from '../../preflight/utils.js';
+import { saveIntermediateResults, formatStructuredAuditLog } from '../../preflight/utils.js';
 
 import { sendReadabilityToMystique } from '../shared/async-mystique.js';
 import {
@@ -157,6 +157,9 @@ export default async function readability(context, auditContext) {
     site, job, log,
   } = context;
   let isProcessing = false;
+  // Tracks whether the suggest-step Mystique dispatch threw, so the structured completion line
+  // can report status=fail (the readability audit's one hard failure mode).
+  let suggestSendFailed = false;
   const {
     previewUrls,
     step,
@@ -423,6 +426,7 @@ export default async function readability(context, auditContext) {
             + 'readability issues already have suggestions');
         }
       } catch (error) {
+        suggestSendFailed = true;
         log.error('[readability-suggest handler] readability: Error sending issues to Mystique:', {
           error: error.message,
           stack: error.stack,
@@ -470,6 +474,16 @@ export default async function readability(context, auditContext) {
     `[readability-suggest handler] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. `
     + `Readability audit completed in ${readabilityElapsed} seconds`,
   );
+
+  // Structured completion line (info + [preflight-audit] prefix + pfauditmetric marker) so the
+  // SITES-49489 dashboard picks up readability. fail = the suggest-step Mystique dispatch threw.
+  const structured = formatStructuredAuditLog({
+    audit: PREFLIGHT_READABILITY,
+    status: suggestSendFailed ? 'fail' : 'ok',
+    durationMs: readabilityEndTime - readabilityStartTime,
+    error: suggestSendFailed ? 'Mystique readability suggestion dispatch failed' : undefined,
+  });
+  log.info(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Readability audit completed in ${readabilityElapsed} seconds.${structured}`);
 
   timeExecutionBreakdown.push({
     name: auditStepName,


### PR DESCRIPTION
## Summary
Follow-up to #2864. These three audits were the only `AVAILABLE_CHECKS` **not** emitting the structured completion line, so the SITES-49489 dashboard never showed them. They run via async round-trips (accessibility & form-accessibility poll S3; readability may dispatch to Mystique) rather than the self-contained sync path the other 7 use, so they were out of scope of the earlier logging PRs.

Each now emits a dedicated **info-level** `[preflight-audit] … pfauditmetric audit=<name> status=<ok|fail> duration_ms=<n> [error="…"]` completion line:
- **accessibility** — `fail` when some/all pages returned no scrape data (SITES-49365/49491 timeout) or a page threw during processing.
- **form-accessibility** — `fail` when the Mystique round-trip timed out (fresh result file missing — the **SITES-49003** signature) or a form threw. This finally makes the notorious forms-a11y hang visible on the dashboard.
- **readability** — `fail` when the suggest-step Mystique dispatch threw.

Info level matters: accessibility/readability completion logs were previously `debug` (suppressed in prod); the `[preflight-audit]` prefix + `pfauditmetric` marker keep them visible to the dashboard's base search. With this, **all 10 preflight `AVAILABLE_CHECKS` are instrumented.**

## Related Issues
- Part of SITES-49489; follows #2862 / #2864.

## Test plan
- [x] `npm test` — full suite; **100% coverage on all three changed files** (existing tests already exercise the ok + missing-data/error branches)
- [x] `npm run lint` clean
- [ ] After deploy: run a preflight and confirm accessibility / form-accessibility / readability appear on the dashboard

## Checklist
- [x] Related issues linked
- [x] Issue reference (SITES-49489) in the commit body
- [x] N/A — no opportunity data sources changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```