### PR TITLE
fix(offsite-opportunities): Populate youtube, reddit and top cited buckets using only one domain-urls request

### DIFF
--- a/docs/decisions/002-offsite-cited-urls-semrush-source.md
+++ b/docs/decisions/002-offsite-cited-urls-semrush-source.md
@@ -134,3 +134,9 @@ tracking ticket will be filed before this debt is resolved; not required to clos
   hostname-less, `platform=all` request now returns every host's URLs, already aggregated,
   in one citations-sorted page — producing the same exact-citation-count contract with 1
   request instead of up to 78, with no separate domain-discovery hop needed.
+- **Three requests (`hostname=youtube.com`, `hostname=reddit.com`, and one hostname-less
+  request for third-party), all `platform=all`.** Would preserve independent per-bucket
+  page sizing — closing the coverage-starvation risk in Consequences — while still cutting
+  request volume ~25x. Rejected in favor of the single request for simplicity (one fewer
+  moving part, one `fallbackReason` surface instead of three); revisit if shadow-run parity
+  (LLMO-6711) shows a bucket is actually being starved in practice.

--- a/docs/decisions/002-offsite-cited-urls-semrush-source.md
+++ b/docs/decisions/002-offsite-cited-urls-semrush-source.md
@@ -2,7 +2,7 @@
 
 - **Status:** Proposed
 - **Date:** 2026-08-05
