### PR TITLE
fix(audits): scope domain-keyed top pages + experimentation opportunities to site sub-path

### DIFF
--- a/src/canonical/handler.js
+++ b/src/canonical/handler.js
@@ -89,6 +89,7 @@ export async function submitForScraping(context) {
     dataAccess,
     auditType,
     getAgenticUrls: () => Promise.resolve([]),
+    scopeTopPagesToBasePath: true,
     log,
   });
 

--- a/src/experimentation-opportunities/handler.js
+++ b/src/experimentation-opportunities/handler.js
@@ -17,6 +17,7 @@ import { isNonEmptyArray } from '@adobe/spacecat-shared-utils';
 import { AuditBuilder } from '../common/audit-builder.js';
 import { wwwUrlResolver } from '../common/index.js';
 import { getCountryCodeFromLang, parseCustomUrls } from '../utils/url-utils.js';
+import { filterByAuditScope } from '../internal-links/subpath-filter.js';
 import {
   getObjectFromKey,
 } from '../utils/s3-utils.js';
@@ -159,16 +160,22 @@ export async function processCustomUrls(customUrls, rumAPIClient, options, conte
  * @returns
  */
 export async function experimentOpportunitiesAuditRunner(auditUrl, context) {
-  const { log } = context;
+  const { log, site } = context;
 
   const rumAPIClient = RUMAPIClient.createFrom(context);
   const options = {
+    // auditUrl resolves via wwwUrlResolver (already a bare hostname), so no strip needed here.
     domain: auditUrl,
     interval: DAYS,
     granularity: 'hourly',
   };
   const queryResults = await rumAPIClient.queryMulti(OPPTY_QUERIES, options);
-  const experimentationOpportunities = Object.values(queryResults).flatMap((oppty) => oppty);
+  const rawOpportunities = Object.values(queryResults).flatMap((oppty) => oppty);
+  // Scope whole-domain RUM opportunities to the site sub-path (no-op for root-domain sites).
+  const baseURL = site?.getBaseURL?.();
+  const experimentationOpportunities = baseURL
+    ? filterByAuditScope(rawOpportunities, baseURL, { urlProperty: 'page' }, log)
+    : rawOpportunities;
   processRageClickOpportunities(experimentationOpportunities);
   log.debug(`Found ${experimentationOpportunities.length} experimentation opportunites for ${auditUrl}`);
 

--- a/src/headings/handler.js
+++ b/src/headings/handler.js
@@ -388,6 +388,7 @@ export async function headingsAuditRunner(baseURL, context, site) {
       auditType,
       getAgenticUrls: () => getTopAgenticUrlsFromAthena(site, context),
       topOrganicLimit: 200,
+      scopeTopPagesToBasePath: true,
       log,
     });
     const topPages = mergedInput.urls.map((url) => ({ url }));

--- a/src/hreflang/handler.js
+++ b/src/hreflang/handler.js
@@ -176,6 +176,7 @@ export async function hreflangAuditRunner(baseURL, context, site) {
       auditType,
       getAgenticUrls: () => Promise.resolve([]),
       topOrganicLimit: 200,
+      scopeTopPagesToBasePath: true,
       log,
     });
     const topPages = mergedInput.urls.map((url) => ({ url }));

