### PR TITLE
fix: resolve the organization's own brandalf flag row, not a brand's override

### DIFF
--- a/src/utils/brandalf-utils.js
+++ b/src/utils/brandalf-utils.js
@@ -14,9 +14,27 @@ const BRANDALF_FLAG_NAME = 'brandalf';
 const FEATURE_FLAG_PRODUCT = 'LLMO';
 
 /**
+ * The organization's own row, not a brand's override of it. `brand_id` is absent
+ * from every row before the brand-scope migration and NULL on the organization's
+ * row after it, so this selects correctly under both schemas.
+ *
+ * The query feeding this predicate must keep selecting the full row. Naming
+ * `brand_id` in a projection — or filtering on it — fails against the current
+ * schema, where the column does not exist yet; narrowing the projection once it
+ * does exist makes every override row arrive with `brand_id: undefined` and read
+ * as the organization's own.
+ *
+ * @param {object} row - Raw PostgREST `feature_flags` row.
+ * @returns {boolean} `true` for the organization-level row.
+ */
+const isOrgRow = (row) => (row.brand_id ?? null) === null;
+
+/**
  * Checks whether the brandalf feature flag is enabled for an organization by
  * reading the `feature_flags` table directly via the mysticat PostgREST client
  * (available at `context.dataAccess.services.postgrestClient`).
+ *
+ * Resolves the organization's own value, ignoring any brand's override of it.
  *
  * @param {string} organizationId - SpaceCat org UUID
  * @param {object} postgrestClient - mysticat PostgREST client (dataAccess.services.postgrestClient)
@@ -33,13 +51,13 @@ export async function isBrandalfEnabled(organizationId, postgrestClient, log) {
   }
 
   try {
+    // Wildcard projection is required — see `isOrgRow`.
     const { data, error } = await postgrestClient
       .from('feature_flags')
-      .select('flag_value')
+      .select('*')
       .eq('organization_id', organizationId)
       .eq('product', FEATURE_FLAG_PRODUCT)
-      .eq('flag_name', BRANDALF_FLAG_NAME)
-      .maybeSingle();
+      .eq('flag_name', BRANDALF_FLAG_NAME);
 
     if (error) {
       log?.warn(`Failed to read brandalf flag for org ${organizationId}: ${error.message}`);
@@ -48,7 +66,7 @@ export async function isBrandalfEnabled(organizationId, postgrestClient, log) {
 
     // Absent row => flag not set => disabled, matching the previous behaviour
     // where a missing flag resolved to `false`.
-    return data?.flag_value === true;
+    return (data ?? []).find(isOrgRow)?.flag_value === true;
   } catch (error) {
     log?.warn(`Error checking brandalf flag for org ${organizationId}: ${error.message}`);
     return null;

--- a/test/utils/brandalf-utils.test.js
+++ b/test/utils/brandalf-utils.test.js
@@ -42,14 +42,17 @@ describe('brandalf-utils', () => {
   });
 
   /**
-   * Builds a chainable PostgREST client stub whose terminal `maybeSingle()`
-   * resolves to `{ data, error }`.
+   * Builds a chainable PostgREST client stub. The builder is awaited directly
+   * rather than through a terminal method, so the query object is a thenable
+   * resolving to `{ data, error }` — or rejecting with `rejectsWith`.
    */
