### PR TITLE
fix(cwv): reclaim stale stuck IN_PROGRESS suggestions on re-audit

### DIFF
--- a/docs/decisions/003-reclaim-stale-inprogress-cwv-suggestions.md
+++ b/docs/decisions/003-reclaim-stale-inprogress-cwv-suggestions.md
@@ -1,0 +1,89 @@
+# 003 — CWV Re-audit Reclaims Stale Stuck `IN_PROGRESS` Suggestions
+
+- **Status:** Accepted
+- **Date:** 2026-08-07
+
+## Context
+
+Mystique flips a CWV `CODE_CHANGE` suggestion to `IN_PROGRESS` the moment it
+finishes generating a code-fix patch and hands it off for deploy — that status
+is the deploy hand-off signal, and it is the sole trigger consumed by the
+autofix-worker. On the large majority of sites `cwv-auto-fix` is **off**, so
+nothing ever consumes the hand-off: the suggestion sits `IN_PROGRESS` forever.
+
+The CWV re-audit (`syncOpportunitiesAndSuggestions`) preserves `IN_PROGRESS` on
+every run (it is in the merge skip-set), so these never self-heal. They
+**accumulate every weekly audit** and pile up in the customer-facing "Deployed"
+tab, even though the patch is ready and no deploy is or ever will be in flight.
+A transient upstream outage (e.g. the Aug 2026 clientlib-builder outage that
+stranded ~2,048 suggestions across ~203 sites) produces the same end state at
+scale.
+
+The durable fix (blackboard V2) is far off. We need a near-term, self-healing
+mechanism that does **not** disturb sites that legitimately do auto-deploy.
+
+## Decision
+
+Add a CWV-specific `mergeStatusFunction` (`createMergeCwvStatus`) to the
+`syncSuggestions` call in `syncOpportunitiesAndSuggestions`. On re-audit it
+reclaims a matched suggestion `IN_PROGRESS → NEW` **only when all** of the
+following hold:
+
+1. the suggestion is `IN_PROGRESS`;
+2. it has **no active fix entity** — no `FixEntity` with status
+   `PENDING`/`DEPLOYED`/`PUBLISHED` references it (keyed by
+   `changeDetails.suggestionId`); and
+3. it is **stale** — more than `STALE_IN_PROGRESS_MS` (24h) since `updatedAt`.
+
+Every other case delegates to the existing `defaultMergeStatusFunction`,
+preserving its `OUTDATED`-regression and `ERROR → NEW` behaviour unchanged.
+
+Fetching the opportunity's fix entities is wrapped in try/catch. On **any**
+failure we set `fixFetchFailed` and skip reclaim entirely for that run
+(fail-safe) rather than risk reclaiming a suggestion whose deploy is genuinely
+in flight.
+
+## Why this is safe
+
+- **No data loss.** The generated patch lives in `suggestion.data`; only the
+  status flips. A reclaimed suggestion is a `NEW` suggestion with its patch
+  intact (`isCodeChangeAvailable === true`), so it re-surfaces as actionable and
+  is **not** re-dispatched for regeneration.
+- **Never touches a live deploy.** The active-fix guard skips anything with a
+  `PENDING`/`DEPLOYED`/`PUBLISHED` fix; the 24h staleness window is far longer
+  than a normal deploy hand-off, so a freshly-set `IN_PROGRESS` is never
+  reclaimed mid-flight.
+- **Reversible.** The flip is a plain status change via the same API.
+- **Fail-safe.** A fix-entity fetch error disables reclaim for that run.
+
+## Alternatives Considered
+
+- **Fix at the source in the autofix-worker** (revert `IN_PROGRESS → NEW` when
+  the deploy hand-off is never consumed). This is the correct long-term home and
+  is partly addressed by autofix-worker #686 for the no-PR/`CM_STANDARD`
+  structural strand, but it does **not** cover the transient-outage strand (the
+  worker never receives a result to act on) and does not clean up the backlog
+  already stuck. The re-audit reclaim is the one place that runs periodically on
+  every site regardless of deploy channel.
+- **A scheduled cleanup job** that sweeps stale `IN_PROGRESS`. Rejected as the
+  primary mechanism: another moving part to operate and monitor, when the
+  re-audit already visits every site on a cadence and holds the fix-entity
+  context needed for the active-deploy guard.
+- **Reclaim regardless of age (no staleness window).** Rejected: would race a
+  legitimate, freshly-set `IN_PROGRESS` on an auto-deploy site before its fix
+  entity exists.
+- **Reclaim regardless of fix entities.** Rejected: would disturb real in-flight
+  and live deploys.
+
+## Consequences
+
+- On the first re-audit after this ships, each site's accumulated stale
+  `IN_PROGRESS` suggestions flip to `NEW` in one pass (a one-time cleanup,
+  bounded per site). This is customer-visible: stuck "Deployed" items reappear
+  as actionable "Current" items — the intended outcome.
+- Suggestions whose fix entity is a **stuck `PENDING`** (e.g. a deploy PR that
+  was opened but never merged) are deliberately **not** reclaimed by this path;
+  they are handled separately (`delete-cwv-fixes`).
+- The 24h threshold is the one tuning knob. If a deploy pipeline can legitimately
+  hold a suggestion `IN_PROGRESS` with no fix entity for longer than 24h, raise
+  `STALE_IN_PROGRESS_MS`.

