### PR TITLE
[DO NOT MERGE][dev-test] Combined sub-path fixes (#2880 + #2881 + #2882) + local seo-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@adobe/helix-shared-wrap": "2.0.2",
         "@adobe/helix-status": "10.1.5",
         "@adobe/helix-universal-logger": "3.0.30",
-        "@adobe/mysticat-shared-seo-client": "1.8.0",
+        "@adobe/mysticat-shared-seo-client": "https://gist.githubusercontent.com/rpapani/ff3773ce98a56367658188ba96b1cb19/raw/507940b8aafefcea5f021c94526febe9e2a8e4d4/adobe-mysticat-shared-seo-client-1.8.0.tgz",
         "@adobe/spacecat-helix-content-sdk": "1.4.33",
         "@adobe/spacecat-shared-athena-client": "1.11.0",
         "@adobe/spacecat-shared-data-access": "4.19.0",
@@ -551,8 +551,8 @@
     },
     "node_modules/@adobe/mysticat-shared-seo-client": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@adobe/mysticat-shared-seo-client/-/mysticat-shared-seo-client-1.8.0.tgz",
-      "integrity": "sha512-bAwgWSw7bClDqmvWTtWUIwnp2BOgcNXe3NwlSj8rG4ClgBNMUhsi/zFl2R1rHPNGw/j7QUNKiUyLIdWO295Z+g==",
+      "resolved": "https://gist.githubusercontent.com/rpapani/ff3773ce98a56367658188ba96b1cb19/raw/507940b8aafefcea5f021c94526febe9e2a8e4d4/adobe-mysticat-shared-seo-client-1.8.0.tgz",
+      "integrity": "sha512-DaDoYbfvwoWLaTbxQs2leKJPX7eEWmuwLSMwNeJO3i2huCDddmXee1UnYohLNsZZ8AwEbzdUJFSOaRAzhsqtfw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/fetch": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@adobe/helix-shared-wrap": "2.0.2",
     "@adobe/helix-status": "10.1.5",
     "@adobe/helix-universal-logger": "3.0.30",
-    "@adobe/mysticat-shared-seo-client": "1.8.0",
+    "@adobe/mysticat-shared-seo-client": "https://gist.githubusercontent.com/rpapani/ff3773ce98a56367658188ba96b1cb19/raw/507940b8aafefcea5f021c94526febe9e2a8e4d4/adobe-mysticat-shared-seo-client-1.8.0.tgz",
     "@adobe/spacecat-helix-content-sdk": "1.4.33",
     "@adobe/spacecat-shared-athena-client": "1.11.0",
     "@adobe/spacecat-shared-data-access": "4.19.0",

--- a/src/backlinks/handler.js
+++ b/src/backlinks/handler.js
@@ -24,7 +24,7 @@ import { createOpportunityData } from './opportunity-data-mapper.js';
 import { syncSuggestionsWithPublishDetection, warnOnInvalidSuggestionData, resolveOpportunityIfNoIssues } from '../utils/data-access.js';
 import { sendLowSuggestionCountAlert } from '../support/plg-suggestion-alert.js';
 import { getMergedAuditInputUrls } from '../utils/audit-input-urls.js';
-import { filterByAuditScope, extractPathPrefix } from '../internal-links/subpath-filter.js';
+import { filterByAuditScope, extractPathPrefix, isWithinAuditScope } from '../internal-links/subpath-filter.js';
 import {
   filterBrokenSuggestedUrls,
   isHtmlContentType,
@@ -329,11 +329,27 @@ export async function brokenBacklinksAuditRunner(auditUrl, context, site) {
       return true;
     });
 
+    // Directory-boundary-safe sub-path scoping. The host-only subdomain filter above and the
+    // server-side `target_url LIKE '%host/path%'` filter (mysticat-shared-seo-client) are both
+    // coarse: the LIKE match also captures sibling paths (e.g. '%oklahoma.gov/omes%' matches
+    // '/omes-budget'). isWithinAuditScope enforces the trailing-slash directory boundary so a
+    // sub-path site keeps only '/omes/*' targets. It is a no-op for root sites (no base path),
+    // and honours the effective base (overrideBaseURL) the same way as the subdomain filter
+    // (SITES-49721).
+    const effectiveBaseURL = overrideBaseURL || siteBaseURL;
+    const scopedBacklinks = filteredBacklinks?.filter((backlink) => {
+      if (isWithinAuditScope(backlink.url_to, effectiveBaseURL)) {
+        return true;
+      }
+      log.debug(`Excluding backlink ${backlink.url_to}: outside audit sub-path scope ${effectiveBaseURL}`);
+      return false;
+    });
+
     return {
       fullAuditRef,
       auditResult: {
         finalUrl: auditUrl,
-        brokenBacklinks: await filterOutValidBacklinks(filteredBacklinks, log),
+        brokenBacklinks: await filterOutValidBacklinks(scopedBacklinks, log),
       },
     };
   } catch (e) {

--- a/src/backlinks/handler.js
+++ b/src/backlinks/handler.js
@@ -329,16 +329,13 @@ export async function brokenBacklinksAuditRunner(auditUrl, context, site) {
       return true;
     });
 
