### PR TITLE
fix(metatags): emit absolute suggestion/page URLs for sub-path sites (metatags + product-metatags)

### DIFF
--- a/src/metatags/handler.js
+++ b/src/metatags/handler.js
@@ -52,10 +52,9 @@ export async function opportunityAndSuggestions(finalUrl, auditData, context) {
   const { log } = context;
   const { detectedTags } = auditData.auditResult;
   log.debug(`started to audit metatags for site url: ${auditData.auditResult.finalUrl}`);
-  // Default to hostname-only: the endpoint is the page's absolute pathname, so it must
-  // be appended to the origin. Appending to a base that already carries a path (a
-  // sub-path site, e.g. https://oklahoma.gov/omes) duplicated it (/omes/omes/...).
-  // For root-domain sites the base has no path, so this is a no-op.
+  // Default hostname-only: the endpoint is an absolute pathname appended to the origin.
+  // A base that already carries a path (sub-path site, e.g. example.com/foo) duplicated
+  // it (/foo/foo/...). No-op for root-domain sites.
   let useHostnameOnly = true;
   try {
     const siteId = opportunity.getSiteId();
@@ -351,9 +350,9 @@ export async function runAuditAndGenerateSuggestions(context) {
     },
   );
 
-  // Get useHostnameOnly setting. Defaults to true so an absolute endpoint is appended
-  // to the origin, not to a base URL that already carries a path (sub-path sites would
-  // otherwise get a duplicated /omes/omes/... URL). No-op for root-domain sites.
+  // Default hostname-only so an absolute endpoint is appended to the origin, not to a
+  // base URL that already carries a path (sub-path sites would otherwise get a duplicated
+  // /foo/foo/... URL). No-op for root-domain sites.
   let useHostnameOnly = true;
   try {
     const siteId = opportunity.getSiteId();
@@ -444,11 +443,9 @@ export async function runAuditAndGenerateSuggestions(context) {
     };
   });
 
-  // Build unique pageUrls from all suggestions. Resolve each endpoint (an absolute
-  // path) against the base URL's origin rather than string-concatenating onto the
-  // full base URL: for a subpath site (e.g. baseURL https://oklahoma.gov/omes) the
-  // endpoint already carries the full path (/omes/...), so concatenation produced a
-  // malformed /omes/omes/... URL. No-op for root-domain sites.
+  // Resolve each endpoint (an absolute path) against the base URL's origin. Concatenating
+  // onto a base that already carries a path (sub-path site, e.g. example.com/foo) produced
+  // a malformed /foo/foo/... URL. No-op for root-domain sites.
   const pageUrls = [
     ...new Set(suggestionMap.map((s) => new URL(s.endpoint, site.getBaseURL()).toString())),
   ];

--- a/src/metatags/handler.js
+++ b/src/metatags/handler.js
@@ -52,11 +52,15 @@ export async function opportunityAndSuggestions(finalUrl, auditData, context) {
   const { log } = context;
   const { detectedTags } = auditData.auditResult;
   log.debug(`started to audit metatags for site url: ${auditData.auditResult.finalUrl}`);
-  let useHostnameOnly = false;
+  // Default to hostname-only: the endpoint is the page's absolute pathname, so it must
+  // be appended to the origin. Appending to a base that already carries a path (a
+  // sub-path site, e.g. https://oklahoma.gov/omes) duplicated it (/omes/omes/...).
+  // For root-domain sites the base has no path, so this is a no-op.
+  let useHostnameOnly = true;
   try {
     const siteId = opportunity.getSiteId();
     const site = await context.dataAccess.Site.findById(siteId);
-    useHostnameOnly = site?.getDeliveryConfig?.()?.useHostnameOnly ?? false;
+    useHostnameOnly = site?.getDeliveryConfig?.()?.useHostnameOnly ?? true;
   } catch (error) {
     log.error('Error in meta-tags configuration:', error);
   }
@@ -347,12 +351,14 @@ export async function runAuditAndGenerateSuggestions(context) {
     },
   );
 