--- a/src/internal-links/subpath-filter.js
+++ b/src/internal-links/subpath-filter.js
@@ -97,8 +97,9 @@ export function filterByAuditScope(items, baseURL, options = {}, log = console) 
   try {
     const baseURLWithSchema = prependSchema(baseURL);
     const parsedBaseURL = new URL(baseURLWithSchema);
-    const basePath = parsedBaseURL.pathname;
-    const hasBasePath = basePath && basePath !== '/';
+    // Trim trailing slash(es) to stay consistent with isWithinAuditScope.
+    const basePath = parsedBaseURL.pathname.replace(/\/+$/, '');
+    const hasBasePath = basePath.length > 0;
 
     // If baseURL has no subpath, return all items
     if (!hasBasePath) {

--- a/src/internal-links/subpath-filter.js
+++ b/src/internal-links/subpath-filter.js
@@ -29,11 +29,12 @@ export function isWithinAuditScope(url, baseURL) {
   }
 
   try {
-    // Parse baseURL to extract path
+    // Parse baseURL to extract path. Trim trailing slash(es) so a baseURL like
+    // `example.com/foo/` doesn't become `/foo//` and drop legit in-scope URLs.
     const baseURLWithSchema = prependSchema(baseURL);
     const parsedBaseURL = new URL(baseURLWithSchema);
-    const basePath = parsedBaseURL.pathname;
-    const hasBasePath = basePath && basePath !== '/';
+    const basePath = parsedBaseURL.pathname.replace(/\/+$/, '');
+    const hasBasePath = basePath.length > 0;
 
     // If baseURL has no subpath, include all URLs
     if (!hasBasePath) {

--- a/src/llm-blocked/handler.js
+++ b/src/llm-blocked/handler.js
@@ -78,6 +78,7 @@ export async function checkLLMBlocked(context) {
     dataAccess,
     auditType: 'llm-blocked',
     getAgenticUrls: () => getTopAgenticUrlsFromAthena(site, context),
+    scopeTopPagesToBasePath: true,
     log,
   });
 

--- a/src/metatags/handler.js
+++ b/src/metatags/handler.js
@@ -507,6 +507,7 @@ export async function submitForScraping(context) {
     dataAccess,
     auditType,
     getAgenticUrls: () => Promise.resolve([]),
+    scopeTopPagesToBasePath: true,
     log,
   });
   log.debug(`Final URLs to scrape after merging and deduplication: ${finalUrls.length}`);

--- a/src/product-metatags/handler.js
+++ b/src/product-metatags/handler.js
@@ -831,6 +831,7 @@ export async function submitForScraping(context) {
     auditType,
     getAgenticUrls: () => Promise.resolve([]),
     topPages,
+    scopeTopPagesToBasePath: true,
     log,
   });
   log.info(`[PRODUCT-METATAGS] Final URLs to scrape after merging and deduplication: ${finalUrls.length}`);

--- a/src/readability/opportunities/handler.js
+++ b/src/readability/opportunities/handler.js
@@ -32,6 +32,7 @@ async function getReadabilityUrlsToScrape(context) {
     site,
     dataAccess,
     auditType: AUDIT_TYPE,
+    scopeTopPagesToBasePath: true,
     getAgenticUrls: () => getTopAgenticUrlsFromAthena(site, context, TOP_PAGES_LIMIT),
     getTopPages: async () => {
       const topPages = await dataAccess?.SiteTopPage?.allBySiteIdAndSourceAndGeo?.(

--- a/src/semantic-value-visibility/handler.js
+++ b/src/semantic-value-visibility/handler.js
@@ -80,6 +80,7 @@ export async function auditRunner(auditUrl, context, site) {
     site,
     dataAccess,
     auditType: AUDIT_TYPE,
+    scopeTopPagesToBasePath: true,
     getAgenticUrls: () => getTopAgenticUrlsFromAthena(site, context, MAX_TOP_PAGES),
     getTopPages: async () => {
       if (!dataAccess?.SiteTopPage?.allBySiteIdAndSourceAndGeo) {

--- a/src/structured-data/handler.js
+++ b/src/structured-data/handler.js
@@ -170,6 +170,7 @@ export async function submitForScraping(context) {
     dataAccess,
     auditType,
     getAgenticUrls: () => Promise.resolve([]),
+    scopeTopPagesToBasePath: true,
     log,
   });
 
@@ -204,6 +205,7 @@ export async function runAuditAndGenerateSuggestions(context) {
       dataAccess,
       auditType,
       getAgenticUrls: () => Promise.resolve([]),
+      scopeTopPagesToBasePath: true,
       log,
     });
     let allPages = allUrls.map((url) => ({ url }));

--- a/src/summarization/handler.js
+++ b/src/summarization/handler.js
@@ -88,6 +88,7 @@ async function getSummarizationInputUrls(context) {
     site,
     dataAccess,
     auditType: AUDIT_TYPE,
+    scopeTopPagesToBasePath: true,
     getAgenticUrls: () => getTopAgenticUrlsFromAthena(site, context, MAX_TOP_PAGES),
     getTopPages: async () => {
       const topPages = await dataAccess?.SiteTopPage?.allBySiteIdAndSourceAndGeo?.(
@@ -129,6 +130,7 @@ export async function importTopPages(context) {
       auditType: AUDIT_TYPE,
       getAgenticUrls: () => Promise.resolve([]),
       topOrganicLimit: MAX_TOP_PAGES,
+      scopeTopPagesToBasePath: true,
       log,
     });
 

--- a/src/toc/handler.js
+++ b/src/toc/handler.js
@@ -73,6 +73,7 @@ async function getTocInputUrls(context, site) {
     site,
     dataAccess,
     auditType,
+    scopeTopPagesToBasePath: true,
     getAgenticUrls: () => getTopAgenticUrlsFromAthena(site, context, MAX_TOP_PAGES),
     getTopPages: async () => {
       const topPages = await dataAccess?.SiteTopPage?.allBySiteIdAndSourceAndGeo?.(

--- a/src/utils/audit-input-urls.js
+++ b/src/utils/audit-input-urls.js
@@ -114,6 +114,9 @@ export function mergeAndGetUniqueHtmlUrls(...urlArrays) {
  * when top pages should be loaded lazily or in parallel with other inputs.
  * @param {number} [options.topOrganicLimit] - Optional cap for SEO URLs
  * @param {Function} [options.topPagesToUrls] - Maps SEO page records to URL strings
+ * @param {boolean} [options.scopeTopPagesToBasePath] - When true, filters the domain-keyed top
+ * pages to the site base path (no-op for root-domain sites). Off by default; callers that do
+ * their own sub-path filtering (e.g. broken-backlinks) should leave it off.
  * @param {Object} [options.log] - Optional logger instance
  * @returns {Promise<Object>}
  */
@@ -126,6 +129,7 @@ export async function getMergedAuditInputUrls({
   getTopPages,
   topOrganicLimit,
   topPagesToUrls = defaultTopPagesToUrls,
+  scopeTopPagesToBasePath = false,
   log,
 }) {
   const { SiteTopPage } = dataAccess || {};
@@ -149,13 +153,12 @@ export async function getMergedAuditInputUrls({
   const limitedTopPages = Number.isInteger(topOrganicLimit)
     ? normalizedTopPages.slice(0, topOrganicLimit)
     : normalizedTopPages;
-  const allTopPagesUrls = topPagesToUrls(limitedTopPages);
-  // Scope domain-keyed top pages to the site sub-path (no-op for root-domain sites);
-  // operator-included and agentic URLs stay explicit and are not filtered.
-  const baseURL = site?.getBaseURL?.();
-  const topPagesUrls = baseURL
-    ? filterByAuditScope(allTopPagesUrls, baseURL, {}, log)
-    : allTopPagesUrls;
+  let topPagesUrls = topPagesToUrls(limitedTopPages);
+  // Opt-in: scope domain-keyed top pages to the site sub-path (no-op for root-domain sites).
+  // Operator-included and agentic URLs stay explicit and are never filtered.
+  if (scopeTopPagesToBasePath) {
+    topPagesUrls = filterByAuditScope(topPagesUrls, site?.getBaseURL?.(), {}, log);
+  }
   const includedURLs = await siteConfig?.getIncludedURLs?.(auditType) || [];
   const auditTargetUrls = getAuditTargetUrls(site, log);
   const { urls, filteredCount } = mergeAndGetUniqueHtmlUrls(

--- a/src/utils/audit-input-urls.js
+++ b/src/utils/audit-input-urls.js
@@ -11,6 +11,7 @@
  */
 
 import { getAuditTargetUrls } from './data-access.js';
+import { filterByAuditScope } from '../internal-links/subpath-filter.js';
 
 /**
  * Common non-HTML file extensions that should be filtered out from scrape inputs.
@@ -148,7 +149,13 @@ export async function getMergedAuditInputUrls({
   const limitedTopPages = Number.isInteger(topOrganicLimit)
     ? normalizedTopPages.slice(0, topOrganicLimit)
     : normalizedTopPages;
-  const topPagesUrls = topPagesToUrls(limitedTopPages);
+  const allTopPagesUrls = topPagesToUrls(limitedTopPages);
+  // Scope domain-keyed top pages to the site sub-path (no-op for root-domain sites);
+  // operator-included and agentic URLs stay explicit and are not filtered.
+  const baseURL = site?.getBaseURL?.();
+  const topPagesUrls = baseURL
+    ? filterByAuditScope(allTopPagesUrls, baseURL, {}, log)
+    : allTopPagesUrls;
   const includedURLs = await siteConfig?.getIncludedURLs?.(auditType) || [];
   const auditTargetUrls = getAuditTargetUrls(site, log);
   const { urls, filteredCount } = mergeAndGetUniqueHtmlUrls(

--- a/src/utils/audit-input-urls.js
+++ b/src/utils/audit-input-urls.js
@@ -156,7 +156,18 @@ export async function getMergedAuditInputUrls({
   // domain (a low-traffic sub-path can otherwise rank entirely below the domain-wide cutoff).
   let topPagesUrls = topPagesToUrls(normalizedTopPages);
   if (scopeTopPagesToBasePath) {
+    const preScopeCount = topPagesUrls.length;
     topPagesUrls = filterByAuditScope(topPagesUrls, site?.getBaseURL?.(), {}, log);
+    // Distinguish "top pages exist but none are in the sub-path" (e.g. a newly onboarded
+    // sub-path site, or a top-pages import that hasn't caught up) from "no top pages at
+    // all" — a downstream empty-set throw is otherwise indistinguishable from a broken import.
+    if (preScopeCount > 0 && topPagesUrls.length === 0) {
+      log?.info?.(
+        `[audit-input-urls] All ${preScopeCount} top pages are outside the audit scope for `
+        + `${site?.getBaseURL?.()}; the sub-path may be newly onboarded or its top-pages import `
+        + 'may not yet cover it.',
+      );
+    }
   }
   if (Number.isInteger(topOrganicLimit)) {
     topPagesUrls = topPagesUrls.slice(0, topOrganicLimit);

--- a/src/utils/audit-input-urls.js
+++ b/src/utils/audit-input-urls.js
@@ -150,14 +150,16 @@ export async function getMergedAuditInputUrls({
     site?.getConfig?.(),
   ]);
   const normalizedTopPages = topPages || [];
-  const limitedTopPages = Number.isInteger(topOrganicLimit)
-    ? normalizedTopPages.slice(0, topOrganicLimit)
-    : normalizedTopPages;
-  let topPagesUrls = topPagesToUrls(limitedTopPages);
   // Opt-in: scope domain-keyed top pages to the site sub-path (no-op for root-domain sites).
-  // Operator-included and agentic URLs stay explicit and are never filtered.
+  // Operator-included and agentic URLs stay explicit and are never filtered. Scope BEFORE
+  // applying topOrganicLimit so the "top N" is computed within the sub-path, not the whole
+  // domain (a low-traffic sub-path can otherwise rank entirely below the domain-wide cutoff).
+  let topPagesUrls = topPagesToUrls(normalizedTopPages);
   if (scopeTopPagesToBasePath) {
     topPagesUrls = filterByAuditScope(topPagesUrls, site?.getBaseURL?.(), {}, log);
+  }
+  if (Number.isInteger(topOrganicLimit)) {
+    topPagesUrls = topPagesUrls.slice(0, topOrganicLimit);
   }
   const includedURLs = await siteConfig?.getIncludedURLs?.(auditType) || [];
   const auditTargetUrls = getAuditTargetUrls(site, log);

--- a/test/audits/experimentation-opportunities.test.js
+++ b/test/audits/experimentation-opportunities.test.js
@@ -414,6 +414,38 @@ describe('Experimentation Opportunities Tests', () => {
     });
   });
 
+  describe('sub-path scoping', () => {
+    it('filters whole-domain opportunities to the site sub-path', async () => {
+      context.data = null;
+      context.site = { ...site, getBaseURL: () => 'https://abc.com/foo' };
+      context.rumApiClient.queryMulti = sinon.stub().resolves({
+        'high-organic-low-ctr': [
+          { type: 'high-organic-low-ctr', page: 'https://abc.com/foo/in-scope' },
+          { type: 'high-organic-low-ctr', page: 'https://abc.com/bar/out-of-scope' },
+        ],
+      });
+
+      const result = await experimentOpportunitiesAuditRunner('abc.com', context);
+      const pages = result.auditResult.experimentationOpportunities.map((o) => o.page);
+
+      expect(pages).to.deep.equal(['https://abc.com/foo/in-scope']);
+    });
+
+    it('passes opportunities through when the site has no base URL', async () => {
+      context.data = null;
+      context.site = undefined;
+      context.rumApiClient.queryMulti = sinon.stub().resolves({
+        'high-organic-low-ctr': [
+          { type: 'high-organic-low-ctr', page: 'https://abc.com/bar/anything' },
+        ],
+      });
+
+      const result = await experimentOpportunitiesAuditRunner('abc.com', context);
+
+      expect(result.auditResult.experimentationOpportunities).to.have.length(1);
+    });
+  });
+
   describe('Additional URLs Processing', () => {
     describe('Successfully process additional URLs', () => {
       it('should use custom URLs when provided and create opportunities for all URLs', async () => {

--- a/test/audits/internal-links/subpath-filter.test.js
+++ b/test/audits/internal-links/subpath-filter.test.js
@@ -56,6 +56,16 @@ describe('subpath-filter', () => {
       expect(isWithinAuditScope('/products', 'bulk.com/uk')).to.equal(false);
     });
 
+    it('should handle a baseURL with a trailing slash', () => {
+      // `bulk.com/uk/` must behave exactly like `bulk.com/uk` (not build `/uk//`).
+      expect(isWithinAuditScope('https://bulk.com/uk/page1', 'bulk.com/uk/')).to.equal(true);
+      expect(isWithinAuditScope('https://bulk.com/uk', 'bulk.com/uk/')).to.equal(true);
+      expect(isWithinAuditScope('https://bulk.com/uk.html', 'bulk.com/uk/')).to.equal(true);
+      expect(isWithinAuditScope('https://bulk.com/fr/page1', 'bulk.com/uk/')).to.equal(false);
+      // A bare host with a trailing slash is still root scope (everything included).
+      expect(isWithinAuditScope('https://bulk.com/anything', 'bulk.com/')).to.equal(true);
+    });
+
     it('should avoid false positives with trailing slash matching', () => {
       // /fr/ should not match /french/
       expect(isWithinAuditScope('https://bulk.com/french/page', 'bulk.com/fr')).to.equal(false);

--- a/test/utils/audit-input-urls.test.js
+++ b/test/utils/audit-input-urls.test.js
@@ -225,6 +225,7 @@ describe('audit-input-urls', () => {
         site,
         auditType: 'readability',
         getAgenticUrls: async () => ['https://example.com/bar/agentic'],
+        scopeTopPagesToBasePath: true,
         topPages: [
           { url: 'https://example.com/foo/in-scope', traffic: 100, urlId: 't1' },
           { url: 'https://example.com/bar/out-of-scope', traffic: 90, urlId: 't2' },

--- a/test/utils/audit-input-urls.test.js
+++ b/test/utils/audit-input-urls.test.js
@@ -212,6 +212,36 @@ describe('audit-input-urls', () => {
       ]);
     });
 
+    it('scopes top pages to the site sub-path while keeping included/agentic URLs', async () => {
+      const site = {
+        getId: () => 'site-123',
+        getBaseURL: () => 'https://example.com/foo',
+        getConfig: () => ({
+          getIncludedURLs: () => ['https://example.com/bar/included'],
+        }),
+      };
+
+      const result = await getMergedAuditInputUrls({
+        site,
+        auditType: 'readability',
+        getAgenticUrls: async () => ['https://example.com/bar/agentic'],
+        topPages: [
+          { url: 'https://example.com/foo/in-scope', traffic: 100, urlId: 't1' },
+          { url: 'https://example.com/bar/out-of-scope', traffic: 90, urlId: 't2' },
+        ],
+      });
+
+      // Domain-keyed top pages are scoped to /foo; out-of-scope pages are dropped.
+      expect(result.topPagesUrls).to.deep.equal(['https://example.com/foo/in-scope']);
+      // Explicit included/agentic URLs are preserved even outside the sub-path.
+      expect(result.urls).to.include.members([
+        'https://example.com/foo/in-scope',
+        'https://example.com/bar/included',
+        'https://example.com/bar/agentic',
+      ]);
+      expect(result.urls).to.not.include('https://example.com/bar/out-of-scope');
+    });
+
     it('should use provided getTopPages callback without calling dataAccess', async () => {
       const site = {
         getId: () => 'site-123',

--- a/test/utils/audit-input-urls.test.js
+++ b/test/utils/audit-input-urls.test.js
@@ -268,6 +268,28 @@ describe('audit-input-urls', () => {
       expect(result.topPagesUrls).to.deep.equal(['https://example.com/foo/c']);
     });
 
+    it('does not scope top pages when scopeTopPagesToBasePath is off (default), even on a sub-path site', async () => {
+      const site = {
+        getId: () => 'site-123',
+        getBaseURL: () => 'https://example.com/foo',
+        getConfig: () => ({ getIncludedURLs: () => [] }),
+      };
+
+      // Flag omitted → defaults to false → out-of-scope top pages are retained.
+      const result = await getMergedAuditInputUrls({
+        site,
+        auditType: 'readability',
+        getAgenticUrls: async () => [],
+        topPages: [
+          { url: 'https://example.com/foo/in', traffic: 100, urlId: 't1' },
+          { url: 'https://example.com/bar/out', traffic: 90, urlId: 't2' },
+        ],
+      });
+
+      expect(result.topPagesUrls).to.include('https://example.com/foo/in');
+      expect(result.topPagesUrls).to.include('https://example.com/bar/out');
+    });
+
     it('should use provided getTopPages callback without calling dataAccess', async () => {
       const site = {
         getId: () => 'site-123',

--- a/test/utils/audit-input-urls.test.js
+++ b/test/utils/audit-input-urls.test.js
@@ -243,6 +243,31 @@ describe('audit-input-urls', () => {
       expect(result.urls).to.not.include('https://example.com/bar/out-of-scope');
     });
 
+    it('scopes to the sub-path before applying topOrganicLimit', async () => {
+      const site = {
+        getId: () => 'site-123',
+        getBaseURL: () => 'https://example.com/foo',
+        getConfig: () => ({ getIncludedURLs: () => [] }),
+      };
+
+      // Two higher-traffic out-of-scope pages rank above the in-scope one; with a
+      // limit of 2 a slice-then-scope order would drop the /foo page entirely.
+      const result = await getMergedAuditInputUrls({
+        site,
+        auditType: 'readability',
+        getAgenticUrls: async () => [],
+        scopeTopPagesToBasePath: true,
+        topOrganicLimit: 2,
+        topPages: [
+          { url: 'https://example.com/bar/a', traffic: 100, urlId: 't1' },
+          { url: 'https://example.com/bar/b', traffic: 90, urlId: 't2' },
+          { url: 'https://example.com/foo/c', traffic: 10, urlId: 't3' },
+        ],
+      });
+
+      expect(result.topPagesUrls).to.deep.equal(['https://example.com/foo/c']);
+    });
+
     it('should use provided getTopPages callback without calling dataAccess', async () => {
       const site = {
         getId: () => 'site-123',

--- a/test/utils/audit-input-urls.test.js
+++ b/test/utils/audit-input-urls.test.js
@@ -290,6 +290,31 @@ describe('audit-input-urls', () => {
       expect(result.topPagesUrls).to.include('https://example.com/bar/out');
     });
 
+    it('logs a distinct message when scoping empties a non-empty top-pages set', async () => {
+      const site = {
+        getId: () => 'site-123',
+        getBaseURL: () => 'https://example.com/foo',
+        getConfig: () => ({ getIncludedURLs: () => [] }),
+      };
+      const infoLogs = [];
+      const log = { info: (msg) => infoLogs.push(msg), debug: () => {}, warn: () => {} };
+
+      const result = await getMergedAuditInputUrls({
+        site,
+        auditType: 'readability',
+        getAgenticUrls: async () => [],
+        scopeTopPagesToBasePath: true,
+        log,
+        topPages: [
+          { url: 'https://example.com/bar/a', traffic: 100, urlId: 't1' },
+          { url: 'https://example.com/bar/b', traffic: 90, urlId: 't2' },
+        ],
+      });
+
+      expect(result.topPagesUrls).to.deep.equal([]);
+      expect(infoLogs.some((m) => m.includes('outside the audit scope'))).to.equal(true);
+    });
+
     it('should use provided getTopPages callback without calling dataAccess', async () => {
       const site = {
         getId: () => 'site-123',


### PR DESCRIPTION
## Problem
Sub-path sites (a `baseURL` that carries a path, e.g. `example.com/foo`) inherited **whole-domain** data in two remaining V1 audit paths, because RUM/top-pages are keyed per hostname:

1. **Top pages** — `getMergedAuditInputUrls` returned the domain's entire top-pages set, so audits built on it (structured-data, hreflang, toc, canonical, llm-blocked) scraped/audited pages outside the site's sub-path.
2. **Experimentation opportunities** — `experimentation-opportunities` returned whole-domain RUM opportunities, attributing other sub-paths' pages to the site.

Follow-up hardening for the sub-path work in #2873 / #2880 / #2881 / #2882.

## Fix
Scope to the site base path, reusing the existing directory-boundary-safe `isWithinAuditScope` / `filterByAuditScope` helper (host-normalized, `${basePath}.html` landing-aware). **No-op for root-domain sites.**

- **`src/utils/audit-input-urls.js`** — new opt-in `scopeTopPagesToBasePath` option (default **off**) that filters the domain-keyed top pages to the base path. Operator-**included** and **agentic** URLs are always left explicit/unfiltered. Enabled for the audits that source URLs solely from this helper: **structured-data, hreflang, toc, canonical, llm-blocked**. Left **off** for **broken-backlinks**, which does its own sub-path filtering and emits a precise "all top pages filtered out by audit scope" error — so its behavior is unchanged.
- **`src/experimentation-opportunities/handler.js`** — filter the whole-domain RUM opportunities by base path. `domain` here already resolves to a bare hostname via `wwwUrlResolver`, so no additional hostname strip is needed.

### structured-data
No structured-data-specific change: it sources every URL (and its GSC per-URL inspection list) from `getMergedAuditInputUrls`, so opting the helper in scopes it automatically. Verified by tracing `getIssuesFromGSC`, which iterates the already-scoped page list.

### Verified non-issues (traced, no change)
- `llmo-customer-analysis` `checkOptelData` — `getRUMUrl` already returns a bare hostname; it's a boolean pageviews existence gate (no per-URL leak).
- `experimentation-ess` and `metatags` / `product-metatags` `calculateProjectedTraffic` — `domain` comes from `wwwUrlResolver` (bare hostname), so the domainkey lookup does not 404 for sub-path sites.

## Tests
- New sub-path scoping test in `test/utils/audit-input-urls.test.js` (out-of-scope top pages dropped; included/agentic preserved).
- New `sub-path scoping` cases in `test/audits/experimentation-opportunities.test.js` (filtering + no-baseURL pass-through).
- Full suite green (9581 passing) with 100% coverage; all consumer suites (backlinks, structured-data, canonical, hreflang, toc, llm-blocked) pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Xinyi Feng", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```