### PR TITLE
feat(toc): freeze suggestions with data.isVerified=true from re-audit…

### DIFF
--- a/src/toc/handler.js
+++ b/src/toc/handler.js
@@ -721,6 +721,11 @@ export async function opportunityAndSuggestions(auditUrl, auditData, context) {
       || existingSuggestion.edgeOptimizeStatus) {
       return { ...existingSuggestion };
     }
+    // Suggestions manually verified/updated by the LLMO team (data.isVerified) are frozen -
+    // never touched by subsequent audit runs, regardless of what changed upstream.
+    if (existingSuggestion.isVerified) {
+      return { ...existingSuggestion };
+    }
     const converted = { ...newSuggestion };
     if (converted.transformRules && Array.isArray(converted.transformRules.value)) {
       converted.transformRules = {

--- a/src/toc/handler.js
+++ b/src/toc/handler.js
@@ -721,8 +721,6 @@ export async function opportunityAndSuggestions(auditUrl, auditData, context) {
       || existingSuggestion.edgeOptimizeStatus) {
       return { ...existingSuggestion };
     }
-    // Suggestions manually verified/updated by the LLMO team (data.isVerified) are frozen -
-    // never touched by subsequent audit runs, regardless of what changed upstream.
     if (existingSuggestion.isVerified) {
       return { ...existingSuggestion };
     }

--- a/test/audits/toc.test.js
+++ b/test/audits/toc.test.js
@@ -2655,6 +2655,61 @@ describe('TOC (Table of Contents) Audit', () => {
       expect(merged.isEdited).to.equal(true);
     });
 
+    it('returns existing suggestion unchanged when isVerified is true', async () => {
+      const convertToOpportunityStub = sinon.stub().resolves({
+        getId: () => 'test-opportunity-id',
+      });
+
+      let capturedMergeDataFunction;
+      const syncSuggestionsStub = sinon.stub().callsFake((args) => {
+        capturedMergeDataFunction = args.mergeDataFunction;
+        return Promise.resolve();
+      });
+
+      const mockedHandler = await esmock('../../src/toc/handler.js', {
+        '../../src/common/opportunity.js': {
+          convertToOpportunity: convertToOpportunityStub,
+        },
+        '../../src/utils/data-access.js': {
+          syncSuggestions: syncSuggestionsStub,
+        },
+      });
+
+      const auditUrl = 'https://example.com';
+      const auditData = {
+        suggestions: {
+          toc: [{
+            type: 'CODE_CHANGE',
+            checkType: 'toc',
+            url: 'https://example.com/page1',
+          }],
+        },
+      };
+
+      await mockedHandler.opportunityAndSuggestions(auditUrl, auditData, context);
+
+      const existingSuggestion = {
+        url: 'https://example.com/page1',
+        isVerified: true,
+        transformRules: {
+          value: [{ text: 'LLMO-Verified Title', level: 1 }],
+        },
+      };
+      const newSuggestion = {
+        url: 'https://example.com/page1',
+        transformRules: {
+          value: [{ text: 'New Audit Title', level: 1 }],
+        },
+      };
+
+      const merged = capturedMergeDataFunction(existingSuggestion, newSuggestion);
+
+      // Must return existing data unchanged — suggestions manually verified/updated by the
+      // LLMO team must never be touched by subsequent audit runs.
+      expect(merged.isVerified).to.equal(true);
+      expect(merged.transformRules.value).to.deep.equal([{ text: 'LLMO-Verified Title', level: 1 }]);
+    });
+
     it('preserves Mystique-persisted prompts across re-audits when the new suggestion has none', async () => {
       const convertToOpportunityStub = sinon.stub().resolves({
         getId: () => 'test-opportunity-id',


### PR DESCRIPTION
… merges

Suggestions manually verified/updated by the LLMO team (data.isVerified) are now protected the same way edge-deployed suggestions already are: mergeDataFunction returns the existing suggestion unchanged, so a subsequent audit run never overwrites it.

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi", "Yaashi Madan"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```