### PR TITLE
fix(backlinks): scope broken-backlink results to the site sub-path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@adobe/helix-shared-wrap": "2.0.2",
         "@adobe/helix-status": "10.1.5",
         "@adobe/helix-universal-logger": "3.0.30",
-        "@adobe/mysticat-shared-seo-client": "1.8.0",
+        "@adobe/mysticat-shared-seo-client": "1.8.1",
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
         "@adobe/spacecat-shared-athena-client": "1.11.0",
         "@adobe/spacecat-shared-data-access": "4.19.0",
@@ -550,9 +550,9 @@
       }
     },
     "node_modules/@adobe/mysticat-shared-seo-client": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@adobe/mysticat-shared-seo-client/-/mysticat-shared-seo-client-1.8.0.tgz",
-      "integrity": "sha512-bAwgWSw7bClDqmvWTtWUIwnp2BOgcNXe3NwlSj8rG4ClgBNMUhsi/zFl2R1rHPNGw/j7QUNKiUyLIdWO295Z+g==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@adobe/mysticat-shared-seo-client/-/mysticat-shared-seo-client-1.8.1.tgz",
+      "integrity": "sha512-30doVbyHCF7rfE9DmFn2brlaNc3dixsgpmgtZ1XA2Pc/GY7yjNrZs4gkSJbBxNoDqGWeA2e8CRxNP9horZpJGA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@adobe/helix-shared-wrap": "2.0.2",
     "@adobe/helix-status": "10.1.5",
     "@adobe/helix-universal-logger": "3.0.30",
-    "@adobe/mysticat-shared-seo-client": "1.8.0",
+    "@adobe/mysticat-shared-seo-client": "1.8.1",
     "@adobe/spacecat-helix-content-sdk": "1.4.33",
     "@adobe/spacecat-shared-athena-client": "1.11.0",
     "@adobe/spacecat-shared-data-access": "4.19.0",

--- a/src/backlinks/handler.js
+++ b/src/backlinks/handler.js
@@ -24,7 +24,7 @@ import { createOpportunityData } from './opportunity-data-mapper.js';
 import { syncSuggestionsWithPublishDetection, warnOnInvalidSuggestionData, resolveOpportunityIfNoIssues } from '../utils/data-access.js';
 import { sendLowSuggestionCountAlert } from '../support/plg-suggestion-alert.js';
 import { getMergedAuditInputUrls } from '../utils/audit-input-urls.js';
-import { filterByAuditScope, extractPathPrefix } from '../internal-links/subpath-filter.js';
+import { filterByAuditScope, extractPathPrefix, isWithinAuditScope } from '../internal-links/subpath-filter.js';
 import {
   filterBrokenSuggestedUrls,
   isHtmlContentType,
@@ -329,11 +329,27 @@ export async function brokenBacklinksAuditRunner(auditUrl, context, site) {
       return true;
     });
 
+    // Directory-boundary-safe sub-path scoping. The host-only subdomain filter above and the
+    // server-side `target_url LIKE '%host/path%'` filter (mysticat-shared-seo-client) are both
+    // coarse: the LIKE match also captures sibling paths (e.g. '%oklahoma.gov/omes%' matches
+    // '/omes-budget'). isWithinAuditScope enforces the trailing-slash directory boundary so a
+    // sub-path site keeps only '/omes/*' targets. It is a no-op for root sites (no base path),
+    // and honours the effective base (overrideBaseURL) the same way as the subdomain filter
+    // (SITES-49721).
+    const effectiveBaseURL = overrideBaseURL || siteBaseURL;
+    const scopedBacklinks = filteredBacklinks?.filter((backlink) => {
+      if (isWithinAuditScope(backlink.url_to, effectiveBaseURL)) {
+        return true;
+      }
+      log.debug(`Excluding backlink ${backlink.url_to}: outside audit sub-path scope ${effectiveBaseURL}`);
+      return false;
+    });
+
     return {
       fullAuditRef,
       auditResult: {
         finalUrl: auditUrl,
-        brokenBacklinks: await filterOutValidBacklinks(filteredBacklinks, log),
+        brokenBacklinks: await filterOutValidBacklinks(scopedBacklinks, log),
       },
     };
   } catch (e) {

--- a/src/backlinks/handler.js
+++ b/src/backlinks/handler.js
@@ -329,16 +329,13 @@ export async function brokenBacklinksAuditRunner(auditUrl, context, site) {
       return true;
     });
 