-  function stubPostgrestClient({ data = null, error = null } = {}) {
+  function stubPostgrestClient({ data = null, error = null, rejectsWith = null } = {}) {
     const query = {
       select: sandbox.stub().returnsThis(),
       eq: sandbox.stub().returnsThis(),
-      maybeSingle: sandbox.stub().resolves({ data, error }),
+      then: (resolve, reject) => (
+        rejectsWith ? reject(rejectsWith) : resolve({ data, error })
+      ),
     };
     const from = sandbox.stub().returns(query);
     return { client: { from }, query, from };
@@ -57,20 +60,24 @@ describe('brandalf-utils', () => {
 
   describe('isBrandalfEnabled', () => {
     it('returns true when the brandalf flag is enabled', async () => {
-      const { client, from, query } = stubPostgrestClient({ data: { flag_value: true } });
+      const { client, from, query } = stubPostgrestClient({
+        data: [{ flag_value: true, brand_id: null }],
+      });
 
       const result = await isBrandalfEnabled('org-123', client, log);
 
       expect(result).to.equal(true);
       expect(from).to.have.been.calledWith('feature_flags');
-      expect(query.select).to.have.been.calledWith('flag_value');
+      // Wildcard projection is load-bearing — see `isOrgRow` for why.
+      expect(query.select).to.have.been.calledWith('*');
+      expect(query.eq).to.not.have.been.calledWithMatch('brand_id');
       expect(query.eq).to.have.been.calledWith('organization_id', 'org-123');
       expect(query.eq).to.have.been.calledWith('product', 'LLMO');
       expect(query.eq).to.have.been.calledWith('flag_name', 'brandalf');
     });
 
     it('returns false without querying when organizationId is missing', async () => {
-      const { client, from } = stubPostgrestClient({ data: { flag_value: true } });
+      const { client, from } = stubPostgrestClient({ data: [{ flag_value: true }] });
 
       const result = await isBrandalfEnabled(null, client, log);
 
@@ -94,6 +101,14 @@ describe('brandalf-utils', () => {
     });
 
     it('returns false when no flag row exists', async () => {
+      const { client } = stubPostgrestClient({ data: [] });
+
+      const result = await isBrandalfEnabled('org-123', client, log);
+
+      expect(result).to.equal(false);
+    });
+
+    it('returns false when the query yields no rows at all', async () => {
       const { client } = stubPostgrestClient({ data: null });
 
       const result = await isBrandalfEnabled('org-123', client, log);
@@ -102,11 +117,44 @@ describe('brandalf-utils', () => {
     });
 
     it('returns false when the flag row is explicitly disabled', async () => {
-      const { client } = stubPostgrestClient({ data: { flag_value: false } });
+      const { client } = stubPostgrestClient({ data: [{ flag_value: false }] });
 
       const result = await isBrandalfEnabled('org-123', client, log);
 
       expect(result).to.equal(false);
+    });
+
+    it("resolves the organization's own row, not a brand's override of it", async () => {
+      const { client } = stubPostgrestClient({
+        data: [
+          { flag_value: false, brand_id: 'brand-a' },
+          { flag_value: true, brand_id: null },
+          { flag_value: false, brand_id: 'brand-b' },
+        ],
+      });
+
+      const result = await isBrandalfEnabled('org-123', client, log);
+
+      expect(result).to.equal(true);
+      expect(log.warn).to.not.have.been.called;
+    });
+
+    it('ignores a brand override when the organization has no row of its own', async () => {
+      const { client } = stubPostgrestClient({
+        data: [{ flag_value: true, brand_id: 'brand-a' }],
+      });
+
+      const result = await isBrandalfEnabled('org-123', client, log);
+
+      expect(result).to.equal(false);
+    });
+
+    it('treats a pre-migration row, which carries no brand_id, as the organization row', async () => {
+      const { client } = stubPostgrestClient({ data: [{ flag_value: true }] });
+
+      const result = await isBrandalfEnabled('org-123', client, log);
+
+      expect(result).to.equal(true);
     });
 
     it('returns null and warns when the query returns an error', async () => {
@@ -121,12 +169,7 @@ describe('brandalf-utils', () => {
     });
 
     it('returns null and warns when the query throws', async () => {
-      const query = {
-        select: sandbox.stub().returnsThis(),
-        eq: sandbox.stub().returnsThis(),
-        maybeSingle: sandbox.stub().rejects(new Error('connection reset')),
-      };
-      const client = { from: sandbox.stub().returns(query) };
+      const { client } = stubPostgrestClient({ rejectsWith: new Error('connection reset') });
 
       const result = await isBrandalfEnabled('org-123', client, log);
 


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract

`isBrandalfEnabled` resolves the organization's own `feature_flags` row explicitly instead of assuming its query matches at most one row. One helper in `src/utils/brandalf-utils.js`, plus test coverage for a brand-scoped row sitting alongside the organization's.

Closes https://github.com/adobe/spacecat-audit-worker/issues/2869

## 2. Reasoning

`feature_flags` in mysticat-data-service is becoming optionally brand-aware. A nullable `brand_id` joins the unique key, and a row naming a brand overrides the organization's value for that brand alone: resolution for a given organization and brand takes the brand's own row if one exists, else the organization's row, else the flag does not exist for that brand.

This repo reads that table directly rather than through the api-service feature-flags endpoint, and the read terminated in `.maybeSingle()` — which raises as soon as more than one row matches. After the migration, more than one row matches the moment an organization holds a per-brand `brandalf` override.

Nothing writes one today: the Serenity migration CLI writes per-brand rows only for `serenity`, and `brandalf` is written at organization scope by spacecat-api-service alone. So this code is correct on the day the migration lands — by convention, not by construction. Nothing in the schema prevents a `brandalf` override, and the whole point of the migration is that per-brand rows become an ordinary thing to write.

The failure mode is quiet rather than loud. On a query error the helper logs a warning and returns `null`. `null` means "unknown", and both call sites treat unknown as not-enabled — so the first per-brand `brandalf` row would silently degrade brandalf resolution for that organization, with a single warning line to explain it. That is the kind of thing that gets diagnosed twice.

## 3. High-level overview of the changes

Before: the read selected the `flag_value` column and terminated in `.maybeSingle()`, so it depended on the `(organization_id, product, flag_name)` tuple matching at most one row.

After: the read selects every matching row and picks the organization's own — the row whose `brand_id` is NULL, or absent entirely on the pre-migration schema. A brand's override of the same flag is ignored.

Behaviour delta today: none. With no override row present, the new selection returns exactly what `.maybeSingle()` returned — enabled, disabled, and absent-row all resolve as before, and an error still resolves to `null`. What changes is the behaviour on the day an override exists: the organization's value continues to resolve instead of collapsing into an unknown.

The change is correct against both the old and the new schema, so it can ship before, during, or after the migration with no coordination.

One thing worth flagging for review, because it looks like a tidy-up: **the wildcard projection is load-bearing.** Naming `brand_id` in the projection, or filtering on it, fails against the current schema where the column does not exist yet — every read would error. Narrowing the projection back to `flag_value` once the column does exist makes `brand_id` arrive as `undefined` on every row, which makes every brand override read as the organization's own and silently disables the predicate. The wildcard is the only shape correct under both schemas. The diff carries comments saying so at both the predicate and the call site.

## 4. Required information

- Jira / issue: https://github.com/adobe/spacecat-audit-worker/issues/2869
- Spec: https://github.com/adobe/serenity-docs/issues/317
- Other: pattern already merged in spacecat-api-service — https://github.com/adobe/spacecat-api-service/pull/3021 — same `isOrgRow` predicate and the same wildcard-projection requirement

## 5. Affected / used mysticat-workspace projects

- **mysticat-data-service** — contract. Owns the `feature_flags` table and the brand-scope migration this read must survive. Not changed here.
- **spacecat-api-service** — contract. Sole writer of `brandalf` at organization scope, and the repo the resolution pattern is borrowed from. Not changed here.

## 6. Additional information outside the code

The changed read was exercised against the real `@supabase/postgrest-js` client rather than only against test doubles, by pointing it at a throwaway local HTTP server that served `feature_flags` rows and recorded the request line the builder emitted.

Scenarios driven, covering both schema shapes:

- Pre-migration rows carrying no `brand_id` at all — flag on, flag off, and no row.
- Post-migration organization row alone.
- Post-migration organization row plus a brand override, in both orders and with the two rows disagreeing in both directions — the organization's value resolved in every case.
- A brand override with no organization row — resolved as not-enabled.

The emitted query never names or filters `brand_id` under either schema, confirming it is valid against the table as it exists today.

The same harness confirmed the premise of the change: with two matching rows the previous `.maybeSingle()` call fails with `JSON object requested, multiple (or no) rows returned`, which the helper converts into exactly the quiet `null` this PR removes.

A review finding raised during development was declined: it claimed the pre-existing optional-chaining on the logger and site accessors in this file would trip the repo's branch-coverage gate and needed either new tests or `c8` ignore comments. It does not reproduce, and those lines are untouched by this change.

## 7. Test plan

Locally, beyond the automated tests, the helper was driven against a real PostgREST client as described in section 6 — that is the meaningful end-to-end check here, since the change is a query-shape change and the behaviour that matters is what the client emits and how it handles a multi-row response.

Both call sites (`src/utils/offsite-brand-presence-enrichment.js` and `src/llmo-customer-analysis/handler.js`) stub this helper, so their behaviour is unchanged by construction; their suites were run to confirm that.

To verify on **dev** after deploy:

- Pick an organization with `brandalf` enabled and run an offsite brand-presence audit or an llmo-customer-analysis run for one of its sites. Brand resolution should proceed exactly as before, with no `Failed to read brandalf flag` warning in the logs.
- Confirm the negative case too: an organization without the flag still skips brand resolution.

Once the brand-scope migration has landed on an environment, the case this PR exists for can be verified directly: insert a per-brand `brandalf` row alongside the organization's row for a test organization, then run the audit and confirm the organization's value still resolves and no warning is logged. On the pre-migration schema there is no way to construct that state, which is why it is covered by tests rather than by an environment check.

## 8. Deployment & merge order

- Related, with no ordering constraint: https://github.com/adobe/mysticat-data-service/pull/891 — the brand-scope migration this read is being hardened against.

This PR is independent of that migration in both directions. It does not block it and is not blocked by it, because the new read is correct under both the pre- and post-migration schema. Either can merge and deploy first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```