### PR TITLE
fix(internal-links)[v1]: parse srcset per spec so Scene7 image URLs don't create phantom broken links (SITES-49919)

### DIFF
--- a/src/internal-links/crawl-detection.js
+++ b/src/internal-links/crawl-detection.js
@@ -166,12 +166,64 @@ function extractMetaRefreshUrl(content = '') {
   return match?.[1]?.trim() || '';
 }
 
+/**
+ * Splits an HTML `srcset` attribute value into its candidate URLs following the
+ * WHATWG rules: a candidate URL is a run of non-whitespace characters (which MAY
+ * contain commas — e.g. Scene7's `qlt=85,0` quality parameter), optionally
+ * followed by whitespace and a descriptor, with candidates separated by commas.
+ * A naive `split(',')` wrongly breaks URLs whose query string contains a comma,
+ * orphaning fragments like `0&resMode=sharp` that then resolve against the page
+ * into phantom internal links. Collecting the URL as a non-whitespace run avoids
+ * that.
+ *
+ * @param {string} rawValue - The raw `srcset` attribute value.
+ * @returns {string[]} Candidate URL strings, descriptors stripped.
+ */
+export function splitSrcsetCandidates(rawValue) {
+  const input = String(rawValue);
+  const { length } = input;
+  const isWhitespace = (ch) => /\s/.test(ch);
+  const urls = [];
+  let pos = 0;
+
+  while (pos < length) {
+    // Skip whitespace and the commas that separate candidates.
+    while (pos < length && (isWhitespace(input[pos]) || input[pos] === ',')) {
+      pos += 1;
+    }
+    if (pos >= length) {
+      break;
+    }
+
+    // A candidate URL is a run of non-whitespace characters (commas included).
+    let url = '';
+    while (pos < length && !isWhitespace(input[pos])) {
+      url += input[pos];
+      pos += 1;
+    }
+
+    // Trailing commas on the URL are candidate separators, not part of the URL.
+    let hadTrailingComma = false;
+    while (url.endsWith(',')) {
+      url = url.slice(0, -1);
+      hadTrailingComma = true;
+    }
+    urls.push(url);
+
+    // With no trailing comma, an optional descriptor follows up to the next
+    // comma — skip it so it is not mistaken for another URL.
+    if (!hadTrailingComma) {
+      while (pos < length && input[pos] !== ',') {
+        pos += 1;
+      }
+    }
+  }
+
+  return urls;
+}
+
 function resolveUrlCandidates(rawValue, pageUrl) {
-  return String(rawValue)
-    .split(',')
-    .map((entry) => entry.trim())
-    .filter(Boolean)
-    .map((entry) => entry.split(/\s+/)[0])
+  return splitSrcsetCandidates(rawValue)
     .map((entry) => normalizeDetectedUrlCandidate(entry))
     .filter((entry) => entry && !entry.startsWith('data:') && !entry.startsWith('#'))
     .map((entry) => stripAbsoluteUrlHash(new URL(entry, pageUrl).toString()));

--- a/test/audits/internal-links/crawl-detection.test.js
+++ b/test/audits/internal-links/crawl-detection.test.js
@@ -25,6 +25,7 @@ describe('Crawl Detection Module', () => {
   let detectBrokenLinksFromCrawlBatch;
   let mergeAndDeduplicate;
   let PAGES_PER_BATCH;
+  let splitSrcsetCandidates;
   let getObjectFromKeyStub;
   let isLinkInaccessibleStub;
   let isWithinAuditScopeStub;
@@ -78,6 +79,7 @@ describe('Crawl Detection Module', () => {
     detectBrokenLinksFromCrawlBatch = module.detectBrokenLinksFromCrawlBatch;
     mergeAndDeduplicate = module.mergeAndDeduplicate;
     PAGES_PER_BATCH = module.PAGES_PER_BATCH;
+    splitSrcsetCandidates = module.splitSrcsetCandidates;
 
     // Reset log stubs
     mockContext.log.info.reset();
@@ -97,6 +99,44 @@ describe('Crawl Detection Module', () => {
     statusBucket: statusBucket || (isBroken ? '4xx' : '2xx-3xx'),
     contentType: 'text/html',
     ...extra,
+  });
+
+  describe('splitSrcsetCandidates (srcset comma-split fix, SITES-49919)', () => {
+    it('keeps a single Scene7 URL intact when its query contains a comma (qlt=85,0)', () => {
+      const src = 'https://worldbank.scene7.com/is/image/worldbankprod/WB_flags_716x402?wid=780&hei=439&qlt=85,0&resMode=sharp';
+      expect(splitSrcsetCandidates(src)).to.deep.equal([src]);
+    });
+
+    it('does not orphan a "0&resMode=sharp" fragment from a comma inside the query', () => {
+      const out = splitSrcsetCandidates('https://s7.example.com/is/image/x?wid=780&qlt=85,0&resMode=sharp');
+      expect(out).to.have.lengthOf(1);
+      expect(out.includes('0&resMode=sharp')).to.equal(false);
+    });
+
+    it('splits multiple candidates and strips descriptors', () => {
+      expect(splitSrcsetCandidates('a.jpg 1x, b.jpg 2x')).to.deep.equal(['a.jpg', 'b.jpg']);
+    });
+
+    it('preserves commas inside a URL while still splitting real candidates', () => {
+      expect(splitSrcsetCandidates('a.jpg?q=1,2 780w, b.jpg 1200w')).to.deep.equal(['a.jpg?q=1,2', 'b.jpg']);
+    });
+
+    it('handles a candidate that ends in a comma with no descriptor', () => {
+      expect(splitSrcsetCandidates('a.jpg, b.jpg')).to.deep.equal(['a.jpg', 'b.jpg']);
+    });
+
+    it('handles multiple and trailing commas', () => {
+      expect(splitSrcsetCandidates('a.jpg,, b.jpg,')).to.deep.equal(['a.jpg', 'b.jpg']);
+    });
+
+    it('returns an empty array for empty or whitespace-only input', () => {
+      expect(splitSrcsetCandidates('')).to.deep.equal([]);
+      expect(splitSrcsetCandidates(' \t\n ')).to.deep.equal([]);
+    });
+
+    it('trims leading whitespace and commas before a lone URL with a descriptor', () => {
+      expect(splitSrcsetCandidates('  ,  a.jpg 780w')).to.deep.equal(['a.jpg']);
+    });
   });
 
   describe('detectBrokenLinksFromCrawlBatch', () => {


### PR DESCRIPTION
## Problem

The **broken-internal-links** audit (v1) surfaces false-positive broken links whose target (`url_to`) is a mangled Scene7/AEM image-rendition fragment — e.g. `…/food-security-update/0&resMode=sharp&fmt=webp`. These aren't real hyperlinks; the underlying images return **200**, and the fragment is **never present in the page HTML**.

## Root cause

`resolveUrlCandidates` (`src/internal-links/crawl-detection.js`) split a page's `srcset` on a raw comma:

```js
String(rawValue).split(',')...  // BUG
```

Scene7 image URLs contain a comma **inside the query string** — the quality param `qlt=85,0`. Real value on the page:

```
srcset="https://worldbank.scene7.com/is/image/worldbankprod/WB_flags_716x402?wid=780&hei=439&qlt=85,0&resMode=sharp"
```

The naive split broke that single URL into:
- `…/WB_flags_716x402?wid=780&hei=439&qlt=85` (external host → correctly dropped), and
- `0&resMode=sharp` (a **relative** URL).

`0&resMode=sharp` resolved against the page's parent dir → `…/en/topic/agriculture/brief/0&resMode=sharp`, passed the internal-host check, validated as a genuine 404, and was surfaced as a broken internal link. Per the HTML `srcset` spec, a URL is a run of non-whitespace characters (commas included) — the comma-split is simply wrong.

## Fix

Replace `.split(',')` with `splitSrcsetCandidates`, a spec-correct parser: collect the URL as a run of non-whitespace chars (commas preserved), then skip an optional descriptor up to the next comma; commas separate candidates only at candidate boundaries. The Scene7 URL now stays intact (single candidate → dropped as external host) and **no orphan fragment is produced**.

## Scope: v1 only

`resolveUrlCandidates` lives in `spacecat-audit-worker`'s crawl detector — the **v1** broken-internal-links path. **This fix is v1 only.** v2 broken-internal-links runs entirely on Mystique (no `spacecat-audit-worker` code) and is out of scope here (and may not be GA yet).

## Trace (worldbank.org prod — SITES-49919)

Input `srcset` `…qlt=85,0&resMode=sharp`:
- **Before:** `split(',')` → `[…qlt=85, 0&resMode=sharp]` → `0&resMode=sharp` resolves to `…/brief/0&resMode=sharp` → internal host → 404 → **phantom broken link** (6 such NEW suggestions on the site).
- **After:** `splitSrcsetCandidates` → `[…qlt=85,0&resMode=sharp]` (one URL) → external `scene7.com` host → dropped → **no suggestion**.

This eliminates all 6 false positives on the site (opportunity `a588a8be-021c-467a-b19d-bff3a7ce68fd`), verified: the real Scene7 images are 200 and the fragments were absent from the page HTML.

## Tests

- New `splitSrcsetCandidates` unit suite: single URL with a query comma stays intact; no `0&resMode=sharp` orphan; multi-candidate split + descriptor strip; commas-in-URL preserved alongside real splits; trailing/multiple commas; empty/whitespace-only input; leading whitespace/commas.
- Full suite: **9663 passing**, `crawl-detection.js` **100%** coverage (lines/branches/functions), lint clean.

Fixes SITES-49919.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
