### PR TITLE
fix: scope CWV audit RUM pages to site base path for subpath sites (SITES-49656)

### DIFF
--- a/src/cwv/cwv-audit-result.js
+++ b/src/cwv/cwv-audit-result.js
@@ -14,6 +14,7 @@ import RUMAPIClient from '@adobe/spacecat-shared-rum-api-client';
 import { Audit, Entitlement } from '@adobe/spacecat-shared-data-access';
 import { TierClient } from '@adobe/spacecat-shared-tier-client';
 import { removeTrailingSlash } from '../utils/url-utils.js';
+import { isWithinAuditScope } from '../internal-links/subpath-filter.js';
 
 const DAILY_THRESHOLD = 1000; // pageviews
 const INTERVAL = 7; // days
@@ -115,10 +116,21 @@ export async function buildCWVAuditResult(context) {
   };
   const cwvData = await rumApiClient.query(Audit.AUDIT_TYPES.CWV, options);
 
+  // SITES-49656: subpath sites (a concrete path onboarded as its own site, e.g.
+  // https://oklahoma.gov/omes) share the domain-keyed RUM query with the whole
+  // domain, so cwvData carries sibling-site pages. Scope the per-URL entries to
+  // the site's base path — reusing the internal-links audit-scope filter — before
+  // top-N/threshold selection so the report and resulting opportunities don't
+  // bleed in unrelated pages. Root-domain sites (no base path) are unaffected;
+  // operator-configured `group` entries are left untouched.
+  const scopedCwvData = cwvData.filter(
+    (item) => item.type !== 'url' || isWithinAuditScope(item.url, baseURL),
+  );
+
   const stats = { homepage: false, topNCount: 0, thresholdCount: 0 };
 
   // Always include: homepage + top N pages + pages meeting threshold
-  const filteredCwvData = [...cwvData]
+  const filteredCwvData = [...scopedCwvData]
     .sort((a, b) => b.pageviews - a.pageviews)
     .reduce((list, item) => {
       // 1) Homepage
@@ -145,7 +157,7 @@ export async function buildCWVAuditResult(context) {
     }, []);
 
   log.info(
-    `[audit-worker-cwv] siteId: ${siteId} | baseURL: ${baseURL} | Total=${cwvData.length}, Reported=${filteredCwvData.length} | `
+    `[audit-worker-cwv] siteId: ${siteId} | baseURL: ${baseURL} | Total=${cwvData.length}, Scoped=${scopedCwvData.length}, Reported=${filteredCwvData.length} | `
     + `Homepage: ${stats.homepage ? 'included' : 'not included'} | `
     + `Top${topPagesCount} pages: ${stats.topNCount} | `
     + `Pages above threshold: ${stats.thresholdCount}`,

--- a/test/audits/cwv/cwv-audit-result.test.js
+++ b/test/audits/cwv/cwv-audit-result.test.js
@@ -243,5 +243,83 @@ describe('CWV Audit Result', () => {
         expect(log.warn.calledWithMatch(/Failed to determine ASO tier/)).to.be.true;
       });
     });
