### PR TITLE
fix(audits): query RUM by hostname for sub-path sites (cwv, internal-links, forms, alt-text)

### DIFF
--- a/src/cwv/cwv-audit-result.js
+++ b/src/cwv/cwv-audit-result.js
@@ -110,9 +110,8 @@ export async function buildCWVAuditResult(context) {
   const rumApiClient = RUMAPIClient.createFrom(context);
   const groupedURLs = site.getConfig().getGroupedURLs(Audit.AUDIT_TYPES.CWV);
   const options = {
-    // RUM is keyed per hostname; a sub-path site's auditUrl carries a path
-    // (e.g. oklahoma.gov/omes) with no domainkey. Query by hostname, then the
-    // per-URL results below are scoped to the site's base path.
+    // RUM is keyed per hostname; a sub-path auditUrl (e.g. example.com/foo) has no
+    // domainkey. Query by hostname; per-URL results are scoped to the base path below.
     domain: getRUMDomain(auditUrl),
     interval: INTERVAL,
     granularity: 'hourly',
@@ -120,13 +119,9 @@ export async function buildCWVAuditResult(context) {
   };
   const cwvData = await rumApiClient.query(Audit.AUDIT_TYPES.CWV, options);
 
-  // SITES-49656: subpath sites (a concrete path onboarded as its own site, e.g.
-  // https://oklahoma.gov/omes) share the domain-keyed RUM query with the whole
-  // domain, so cwvData carries sibling-site pages. Scope the per-URL entries to
-  // the site's base path — reusing the internal-links audit-scope filter — before
-  // top-N/threshold selection so the report and resulting opportunities don't
-  // bleed in unrelated pages. Root-domain sites (no base path) are unaffected;
-  // operator-configured `group` entries are left untouched.
+  // SITES-49656: sub-path sites (e.g. example.com/foo) share the domain-keyed RUM
+  // query, so scope per-URL entries to the base path before top-N/threshold selection.
+  // Root-domain sites and operator-configured `group` entries are unaffected.
   const scopedCwvData = cwvData.filter(
     (item) => item.type !== 'url' || isWithinAuditScope(item.url, baseURL),
   );

--- a/src/cwv/cwv-audit-result.js
+++ b/src/cwv/cwv-audit-result.js
@@ -15,6 +15,7 @@ import { Audit, Entitlement } from '@adobe/spacecat-shared-data-access';
 import { TierClient } from '@adobe/spacecat-shared-tier-client';
 import { removeTrailingSlash } from '../utils/url-utils.js';
 import { isWithinAuditScope } from '../internal-links/subpath-filter.js';
+import { getRUMDomain } from '../support/utils.js';
 
 const DAILY_THRESHOLD = 1000; // pageviews
 const INTERVAL = 7; // days
@@ -109,7 +110,10 @@ export async function buildCWVAuditResult(context) {
   const rumApiClient = RUMAPIClient.createFrom(context);
   const groupedURLs = site.getConfig().getGroupedURLs(Audit.AUDIT_TYPES.CWV);
   const options = {
-    domain: auditUrl,
+    // RUM is keyed per hostname; a sub-path site's auditUrl carries a path
+    // (e.g. oklahoma.gov/omes) with no domainkey. Query by hostname, then the
+    // per-URL results below are scoped to the site's base path.
+    domain: getRUMDomain(auditUrl),
     interval: INTERVAL,
     granularity: 'hourly',
     groupedURLs,

--- a/src/forms-opportunities/handler.js
+++ b/src/forms-opportunities/handler.js
@@ -39,9 +39,8 @@ export async function formsAuditRunner(auditUrl, context) {
   const { site, log } = context;
   const rumAPIClient = RUMAPIClient.createFrom(context);
   const options = {
-    // RUM is keyed per hostname; a sub-path site's auditUrl carries a path
-    // (e.g. oklahoma.gov/omes) with no domainkey. Query by hostname, then scope
-    // the returned per-URL form vitals to the site's base path.
+    // RUM is keyed per hostname; a sub-path auditUrl (e.g. example.com/foo) has no
+    // domainkey. Query by hostname; form vitals are scoped to the base path below.
     domain: getRUMDomain(auditUrl),
     interval: FORMS_AUDIT_INTERVAL,
     granularity: 'hourly',

--- a/src/forms-opportunities/handler.js
+++ b/src/forms-opportunities/handler.js
@@ -21,7 +21,8 @@ import {
   getUrlsDataForAccessibilityAudit,
   sendMessageToMystiqueForGuidance,
 } from './utils.js';
-import { getScrapedDataForSiteId } from '../support/utils.js';
+import { getScrapedDataForSiteId, getRUMDomain } from '../support/utils.js';
+import { filterByAuditScope } from '../internal-links/subpath-filter.js';
 import createLowConversionOpportunities from './oppty-handlers/low-conversion-handler.js';
 import createLowNavigationOpportunities from './oppty-handlers/low-navigation-handler.js';
 import createLowViewsOpportunities from './oppty-handlers/low-views-handler.js';
@@ -35,16 +36,20 @@ const FORMS_OPPTY_QUERIES = [
 ];
 
 export async function formsAuditRunner(auditUrl, context) {
+  const { site, log } = context;
   const rumAPIClient = RUMAPIClient.createFrom(context);
   const options = {
-    domain: auditUrl,
+    // RUM is keyed per hostname; a sub-path site's auditUrl carries a path
+    // (e.g. oklahoma.gov/omes) with no domainkey. Query by hostname, then scope
+    // the returned per-URL form vitals to the site's base path.
+    domain: getRUMDomain(auditUrl),
     interval: FORMS_AUDIT_INTERVAL,
     granularity: 'hourly',
   };
 
   const queryResults = await rumAPIClient.queryMulti(FORMS_OPPTY_QUERIES, options);
   const auditResult = {
-    formVitals: queryResults['form-vitals'],
+    formVitals: filterByAuditScope(queryResults['form-vitals'], site?.getBaseURL?.(), {}, log),
     auditContext: {
       interval: FORMS_AUDIT_INTERVAL,
     },

--- a/src/image-alt-text/url-utils.js
+++ b/src/image-alt-text/url-utils.js
@@ -72,8 +72,8 @@ export async function getTopPageUrls({
         baseUrls = results
           .sort((a, b) => (b.earned || 0) - (a.earned || 0))
           .map((r) => normalizeUrl(r.url));
-        // RUM data is domain-wide; scope to the site's base path so a sub-path site
-        // (e.g. oklahoma.gov/omes) doesn't inherit the whole domain. No-op for root.
+        // RUM data is domain-wide; scope to the base path so a sub-path site
+        // (e.g. example.com/foo) doesn't inherit the whole domain. No-op for root.
         baseUrls = filterByAuditScope(baseUrls, site.getBaseURL(), {}, log);
         log.info(`[${AUDIT_TYPE}]: Found ${baseUrls.length} URLs from RUM`);
       }

--- a/src/image-alt-text/url-utils.js
+++ b/src/image-alt-text/url-utils.js
@@ -15,6 +15,7 @@ import RUMAPIClient from '@adobe/spacecat-shared-rum-api-client';
 import { getRUMUrl } from '../support/utils.js';
 import { RUM_INTERVAL } from './constants.js';
 import { getAuditTargetUrls } from '../utils/data-access.js';
+import { filterByAuditScope } from '../internal-links/subpath-filter.js';
 
 const AUDIT_TYPE = AuditModel.AUDIT_TYPES.ALT_TEXT;
 
@@ -71,6 +72,9 @@ export async function getTopPageUrls({
         baseUrls = results
           .sort((a, b) => (b.earned || 0) - (a.earned || 0))
           .map((r) => normalizeUrl(r.url));
+        // RUM data is domain-wide; scope to the site's base path so a sub-path site
+        // (e.g. oklahoma.gov/omes) doesn't inherit the whole domain. No-op for root.
+        baseUrls = filterByAuditScope(baseUrls, site.getBaseURL(), {}, log);
         log.info(`[${AUDIT_TYPE}]: Found ${baseUrls.length} URLs from RUM`);
       }
     } catch (err) {

--- a/src/internal-links/rum-detection.js
+++ b/src/internal-links/rum-detection.js
@@ -13,6 +13,7 @@
 import { createInternalLinksConfigResolver } from './config.js';
 import { createInternalLinksStepLogger } from './logging.js';
 import { isCrossLocalePDP404RumPair } from './scope-utils.js';
+import { getRUMDomain } from '../support/utils.js';
 
 const RUM_VALIDATION_CONCURRENCY = 10;
 
@@ -69,7 +70,10 @@ export function createInternalLinksRumSteps({
     try {
       const rumAPIClient = context.rumApiClient || createRUMAPIClient(context);
       const options = {
-        domain: finalUrl,
+        // RUM is keyed per hostname; a sub-path site's finalUrl carries a path
+        // (e.g. oklahoma.gov/omes) with no domainkey. Query by hostname, then the
+        // 404 pairs are scoped to the site's base path below.
+        domain: getRUMDomain(finalUrl),
         interval,
         granularity: 'hourly',
       };

--- a/src/internal-links/rum-detection.js
+++ b/src/internal-links/rum-detection.js
@@ -70,9 +70,8 @@ export function createInternalLinksRumSteps({
     try {
       const rumAPIClient = context.rumApiClient || createRUMAPIClient(context);
       const options = {
-        // RUM is keyed per hostname; a sub-path site's finalUrl carries a path
-        // (e.g. oklahoma.gov/omes) with no domainkey. Query by hostname, then the
-        // 404 pairs are scoped to the site's base path below.
+        // RUM is keyed per hostname; a sub-path finalUrl (e.g. example.com/foo) has no
+        // domainkey. Query by hostname; 404 pairs are scoped to the base path below.
         domain: getRUMDomain(finalUrl),
         interval,
         granularity: 'hourly',

--- a/src/internal-links/subpath-filter.js
+++ b/src/internal-links/subpath-filter.js
@@ -16,8 +16,7 @@ import { prependSchema, stripWWW } from '@adobe/spacecat-shared-utils';
  * Checks if a URL is within the audit scope defined by baseURL.
  * For baseURL with subpath (e.g., bulk.com/uk), only URLs starting with that subpath are included.
  * For baseURL without subpath (e.g., bulk.com), all URLs are included.
- *
- * This follows the same pattern as redirect-chains audit (handler.js lines 458-493).
+ * The section landing page (`${basePath}.html`) is treated as in scope.
  *
  * @param {string} url - The URL to check (can be relative or absolute)
  * @param {string} baseURL - The base URL defining the audit scope
@@ -43,11 +42,13 @@ export function isWithinAuditScope(url, baseURL) {
 
     // Ensure we match with a trailing slash to avoid false positives (e.g., /fr/ not /french)
     const basePathWithSlash = `${basePath}/`;
+    // The section's landing page (e.g. /foo.html) is in scope too.
+    const basePathLanding = `${basePath}.html`;
 
     // Handle relative URLs
     if (!url.startsWith('http://') && !url.startsWith('https://')) {
       // Relative URL - check if it starts with the scope path
-      return url.startsWith(basePathWithSlash) || url === basePath;
+      return url.startsWith(basePathWithSlash) || url === basePath || url === basePathLanding;
     }
 
     // Handle absolute URLs
@@ -62,7 +63,9 @@ export function isWithinAuditScope(url, baseURL) {
     }
 
     // Compare paths (protocol-agnostic)
-    return parsedUrl.pathname.startsWith(basePathWithSlash) || parsedUrl.pathname === basePath;
+    return parsedUrl.pathname.startsWith(basePathWithSlash)
+      || parsedUrl.pathname === basePath
+      || parsedUrl.pathname === basePathLanding;
   } catch (error) {
     // If URL parsing fails, exclude it to be safe
     return false;

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -89,12 +89,8 @@ export async function getRUMUrl(url) {
 
 /**
  * Resolves the RUM query domain (hostname) from a resolved audit/final URL.
- *
- * RUM data is keyed per hostname; a sub-path site's resolved URL carries a path
- * (e.g. "oklahoma.gov/omes"), which has no RUM domainkey and 404s the domainkey
- * exchange. Strip to the hostname so the domain-wide RUM data can be fetched, then
- * the per-URL results are filtered to the site's base path by the caller. No-op for
- * bare-hostname / root URLs.
+ * RUM is keyed per hostname, so a sub-path URL (e.g. "example.com/foo") must be
+ * stripped to its hostname; the per-URL results are scoped by the caller. No-op for root.
  *
  * @param {string} url - The resolved audit/final URL (scheme and path optional).
  * @returns {string} The hostname, or the original value if it cannot be parsed.

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -88,6 +88,26 @@ export async function getRUMUrl(url) {
 }
 
 /**
+ * Resolves the RUM query domain (hostname) from a resolved audit/final URL.
+ *
+ * RUM data is keyed per hostname; a sub-path site's resolved URL carries a path
+ * (e.g. "oklahoma.gov/omes"), which has no RUM domainkey and 404s the domainkey
+ * exchange. Strip to the hostname so the domain-wide RUM data can be fetched, then
+ * the per-URL results are filtered to the site's base path by the caller. No-op for
+ * bare-hostname / root URLs.
+ *
+ * @param {string} url - The resolved audit/final URL (scheme and path optional).
+ * @returns {string} The hostname, or the original value if it cannot be parsed.
+ */
+export function getRUMDomain(url) {
+  try {
+    return new URL(prependSchema(url)).hostname;
+  } catch {
+    return url;
+  }
+}
+
+/**
  * Checks if a given URL contains a domain with a non-www subdomain.
  *
  * @param {string} baseUrl - The URL to check for the presence of a domain with a non-www subdomain.

--- a/test/audits/cwv/cwv-audit-result.test.js
+++ b/test/audits/cwv/cwv-audit-result.test.js
@@ -246,8 +246,8 @@ describe('CWV Audit Result', () => {
 
     describe('subpath-site base-path scoping (SITES-49656)', () => {
       const subpathSite = {
-        getId: () => 'omes',
-        getBaseURL: () => 'https://www.example.gov/omes',
+        getId: () => 'us',
+        getBaseURL: () => 'https://www.example.gov/us',
         getConfig: () => ({ getGroupedURLs: () => [] }),
       };
 
@@ -270,34 +270,34 @@ describe('CWV Audit Result', () => {
       it('keeps only pages under the site base path and drops sibling-site pages', async () => {
         const cwvDataFromRum = [
           {
-            type: 'url', url: 'https://www.example.gov/omes', pageviews: 100000, organic: 0, metrics: [],
+            type: 'url', url: 'https://www.example.gov/us', pageviews: 100000, organic: 0, metrics: [],
           },
           {
-            type: 'url', url: 'https://www.example.gov/omes/leadership.html', pageviews: 6000, organic: 0, metrics: [],
+            type: 'url', url: 'https://www.example.gov/us/leadership.html', pageviews: 6000, organic: 0, metrics: [],
           },
           {
-            type: 'url', url: 'https://www.example.gov/okdhs.html', pageviews: 5900, organic: 0, metrics: [],
+            type: 'url', url: 'https://www.example.gov/other.html', pageviews: 5900, organic: 0, metrics: [],
           },
           {
-            type: 'url', url: 'https://www.example.gov/omes-budget', pageviews: 5800, organic: 0, metrics: [],
+            type: 'url', url: 'https://www.example.gov/us-budget', pageviews: 5800, organic: 0, metrics: [],
           },
           {
-            type: 'group', pattern: '/omes/*', name: 'OMES pages', pageviews: 5000, organic: 0, metrics: [],
+            type: 'group', pattern: '/us/*', name: 'US pages', pageviews: 5000, organic: 0, metrics: [],
           },
         ];
         const { buildCWVAuditResult: build } = await buildForSubpath(cwvDataFromRum);
 
         const result = await build({
-          site: subpathSite, finalUrl: 'www.example.gov/omes', log, env: {},
+          site: subpathSite, finalUrl: 'www.example.gov/us', log, env: {},
         });
 
         const urls = result.auditResult.cwv.filter((e) => e.type === 'url').map((e) => e.url);
-        expect(urls).to.include('https://www.example.gov/omes');
-        expect(urls).to.include('https://www.example.gov/omes/leadership.html');
-        // sibling agency page on the same domain but outside /omes — must be dropped
-        expect(urls).to.not.include('https://www.example.gov/okdhs.html');
-        // directory-boundary safety: /omes-budget is a sibling, not under /omes/
-        expect(urls).to.not.include('https://www.example.gov/omes-budget');
+        expect(urls).to.include('https://www.example.gov/us');
+        expect(urls).to.include('https://www.example.gov/us/leadership.html');
+        // sibling agency page on the same domain but outside /us — must be dropped
+        expect(urls).to.not.include('https://www.example.gov/other.html');
+        // directory-boundary safety: /us-budget is a sibling, not under /us/
+        expect(urls).to.not.include('https://www.example.gov/us-budget');
         // operator-configured group entries pass through untouched
         expect(result.auditResult.cwv.find((e) => e.type === 'group')).to.exist;
       });
@@ -311,11 +311,11 @@ describe('CWV Audit Result', () => {
         });
 
         await build({
-          site: subpathSite, finalUrl: 'www.example.gov/omes', log, env: {},
+          site: subpathSite, finalUrl: 'www.example.gov/us', log, env: {},
         });
 
-        // Sub-path finalUrl (www.example.gov/omes) must be stripped to the hostname for
-        // the RUM query — the per-URL results are scoped to /omes separately.
+        // Sub-path finalUrl (www.example.gov/us) must be stripped to the hostname for
+        // the RUM query — the per-URL results are scoped to /us separately.
         expect(queryStub.getCalls().some((c) => c.args[1]?.domain === 'www.example.gov'))
           .to.equal(true);
       });
@@ -323,7 +323,7 @@ describe('CWV Audit Result', () => {
       it('drops url entries whose URL cannot be parsed', async () => {
         const cwvDataFromRum = [
           {
-            type: 'url', url: 'https://www.example.gov/omes', pageviews: 100000, organic: 0, metrics: [],
+            type: 'url', url: 'https://www.example.gov/us', pageviews: 100000, organic: 0, metrics: [],
           },
           {
             type: 'url', url: ':::not-a-url', pageviews: 6000, organic: 0, metrics: [],
@@ -332,11 +332,11 @@ describe('CWV Audit Result', () => {
         const { buildCWVAuditResult: build } = await buildForSubpath(cwvDataFromRum);
 
         const result = await build({
-          site: subpathSite, finalUrl: 'www.example.gov/omes', log, env: {},
+          site: subpathSite, finalUrl: 'www.example.gov/us', log, env: {},
         });
 
         const urls = result.auditResult.cwv.filter((e) => e.type === 'url').map((e) => e.url);
-        expect(urls).to.deep.equal(['https://www.example.gov/omes']);
+        expect(urls).to.deep.equal(['https://www.example.gov/us']);
       });
     });
   });

--- a/test/audits/cwv/cwv-audit-result.test.js
+++ b/test/audits/cwv/cwv-audit-result.test.js
@@ -302,6 +302,24 @@ describe('CWV Audit Result', () => {
         expect(result.auditResult.cwv.find((e) => e.type === 'group')).to.exist;
       });
 
+      it('queries RUM by hostname (not the sub-path) so the domainkey resolves', async () => {
+        const queryStub = sandbox.stub().resolves([]);
+        const { buildCWVAuditResult: build } = await esmock('../../../src/cwv/cwv-audit-result.js', {
+          '@adobe/spacecat-shared-rum-api-client': {
+            default: { createFrom: sandbox.stub().returns({ query: queryStub }) },
+          },
+        });
+
+        await build({
+          site: subpathSite, finalUrl: 'www.example.gov/omes', log, env: {},
+        });
+
+        // Sub-path finalUrl (www.example.gov/omes) must be stripped to the hostname for
+        // the RUM query — the per-URL results are scoped to /omes separately.
+        expect(queryStub.getCalls().some((c) => c.args[1]?.domain === 'www.example.gov'))
+          .to.equal(true);
+      });
+
       it('drops url entries whose URL cannot be parsed', async () => {
         const cwvDataFromRum = [
           {

--- a/test/audits/forms/handler.test.js
+++ b/test/audits/forms/handler.test.js
@@ -74,12 +74,41 @@ describe('Forms Vitals audit', () => {
   });
 
   it('queries RUM by the bare hostname (not the sub-path) so the domainkey resolves', async () => {
-    const subpathSite = { getBaseURL: () => 'https://example.com/foo' };
-    await formsAuditRunner('https://example.com/foo', context, subpathSite);
+    await formsAuditRunner('https://example.com/foo', context, site);
 
     // The RUM `domain` must be the hostname, not the sub-path audit URL.
     const call = context.rumApiClient.queryMulti.getCalls().at(-1);
     expect(call.args[1].domain).to.equal('example.com');
+  });
+
+  it('scopes form-vitals to the site base path, dropping out-of-scope forms', async () => {
+    const subpathContext = new MockContextBuilder()
+      .withSandbox(sandbox)
+      .withOverrides({
+        runtime: { name: 'aws-lambda', region: 'us-east-1' },
+        func: { package: 'spacecat-services', version: 'ci', name: 'test' },
+        site: { getBaseURL: () => 'https://example.com/foo' },
+        rumApiClient: {
+          queryMulti: sinon.stub().resolves({
+            cwv: [],
+            'form-vitals': [
+              { url: 'https://example.com/foo/contact' },
+              { url: 'https://example.com/foo/signup' },
+              { url: 'https://example.com/other/contact' }, // sibling agency — out of scope
+              { url: 'https://example.com/foobar' }, // boundary sibling — out of scope
+            ],
+          }),
+        },
+      })
+      .build();
+
+    const result = await formsAuditRunner('https://example.com/foo', subpathContext);
+
+    const urls = result.auditResult.formVitals.map((v) => v.url);
+    expect(urls).to.deep.equal([
+      'https://example.com/foo/contact',
+      'https://example.com/foo/signup',
+    ]);
   });
 });
 

--- a/test/audits/forms/handler.test.js
+++ b/test/audits/forms/handler.test.js
@@ -72,6 +72,15 @@ describe('Forms Vitals audit', () => {
     );
     expect(result).to.deep.equal(expectedFormVitalsData);
   });
+
+  it('queries RUM by the bare hostname (not the sub-path) so the domainkey resolves', async () => {
+    const subpathSite = { getBaseURL: () => 'https://example.com/foo' };
+    await formsAuditRunner('https://example.com/foo', context, subpathSite);
+
+    // The RUM `domain` must be the hostname, not the sub-path audit URL.
+    const call = context.rumApiClient.queryMulti.getCalls().at(-1);
+    expect(call.args[1].domain).to.equal('example.com');
+  });
 });
 
 describe('audit and send scraping step', () => {

--- a/test/audits/internal-links/rum-detection.test.js
+++ b/test/audits/internal-links/rum-detection.test.js
@@ -146,6 +146,26 @@ describe('internal-links rum-detection', () => {
     expect(log.info).to.have.been.calledWith('No 404 internal links found in RUM data');
   });
 
+  it('queries RUM by the bare hostname (not the sub-path) so the domainkey resolves', async () => {
+    const query = sinon.stub().resolves([]);
+    const rumApiClient = { query };
+    const log = createLog();
+    const { internalLinksAuditRunner } = createSteps();
+
+    await internalLinksAuditRunner('https://audit.example', {
+      log,
+      site: {
+        getId: () => 'site-1',
+        getBaseURL: () => 'https://example.com/foo',
+      },
+      rumApiClient,
+      finalUrl: 'https://example.com/foo',
+    });
+
+    // The RUM `domain` must be the hostname, not the sub-path finalUrl.
+    expect(query.firstCall.args[1].domain).to.equal('example.com');
+  });
+
   it('runs the top-pages step on successful rum detection', async () => {
     const rumApiClient = {
       query: sinon.stub().resolves([

--- a/test/audits/internal-links/subpath-filter.test.js
+++ b/test/audits/internal-links/subpath-filter.test.js
@@ -78,6 +78,17 @@ describe('subpath-filter', () => {
       expect(isWithinAuditScope('https://bulk.com/fr/page1', 'bulk.com/uk')).to.equal(false);
     });
 
+    it('should keep the section landing page (basePath.html) but not siblings', () => {
+      // The `${basePath}.html` landing page is in scope.
+      expect(isWithinAuditScope('https://example.com/foo.html', 'https://example.com/foo')).to.equal(true);
+      expect(isWithinAuditScope('/foo.html', 'https://example.com/foo')).to.equal(true);
+      // Boundary safety: siblings sharing the prefix must still be dropped.
+      expect(isWithinAuditScope('https://example.com/foobar', 'https://example.com/foo')).to.equal(false);
+      expect(isWithinAuditScope('https://example.com/foo-x', 'https://example.com/foo')).to.equal(false);
+      expect(isWithinAuditScope('/foobar', 'https://example.com/foo')).to.equal(false);
+      expect(isWithinAuditScope('/foo-x', 'https://example.com/foo')).to.equal(false);
+    });
+
     it('should return false for invalid URLs', () => {
       // Invalid URLs cause parsing errors, which return false
       expect(isWithinAuditScope('not-a-url', 'bulk.com/uk')).to.equal(false);

--- a/test/support/utils.test.js
+++ b/test/support/utils.test.js
@@ -202,8 +202,8 @@ describe('getRUMDomain', () => {
   });
 
   it('returns the hostname for a sub-path URL (RUM is keyed per hostname)', () => {
-    expect(utils.getRUMDomain('https://oklahoma.gov/omes')).to.equal('oklahoma.gov');
-    expect(utils.getRUMDomain('oklahoma.gov/omes')).to.equal('oklahoma.gov');
+    expect(utils.getRUMDomain('https://example.gov/us')).to.equal('example.gov');
+    expect(utils.getRUMDomain('example.gov/us')).to.equal('example.gov');
   });
 
   it('is a no-op for a bare hostname (root sites)', () => {

--- a/test/support/utils.test.js
+++ b/test/support/utils.test.js
@@ -181,6 +181,41 @@ describe('getRUMUrl', () => {
   });
 });
 
+describe('getRUMDomain', () => {
+  let utils;
+
+  beforeEach(async () => {
+    sinon.restore();
+    utils = await esmock('../../src/support/utils.js', {
+      '@adobe/spacecat-shared-utils': {
+        hasText: (str) => typeof str === 'string' && str.trim().length > 0,
+        isNonEmptyArray: (arr) => Array.isArray(arr) && arr.length > 0,
+        isNonEmptyObject: (obj) => obj && typeof obj === 'object' && Object.keys(obj).length > 0,
+        prependSchema: (url) => (url.startsWith('http') ? url : `https://${url}`),
+        tracingFetch: sinon.stub(),
+      },
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('returns the hostname for a sub-path URL (RUM is keyed per hostname)', () => {
+    expect(utils.getRUMDomain('https://oklahoma.gov/omes')).to.equal('oklahoma.gov');
+    expect(utils.getRUMDomain('oklahoma.gov/omes')).to.equal('oklahoma.gov');
+  });
+
+  it('is a no-op for a bare hostname (root sites)', () => {
+    expect(utils.getRUMDomain('example.com')).to.equal('example.com');
+    expect(utils.getRUMDomain('https://www.example.com')).to.equal('www.example.com');
+  });
+
+  it('returns the input when it cannot be parsed', () => {
+    expect(utils.getRUMDomain('')).to.equal('');
+  });
+});
+
 describe('getBaseUrlPagesFromSitemapContents', () => {
   it('should return an empty array when the sitemap content is empty', () => {
     const result = getBaseUrlPagesFromSitemapContents('https://my-site.adbe', undefined);


### PR DESCRIPTION
## What
cwv, broken-internal-links and forms-opportunities passed the resolved audit URL **directly** as the RUM `domain`. For a **sub-path site** the resolved URL carries a path (e.g. `example.com/foo`) which has **no RUM domainkey**, so the domainkey exchange 404s and the audit **fails outright**:
```
Query 'cwv' failed. Opts:{"domain":"example.com/foo",...}
Error during fetching domainkey for domain 'example.com/foo' using admin key. Status: 404
```
(Verified in prod on a sub-path site — both cwv and broken-internal-links errored at the initial step.)

## Fix
- New shared `getRUMDomain(url)` (`src/support/utils.js`) — strips a resolved audit/final URL to its **hostname** (no-op for root/bare-hostname sites).
- Use it for the RUM `domain` in **cwv** (`cwv-audit-result.js`), **broken-internal-links** (`internal-links/rum-detection.js`), and **forms-opportunities** (`forms-opportunities/handler.js`).
- RUM is domain-wide, so results are scoped to the site base path: cwv & internal-links already had `isWithinAuditScope` filters; **forms** now filters `formVitals` via `filterByAuditScope`, and **image-alt-text** scopes its RUM `traffic-acquisition` fallback URLs (its domain was already hostname-only via `getRUMUrl`).

All no-ops for root-domain sites.

## Landing-page widening
The shared subpath filter (`isWithinAuditScope`) used a strict `${basePath}/` boundary, which silently dropped the section's own landing page (`${basePath}.html`) for a sub-path site. The filter now also accepts `${basePath}.html` in both the absolute- and relative-URL branches, while preserving directory-boundary safety (siblings like `/foobar` / `/foo-x` are still dropped).

## Why it complements #2873
The merged CWV per-URL base-path filter (#2873) only runs **after** a successful RUM query. On a sub-path site the query itself 404s first — this PR fixes that earlier failure so the filter can do its job.

## Deferred call sites (found in review)
Not addressed here to avoid a whole-domain leak (each needs both the hostname-strip and a base-path filter together):
- `experimentation-ess/common.js` (`processAudit`) — path-carrying `domain`, no try/catch, would 404 the domainkey exchange for sub-path sites.
- `metatags/handler.js` + `product-metatags/handler.js` `calculateProjectedTraffic` — wwwUrlResolver-sourced RUM `traffic-acquisition` domain; fails soft to zero projected traffic for sub-path sites.

## Tests
- `getRUMDomain` unit tests (hostname strip / root no-op / unparseable fallback).
- cwv, internal-links, and forms: assert the RUM query `domain` is the bare hostname, not the sub-path URL.
- subpath-filter: asserts the `${basePath}.html` landing page is kept while sibling prefixes are still dropped.
- All affected suites green; lint clean.

## Context
Bug 3 of **SITES-49656** (multi-site-per-domain / sub-path onboarding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Xinyi Feng", "Julien Ramboz", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```