-    // Directory-boundary-safe sub-path scoping. The host-only subdomain filter above and the
-    // server-side `target_url LIKE '%host/path%'` filter (mysticat-shared-seo-client) are both
-    // coarse: the LIKE match also captures sibling paths (e.g. '%oklahoma.gov/omes%' matches
-    // '/omes-budget'). isWithinAuditScope enforces the trailing-slash directory boundary so a
-    // sub-path site keeps only '/omes/*' targets. It is a no-op for root sites (no base path),
-    // and honours the effective base (overrideBaseURL) the same way as the subdomain filter
-    // (SITES-49721).
+    // Directory-boundary-safe sub-path scoping (SITES-49721). The host-only subdomain filter
+    // and the server-side `target_url LIKE '%host/path%'` filter are both coarse (the LIKE also
+    // matches siblings, e.g. '%example.com/foo%' matches '/foo-budget'). prependSchema keeps
+    // scheme-less Semrush target URLs from being treated as relative and dropped. No-op for root.
     const effectiveBaseURL = overrideBaseURL || siteBaseURL;
     const scopedBacklinks = filteredBacklinks?.filter((backlink) => {
-      if (isWithinAuditScope(backlink.url_to, effectiveBaseURL)) {
+      if (isWithinAuditScope(prependSchema(backlink.url_to), effectiveBaseURL)) {
         return true;
       }
       log.debug(`Excluding backlink ${backlink.url_to}: outside audit sub-path scope ${effectiveBaseURL}`);

--- a/test/audits/backlinks.test.js
+++ b/test/audits/backlinks.test.js
@@ -535,6 +535,123 @@ describe('Backlinks Tests', function () {
     });
   });
 
+  describe('sub-path (base-path) scoping (SITES-49721)', () => {
+    it('keeps only /omes/* targets for a sub-path site, dropping same-host and boundary paths', async () => {
+      const backlinks = [
+        {
+          title: 'in scope',
+          url_from: 'https://ref.com/a',
+          url_to: 'https://foo.com/omes/procurement',
+          traffic_domain: 50,
+        },
+        {
+          title: 'same host, different agency — should be dropped',
+          url_from: 'https://ref.com/b',
+          url_to: 'https://foo.com/other-agency',
+          traffic_domain: 40,
+        },
+        {
+          title: 'directory boundary sibling — should be dropped',
+          url_from: 'https://ref.com/c',
+          url_to: 'https://foo.com/omes-budget/report',
+          traffic_domain: 30,
+        },
+      ];
+
+      // Only the in-scope target should ever be fetched (others are filtered out first).
+      nock('https://foo.com')
+        .get('/omes/procurement')
+        .reply(404);
+
+      const subPathSite = {
+        getId: () => 'subpath-site',
+        getBaseURL: () => 'https://foo.com/omes',
+        getConfig: () => Config({}),
+      };
+
+      mockSeoClient.getBrokenBacklinks.resolves({
+        result: { backlinks },
+        fullAuditRef: auditUrl,
+      });
+
+      const result = await brokenBacklinksAuditRunner(auditUrl, context, subPathSite);
+      const resultUrls = result.auditResult.brokenBacklinks.map((b) => b.url_to);
+      expect(resultUrls).to.deep.equal(['https://foo.com/omes/procurement']);
+    });
+
+    it('scopes to the sub-path of the configured overrideBaseURL', async () => {
+      const backlinks = [
+        {
+          title: 'in scope on override host',
+          url_from: 'https://ref.com/a',
+          url_to: 'https://applyonline.hdfc.bank.in/omes/loan',
+          traffic_domain: 50,
+        },
+        {
+          title: 'boundary sibling on override host — should be dropped',
+          url_from: 'https://ref.com/b',
+          url_to: 'https://applyonline.hdfc.bank.in/omes-budget',
+          traffic_domain: 40,
+        },
+      ];
+
+      nock('https://applyonline.hdfc.bank.in')
+        .get('/omes/loan')
+        .reply(404);
+
+      const siteWithOverride = {
+        getId: () => 'override-subpath-site',
+        getBaseURL: () => 'https://applyonline.hdfcbank.com',
+        getConfig: () => Config({
+          fetchConfig: { overrideBaseURL: 'https://applyonline.hdfc.bank.in/omes' },
+        }),
+      };
+
+      mockSeoClient.getBrokenBacklinks.resolves({
+        result: { backlinks },
+        fullAuditRef: auditUrl,
+      });
+
+      const result = await brokenBacklinksAuditRunner(
+        'applyonline.hdfc.bank.in',
+        context,
+        siteWithOverride,
+      );
+      const resultUrls = result.auditResult.brokenBacklinks.map((b) => b.url_to);
+      expect(resultUrls).to.deep.equal(['https://applyonline.hdfc.bank.in/omes/loan']);
+    });
+
+    it('is a no-op for root-domain sites (all same-host paths kept)', async () => {
+      const backlinks = [
+        {
+          title: 'path a',
+          url_from: 'https://ref.com/a',
+          url_to: 'https://foo.com/omes/procurement',
+          traffic_domain: 50,
+        },
+        {
+          title: 'path b',
+          url_from: 'https://ref.com/b',
+          url_to: 'https://foo.com/other-agency',
+          traffic_domain: 40,
+        },
+      ];
+
+      nock('https://foo.com').get('/omes/procurement').reply(404);
+      nock('https://foo.com').get('/other-agency').reply(404);
+
+      mockSeoClient.getBrokenBacklinks.resolves({
+        result: { backlinks },
+        fullAuditRef: auditUrl,
+      });
+
+      const result = await brokenBacklinksAuditRunner(auditUrl, context, site2);
+      const resultUrls = result.auditResult.brokenBacklinks.map((b) => b.url_to);
+      expect(resultUrls).to.include('https://foo.com/omes/procurement');
+      expect(resultUrls).to.include('https://foo.com/other-agency');
+    });
+  });
+
   describe('soft-404 detection', () => {
     it('should keep backlink when 200 response has X-Robots-Tag: noindex', async () => {
       nock('https://foo.com')

--- a/test/audits/backlinks.test.js
+++ b/test/audits/backlinks.test.js
@@ -536,12 +536,12 @@ describe('Backlinks Tests', function () {
   });
 
   describe('sub-path (base-path) scoping (SITES-49721)', () => {
-    it('keeps only /omes/* targets for a sub-path site, dropping same-host and boundary paths', async () => {
+    it('keeps only /us/* targets for a sub-path site, dropping same-host and boundary paths', async () => {
       const backlinks = [
         {
           title: 'in scope',
           url_from: 'https://ref.com/a',
-          url_to: 'https://foo.com/omes/procurement',
+          url_to: 'https://foo.com/us/procurement',
           traffic_domain: 50,
         },
         {
@@ -553,19 +553,19 @@ describe('Backlinks Tests', function () {
         {
           title: 'directory boundary sibling — should be dropped',
           url_from: 'https://ref.com/c',
-          url_to: 'https://foo.com/omes-budget/report',
+          url_to: 'https://foo.com/us-budget/report',
           traffic_domain: 30,
         },
       ];
 
       // Only the in-scope target should ever be fetched (others are filtered out first).
       nock('https://foo.com')
-        .get('/omes/procurement')
+        .get('/us/procurement')
         .reply(404);
 
       const subPathSite = {
         getId: () => 'subpath-site',
-        getBaseURL: () => 'https://foo.com/omes',
+        getBaseURL: () => 'https://foo.com/us',
         getConfig: () => Config({}),
       };
 
@@ -576,7 +576,7 @@ describe('Backlinks Tests', function () {
 
       const result = await brokenBacklinksAuditRunner(auditUrl, context, subPathSite);
       const resultUrls = result.auditResult.brokenBacklinks.map((b) => b.url_to);
-      expect(resultUrls).to.deep.equal(['https://foo.com/omes/procurement']);
+      expect(resultUrls).to.deep.equal(['https://foo.com/us/procurement']);
     });
 
     it('scopes to the sub-path of the configured overrideBaseURL', async () => {
@@ -584,26 +584,26 @@ describe('Backlinks Tests', function () {
         {
           title: 'in scope on override host',
           url_from: 'https://ref.com/a',
-          url_to: 'https://applyonline.hdfc.bank.in/omes/loan',
+          url_to: 'https://applyonline.hdfc.bank.in/us/loan',
           traffic_domain: 50,
         },
         {
           title: 'boundary sibling on override host — should be dropped',
           url_from: 'https://ref.com/b',
-          url_to: 'https://applyonline.hdfc.bank.in/omes-budget',
+          url_to: 'https://applyonline.hdfc.bank.in/us-budget',
           traffic_domain: 40,
         },
       ];
 
       nock('https://applyonline.hdfc.bank.in')
-        .get('/omes/loan')
+        .get('/us/loan')
         .reply(404);
 
       const siteWithOverride = {
         getId: () => 'override-subpath-site',
         getBaseURL: () => 'https://applyonline.hdfcbank.com',
         getConfig: () => Config({
-          fetchConfig: { overrideBaseURL: 'https://applyonline.hdfc.bank.in/omes' },
+          fetchConfig: { overrideBaseURL: 'https://applyonline.hdfc.bank.in/us' },
         }),
       };
 
@@ -618,7 +618,7 @@ describe('Backlinks Tests', function () {
         siteWithOverride,
       );
       const resultUrls = result.auditResult.brokenBacklinks.map((b) => b.url_to);
-      expect(resultUrls).to.deep.equal(['https://applyonline.hdfc.bank.in/omes/loan']);
+      expect(resultUrls).to.deep.equal(['https://applyonline.hdfc.bank.in/us/loan']);
     });
 
     it('is a no-op for root-domain sites (all same-host paths kept)', async () => {
@@ -626,7 +626,7 @@ describe('Backlinks Tests', function () {
         {
           title: 'path a',
           url_from: 'https://ref.com/a',
-          url_to: 'https://foo.com/omes/procurement',
+          url_to: 'https://foo.com/us/procurement',
           traffic_domain: 50,
         },
         {
@@ -637,7 +637,7 @@ describe('Backlinks Tests', function () {
         },
       ];
 
-      nock('https://foo.com').get('/omes/procurement').reply(404);
+      nock('https://foo.com').get('/us/procurement').reply(404);
       nock('https://foo.com').get('/other-agency').reply(404);
 
       mockSeoClient.getBrokenBacklinks.resolves({
@@ -647,8 +647,43 @@ describe('Backlinks Tests', function () {
 
       const result = await brokenBacklinksAuditRunner(auditUrl, context, site2);
       const resultUrls = result.auditResult.brokenBacklinks.map((b) => b.url_to);
-      expect(resultUrls).to.include('https://foo.com/omes/procurement');
+      expect(resultUrls).to.include('https://foo.com/us/procurement');
       expect(resultUrls).to.include('https://foo.com/other-agency');
+    });
+
+    it('keeps a scheme-less in-scope target and drops a scheme-less out-of-scope one', async () => {
+      // Semrush target_url can be scheme-less; without prependSchema, isWithinAuditScope
+      // treats it as a relative path and silently drops it even when in scope.
+      const backlinks = [
+        {
+          title: 'scheme-less in scope',
+          url_from: 'https://ref.com/a',
+          url_to: 'foo.com/us/procurement',
+          traffic_domain: 50,
+        },
+        {
+          title: 'scheme-less sibling — out of scope',
+          url_from: 'https://ref.com/b',
+          url_to: 'foo.com/us-budget/report',
+          traffic_domain: 40,
+        },
+      ];
+
+      const subPathSite = {
+        getId: () => 'subpath-site',
+        getBaseURL: () => 'https://foo.com/us',
+        getConfig: () => Config({}),
+      };
+
+      mockSeoClient.getBrokenBacklinks.resolves({
+        result: { backlinks },
+        fullAuditRef: auditUrl,
+      });
+
+      const result = await brokenBacklinksAuditRunner(auditUrl, context, subPathSite);
+      const resultUrls = result.auditResult.brokenBacklinks.map((b) => b.url_to);
+      expect(resultUrls).to.include('foo.com/us/procurement');
+      expect(resultUrls).to.not.include('foo.com/us-budget/report');
     });
   });
 


### PR DESCRIPTION
## What
Broken-backlink results from Semrush are only host-filtered (`isOnDifferentSubdomain`), never base-path filtered, so a **sub-path site** still receives whole-domain target URLs. The companion server-side `target_url LIKE '%host/path%'` filter (seo-client) is a coarse substring match — e.g. `%example.com/foo%` also matches `/foo-budget`.

## Fix
Add a directory-boundary-safe base-path filter on each broken backlink's target URL (`url_to`), reusing `isWithinAuditScope` from `internal-links/subpath-filter.js`, keyed off the effective base (`overrideBaseURL || baseURL`, matching the subdomain filter). No-op for root sites; the host-only subdomain filter is unchanged and runs alongside it.

Semrush `target_url` can be **scheme-less** (`example.com/foo/page`), which `isWithinAuditScope` treats as a relative path and silently drops even when in-scope. `url_to` is wrapped with `prependSchema` (already imported from `@adobe/spacecat-shared-utils`) — a no-op when a scheme is present, matching this file's existing `isOnDifferentSubdomain` / `normalizeUrl` convention.

## Composition with the seo-client PR
This composes with the seo-client change: the coarse server-side `LIKE` pre-filter is refined here to a precise directory boundary, and this now also handles scheme-less target URLs.

## Tests
- sub-path scoping keeps `/foo/*`, drops same-host siblings and the `/foo-budget` boundary path;
- honours the configured `overrideBaseURL` sub-path;
- no-op for root-domain sites;
- **scheme-less** in-scope `url_to` is kept while a scheme-less out-of-scope one is dropped.
- Suite green; lint clean.

## Context
Part of **SITES-49721** (multi-site-per-domain / sub-path onboarding).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Xinyi Feng", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```