-  // Get useHostnameOnly setting
-  let useHostnameOnly = false;
+  // Get useHostnameOnly setting. Defaults to true so an absolute endpoint is appended
+  // to the origin, not to a base URL that already carries a path (sub-path sites would
+  // otherwise get a duplicated /omes/omes/... URL). No-op for root-domain sites.
+  let useHostnameOnly = true;
   try {
     const siteId = opportunity.getSiteId();
     const siteObj = await context.dataAccess.Site.findById(siteId);
-    useHostnameOnly = siteObj?.getDeliveryConfig?.()?.useHostnameOnly ?? false;
+    useHostnameOnly = siteObj?.getDeliveryConfig?.()?.useHostnameOnly ?? true;
   } catch (error) {
     log.error('Error in meta-tags configuration:', error);
   }

--- a/src/metatags/handler.js
+++ b/src/metatags/handler.js
@@ -438,8 +438,14 @@ export async function runAuditAndGenerateSuggestions(context) {
     };
   });
 
-  // Build unique pageUrls from all suggestions
-  const pageUrls = [...new Set(suggestionMap.map((s) => `${site.getBaseURL()}${s.endpoint}`))];
+  // Build unique pageUrls from all suggestions. Resolve each endpoint (an absolute
+  // path) against the base URL's origin rather than string-concatenating onto the
+  // full base URL: for a subpath site (e.g. baseURL https://oklahoma.gov/omes) the
+  // endpoint already carries the full path (/omes/...), so concatenation produced a
+  // malformed /omes/omes/... URL. No-op for root-domain sites.
+  const pageUrls = [
+    ...new Set(suggestionMap.map((s) => new URL(s.endpoint, site.getBaseURL()).toString())),
+  ];
 
   log.info(`[metatags] Sending ${suggestionMap.length} suggestions to Mystique (${pageUrls.length} unique pages)`);
 

