### PR TITLE
fix(broken-backlinks): publish detection never promoted DEPLOYED fixes to PUBLISHED

### DIFF
--- a/src/utils/data-access.js
+++ b/src/utils/data-access.js
@@ -819,8 +819,8 @@ export async function publishDeployedFixEntities({
   }
   const { dataAccess, log } = context;
   try {
-    const { FixEntity, Suggestion } = dataAccess || {};
-    if (!FixEntity?.allByOpportunityIdAndStatus || !Suggestion?.getFixEntitiesBySuggestionId) {
+    const { FixEntity } = dataAccess || {};
+    if (!FixEntity?.allByOpportunityIdAndStatus) {
       log.debug('FixEntity APIs not available; skipping publish.');
       return;
     }
@@ -843,20 +843,14 @@ export async function publishDeployedFixEntities({
 
     // Helper to check a single fix entity with bounded HTTP calls
     const checkFixEntity = async (fixEntity) => {
-      const suggestionIds = fixEntity.getSuggestionIds?.() || [];
-      if (suggestionIds.length === 0) {
+      // A FixEntity exposes its linked suggestions via the async many-to-many accessor
+      // getSuggestions(), which resolves to an array of Suggestion models. (There is no
+      // getSuggestionIds() on FixEntity, and Suggestion.getFixEntitiesBySuggestionId()
+      // returns FixEntities — not suggestions — so neither can drive this check.)
+      const suggestionResults = (await fixEntity.getSuggestions?.()) || [];
+      if (suggestionResults.length === 0) {
         return { fixEntity, allResolved: false };
       }
-
-      // Fetch all suggestions first (DB calls)
-      const suggestionResults = await Promise.all(
-        suggestionIds.map(async (suggestionId) => {
-          const { data: suggestions = [] } = await Suggestion.getFixEntitiesBySuggestionId(
-            suggestionId,
-          );
-          return suggestions[0];
-        }),
-      );
 
       // Fast-path check using current audit data (no HTTP)
       for (const suggestion of suggestionResults) {

--- a/test/utils/data-access.test.js
+++ b/test/utils/data-access.test.js
@@ -3376,9 +3376,6 @@ describe('data-access', () => {
           allByOpportunityIdAndStatus: sinon.stub().resolves([]),
           saveMany: sinon.stub().resolves(),
         },
-        Suggestion: {
-          getFixEntitiesBySuggestionId: sinon.stub().resolves({ data: [] }),
-        },
       };
     });
 
@@ -3416,12 +3413,11 @@ describe('data-access', () => {
       expect(mockLogger.debug).to.have.been.calledWith('FixEntity APIs not available; skipping publish.');
     });
 
-    it('should handle fix entity with getSuggestionIds returning undefined', async () => {
+    it('should handle fix entity with getSuggestions returning undefined', async () => {
       const fixEntity = {
         getId: sinon.stub().returns('fix-undefined'),
-        getSuggestionIds: sinon.stub().returns(undefined),
+        getSuggestions: sinon.stub().resolves(undefined),
         setStatus: sinon.stub(),
-        save: sinon.stub().resolves(),
       };
 
       mockDataAccess.FixEntity.allByOpportunityIdAndStatus.resolves([fixEntity]);
@@ -3432,7 +3428,7 @@ describe('data-access', () => {
         isIssueResolvedOnProduction: sinon.stub().resolves(true),
       });
 
-      // Should not publish since suggestionIds is empty after || []
+      // Should not publish since suggestions is empty after || []
       expect(fixEntity.setStatus).to.not.have.been.called;
     });
 
@@ -3448,12 +3444,11 @@ describe('data-access', () => {
       expect(mockDataAccess.FixEntity.allByOpportunityIdAndStatus).to.have.been.called;
     });
 
-    it('should skip fix entity with empty suggestionIds', async () => {
+    it('should skip fix entity with empty suggestions', async () => {
       const fixEntity = {
         getId: sinon.stub().returns('fix-1'),
-        getSuggestionIds: sinon.stub().returns([]),
+        getSuggestions: sinon.stub().resolves([]),
         setStatus: sinon.stub(),
-        save: sinon.stub().resolves(),
       };
 
       mockDataAccess.FixEntity.allByOpportunityIdAndStatus.resolves([fixEntity]);
@@ -3467,16 +3462,14 @@ describe('data-access', () => {
       expect(fixEntity.setStatus).to.not.have.been.called;
     });
 
-    it('should not publish when suggestion not found', async () => {
+    it('should not publish when a linked suggestion is missing', async () => {
       const fixEntity = {
         getId: sinon.stub().returns('fix-2'),
-        getSuggestionIds: sinon.stub().returns(['sugg-1']),
+        getSuggestions: sinon.stub().resolves([null]),
         setStatus: sinon.stub(),
-        save: sinon.stub().resolves(),
       };
 
       mockDataAccess.FixEntity.allByOpportunityIdAndStatus.resolves([fixEntity]);
-      mockDataAccess.Suggestion.getFixEntitiesBySuggestionId.resolves({ data: [] });
 
       await publishDeployedFixEntities({
         opportunityId: 'opp-id',
@@ -3494,22 +3487,24 @@ describe('data-access', () => {
 
       const fixEntity = {
         getId: sinon.stub().returns('fix-3'),
-        getSuggestionIds: sinon.stub().returns(['sugg-1']),
+        getSuggestions: sinon.stub().resolves([suggestion]),
         setStatus: sinon.stub(),
-        save: sinon.stub().resolves(),
       };
 
       mockDataAccess.FixEntity.allByOpportunityIdAndStatus.resolves([fixEntity]);
-      mockDataAccess.Suggestion.getFixEntitiesBySuggestionId.resolves({ data: [suggestion] });
+
+      const isIssueResolvedOnProduction = sinon.stub().resolves(true);
 
       await publishDeployedFixEntities({
         opportunityId: 'opp-id',
         context: { dataAccess: mockDataAccess, log: mockLogger },
-        isIssueResolvedOnProduction: sinon.stub().resolves(true),
+        isIssueResolvedOnProduction,
         currentAuditData: [{ key: 'existing-key' }],
         buildKey: (d) => d?.key,
       });
 
+      // Fast-path short-circuits before any HTTP verification.
+      expect(isIssueResolvedOnProduction).to.not.have.been.called;
       expect(fixEntity.setStatus).to.not.have.been.called;
     });
 
@@ -3520,13 +3515,11 @@ describe('data-access', () => {
 
       const fixEntity = {
         getId: sinon.stub().returns('fix-4'),
-        getSuggestionIds: sinon.stub().returns(['sugg-1']),
+        getSuggestions: sinon.stub().resolves([suggestion]),
         setStatus: sinon.stub(),
-        save: sinon.stub().resolves(),
       };
 
       mockDataAccess.FixEntity.allByOpportunityIdAndStatus.resolves([fixEntity]);
-      mockDataAccess.Suggestion.getFixEntitiesBySuggestionId.resolves({ data: [suggestion] });
 
       await publishDeployedFixEntities({
         opportunityId: 'opp-id',
@@ -3544,13 +3537,11 @@ describe('data-access', () => {
 
       const fixEntity = {
         getId: sinon.stub().returns('fix-5'),
-        getSuggestionIds: sinon.stub().returns(['sugg-1']),
+        getSuggestions: sinon.stub().resolves([suggestion]),
         setStatus: sinon.stub(),
-        save: sinon.stub().resolves(),
       };
 
       mockDataAccess.FixEntity.allByOpportunityIdAndStatus.resolves([fixEntity]);
-      mockDataAccess.Suggestion.getFixEntitiesBySuggestionId.resolves({ data: [suggestion] });
 
       await publishDeployedFixEntities({
         opportunityId: 'opp-id',
@@ -3563,6 +3554,39 @@ describe('data-access', () => {
       expect(mockLogger.info).to.have.been.calledWith('Published fix entity fix-5');
     });
 
+    // Regression: publish detection must use the real data-access contract.
+    // A DEPLOYED FixEntity exposes its linked suggestions via the async M2M accessor
+    // `fixEntity.getSuggestions()` (returns an array of Suggestion models). There is no
+    // `FixEntity.getSuggestionIds()`, and `Suggestion.getFixEntitiesBySuggestionId()`
+    // returns FixEntities (not suggestions) as a bare array. Using those meant no deployed
+    // fix was ever promoted to PUBLISHED in production (first surfaced by jll.com).
+    it('publishes using the real fixEntity.getSuggestions() contract', async () => {
+      const suggestion = {
+        getData: sinon.stub().returns({ url_from: 'https://ref.example/a', url_to: 'https://jll.com/x' }),
+      };
+
+      const fixEntity = {
+        getId: sinon.stub().returns('fix-real'),
+        getSuggestions: sinon.stub().resolves([suggestion]),
+        setStatus: sinon.stub(),
+      };
+
+      mockDataAccess.FixEntity.allByOpportunityIdAndStatus.resolves([fixEntity]);
+
+      const isIssueResolvedOnProduction = sinon.stub().resolves(true);
+
+      await publishDeployedFixEntities({
+        opportunityId: 'opp-id',
+        context: { dataAccess: mockDataAccess, log: mockLogger },
+        isIssueResolvedOnProduction,
+      });
+
+      expect(isIssueResolvedOnProduction).to.have.been.calledOnceWith(suggestion);
+      expect(fixEntity.setStatus).to.have.been.calledWith('PUBLISHED');
+      expect(mockDataAccess.FixEntity.saveMany).to.have.been.calledWith([fixEntity]);
+      expect(mockLogger.info).to.have.been.calledWith('Published fix entity fix-real');
+    });
+
     it('should log debug when FixEntity.saveMany() throws', async () => {
       const suggestion = {
         getData: sinon.stub().returns({ key: 'resolved-key' }),
@@ -3570,14 +3594,12 @@ describe('data-access', () => {
 
       const fixEntity = {
         getId: sinon.stub().returns('fix-6'),
-        getSuggestionIds: sinon.stub().returns(['sugg-1']),
+        getSuggestions: sinon.stub().resolves([suggestion]),
         setStatus: sinon.stub(),
-        save: sinon.stub().resolves(),
       };
 
       mockDataAccess.FixEntity.allByOpportunityIdAndStatus.resolves([fixEntity]);
       mockDataAccess.FixEntity.saveMany.rejects(new Error('Save error'));
-      mockDataAccess.Suggestion.getFixEntitiesBySuggestionId.resolves({ data: [suggestion] });
 
       await publishDeployedFixEntities({
         opportunityId: 'opp-id',
@@ -3630,7 +3652,6 @@ describe('data-access', () => {
           Suggestion: {
             bulkUpdateStatus: sinon.stub().resolves(),
             saveMany: sinon.stub().resolves(),
-            getFixEntitiesBySuggestionId: sinon.stub().resolves({ data: [] }),
           },
           FixEntity: {
             allByOpportunityIdAndStatus: sinon.stub().resolves([]),


### PR DESCRIPTION
## Summary

Automated **publish detection** for the `broken-backlinks` audit never promoted a `DEPLOYED` FixEntity to `PUBLISHED`. The fix is live in production (the broken backlink redirects to the AI-suggested URL), but the system kept showing it as *Deployed*. **Systemic**, not customer-specific — first surfaced on **jll.com**, the first ASO Trial customer to deploy a broken-backlinks fix.

Jira: [SITES-49713](https://jira.corp.adobe.com/browse/SITES-49713)

## Root cause

In `publishDeployedFixEntities()` (`src/utils/data-access.js`), the per-fix-entity check used two data-access APIs that don't behave as assumed (verified against `@adobe/spacecat-shared-data-access@4.18.0`):

- **`fixEntity.getSuggestionIds()` does not exist** on the FixEntity model. `fixEntity.getSuggestionIds?.()` → `undefined` → `|| []` → empty → returns `allResolved: false` immediately, never verifying production.
- **`Suggestion.getFixEntitiesBySuggestionId(id)` returns a bare array of _FixEntity_ models** (via the junction table) — not a `{ data }` envelope and not Suggestions. The code did `const { data: suggestions = [] } = ...` (→ `undefined` → `[]`) and passed the result to `isIssueResolvedOnProduction(suggestion)`, which expects a Suggestion.

Either defect alone guarantees no DEPLOYED broken-backlinks fix is ever promoted to PUBLISHED.

## Fix

Use the real many-to-many accessor **`fixEntity.getSuggestions()`** (async; resolves to an array of Suggestion models) to drive the fast-path and production verification. This also replaces an N-per-entity query with one call per fix entity (consistent with the repo's N+1 guidance).

## Why tests didn't catch it

The prior unit tests mocked the **assumed** (incorrect) contract — fix-entity stubs with `getSuggestionIds`, and `getFixEntitiesBySuggestionId` resolving `{ data: [suggestion] }` — so the suite passed at 100% coverage while the feature was broken end to end. Tests rewritten to the real API shapes, plus a regression test asserting a resolved deployed fix is published.

## Test plan

- [x] `data-access.js` at 100% lines/branches/statements/functions
- [x] Full suite green with global coverage gate (`npm test`)
- [x] Lint clean
- [ ] Verify on jll.com after deploy (fix promotes DEPLOYED → PUBLISHED on next audit)

cc @absarasw (owns publish detection, #1999)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Abhinav Saraswat", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```