+
+    describe('subpath-site base-path scoping (SITES-49656)', () => {
+      const subpathSite = {
+        getId: () => 'omes',
+        getBaseURL: () => 'https://www.example.gov/omes',
+        getConfig: () => ({ getGroupedURLs: () => [] }),
+      };
+
+      function buildForSubpath(cwvDataFromRum) {
+        return esmock('../../../src/cwv/cwv-audit-result.js', {
+          '@adobe/spacecat-shared-rum-api-client': {
+            default: {
+              createFrom: sandbox.stub().returns({
+                query: sandbox.stub().resolves(cwvDataFromRum),
+              }),
+            },
+          },
+        });
+      }
+
+      beforeEach(() => {
+        fetchStub.resolves({ status: 200 });
+      });
+
+      it('keeps only pages under the site base path and drops sibling-site pages', async () => {
+        const cwvDataFromRum = [
+          {
+            type: 'url', url: 'https://www.example.gov/omes', pageviews: 100000, organic: 0, metrics: [],
+          },
+          {
+            type: 'url', url: 'https://www.example.gov/omes/leadership.html', pageviews: 6000, organic: 0, metrics: [],
+          },
+          {
+            type: 'url', url: 'https://www.example.gov/okdhs.html', pageviews: 5900, organic: 0, metrics: [],
+          },
+          {
+            type: 'url', url: 'https://www.example.gov/omes-budget', pageviews: 5800, organic: 0, metrics: [],
+          },
+          {
+            type: 'group', pattern: '/omes/*', name: 'OMES pages', pageviews: 5000, organic: 0, metrics: [],
+          },
+        ];
+        const { buildCWVAuditResult: build } = await buildForSubpath(cwvDataFromRum);
+
+        const result = await build({
+          site: subpathSite, finalUrl: 'www.example.gov/omes', log, env: {},
+        });
+
+        const urls = result.auditResult.cwv.filter((e) => e.type === 'url').map((e) => e.url);
+        expect(urls).to.include('https://www.example.gov/omes');
+        expect(urls).to.include('https://www.example.gov/omes/leadership.html');
+        // sibling agency page on the same domain but outside /omes — must be dropped
+        expect(urls).to.not.include('https://www.example.gov/okdhs.html');
+        // directory-boundary safety: /omes-budget is a sibling, not under /omes/
+        expect(urls).to.not.include('https://www.example.gov/omes-budget');
+        // operator-configured group entries pass through untouched
+        expect(result.auditResult.cwv.find((e) => e.type === 'group')).to.exist;
+      });
+
+      it('drops url entries whose URL cannot be parsed', async () => {
+        const cwvDataFromRum = [
+          {
+            type: 'url', url: 'https://www.example.gov/omes', pageviews: 100000, organic: 0, metrics: [],
+          },
+          {
+            type: 'url', url: ':::not-a-url', pageviews: 6000, organic: 0, metrics: [],
+          },
+        ];
+        const { buildCWVAuditResult: build } = await buildForSubpath(cwvDataFromRum);
+
+        const result = await build({
+          site: subpathSite, finalUrl: 'www.example.gov/omes', log, env: {},
+        });
+
+        const urls = result.auditResult.cwv.filter((e) => e.type === 'url').map((e) => e.url);
+        expect(urls).to.deep.equal(['https://www.example.gov/omes']);
+      });
+    });
   });
 });


### PR DESCRIPTION
## Problem

The CWV audit (`buildCWVAuditResult`) queries RUM by **domain** and selects
homepage + top-N-by-traffic + threshold pages with **no base-path filter**. A
site onboarded as a concrete subpath of a domain (e.g. `oklahoma.gov/omes`,
`fedex.com/en-ge`) therefore surfaces unrelated sibling-site pages that live
under the same domain but outside the site's path (`okdhs.html`, `trs.html`,
`ohca.html`, …) as CWV opportunities.

Part of SITES-49656 (multi-site-per-domain onboarding). This PR fixes the CWV /
RUM slice only; the shared top-pages and meta-tags slices in that ticket are
owned separately.

## Fix

Filter the per-URL RUM entries to the site's base path **before** the
top-N/threshold selection, reusing the existing audit-scope filter
`isWithinAuditScope` (the same `internal-links` helper the `backlinks` audit
already imports). The RUM data is already per-URL — the per-domain domain key is
only an access key — so no RUM-bundler change is needed.

- Root-domain sites (no base path) are unaffected — the filter is a no-op.
- Operator-configured `group` entries pass through untouched.
- Relies on the site's `baseURL` carrying the subpath (how these sites are
  onboarded, and already assumed by the existing homepage check).

## Testing

- `test/audits/cwv/cwv-audit-result.test.js`: added base-path scoping tests —
  keeps in-scope pages + homepage + `group` entries, drops sibling-site pages,
  drops directory-boundary siblings (`/omes-budget` vs `/omes`), drops
  unparseable URLs. Red before the change, green after.
- `src/cwv/cwv-audit-result.js` at 100% line/branch/function/statement coverage;
  existing CWV handler tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi", "Tej Kotthakota"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```