### PR TITLE
fix(preflight): [SITES-49849] stop suggesting author page URL as canonical suggestion

### DIFF
--- a/src/preflight/canonical.js
+++ b/src/preflight/canonical.js
@@ -23,21 +23,6 @@ import { getDomElementSelector, toElementTargets } from './utils/dom-selector.js
 export const PREFLIGHT_CANONICAL = 'canonical';
 
 /**
- * Checks whose fix is unambiguously "point the canonical at this page's own URL" -
- * so authors see the correct value, not just the current (wrong) one. Excludes
- * `CANONICAL_TAG_OUTSIDE_HEAD` (the href itself is already correct, only its placement is wrong)
- * and the format checks (absolute/protocol/domain/lowercased — fixing those means transforming
- * the existing href, not replacing it with the page's own URL).
- */
-const CHECKS_SUGGESTING_OWN_URL = new Set([
-  CANONICAL_CHECKS.CANONICAL_TAG_MISSING.check,
-  CANONICAL_CHECKS.CANONICAL_TAG_NO_HREF.check,
-  CANONICAL_CHECKS.CANONICAL_TAG_EMPTY.check,
-  CANONICAL_CHECKS.CANONICAL_SELF_REFERENCED.check,
-  CANONICAL_CHECKS.CANONICAL_TAG_MULTIPLE.check,
-]);
-
-/**
  * Extracts canonical metadata from raw HTML as a fallback when scraper metadata is absent.
  * @param {string} rawBody - Raw HTML string.
  * @returns {{ exists: boolean, href: string|null, inHead: boolean, count: number }}
@@ -186,7 +171,6 @@ export default async function canonical(context, auditContext) {
           issue: CANONICAL_CHECKS.CANONICAL_TAG_MISSING.explanation,
           seoImpact: 'Moderate',
           seoRecommendation: CANONICAL_CHECKS.CANONICAL_TAG_MISSING.suggestion,
-          suggestion: url,
         });
         return;
       }
@@ -207,13 +191,16 @@ export default async function canonical(context, auditContext) {
       const failedChecks = runCanonicalChecks(url, meta, previewBaseURL, log);
       failedChecks.forEach((checkConfig) => {
         const isMultipleTagsCheck = checkConfig.check === multipleTagsCheck;
+        // For author pages in UE,CS,AMS,EDS `url` is the editor host, not the published
+        // site URL, so suggesting it as the canonical is wrong.
+        // Until we can map author -> published via site config, the static `seoRecommendation`
+        // text guides the fix without emitting a concrete (possibly wrong) URL.
         pageAudit.opportunities.push({
           check: checkConfig.check,
           issue: checkConfig.explanation,
           seoImpact: 'Moderate',
           seoRecommendation: checkConfig.suggestion,
           ...(hasHrefValue ? { url: meta.href } : {}),
-          ...(CHECKS_SUGGESTING_OWN_URL.has(checkConfig.check) ? { suggestion: url } : {}),
           ...toElementTargets(isMultipleTagsCheck ? canonicalSelectors : canonicalSelectors[0]),
         });
       });

--- a/test/audits/preflight-canonical.test.js
+++ b/test/audits/preflight-canonical.test.js
@@ -348,10 +348,11 @@ describe('Preflight Canonical Audit', () => {
       await canonicalHandler(ctx, auditCtx);
 
       const [opp] = getCanonicalAudit(auditCtx.auditsResult).opportunities;
-      expect(opp).to.have.all.keys('check', 'issue', 'seoImpact', 'seoRecommendation', 'suggestion');
+      expect(opp).to.have.all.keys('check', 'issue', 'seoImpact', 'seoRecommendation');
       expect(opp.seoImpact).to.equal('Moderate');
-      // A missing canonical tag's fix is unambiguous: point it at the page's own URL.
-      expect(opp.suggestion).to.equal(PAGE_URL);
+      // No `suggestion` URL is emitted: the page's own URL is the editor host for
+      // author pages, so suggesting it as the canonical would be wrong.
+      expect(opp).to.not.have.property('suggestion');
     });
   });
 

--- a/test/fixtures/preflight/preflight-suggest.js
+++ b/test/fixtures/preflight/preflight-suggest.js
@@ -60,7 +60,6 @@ export const suggestionData = [
             seoImpact: 'Moderate',
             seoRecommendation: 'Update the canonical URL to point to itself',
             url: 'https://main--example--page.aem.page/wrong',
-            suggestion: 'https://main--example--page.aem.page/page1',
           },
         ],
       },


### PR DESCRIPTION
Preflight canonical suggested the page's own URL as the canonical fix. For author source pages (UE/AMS/CS/EDS) that URL is the editor host, not the published site URL, so the suggestion pointed authors at the editor host.

Removes the page's own URL from canonical opportunities and the now-unused `CHECKS_SUGGESTING_OWN_URL` set. The static `seoRecommendation` text still guides the fix. A later change will map author -> published via site config and suggest that instead (Tracked here: https://jira.corp.adobe.com/browse/SITES-49906)

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Andrew Top", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```