### PR TITLE
chore: raise dev audit-worker reserved concurrency to 50

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build": "hedy -v --test-bundle",
     "deploy": "hedy -v --deploy --aws-deploy-bucket=spacecat-prod-deploy --pkgVersion=latest --aws-reserved-concurrency=100",
     "deploy-stage": "hedy -v --deploy --aws-deploy-bucket=spacecat-stage-deploy --pkgVersion=latest --aws-reserved-concurrency=10",
-    "deploy-dev": "hedy -v --deploy --pkgVersion=ci$CI_BUILD_NUM -l latest --aws-deploy-bucket=spacecat-dev-deploy --cleanup-ci=24h --aws-reserved-concurrency=10",
+    "deploy-dev": "hedy -v --deploy --pkgVersion=ci$CI_BUILD_NUM -l latest --aws-deploy-bucket=spacecat-dev-deploy --cleanup-ci=24h --aws-reserved-concurrency=50",
     "deploy-secrets": "hedy --aws-update-secrets --params-file=secrets/secrets.env",
     "prepare": "husky",
     "local-build": "sam build",


### PR DESCRIPTION
## What
Raise the **dev** audit-worker Lambda `--aws-reserved-concurrency` from **10 → 50** in `deploy-dev`. Prod (100) and stage (10) unchanged.

## Why
Dev reserves only 10 concurrent executions vs 100 in prod. At the top of the hour the jobs-dispatcher fans out audits for the whole dev fleet at once, saturating the 10-slot ceiling and **throttling** the audit-worker (21 throttles in a single 5-min bucket at 00:05 UTC).

Because `spacecat-audit-jobs` has **`maxReceiveCount = 1`** (redrive policy → shared DLQ), a throttled delivery is fatal: the poller receives the message (ReceiveCount=1), the invocation is throttled, the message isn't processed, and SQS immediately moves it to the DLQ — **with no retry**. The handler never runs.

Concrete symptom: `cdn-logs-analysis` byocdn-other sub-audits (which build the aggregated Athena table) are dispatched with no delay, hit the 00:05 throttle, and get dead-lettered on the first attempt. The delayed `cdn-logs-report` (fixed ~13-min delay) becomes visible after the throttle spike clears, runs successfully against a table that was never built → `TABLE_NOT_FOUND` → empty agentic-traffic data.

(Note on metrics: the DLQ's `NumberOfMessagesSent` does NOT count redrive-moved messages, so it reads 0 even while messages are being dead-lettered — confirm dead-lettering by inspecting the DLQ contents, not that metric.)

Raising concurrency reduces top-of-hour throttling so these transient failures stop happening.

## Not a full fix
This addresses the trigger (throttling). Two durable fixes belong in a follow-up:
- **Raise `maxReceiveCount`** on `spacecat-audit-jobs` (e.g. 3–5) so transient throttles are retried instead of dead-lettered on the first attempt.
- **Gate `cdn-logs-report` on the aggregated table existing** instead of trusting a fixed delay to order it after the sub-audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)