-    // Directory-boundary-safe sub-path scoping. The host-only subdomain filter above and the
-    // server-side `target_url LIKE '%host/path%'` filter (mysticat-shared-seo-client) are both
-    // coarse: the LIKE match also captures sibling paths (e.g. '%oklahoma.gov/omes%' matches
-    // '/omes-budget'). isWithinAuditScope enforces the trailing-slash directory boundary so a
-    // sub-path site keeps only '/omes/*' targets. It is a no-op for root sites (no base path),
-    // and honours the effective base (overrideBaseURL) the same way as the subdomain filter
-    // (SITES-49721).
+    // Directory-boundary-safe sub-path scoping (SITES-49721). The host-only subdomain filter
+    // and the server-side `target_url LIKE '%host/path%'` filter are both coarse (the LIKE also
+    // matches siblings, e.g. '%example.com/foo%' matches '/foo-budget'). prependSchema keeps
+    // scheme-less Semrush target URLs from being treated as relative and dropped. No-op for root.
     const effectiveBaseURL = overrideBaseURL || siteBaseURL;
     const scopedBacklinks = filteredBacklinks?.filter((backlink) => {
-      if (isWithinAuditScope(backlink.url_to, effectiveBaseURL)) {
+      if (isWithinAuditScope(prependSchema(backlink.url_to), effectiveBaseURL)) {
         return true;
       }
       log.debug(`Excluding backlink ${backlink.url_to}: outside audit sub-path scope ${effectiveBaseURL}`);

--- a/src/cwv/cwv-audit-result.js
+++ b/src/cwv/cwv-audit-result.js
@@ -110,9 +110,8 @@ export async function buildCWVAuditResult(context) {
   const rumApiClient = RUMAPIClient.createFrom(context);
   const groupedURLs = site.getConfig().getGroupedURLs(Audit.AUDIT_TYPES.CWV);
   const options = {
-    // RUM is keyed per hostname; a sub-path site's auditUrl carries a path
-    // (e.g. oklahoma.gov/omes) with no domainkey. Query by hostname, then the
-    // per-URL results below are scoped to the site's base path.
+    // RUM is keyed per hostname; a sub-path auditUrl (e.g. example.com/foo) has no
+    // domainkey. Query by hostname; per-URL results are scoped to the base path below.
     domain: getRUMDomain(auditUrl),
     interval: INTERVAL,
     granularity: 'hourly',
@@ -120,13 +119,9 @@ export async function buildCWVAuditResult(context) {
   };
   const cwvData = await rumApiClient.query(Audit.AUDIT_TYPES.CWV, options);
 
-  // SITES-49656: subpath sites (a concrete path onboarded as its own site, e.g.
-  // https://oklahoma.gov/omes) share the domain-keyed RUM query with the whole
-  // domain, so cwvData carries sibling-site pages. Scope the per-URL entries to
-  // the site's base path — reusing the internal-links audit-scope filter — before
-  // top-N/threshold selection so the report and resulting opportunities don't
-  // bleed in unrelated pages. Root-domain sites (no base path) are unaffected;
-  // operator-configured `group` entries are left untouched.
+  // SITES-49656: sub-path sites (e.g. example.com/foo) share the domain-keyed RUM
+  // query, so scope per-URL entries to the base path before top-N/threshold selection.
+  // Root-domain sites and operator-configured `group` entries are unaffected.
   const scopedCwvData = cwvData.filter(
     (item) => item.type !== 'url' || isWithinAuditScope(item.url, baseURL),
   );

--- a/src/cwv/cwv-audit-result.js
+++ b/src/cwv/cwv-audit-result.js
@@ -15,6 +15,7 @@ import { Audit, Entitlement } from '@adobe/spacecat-shared-data-access';
 import { TierClient } from '@adobe/spacecat-shared-tier-client';
 import { removeTrailingSlash } from '../utils/url-utils.js';
 import { isWithinAuditScope } from '../internal-links/subpath-filter.js';
+import { getRUMDomain } from '../support/utils.js';
 
 const DAILY_THRESHOLD = 1000; // pageviews
 const INTERVAL = 7; // days
@@ -109,7 +110,10 @@ export async function buildCWVAuditResult(context) {
   const rumApiClient = RUMAPIClient.createFrom(context);
   const groupedURLs = site.getConfig().getGroupedURLs(Audit.AUDIT_TYPES.CWV);
   const options = {
-    domain: auditUrl,
+    // RUM is keyed per hostname; a sub-path site's auditUrl carries a path
+    // (e.g. oklahoma.gov/omes) with no domainkey. Query by hostname, then the
+    // per-URL results below are scoped to the site's base path.
+    domain: getRUMDomain(auditUrl),
     interval: INTERVAL,
     granularity: 'hourly',
     groupedURLs,

--- a/src/forms-opportunities/handler.js
+++ b/src/forms-opportunities/handler.js
@@ -39,9 +39,8 @@ export async function formsAuditRunner(auditUrl, context) {
   const { site, log } = context;
   const rumAPIClient = RUMAPIClient.createFrom(context);
   const options = {
-    // RUM is keyed per hostname; a sub-path site's auditUrl carries a path
-    // (e.g. oklahoma.gov/omes) with no domainkey. Query by hostname, then scope
-    // the returned per-URL form vitals to the site's base path.
+    // RUM is keyed per hostname; a sub-path auditUrl (e.g. example.com/foo) has no
+    // domainkey. Query by hostname; form vitals are scoped to the base path below.
     domain: getRUMDomain(auditUrl),
     interval: FORMS_AUDIT_INTERVAL,
     granularity: 'hourly',

--- a/src/forms-opportunities/handler.js
+++ b/src/forms-opportunities/handler.js
@@ -21,7 +21,8 @@ import {
   getUrlsDataForAccessibilityAudit,
   sendMessageToMystiqueForGuidance,
 } from './utils.js';
-import { getScrapedDataForSiteId } from '../support/utils.js';
+import { getScrapedDataForSiteId, getRUMDomain } from '../support/utils.js';
+import { filterByAuditScope } from '../internal-links/subpath-filter.js';
 import createLowConversionOpportunities from './oppty-handlers/low-conversion-handler.js';
 import createLowNavigationOpportunities from './oppty-handlers/low-navigation-handler.js';
 import createLowViewsOpportunities from './oppty-handlers/low-views-handler.js';
@@ -35,16 +36,20 @@ const FORMS_OPPTY_QUERIES = [
 ];
 
 export async function formsAuditRunner(auditUrl, context) {
+  const { site, log } = context;
   const rumAPIClient = RUMAPIClient.createFrom(context);
   const options = {
-    domain: auditUrl,
+    // RUM is keyed per hostname; a sub-path site's auditUrl carries a path
+    // (e.g. oklahoma.gov/omes) with no domainkey. Query by hostname, then scope
+    // the returned per-URL form vitals to the site's base path.
+    domain: getRUMDomain(auditUrl),
     interval: FORMS_AUDIT_INTERVAL,
     granularity: 'hourly',
   };
 
   const queryResults = await rumAPIClient.queryMulti(FORMS_OPPTY_QUERIES, options);
   const auditResult = {
-    formVitals: queryResults['form-vitals'],
+    formVitals: filterByAuditScope(queryResults['form-vitals'], site?.getBaseURL?.(), {}, log),
     auditContext: {
       interval: FORMS_AUDIT_INTERVAL,
     },

--- a/src/image-alt-text/url-utils.js
+++ b/src/image-alt-text/url-utils.js
@@ -72,8 +72,8 @@ export async function getTopPageUrls({
         baseUrls = results
           .sort((a, b) => (b.earned || 0) - (a.earned || 0))
           .map((r) => normalizeUrl(r.url));
-        // RUM data is domain-wide; scope to the site's base path so a sub-path site
-        // (e.g. oklahoma.gov/omes) doesn't inherit the whole domain. No-op for root.
+        // RUM data is domain-wide; scope to the base path so a sub-path site
+        // (e.g. example.com/foo) doesn't inherit the whole domain. No-op for root.
         baseUrls = filterByAuditScope(baseUrls, site.getBaseURL(), {}, log);
         log.info(`[${AUDIT_TYPE}]: Found ${baseUrls.length} URLs from RUM`);
       }

--- a/src/image-alt-text/url-utils.js
+++ b/src/image-alt-text/url-utils.js
@@ -15,6 +15,7 @@ import RUMAPIClient from '@adobe/spacecat-shared-rum-api-client';
 import { getRUMUrl } from '../support/utils.js';
 import { RUM_INTERVAL } from './constants.js';
 import { getAuditTargetUrls } from '../utils/data-access.js';
+import { filterByAuditScope } from '../internal-links/subpath-filter.js';
 
 const AUDIT_TYPE = AuditModel.AUDIT_TYPES.ALT_TEXT;
 
@@ -71,6 +72,9 @@ export async function getTopPageUrls({
         baseUrls = results
           .sort((a, b) => (b.earned || 0) - (a.earned || 0))
           .map((r) => normalizeUrl(r.url));
+        // RUM data is domain-wide; scope to the site's base path so a sub-path site
+        // (e.g. oklahoma.gov/omes) doesn't inherit the whole domain. No-op for root.
+        baseUrls = filterByAuditScope(baseUrls, site.getBaseURL(), {}, log);
         log.info(`[${AUDIT_TYPE}]: Found ${baseUrls.length} URLs from RUM`);
       }
     } catch (err) {

--- a/src/internal-links/rum-detection.js
+++ b/src/internal-links/rum-detection.js
@@ -13,6 +13,7 @@
 import { createInternalLinksConfigResolver } from './config.js';
 import { createInternalLinksStepLogger } from './logging.js';
 import { isCrossLocalePDP404RumPair } from './scope-utils.js';
+import { getRUMDomain } from '../support/utils.js';
 
 const RUM_VALIDATION_CONCURRENCY = 10;
 
@@ -69,7 +70,10 @@ export function createInternalLinksRumSteps({
     try {
       const rumAPIClient = context.rumApiClient || createRUMAPIClient(context);
       const options = {
-        domain: finalUrl,
+        // RUM is keyed per hostname; a sub-path site's finalUrl carries a path
+        // (e.g. oklahoma.gov/omes) with no domainkey. Query by hostname, then the
+        // 404 pairs are scoped to the site's base path below.
+        domain: getRUMDomain(finalUrl),
         interval,
         granularity: 'hourly',
       };

--- a/src/internal-links/rum-detection.js
+++ b/src/internal-links/rum-detection.js
@@ -70,9 +70,8 @@ export function createInternalLinksRumSteps({
     try {
       const rumAPIClient = context.rumApiClient || createRUMAPIClient(context);
       const options = {
-        // RUM is keyed per hostname; a sub-path site's finalUrl carries a path
-        // (e.g. oklahoma.gov/omes) with no domainkey. Query by hostname, then the
-        // 404 pairs are scoped to the site's base path below.
+        // RUM is keyed per hostname; a sub-path finalUrl (e.g. example.com/foo) has no
+        // domainkey. Query by hostname; 404 pairs are scoped to the base path below.
         domain: getRUMDomain(finalUrl),
         interval,
         granularity: 'hourly',

--- a/src/internal-links/subpath-filter.js
+++ b/src/internal-links/subpath-filter.js
@@ -16,8 +16,7 @@ import { prependSchema, stripWWW } from '@adobe/spacecat-shared-utils';
  * Checks if a URL is within the audit scope defined by baseURL.
  * For baseURL with subpath (e.g., bulk.com/uk), only URLs starting with that subpath are included.
  * For baseURL without subpath (e.g., bulk.com), all URLs are included.
- *
- * This follows the same pattern as redirect-chains audit (handler.js lines 458-493).
+ * The section landing page (`${basePath}.html`) is treated as in scope.
  *
  * @param {string} url - The URL to check (can be relative or absolute)
  * @param {string} baseURL - The base URL defining the audit scope
@@ -43,11 +42,13 @@ export function isWithinAuditScope(url, baseURL) {
 
     // Ensure we match with a trailing slash to avoid false positives (e.g., /fr/ not /french)
     const basePathWithSlash = `${basePath}/`;
+    // The section's landing page (e.g. /foo.html) is in scope too.
+    const basePathLanding = `${basePath}.html`;
 
     // Handle relative URLs
     if (!url.startsWith('http://') && !url.startsWith('https://')) {
       // Relative URL - check if it starts with the scope path
-      return url.startsWith(basePathWithSlash) || url === basePath;
+      return url.startsWith(basePathWithSlash) || url === basePath || url === basePathLanding;
     }
 
     // Handle absolute URLs
@@ -62,7 +63,9 @@ export function isWithinAuditScope(url, baseURL) {
     }
 
     // Compare paths (protocol-agnostic)
-    return parsedUrl.pathname.startsWith(basePathWithSlash) || parsedUrl.pathname === basePath;
+    return parsedUrl.pathname.startsWith(basePathWithSlash)
+      || parsedUrl.pathname === basePath
+      || parsedUrl.pathname === basePathLanding;
   } catch (error) {
     // If URL parsing fails, exclude it to be safe
     return false;

--- a/src/metatags/handler.js
+++ b/src/metatags/handler.js
@@ -52,10 +52,9 @@ export async function opportunityAndSuggestions(finalUrl, auditData, context) {
   const { log } = context;
   const { detectedTags } = auditData.auditResult;
   log.debug(`started to audit metatags for site url: ${auditData.auditResult.finalUrl}`);
-  // Default to hostname-only: the endpoint is the page's absolute pathname, so it must
-  // be appended to the origin. Appending to a base that already carries a path (a
-  // sub-path site, e.g. https://oklahoma.gov/omes) duplicated it (/omes/omes/...).
-  // For root-domain sites the base has no path, so this is a no-op.
+  // Default hostname-only: the endpoint is an absolute pathname appended to the origin.
+  // A base that already carries a path (sub-path site, e.g. example.com/foo) duplicated
+  // it (/foo/foo/...). No-op for root-domain sites.
   let useHostnameOnly = true;
   try {
     const siteId = opportunity.getSiteId();
@@ -351,9 +350,9 @@ export async function runAuditAndGenerateSuggestions(context) {
     },
   );
 
-  // Get useHostnameOnly setting. Defaults to true so an absolute endpoint is appended
-  // to the origin, not to a base URL that already carries a path (sub-path sites would
-  // otherwise get a duplicated /omes/omes/... URL). No-op for root-domain sites.
+  // Default hostname-only so an absolute endpoint is appended to the origin, not to a
+  // base URL that already carries a path (sub-path sites would otherwise get a duplicated
+  // /foo/foo/... URL). No-op for root-domain sites.
   let useHostnameOnly = true;
   try {
     const siteId = opportunity.getSiteId();
@@ -444,11 +443,9 @@ export async function runAuditAndGenerateSuggestions(context) {
     };
   });
 
-  // Build unique pageUrls from all suggestions. Resolve each endpoint (an absolute
-  // path) against the base URL's origin rather than string-concatenating onto the
-  // full base URL: for a subpath site (e.g. baseURL https://oklahoma.gov/omes) the
-  // endpoint already carries the full path (/omes/...), so concatenation produced a
-  // malformed /omes/omes/... URL. No-op for root-domain sites.
+  // Resolve each endpoint (an absolute path) against the base URL's origin. Concatenating
+  // onto a base that already carries a path (sub-path site, e.g. example.com/foo) produced
+  // a malformed /foo/foo/... URL. No-op for root-domain sites.
   const pageUrls = [
     ...new Set(suggestionMap.map((s) => new URL(s.endpoint, site.getBaseURL()).toString())),
   ];

--- a/src/metatags/handler.js
+++ b/src/metatags/handler.js
@@ -52,11 +52,15 @@ export async function opportunityAndSuggestions(finalUrl, auditData, context) {
   const { log } = context;
   const { detectedTags } = auditData.auditResult;
   log.debug(`started to audit metatags for site url: ${auditData.auditResult.finalUrl}`);
-  let useHostnameOnly = false;
+  // Default to hostname-only: the endpoint is the page's absolute pathname, so it must
+  // be appended to the origin. Appending to a base that already carries a path (a
+  // sub-path site, e.g. https://oklahoma.gov/omes) duplicated it (/omes/omes/...).
+  // For root-domain sites the base has no path, so this is a no-op.
+  let useHostnameOnly = true;
   try {
     const siteId = opportunity.getSiteId();
     const site = await context.dataAccess.Site.findById(siteId);
-    useHostnameOnly = site?.getDeliveryConfig?.()?.useHostnameOnly ?? false;
+    useHostnameOnly = site?.getDeliveryConfig?.()?.useHostnameOnly ?? true;
   } catch (error) {
     log.error('Error in meta-tags configuration:', error);
   }
@@ -347,12 +351,14 @@ export async function runAuditAndGenerateSuggestions(context) {
     },
   );
 
-  // Get useHostnameOnly setting
-  let useHostnameOnly = false;
+  // Get useHostnameOnly setting. Defaults to true so an absolute endpoint is appended
+  // to the origin, not to a base URL that already carries a path (sub-path sites would
+  // otherwise get a duplicated /omes/omes/... URL). No-op for root-domain sites.
+  let useHostnameOnly = true;
   try {
     const siteId = opportunity.getSiteId();
     const siteObj = await context.dataAccess.Site.findById(siteId);
-    useHostnameOnly = siteObj?.getDeliveryConfig?.()?.useHostnameOnly ?? false;
+    useHostnameOnly = siteObj?.getDeliveryConfig?.()?.useHostnameOnly ?? true;
   } catch (error) {
     log.error('Error in meta-tags configuration:', error);
   }

--- a/src/metatags/handler.js
+++ b/src/metatags/handler.js
@@ -438,8 +438,14 @@ export async function runAuditAndGenerateSuggestions(context) {
     };
   });
 
-  // Build unique pageUrls from all suggestions
-  const pageUrls = [...new Set(suggestionMap.map((s) => `${site.getBaseURL()}${s.endpoint}`))];
+  // Build unique pageUrls from all suggestions. Resolve each endpoint (an absolute
+  // path) against the base URL's origin rather than string-concatenating onto the
+  // full base URL: for a subpath site (e.g. baseURL https://oklahoma.gov/omes) the
+  // endpoint already carries the full path (/omes/...), so concatenation produced a
+  // malformed /omes/omes/... URL. No-op for root-domain sites.
+  const pageUrls = [
+    ...new Set(suggestionMap.map((s) => new URL(s.endpoint, site.getBaseURL()).toString())),
+  ];
 
   log.info(`[metatags] Sending ${suggestionMap.length} suggestions to Mystique (${pageUrls.length} unique pages)`);
 

--- a/src/metatags/ssr-meta-validator.js
+++ b/src/metatags/ssr-meta-validator.js
@@ -89,7 +89,11 @@ export async function validateDetectedIssues(detectedTags, baseUrl, log) {
   // Process endpoints sequentially to avoid overwhelming the server
   for (const endpoint of endpoints) {
     const tags = updatedDetectedTags[endpoint];
-    const fullUrl = `${baseUrl}${endpoint}`;
+    // Resolve the endpoint (an absolute path) against the base URL's origin rather
+    // than concatenating onto the full base URL, which for a subpath site (e.g.
+    // baseURL https://oklahoma.gov/omes) would double the path (/omes/omes/...).
+    // No-op for root-domain sites.
+    const fullUrl = new URL(endpoint, baseUrl).toString();
 
     // Check if any of the issues are related to missing tags
     const hasMissingIssues = ['title', 'description', 'h1'].some(

--- a/src/metatags/ssr-meta-validator.js
+++ b/src/metatags/ssr-meta-validator.js
@@ -89,10 +89,9 @@ export async function validateDetectedIssues(detectedTags, baseUrl, log) {
   // Process endpoints sequentially to avoid overwhelming the server
   for (const endpoint of endpoints) {
     const tags = updatedDetectedTags[endpoint];
-    // Resolve the endpoint (an absolute path) against the base URL's origin rather
-    // than concatenating onto the full base URL, which for a subpath site (e.g.
-    // baseURL https://oklahoma.gov/omes) would double the path (/omes/omes/...).
-    // No-op for root-domain sites.
+    // Resolve the endpoint (an absolute path) against the base URL's origin; concatenating
+    // onto a base that already carries a path (sub-path site, e.g. example.com/foo) would
+    // double it (/foo/foo/...). No-op for root-domain sites.
     const fullUrl = new URL(endpoint, baseUrl).toString();
 
     // Check if any of the issues are related to missing tags

--- a/src/product-metatags/handler.js
+++ b/src/product-metatags/handler.js
@@ -160,8 +160,11 @@ export async function opportunityAndSuggestions(finalUrl, auditData, context) {
     return;
   }
 
-  // Fetch site configuration once for all suggestions
-  let useHostnameOnly = false;
+  // Fetch site configuration once for all suggestions.
+  // Default hostname-only: the endpoint is an absolute pathname, so it is appended to
+  // the origin. Appending to a base that already carries a path (a sub-path site, e.g.
+  // example.com/foo) duplicated it (/foo/foo/...). No-op for root-domain sites.
+  let useHostnameOnly = true;
   let site = null;
   let customConfig = null;
   let productUrlTemplate = null;
@@ -171,7 +174,7 @@ export async function opportunityAndSuggestions(finalUrl, auditData, context) {
   try {
     const siteId = opportunity.getSiteId();
     site = await context.dataAccess.Site.findById(siteId);
-    useHostnameOnly = site?.getDeliveryConfig?.()?.useHostnameOnly ?? false;
+    useHostnameOnly = site?.getDeliveryConfig?.()?.useHostnameOnly ?? true;
 
     // Get handler configuration for locale extraction and commerce config
     customConfig = site?.getConfig?.()?.getHandlers?.()?.[auditType];

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -89,12 +89,8 @@ export async function getRUMUrl(url) {
 
 /**
  * Resolves the RUM query domain (hostname) from a resolved audit/final URL.
- *
- * RUM data is keyed per hostname; a sub-path site's resolved URL carries a path
- * (e.g. "oklahoma.gov/omes"), which has no RUM domainkey and 404s the domainkey
- * exchange. Strip to the hostname so the domain-wide RUM data can be fetched, then
- * the per-URL results are filtered to the site's base path by the caller. No-op for
- * bare-hostname / root URLs.
+ * RUM is keyed per hostname, so a sub-path URL (e.g. "example.com/foo") must be
+ * stripped to its hostname; the per-URL results are scoped by the caller. No-op for root.
  *
  * @param {string} url - The resolved audit/final URL (scheme and path optional).
  * @returns {string} The hostname, or the original value if it cannot be parsed.

--- a/src/support/utils.js
+++ b/src/support/utils.js
@@ -88,6 +88,26 @@ export async function getRUMUrl(url) {
 }
 
 /**
+ * Resolves the RUM query domain (hostname) from a resolved audit/final URL.
+ *
+ * RUM data is keyed per hostname; a sub-path site's resolved URL carries a path
+ * (e.g. "oklahoma.gov/omes"), which has no RUM domainkey and 404s the domainkey
+ * exchange. Strip to the hostname so the domain-wide RUM data can be fetched, then
+ * the per-URL results are filtered to the site's base path by the caller. No-op for
+ * bare-hostname / root URLs.
+ *
+ * @param {string} url - The resolved audit/final URL (scheme and path optional).
+ * @returns {string} The hostname, or the original value if it cannot be parsed.
+ */
+export function getRUMDomain(url) {
+  try {
+    return new URL(prependSchema(url)).hostname;
+  } catch {
+    return url;
+  }
+}
+
+/**
  * Checks if a given URL contains a domain with a non-www subdomain.
  *
  * @param {string} baseUrl - The URL to check for the presence of a domain with a non-www subdomain.

--- a/test/audits/backlinks.test.js
+++ b/test/audits/backlinks.test.js
@@ -535,6 +535,123 @@ describe('Backlinks Tests', function () {
     });
   });
 
+  describe('sub-path (base-path) scoping (SITES-49721)', () => {
+    it('keeps only /omes/* targets for a sub-path site, dropping same-host and boundary paths', async () => {
+      const backlinks = [
+        {
+          title: 'in scope',
+          url_from: 'https://ref.com/a',
+          url_to: 'https://foo.com/omes/procurement',
+          traffic_domain: 50,
+        },
+        {
+          title: 'same host, different agency — should be dropped',
+          url_from: 'https://ref.com/b',
+          url_to: 'https://foo.com/other-agency',
+          traffic_domain: 40,
+        },
+        {
+          title: 'directory boundary sibling — should be dropped',
+          url_from: 'https://ref.com/c',
+          url_to: 'https://foo.com/omes-budget/report',
+          traffic_domain: 30,
+        },
+      ];
+
+      // Only the in-scope target should ever be fetched (others are filtered out first).
+      nock('https://foo.com')
+        .get('/omes/procurement')
+        .reply(404);
+
+      const subPathSite = {
+        getId: () => 'subpath-site',
+        getBaseURL: () => 'https://foo.com/omes',
+        getConfig: () => Config({}),
+      };
+
+      mockSeoClient.getBrokenBacklinks.resolves({
+        result: { backlinks },
+        fullAuditRef: auditUrl,
+      });
+
+      const result = await brokenBacklinksAuditRunner(auditUrl, context, subPathSite);
+      const resultUrls = result.auditResult.brokenBacklinks.map((b) => b.url_to);
+      expect(resultUrls).to.deep.equal(['https://foo.com/omes/procurement']);
+    });
+
+    it('scopes to the sub-path of the configured overrideBaseURL', async () => {
+      const backlinks = [
+        {
+          title: 'in scope on override host',
+          url_from: 'https://ref.com/a',
+          url_to: 'https://applyonline.hdfc.bank.in/omes/loan',
+          traffic_domain: 50,
+        },
+        {
+          title: 'boundary sibling on override host — should be dropped',
+          url_from: 'https://ref.com/b',
+          url_to: 'https://applyonline.hdfc.bank.in/omes-budget',
+          traffic_domain: 40,
+        },
+      ];
+
+      nock('https://applyonline.hdfc.bank.in')
+        .get('/omes/loan')
+        .reply(404);
+
+      const siteWithOverride = {
+        getId: () => 'override-subpath-site',
+        getBaseURL: () => 'https://applyonline.hdfcbank.com',
+        getConfig: () => Config({
+          fetchConfig: { overrideBaseURL: 'https://applyonline.hdfc.bank.in/omes' },
+        }),
+      };
+
+      mockSeoClient.getBrokenBacklinks.resolves({
+        result: { backlinks },
+        fullAuditRef: auditUrl,
+      });
+
+      const result = await brokenBacklinksAuditRunner(
+        'applyonline.hdfc.bank.in',
+        context,
+        siteWithOverride,
+      );
+      const resultUrls = result.auditResult.brokenBacklinks.map((b) => b.url_to);
+      expect(resultUrls).to.deep.equal(['https://applyonline.hdfc.bank.in/omes/loan']);
+    });
+
+    it('is a no-op for root-domain sites (all same-host paths kept)', async () => {
+      const backlinks = [
+        {
+          title: 'path a',
+          url_from: 'https://ref.com/a',
+          url_to: 'https://foo.com/omes/procurement',
+          traffic_domain: 50,
+        },
+        {
+          title: 'path b',
+          url_from: 'https://ref.com/b',
+          url_to: 'https://foo.com/other-agency',
+          traffic_domain: 40,
+        },
+      ];
+
+      nock('https://foo.com').get('/omes/procurement').reply(404);
+      nock('https://foo.com').get('/other-agency').reply(404);
+
+      mockSeoClient.getBrokenBacklinks.resolves({
+        result: { backlinks },
+        fullAuditRef: auditUrl,
+      });
+
+      const result = await brokenBacklinksAuditRunner(auditUrl, context, site2);
+      const resultUrls = result.auditResult.brokenBacklinks.map((b) => b.url_to);
+      expect(resultUrls).to.include('https://foo.com/omes/procurement');
+      expect(resultUrls).to.include('https://foo.com/other-agency');
+    });
+  });
+
   describe('soft-404 detection', () => {
     it('should keep backlink when 200 response has X-Robots-Tag: noindex', async () => {
       nock('https://foo.com')

--- a/test/audits/backlinks.test.js
+++ b/test/audits/backlinks.test.js
@@ -536,12 +536,12 @@ describe('Backlinks Tests', function () {
   });
 
   describe('sub-path (base-path) scoping (SITES-49721)', () => {
-    it('keeps only /omes/* targets for a sub-path site, dropping same-host and boundary paths', async () => {
+    it('keeps only /us/* targets for a sub-path site, dropping same-host and boundary paths', async () => {
       const backlinks = [
         {
           title: 'in scope',
           url_from: 'https://ref.com/a',
-          url_to: 'https://foo.com/omes/procurement',
+          url_to: 'https://foo.com/us/procurement',
           traffic_domain: 50,
         },
         {
@@ -553,19 +553,19 @@ describe('Backlinks Tests', function () {
         {
           title: 'directory boundary sibling — should be dropped',
           url_from: 'https://ref.com/c',
-          url_to: 'https://foo.com/omes-budget/report',
+          url_to: 'https://foo.com/us-budget/report',
           traffic_domain: 30,
         },
       ];
 
       // Only the in-scope target should ever be fetched (others are filtered out first).
       nock('https://foo.com')
-        .get('/omes/procurement')
+        .get('/us/procurement')
         .reply(404);
 
       const subPathSite = {
         getId: () => 'subpath-site',
-        getBaseURL: () => 'https://foo.com/omes',
+        getBaseURL: () => 'https://foo.com/us',
         getConfig: () => Config({}),
       };
 
@@ -576,7 +576,7 @@ describe('Backlinks Tests', function () {
 
       const result = await brokenBacklinksAuditRunner(auditUrl, context, subPathSite);
       const resultUrls = result.auditResult.brokenBacklinks.map((b) => b.url_to);
-      expect(resultUrls).to.deep.equal(['https://foo.com/omes/procurement']);
+      expect(resultUrls).to.deep.equal(['https://foo.com/us/procurement']);
     });
 
     it('scopes to the sub-path of the configured overrideBaseURL', async () => {
@@ -584,26 +584,26 @@ describe('Backlinks Tests', function () {
         {
           title: 'in scope on override host',
           url_from: 'https://ref.com/a',
-          url_to: 'https://applyonline.hdfc.bank.in/omes/loan',
+          url_to: 'https://applyonline.hdfc.bank.in/us/loan',
           traffic_domain: 50,
         },
         {
           title: 'boundary sibling on override host — should be dropped',
           url_from: 'https://ref.com/b',
-          url_to: 'https://applyonline.hdfc.bank.in/omes-budget',
+          url_to: 'https://applyonline.hdfc.bank.in/us-budget',
           traffic_domain: 40,
         },
       ];
 
       nock('https://applyonline.hdfc.bank.in')
-        .get('/omes/loan')
+        .get('/us/loan')
         .reply(404);
 
       const siteWithOverride = {
         getId: () => 'override-subpath-site',
         getBaseURL: () => 'https://applyonline.hdfcbank.com',
         getConfig: () => Config({
-          fetchConfig: { overrideBaseURL: 'https://applyonline.hdfc.bank.in/omes' },
+          fetchConfig: { overrideBaseURL: 'https://applyonline.hdfc.bank.in/us' },
         }),
       };
 
@@ -618,7 +618,7 @@ describe('Backlinks Tests', function () {
         siteWithOverride,
       );
       const resultUrls = result.auditResult.brokenBacklinks.map((b) => b.url_to);
-      expect(resultUrls).to.deep.equal(['https://applyonline.hdfc.bank.in/omes/loan']);
+      expect(resultUrls).to.deep.equal(['https://applyonline.hdfc.bank.in/us/loan']);
     });
 
     it('is a no-op for root-domain sites (all same-host paths kept)', async () => {
@@ -626,7 +626,7 @@ describe('Backlinks Tests', function () {
         {
           title: 'path a',
           url_from: 'https://ref.com/a',
-          url_to: 'https://foo.com/omes/procurement',
+          url_to: 'https://foo.com/us/procurement',
           traffic_domain: 50,
         },
         {
@@ -637,7 +637,7 @@ describe('Backlinks Tests', function () {
         },
       ];
 
-      nock('https://foo.com').get('/omes/procurement').reply(404);
+      nock('https://foo.com').get('/us/procurement').reply(404);
       nock('https://foo.com').get('/other-agency').reply(404);
 
       mockSeoClient.getBrokenBacklinks.resolves({
@@ -647,8 +647,43 @@ describe('Backlinks Tests', function () {
 
       const result = await brokenBacklinksAuditRunner(auditUrl, context, site2);
       const resultUrls = result.auditResult.brokenBacklinks.map((b) => b.url_to);
-      expect(resultUrls).to.include('https://foo.com/omes/procurement');
+      expect(resultUrls).to.include('https://foo.com/us/procurement');
       expect(resultUrls).to.include('https://foo.com/other-agency');
+    });
+
+    it('keeps a scheme-less in-scope target and drops a scheme-less out-of-scope one', async () => {
+      // Semrush target_url can be scheme-less; without prependSchema, isWithinAuditScope
+      // treats it as a relative path and silently drops it even when in scope.
+      const backlinks = [
+        {
+          title: 'scheme-less in scope',
+          url_from: 'https://ref.com/a',
+          url_to: 'foo.com/us/procurement',
+          traffic_domain: 50,
+        },
+        {
+          title: 'scheme-less sibling — out of scope',
+          url_from: 'https://ref.com/b',
+          url_to: 'foo.com/us-budget/report',
+          traffic_domain: 40,
+        },
+      ];
+
+      const subPathSite = {
+        getId: () => 'subpath-site',
+        getBaseURL: () => 'https://foo.com/us',
+        getConfig: () => Config({}),
+      };
+
+      mockSeoClient.getBrokenBacklinks.resolves({
+        result: { backlinks },
+        fullAuditRef: auditUrl,
+      });
+
+      const result = await brokenBacklinksAuditRunner(auditUrl, context, subPathSite);
+      const resultUrls = result.auditResult.brokenBacklinks.map((b) => b.url_to);
+      expect(resultUrls).to.include('foo.com/us/procurement');
+      expect(resultUrls).to.not.include('foo.com/us-budget/report');
     });
   });
 

--- a/test/audits/cwv/cwv-audit-result.test.js
+++ b/test/audits/cwv/cwv-audit-result.test.js
@@ -246,8 +246,8 @@ describe('CWV Audit Result', () => {
 
     describe('subpath-site base-path scoping (SITES-49656)', () => {
       const subpathSite = {
-        getId: () => 'omes',
-        getBaseURL: () => 'https://www.example.gov/omes',
+        getId: () => 'us',
+        getBaseURL: () => 'https://www.example.gov/us',
         getConfig: () => ({ getGroupedURLs: () => [] }),
       };
 
@@ -270,34 +270,34 @@ describe('CWV Audit Result', () => {
       it('keeps only pages under the site base path and drops sibling-site pages', async () => {
         const cwvDataFromRum = [
           {
-            type: 'url', url: 'https://www.example.gov/omes', pageviews: 100000, organic: 0, metrics: [],
+            type: 'url', url: 'https://www.example.gov/us', pageviews: 100000, organic: 0, metrics: [],
           },
           {
-            type: 'url', url: 'https://www.example.gov/omes/leadership.html', pageviews: 6000, organic: 0, metrics: [],
+            type: 'url', url: 'https://www.example.gov/us/leadership.html', pageviews: 6000, organic: 0, metrics: [],
           },
           {
-            type: 'url', url: 'https://www.example.gov/okdhs.html', pageviews: 5900, organic: 0, metrics: [],
+            type: 'url', url: 'https://www.example.gov/other.html', pageviews: 5900, organic: 0, metrics: [],
           },
           {
-            type: 'url', url: 'https://www.example.gov/omes-budget', pageviews: 5800, organic: 0, metrics: [],
+            type: 'url', url: 'https://www.example.gov/us-budget', pageviews: 5800, organic: 0, metrics: [],
           },
           {
-            type: 'group', pattern: '/omes/*', name: 'OMES pages', pageviews: 5000, organic: 0, metrics: [],
+            type: 'group', pattern: '/us/*', name: 'US pages', pageviews: 5000, organic: 0, metrics: [],
           },
         ];
         const { buildCWVAuditResult: build } = await buildForSubpath(cwvDataFromRum);
 
         const result = await build({
-          site: subpathSite, finalUrl: 'www.example.gov/omes', log, env: {},
+          site: subpathSite, finalUrl: 'www.example.gov/us', log, env: {},
         });
 
         const urls = result.auditResult.cwv.filter((e) => e.type === 'url').map((e) => e.url);
-        expect(urls).to.include('https://www.example.gov/omes');
-        expect(urls).to.include('https://www.example.gov/omes/leadership.html');
-        // sibling agency page on the same domain but outside /omes — must be dropped
-        expect(urls).to.not.include('https://www.example.gov/okdhs.html');
-        // directory-boundary safety: /omes-budget is a sibling, not under /omes/
-        expect(urls).to.not.include('https://www.example.gov/omes-budget');
+        expect(urls).to.include('https://www.example.gov/us');
+        expect(urls).to.include('https://www.example.gov/us/leadership.html');
+        // sibling agency page on the same domain but outside /us — must be dropped
+        expect(urls).to.not.include('https://www.example.gov/other.html');
+        // directory-boundary safety: /us-budget is a sibling, not under /us/
+        expect(urls).to.not.include('https://www.example.gov/us-budget');
         // operator-configured group entries pass through untouched
         expect(result.auditResult.cwv.find((e) => e.type === 'group')).to.exist;
       });
@@ -311,11 +311,11 @@ describe('CWV Audit Result', () => {
         });
 
         await build({
-          site: subpathSite, finalUrl: 'www.example.gov/omes', log, env: {},
+          site: subpathSite, finalUrl: 'www.example.gov/us', log, env: {},
         });
 
-        // Sub-path finalUrl (www.example.gov/omes) must be stripped to the hostname for
-        // the RUM query — the per-URL results are scoped to /omes separately.
+        // Sub-path finalUrl (www.example.gov/us) must be stripped to the hostname for
+        // the RUM query — the per-URL results are scoped to /us separately.
         expect(queryStub.getCalls().some((c) => c.args[1]?.domain === 'www.example.gov'))
           .to.equal(true);
       });
@@ -323,7 +323,7 @@ describe('CWV Audit Result', () => {
       it('drops url entries whose URL cannot be parsed', async () => {
         const cwvDataFromRum = [
           {
-            type: 'url', url: 'https://www.example.gov/omes', pageviews: 100000, organic: 0, metrics: [],
+            type: 'url', url: 'https://www.example.gov/us', pageviews: 100000, organic: 0, metrics: [],
           },
           {
             type: 'url', url: ':::not-a-url', pageviews: 6000, organic: 0, metrics: [],
@@ -332,11 +332,11 @@ describe('CWV Audit Result', () => {
         const { buildCWVAuditResult: build } = await buildForSubpath(cwvDataFromRum);
 
         const result = await build({
-          site: subpathSite, finalUrl: 'www.example.gov/omes', log, env: {},
+          site: subpathSite, finalUrl: 'www.example.gov/us', log, env: {},
         });
 
         const urls = result.auditResult.cwv.filter((e) => e.type === 'url').map((e) => e.url);
-        expect(urls).to.deep.equal(['https://www.example.gov/omes']);
+        expect(urls).to.deep.equal(['https://www.example.gov/us']);
       });
     });
   });

--- a/test/audits/cwv/cwv-audit-result.test.js
+++ b/test/audits/cwv/cwv-audit-result.test.js
@@ -302,6 +302,24 @@ describe('CWV Audit Result', () => {
         expect(result.auditResult.cwv.find((e) => e.type === 'group')).to.exist;
       });
 
+      it('queries RUM by hostname (not the sub-path) so the domainkey resolves', async () => {
+        const queryStub = sandbox.stub().resolves([]);
+        const { buildCWVAuditResult: build } = await esmock('../../../src/cwv/cwv-audit-result.js', {
+          '@adobe/spacecat-shared-rum-api-client': {
+            default: { createFrom: sandbox.stub().returns({ query: queryStub }) },
+          },
+        });
+
+        await build({
+          site: subpathSite, finalUrl: 'www.example.gov/omes', log, env: {},
+        });
+
+        // Sub-path finalUrl (www.example.gov/omes) must be stripped to the hostname for
+        // the RUM query — the per-URL results are scoped to /omes separately.
+        expect(queryStub.getCalls().some((c) => c.args[1]?.domain === 'www.example.gov'))
+          .to.equal(true);
+      });
+
       it('drops url entries whose URL cannot be parsed', async () => {
         const cwvDataFromRum = [
           {

--- a/test/audits/forms/handler.test.js
+++ b/test/audits/forms/handler.test.js
@@ -74,12 +74,41 @@ describe('Forms Vitals audit', () => {
   });
 
   it('queries RUM by the bare hostname (not the sub-path) so the domainkey resolves', async () => {
-    const subpathSite = { getBaseURL: () => 'https://example.com/foo' };
-    await formsAuditRunner('https://example.com/foo', context, subpathSite);
+    await formsAuditRunner('https://example.com/foo', context, site);
 
     // The RUM `domain` must be the hostname, not the sub-path audit URL.
     const call = context.rumApiClient.queryMulti.getCalls().at(-1);
     expect(call.args[1].domain).to.equal('example.com');
+  });
+
+  it('scopes form-vitals to the site base path, dropping out-of-scope forms', async () => {
+    const subpathContext = new MockContextBuilder()
+      .withSandbox(sandbox)
+      .withOverrides({
+        runtime: { name: 'aws-lambda', region: 'us-east-1' },
+        func: { package: 'spacecat-services', version: 'ci', name: 'test' },
+        site: { getBaseURL: () => 'https://example.com/foo' },
+        rumApiClient: {
+          queryMulti: sinon.stub().resolves({
+            cwv: [],
+            'form-vitals': [
+              { url: 'https://example.com/foo/contact' },
+              { url: 'https://example.com/foo/signup' },
+              { url: 'https://example.com/other/contact' }, // sibling agency — out of scope
+              { url: 'https://example.com/foobar' }, // boundary sibling — out of scope
+            ],
+          }),
+        },
+      })
+      .build();
+
+    const result = await formsAuditRunner('https://example.com/foo', subpathContext);
+
+    const urls = result.auditResult.formVitals.map((v) => v.url);
+    expect(urls).to.deep.equal([
+      'https://example.com/foo/contact',
+      'https://example.com/foo/signup',
+    ]);
   });
 });
 

--- a/test/audits/forms/handler.test.js
+++ b/test/audits/forms/handler.test.js
@@ -72,6 +72,15 @@ describe('Forms Vitals audit', () => {
     );
     expect(result).to.deep.equal(expectedFormVitalsData);
   });
+
+  it('queries RUM by the bare hostname (not the sub-path) so the domainkey resolves', async () => {
+    const subpathSite = { getBaseURL: () => 'https://example.com/foo' };
+    await formsAuditRunner('https://example.com/foo', context, subpathSite);
+
+    // The RUM `domain` must be the hostname, not the sub-path audit URL.
+    const call = context.rumApiClient.queryMulti.getCalls().at(-1);
+    expect(call.args[1].domain).to.equal('example.com');
+  });
 });
 
 describe('audit and send scraping step', () => {

--- a/test/audits/internal-links/rum-detection.test.js
+++ b/test/audits/internal-links/rum-detection.test.js
@@ -146,6 +146,26 @@ describe('internal-links rum-detection', () => {
     expect(log.info).to.have.been.calledWith('No 404 internal links found in RUM data');
   });
 
+  it('queries RUM by the bare hostname (not the sub-path) so the domainkey resolves', async () => {
+    const query = sinon.stub().resolves([]);
+    const rumApiClient = { query };
+    const log = createLog();
+    const { internalLinksAuditRunner } = createSteps();
+
+    await internalLinksAuditRunner('https://audit.example', {
+      log,
+      site: {
+        getId: () => 'site-1',
+        getBaseURL: () => 'https://example.com/foo',
+      },
+      rumApiClient,
+      finalUrl: 'https://example.com/foo',
+    });
+
+    // The RUM `domain` must be the hostname, not the sub-path finalUrl.
+    expect(query.firstCall.args[1].domain).to.equal('example.com');
+  });
+
   it('runs the top-pages step on successful rum detection', async () => {
     const rumApiClient = {
       query: sinon.stub().resolves([

--- a/test/audits/internal-links/subpath-filter.test.js
+++ b/test/audits/internal-links/subpath-filter.test.js
@@ -78,6 +78,17 @@ describe('subpath-filter', () => {
       expect(isWithinAuditScope('https://bulk.com/fr/page1', 'bulk.com/uk')).to.equal(false);
     });
 
+    it('should keep the section landing page (basePath.html) but not siblings', () => {
+      // The `${basePath}.html` landing page is in scope.
+      expect(isWithinAuditScope('https://example.com/foo.html', 'https://example.com/foo')).to.equal(true);
+      expect(isWithinAuditScope('/foo.html', 'https://example.com/foo')).to.equal(true);
+      // Boundary safety: siblings sharing the prefix must still be dropped.
+      expect(isWithinAuditScope('https://example.com/foobar', 'https://example.com/foo')).to.equal(false);
+      expect(isWithinAuditScope('https://example.com/foo-x', 'https://example.com/foo')).to.equal(false);
+      expect(isWithinAuditScope('/foobar', 'https://example.com/foo')).to.equal(false);
+      expect(isWithinAuditScope('/foo-x', 'https://example.com/foo')).to.equal(false);
+    });
+
     it('should return false for invalid URLs', () => {
       // Invalid URLs cause parsing errors, which return false
       expect(isWithinAuditScope('not-a-url', 'bulk.com/uk')).to.equal(false);

--- a/test/audits/product-metatags.test.js
+++ b/test/audits/product-metatags.test.js
@@ -1456,6 +1456,37 @@ describe('Product MetaTags', () => {
         expect(logStub.info.args.some((c) => c && c[0] && /\[PRODUCT-METATAGS] Successfully synced \d+ suggestions for site: site-id and product-metatags audit type\./.test(c[0]))).to.be.true;
       });
 
+      it('builds absolute suggestion data.url for a subpath site — no /foo/foo (SITES-49656)', async () => {
+        dataAccessStub.Opportunity.allBySiteIdAndStatus.resolves([opportunity]);
+        opportunity.getSuggestions.returns([]);
+        // Default hostname-only (getDeliveryConfig returns {}): the endpoint already
+        // carries the /foo prefix, so it must resolve against the origin, not the base URL.
+        const subpathAuditData = {
+          siteId: 'site-id',
+          auditId: 'audit-id',
+          auditResult: {
+            finalUrl: 'https://example.com/foo',
+            detectedTags: {
+              '/foo/product1': {
+                title: {
+                  tagContent: 'Amazing Product - Buy Now',
+                  seoRecommendation: 'Unique across pages',
+                  issue: 'Duplicate Title',
+                  issueDetails: '3 pages share same title',
+                  seoImpact: 'High',
+                },
+              },
+            },
+          },
+        };
+
+        await opportunityAndSuggestions(auditUrl, subpathAuditData, context);
+
+        const newSuggestions = opportunity.addSuggestions.getCall(0).args[0];
+        expect(newSuggestions[0].data.url).to.equal('https://example.com/foo/product1');
+        expect(newSuggestions[0].data.url).to.not.contain('/foo/foo/');
+      });
+
       it('should throw error if fetching opportunity fails', async () => {
         dataAccessStub.Opportunity.allBySiteIdAndStatus.rejects(new Error('some-error'));
         try {
@@ -1738,8 +1769,8 @@ describe('Product MetaTags', () => {
 
         const addSuggestionsCall = opportunity.addSuggestions.getCall(0);
         const suggestions = addSuggestionsCall.args[0];
-        // Should preserve full URL path since useHostnameOnly is undefined
-        expect(suggestions[0].data.url).to.equal('http://localhost:8080/path/product1');
+        // Defaults to hostname-only when useHostnameOnly is undefined (endpoint is absolute)
+        expect(suggestions[0].data.url).to.equal('http://localhost:8080/product1');
         expect(logStub.info).to.be.calledWith('[PRODUCT-METATAGS] Successfully synced 4 suggestions for site: site-id and product-metatags audit type.');
       });
 
@@ -1759,8 +1790,8 @@ describe('Product MetaTags', () => {
 
         const addSuggestionsCall = opportunity.addSuggestions.getCall(0);
         const suggestions = addSuggestionsCall.args[0];
-        // Should preserve full URL path since getSite returns undefined
-        expect(suggestions[0].data.url).to.equal('http://localhost:8080/path/product1');
+        // Defaults to hostname-only when the site lookup returns the default config
+        expect(suggestions[0].data.url).to.equal('http://localhost:8080/product1');
         expect(logStub.info).to.be.calledWith('[PRODUCT-METATAGS] Successfully synced 4 suggestions for site: site-id and product-metatags audit type.');
       });
 
@@ -1780,8 +1811,8 @@ describe('Product MetaTags', () => {
 
         const addSuggestionsCall = opportunity.addSuggestions.getCall(0);
         const suggestions = addSuggestionsCall.args[0];
-        // Should preserve full URL path since getSite returns null
-        expect(suggestions[0].data.url).to.equal('http://localhost:8080/path/product1');
+        // Defaults to hostname-only when the site lookup returns the default config
+        expect(suggestions[0].data.url).to.equal('http://localhost:8080/product1');
         expect(logStub.info).to.be.calledWith('[PRODUCT-METATAGS] Successfully synced 4 suggestions for site: site-id and product-metatags audit type.');
       });
 
@@ -1804,8 +1835,8 @@ describe('Product MetaTags', () => {
 
         const addSuggestionsCall = opportunity.addSuggestions.getCall(0);
         const suggestions = addSuggestionsCall.args[0];
-        // Should preserve full URL path since error caused useHostnameOnly to stay false
-        expect(suggestions[0].data.url).to.equal('http://localhost:8080/path/product1');
+        // Defaults to hostname-only when the site lookup errors
+        expect(suggestions[0].data.url).to.equal('http://localhost:8080/product1');
       });
 
       it('should include product tags in suggestions when available', async () => {

--- a/test/metatags/metatags.test.js
+++ b/test/metatags/metatags.test.js
@@ -1870,6 +1870,48 @@ describe('Meta Tags', () => {
         expect(sentMessage.data.pageUrls).to.have.lengthOf(2);
       });
 
+      it('builds absolute pageUrls for a subpath site without duplicating the base path (SITES-49656)', async () => {
+        site.getBaseURL.returns('https://oklahoma.gov/omes');
+        dataAccessStub.Suggestion.allByOpportunityIdAndStatus.resolves([
+          {
+            getId: sinon.stub().returns('sugg-omes-1'),
+            getData: sinon.stub().returns({
+              url: 'https://oklahoma.gov/omes/divisions/finance.html',
+              tagName: 'title',
+            }),
+          },
+          {
+            getId: sinon.stub().returns('sugg-omes-2'),
+            getData: sinon.stub().returns({
+              url: 'https://oklahoma.gov/omes/about-omes/contact.html',
+              tagName: 'description',
+            }),
+          },
+        ]);
+
+        const auditStub = await esmock('../../src/metatags/handler.js', {
+          '../../src/support/utils.js': { getRUMDomainkey: sinon.stub().resolves('key'), calculateCPCValue: sinon.stub().resolves(5000) },
+          '@adobe/spacecat-shared-rum-api-client': RUMAPIClientStub,
+          '../../src/common/index.js': { wwwUrlResolver: (siteObj) => siteObj.getBaseURL() },
+          '../../src/common/opportunity.js': { convertToOpportunity: sinon.stub().resolves(metatagsOppty) },
+          '../../src/utils/data-access.js': { syncSuggestions: sinon.stub().resolves() },
+          '../../src/metatags/ssr-meta-validator.js': {
+            validateDetectedIssues: sinon.stub().callsFake(async (detectedTags) => detectedTags),
+          },
+        });
+
+        await auditStub.runAuditAndGenerateSuggestions(context);
+
+        const sentMessage = context.sqs.sendMessage.firstCall.args[1];
+        // endpoint already carries /omes; must resolve against origin, not concatenate
+        // onto the full base URL (which produced the malformed /omes/omes/... URL).
+        expect(sentMessage.data.pageUrls).to.have.members([
+          'https://oklahoma.gov/omes/divisions/finance.html',
+          'https://oklahoma.gov/omes/about-omes/contact.html',
+        ]);
+        sentMessage.data.pageUrls.forEach((u) => expect(u).to.not.contain('/omes/omes/'));
+      });
+
       it('when site.requiresValidation is false, fetches suggestions only for NEW status', async () => {
         site.requiresValidation = false;
         dataAccessStub.Suggestion.allByOpportunityIdAndStatus.resetHistory();

--- a/test/metatags/metatags.test.js
+++ b/test/metatags/metatags.test.js
@@ -1454,6 +1454,32 @@ describe('Meta Tags', () => {
         expect(logStub.debug).to.be.calledWith('Successfully synced Opportunity And Suggestions for site: site-id and meta-tags audit type.');
       });
 
+      it('resolves absolute endpoints against the origin for a sub-path site — no /omes/omes (SITES-49656)', async () => {
+        dataAccessStub.Opportunity.allBySiteIdAndStatus.resolves([opportunity]);
+        dataAccessStub.Site.findById = sinon.stub().resolves({
+          getId: () => 'site-id',
+          getDeliveryConfig: () => ({}), // no useHostnameOnly set — defaults to hostname-only
+        });
+        const auditDataSubpath = {
+          ...testData.auditData,
+          auditResult: {
+            ...testData.auditData.auditResult,
+            finalUrl: 'https://oklahoma.gov/omes',
+            detectedTags: {
+              '/omes/divisions/finance.html': {
+                title: { issue: 'Missing Title', seoImpact: 'High' },
+              },
+            },
+          },
+        };
+
+        await opportunityAndSuggestions(auditUrl, auditDataSubpath, context);
+
+        const addSuggestionsCall = opportunity.addSuggestions.getCall(0);
+        const suggestions = addSuggestionsCall.args[0];
+        expect(suggestions[0].data.url).to.equal('https://oklahoma.gov/omes/divisions/finance.html');
+      });
+
       it('should handle case when config.useHostnameOnly is undefined', async () => {
         dataAccessStub.Opportunity.allBySiteIdAndStatus.resolves([opportunity]);
         dataAccessStub.Site.findById = sinon.stub().resolves({
@@ -1473,8 +1499,8 @@ describe('Meta Tags', () => {
 
         const addSuggestionsCall = opportunity.addSuggestions.getCall(0);
         const suggestions = addSuggestionsCall.args[0];
-        // Should preserve full URL path since useHostnameOnly is undefined
-        expect(suggestions[0].data.url).to.equal('http://localhost:8080/path/page1');
+        // Defaults to hostname-only when useHostnameOnly is undefined (endpoint is absolute)
+        expect(suggestions[0].data.url).to.equal('http://localhost:8080/page1');
         expect(logStub.debug).to.be.calledWith('Successfully synced Opportunity And Suggestions for site: site-id and meta-tags audit type.');
       });
 
@@ -1494,8 +1520,8 @@ describe('Meta Tags', () => {
 
         const addSuggestionsCall = opportunity.addSuggestions.getCall(0);
         const suggestions = addSuggestionsCall.args[0];
-        // Should preserve full URL path since getSite returns undefined
-        expect(suggestions[0].data.url).to.equal('http://localhost:8080/path/page1');
+        // Defaults to hostname-only when getSite returns undefined
+        expect(suggestions[0].data.url).to.equal('http://localhost:8080/page1');
         expect(logStub.debug).to.be.calledWith('Successfully synced Opportunity And Suggestions for site: site-id and meta-tags audit type.');
       });
 
@@ -1515,8 +1541,8 @@ describe('Meta Tags', () => {
 
         const addSuggestionsCall = opportunity.addSuggestions.getCall(0);
         const suggestions = addSuggestionsCall.args[0];
-        // Should preserve full URL path since getSite returns null
-        expect(suggestions[0].data.url).to.equal('http://localhost:8080/path/page1');
+        // Defaults to hostname-only when getSite returns null
+        expect(suggestions[0].data.url).to.equal('http://localhost:8080/page1');
         expect(logStub.debug).to.be.calledWith('Successfully synced Opportunity And Suggestions for site: site-id and meta-tags audit type.');
       });
 
@@ -1538,8 +1564,8 @@ describe('Meta Tags', () => {
 
         const addSuggestionsCall = opportunity.addSuggestions.getCall(0);
         const suggestions = addSuggestionsCall.args[0];
-        // Should preserve full URL path since error caused useHostnameOnly to stay false
-        expect(suggestions[0].data.url).to.equal('http://localhost:8080/path/page1');
+        // Defaults to hostname-only when the site lookup errors
+        expect(suggestions[0].data.url).to.equal('http://localhost:8080/page1');
       });
     });
 

--- a/test/metatags/metatags.test.js
+++ b/test/metatags/metatags.test.js
@@ -1454,7 +1454,7 @@ describe('Meta Tags', () => {
         expect(logStub.debug).to.be.calledWith('Successfully synced Opportunity And Suggestions for site: site-id and meta-tags audit type.');
       });
 
-      it('resolves absolute endpoints against the origin for a sub-path site — no /omes/omes (SITES-49656)', async () => {
+      it('resolves absolute endpoints against the origin for a sub-path site — no /foo/foo (SITES-49656)', async () => {
         dataAccessStub.Opportunity.allBySiteIdAndStatus.resolves([opportunity]);
         dataAccessStub.Site.findById = sinon.stub().resolves({
           getId: () => 'site-id',
@@ -1464,9 +1464,9 @@ describe('Meta Tags', () => {
           ...testData.auditData,
           auditResult: {
             ...testData.auditData.auditResult,
-            finalUrl: 'https://oklahoma.gov/omes',
+            finalUrl: 'https://example.com/foo',
             detectedTags: {
-              '/omes/divisions/finance.html': {
+              '/foo/divisions/finance.html': {
                 title: { issue: 'Missing Title', seoImpact: 'High' },
               },
             },
@@ -1477,7 +1477,7 @@ describe('Meta Tags', () => {
 
         const addSuggestionsCall = opportunity.addSuggestions.getCall(0);
         const suggestions = addSuggestionsCall.args[0];
-        expect(suggestions[0].data.url).to.equal('https://oklahoma.gov/omes/divisions/finance.html');
+        expect(suggestions[0].data.url).to.equal('https://example.com/foo/divisions/finance.html');
       });
 
       it('should handle case when config.useHostnameOnly is undefined', async () => {
@@ -1897,19 +1897,19 @@ describe('Meta Tags', () => {
       });
 
       it('builds absolute pageUrls for a subpath site without duplicating the base path (SITES-49656)', async () => {
-        site.getBaseURL.returns('https://oklahoma.gov/omes');
+        site.getBaseURL.returns('https://example.com/foo');
         dataAccessStub.Suggestion.allByOpportunityIdAndStatus.resolves([
           {
-            getId: sinon.stub().returns('sugg-omes-1'),
+            getId: sinon.stub().returns('sugg-foo-1'),
             getData: sinon.stub().returns({
-              url: 'https://oklahoma.gov/omes/divisions/finance.html',
+              url: 'https://example.com/foo/divisions/finance.html',
               tagName: 'title',
             }),
           },
           {
-            getId: sinon.stub().returns('sugg-omes-2'),
+            getId: sinon.stub().returns('sugg-foo-2'),
             getData: sinon.stub().returns({
-              url: 'https://oklahoma.gov/omes/about-omes/contact.html',
+              url: 'https://example.com/foo/about-foo/contact.html',
               tagName: 'description',
             }),
           },
@@ -1929,13 +1929,45 @@ describe('Meta Tags', () => {
         await auditStub.runAuditAndGenerateSuggestions(context);
 
         const sentMessage = context.sqs.sendMessage.firstCall.args[1];
-        // endpoint already carries /omes; must resolve against origin, not concatenate
-        // onto the full base URL (which produced the malformed /omes/omes/... URL).
+        // endpoint already carries /foo; must resolve against origin, not concatenate
+        // onto the full base URL (which produced the malformed /foo/foo/... URL).
         expect(sentMessage.data.pageUrls).to.have.members([
-          'https://oklahoma.gov/omes/divisions/finance.html',
-          'https://oklahoma.gov/omes/about-omes/contact.html',
+          'https://example.com/foo/divisions/finance.html',
+          'https://example.com/foo/about-foo/contact.html',
         ]);
-        sentMessage.data.pageUrls.forEach((u) => expect(u).to.not.contain('/omes/omes/'));
+        sentMessage.data.pageUrls.forEach((u) => expect(u).to.not.contain('/foo/foo/'));
+      });
+
+      it('hands syncSuggestions absolute suggestion data.url for a subpath site — no /foo/foo (SITES-49656)', async () => {
+        site.getBaseURL.returns('https://example.com/foo');
+        context.finalUrl = 'https://example.com/foo';
+        dataAccessStub.Site.findById.resolves({
+          getId: () => 'site-id',
+          getDeliveryConfig: () => ({}), // no useHostnameOnly set — defaults to hostname-only
+        });
+        const syncSuggestionsSpy = sinon.stub().resolves();
+
+        const auditStub = await esmock('../../src/metatags/handler.js', {
+          '../../src/support/utils.js': { getRUMDomainkey: sinon.stub().resolves('key'), calculateCPCValue: sinon.stub().resolves(5000) },
+          '@adobe/spacecat-shared-rum-api-client': RUMAPIClientStub,
+          '../../src/common/index.js': { wwwUrlResolver: (siteObj) => siteObj.getBaseURL() },
+          '../../src/common/opportunity.js': { convertToOpportunity: sinon.stub().resolves(metatagsOppty) },
+          '../../src/utils/data-access.js': { syncSuggestions: syncSuggestionsSpy },
+          '../../src/metatags/ssr-meta-validator.js': {
+            // endpoint already carries the /foo prefix — must resolve against the origin
+            validateDetectedIssues: sinon.stub().resolves({
+              '/foo/divisions/finance.html': {
+                title: { issue: 'Missing Title', seoImpact: 'High' },
+              },
+            }),
+          },
+        });
+
+        await auditStub.runAuditAndGenerateSuggestions(context);
+
+        const { newData } = syncSuggestionsSpy.firstCall.args[0];
+        expect(newData[0].url).to.equal('https://example.com/foo/divisions/finance.html');
+        expect(newData[0].url).to.not.contain('/foo/foo/');
       });
 
       it('when site.requiresValidation is false, fetches suggestions only for NEW status', async () => {

--- a/test/metatags/ssr-validator.test.js
+++ b/test/metatags/ssr-validator.test.js
@@ -331,7 +331,7 @@ describe('SSR Meta Validator', () => {
 
     it('resolves subpath endpoints against the origin without duplicating the base path', async () => {
       const detectedTags = {
-        '/omes/page1': {
+        '/foo/page1': {
           title: { issue: 'Missing title tag' },
         },
       };
@@ -342,12 +342,12 @@ describe('SSR Meta Validator', () => {
         text: async () => '<html><head><title>Present</title></head></html>',
       });
 
-      await validateDetectedIssues(detectedTags, 'https://oklahoma.gov/omes', log);
+      await validateDetectedIssues(detectedTags, 'https://example.com/foo', log);
 
-      // The endpoint already carries the /omes path; it must be resolved against the
-      // origin (https://oklahoma.gov/omes/page1), not concatenated onto the base URL
-      // (which would produce https://oklahoma.gov/omes/omes/page1).
-      expect(fetchStub.firstCall.args[0]).to.equal('https://oklahoma.gov/omes/page1');
+      // The endpoint already carries the /foo path; it must be resolved against the
+      // origin (https://example.com/foo/page1), not concatenated onto the base URL
+      // (which would produce https://example.com/foo/foo/page1).
+      expect(fetchStub.firstCall.args[0]).to.equal('https://example.com/foo/page1');
     });
 
     it('should keep real issues when not found in SSR', async () => {

--- a/test/metatags/ssr-validator.test.js
+++ b/test/metatags/ssr-validator.test.js
@@ -329,6 +329,27 @@ describe('SSR Meta Validator', () => {
       expect(log.info).to.have.been.calledWith('SSR validation complete. Removed 3 false positives from 2 endpoints');
     });
 
+    it('resolves subpath endpoints against the origin without duplicating the base path', async () => {
+      const detectedTags = {
+        '/omes/page1': {
+          title: { issue: 'Missing title tag' },
+        },
+      };
+
+      fetchStub.resolves({
+        ok: true,
+        status: 200,
+        text: async () => '<html><head><title>Present</title></head></html>',
+      });
+
+      await validateDetectedIssues(detectedTags, 'https://oklahoma.gov/omes', log);
+
+      // The endpoint already carries the /omes path; it must be resolved against the
+      // origin (https://oklahoma.gov/omes/page1), not concatenated onto the base URL
+      // (which would produce https://oklahoma.gov/omes/omes/page1).
+      expect(fetchStub.firstCall.args[0]).to.equal('https://oklahoma.gov/omes/page1');
+    });
+
     it('should keep real issues when not found in SSR', async () => {
       const detectedTags = {
         '/page1': {

--- a/test/support/utils.test.js
+++ b/test/support/utils.test.js
@@ -202,8 +202,8 @@ describe('getRUMDomain', () => {
   });
 
   it('returns the hostname for a sub-path URL (RUM is keyed per hostname)', () => {
-    expect(utils.getRUMDomain('https://oklahoma.gov/omes')).to.equal('oklahoma.gov');
-    expect(utils.getRUMDomain('oklahoma.gov/omes')).to.equal('oklahoma.gov');
+    expect(utils.getRUMDomain('https://example.gov/us')).to.equal('example.gov');
+    expect(utils.getRUMDomain('example.gov/us')).to.equal('example.gov');
   });
 
   it('is a no-op for a bare hostname (root sites)', () => {

--- a/test/support/utils.test.js
+++ b/test/support/utils.test.js
@@ -181,6 +181,41 @@ describe('getRUMUrl', () => {
   });
 });
 
+describe('getRUMDomain', () => {
+  let utils;
+
+  beforeEach(async () => {
+    sinon.restore();
+    utils = await esmock('../../src/support/utils.js', {
+      '@adobe/spacecat-shared-utils': {
+        hasText: (str) => typeof str === 'string' && str.trim().length > 0,
+        isNonEmptyArray: (arr) => Array.isArray(arr) && arr.length > 0,
+        isNonEmptyObject: (obj) => obj && typeof obj === 'object' && Object.keys(obj).length > 0,
+        prependSchema: (url) => (url.startsWith('http') ? url : `https://${url}`),
+        tracingFetch: sinon.stub(),
+      },
+    });
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('returns the hostname for a sub-path URL (RUM is keyed per hostname)', () => {
+    expect(utils.getRUMDomain('https://oklahoma.gov/omes')).to.equal('oklahoma.gov');
+    expect(utils.getRUMDomain('oklahoma.gov/omes')).to.equal('oklahoma.gov');
+  });
+
+  it('is a no-op for a bare hostname (root sites)', () => {
+    expect(utils.getRUMDomain('example.com')).to.equal('example.com');
+    expect(utils.getRUMDomain('https://www.example.com')).to.equal('www.example.com');
+  });
+
+  it('returns the input when it cannot be parsed', () => {
+    expect(utils.getRUMDomain('')).to.equal('');
+  });
+});
+
 describe('getBaseUrlPagesFromSitemapContents', () => {
   it('should return an empty array when the sitemap content is empty', () => {
     const result = getBaseUrlPagesFromSitemapContents('https://my-site.adbe', undefined);


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — dev validation only
This PR exists **only** so the dev environment (which deploys the latest PR) can validate **all** the sub-path fixes at once against the dev OMES-style site. The real changes land via the individual PRs below; this branch additionally pins a **locally-built** `@adobe/mysticat-shared-seo-client` tarball, which must never reach `main`. Close (do not merge) once dev validation is done.

## What it combines
- **#2881** — query RUM by hostname for sub-path sites (cwv, broken-internal-links, forms, image-alt-text) + `isWithinAuditScope` landing-page (`basePath.html`) widening.
- **#2880** — meta-tags absolute page/suggestion URLs (+ product-metatags sibling fix).
- **#2882** — base-path filter on broken-backlink results (scheme-safe via `prependSchema`).
- **seo-client (#1875)** via local tarball — `getBrokenBacklinksV2` scopes sub-paths with a `target_url` clause (so broken-backlinks actually runs the fix in dev). Only `package.json` + `package-lock.json` differ from the merge of the three PRs.

All three branches merged cleanly (non-conflicting); combined suite green (582 tests across the changed areas).

## How to validate in dev (OMES-style sub-path site)
Trigger cwv / broken-internal-links / meta-tags / alt-text / broken-backlinks and confirm on `/…` sub-path: RUM audits no longer 404 and stay in-scope; meta-tags emit clean `…/<page>` URLs (no doubled path); broken-backlinks returns real sub-path targets; nothing leaks outside the sub-path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)