--- a/src/metatags/ssr-meta-validator.js
+++ b/src/metatags/ssr-meta-validator.js
@@ -89,7 +89,11 @@ export async function validateDetectedIssues(detectedTags, baseUrl, log) {
   // Process endpoints sequentially to avoid overwhelming the server
   for (const endpoint of endpoints) {
     const tags = updatedDetectedTags[endpoint];
-    const fullUrl = `${baseUrl}${endpoint}`;
+    // Resolve the endpoint (an absolute path) against the base URL's origin rather
+    // than concatenating onto the full base URL, which for a subpath site (e.g.
+    // baseURL https://oklahoma.gov/omes) would double the path (/omes/omes/...).
+    // No-op for root-domain sites.
+    const fullUrl = new URL(endpoint, baseUrl).toString();
 
     // Check if any of the issues are related to missing tags
     const hasMissingIssues = ['title', 'description', 'h1'].some(

--- a/src/metatags/ssr-meta-validator.js
+++ b/src/metatags/ssr-meta-validator.js
@@ -89,10 +89,9 @@ export async function validateDetectedIssues(detectedTags, baseUrl, log) {
   // Process endpoints sequentially to avoid overwhelming the server
   for (const endpoint of endpoints) {
     const tags = updatedDetectedTags[endpoint];
-    // Resolve the endpoint (an absolute path) against the base URL's origin rather
-    // than concatenating onto the full base URL, which for a subpath site (e.g.
-    // baseURL https://oklahoma.gov/omes) would double the path (/omes/omes/...).
-    // No-op for root-domain sites.
+    // Resolve the endpoint (an absolute path) against the base URL's origin; concatenating
+    // onto a base that already carries a path (sub-path site, e.g. example.com/foo) would
+    // double it (/foo/foo/...). No-op for root-domain sites.
     const fullUrl = new URL(endpoint, baseUrl).toString();
 
     // Check if any of the issues are related to missing tags

--- a/src/product-metatags/handler.js
+++ b/src/product-metatags/handler.js
@@ -160,8 +160,11 @@ export async function opportunityAndSuggestions(finalUrl, auditData, context) {
     return;
   }
 
-  // Fetch site configuration once for all suggestions
-  let useHostnameOnly = false;
+  // Fetch site configuration once for all suggestions.
+  // Default hostname-only: the endpoint is an absolute pathname, so it is appended to
+  // the origin. Appending to a base that already carries a path (a sub-path site, e.g.
+  // example.com/foo) duplicated it (/foo/foo/...). No-op for root-domain sites.
+  let useHostnameOnly = true;
   let site = null;
   let customConfig = null;
   let productUrlTemplate = null;
@@ -171,7 +174,7 @@ export async function opportunityAndSuggestions(finalUrl, auditData, context) {
   try {
     const siteId = opportunity.getSiteId();
     site = await context.dataAccess.Site.findById(siteId);
-    useHostnameOnly = site?.getDeliveryConfig?.()?.useHostnameOnly ?? false;
+    useHostnameOnly = site?.getDeliveryConfig?.()?.useHostnameOnly ?? true;
 
     // Get handler configuration for locale extraction and commerce config
     customConfig = site?.getConfig?.()?.getHandlers?.()?.[auditType];

--- a/test/audits/product-metatags.test.js
+++ b/test/audits/product-metatags.test.js
@@ -1456,6 +1456,37 @@ describe('Product MetaTags', () => {
         expect(logStub.info.args.some((c) => c && c[0] && /\[PRODUCT-METATAGS] Successfully synced \d+ suggestions for site: site-id and product-metatags audit type\./.test(c[0]))).to.be.true;
       });
 
+      it('builds absolute suggestion data.url for a subpath site — no /foo/foo (SITES-49656)', async () => {
+        dataAccessStub.Opportunity.allBySiteIdAndStatus.resolves([opportunity]);
+        opportunity.getSuggestions.returns([]);
+        // Default hostname-only (getDeliveryConfig returns {}): the endpoint already
+        // carries the /foo prefix, so it must resolve against the origin, not the base URL.
+        const subpathAuditData = {
+          siteId: 'site-id',
+          auditId: 'audit-id',
+          auditResult: {
+            finalUrl: 'https://example.com/foo',
+            detectedTags: {
+              '/foo/product1': {
+                title: {
+                  tagContent: 'Amazing Product - Buy Now',
+                  seoRecommendation: 'Unique across pages',
+                  issue: 'Duplicate Title',
+                  issueDetails: '3 pages share same title',
+                  seoImpact: 'High',
+                },
+              },
+            },
+          },
+        };
+
+        await opportunityAndSuggestions(auditUrl, subpathAuditData, context);
+
+        const newSuggestions = opportunity.addSuggestions.getCall(0).args[0];
+        expect(newSuggestions[0].data.url).to.equal('https://example.com/foo/product1');
+        expect(newSuggestions[0].data.url).to.not.contain('/foo/foo/');
+      });
+
       it('should throw error if fetching opportunity fails', async () => {
         dataAccessStub.Opportunity.allBySiteIdAndStatus.rejects(new Error('some-error'));
         try {
@@ -1738,8 +1769,8 @@ describe('Product MetaTags', () => {
 
         const addSuggestionsCall = opportunity.addSuggestions.getCall(0);
         const suggestions = addSuggestionsCall.args[0];
-        // Should preserve full URL path since useHostnameOnly is undefined
-        expect(suggestions[0].data.url).to.equal('http://localhost:8080/path/product1');
+        // Defaults to hostname-only when useHostnameOnly is undefined (endpoint is absolute)
+        expect(suggestions[0].data.url).to.equal('http://localhost:8080/product1');
         expect(logStub.info).to.be.calledWith('[PRODUCT-METATAGS] Successfully synced 4 suggestions for site: site-id and product-metatags audit type.');
       });
 
@@ -1759,8 +1790,8 @@ describe('Product MetaTags', () => {
 
         const addSuggestionsCall = opportunity.addSuggestions.getCall(0);
         const suggestions = addSuggestionsCall.args[0];
-        // Should preserve full URL path since getSite returns undefined
-        expect(suggestions[0].data.url).to.equal('http://localhost:8080/path/product1');
+        // Defaults to hostname-only when the site lookup returns the default config
+        expect(suggestions[0].data.url).to.equal('http://localhost:8080/product1');
         expect(logStub.info).to.be.calledWith('[PRODUCT-METATAGS] Successfully synced 4 suggestions for site: site-id and product-metatags audit type.');
       });
 
@@ -1780,8 +1811,8 @@ describe('Product MetaTags', () => {
 
         const addSuggestionsCall = opportunity.addSuggestions.getCall(0);
         const suggestions = addSuggestionsCall.args[0];
-        // Should preserve full URL path since getSite returns null
-        expect(suggestions[0].data.url).to.equal('http://localhost:8080/path/product1');
+        // Defaults to hostname-only when the site lookup returns the default config
+        expect(suggestions[0].data.url).to.equal('http://localhost:8080/product1');
         expect(logStub.info).to.be.calledWith('[PRODUCT-METATAGS] Successfully synced 4 suggestions for site: site-id and product-metatags audit type.');
       });
 
@@ -1804,8 +1835,8 @@ describe('Product MetaTags', () => {
 
         const addSuggestionsCall = opportunity.addSuggestions.getCall(0);
         const suggestions = addSuggestionsCall.args[0];
-        // Should preserve full URL path since error caused useHostnameOnly to stay false
-        expect(suggestions[0].data.url).to.equal('http://localhost:8080/path/product1');
+        // Defaults to hostname-only when the site lookup errors
+        expect(suggestions[0].data.url).to.equal('http://localhost:8080/product1');
       });
 
       it('should include product tags in suggestions when available', async () => {

--- a/test/metatags/metatags.test.js
+++ b/test/metatags/metatags.test.js
@@ -1870,6 +1870,48 @@ describe('Meta Tags', () => {
         expect(sentMessage.data.pageUrls).to.have.lengthOf(2);
       });
 
+      it('builds absolute pageUrls for a subpath site without duplicating the base path (SITES-49656)', async () => {
+        site.getBaseURL.returns('https://oklahoma.gov/omes');
+        dataAccessStub.Suggestion.allByOpportunityIdAndStatus.resolves([
+          {
+            getId: sinon.stub().returns('sugg-omes-1'),
+            getData: sinon.stub().returns({
+              url: 'https://oklahoma.gov/omes/divisions/finance.html',
+              tagName: 'title',
+            }),
+          },
+          {
+            getId: sinon.stub().returns('sugg-omes-2'),
+            getData: sinon.stub().returns({
+              url: 'https://oklahoma.gov/omes/about-omes/contact.html',
+              tagName: 'description',
+            }),
+          },
+        ]);
+
+        const auditStub = await esmock('../../src/metatags/handler.js', {
+          '../../src/support/utils.js': { getRUMDomainkey: sinon.stub().resolves('key'), calculateCPCValue: sinon.stub().resolves(5000) },
+          '@adobe/spacecat-shared-rum-api-client': RUMAPIClientStub,
+          '../../src/common/index.js': { wwwUrlResolver: (siteObj) => siteObj.getBaseURL() },
+          '../../src/common/opportunity.js': { convertToOpportunity: sinon.stub().resolves(metatagsOppty) },
+          '../../src/utils/data-access.js': { syncSuggestions: sinon.stub().resolves() },
+          '../../src/metatags/ssr-meta-validator.js': {
+            validateDetectedIssues: sinon.stub().callsFake(async (detectedTags) => detectedTags),
+          },
+        });
+
+        await auditStub.runAuditAndGenerateSuggestions(context);
+
+        const sentMessage = context.sqs.sendMessage.firstCall.args[1];
+        // endpoint already carries /omes; must resolve against origin, not concatenate
+        // onto the full base URL (which produced the malformed /omes/omes/... URL).
+        expect(sentMessage.data.pageUrls).to.have.members([
+          'https://oklahoma.gov/omes/divisions/finance.html',
+          'https://oklahoma.gov/omes/about-omes/contact.html',
+        ]);
+        sentMessage.data.pageUrls.forEach((u) => expect(u).to.not.contain('/omes/omes/'));
+      });
+
       it('when site.requiresValidation is false, fetches suggestions only for NEW status', async () => {
         site.requiresValidation = false;
         dataAccessStub.Suggestion.allByOpportunityIdAndStatus.resetHistory();

--- a/test/metatags/metatags.test.js
+++ b/test/metatags/metatags.test.js
@@ -1454,6 +1454,32 @@ describe('Meta Tags', () => {
         expect(logStub.debug).to.be.calledWith('Successfully synced Opportunity And Suggestions for site: site-id and meta-tags audit type.');
       });
 
+      it('resolves absolute endpoints against the origin for a sub-path site — no /omes/omes (SITES-49656)', async () => {
+        dataAccessStub.Opportunity.allBySiteIdAndStatus.resolves([opportunity]);
+        dataAccessStub.Site.findById = sinon.stub().resolves({
+          getId: () => 'site-id',
+          getDeliveryConfig: () => ({}), // no useHostnameOnly set — defaults to hostname-only
+        });
+        const auditDataSubpath = {
+          ...testData.auditData,
+          auditResult: {
+            ...testData.auditData.auditResult,
+            finalUrl: 'https://oklahoma.gov/omes',
+            detectedTags: {
+              '/omes/divisions/finance.html': {
+                title: { issue: 'Missing Title', seoImpact: 'High' },
+              },
+            },
+          },
+        };
+
+        await opportunityAndSuggestions(auditUrl, auditDataSubpath, context);
+
+        const addSuggestionsCall = opportunity.addSuggestions.getCall(0);
+        const suggestions = addSuggestionsCall.args[0];
+        expect(suggestions[0].data.url).to.equal('https://oklahoma.gov/omes/divisions/finance.html');
+      });
+
       it('should handle case when config.useHostnameOnly is undefined', async () => {
         dataAccessStub.Opportunity.allBySiteIdAndStatus.resolves([opportunity]);
         dataAccessStub.Site.findById = sinon.stub().resolves({
@@ -1473,8 +1499,8 @@ describe('Meta Tags', () => {
 
         const addSuggestionsCall = opportunity.addSuggestions.getCall(0);
         const suggestions = addSuggestionsCall.args[0];
-        // Should preserve full URL path since useHostnameOnly is undefined
-        expect(suggestions[0].data.url).to.equal('http://localhost:8080/path/page1');
+        // Defaults to hostname-only when useHostnameOnly is undefined (endpoint is absolute)
+        expect(suggestions[0].data.url).to.equal('http://localhost:8080/page1');
         expect(logStub.debug).to.be.calledWith('Successfully synced Opportunity And Suggestions for site: site-id and meta-tags audit type.');
       });
 
@@ -1494,8 +1520,8 @@ describe('Meta Tags', () => {
 
         const addSuggestionsCall = opportunity.addSuggestions.getCall(0);
         const suggestions = addSuggestionsCall.args[0];
-        // Should preserve full URL path since getSite returns undefined
-        expect(suggestions[0].data.url).to.equal('http://localhost:8080/path/page1');
+        // Defaults to hostname-only when getSite returns undefined
+        expect(suggestions[0].data.url).to.equal('http://localhost:8080/page1');
         expect(logStub.debug).to.be.calledWith('Successfully synced Opportunity And Suggestions for site: site-id and meta-tags audit type.');
       });
 
@@ -1515,8 +1541,8 @@ describe('Meta Tags', () => {
 
         const addSuggestionsCall = opportunity.addSuggestions.getCall(0);
         const suggestions = addSuggestionsCall.args[0];
-        // Should preserve full URL path since getSite returns null
-        expect(suggestions[0].data.url).to.equal('http://localhost:8080/path/page1');
+        // Defaults to hostname-only when getSite returns null
+        expect(suggestions[0].data.url).to.equal('http://localhost:8080/page1');
         expect(logStub.debug).to.be.calledWith('Successfully synced Opportunity And Suggestions for site: site-id and meta-tags audit type.');
       });
 
@@ -1538,8 +1564,8 @@ describe('Meta Tags', () => {
 
         const addSuggestionsCall = opportunity.addSuggestions.getCall(0);
         const suggestions = addSuggestionsCall.args[0];
-        // Should preserve full URL path since error caused useHostnameOnly to stay false
-        expect(suggestions[0].data.url).to.equal('http://localhost:8080/path/page1');
+        // Defaults to hostname-only when the site lookup errors
+        expect(suggestions[0].data.url).to.equal('http://localhost:8080/page1');
       });
     });
 

--- a/test/metatags/metatags.test.js
+++ b/test/metatags/metatags.test.js
@@ -1454,7 +1454,7 @@ describe('Meta Tags', () => {
         expect(logStub.debug).to.be.calledWith('Successfully synced Opportunity And Suggestions for site: site-id and meta-tags audit type.');
       });
 
-      it('resolves absolute endpoints against the origin for a sub-path site — no /omes/omes (SITES-49656)', async () => {
+      it('resolves absolute endpoints against the origin for a sub-path site — no /foo/foo (SITES-49656)', async () => {
         dataAccessStub.Opportunity.allBySiteIdAndStatus.resolves([opportunity]);
         dataAccessStub.Site.findById = sinon.stub().resolves({
           getId: () => 'site-id',
@@ -1464,9 +1464,9 @@ describe('Meta Tags', () => {
           ...testData.auditData,
           auditResult: {
             ...testData.auditData.auditResult,
-            finalUrl: 'https://oklahoma.gov/omes',
+            finalUrl: 'https://example.com/foo',
             detectedTags: {
-              '/omes/divisions/finance.html': {
+              '/foo/divisions/finance.html': {
                 title: { issue: 'Missing Title', seoImpact: 'High' },
               },
             },
@@ -1477,7 +1477,7 @@ describe('Meta Tags', () => {
 
         const addSuggestionsCall = opportunity.addSuggestions.getCall(0);
         const suggestions = addSuggestionsCall.args[0];
-        expect(suggestions[0].data.url).to.equal('https://oklahoma.gov/omes/divisions/finance.html');
+        expect(suggestions[0].data.url).to.equal('https://example.com/foo/divisions/finance.html');
       });
 
       it('should handle case when config.useHostnameOnly is undefined', async () => {
@@ -1897,19 +1897,19 @@ describe('Meta Tags', () => {
       });
 
       it('builds absolute pageUrls for a subpath site without duplicating the base path (SITES-49656)', async () => {
-        site.getBaseURL.returns('https://oklahoma.gov/omes');
+        site.getBaseURL.returns('https://example.com/foo');
         dataAccessStub.Suggestion.allByOpportunityIdAndStatus.resolves([
           {
-            getId: sinon.stub().returns('sugg-omes-1'),
+            getId: sinon.stub().returns('sugg-foo-1'),
             getData: sinon.stub().returns({
-              url: 'https://oklahoma.gov/omes/divisions/finance.html',
+              url: 'https://example.com/foo/divisions/finance.html',
               tagName: 'title',
             }),
           },
           {
-            getId: sinon.stub().returns('sugg-omes-2'),
+            getId: sinon.stub().returns('sugg-foo-2'),
             getData: sinon.stub().returns({
-              url: 'https://oklahoma.gov/omes/about-omes/contact.html',
+              url: 'https://example.com/foo/about-foo/contact.html',
               tagName: 'description',
             }),
           },
@@ -1929,13 +1929,45 @@ describe('Meta Tags', () => {
         await auditStub.runAuditAndGenerateSuggestions(context);
 
         const sentMessage = context.sqs.sendMessage.firstCall.args[1];
-        // endpoint already carries /omes; must resolve against origin, not concatenate
-        // onto the full base URL (which produced the malformed /omes/omes/... URL).
+        // endpoint already carries /foo; must resolve against origin, not concatenate
+        // onto the full base URL (which produced the malformed /foo/foo/... URL).
         expect(sentMessage.data.pageUrls).to.have.members([
-          'https://oklahoma.gov/omes/divisions/finance.html',
-          'https://oklahoma.gov/omes/about-omes/contact.html',
+          'https://example.com/foo/divisions/finance.html',
+          'https://example.com/foo/about-foo/contact.html',
         ]);
-        sentMessage.data.pageUrls.forEach((u) => expect(u).to.not.contain('/omes/omes/'));
+        sentMessage.data.pageUrls.forEach((u) => expect(u).to.not.contain('/foo/foo/'));
+      });
+
+      it('hands syncSuggestions absolute suggestion data.url for a subpath site — no /foo/foo (SITES-49656)', async () => {
+        site.getBaseURL.returns('https://example.com/foo');
+        context.finalUrl = 'https://example.com/foo';
+        dataAccessStub.Site.findById.resolves({
+          getId: () => 'site-id',
+          getDeliveryConfig: () => ({}), // no useHostnameOnly set — defaults to hostname-only
+        });
+        const syncSuggestionsSpy = sinon.stub().resolves();
+
+        const auditStub = await esmock('../../src/metatags/handler.js', {
+          '../../src/support/utils.js': { getRUMDomainkey: sinon.stub().resolves('key'), calculateCPCValue: sinon.stub().resolves(5000) },
+          '@adobe/spacecat-shared-rum-api-client': RUMAPIClientStub,
+          '../../src/common/index.js': { wwwUrlResolver: (siteObj) => siteObj.getBaseURL() },
+          '../../src/common/opportunity.js': { convertToOpportunity: sinon.stub().resolves(metatagsOppty) },
+          '../../src/utils/data-access.js': { syncSuggestions: syncSuggestionsSpy },
+          '../../src/metatags/ssr-meta-validator.js': {
+            // endpoint already carries the /foo prefix — must resolve against the origin
+            validateDetectedIssues: sinon.stub().resolves({
+              '/foo/divisions/finance.html': {
+                title: { issue: 'Missing Title', seoImpact: 'High' },
+              },
+            }),
+          },
+        });
+
+        await auditStub.runAuditAndGenerateSuggestions(context);
+
+        const { newData } = syncSuggestionsSpy.firstCall.args[0];
+        expect(newData[0].url).to.equal('https://example.com/foo/divisions/finance.html');
+        expect(newData[0].url).to.not.contain('/foo/foo/');
       });
 
       it('when site.requiresValidation is false, fetches suggestions only for NEW status', async () => {

--- a/test/metatags/ssr-validator.test.js
+++ b/test/metatags/ssr-validator.test.js
@@ -331,7 +331,7 @@ describe('SSR Meta Validator', () => {
 
     it('resolves subpath endpoints against the origin without duplicating the base path', async () => {
       const detectedTags = {
-        '/omes/page1': {
+        '/foo/page1': {
           title: { issue: 'Missing title tag' },
         },
       };
@@ -342,12 +342,12 @@ describe('SSR Meta Validator', () => {
         text: async () => '<html><head><title>Present</title></head></html>',
       });
 
-      await validateDetectedIssues(detectedTags, 'https://oklahoma.gov/omes', log);
+      await validateDetectedIssues(detectedTags, 'https://example.com/foo', log);
 
-      // The endpoint already carries the /omes path; it must be resolved against the
-      // origin (https://oklahoma.gov/omes/page1), not concatenated onto the base URL
-      // (which would produce https://oklahoma.gov/omes/omes/page1).
-      expect(fetchStub.firstCall.args[0]).to.equal('https://oklahoma.gov/omes/page1');
+      // The endpoint already carries the /foo path; it must be resolved against the
+      // origin (https://example.com/foo/page1), not concatenated onto the base URL
+      // (which would produce https://example.com/foo/foo/page1).
+      expect(fetchStub.firstCall.args[0]).to.equal('https://example.com/foo/page1');
     });
 
     it('should keep real issues when not found in SSR', async () => {

--- a/test/metatags/ssr-validator.test.js
+++ b/test/metatags/ssr-validator.test.js
@@ -329,6 +329,27 @@ describe('SSR Meta Validator', () => {
       expect(log.info).to.have.been.calledWith('SSR validation complete. Removed 3 false positives from 2 endpoints');
     });
 
+    it('resolves subpath endpoints against the origin without duplicating the base path', async () => {
+      const detectedTags = {
+        '/omes/page1': {
+          title: { issue: 'Missing title tag' },
+        },
+      };
+
+      fetchStub.resolves({
+        ok: true,
+        status: 200,
+        text: async () => '<html><head><title>Present</title></head></html>',
+      });
+
+      await validateDetectedIssues(detectedTags, 'https://oklahoma.gov/omes', log);
+
+      // The endpoint already carries the /omes path; it must be resolved against the
+      // origin (https://oklahoma.gov/omes/page1), not concatenated onto the base URL
+      // (which would produce https://oklahoma.gov/omes/omes/page1).
+      expect(fetchStub.firstCall.args[0]).to.equal('https://oklahoma.gov/omes/page1');
+    });
+
     it('should keep real issues when not found in SSR', async () => {
       const detectedTags = {
         '/page1': {


### PR DESCRIPTION
## What
Meta-tags and product-meta-tags built the suggestion `data.url`, the Mystique `pageUrls`, and the SSR-validator fetch URL by **string-concatenating** the page's absolute pathname onto the full base/final URL:

```js
`${site.getBaseURL()}${endpoint}`        // pageUrls
getBaseUrl(finalUrl, useHostnameOnly) + endpoint   // suggestion data.url
`${baseUrl}${endpoint}`                  // SSR validator
```

For a **sub-path site** (baseURL e.g. `https://example.com/foo`) the endpoint already carries the `/foo` prefix, so concatenation produced a malformed `https://example.com/foo/foo/...` URL.

## Fix
- **metatags** (`handler.js`, `ssr-meta-validator.js`): resolve each endpoint (an absolute path) against the base URL's **origin** — `new URL(endpoint, baseUrl)` for `pageUrls`/SSR, and default `useHostnameOnly` to **true** (both the initial value and the `?? true` fallback) so `getBaseUrl(finalUrl)` returns the origin for the suggestion `data.url`. Now that endpoints are always absolute pathnames, hostname-only is the correct default.
- **product-metatags** (`handler.js`): identical defect — same `useHostnameOnly` default flip (initial value + `?? true`).

All spots are **no-ops for root-domain sites** (their base URL has no path).

## Re-keying note
Existing sub-path sites' malformed suggestions will be re-keyed (**OUTDATED → new**) on the next run, since `buildKey` includes `data.url`.

## Tests
- metatags: SSR validator and `opportunityAndSuggestions` sub-path `data.url` assertions; a **wired** `runAuditAndGenerateSuggestions` assertion on the `newData` handed to `syncSuggestions` (data.url is `https://example.com/foo/<page>`, not `/foo/foo/`); the four `useHostnameOnly`-default tests updated to the hostname-only result.
- product-metatags: sub-path `data.url` assertion on the wired `syncSuggestions` → `addSuggestions` path; existing default-branch assertions corrected.
- All affected suites green; lint clean; coverage bar held.

## Context
Bug 2 of **SITES-49656** (multi-site-per-domain / sub-path onboarding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Xinyi Feng", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```