--- a/src/cwv/opportunity-sync.js
+++ b/src/cwv/opportunity-sync.js
@@ -265,6 +265,14 @@ export async function syncOpportunitiesAndSuggestions(context) {
     const fixEntities = await opportunity.getFixEntities();
     (fixEntities || []).forEach((fixEntity) => {
       if (ACTIVE_FIX_STATUSES.has(fixEntity.getStatus())) {
+        // Contract (cross-repo): the CWV fix→suggestion link is the denormalized
+        // changeDetails.suggestionId that spacecat-autofix-worker owns — its
+        // cwv/handler.js writes changeDetails = { suggestionId, issueId, issueTitle }
+        // and code-repo-manager.js reads it back. We deliberately key on that
+        // rather than the canonical FixEntitySuggestion join for an O(1) reverse
+        // lookup. If a future CWV fix writer ever lands without suggestionId, this
+        // guard misses it — but the 24h staleness window + fail-safe (fixFetchFailed)
+        // bound the blast radius, so a genuinely-live deploy is never reclaimed here.
         const suggestionId = fixEntity.getChangeDetails?.()?.suggestionId;
         if (suggestionId) {
           activeFixSuggestionIds.add(suggestionId);

--- a/src/cwv/opportunity-sync.js
+++ b/src/cwv/opportunity-sync.js
@@ -10,8 +10,8 @@
  * governing permissions and limitations under the License.
  */
 
-import { Audit, Suggestion } from '@adobe/spacecat-shared-data-access';
-import { syncSuggestions } from '../utils/data-access.js';
+import { Audit, Suggestion, FixEntity } from '@adobe/spacecat-shared-data-access';
+import { syncSuggestions, defaultMergeStatusFunction } from '../utils/data-access.js';
 import { createOpportunityData } from './opportunity-data-mapper.js';
 import { convertToOpportunity } from '../common/opportunity.js';
 import calculateKpiDeltasForAudit, { THRESHOLDS, METRICS, calculateConfidenceScore } from './kpi-metrics.js';
@@ -144,6 +144,60 @@ export function mergeCwvData(existingData, newDataItem) {
 }
 
 /**
+ * How long a CWV suggestion may sit IN_PROGRESS before a re-audit treats it as
+ * stale and reclaims it back to NEW. Mystique flips a suggestion to IN_PROGRESS
+ * the moment it hands a generated patch off for deploy; on an auto-deploy-off
+ * site nothing ever consumes that hand-off, so without this the suggestion is
+ * stuck forever. 24h is comfortably longer than the transient deploy window, so
+ * a genuinely in-flight IN_PROGRESS is never reclaimed mid-deploy.
+ */
+export const STALE_IN_PROGRESS_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * FixEntity statuses that represent a real in-flight or live deploy. A suggestion
+ * covered by a fix in one of these states must never be reclaimed — the deploy
+ * hand-off is legitimately still owned downstream.
+ */
+const ACTIVE_FIX_STATUSES = new Set([
+  FixEntity.STATUSES.PENDING,
+  FixEntity.STATUSES.DEPLOYED,
+  FixEntity.STATUSES.PUBLISHED,
+]);
+
+/**
+ * Builds the CWV mergeStatusFunction for syncSuggestions. On re-audit it reclaims
+ * STALE stuck IN_PROGRESS suggestions back to NEW so they self-heal instead of
+ * accumulating every weekly run (Mystique sets IN_PROGRESS as the deploy hand-off;
+ * on auto-deploy-off sites nothing ever deploys it). A suggestion is reclaimed ONLY
+ * when ALL of the following hold:
+ *   - it is IN_PROGRESS,
+ *   - it has NO active fix entity (PENDING/DEPLOYED/PUBLISHED) — never touch a real
+ *     in-flight/live deploy, and
+ *   - it is stale (> STALE_IN_PROGRESS_MS since updatedAt) — never touch a freshly-set
+ *     IN_PROGRESS still inside the transient deploy window.
+ * Every other case delegates to defaultMergeStatusFunction, preserving its behaviour
+ * (incl. OUTDATED-regression and ERROR→NEW handling).
+ *
+ * @param {Set<string>} activeFixSuggestionIds - suggestion ids covered by an active fix.
+ * @param {boolean} fixFetchFailed - true if the fix-entity fetch failed; when true the
+ *   function behaves exactly like defaultMergeStatusFunction (fail safe: no reclaim).
+ * @returns {Function} mergeStatusFunction(existing, newDataItem, context)
+ */
+export function createMergeCwvStatus(activeFixSuggestionIds, fixFetchFailed) {
+  return (existing, newDataItem, context) => {
+    if (
+      !fixFetchFailed
+      && existing.getStatus() === Suggestion.STATUSES.IN_PROGRESS
+      && !activeFixSuggestionIds.has(existing.getId())
+      && Date.now() - new Date(existing.getUpdatedAt()).getTime() > STALE_IN_PROGRESS_MS
+    ) {
+      return Suggestion.STATUSES.NEW;
+    }
+    return defaultMergeStatusFunction(existing, newDataItem, context);
+  };
+}
+
+/**
  * Synchronizes opportunities and suggestions for a CWV audit
  * Creates or updates opportunity and syncs suggestions
  * @param {Object} context - Context object containing site, audit, finalUrl, log, dataAccess
@@ -200,6 +254,29 @@ export async function syncOpportunitiesAndSuggestions(context) {
     kpiDeltas,
   );
 
+  // Build the set of suggestion ids that are covered by an ACTIVE fix entity
+  // (PENDING/DEPLOYED/PUBLISHED). mergeCwvStatus uses this to reclaim ONLY the
+  // stuck IN_PROGRESS suggestions that have no real in-flight/live deploy. On any
+  // fetch failure we fail safe — skip reclaim entirely this run (fixFetchFailed) —
+  // rather than risk reclaiming a suggestion whose deploy is genuinely in flight.
+  const activeFixSuggestionIds = new Set();
+  let fixFetchFailed = false;
+  try {
+    const fixEntities = await opportunity.getFixEntities();
+    (fixEntities || []).forEach((fixEntity) => {
+      if (ACTIVE_FIX_STATUSES.has(fixEntity.getStatus())) {
+        const suggestionId = fixEntity.getChangeDetails?.()?.suggestionId;
+        if (suggestionId) {
+          activeFixSuggestionIds.add(suggestionId);
+        }
+      }
+    });
+  } catch (e) {
+    fixFetchFailed = true;
+    log.warn(`[syncOpportunitiesAndSuggestions] site ${site.getId()} - failed to fetch fix entities; skipping IN_PROGRESS reclaim this run: ${e.message}`);
+  }
+  const mergeCwvStatus = createMergeCwvStatus(activeFixSuggestionIds, fixFetchFailed);
+
   // Sync suggestions
   const buildKey = (data) => (data.type === 'url' ? data.url : data.pattern);
   const maxConfidenceForUrls = Math.max(
@@ -218,6 +295,10 @@ export async function syncOpportunitiesAndSuggestions(context) {
     // OUTDATED for any metric whose failure has resolved (skip list preserves
     // APPROVED/REJECTED/FIXED/SKIPPED/IN_PROGRESS/ERROR/OUTDATED).
     mergeDataFunction: mergeCwvData,
+    // On re-audit: reclaim STALE stuck IN_PROGRESS suggestions (no active fix,
+    // >24h old) back to NEW so the Mystique deploy hand-off self-heals on
+    // auto-deploy-off sites instead of accumulating every weekly audit.
+    mergeStatusFunction: mergeCwvStatus,
     mapNewSuggestion: (entry) => ({
       opportunityId: opportunity.getId(),
       type: 'CODE_CHANGE',

--- a/test/audits/cwv.test.js
+++ b/test/audits/cwv.test.js
@@ -450,6 +450,7 @@ describe('collectCWVDataAndImportCode Tests', () => {
         getAuditId: () => 'audit-id',
         addSuggestions: sandbox.stub().resolves(addSuggestionsResponse),
         getSuggestions: sandbox.stub().resolves([]),
+        getFixEntities: sandbox.stub().resolves([]),
         setAuditId: sandbox.stub(),
         setScopeType: sandbox.stub(),
         setScopeId: sandbox.stub(),
@@ -733,6 +734,126 @@ describe('collectCWVDataAndImportCode Tests', () => {
 
       expect(context.dataAccess.Suggestion.bulkUpdateStatus)
         .to.have.been.calledOnceWith([resolved], 'OUTDATED');
+    });
+
+    it('reclaims a stale stuck IN_PROGRESS suggestion (no active fix) to NEW, but preserves one with an active fix (deploy-handoff self-heal)', async () => {
+      sinon.stub(GoogleClient, 'createFrom').resolves({});
+      context.dataAccess.Opportunity.allBySiteIdAndStatus.resolves([oppty]);
+
+      const staleUpdatedAt = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+      const failing = [{ deviceType: 'mobile', lcp: 6000, cls: 1.2, inp: 800 }];
+
+      // Matched (key present in this run's failing set), stale, IN_PROGRESS, NOT
+      // covered by an active fix → reclaimed back to NEW.
+      const reclaimable = {
+        opportunityId: oppty.getId(),
+        getId: () => 's-reclaim',
+        getData: () => ({ type: 'url', url: 'https://www.aem.live/docs/', metrics: failing }),
+        getStatus: () => 'IN_PROGRESS',
+        getUpdatedAt: () => staleUpdatedAt,
+        setData: sinon.stub(),
+        setRank: sinon.stub(),
+        setStatus: sinon.stub(),
+        setUpdatedBy: sinon.stub().returnsThis(),
+        save: sinon.stub(),
+        remove: sinon.stub(),
+      };
+      // Matched, stale, IN_PROGRESS, but HAS an active (PENDING) fix → preserved.
+      const withActiveFix = {
+        opportunityId: oppty.getId(),
+        getId: () => 's-active',
+        getData: () => ({ type: 'group', pattern: 'https://www.aem.live/home/*', metrics: failing }),
+        getStatus: () => 'IN_PROGRESS',
+        getUpdatedAt: () => staleUpdatedAt,
+        setData: sinon.stub(),
+        setRank: sinon.stub(),
+        setStatus: sinon.stub(),
+        setUpdatedBy: sinon.stub().returnsThis(),
+        save: sinon.stub(),
+        remove: sinon.stub(),
+      };
+      oppty.getSuggestions.resolves([reclaimable, withActiveFix]);
+      oppty.getFixEntities.resolves([
+        // active fix keyed to s-active → covered, must not be reclaimed
+        { getStatus: () => 'PENDING', getChangeDetails: () => ({ suggestionId: 's-active' }) },
+        // inactive fix → ignored (does not shield its suggestion)
+        { getStatus: () => 'FAILED', getChangeDetails: () => ({ suggestionId: 's-ignored' }) },
+        // active fix with no suggestionId → skipped when building the covered set
+        { getStatus: () => 'DEPLOYED', getChangeDetails: () => ({}) },
+      ]);
+
+      const stepContext = { ...context, site, audit: mockAudit, finalUrl: auditUrl };
+      await syncOpportunityAndSuggestionsStep(stepContext);
+
+      // reclaimable flipped IN_PROGRESS → NEW, stamped system
+      expect(reclaimable.setStatus).to.have.been.calledOnceWith('NEW');
+      expect(reclaimable.setUpdatedBy).to.have.been.calledWith('system');
+      // active-fix suggestion left alone (never reclaimed)
+      expect(withActiveFix.setStatus).to.not.have.been.called;
+    });
+
+    it('does NOT reclaim any IN_PROGRESS suggestion when the fix-entity fetch fails (fail safe)', async () => {
+      sinon.stub(GoogleClient, 'createFrom').resolves({});
+      context.dataAccess.Opportunity.allBySiteIdAndStatus.resolves([oppty]);
+
+      const staleUpdatedAt = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+      const stale = {
+        opportunityId: oppty.getId(),
+        getId: () => 's-reclaim',
+        getData: () => ({
+          type: 'url',
+          url: 'https://www.aem.live/docs/',
+          metrics: [{ deviceType: 'mobile', lcp: 6000, cls: 1.2, inp: 800 }],
+        }),
+        getStatus: () => 'IN_PROGRESS',
+        getUpdatedAt: () => staleUpdatedAt,
+        setData: sinon.stub(),
+        setRank: sinon.stub(),
+        setStatus: sinon.stub(),
+        setUpdatedBy: sinon.stub().returnsThis(),
+        save: sinon.stub(),
+        remove: sinon.stub(),
+      };
+      oppty.getSuggestions.resolves([stale]);
+      oppty.getFixEntities.rejects(new Error('boom'));
+
+      const stepContext = { ...context, site, audit: mockAudit, finalUrl: auditUrl };
+      await syncOpportunityAndSuggestionsStep(stepContext);
+
+      // Fetch failure → skip reclaim entirely; the stuck suggestion is left untouched.
+      expect(stale.setStatus).to.not.have.been.called;
+      expect(context.log.warn).to.have.been.calledWithMatch(/failed to fetch fix entities/);
+    });
+
+    it('treats a null fix-entities result as "no active fixes" and still reclaims a stale IN_PROGRESS suggestion', async () => {
+      sinon.stub(GoogleClient, 'createFrom').resolves({});
+      context.dataAccess.Opportunity.allBySiteIdAndStatus.resolves([oppty]);
+
+      const staleUpdatedAt = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+      const stale = {
+        opportunityId: oppty.getId(),
+        getId: () => 's-reclaim',
+        getData: () => ({
+          type: 'url',
+          url: 'https://www.aem.live/docs/',
+          metrics: [{ deviceType: 'mobile', lcp: 6000, cls: 1.2, inp: 800 }],
+        }),
+        getStatus: () => 'IN_PROGRESS',
+        getUpdatedAt: () => staleUpdatedAt,
+        setData: sinon.stub(),
+        setRank: sinon.stub(),
+        setStatus: sinon.stub(),
+        setUpdatedBy: sinon.stub().returnsThis(),
+        save: sinon.stub(),
+        remove: sinon.stub(),
+      };
+      oppty.getSuggestions.resolves([stale]);
+      oppty.getFixEntities.resolves(null);
+
+      const stepContext = { ...context, site, audit: mockAudit, finalUrl: auditUrl };
+      await syncOpportunityAndSuggestionsStep(stepContext);
+
+      expect(stale.setStatus).to.have.been.calledOnceWith('NEW');
     });
 
     it('creates a new opportunity object when GSC connection returns null', async () => {
@@ -1315,5 +1436,79 @@ describe('Per-issue prune-on-resolve merge helpers', () => {
       // metrics overwritten by new data
       expect(result.metrics[0].lcp).to.equal(1800);
     });
+  });
+});
+
+describe('createMergeCwvStatus — reclaim stale stuck IN_PROGRESS suggestions', () => {
+  let createMergeCwvStatus;
+  let STALE_IN_PROGRESS_MS;
+
+  before(async () => {
+    ({ createMergeCwvStatus, STALE_IN_PROGRESS_MS } = await import('../../src/cwv/opportunity-sync.js'));
+  });
+
+  const twoDaysAgo = () => new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+  const nowIso = () => new Date().toISOString();
+
+  const makeSuggestion = ({ id, status, updatedAt }) => ({
+    getId: () => id,
+    getStatus: () => status,
+    getUpdatedAt: () => updatedAt,
+  });
+
+  const ctx = {
+    log: { warn: () => {}, info: () => {} },
+    site: { requiresValidation: false },
+    isTBYB: false,
+  };
+
+  it('exposes a 24h staleness window', () => {
+    expect(STALE_IN_PROGRESS_MS).to.equal(24 * 60 * 60 * 1000);
+  });
+
+  it('reclaims a stale IN_PROGRESS suggestion with no active fix back to NEW', () => {
+    const merge = createMergeCwvStatus(new Set(), false);
+    const s = makeSuggestion({ id: 's1', status: 'IN_PROGRESS', updatedAt: twoDaysAgo() });
+    expect(merge(s, {}, ctx)).to.equal(SuggestionModel.STATUSES.NEW);
+  });
+
+  it('preserves an IN_PROGRESS suggestion that has an active fix (not reclaimed)', () => {
+    const merge = createMergeCwvStatus(new Set(['s1']), false);
+    const s = makeSuggestion({ id: 's1', status: 'IN_PROGRESS', updatedAt: twoDaysAgo() });
+    expect(merge(s, {}, ctx)).to.equal(null);
+  });
+
+  it('preserves a fresh IN_PROGRESS suggestion that is not yet stale', () => {
+    const merge = createMergeCwvStatus(new Set(), false);
+    const s = makeSuggestion({ id: 's1', status: 'IN_PROGRESS', updatedAt: nowIso() });
+    expect(merge(s, {}, ctx)).to.equal(null);
+  });
+
+  it('does not reclaim when the fix-entity fetch failed (fail safe)', () => {
+    const merge = createMergeCwvStatus(new Set(), true);
+    const s = makeSuggestion({ id: 's1', status: 'IN_PROGRESS', updatedAt: twoDaysAgo() });
+    expect(merge(s, {}, ctx)).to.equal(null);
+  });
+
+  it('leaves a NEW suggestion unchanged (delegates to default)', () => {
+    const merge = createMergeCwvStatus(new Set(), false);
+    const s = makeSuggestion({ id: 's1', status: 'NEW', updatedAt: twoDaysAgo() });
+    expect(merge(s, {}, ctx)).to.equal(null);
+  });
+
+  it('preserves the default OUTDATED-regression handling (delegates to default)', () => {
+    const merge = createMergeCwvStatus(new Set(), false);
+    const s = makeSuggestion({ id: 's1', status: 'OUTDATED', updatedAt: twoDaysAgo() });
+    // requiresValidation=false → regression path returns NEW
+    expect(merge(s, {}, ctx)).to.equal(SuggestionModel.STATUSES.NEW);
+    // requiresValidation=true → PENDING_VALIDATION
+    const ctxRV = { ...ctx, site: { requiresValidation: true }, isTBYB: false };
+    expect(merge(s, {}, ctxRV)).to.equal(SuggestionModel.STATUSES.PENDING_VALIDATION);
+  });
+
+  it('transitions ERROR suggestions to NEW via the default (delegates to default)', () => {
+    const merge = createMergeCwvStatus(new Set(), false);
+    const s = makeSuggestion({ id: 's1', status: 'ERROR', updatedAt: twoDaysAgo() });
+    expect(merge(s, {}, ctx)).to.equal(SuggestionModel.STATUSES.NEW);
   });
 });


### PR DESCRIPTION
## Problem

Mystique flips a CWV `CODE_CHANGE` suggestion to **`IN_PROGRESS`** the moment it finishes generating a code-fix patch — that status is the *deploy hand-off* signal and the sole trigger consumed by the autofix-worker. On the large majority of sites `cwv-auto-fix` is **off**, so nothing ever consumes the hand-off and the suggestion sits `IN_PROGRESS` **forever**.

The CWV re-audit preserves `IN_PROGRESS` on every run, so these never self-heal — they **accumulate every weekly audit** and clog the customer-facing "Deployed" tab even though the patch is ready and no deploy is (or ever will be) in flight. A transient upstream outage — e.g. the **Aug 2026 clientlib-builder outage** that stranded ~2,048 suggestions across ~203 sites — produces the same end state at scale.

Blackboard V2 (the durable fix) is far off; this is the near-term, self-healing stopgap.

## Fix

Add a CWV-specific `mergeStatusFunction` (`createMergeCwvStatus`) to the `syncSuggestions` call in `syncOpportunitiesAndSuggestions`. On re-audit it reclaims a matched suggestion **`IN_PROGRESS → NEW` only when all** hold:

1. the suggestion is `IN_PROGRESS`;
2. it has **no active fix entity** (`PENDING`/`DEPLOYED`/`PUBLISHED`, keyed by `changeDetails.suggestionId`); and
3. it is **stale** (> `STALE_IN_PROGRESS_MS` = **24h** since `updatedAt`).

Every other case delegates to the existing `defaultMergeStatusFunction` unchanged (preserving `OUTDATED`-regression and `ERROR → NEW`). The fix-entity fetch is wrapped in try/catch — **any failure fails safe** (skips reclaim for that run).

## Why it is safe

- **No data loss** — the patch lives in `suggestion.data`; only the status flips. Reclaimed suggestions keep `isCodeChangeAvailable === true`, so they re-surface as actionable and are **not** re-dispatched for regeneration.
- **Never touches a live deploy** — active-fix guard + 24h window (far longer than a real hand-off) mean a freshly-set `IN_PROGRESS` is never reclaimed mid-flight.
- **Reversible** — plain status change via the same API.
- **Fail-safe** — fix-entity fetch error disables reclaim for that run.

## Consequences

- First re-audit after ship flips each site's accumulated stale `IN_PROGRESS` to `NEW` in one bounded pass (one-time cleanup). Customer-visible: stuck "Deployed" items reappear as actionable "Current" items — the intended outcome.
- Suggestions with a **stuck `PENDING`** fix (deploy PR opened, never merged) are deliberately **not** reclaimed here — handled via `delete-cwv-fixes`.
- The 24h threshold is the one tuning knob (`STALE_IN_PROGRESS_MS`).

See **ADR-003** (`docs/decisions/003-reclaim-stale-inprogress-cwv-suggestions.md`) for the full decision record and alternatives.

## Testing

11 new tests (3 integration through `syncOpportunityAndSuggestionsStep`, 8 unit on `createMergeCwvStatus`): stale-reclaim, active-fix-preserved, fresh-not-stale, fetch-failure-no-reclaim, non-`IN_PROGRESS` unchanged, `OUTDATED`-regression (both branches), `ERROR → NEW`, 24h constant. Full `npm test` green with **100% line/branch/statement** coverage; `npm run lint` clean.

## Relationship to other work

Complements autofix-worker **#686** (no-PR/`CM_STANDARD` structural strand). This PR covers the strand #686 cannot reach — the transient-outage / auto-deploy-off backlog — because the re-audit is the one place that runs periodically on every site regardless of deploy channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Julien Ramboz", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```