-- **Related:** spec `docs/specs/2026-08-05-offsite-cited-urls-semrush-source.md` · plan `docs/plans/2026-07-17-offsite-cited-urls-semrush-migration.md` · [LLMO-6488](https://jira.corp.adobe.com/browse/LLMO-6488) / [LLMO-6709](https://jira.corp.adobe.com/browse/LLMO-6709) / [LLMO-6710](https://jira.corp.adobe.com/browse/LLMO-6710)
+- **Related:** spec `docs/specs/2026-08-05-offsite-cited-urls-semrush-source.md` · plan `docs/plans/2026-07-17-offsite-cited-urls-semrush-migration.md` · [LLMO-6488](https://jira.corp.adobe.com/browse/LLMO-6488) / [LLMO-6709](https://jira.corp.adobe.com/browse/LLMO-6709) / [LLMO-6710](https://jira.corp.adobe.com/browse/LLMO-6710) / [LLMO-6844](https://jira.corp.adobe.com/browse/LLMO-6844) / [LLMO-6818](https://jira.corp.adobe.com/browse/LLMO-6818)
 
 ## Context
 
@@ -17,7 +17,7 @@ involves several non-obvious trade-offs, so it warrants an ADR alongside the spe
 
 1. **Source swap behind a flag, Semrush-first — failure handling depends on HOW it
    was enabled.** When Semrush is enabled (env var
-   `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED=true`, or the per-run override in Decision 6),
+   `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED=true`, or the per-run override in Decision 7),
    the runner uses the Semrush loader. On a Semrush **failure** (loader returns `null`):
    - **Env-enabled, or override `false`/absent →** fall back to the legacy
      `loadBrandPresenceData` (PostgREST → SharePoint), so production is never silently
@@ -28,41 +28,28 @@ involves several non-obvious trade-offs, so it warrants an ADR alongside the spe
      masked by legacy.
    A genuinely-empty-but-successful result (Map size 0) is **not** a failure — it is used as
    a normal zero-URL Semrush run in both modes. Flag off (no override) = legacy only.
-2. **What counts as a Semrush FAILURE (`null`), at the SURFACE granularity.** The loader
-   returns `null` on: no org/brand, transient
-   brand-resolution failure, no date window, IMS-token failure, or when a **whole
-   surface (hostname) produced zero successful responses**. Rationale: a dropped
-   *surface* (all YouTube or all Reddit engines failed) is indistinguishable from a
-   genuine zero and must fall back; a **single failed engine is a partial count**,
-   not a dropped surface, and is tolerated (the successful engines still contribute).
-   This keeps the strictness aligned with the "don't drop a surface" goal rather than
-   over-firing on any one of ~12 requests. **Follow-up:** a bounded retry on
-   retriable statuses (`RETRIABLE_STATUSES`) — as the legacy path does — would
-   further reduce transient surface-level fallbacks; not in this PR.
-2b. **`dataSource` on the audit result.** `auditResult.dataSource` = `'semrush'` |
-   `'legacy'`, plus one of two structured signals depending on outcome: a fully-failed
-   attempt sets `fallbackReason` to a specific code (`no-organization-id`,
+2. **A single `domain-urls` request — no `hostname`, `platform=all` — serves all three
+   buckets.** LLMO-6844 made `hostname` optional (returns URLs across every source host)
+   and LLMO-6818 added `platform=all` (aggregates citations across every AI engine
+   server-side). One request returns a citations-sorted page spanning every host and
+   engine; the worker classifies each row client-side into `youtube.com`, `reddit.com`, or
+   third-party "cited" (`domain: null`) — see `classifyRow` in the loader.
+3. **Failure is whole-request.** With one request, there's no per-engine partial
+   tolerance — the loader returns `null` on: no org/brand, transient brand-resolution
+   failure, no date window, IMS-token failure, or the `domain-urls` request itself failing
+   (network error, timeout, non-2xx, unparseable body). `auditResult.dataSource` =
+   `'semrush'` | `'legacy'`, plus `fallbackReason` on failure (`no-organization-id`,
    `no-active-brand`, `brand-resolution-failed`, `no-date-window`, `ims-token-failed`,
-   or `surface-failed:<hostname>`) instead of one generic string; a *succeeded* attempt
-   that still tolerated partial engine/auth failures (Decision 2 above) sets
-   `semrushEngineFailureCount` / `semrushDegradedHosts` so that degradation is visible
-   without going back to logs — `dataSource: 'semrush'` alone does not distinguish a
-   clean run from one where some engines failed. Any 401/403 among the tolerated
-   failures is also logged as a distinct WARN even on overall success, since an
-   intermittent auth rejection is the signal to watch for during the pre-LLMO-6709
-   window. All of this feeds shadow-run parity (LLMO-6711) without grepping logs.
-2c. **Scope + hygiene guards.** Off-host (`domain: null`) rows are dropped so nothing
-   leaks into the top-cited bucket / TOP_CITED scrape; citations are clamped
-   (`Math.max(0, …)`) and URLs with total count ≤ 0 are dropped so a negative/zero
-   value can't corrupt the citations-descending ranking.
-3. **Explicit multi-engine query, not an omitted `platform`.** Omitting `platform`
-   on `domain-urls`/`cited-domains` does **not** aggregate across engines (the
-   proxy resolves it to a single default engine). We query the full offsite provider
-   set mapped to serenity models — `SEMRUSH_PLATFORM_BY_PROVIDER` (`google-ai-mode`,
-   `search-gpt`, `microsoft-copilot`, `gemini-2.5-flash`, `google-ai-overview`,
-   `perplexity`) — and **sum** citations per URL. Validating this map upstream is
-   LLMO-6710.
-4. **Auth = IMS service bearer via v2 `getServiceAccessToken()` (`authorization_code`
+   `domain-urls-auth-failed` for a 401/403, or `domain-urls-failed` otherwise) — feeds
+   shadow-run parity (LLMO-6711) without grepping logs.
+4. **Per-row bucket + hygiene filters (`classifyRow`).** `youtube.com` / `reddit.com` rows
+   must additionally pass `YOUTUBE_URL_REGEX` / `REDDIT_URL_REGEX` (drops non-thread Reddit
+   and lookalike YouTube hosts, matching the legacy classify). Third-party rows are dropped
+   when `contentType: "Owned"`, when the host is in `TOP_CITED_EXCLUDED_DOMAINS` (e.g.
+   `wikipedia.org`), or when `isExcludedCitedHost` flags a social/search/brand-lookalike
+   host — the legacy top-cited gate, now applied per URL rather than per domain rollup.
+   Citations are clamped (`Math.max(0, …)`) and zero-citation URLs are dropped.
+5. **Auth = IMS service bearer via v2 `getServiceAccessToken()` (`authorization_code`
    grant), default IMS client.** This is the same S2S path `commerce-product-enrichments`,
    `vulnerabilities` and `permissions` use. v3 `getServiceAccessTokenV3()`
    (`client_credentials`) was tried first but returns IMS **`400 unauthorized_client`** —
@@ -71,63 +58,60 @@ involves several non-obvious trade-offs, so it warrants an ADR alongside the spe
    The token is forwarded unchanged to Semrush; no `x-promise-token` for a service caller.
    **Open risk (LLMO-6709):** the proxy is designed around a real *user* IMS token, so whether
    Semrush accepts the worker's *service* token is unverified — the flag stays off until
-   confirmed end-to-end (use `enableSemrush:true` on one canary run, per Decision 6, to test).
-5. **Format parity.** The loader re-applies `YOUTUBE_URL_REGEX` / `REDDIT_URL_REGEX`
-   (matching the legacy `handler.js` classify) so non-thread Reddit and lookalike
-   YouTube hosts are dropped identically.
-6. **Per-run override via Slack custom arg — how the first live runs get tested.**
+   confirmed end-to-end (use `enableSemrush:true` on one canary run, per Decision 7, to test).
+6. **`PAGE_SIZE` is a fixed constant (1000).** The response is sorted by
+   citations globally across every host, so a low-citation bucket can be starved by too
+   small a page — a generous page is cheap since it's one request either way. 1000 is the
+   `domain-urls` server-side `pageSize` clamp, so it's the max we can actually get currently.
+7. **Per-run override via Slack custom arg — how the first live runs get tested.**
    `enableSemrush` (`auditContext.messageData.enableSemrush`, resolved by
    `resolveEnableSemrush`) lets a single Slack-triggered `offsite-brand-presence` /
    `cited-analysis` / `youtube-analysis` / `reddit-analysis` run override the env var —
    `true` forces the Semrush attempt on for that run **and makes a failure a hard stop with
    no legacy fallback** (Decision 1), `false` forces legacy even when the env var is on,
-   anything else (absent, empty, invalid) falls through to the env var unchanged. This is the intended mechanism for verifying LLMO-6709 against the real
-   Semrush proxy on one site at a time, before `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED`
-   is flipped fleet-wide. Same tri-state mechanism as the existing `enableBrandProfile`
-   override. It is a **per-run** override only (one Slack invocation), not the persistent
-   **per-site** cutover tracked under LLMO-6711.
+   anything else (absent, empty, invalid) falls through to the env var unchanged. This is the
+   intended mechanism for verifying LLMO-6709 against the real Semrush proxy on one site at a
+   time, before `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED` is flipped fleet-wide. Same tri-state
+   mechanism as the existing `enableBrandProfile` override. It is a **per-run** override only
+   (one Slack invocation), not the persistent **per-site** cutover tracked under LLMO-6711.
 
 ## Consequences
 
-- Enabling the flag can never silently zero out offsite (fallback), but the
-  fallback **masks** Semrush failures — read `auditResult.dataSource` /
-  `fallbackReason` (and the `Service token rejected` / `No successful Semrush
-  response` logs) to know when Semrush is not actually serving.
-- `pageSize=100` assumes a server-side citations-descending sort (unconfirmed); the
-  loader logs a truncation warning on a full page so an unsorted/capped response is
-  visible rather than silently dropping high-citation URLs.
-- The flag is **environment-global** (not per-site); per-site cutover is LLMO-6711.
-  A per-run Slack override (`enableSemrush`, see Decision 6) exists for ad-hoc testing
-  of one run, but does not persist across runs or substitute for the per-site cutover.
+- Enabling the flag can never silently zero out offsite (fallback), but the fallback
+  **masks** Semrush failures — read `auditResult.dataSource` / `fallbackReason` (and the
+  `Service token rejected` / `domain-urls returned HTTP` logs) to know when Semrush is not
+  actually serving.
+- **Request volume dropped from ~12–78 requests to exactly 1** per audit run. The
+  trade-off is coverage risk at the tails: a bucket whose citation volume is
+  systematically lower than the others (e.g. `reddit.com` on a site where third-party
+  press coverage dominates) can be starved within one global-citations-sorted page —
+  mitigated, not eliminated, by the generous fixed `PAGE_SIZE`.
+- The flag is **environment-global** (not per-site); per-site cutover is LLMO-6711. The
+  per-run Slack override (Decision 7) exists for ad-hoc testing of one run only.
 
 ## Known gaps / non-goals (tracked)
 
-- **Region scoping** is not implemented; the legacy path spans `ACCEPTED_REGIONS`
-  (six markets) while this loader sends no region. Documented as a follow-up
-  (LLMO-6710) — must be closed before non-US parity can be claimed.
-- Generic "cited" (third-party) bucket — needs a `cited-domains` discovery hop
-  (LLMO-6709 follow-up).
+- **Region scoping** is not implemented; the legacy path spans `ACCEPTED_REGIONS` (six
+  markets) while this loader sends no region. Follow-up: LLMO-6710 — must close before
+  non-US parity can be claimed.
+- **Per-domain diversity within the cited bucket** is not enforced: the loader emits every
+  qualifying third-party row and relies on `selectTopUrls`'s top-N-by-citations logic
+  downstream, so a single very-high-citation domain can dominate the cited bucket.
 
 ## Enablement runbook (ordered gates before turning the flag on anywhere)
 
 The flag-off path is safe to merge now. Before `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED=true`
 fleet-wide in any environment, close these in order (LLMO-6709 → 6711). The per-run Slack
-override (`enableSemrush`, Decision 6) is the intended tool for step 1 below: use it to run a
-single live request against the real Semrush proxy on one site and confirm the auth path
-works end-to-end, before flipping the env var for the whole fleet.
+override (`enableSemrush`, Decision 7) is the intended tool for step 1: run a single live
+request against the real Semrush proxy on one site and confirm the auth path works
+end-to-end before flipping the env var fleet-wide.
 
 1. **Auth/authz verified (LLMO-6709).** Confirm the worker's **service** IMS token is
-   accepted by the Semrush proxy end-to-end (it is forwarded unchanged; the proxy is designed
-   around a *user* token). Confirm `tracingFetch` does **not** emit the `Authorization` header
-   into traces/spans (service-bearer leak). Confirm the token is org-scoped, or document that
-   tenant isolation is fully delegated to the proxy's per-caller org authz — the worker sends
-   `spaceCatId = site.getOrganizationId()` with a broad service token and asserts no boundary
-   itself (confused-deputy surface).
+   accepted by the Semrush proxy end-to-end. Confirm `tracingFetch` does not emit the
+   `Authorization` header into traces/spans (service-bearer leak).
 2. **`dataSource` shipped** (this PR) — so parity can be measured.
-3. **Shadow-run parity on a canary site (LLMO-6711)** — top-70 overlap per surface vs legacy.
-4. **Fleet enable** per environment (the flag is environment-global) — **US markets only**
-   until region scoping (LLMO-6710, see Known gaps below) closes; non-US parity cannot be
-   claimed before then.
+3. **Shadow-run parity on a canary site (LLMO-6711)** — top-70 overlap per bucket vs legacy.
+4. **Fleet enable** per environment — **US markets only** until region scoping (LLMO-6710) closes.
 
 ## Configuration / client-convention debt (to resolve before the 3rd caller)
 
@@ -144,7 +128,9 @@ tracking ticket will be filed before this debt is resolved; not required to clos
 
 - **No fallback (Semrush-only when on).** Rejected: a Semrush outage would zero out
   offsite for every audited site with no safety net.
-- **Per-domain fallback** (fall back only for the failed surface). Deferred: more
-  complex; the full-run fallback is simpler and strictly safe.
-- **Omit `platform` and rely on server-side aggregation.** Rejected: not how these
-  two endpoints resolve an absent platform (single-engine narrowing).
+- **Per-hostname × per-engine fan-out, summing citations client-side, plus a two-hop
+  `cited-domains` → `domain-urls` discovery walk for the third-party bucket.** Superseded
+  once LLMO-6844 (optional `hostname`) and LLMO-6818 (`platform=all`) landed: a single
+  hostname-less, `platform=all` request now returns every host's URLs, already aggregated,
+  in one citations-sorted page — producing the same exact-citation-count contract with 1
+  request instead of up to 78, with no separate domain-discovery hop needed.

--- a/docs/specs/2026-08-05-offsite-cited-urls-semrush-source.md
+++ b/docs/specs/2026-08-05-offsite-cited-urls-semrush-source.md
@@ -4,7 +4,7 @@
 **Author:** Andrei Paraschiv
 **Date:** 2026-08-05
 **Epic:** [LLMO-6488](https://jira.corp.adobe.com/browse/LLMO-6488) · **Story:** [LLMO-6709](https://jira.corp.adobe.com/browse/LLMO-6709)
-**Related:** ADR `docs/decisions/002-offsite-cited-urls-semrush-source.md` · migration plan `docs/plans/2026-07-17-offsite-cited-urls-semrush-migration.md` · PR #2847 · [LLMO-6844](https://jira.corp.adobe.com/browse/LLMO-6844) (optional `hostname`) · [LLMO-6818](https://jira.corp.adobe.com/browse/LLMO-6818) (`platform=all`)
+**Related:** ADR `docs/decisions/002-offsite-cited-urls-semrush-source.md` · migration plan `docs/plans/2026-07-17-offsite-cited-urls-semrush-migration.md` · PR #2847 (original per-hostname × per-engine design) · PR #2868 (single-request revision) · [LLMO-6844](https://jira.corp.adobe.com/browse/LLMO-6844) (optional `hostname`) · [LLMO-6818](https://jira.corp.adobe.com/browse/LLMO-6818) (`platform=all`)
 
 ---
 

--- a/docs/specs/2026-08-05-offsite-cited-urls-semrush-source.md
+++ b/docs/specs/2026-08-05-offsite-cited-urls-semrush-source.md
@@ -4,7 +4,7 @@
 **Author:** Andrei Paraschiv
 **Date:** 2026-08-05
 **Epic:** [LLMO-6488](https://jira.corp.adobe.com/browse/LLMO-6488) · **Story:** [LLMO-6709](https://jira.corp.adobe.com/browse/LLMO-6709)
-**Related:** ADR `docs/decisions/002-offsite-cited-urls-semrush-source.md` · migration plan `docs/plans/2026-07-17-offsite-cited-urls-semrush-migration.md` · PR #2847
+**Related:** ADR `docs/decisions/002-offsite-cited-urls-semrush-source.md` · migration plan `docs/plans/2026-07-17-offsite-cited-urls-semrush-migration.md` · PR #2847 · [LLMO-6844](https://jira.corp.adobe.com/browse/LLMO-6844) (optional `hostname`) · [LLMO-6818](https://jira.corp.adobe.com/browse/LLMO-6818) (`platform=all`)
 
 ---
 
@@ -25,14 +25,15 @@ selection.
 - Preserve today's selection semantics: `selectTopUrls` (per-surface top-70, ranked by
   citations) and the DRS scrape / poll / analysis path are **unchanged**.
 - Behavioral parity with the legacy path for the URL set it produces.
+- Source **all three buckets — youtube.com, reddit.com, and third-party "cited"** — from a
+  **single** `domain-urls` request per audit run (LLMO-6844 + LLMO-6818).
 
 **Non-goals (known gaps, tracked)**
-- The generic "cited" (top third-party) bucket — needs a `cited-domains` discovery hop;
-  tracked as a follow-up under LLMO-6709. This spec covers **YouTube + Reddit** only.
 - **Region scoping.** The legacy path spans `ACCEPTED_REGIONS` (six markets) while this loader
-  sends **no region param**. If the endpoint defaults to a single region, non-US orgs will
-  diverge from legacy. Deferred to LLMO-6710 (region + platform mapping) — must be closed
-  before non-US parity is claimed.
+  sends **no region param**. Deferred to LLMO-6710 — must be closed before non-US parity is
+  claimed.
+- **Per-domain diversity within the cited bucket.** The loader does not cap how many URLs a
+  single third-party domain contributes; `selectTopUrls` downstream ranks by citations only.
 - Changing ranking, bucketing, DRS, or the analysis audits.
 - Per-URL prompt attribution (LLMO-6712) and topic/category enrichment (LLMO-6708).
 
@@ -40,17 +41,25 @@ selection.
 
 ### 3.1 Endpoint (spacecat-api-service wrapper)
 
-`GET {SPACECAT_API_URI}/v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/domain-urls?hostname={host}&startDate=&endDate=&pageSize=100`
+**One** `url-inspector` endpoint call, served by the api-service **Elements proxy**
+(`src/controllers/elements.js` → `listDomainUrls`, Semrush element `STATS_PER_URL`); path
+segments (`spaceCatId`, `brandId`) are URL-encoded:
 
-Served by the api-service **Elements proxy** (`src/controllers/elements.js` →
-`listDomainUrls`, Semrush element `STATS_PER_URL`). Response: `{ urls: [{ url, citations,
-promptsCited, categories, regions, contentType, urlId }] }`. `llmo.experiencecloud.live/api/v1`
-is an edge alias for the same service. Path segments (`spaceCatId`, `brandId`) are URL-encoded.
+```
+GET {SPACECAT_API_URI}/v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence
+    /url-inspector/domain-urls?platform=all&startDate=&endDate=&pageSize=1000
+```
 
-`pageSize=100` covers the per-surface top-70 in one page. A server-side citations-descending
-sort is **assumed but not confirmed**; the loader logs a truncation warning on a full page so a
-capped/unsorted response is visible rather than silently dropping high-citation URLs. Each
-request carries a 10s timeout; requests run concurrently.
+No `hostname` is sent — LLMO-6844 made it optional, so the endpoint returns URLs across
+**every** source host instead of one. `platform=all` (LLMO-6818) aggregates citations across
+every AI engine **server-side**. Response:
+`{ urls: [{ url, citations, promptsCited, categories, regions, contentType, urlId }],
+totalCount }`, sorted by citations descending.
+
+The request carries a 10s timeout. `PAGE_SIZE` (1000, a fixed constant — §3.4) matches the
+`domain-urls` server-side `pageSize` clamp — the max we can actually get in one page. The
+loader logs a truncation warning on a full page, since the sort is global across every host
+and a low-citation bucket can be starved by too small a page.
 
 ### 3.2 Auth
 
@@ -69,14 +78,21 @@ flag stays off until verified (test one canary run via the `enableSemrush:true` 
 
 1. Resolve `spaceCatId = site.getOrganizationId()`, `brandId = resolveBrandForSite(...)`,
    `{ startDate, endDate } = getDateWindowForPreviousWeeks(previousWeeks)`.
-2. For each `OFFSITE_DOMAINS` hostname (`youtube.com`, `reddit.com`) × each configured platform,
-   call `domain-urls` and fold rows into `allUrls`:
+2. Make the single `domain-urls` request (§3.1) and classify each row (`classifyRow`):
    - normalize + classify via the shared `classifyAndNormalize` (owned-URL filtering, youtu.be
      canonicalization, domain assignment);
-   - **enforce `YOUTUBE_URL_REGEX` / `REDDIT_URL_REGEX`** (parity with `handler.js:199-204`) so
-     non-thread Reddit URLs and lookalike YouTube hosts are dropped, matching the legacy path;
-   - `count = row.citations` (exact); sum across platforms for the same URL.
-3. Handler branch: when `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED === 'true'` it tries Semrush
+   - every other row is the third-party "cited" bucket (`domain: null`), **unless**
+     `contentType: "Owned"`, the host is in `TOP_CITED_EXCLUDED_DOMAINS` (e.g.
+     `wikipedia.org`), or `isExcludedCitedHost` (social/search/brand-owned-lookalike + brand
+     tokens) flags it — the legacy top-cited gate, applied per URL row instead of per
+     domain-level rollup;
+   - `count = row.citations` (exact, already summed across every engine server-side); citations
+     are clamped (`Math.max(0, …)`) and a zero-citation URL is dropped; duplicate URLs within
+     the page are summed defensively.
+3. **Format parity.** The loader re-applies `YOUTUBE_URL_REGEX` / `REDDIT_URL_REGEX`
+   (matching the legacy `handler.js` classify) to `youtube.com` / `reddit.com` rows so
+   non-thread Reddit and lookalike YouTube hosts are dropped identically.
+4. Handler branch: when `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED === 'true'` it tries Semrush
    **first**; if the loader yields no usable URLs (auth failure, no brand, outage, empty result)
    it **falls back** to the legacy `loadBrandPresenceData` (PostgREST → SharePoint) +
    `extractUrlsAndTopics`, so a Semrush problem can never silently zero out offsite. Flag off =
@@ -84,27 +100,14 @@ flag stays off until verified (test one canary run via the `enableSemrush:true` 
    A Slack-triggered `offsite-brand-presence`/`cited-analysis`/`youtube-analysis`/`reddit-analysis`
    run can override this env var for that single run via the `enableSemrush` custom arg
    (`auditContext.messageData.enableSemrush`, resolved by `resolveEnableSemrush` — same
-   tri-state mechanism as `enableBrandProfile`); `cited-analysis`/`youtube-analysis`/
-   `reddit-analysis` forward it through `requestOffsiteScrape` so the override survives when
-   they trigger a scoped `offsite-brand-presence` re-scrape. See ADR-002 decision 6.
+   tri-state mechanism as `enableBrandProfile`). See ADR-002 decision 7.
 
-### 3.4 Platform aggregation
-
-Omitting `platform` does **not** aggregate across engines on `domain-urls`/`cited-domains` —
-the proxy resolves an absent value to a single default engine. So the loader queries an
-**explicit engine list** — the full offsite provider set mapped to serenity models via
-`SEMRUSH_PLATFORM_BY_PROVIDER` (offsite `constants.js`): `google-ai-mode`, `search-gpt`,
-`microsoft-copilot`, `gemini-2.5-flash`, `google-ai-overview`, `perplexity` — and **sums**
-citations per URL, mirroring the legacy multi-engine mix. `OFFSITE_SEMRUSH_PLATFORMS`
-(comma-separated) queries each engine and **sums citations per URL**. (LLMO-6710.)
-
-### 3.5 Config
+### 3.4 Config
 
 | Env | Default | Purpose |
 |---|---|---|
 | `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED` | (off) | `"true"` switches source to Semrush |
 | `SPACECAT_API_URI` | `https://spacecat.experiencecloud.live/api/v1` | api-service base |
-| `OFFSITE_SEMRUSH_PLATFORMS` | full provider set (`SEMRUSH_PLATFORM_BY_PROVIDER`) | override: engines to query + sum |
 | `enableSemrush` (Slack custom arg, not an env var) | (unset — env var applies) | per-run override of `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED` |
 
 ## 4. Alternatives considered
@@ -113,24 +116,32 @@ citations per URL, mirroring the legacy multi-engine mix. `OFFSITE_SEMRUSH_PLATF
   the migration plan) — superseded: the api-service wrapper already exists and is UI-validated.
 - **Route Semrush rows through the existing `extractUrlsAndTopics`** — rejected: it recounts by
   repetition and would discard the exact citation numbers.
+- **Per-hostname × per-engine fan-out, summing citations client-side, plus a two-hop
+  `cited-domains` → `domain-urls` discovery walk for the third-party bucket.** Superseded once
+  LLMO-6844 (optional `hostname`) and LLMO-6818 (`platform=all`) landed: the single
+  hostname-less, `platform=all` request already returns every host's URLs, aggregated, in one
+  citations-sorted page — the same exact-citation-count contract with 1 request instead of up
+  to 78, with no separate domain-discovery hop.
 
 ## 5. Behavioral-parity note (reviewer follow-up)
 
 There are two `classifyAndNormalize` functions: the enrichment one (hostname match +
 normalization) and the stricter `handler.js` one (adds `YOUTUBE_URL_REGEX` / `REDDIT_URL_REGEX`
-+ `isExcludedCitedHost`). The loader normalizes with the former and **re-applies the two
-regexes** to match the legacy filter for its YouTube/Reddit scope. `isExcludedCitedHost` /
-brand-token filtering only affect the top-cited bucket and will be applied when that bucket is
-added.
++ `isExcludedCitedHost`). The loader normalizes with the former and re-creates the stricter
+filter itself in `classifyRow`: it **re-applies the two regexes** to the YouTube/Reddit rows,
+and applies `TOP_CITED_EXCLUDED_DOMAINS` + `isExcludedCitedHost` + brand tokens to the
+third-party "cited" rows — matching the legacy filter for each bucket.
 
 ## 6. Success criteria
 
 - Flag off ⇒ byte-for-byte today's behavior (no regression).
-- Flag on ⇒ YouTube/Reddit cited URLs come from Semrush with exact citation counts; strict
-  format filtering matches the legacy path.
-- Env-enabled + Semrush fails ⇒ automatic fallback to the legacy PostgREST → SharePoint
+- Flag on ⇒ YouTube/Reddit and top-cited third-party URLs come from Semrush with exact
+  citation counts (server-side-aggregated across engines via `platform=all`); strict format
+  filtering and the top-cited earned-host gate match the legacy path.
+- Flag on + Semrush unavailable ⇒ automatic fallback to the legacy PostgREST → SharePoint
   source (no offsite gap).
 - `enableSemrush:true` (Slack override) + Semrush fails ⇒ **hard stop** (`success:false`,
   `dataSource:'semrush'`, no fallback) so the failure is visible during LLMO-6709 testing.
-- Shadow-run (LLMO-6711) shows acceptable top-70 overlap per surface vs the legacy source.
+- Shadow-run (LLMO-6711) shows acceptable top-70 overlap per bucket vs the legacy source.
+- Exactly one `domain-urls` request per audit run when Semrush is enabled.
 - 100% test coverage on the new module; full suite green.

--- a/src/offsite-brand-presence/constants.js
+++ b/src/offsite-brand-presence/constants.js
@@ -28,9 +28,10 @@ export const PROVIDERS_SET = new Set(PROVIDERS);
 // Serenity/Semrush `platform` (model) value per offsite audit provider. Values
 // are the SerenityModel enum (see project-elmo-ui `src/api/serenityApi.ts`).
 // 'all' (chatgpt-paid) has no distinct serenity model — 'search-gpt' covers it —
-// so it is intentionally omitted. Used by the Semrush URL-Inspector loader to
-// query each engine explicitly (omitting `platform` narrows to one engine, it
-// does NOT aggregate). Completing/validating this map is LLMO-6710.
+// so it is intentionally omitted. Currently unused: the Semrush URL-Inspector loader
+// (offsite-brand-presence-semrush.js) queries `platform=all`, which aggregates across
+// every engine server-side, instead of walking this map per engine. Kept for LLMO-6710
+// (region + platform mapping) — completing/validating it is that follow-up's job.
 export const SEMRUSH_PLATFORM_BY_PROVIDER = Object.freeze({
   'ai-mode': 'google-ai-mode',
   chatgpt: 'search-gpt',

--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -980,21 +980,9 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
         allUrls.set(url, info);
       }
       usedSemrush = true;
-      // Surfaced even on success: a run that tolerated partial engine/auth failures
-      // reports the same dataSource: 'semrush' as a clean run otherwise, which is
-      // exactly the signal LLMO-6711's shadow-run parity work needs to avoid grepping
-      // logs, and the one auth-rejection signal that matters most pre-LLMO-6709.
-      if (semrushDiagnostics.authFailureDetected) {
-        log.warn(`${LOG_PREFIX} Semrush succeeded but at least one engine request returned 401/403 — possible auth/token issue during the pre-LLMO-6709 verification window`, {
-          siteId,
-          degradedHosts: semrushDiagnostics.degradedHosts,
-          engineFailureCount: semrushDiagnostics.engineFailureCount,
-        });
-      }
     }
   }
   const dataSource = usedSemrush ? 'semrush' : 'legacy';
-  const semrushDegraded = usedSemrush && (semrushDiagnostics?.engineFailureCount ?? 0) > 0;
 
   // Legacy source: runs when the flag is off, OR when Semrush was env-enabled but
   // failed (fallback). An enableSemrush:true run that failed already hard-stopped
@@ -1106,10 +1094,6 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
       weeks: previousWeeks,
       dataSource,
       ...(fallbackReason ? { fallbackReason } : {}),
-      ...(semrushDegraded ? {
-        semrushEngineFailureCount: semrushDiagnostics.engineFailureCount,
-        semrushDegradedHosts: semrushDiagnostics.degradedHosts,
-      } : {}),
     },
     fullAuditRef: finalUrl,
   };

--- a/src/utils/offsite-brand-presence-semrush.js
+++ b/src/utils/offsite-brand-presence-semrush.js
@@ -95,9 +95,11 @@ export function buildDomainUrlsUrl({
 /**
  * Fetches the single `domain-urls` page (all hosts, all platforms).
  *
- * @returns {Promise<{ rows: object[], ok: boolean, authFailure: boolean }>} `ok` is false
- *   on network error / timeout / non-2xx / unparseable body. `authFailure` distinguishes a
- *   401/403 (auth issue) from other failures.
+ * @returns {Promise<{ rows: object[], ok: boolean, authFailure: boolean, truncated: boolean }>}
+ *   `ok` is false on network error / timeout / non-2xx / unparseable body. `authFailure`
+ *   distinguishes a 401/403 (auth issue) from other failures. `truncated` is true when a
+ *   full page came back (LLMO-6711 shadow-run parity signal — a starved run is visible on
+ *   `diagnostics` without grepping logs).
  */
 async function fetchDomainUrls(url, headers, log, siteId, pageSize) {
   const ctx = { siteId };
@@ -109,7 +111,9 @@ async function fetchDomainUrls(url, headers, log, siteId, pageSize) {
     log.error(`${LOG_PREFIX} Fetch failed for domain-urls: ${error.message}`, {
       ...ctx, error: error.message, durationMs: Date.now() - startedAt,
     });
-    return { rows: [], ok: false, authFailure: false };
+    return {
+      rows: [], ok: false, authFailure: false, truncated: false,
+    };
   }
 
   if (!response.ok) {
@@ -123,7 +127,9 @@ async function fetchDomainUrls(url, headers, log, siteId, pageSize) {
         ...ctx, status: response.status, durationMs: Date.now() - startedAt,
       });
     }
-    return { rows: [], ok: false, authFailure };
+    return {
+      rows: [], ok: false, authFailure, truncated: false,
+    };
   }
 
   let body;
@@ -133,21 +139,32 @@ async function fetchDomainUrls(url, headers, log, siteId, pageSize) {
     log.error(`${LOG_PREFIX} Could not parse domain-urls response: ${error.message}`, {
       ...ctx, error: error.message, durationMs: Date.now() - startedAt,
     });
-    return { rows: [], ok: false, authFailure: false };
+    return {
+      rows: [], ok: false, authFailure: false, truncated: false,
+    };
   }
 
   const raw = Array.isArray(body?.urls) ? body.urls : [];
-  if (raw.length >= pageSize) {
+  const truncated = raw.length >= pageSize;
+  if (truncated) {
     log.warn(`${LOG_PREFIX} domain-urls returned a full page (${raw.length} >= ${pageSize}); response may be truncated`, {
       ...ctx, rowCount: raw.length, pageSize,
     });
   }
-  return { rows: raw.slice(0, pageSize), ok: true, authFailure: false };
+  return {
+    rows: raw.slice(0, pageSize), ok: true, authFailure: false, truncated,
+  };
 }
 
 /**
  * Classifies one `domain-urls` row into a bucket, or drops it.
  *
+ * - Non-`http(s)` schemes (`mailto:`, `tel:`, `data:`, `javascript:`, `ftp:`, `ws:`, ...) are
+ *   dropped upfront via an explicit allowlist on the raw `row.url`, rather than relying on
+ *   `classifyAndNormalize` happening to produce an unparseable value for some of them
+ *   (opaque schemes serialize `origin` to the literal string `"null"`) — that's incidental
+ *   for opaque schemes and doesn't catch a scheme that reparses cleanly (`ftp:`, `ws:`) but
+ *   is never a real citation source.
  * - `youtube.com` / `reddit.com` — matched via `classifyAndNormalize`, then the strict
  *   format regexes (drops non-thread Reddit URLs and lookalike YouTube hosts).
  * - Everything else is the third-party "cited" bucket (`domain: null`), unless it's
@@ -157,7 +174,20 @@ async function fetchDomainUrls(url, headers, log, siteId, pageSize) {
  * @returns {{url: string, domain: string|null}|null} `null` when the row is dropped.
  */
 function classifyRow(row, siteHostname, brandTokens) {
-  const classified = row?.url ? classifyAndNormalize(row.url, siteHostname) : null;
+  if (!row?.url) {
+    return null;
+  }
+  let scheme;
+  try {
+    scheme = new URL(row.url).protocol;
+  } catch {
+    return null;
+  }
+  if (scheme !== 'http:' && scheme !== 'https:') {
+    return null;
+  }
+
+  const classified = classifyAndNormalize(row.url, siteHostname);
   if (!classified) {
     return null;
   }
@@ -167,17 +197,11 @@ function classifyRow(row, siteHostname, brandTokens) {
   if (classified.domain === 'reddit.com') {
     return REDDIT_URL_REGEX.test(row.url) ? { url: classified.url, domain: 'reddit.com' } : null;
   }
-  if (row?.contentType === 'Owned') {
+  if (row.contentType === 'Owned') {
     return null;
   }
-  let host;
-  try {
-    host = new URL(classified.url).hostname.toLowerCase().replace(/^www\./, '');
-  } catch {
-    // classified.url already passed through classifyAndNormalize's own URL parse, so this
-    // should be unreachable — defensive only, in case that contract ever changes.
-    return null;
-  }
+  // The allowlist above guarantees classified.url is always a reparseable http(s) URL here.
+  const host = new URL(classified.url).hostname.toLowerCase().replace(/^www\./, '');
   if (TOP_CITED_EXCLUDED_DOMAINS.some((d) => host === d || host.endsWith(`.${d}`))) {
     return null;
   }
@@ -213,8 +237,9 @@ function classifyRow(row, siteHostname, brandTokens) {
  * @param {object} [params.diagnostics] - Optional out-param, mutated in place. On a null
  *   return, set to `{ fallbackReason }` with a specific code (`no-organization-id`,
  *   `no-active-brand`, `brand-resolution-failed`, `no-date-window`, `ims-token-failed`,
- *   `domain-urls-auth-failed`, or `domain-urls-failed`). Left unset on a successful return —
- *   with a single request there's no per-engine degradation to report.
+ *   `domain-urls-auth-failed`, or `domain-urls-failed`). On a successful return, set to
+ *   `{ truncated }` — true when the response came back at `PAGE_SIZE`, so a bucket may be
+ *   starved (LLMO-6711 shadow-run parity signal).
  * @returns {Promise<Map<string, {count:number, domain:string|null}> | null>}
  */
 export async function loadCitedUrlsFromSemrush({
@@ -331,6 +356,7 @@ export async function loadCitedUrlsFromSemrush({
     setDiagnostics({ fallbackReason: result.authFailure ? 'domain-urls-auth-failed' : 'domain-urls-failed' });
     return null;
   }
+  setDiagnostics({ truncated: result.truncated });
 
   const brandKeywords = site.getConfig?.()?.getBrandKeywords?.() || [];
   const brandTokens = computeBrandTokens(siteHostname, brandKeywords);

--- a/src/utils/offsite-brand-presence-semrush.js
+++ b/src/utils/offsite-brand-presence-semrush.js
@@ -15,11 +15,11 @@ import { tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
 import { resolveBrandResultForSite } from './brand-resolver.js';
 import { getDateWindowForPreviousWeeks } from './offsite-brand-presence-postgrest.js';
 import { classifyAndNormalize } from './offsite-brand-presence-enrichment.js';
+import { computeBrandTokens, isExcludedCitedHost } from './offsite-audit-utils.js';
 import {
-  OFFSITE_DOMAINS,
+  TOP_CITED_EXCLUDED_DOMAINS,
   YOUTUBE_URL_REGEX,
   REDDIT_URL_REGEX,
-  SEMRUSH_PLATFORM_BY_PROVIDER,
 } from '../offsite-brand-presence/constants.js';
 
 const LOG_PREFIX = '[offsite-brand-presence][semrush]';
@@ -34,54 +34,18 @@ const LOG_PREFIX = '[offsite-brand-presence][semrush]';
 export const SPACECAT_API_DEFAULT_BASE_URL = 'https://spacecat.experiencecloud.live/api/v1';
 
 /**
- * Rows requested per url-inspector page — covers the per-surface top-70
- * (`DRS_URLS_LIMIT`) in a single page. NOTE: a server-side citations-descending
- * sort is *assumed but not confirmed* for `domain-urls`; `fetchRows` logs a
- * truncation warning when a full page comes back and hard-caps the array at
- * `PAGE_SIZE` as defence against a malfunctioning upstream.
+ * `domain-urls` page size. One request (no `hostname`, `platform=all`) covers all three
+ * buckets (youtube.com, reddit.com, cited third-party), sorted by citations globally, so
+ * this needs to be generous or a low-citation bucket gets starved. 1000 is the server-side
+ * clamp (`domain-urls` in spacecat-api-service), so this is the max we can actually get.
  */
-const PAGE_SIZE = 100;
+export const PAGE_SIZE = 1000;
 
 /**
- * Per-request timeout. A hung upstream must never stall the audit, or the whole
- * Semrush attempt (and therefore the legacy fallback in the handler) would never
- * resolve and the Lambda would run to its own timeout — worse than legacy-only.
- * (Unit tests stub the fetch; actual abort behaviour is a shadow-run integration
- * concern, not covered here.)
+ * Per-request timeout so a hung upstream can't stall the whole audit past the Lambda's
+ * own timeout.
  */
 const FETCH_TIMEOUT_MS = 10_000;
-
-/**
- * Default engine (serenity `platform`) values to query — the full offsite
- * provider set mapped to serenity models (`SEMRUSH_PLATFORM_BY_PROVIDER`).
- *
- * IMPORTANT: omitting `platform` does NOT aggregate across engines on the
- * `domain-urls` / `cited-domains` endpoints — the proxy resolves an absent value
- * to a single default engine. To mirror the legacy multi-engine mix we query each
- * engine explicitly and SUM citations per URL.
- */
-export const DEFAULT_SEMRUSH_PLATFORMS = Object.freeze(
-  Object.values(SEMRUSH_PLATFORM_BY_PROVIDER),
-);
-
-/**
- * Resolves which engine platform values to query. `OFFSITE_SEMRUSH_PLATFORMS`
- * (comma-separated) overrides the default list; a blank / separators-only value
- * falls back to the default rather than disabling all requests.
- *
- * @param {object} env - Lambda env.
- * @returns {string[]} platform values (always at least one).
- */
-export function getSemrushPlatforms(env) {
-  const raw = env?.OFFSITE_SEMRUSH_PLATFORMS;
-  if (typeof raw === 'string' && raw.trim()) {
-    const parsed = raw.split(',').map((p) => p.trim()).filter(Boolean);
-    if (parsed.length > 0) {
-      return parsed;
-    }
-  }
-  return [...DEFAULT_SEMRUSH_PLATFORMS];
-}
 
 /**
  * Mints an IMS service access token as an Authorization header value.
@@ -110,111 +74,124 @@ async function getAuthorizationHeader(context) {
 }
 
 /**
- * Builds a url-inspector `domain-urls` request URL. Path segments are
- * URL-encoded (matching `brand-resolver.js`); `platform` is included only when
- * provided.
+ * Builds the single `domain-urls` request URL: no `hostname` (returns every source host)
+ * and `platform=all` (Semrush aggregates citations across every AI engine server-side).
  *
  * @returns {string}
  */
 export function buildDomainUrlsUrl({
-  baseUrl, spaceCatId, brandId, hostname, startDate, endDate, platform,
+  baseUrl, spaceCatId, brandId, startDate, endDate, pageSize,
 }) {
   const params = new URLSearchParams({
     startDate,
     endDate,
-    hostname,
-    pageSize: String(PAGE_SIZE),
+    platform: 'all',
+    pageSize: String(pageSize),
   });
-  if (platform) {
-    params.set('platform', platform);
-  }
   return `${baseUrl}/v2/orgs/${encodeURIComponent(spaceCatId)}/brands/${encodeURIComponent(brandId)}`
     + `/serenity/brand-presence/url-inspector/domain-urls?${params.toString()}`;
 }
 
 /**
- * Fetches one (hostname, platform) page. Every log call carries `siteId`/`hostname`/
- * `platform` as structured fields (in addition to the human-readable message) so a
- * Splunk query can isolate which site/surface/engine combination failed and why,
- * without parsing the message string.
+ * Fetches the single `domain-urls` page (all hosts, all platforms).
  *
- * @returns {Promise<{ hostname: string, rows: object[], ok: boolean, authFailure: boolean }>}
- *   `ok` is false on network error / timeout / non-2xx / unparseable body. `authFailure` is
- *   true specifically for a 401/403 (distinct from other failure causes, since an
- *   intermittent auth/token rejection is the signal to watch during the pre-LLMO-6709
- *   verification window even when tolerated as a partial engine failure). The rows array is
- *   hard-capped at `PAGE_SIZE`.
+ * @returns {Promise<{ rows: object[], ok: boolean, authFailure: boolean }>} `ok` is false
+ *   on network error / timeout / non-2xx / unparseable body. `authFailure` distinguishes a
+ *   401/403 (auth issue) from other failures.
  */
-async function fetchRows({ hostname, platform, url }, headers, log, siteId) {
-  const ctx = { siteId, hostname, platform };
+async function fetchDomainUrls(url, headers, log, siteId, pageSize) {
+  const ctx = { siteId };
   let response;
   const startedAt = Date.now();
   try {
     response = await fetch(url, { headers, timeout: FETCH_TIMEOUT_MS });
   } catch (error) {
-    log.error(`${LOG_PREFIX} Fetch failed for ${hostname}: ${error.message}`, {
+    log.error(`${LOG_PREFIX} Fetch failed for domain-urls: ${error.message}`, {
       ...ctx, error: error.message, durationMs: Date.now() - startedAt,
     });
-    return {
-      hostname, rows: [], ok: false, authFailure: false,
-    };
+    return { rows: [], ok: false, authFailure: false };
   }
 
   if (!response.ok) {
     const authFailure = response.status === 401 || response.status === 403;
     if (authFailure) {
-      // Distinct branch so a rejected service token is visible instead of being
-      // masked as "Semrush returned nothing" (LLMO-6709 verification).
-      log.error(`${LOG_PREFIX} Service token rejected for ${hostname} (HTTP ${response.status}) — verify the IMS service token is authorized by the Semrush proxy (LLMO-6709)`, {
+      log.error(`${LOG_PREFIX} Service token rejected for domain-urls (HTTP ${response.status}) — verify the IMS service token is authorized by the Semrush proxy (LLMO-6709)`, {
         ...ctx, status: response.status, durationMs: Date.now() - startedAt,
       });
     } else {
-      log.error(`${LOG_PREFIX} ${hostname} returned HTTP ${response.status}`, {
+      log.error(`${LOG_PREFIX} domain-urls returned HTTP ${response.status}`, {
         ...ctx, status: response.status, durationMs: Date.now() - startedAt,
       });
     }
-    return {
-      hostname, rows: [], ok: false, authFailure,
-    };
+    return { rows: [], ok: false, authFailure };
   }
 
   let body;
   try {
     body = await response.json();
   } catch (error) {
-    log.error(`${LOG_PREFIX} Could not parse ${hostname} response: ${error.message}`, {
+    log.error(`${LOG_PREFIX} Could not parse domain-urls response: ${error.message}`, {
       ...ctx, error: error.message, durationMs: Date.now() - startedAt,
     });
-    return {
-      hostname, rows: [], ok: false, authFailure: false,
-    };
+    return { rows: [], ok: false, authFailure: false };
   }
 
   const raw = Array.isArray(body?.urls) ? body.urls : [];
-  if (raw.length >= PAGE_SIZE) {
-    log.warn(`${LOG_PREFIX} ${hostname} returned a full page (${raw.length} >= ${PAGE_SIZE}); response may be truncated — top URLs by citations could be missing`, {
-      ...ctx, rowCount: raw.length, pageSize: PAGE_SIZE,
+  if (raw.length >= pageSize) {
+    log.warn(`${LOG_PREFIX} domain-urls returned a full page (${raw.length} >= ${pageSize}); response may be truncated`, {
+      ...ctx, rowCount: raw.length, pageSize,
     });
   }
-  return {
-    hostname, rows: raw.slice(0, PAGE_SIZE), ok: true, authFailure: false,
-  };
+  return { rows: raw.slice(0, pageSize), ok: true, authFailure: false };
 }
 
 /**
- * Loads the offsite cited URLs from the Semrush-backed Serenity URL-Inspector
- * endpoints (via the spacecat-api-service Elements proxy), producing the exact
- * `allUrls: Map<url, { count, domain }>` shape the existing `selectTopUrls` -> DRS
- * pipeline consumes. `count` = exact citation volume (summed across engines).
+ * Classifies one `domain-urls` row into a bucket, or drops it.
  *
- * Returns `null` (so the handler falls back to the legacy source) when a usable
- * result cannot be produced: no org/brand, transient brand-resolution failure,
- * no date window, auth failure, or when a whole surface (hostname) produced zero
- * successful responses. A single failed engine is tolerated as a partial count.
+ * - `youtube.com` / `reddit.com` — matched via `classifyAndNormalize`, then the strict
+ *   format regexes (drops non-thread Reddit URLs and lookalike YouTube hosts).
+ * - Everything else is the third-party "cited" bucket (`domain: null`), unless it's
+ *   `contentType: 'Owned'`, in `TOP_CITED_EXCLUDED_DOMAINS` (e.g. `wikipedia.org`), or a
+ *   social/search/brand-lookalike host per `isExcludedCitedHost`.
  *
- * Scope: youtube.com + reddit.com only — off-host rows are dropped so nothing
- * leaks into the top-cited bucket. Region scoping and the generic cited bucket
- * are follow-ups (LLMO-6709 / LLMO-6710).
+ * @returns {{url: string, domain: string|null}|null} `null` when the row is dropped.
+ */
+function classifyRow(row, siteHostname, brandTokens) {
+  const classified = row?.url ? classifyAndNormalize(row.url, siteHostname) : null;
+  if (!classified) {
+    return null;
+  }
+  if (classified.domain === 'youtube.com') {
+    return YOUTUBE_URL_REGEX.test(row.url) ? { url: classified.url, domain: 'youtube.com' } : null;
+  }
+  if (classified.domain === 'reddit.com') {
+    return REDDIT_URL_REGEX.test(row.url) ? { url: classified.url, domain: 'reddit.com' } : null;
+  }
+  if (row?.contentType === 'Owned') {
+    return null;
+  }
+  const host = new URL(classified.url).hostname.toLowerCase().replace(/^www\./, '');
+  if (TOP_CITED_EXCLUDED_DOMAINS.some((d) => host === d || host.endsWith(`.${d}`))) {
+    return null;
+  }
+  if (isExcludedCitedHost(host, brandTokens)) {
+    return null;
+  }
+  return { url: classified.url, domain: null };
+}
+
+/**
+ * Loads the offsite cited URLs from the Semrush-backed `domain-urls` endpoint (via the
+ * spacecat-api-service Elements proxy) in a single request — no `hostname`, `platform=all`
+ * — producing the `allUrls: Map<url, { count, domain }>` shape `selectTopUrls` -> DRS
+ * consumes. `count` = exact citations, aggregated across every AI engine by Semrush.
+ *
+ * Returns `null` (so the handler falls back to the legacy source) when no usable result can be
+ * produced: no org/brand, transient brand-resolution failure, no date window, IMS token
+ * failure, or the `domain-urls` request itself failed.
+ *
+ * The response is split client-side into three buckets: `youtube.com`, `reddit.com`, and
+ * third-party "cited" — see `classifyRow`. Region scoping remains a follow-up (LLMO-6710).
  *
  * @param {object} params
  * @param {object} params.site - Site model (`getOrganizationId()`).
@@ -333,144 +310,62 @@ export async function loadCitedUrlsFromSemrush({
     ...(context.promiseToken ? { 'x-promise-token': context.promiseToken } : {}),
   };
 
-  const platforms = getSemrushPlatforms(env);
-  const requests = [];
-  for (const hostname of Object.keys(OFFSITE_DOMAINS)) {
-    for (const platform of platforms) {
-      requests.push({
-        hostname,
-        platform,
-        url: buildDomainUrlsUrl({
-          baseUrl, spaceCatId, brandId: brand.brandId, hostname, startDate, endDate, platform,
-        }),
-      });
-    }
-  }
-  const hostnames = Object.keys(OFFSITE_DOMAINS);
-  log.info(`${LOG_PREFIX} Querying ${hostnames.length} hostnames x ${platforms.length} platforms (${requests.length} requests)`, {
-    siteId, orgId: spaceCatId, brandId: brand.brandId, hostnames, platforms,
+  const url = buildDomainUrlsUrl({
+    baseUrl, spaceCatId, brandId: brand.brandId, startDate, endDate, pageSize: PAGE_SIZE,
   });
-  await notify(`:satellite: Querying ${hostnames.length} surface(s) x ${platforms.length} engine(s) (${requests.length} requests)...`);
+  log.info(`${LOG_PREFIX} Querying domain-urls (all hosts, all platforms)`, {
+    siteId, orgId: spaceCatId, brandId: brand.brandId, pageSize: PAGE_SIZE,
+  });
+  await notify(':satellite: Querying `domain-urls` (all hosts, all platforms) in a single request...');
 
-  const results = await Promise.all(requests.map((r) => fetchRows(r, headers, log, siteId)));
-
-  // Group by surface (hostname). Fall back to legacy only when a whole surface
-  // produced ZERO successful responses (that surface would be dropped) — a single
-  // failed engine is a partial count, not a dropped surface, and is tolerated.
-  const byHost = new Map();
-  for (const hostname of Object.keys(OFFSITE_DOMAINS)) {
-    byHost.set(hostname, {
-      anyOk: false, okCount: 0, failCount: 0, authFailureCount: 0, rows: [],
+  const result = await fetchDomainUrls(url, headers, log, siteId, PAGE_SIZE);
+  if (!result.ok) {
+    log.warn(`${LOG_PREFIX} domain-urls request failed; using legacy fallback`, {
+      siteId, orgId: spaceCatId, durationMs: elapsed(),
     });
-  }
-  for (const result of results) {
-    const entry = byHost.get(result.hostname);
-    if (result.ok) {
-      entry.anyOk = true;
-      entry.okCount += 1;
-      entry.rows.push(...result.rows);
-    } else {
-      entry.failCount += 1;
-      if (result.authFailure) {
-        entry.authFailureCount += 1;
-      }
-    }
-  }
-  for (const [hostname, entry] of byHost) {
-    // One summary line per hostname (not per-request) — enough to see partial engine
-    // degradation in Splunk without a log line per one of the ~12 concurrent requests.
-    log.info(`${LOG_PREFIX} ${hostname}: ${entry.okCount}/${entry.okCount + entry.failCount} engine requests succeeded`, {
-      siteId, hostname, okCount: entry.okCount, failCount: entry.failCount,
-    });
-    if (!entry.anyOk) {
-      log.warn(`${LOG_PREFIX} No successful Semrush response for ${hostname}; using legacy fallback`, {
-        siteId, orgId: spaceCatId, hostname, platformsQueried: platforms, durationMs: elapsed(),
-      });
-      // Sequential, not Promise.all: these post to a Slack thread where message
-      // order is the whole point (a readable narrative), not a perf-sensitive loop.
-      // eslint-disable-next-line no-await-in-loop
-      await notify(`:x: \`${hostname}\`: 0/${entry.okCount + entry.failCount} engine requests succeeded — falling back to the legacy source.`);
-      setDiagnostics({ fallbackReason: `surface-failed:${hostname}` });
-      return null;
-    }
-    // eslint-disable-next-line no-await-in-loop
-    await notify(`:white_check_mark: \`${hostname}\`: ${entry.okCount}/${entry.okCount + entry.failCount} engine requests succeeded.`);
+    await notify(':x: `domain-urls` request failed — falling back to the legacy source.');
+    setDiagnostics({ fallbackReason: result.authFailure ? 'domain-urls-auth-failed' : 'domain-urls-failed' });
+    return null;
   }
 
-  // Partial-degradation signal for LLMO-6711 shadow-run parity: a surface that
-  // tolerated failed engines (see above) still reports dataSource: 'semrush' below
-  // with no fallbackReason, so this is the only structured way to tell "clean run"
-  // from "succeeded, but N engine requests failed" without going back to logs. Any
-  // 401/403 is called out distinctly since an intermittent auth rejection is the
-  // signal to watch for during the pre-LLMO-6709 verification window specifically.
-  const engineFailureCount = [...byHost.values()].reduce((sum, entry) => sum + entry.failCount, 0);
-  const degradedHosts = [...byHost.entries()]
-    .filter(([, entry]) => entry.failCount > 0)
-    .map(([hostname]) => hostname);
-  const authFailureDetected = [...byHost.values()].some((entry) => entry.authFailureCount > 0);
-  setDiagnostics({ engineFailureCount, degradedHosts, authFailureDetected });
+  const brandKeywords = site.getConfig?.()?.getBrandKeywords?.() || [];
+  const brandTokens = computeBrandTokens(siteHostname, brandKeywords);
 
   const allUrls = new Map();
-  for (const [, entry] of byHost) {
-    for (const row of entry.rows) {
-      const classified = row?.url ? classifyAndNormalize(row.url, siteHostname) : null;
-      if (!classified) {
-        // eslint-disable-next-line no-continue
-        continue;
-      }
-      // Enforce the youtube/reddit-only scope on the OUTPUT. A `domain: null`
-      // (off-host) row would otherwise pass both regex guards below and reach
-      // selectTopUrls' top-cited bucket -> live TOP_CITED scrape, bypassing the
-      // legacy isExcludedCitedHost / brand-token filtering this PR scopes out.
-      if (classified.domain !== 'youtube.com' && classified.domain !== 'reddit.com') {
-        // eslint-disable-next-line no-continue
-        continue;
-      }
-      // Strict-format parity with the legacy handler path (non-thread Reddit,
-      // lookalike YouTube host).
-      if (classified.domain === 'youtube.com' && !YOUTUBE_URL_REGEX.test(row.url)) {
-        // eslint-disable-next-line no-continue
-        continue;
-      }
-      if (classified.domain === 'reddit.com' && !REDDIT_URL_REGEX.test(row.url)) {
-        // eslint-disable-next-line no-continue
-        continue;
-      }
-      // Clamp: a negative value would subtract when summed and corrupt the
-      // citations-descending ranking; NaN / non-numeric -> 0.
-      const citations = Math.max(0, Number(row.citations) || 0);
-      const existing = allUrls.get(classified.url);
-      if (existing) {
-        existing.count += citations;
-      } else {
-        allUrls.set(classified.url, { count: citations, domain: classified.domain });
-      }
+  const bucketCounts = { 'youtube.com': 0, 'reddit.com': 0, cited: 0 };
+  for (const row of result.rows) {
+    const bucketed = classifyRow(row, siteHostname, brandTokens);
+    if (!bucketed) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    // Clamp so a negative/non-numeric value can't corrupt the citations ranking; a
+    // zero-citation URL is dropped as not a real cited source.
+    const citations = Math.max(0, Number(row.citations) || 0);
+    if (citations === 0) {
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+    const existing = allUrls.get(bucketed.url);
+    if (existing) {
+      existing.count += citations;
+    } else {
+      allUrls.set(bucketed.url, { count: citations, domain: bucketed.domain });
+      bucketCounts[bucketed.domain ?? 'cited'] += 1;
     }
   }
 
-  // Drop URLs whose total citation volume is zero (malformed / all-zero rows): a
-  // zero-citation URL is not a real cited source and must not be scraped. count can
-  // never go negative here — each contribution is Math.max(0, ...)-clamped above, so
-  // a sum of non-negative values is always >= 0; the check is `=== 0`, not `<= 0`.
-  for (const [url, info] of allUrls) {
-    if (info.count === 0) {
-      allUrls.delete(url);
-    }
-  }
-
-  // Loaded-per-surface counts, for the "loaded N results from <hostname>" progress
-  // update — distinct from the engine-success-ratio message above, since a surface can
-  // have every engine succeed yet contribute zero URLs (e.g. all filtered as off-format).
-  const loadedByHostname = new Map(hostnames.map((hostname) => [hostname, 0]));
-  for (const [, info] of allUrls) {
-    // info.domain is always youtube.com/reddit.com here — the earlier scope guard
-    // already dropped any other domain, so loadedByHostname always has this key.
-    loadedByHostname.set(info.domain, loadedByHostname.get(info.domain) + 1);
-  }
-  for (const [hostname, count] of loadedByHostname) {
-    // eslint-disable-next-line no-await-in-loop
-    await notify(`:package: Loaded ${count} URL(s) from \`${hostname}\`.`);
-  }
+  log.info(`${LOG_PREFIX} Bucketed domain-urls response`, {
+    siteId,
+    orgId: spaceCatId,
+    brandId: brand.brandId,
+    receivedCount: result.rows.length,
+    uniqueUrlCount: allUrls.size,
+    youtubeCount: bucketCounts['youtube.com'],
+    redditCount: bucketCounts['reddit.com'],
+    citedCount: bucketCounts.cited,
+  });
+  await notify(`:package: Loaded ${bucketCounts['youtube.com']} \`youtube.com\`, ${bucketCounts['reddit.com']} \`reddit.com\`, and ${bucketCounts.cited} cited (third-party) URL(s).`);
 
   log.info(`${LOG_PREFIX} Collected ${allUrls.size} cited URLs from Semrush`, {
     siteId,

--- a/src/utils/offsite-brand-presence-semrush.js
+++ b/src/utils/offsite-brand-presence-semrush.js
@@ -170,7 +170,14 @@ function classifyRow(row, siteHostname, brandTokens) {
   if (row?.contentType === 'Owned') {
     return null;
   }
-  const host = new URL(classified.url).hostname.toLowerCase().replace(/^www\./, '');
+  let host;
+  try {
+    host = new URL(classified.url).hostname.toLowerCase().replace(/^www\./, '');
+  } catch {
+    // classified.url already passed through classifyAndNormalize's own URL parse, so this
+    // should be unreachable — defensive only, in case that contract ever changes.
+    return null;
+  }
   if (TOP_CITED_EXCLUDED_DOMAINS.some((d) => host === d || host.endsWith(`.${d}`))) {
     return null;
   }
@@ -203,14 +210,11 @@ function classifyRow(row, siteHostname, brandTokens) {
  *   each stage of the attempt. Kept generic (not a Slack import) so this module stays testable
  *   without a Slack dependency; a failure here is logged and swallowed, never thrown — a Slack
  *   outage must not affect the Semrush attempt itself.
- * @param {object} [params.diagnostics] - Optional out-param, mutated in place. On a null return,
- *   set to `{ fallbackReason }` with a specific code (`no-organization-id`, `no-active-brand`,
- *   `brand-resolution-failed`, `no-date-window`, `ims-token-failed`, or `surface-failed:<host>`)
- *   instead of the single generic reason the handler used to report for every case. On a
- *   successful (non-null) return, set to
- *   `{ engineFailureCount, degradedHosts, authFailureDetected }` so a surface that tolerated
- *   partial engine failures is distinguishable from a clean run — both `dataSource` and
- *   `fallbackReason` alone report success/fail but not degradation.
+ * @param {object} [params.diagnostics] - Optional out-param, mutated in place. On a null
+ *   return, set to `{ fallbackReason }` with a specific code (`no-organization-id`,
+ *   `no-active-brand`, `brand-resolution-failed`, `no-date-window`, `ims-token-failed`,
+ *   `domain-urls-auth-failed`, or `domain-urls-failed`). Left unset on a successful return —
+ *   with a single request there's no per-engine degradation to report.
  * @returns {Promise<Map<string, {count:number, domain:string|null}> | null>}
  */
 export async function loadCitedUrlsFromSemrush({
@@ -361,6 +365,7 @@ export async function loadCitedUrlsFromSemrush({
     brandId: brand.brandId,
     receivedCount: result.rows.length,
     uniqueUrlCount: allUrls.size,
+    droppedCount: result.rows.length - allUrls.size,
     youtubeCount: bucketCounts['youtube.com'],
     redditCount: bucketCounts['reddit.com'],
     citedCount: bucketCounts.cited,

--- a/test/audits/offsite-brand-presence.test.js
+++ b/test/audits/offsite-brand-presence.test.js
@@ -268,37 +268,6 @@ describe('Offsite Brand Presence Handler', () => {
       expect(mockLoadBrandPresenceData).to.not.have.been.called;
     });
 
-    it('surfaces semrushEngineFailureCount/semrushDegradedHosts and warns when the loader reports degradation', async () => {
-      context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
-      mockLoadCitedUrlsFromSemrush.callsFake(async (args) => {
-        Object.assign(args.diagnostics, {
-          engineFailureCount: 1,
-          degradedHosts: ['youtube.com'],
-          authFailureDetected: true,
-        });
-        return new Map([['https://youtu.be/abc', { count: 5, domain: 'youtube.com' }]]);
-      });
-
-      const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
-
-      expect(result.auditResult.dataSource).to.equal('semrush');
-      expect(result.auditResult.semrushEngineFailureCount).to.equal(1);
-      expect(result.auditResult.semrushDegradedHosts).to.deep.equal(['youtube.com']);
-      expect(log.warn).to.have.been.calledWithMatch(/possible auth\/token issue/);
-    });
-
-    it('does not surface degradation fields on a clean Semrush success', async () => {
-      context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
-      mockLoadCitedUrlsFromSemrush.resolves(new Map([
-        ['https://youtu.be/abc', { count: 5, domain: 'youtube.com' }],
-      ]));
-
-      const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
-
-      expect(result.auditResult).to.not.have.property('semrushEngineFailureCount');
-      expect(result.auditResult).to.not.have.property('semrushDegradedHosts');
-    });
-
     it('wires onProgress to post Semrush progress updates into the Slack thread', async () => {
       context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
       mockLoadCitedUrlsFromSemrush.resolves(new Map([

--- a/test/utils/offsite-brand-presence-semrush.test.js
+++ b/test/utils/offsite-brand-presence-semrush.test.js
@@ -50,11 +50,12 @@ describe('offsite-brand-presence-semrush', function () {
   const warnedWith = (re) => log.warn.getCalls().some((c) => re.test(c.args[0]));
   const erroredWith = (re) => log.error.getCalls().some((c) => re.test(c.args[0]));
 
-  async function loadModule() {
+  async function loadModule(overrides = {}) {
     return esmock('../../src/utils/offsite-brand-presence-semrush.js', {
       '@adobe/spacecat-shared-ims-client': { ImsClient: { createFrom: imsCreateFrom } },
       '../../src/utils/brand-resolver.js': { resolveBrandResultForSite },
       '@adobe/spacecat-shared-utils': { ...spacecatSharedUtils, tracingFetch: fetchStub },
+      ...overrides,
     });
   }
 
@@ -200,6 +201,19 @@ describe('offsite-brand-presence-semrush', function () {
     }));
     const allUrls = await mod.loadCitedUrlsFromSemrush({
       site: brandSite, previousWeeks: PREVIOUS_WEEKS, context: makeContext(), siteHostname: 'lovesac.com',
+    });
+    expect(allUrls.size).to.equal(0);
+  });
+
+  it('drops (does not throw on) a cited row whose classified URL fails re-parsing', async () => {
+    const modWithBadUrl = await loadModule({
+      '../../src/utils/offsite-brand-presence-enrichment.js': {
+        classifyAndNormalize: () => ({ url: 'not a valid url', domain: null }),
+      },
+    });
+    fetchStub.resolves(okJson({ urls: [{ url: CITED_URL, citations: 99 }] }));
+    const allUrls = await modWithBadUrl.loadCitedUrlsFromSemrush({
+      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
     });
     expect(allUrls.size).to.equal(0);
   });

--- a/test/utils/offsite-brand-presence-semrush.test.js
+++ b/test/utils/offsite-brand-presence-semrush.test.js
@@ -205,17 +205,40 @@ describe('offsite-brand-presence-semrush', function () {
     expect(allUrls.size).to.equal(0);
   });
 
-  it('drops (does not throw on) a cited row whose classified URL fails re-parsing', async () => {
-    const modWithBadUrl = await loadModule({
-      '../../src/utils/offsite-brand-presence-enrichment.js': {
-        classifyAndNormalize: () => ({ url: 'not a valid url', domain: null }),
-      },
-    });
-    fetchStub.resolves(okJson({ urls: [{ url: CITED_URL, citations: 99 }] }));
-    const allUrls = await modWithBadUrl.loadCitedUrlsFromSemrush({
-      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
-    });
-    expect(allUrls.size).to.equal(0);
+  it('drops opaque-scheme rows (mailto:/tel:/data:/javascript:) via the scheme allowlist', async () => {
+    fetchStub.resolves(okJson({
+      urls: [
+        { url: 'mailto:foo@bar.com', citations: 99 },
+        { url: 'tel:+123456789', citations: 99 },
+        { url: 'data:text/plain;base64,SGVsbG8=', citations: 99 },
+        { url: 'javascript:alert(1)', citations: 99 }, // eslint-disable-line no-script-url -- test data, never executed
+        { url: CITED_URL, citations: 5 },
+      ],
+    }));
+    const allUrls = await run();
+    expect([...allUrls.keys()]).to.deep.equal([CITED_URL]);
+  });
+
+  it('drops non-http(s) schemes that reparse cleanly (ftp:/ws:) via the scheme allowlist', async () => {
+    // These don't throw on reparse (unlike opaque schemes) — the allowlist is what catches
+    // them, not an incidental parse failure.
+    fetchStub.resolves(okJson({
+      urls: [
+        { url: 'ftp://example.com/file.txt', citations: 99 },
+        { url: 'ws://example.com/socket', citations: 99 },
+        { url: CITED_URL, citations: 5 },
+      ],
+    }));
+    const allUrls = await run();
+    expect([...allUrls.keys()]).to.deep.equal([CITED_URL]);
+  });
+
+  it('drops a row whose url is not a valid URL at all', async () => {
+    fetchStub.resolves(okJson({
+      urls: [{ url: 'not a url', citations: 99 }, { url: CITED_URL, citations: 5 }],
+    }));
+    const allUrls = await run();
+    expect([...allUrls.keys()]).to.deep.equal([CITED_URL]);
   });
 
   it('filters owned URLs (siteHostname) and rows without a url', async () => {
@@ -269,6 +292,26 @@ describe('offsite-brand-presence-semrush', function () {
     expect(allUrls.get(YT_NORM).count).to.equal(7);
   });
 
+  it('sums duplicate URLs within the cited bucket too', async () => {
+    fetchStub.resolves(okJson({
+      urls: [{ url: CITED_URL, citations: 3 }, { url: CITED_URL, citations: 4 }],
+    }));
+    const allUrls = await run();
+    expect(allUrls.get(CITED_URL)).to.deep.equal({ count: 7, domain: null });
+  });
+
+  it('counts the cited bucket correctly (not mis-keyed) when only cited URLs are present', async () => {
+    const CITED_URL_2 = 'https://another.example/page';
+    fetchStub.resolves(okJson({
+      urls: [{ url: CITED_URL, citations: 5 }, { url: CITED_URL_2, citations: 3 }],
+    }));
+    const onProgress = sandbox.stub().resolves();
+    const allUrls = await run({}, {}, onProgress);
+    expect(allUrls.size).to.equal(2);
+    const messages = onProgress.getCalls().map((c) => c.args[0]);
+    expect(messages.some((m) => /Loaded 0 `youtube\.com`, 0 `reddit\.com`, and 2 cited/.test(m))).to.equal(true);
+  });
+
   // --- body / truncation ----------------------------------------------------
 
   it('treats a non-array urls body as empty (no fallback)', async () => {
@@ -277,19 +320,23 @@ describe('offsite-brand-presence-semrush', function () {
     expect(allUrls.size).to.equal(0);
   });
 
-  it('warns and hard-caps at PAGE_SIZE when a full page is returned', async () => {
+  it('warns, sets diagnostics.truncated, and hard-caps at PAGE_SIZE when a full page is returned', async () => {
     const rows = Array.from({ length: mod.PAGE_SIZE + 1 }, (_, i) => ({ url: `${YT_URL}${i}`, citations: 1 }));
     fetchStub.resolves(okJson({ urls: rows }));
-    const allUrls = await run();
+    const diagnostics = {};
+    const allUrls = await run({}, {}, undefined, diagnostics);
     expect(warnedWith(/full page/)).to.equal(true);
     expect(allUrls.size).to.equal(mod.PAGE_SIZE);
+    expect(diagnostics.truncated).to.equal(true);
   });
 
-  it('does not warn on a page one row under PAGE_SIZE (truncation off-by-one)', async () => {
+  it('does not warn and sets diagnostics.truncated to false on a page one row under PAGE_SIZE', async () => {
     const rows = Array.from({ length: mod.PAGE_SIZE - 1 }, (_, i) => ({ url: `${YT_URL}${i}`, citations: 1 }));
     fetchStub.resolves(okJson({ urls: rows }));
-    await run();
+    const diagnostics = {};
+    await run({}, {}, undefined, diagnostics);
     expect(warnedWith(/full page/)).to.equal(false);
+    expect(diagnostics.truncated).to.equal(false);
   });
 
   it('warns on an exactly-PAGE_SIZE page (>= boundary, not >)', async () => {

--- a/test/utils/offsite-brand-presence-semrush.test.js
+++ b/test/utils/offsite-brand-presence-semrush.test.js
@@ -25,15 +25,9 @@ const PREVIOUS_WEEKS = [{ week: 29, year: 2026 }, { week: 28, year: 2026 }];
 const YT_URL = 'https://www.youtube.com/watch?v=abc';
 const YT_NORM = 'https://youtu.be/abc';
 const RD_URL = 'https://www.reddit.com/r/Lovesac/comments/1/pros_cons';
-
-// Full provider engine set (SEMRUSH_PLATFORM_BY_PROVIDER values), the default.
-const DEFAULT_PLATFORMS = [
-  'google-ai-mode', 'search-gpt', 'microsoft-copilot', 'gemini-2.5-flash', 'google-ai-overview', 'perplexity',
-];
+const CITED_URL = 'https://example.org/page';
 
 const okJson = (body) => ({ ok: true, status: 200, json: async () => body });
-const ONE_ENGINE = { OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt' };
-const TWO_ENGINES = { OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt, google-ai-mode' };
 
 describe('offsite-brand-presence-semrush', function () {
   this.timeout(10000);
@@ -47,7 +41,11 @@ describe('offsite-brand-presence-semrush', function () {
   let mod;
 
   const SITE_ID = '5b0d4d6e-3d2e-4a5b-8e2a-9b6f7c9c1e2a';
-  const site = { getOrganizationId: () => ORG_ID, getId: () => SITE_ID };
+  const site = {
+    getOrganizationId: () => ORG_ID,
+    getId: () => SITE_ID,
+    getConfig: () => ({ getBrandKeywords: () => [] }),
+  };
   const makeContext = (env = {}, extra = {}) => ({ log, env, ...extra });
   const warnedWith = (re) => log.warn.getCalls().some((c) => re.test(c.args[0]));
   const erroredWith = (re) => log.error.getCalls().some((c) => re.test(c.args[0]));
@@ -57,13 +55,6 @@ describe('offsite-brand-presence-semrush', function () {
       '@adobe/spacecat-shared-ims-client': { ImsClient: { createFrom: imsCreateFrom } },
       '../../src/utils/brand-resolver.js': { resolveBrandResultForSite },
       '@adobe/spacecat-shared-utils': { ...spacecatSharedUtils, tracingFetch: fetchStub },
-    });
-  }
-
-  function stubByHostname(fn) {
-    fetchStub.callsFake(async (url) => {
-      const params = new URL(url).searchParams;
-      return fn(params.get('hostname'), params.get('platform'));
     });
   }
 
@@ -95,23 +86,30 @@ describe('offsite-brand-presence-semrush', function () {
 
   // --- happy path -----------------------------------------------------------
 
-  it('queries each engine per hostname and SUMS citations per URL', async () => {
-    stubByHostname((hostname, platform) => (hostname === 'youtube.com'
-      ? okJson({ urls: [{ url: YT_URL, citations: platform === 'google-ai-mode' ? 5 : 10 }] })
-      : okJson({ urls: [{ url: RD_URL, citations: platform === 'google-ai-mode' ? 4 : 7 }] })));
-
-    const allUrls = await run(TWO_ENGINES);
-
-    expect(fetchStub.callCount).to.equal(4); // 2 hosts x 2 engines
-    expect(allUrls.get(YT_NORM)).to.deep.equal({ count: 15, domain: 'youtube.com' }); // 10 + 5
-    expect(allUrls.get(RD_URL)).to.deep.equal({ count: 11, domain: 'reddit.com' }); // 7 + 4
-  });
-
-  it('defaults to the full provider engine set (one request per engine per hostname)', async () => {
+  it('makes exactly ONE domain-urls request (no hostname, platform=all)', async () => {
     fetchStub.resolves(okJson({ urls: [] }));
     await run();
-    expect(mod.getSemrushPlatforms(undefined)).to.have.lengthOf(6);
-    expect(fetchStub.callCount).to.equal(12); // 2 hosts x 6 engines
+
+    expect(fetchStub.callCount).to.equal(1);
+    const [url] = fetchStub.firstCall.args;
+    expect(new URL(url).searchParams.has('hostname')).to.equal(false);
+    expect(new URL(url).searchParams.get('platform')).to.equal('all');
+  });
+
+  it('splits the single response into youtube / reddit / cited buckets', async () => {
+    fetchStub.resolves(okJson({
+      urls: [
+        { url: YT_URL, citations: 10 },
+        { url: RD_URL, citations: 7 },
+        { url: CITED_URL, citations: 5, contentType: 'Third-party' },
+      ],
+    }));
+
+    const allUrls = await run();
+
+    expect(allUrls.get(YT_NORM)).to.deep.equal({ count: 10, domain: 'youtube.com' });
+    expect(allUrls.get(RD_URL)).to.deep.equal({ count: 7, domain: 'reddit.com' });
+    expect(allUrls.get(CITED_URL)).to.deep.equal({ count: 5, domain: null });
   });
 
   it('sends Authorization+Accept+timeout, no Content-Type, no x-promise-token by default', async () => {
@@ -120,7 +118,6 @@ describe('offsite-brand-presence-semrush', function () {
 
     const [url, opts] = fetchStub.firstCall.args;
     expect(url).to.contain(`${mod.SPACECAT_API_DEFAULT_BASE_URL}/v2/orgs/${ORG_ID}/brands/${BRAND_ID}`);
-    expect(new URL(url).searchParams.get('platform')).to.be.oneOf(DEFAULT_PLATFORMS);
     expect(opts.headers.Authorization).to.equal('Bearer tok');
     expect(opts.headers.Accept).to.equal('application/json');
     expect(opts.headers).to.not.have.property('Content-Type');
@@ -147,79 +144,114 @@ describe('offsite-brand-presence-semrush', function () {
     expect(fetchStub.firstCall.args[0]).to.contain('https://stage.example/api/v2/orgs/');
   });
 
-  it('honours an OFFSITE_SEMRUSH_PLATFORMS override', async () => {
+  it('always requests PAGE_SIZE', async () => {
     fetchStub.resolves(okJson({ urls: [] }));
-    await run(ONE_ENGINE);
-    expect(fetchStub.callCount).to.equal(2); // 2 hosts x 1 engine
-    fetchStub.getCalls().forEach((c) => {
-      expect(new URL(c.args[0]).searchParams.get('platform')).to.equal('search-gpt');
-    });
+    await run();
+    expect(new URL(fetchStub.firstCall.args[0]).searchParams.get('pageSize')).to.equal(String(mod.PAGE_SIZE));
   });
 
   // --- filtering / scope ----------------------------------------------------
 
   it('drops URLs failing the strict youtube/reddit formats', async () => {
-    stubByHostname((hostname) => (hostname === 'youtube.com'
-      ? okJson({ urls: [{ url: YT_URL, citations: 10 }, { url: 'https://music.youtube.com/watch?v=z', citations: 99 }] })
-      : okJson({ urls: [{ url: RD_URL, citations: 7 }, { url: 'https://www.reddit.com/settings', citations: 99 }] })));
+    fetchStub.resolves(okJson({
+      urls: [
+        { url: YT_URL, citations: 10 },
+        { url: 'https://music.youtube.com/watch?v=z', citations: 99 },
+        { url: RD_URL, citations: 7 },
+        { url: 'https://www.reddit.com/settings', citations: 99 },
+      ],
+    }));
 
-    const allUrls = await run(ONE_ENGINE);
+    const allUrls = await run();
     expect([...allUrls.keys()].sort()).to.deep.equal([YT_NORM, RD_URL].sort());
   });
 
-  it('drops off-host (domain: null) rows so nothing leaks into top-cited', async () => {
-    stubByHostname((hostname) => (hostname === 'youtube.com'
-      ? okJson({ urls: [{ url: YT_URL, citations: 10 }, { url: 'https://example.org/page', citations: 99 }] })
-      : okJson({ urls: [{ url: RD_URL, citations: 7 }] })));
+  it('drops Owned rows from the cited bucket', async () => {
+    fetchStub.resolves(okJson({
+      urls: [{ url: CITED_URL, citations: 99, contentType: 'Owned' }],
+    }));
+    const allUrls = await run();
+    expect(allUrls.size).to.equal(0);
+  });
 
-    const allUrls = await run(ONE_ENGINE);
-    expect([...allUrls.keys()]).to.not.include('https://example.org/page');
-    expect(allUrls.has(YT_NORM)).to.equal(true);
+  it('drops TOP_CITED_EXCLUDED_DOMAINS (e.g. wikipedia.org) from the cited bucket', async () => {
+    fetchStub.resolves(okJson({
+      urls: [{ url: 'https://en.wikipedia.org/wiki/Foo', citations: 99 }],
+    }));
+    const allUrls = await run();
+    expect(allUrls.size).to.equal(0);
+  });
+
+  it('drops social/search excluded-domain lookalikes (isExcludedCitedHost) from the cited bucket', async () => {
+    fetchStub.resolves(okJson({
+      urls: [{ url: 'https://www.facebook.com/somepage', citations: 99 }],
+    }));
+    const allUrls = await run();
+    expect(allUrls.size).to.equal(0);
+  });
+
+  it('drops brand-token lookalikes from the cited bucket', async () => {
+    const brandSite = {
+      ...site,
+      getConfig: () => ({ getBrandKeywords: () => ['lovesac'] }),
+    };
+    fetchStub.resolves(okJson({
+      urls: [{ url: 'https://lovedbylovesac.com/page', citations: 99 }],
+    }));
+    const allUrls = await mod.loadCitedUrlsFromSemrush({
+      site: brandSite, previousWeeks: PREVIOUS_WEEKS, context: makeContext(), siteHostname: 'lovesac.com',
+    });
+    expect(allUrls.size).to.equal(0);
   });
 
   it('filters owned URLs (siteHostname) and rows without a url', async () => {
-    stubByHostname((hostname) => (hostname === 'youtube.com'
-      ? okJson({ urls: [{ url: YT_URL, citations: 10 }, { citations: 3 }] }) // 2nd: no url
-      : okJson({ urls: [{ url: 'https://www.lovesac.com/owned', citations: 99 }] }))); // owned
+    fetchStub.resolves(okJson({
+      urls: [
+        { url: YT_URL, citations: 10 },
+        { citations: 3 }, // no url
+        { url: 'https://www.lovesac.com/owned', citations: 99 }, // site's own host
+      ],
+    }));
 
     const allUrls = await mod.loadCitedUrlsFromSemrush({
-      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(ONE_ENGINE), siteHostname: 'lovesac.com',
+      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(), siteHostname: 'lovesac.com',
     });
     expect([...allUrls.keys()]).to.deep.equal([YT_NORM]);
+  });
+
+  it('tolerates a site with no getConfig()/getBrandKeywords()', async () => {
+    fetchStub.resolves(okJson({ urls: [{ url: YT_URL, citations: 10 }] }));
+    const bareSite = { getOrganizationId: () => ORG_ID, getId: () => SITE_ID };
+    const allUrls = await mod.loadCitedUrlsFromSemrush({
+      site: bareSite, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
+    });
+    expect(allUrls.get(YT_NORM)).to.deep.equal({ count: 10, domain: 'youtube.com' });
   });
 
   // --- citation clamping ----------------------------------------------------
 
   it('drops a URL whose citations are negative (clamped to 0 -> dropped)', async () => {
-    stubByHostname((hostname) => (hostname === 'youtube.com'
-      ? okJson({ urls: [{ url: YT_URL, citations: -5 }] })
-      : okJson({ urls: [{ url: RD_URL, citations: 7 }] })));
-    const allUrls = await run(ONE_ENGINE);
+    fetchStub.resolves(okJson({
+      urls: [{ url: YT_URL, citations: -5 }, { url: RD_URL, citations: 7 }],
+    }));
+    const allUrls = await run();
     expect(allUrls.has(YT_NORM)).to.equal(false);
     expect(allUrls.get(RD_URL).count).to.equal(7);
   });
 
   it('drops a URL whose citations are non-numeric or missing (0 -> dropped)', async () => {
-    stubByHostname((hostname) => (hostname === 'youtube.com'
-      ? okJson({ urls: [{ url: YT_URL, citations: 'abc' }] }) // NaN -> 0
-      : okJson({ urls: [{ url: RD_URL }] }))); // missing -> 0
-    const allUrls = await run(ONE_ENGINE);
+    fetchStub.resolves(okJson({
+      urls: [{ url: YT_URL, citations: 'abc' }, { url: RD_URL }],
+    }));
+    const allUrls = await run();
     expect(allUrls.size).to.equal(0);
   });
 
-  it('keeps a URL when one engine reports 0 but another reports a positive count', async () => {
-    stubByHostname((hostname, platform) => (hostname === 'youtube.com'
-      ? okJson({ urls: [{ url: YT_URL, citations: platform === 'google-ai-mode' ? 5 : 0 }] })
-      : okJson({ urls: [{ url: RD_URL, citations: 7 }] })));
-    const allUrls = await run(TWO_ENGINES);
-    expect(allUrls.get(YT_NORM)).to.deep.equal({ count: 5, domain: 'youtube.com' });
-  });
-
-  it('sums duplicate URLs within a single page', async () => {
-    stubByHostname((hostname) => (hostname === 'youtube.com'
-      ? okJson({ urls: [{ url: YT_URL, citations: 3 }, { url: YT_URL, citations: 4 }] })
-      : okJson({ urls: [{ url: RD_URL, citations: 1 }] })));
-    const allUrls = await run(ONE_ENGINE);
+  it('sums duplicate URLs within the single page', async () => {
+    fetchStub.resolves(okJson({
+      urls: [{ url: YT_URL, citations: 3 }, { url: YT_URL, citations: 4 }],
+    }));
+    const allUrls = await run();
     expect(allUrls.get(YT_NORM).count).to.equal(7);
   });
 
@@ -232,129 +264,69 @@ describe('offsite-brand-presence-semrush', function () {
   });
 
   it('warns and hard-caps at PAGE_SIZE when a full page is returned', async () => {
-    const rows = Array.from({ length: 101 }, (_, i) => ({ url: `${YT_URL}${i}`, citations: 1 }));
-    stubByHostname((hostname) => (hostname === 'youtube.com'
-      ? okJson({ urls: rows })
-      : okJson({ urls: [{ url: RD_URL, citations: 1 }] })));
-    const allUrls = await run(ONE_ENGINE);
+    const rows = Array.from({ length: mod.PAGE_SIZE + 1 }, (_, i) => ({ url: `${YT_URL}${i}`, citations: 1 }));
+    fetchStub.resolves(okJson({ urls: rows }));
+    const allUrls = await run();
     expect(warnedWith(/full page/)).to.equal(true);
-    expect([...allUrls.keys()].filter((k) => k.startsWith('https://youtu.be/')).length).to.equal(100);
+    expect(allUrls.size).to.equal(mod.PAGE_SIZE);
   });
 
-  it('does not warn on a 99-row page (truncation off-by-one)', async () => {
-    const rows = Array.from({ length: 99 }, (_, i) => ({ url: `${YT_URL}${i}`, citations: 1 }));
-    stubByHostname((hostname) => (hostname === 'youtube.com'
-      ? okJson({ urls: rows })
-      : okJson({ urls: [{ url: RD_URL, citations: 1 }] })));
-    await run(ONE_ENGINE);
+  it('does not warn on a page one row under PAGE_SIZE (truncation off-by-one)', async () => {
+    const rows = Array.from({ length: mod.PAGE_SIZE - 1 }, (_, i) => ({ url: `${YT_URL}${i}`, citations: 1 }));
+    fetchStub.resolves(okJson({ urls: rows }));
+    await run();
     expect(warnedWith(/full page/)).to.equal(false);
   });
 
-  it('warns on an exactly-PAGE_SIZE (100-row) page (>= boundary, not >)', async () => {
-    const rows = Array.from({ length: 100 }, (_, i) => ({ url: `${YT_URL}${i}`, citations: 1 }));
-    stubByHostname((hostname) => (hostname === 'youtube.com'
-      ? okJson({ urls: rows })
-      : okJson({ urls: [{ url: RD_URL, citations: 1 }] })));
-    await run(ONE_ENGINE);
+  it('warns on an exactly-PAGE_SIZE page (>= boundary, not >)', async () => {
+    const rows = Array.from({ length: mod.PAGE_SIZE }, (_, i) => ({ url: `${YT_URL}${i}`, citations: 1 }));
+    fetchStub.resolves(okJson({ urls: rows }));
+    await run();
     expect(warnedWith(/full page/)).to.equal(true);
   });
 
-  // --- surface-level fallback (returns null) --------------------------------
+  // --- request-level fallback (returns null) --------------------------------
 
-  it('falls back (null) when a whole hostname has no successful response — reject', async () => {
-    stubByHostname((hostname) => {
-      if (hostname === 'reddit.com') {
-        return Promise.reject(new Error('network down'));
-      }
-      return okJson({ urls: [{ url: YT_URL, citations: 10 }] });
-    });
-    const result = await run(ONE_ENGINE);
+  it('falls back (null) on a network error', async () => {
+    fetchStub.rejects(new Error('network down'));
+    const diagnostics = {};
+    const result = await run({}, {}, undefined, diagnostics);
     expect(result).to.equal(null);
-    expect(warnedWith(/No successful Semrush response for reddit\.com/)).to.equal(true);
+    expect(diagnostics.fallbackReason).to.equal('domain-urls-failed');
   });
 
-  it('falls back (null) on a non-2xx surface', async () => {
-    stubByHostname((hostname) => (hostname === 'reddit.com'
-      ? { ok: false, status: 500 }
-      : okJson({ urls: [{ url: YT_URL, citations: 10 }] })));
-    expect(await run(ONE_ENGINE)).to.equal(null);
+  it('falls back (null) on a non-2xx response', async () => {
+    fetchStub.resolves({ ok: false, status: 500 });
+    const diagnostics = {};
+    expect(await run({}, {}, undefined, diagnostics)).to.equal(null);
+    expect(diagnostics.fallbackReason).to.equal('domain-urls-failed');
   });
 
-  it('logs a distinct rejection and falls back on a 401 surface', async () => {
-    stubByHostname((hostname) => (hostname === 'reddit.com'
-      ? { ok: false, status: 401 }
-      : okJson({ urls: [{ url: YT_URL, citations: 10 }] })));
-    const result = await run(ONE_ENGINE);
+  it('logs a distinct rejection and falls back with domain-urls-auth-failed on a 401', async () => {
+    fetchStub.resolves({ ok: false, status: 401 });
+    const diagnostics = {};
+    const result = await run({}, {}, undefined, diagnostics);
     expect(result).to.equal(null);
     expect(erroredWith(/Service token rejected/)).to.equal(true);
+    expect(diagnostics.fallbackReason).to.equal('domain-urls-auth-failed');
   });
 
-  it('logs a distinct rejection and falls back on a 403 surface', async () => {
-    stubByHostname((hostname) => (hostname === 'reddit.com'
-      ? { ok: false, status: 403 }
-      : okJson({ urls: [{ url: YT_URL, citations: 10 }] })));
-    const result = await run(ONE_ENGINE);
+  it('logs a distinct rejection and falls back with domain-urls-auth-failed on a 403', async () => {
+    fetchStub.resolves({ ok: false, status: 403 });
+    const diagnostics = {};
+    const result = await run({}, {}, undefined, diagnostics);
     expect(result).to.equal(null);
     expect(erroredWith(/Service token rejected/)).to.equal(true);
+    expect(diagnostics.fallbackReason).to.equal('domain-urls-auth-failed');
   });
 
-  it('falls back (null) when a surface body fails to parse', async () => {
-    stubByHostname((hostname) => (hostname === 'reddit.com'
-      ? { ok: true, status: 200, json: async () => { throw new Error('bad json'); } }
-      : okJson({ urls: [{ url: YT_URL, citations: 10 }] })));
-    expect(await run(ONE_ENGINE)).to.equal(null);
-  });
-
-  it('tolerates a single failed engine when the surface still has a successful response', async () => {
-    stubByHostname((hostname, platform) => {
-      if (hostname === 'youtube.com' && platform === 'search-gpt') {
-        return Promise.reject(new Error('flaky engine'));
-      }
-      return hostname === 'youtube.com'
-        ? okJson({ urls: [{ url: YT_URL, citations: 5 }] })
-        : okJson({ urls: [{ url: RD_URL, citations: 7 }] });
+  it('falls back (null) when the response body fails to parse', async () => {
+    fetchStub.resolves({
+      ok: true,
+      status: 200,
+      json: async () => { throw new Error('bad json'); },
     });
-    const allUrls = await run(TWO_ENGINES);
-    expect(allUrls).to.not.equal(null);
-    expect(allUrls.get(YT_NORM).count).to.equal(5);
-    expect(allUrls.get(RD_URL).count).to.equal(14); // reddit ok on both engines
-  });
-
-  // --- diagnostics out-param --------------------------------------------------
-
-  it('reports a specific fallbackReason for a fully-failed surface, distinct from other null causes', async () => {
-    stubByHostname((hostname) => (hostname === 'reddit.com'
-      ? Promise.reject(new Error('network down'))
-      : okJson({ urls: [{ url: YT_URL, citations: 10 }] })));
-    const diagnostics = {};
-    expect(await run(ONE_ENGINE, {}, undefined, diagnostics)).to.equal(null);
-    expect(diagnostics.fallbackReason).to.equal('surface-failed:reddit.com');
-  });
-
-  it('reports engineFailureCount/degradedHosts/authFailureDetected on a successful but degraded run', async () => {
-    stubByHostname((hostname, platform) => {
-      if (hostname === 'youtube.com' && platform === 'search-gpt') {
-        return { ok: false, status: 401 };
-      }
-      return hostname === 'youtube.com'
-        ? okJson({ urls: [{ url: YT_URL, citations: 5 }] })
-        : okJson({ urls: [{ url: RD_URL, citations: 7 }] });
-    });
-    const diagnostics = {};
-    const allUrls = await run(TWO_ENGINES, {}, undefined, diagnostics);
-    expect(allUrls).to.not.equal(null);
-    expect(diagnostics.engineFailureCount).to.equal(1);
-    expect(diagnostics.degradedHosts).to.deep.equal(['youtube.com']);
-    expect(diagnostics.authFailureDetected).to.equal(true);
-  });
-
-  it('reports no degradation on a fully clean run', async () => {
-    fetchStub.resolves(okJson({ urls: [] }));
-    const diagnostics = {};
-    await run(ONE_ENGINE, {}, undefined, diagnostics);
-    expect(diagnostics.engineFailureCount).to.equal(0);
-    expect(diagnostics.degradedHosts).to.deep.equal([]);
-    expect(diagnostics.authFailureDetected).to.equal(false);
+    expect(await run()).to.equal(null);
   });
 
   // --- precondition guards (return null) -----------------------------------
@@ -406,42 +378,37 @@ describe('offsite-brand-presence-semrush', function () {
   // --- progress notifications (onProgress) -----------------------------------
 
   it('invokes onProgress at each stage of a successful attempt', async () => {
-    stubByHostname((hostname) => (hostname === 'youtube.com'
-      ? okJson({ urls: [{ url: YT_URL, citations: 10 }] })
-      : okJson({ urls: [{ url: RD_URL, citations: 7 }] })));
+    fetchStub.resolves(okJson({
+      urls: [{ url: YT_URL, citations: 10 }, { url: RD_URL, citations: 7 }],
+    }));
     const onProgress = sandbox.stub().resolves();
 
-    const allUrls = await run(ONE_ENGINE, {}, onProgress);
+    const allUrls = await run({}, {}, onProgress);
 
     expect(allUrls.size).to.equal(2);
     expect(onProgress).to.have.been.called;
     const messages = onProgress.getCalls().map((c) => c.args[0]);
     expect(messages.some((m) => /Starting Semrush/.test(m))).to.equal(true);
-    expect(messages.some((m) => /Querying/.test(m))).to.equal(true);
-    expect(messages.some((m) => /youtube\.com.*engine requests succeeded/.test(m))).to.equal(true);
-    expect(messages.some((m) => /reddit\.com.*engine requests succeeded/.test(m))).to.equal(true);
-    expect(messages.some((m) => /Loaded 1 URL\(s\) from `youtube\.com`/.test(m))).to.equal(true);
-    expect(messages.some((m) => /Loaded 1 URL\(s\) from `reddit\.com`/.test(m))).to.equal(true);
+    expect(messages.some((m) => /Querying.*single request/.test(m))).to.equal(true);
+    expect(messages.some((m) => /Loaded 1 `youtube\.com`, 1 `reddit\.com`, and 0 cited/.test(m))).to.equal(true);
     expect(messages.some((m) => /total cited URL/.test(m))).to.equal(true);
   });
 
-  it('invokes onProgress with a failure notice on the surface that triggers fallback', async () => {
-    stubByHostname((hostname) => (hostname === 'youtube.com'
-      ? okJson({ urls: [{ url: YT_URL, citations: 10 }] })
-      : { ok: false, status: 500, json: async () => ({}) }));
+  it('invokes onProgress with a failure notice when the request fails', async () => {
+    fetchStub.resolves({ ok: false, status: 500 });
     const onProgress = sandbox.stub().resolves();
 
-    expect(await run(ONE_ENGINE, {}, onProgress)).to.equal(null);
+    expect(await run({}, {}, onProgress)).to.equal(null);
 
     const messages = onProgress.getCalls().map((c) => c.args[0]);
-    expect(messages.some((m) => /reddit\.com.*0\/1 engine requests succeeded/.test(m))).to.equal(true);
+    expect(messages.some((m) => /domain-urls.*request failed/.test(m))).to.equal(true);
   });
 
   it('logs a warning and does not throw when onProgress rejects', async () => {
     fetchStub.resolves(okJson({ urls: [] }));
     const onProgress = sandbox.stub().rejects(new Error('slack down'));
 
-    const allUrls = await run(ONE_ENGINE, {}, onProgress);
+    const allUrls = await run({}, {}, onProgress);
 
     expect(allUrls).to.not.equal(null);
     expect(warnedWith(/Failed to post Semrush progress update/)).to.equal(true);
@@ -449,36 +416,25 @@ describe('offsite-brand-presence-semrush', function () {
 
   // --- pure helpers ---------------------------------------------------------
 
-  describe('getSemrushPlatforms', () => {
-    it('defaults to the confirmed engine list', () => {
-      expect(mod.getSemrushPlatforms(undefined)).to.deep.equal(DEFAULT_PLATFORMS);
-      expect(mod.getSemrushPlatforms({})).to.deep.equal(DEFAULT_PLATFORMS);
-      expect(mod.getSemrushPlatforms({ OFFSITE_SEMRUSH_PLATFORMS: '   ' })).to.deep.equal(DEFAULT_PLATFORMS);
-      // separators-only must NOT disable all requests
-      expect(mod.getSemrushPlatforms({ OFFSITE_SEMRUSH_PLATFORMS: ' , , ' })).to.deep.equal(DEFAULT_PLATFORMS);
-    });
-
-    it('parses a comma-separated override, trimming and dropping empties', () => {
-      expect(mod.getSemrushPlatforms({ OFFSITE_SEMRUSH_PLATFORMS: 'search-gpt, ,google-ai-mode ' }))
-        .to.deep.equal(['search-gpt', 'google-ai-mode']);
-    });
-  });
-
   describe('buildDomainUrlsUrl', () => {
     const baseArgs = {
-      baseUrl: 'https://h/api', spaceCatId: 'o', brandId: 'b', hostname: 'reddit.com', startDate: '2026-07-06', endDate: '2026-08-02',
+      baseUrl: 'https://h/api', spaceCatId: 'o', brandId: 'b', startDate: '2026-07-06', endDate: '2026-08-02', pageSize: 500,
     };
 
-    it('omits platform when not provided and encodes path segments', () => {
+    it('encodes path segments and never includes hostname', () => {
       const url = mod.buildDomainUrlsUrl({ ...baseArgs, spaceCatId: 'o/x', brandId: 'b?y' });
       expect(url).to.contain('/v2/orgs/o%2Fx/brands/b%3Fy/serenity/brand-presence/url-inspector/domain-urls?');
-      expect(new URL(url).searchParams.has('platform')).to.equal(false);
-      expect(new URL(url).searchParams.get('hostname')).to.equal('reddit.com');
+      expect(new URL(url).searchParams.has('hostname')).to.equal(false);
     });
 
-    it('includes platform when provided', () => {
-      const url = mod.buildDomainUrlsUrl({ ...baseArgs, platform: 'search-gpt' });
-      expect(new URL(url).searchParams.get('platform')).to.equal('search-gpt');
+    it('always sends platform=all', () => {
+      const url = mod.buildDomainUrlsUrl(baseArgs);
+      expect(new URL(url).searchParams.get('platform')).to.equal('all');
+    });
+
+    it('sends the requested pageSize', () => {
+      const url = mod.buildDomainUrlsUrl({ ...baseArgs, pageSize: 777 });
+      expect(new URL(url).searchParams.get('pageSize')).to.equal('777');
     });
   });
 });


### PR DESCRIPTION
**What**
Populate the youtube.com, reddit.com, and third-party "cited" buckets from a single
domain-urls request per audit run, instead of the previous per-hostname × per-engine fan-out
(and a two-hop cited-domains discovery walk for the third-party bucket).

**Why**
[LLMO-6844](https://jira.corp.adobe.com/browse/LLMO-6844) made hostname optional on
domain-urls (returns URLs across every source host instead of one) and
[LLMO-6818](https://jira.corp.adobe.com/browse/LLMO-6818) added platform=all (aggregates
citations across every AI engine server-side). Together they make the old fan-out
unnecessary — one request now returns a single citations-sorted page spanning every host and
engine, and the loader classifies each row client-side into a bucket. Request volume drops
from ~12–78 requests to exactly 1 per audit run.

**How**
- src/utils/offsite-brand-presence-semrush.js: loadCitedUrlsFromSemrush() now issues one
domain-urls request (no hostname, platform=all); classifyRow() buckets each row into
youtube.com / reddit.com (enforcing YOUTUBE_URL_REGEX / REDDIT_URL_REGEX for parity
with the legacy classify) or third-party "cited" (domain: null, filtered for
contentType: "Owned", TOP_CITED_EXCLUDED_DOMAINS, and isExcludedCitedHost).
- PAGE_SIZE is now a fixed constant (1000), matching domain-urls's server-side pageSize
clamp — not an env override, since there's no fan-out cost to a large page when it's one
request either way.
- Removed as dead code: the per-engine platform list/env override, the cited-domains
discovery hop, and the per-candidate-domain walk.
- Docs: ADR docs/decisions/002-offsite-cited-urls-semrush-source.md and spec
docs/specs/2026-08-05-offsite-cited-urls-semrush-source.md updated to describe the
single-request design.
- Testing: test/utils/offsite-brand-presence-semrush.test.js rewritten — 100% statement/branch/
function/line coverage on the loader, lint clean.




Please ensure your pull request adheres to the following guidelines:
- [x] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki (→ wiki.corp.adobe.com)](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.
If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

Related Issues
[LLMO-6709](https://jira.corp.adobe.com/browse/LLMO-6709) · depends on [LLMO-6844](https://jira.corp.adobe.com/browse/LLMO-6844) and [LLMO-6818](https://jira.corp.adobe.com/browse/LLMO-6818) (spacecat-api-service)

Thanks for contributing!

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Andrei Paraschiv", "Dominique Jäggi", "TB ADBE"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```