### PR TITLE
fix(internal-links): scope-guard OUTDATED against crawl coverage gaps (SITES-49911)

### DIFF
--- a/src/internal-links/opportunity-suggestions.js
+++ b/src/internal-links/opportunity-suggestions.js
@@ -15,6 +15,49 @@ import { createInternalLinksConfigResolver } from './config.js';
 import { createInternalLinksStepLogger } from './logging.js';
 import { warnOnInvalidSuggestionData } from '../utils/data-access.js';
 import { getMergedAuditInputUrls } from '../utils/audit-input-urls.js';
+import { loadScrapeResultPaths } from './batch-state.js';
+import { normalizeComparableUrl } from './link-key.js';
+import { isWithinAuditScope } from './subpath-filter.js';
+
+/**
+ * Builds the crawl-coverage set for this run: the normalized set of source pages
+ * (urlFrom) that were part of this audit's crawl scope, reconstructed from the
+ * scrape-result-paths manifest. A non-empty set means this was a crawl run, so the
+ * OUTDATED sweep can trust "absence == fix" only for pages in the set (SITES-49911).
+ * Returns null when no manifest exists (RUM/LinkChecker-only runs), so callers fall
+ * back to prior absence-only behavior.
+ *
+ * @param {string} auditId - The audit ID.
+ * @param {Object} loaderContext - Context carrying s3Client/env for the S3 read.
+ * @param {Object} log - Logger instance.
+ * @returns {Promise<Set<string>|null>}
+ */
+async function buildCrawledUrlFromSet(auditId, loaderContext, log) {
+  // No S3 client (e.g. some test contexts / degenerate runs) — do not attempt the
+  // manifest read. Returning null keeps the caller on prior absence-only behavior
+  // without emitting a spurious error log from the S3 layer.
+  if (!loaderContext?.s3Client) {
+    log.debug('Scope guard: no s3Client available; outdating falls back to absence-only');
+    return null;
+  }
+  try {
+    const scrapeResultPaths = await loadScrapeResultPaths(auditId, loaderContext);
+    if (scrapeResultPaths && scrapeResultPaths.size > 0) {
+      const set = new Set(
+        Array.from(scrapeResultPaths.keys())
+          .map((url) => normalizeComparableUrl(url))
+          .filter(Boolean),
+      );
+      log.info(`Scope guard: ${set.size} crawled pages available for outdating coverage`);
+      return set;
+    }
+    log.info('Scope guard: no crawl coverage manifest found; outdating falls back to absence-only');
+    return null;
+  } catch (error) {
+    log.warn(`Scope guard: failed to load crawl coverage (${error.message}); outdating falls back to absence-only`);
+    return null;
+  }
+}
 
 export function createOpportunityAndSuggestionsStep({
   auditType,
@@ -70,6 +113,15 @@ export function createOpportunityAndSuggestionsStep({
       return { status: 'complete', reportedBrokenLinks: reportedLinks };
     }
 
+    // Crawl-coverage set for this run (SITES-49911). Non-empty => this was a crawl run
+    // and "absence == fix" is only trustworthy for pages actually in crawl scope.
+    // Null => RUM/LinkChecker-only run => preserve prior absence-only behavior.
+    const crawledUrlFromSet = await buildCrawledUrlFromSet(
+      audit.getId(),
+      { ...context, log },
+      log,
+    );
+
     if (filteredBrokenInternalLinks.length > maxBrokenLinksReported) {
       log.warn(`Capping reported broken links from ${filteredBrokenInternalLinks.length} to ${maxBrokenLinksReported} (priority order)`);
       await updateAuditResult(
@@ -97,21 +149,51 @@ export function createOpportunityAndSuggestionsStep({
       if (!opportunity) {
         log.info('no broken internal links found, skipping opportunity creation');
       } else {
-        log.info('no broken internal links found, updating opportunity to RESOLVED');
-        await opportunity.setStatus(opptyStatuses.RESOLVED);
         const suggestions = await opportunity.getSuggestions();
         // Preserve operator decisions on SKIPPED / REJECTED — flipping those to
         // OUTDATED would destroy the decision and bump updatedAt, corrupting
         // the ASO "Moved to Rejected / Skipped" metrics (SITES-44646).
-        const suggestionsToOutdate = (suggestions || []).filter((s) => ![
+        const nonFrozen = (suggestions || []).filter((s) => ![
           suggestionStatuses.SKIPPED,
           suggestionStatuses.REJECTED,
         ].includes(s.getStatus()));
-        if (isNonEmptyArray(suggestionsToOutdate)) {
-          await Suggestion.bulkUpdateStatus(suggestionsToOutdate, suggestionStatuses.OUTDATED);
+
+        if (crawledUrlFromSet && crawledUrlFromSet.size > 0) {
+          // Crawl run: "zero broken links" is only trustworthy for pages actually
+          // crawled this run. Outdate a suggestion only if its source page was
+          // covered; hold the opportunity open (do NOT resolve) when any suggestion
+          // sits on a page we did not crawl, since those links are unconfirmed rather
+          // than fixed (SITES-49911).
+          const isCovered = (s) => {
+            const from = normalizeComparableUrl(s.getData()?.urlFrom);
+            return Boolean(from) && crawledUrlFromSet.has(from);
+          };
+          const covered = nonFrozen.filter(isCovered);
+          const uncoveredCount = nonFrozen.length - covered.length;
+
+          if (isNonEmptyArray(covered)) {
+            await Suggestion.bulkUpdateStatus(covered, suggestionStatuses.OUTDATED);
+          }
+
+          if (uncoveredCount === 0) {
+            log.info('no broken internal links found and all suggestions were crawled this run, updating opportunity to RESOLVED');
+            await opportunity.setStatus(opptyStatuses.RESOLVED);
+            opportunity.setUpdatedBy('system');
+            await opportunity.save();
+          } else {
+            log.info(`no broken internal links found, but ${uncoveredCount} suggestion(s) sit on pages not crawled this run; holding opportunity open and outdating only the ${covered.length} confirmed`);
+          }
+        } else {
+          // RUM/LinkChecker-only run (no crawl coverage manifest): preserve prior
+          // behavior — resolve the opportunity and outdate all non-frozen suggestions.
+          log.info('no broken internal links found (no crawl coverage), updating opportunity to RESOLVED');
+          await opportunity.setStatus(opptyStatuses.RESOLVED);
+          if (isNonEmptyArray(nonFrozen)) {
+            await Suggestion.bulkUpdateStatus(nonFrozen, suggestionStatuses.OUTDATED);
+          }
+          opportunity.setUpdatedBy('system');
+          await opportunity.save();
         }
-        opportunity.setUpdatedBy('system');
-        await opportunity.save();
       }
       return { status: 'complete', reportedBrokenLinks: reportedLinks };
     }
@@ -137,6 +219,7 @@ export function createOpportunityAndSuggestionsStep({
       context: contextualContext,
       opportunityId: opportunity.getId(),
       log,
+      crawledUrlFromSet,
     });
 
     const handlerEnabled = await dataAccess.Configuration?.findLatest?.()
@@ -240,6 +323,12 @@ export function createOpportunityAndSuggestionsStep({
         }
 
         let urlsSuggested = pickUrlsFromSerpResults(results, brokenLink.urlTo);
+        if (urlsSuggested.length === 0) {
+          return;
+        }
+        // Keep only suggestions within this audit's scope/subpath so a broken /uk/
+        // link is not "fixed" with an out-of-subpath (e.g. /us/) URL (SITES-49911).
+        urlsSuggested = urlsSuggested.filter((u) => isWithinAuditScope(u, site.getBaseURL()));
         if (urlsSuggested.length === 0) {
           return;
         }

--- a/src/internal-links/suggestions-generator.js
+++ b/src/internal-links/suggestions-generator.js
@@ -15,7 +15,8 @@ import { AzureOpenAIClient } from '@adobe/spacecat-shared-gpt-client';
 import { Audit, Suggestion as SuggestionDataAccess } from '@adobe/spacecat-shared-data-access';
 import { getScrapedDataForSiteId, limitConcurrency } from '../support/utils.js';
 import { handleOutdatedSuggestions } from '../utils/data-access.js';
-import { filterByAuditScope, extractPathPrefix } from './subpath-filter.js';
+import { filterByAuditScope, extractPathPrefix, isWithinAuditScope } from './subpath-filter.js';
+import { normalizeComparableUrl } from './link-key.js';
 
 const AUDIT_TYPE = Audit.AUDIT_TYPES.BROKEN_INTERNAL_LINKS;
 
@@ -315,6 +316,16 @@ export const generateSuggestionData = async (finalUrl, brokenInternalLinks, cont
         const cleanLink = { ...updatedLink };
         delete cleanLink.filteredSiteData;
         delete cleanLink.filteredHeaderLinks;
+        // Enforce audit scope/subpath on the final AI suggestions so a broken /uk/
+        // link is not "fixed" with an out-of-subpath URL (SITES-49911). On sites with
+        // no subpath, isWithinAuditScope is a no-op. If nothing survives, fall back to
+        // the in-scope site base URL rather than emitting a cross-subpath link.
+        if (Array.isArray(cleanLink.urlsSuggested) && cleanLink.urlsSuggested.length > 0) {
+          const inScope = cleanLink.urlsSuggested.filter((u) => isWithinAuditScope(u, baseURL));
+          cleanLink.urlsSuggested = inScope.length > 0
+            ? inScope
+            : getDefaultSuggestedUrls(site, {});
+        }
         return cleanLink;
       },
     ),
@@ -327,10 +338,25 @@ export async function syncBrokenInternalLinksSuggestions({
   brokenInternalLinks,
   context,
   opportunityId,
+  crawledUrlFromSet = null,
 }) {
   if (!context) {
     return;
   }
+
+  // Scope-coverage guard (SITES-49911): a broken-link suggestion should only be
+  // marked OUTDATED when its source page (urlFrom) was actually crawled this run.
+  // Absence from newDataKeys after crawling that page means the link was genuinely
+  // fixed/removed; absence when the page was never crawled is a coverage gap, not a
+  // fix. When we have no crawl coverage manifest (e.g. RUM-only runs), fall back to
+  // the previous absence-only behavior so we don't suppress legitimate outdating.
+  const isWithinCoverage = (data) => {
+    if (!crawledUrlFromSet || crawledUrlFromSet.size === 0) {
+      return true;
+    }
+    const from = normalizeComparableUrl(data?.urlFrom);
+    return Boolean(from) && crawledUrlFromSet.has(from);
+  };
 
   // Include itemType in key to distinguish between links and assets pointing to same URL
   const buildKey = (item) => `${item.urlFrom}-${item.urlTo}-${item.itemType || 'link'}`;
@@ -404,6 +430,8 @@ export async function syncBrokenInternalLinksSuggestions({
     // from the OUTDATED sweep. Only FAQ/Summarization/Readability changed in
     // LLMO-6761; internal-links is out of scope (LLMO-6761).
     protectEditedFromOutdated: true,
+    // SITES-49911: only outdate a pair whose crawled source page was covered this run.
+    isWithinCoverage,
   });
 
   // SKIPPED and REJECTED suggestions are operator decisions that must not be

--- a/src/utils/data-access.js
+++ b/src/utils/data-access.js
@@ -242,7 +242,14 @@ export async function getImsOrgId(site, dataAccess, log) {
  * @param {Set} params.newDataKeys - The set of new data keys to check for outdated suggestions.
  * @param {Function} params.buildKey - The function to build a unique key for each suggestion.
  * @param {Object} params.context - The context object containing the data access object.
- * @param {Set} [params.scrapedUrlsSet] - Optional set of URLs that were scraped in this audit
+ * @param {Set} [params.scrapedUrlsSet] - Optional set of URLs that were scraped in this audit.
+ *   Single-URL coverage guard: a suggestion is only eligible for OUTDATED if its data.url is
+ *   present in the set (i.e. the page was actually re-examined this run).
+ * @param {Function} [params.isWithinCoverage] - Optional coverage predicate over a suggestion's
+ *   data object, returning true when the suggestion was actually re-examined this run. Use this
+ *   instead of scrapedUrlsSet when coverage is keyed by something other than a single `url`
+ *   (e.g. broken-internal-links, whose items are urlFrom/urlTo pairs — SITES-49911). Takes
+ *   precedence over scrapedUrlsSet; when neither is provided the guard is a no-op.
  * @param {boolean} [params.outdateInProgress] - Defaults to false, preserving today's
  *   behavior of leaving IN_PROGRESS suggestions alone. Pass true to also outdate them
  *   when no longer detected.
@@ -259,6 +266,7 @@ export const handleOutdatedSuggestions = async ({
   buildKey,
   statusToSetForOutdated = SuggestionDataAccess.STATUSES.OUTDATED,
   scrapedUrlsSet = null,
+  isWithinCoverage = null,
   outdateInProgress = false,
   protectEditedFromOutdated = false,
 }) => {
@@ -303,9 +311,18 @@ export const handleOutdatedSuggestions = async ({
       );
     })
     .filter((existing) => {
-      // mark suggestions as outdated only if their URL was actually scraped
+      // Scope-coverage guard: only outdate a suggestion if it was actually re-examined
+      // this run, so a suggestion missing from newDataKeys purely because its page/link
+      // fell outside this run's coverage is not mistaken for a genuine fix (SITES-49911).
+      const data = existing.getData?.();
+      // Caller-supplied predicate wins — used when coverage is not keyed by a single `url`
+      // (e.g. broken-internal-links pairs, keyed on the crawled source page urlFrom).
+      if (typeof isWithinCoverage === 'function') {
+        return isWithinCoverage(data);
+      }
+      // Legacy single-URL coverage set: mark outdated only if the URL was actually scraped.
       if (scrapedUrlsSet) {
-        const suggestionUrl = existing.getData()?.url;
+        const suggestionUrl = data?.url;
         return suggestionUrl && scrapedUrlsSet.has(suggestionUrl);
       }
       return true;

--- a/test/audits/internal-links/opportunity-suggestions-step.test.js
+++ b/test/audits/internal-links/opportunity-suggestions-step.test.js
@@ -446,6 +446,104 @@ describe('internal-links opportunity suggestions step', () => {
     expect(suggestionMock.save.calledOnce).to.equal(true);
   });
 
+  it('drops out-of-subpath Bright Data suggestions before saving (SITES-49911)', async () => {
+    const findById = sinon.stub();
+    // Broken link lives under /uk; the SERP result is under /us (out of audit scope).
+    const brightDataClient = {
+      googleSearchWithFallback: sinon.stub().resolves({
+        // Same slug as the broken link (scores > 0 so it survives SERP ranking) but a
+        // different locale (/us) that is outside the /uk audit scope.
+        results: [{ link: 'https://example.com/us/blog/seo-guide' }],
+        keywords: 'blog seo',
+      }),
+    };
+
+    const step = createOpportunityAndSuggestionsStep({
+      auditType: 'broken-internal-links',
+      opptyStatuses: { NEW: 'NEW', RESOLVED: 'RESOLVED' },
+      suggestionStatuses: { NEW: 'NEW', OUTDATED: 'OUTDATED' },
+      isNonEmptyArray: (value) => Array.isArray(value) && value.length > 0,
+      createContextLogger: (log) => log,
+      calculateKpiDeltasForAudit: sinon.stub().returns({}),
+      convertToOpportunity: sinon.stub().resolves({ getId: () => 'oppty-1', getType: () => 'broken-internal-links' }),
+      createOpportunityData: sinon.stub(),
+      syncBrokenInternalLinksSuggestions: sinon.stub().resolves(),
+      filterByAuditScope: (pages) => pages,
+      extractPathPrefix: () => null,
+      isUnscrapeable: () => false,
+      filterBrokenSuggestedUrls: sinon.stub().resolves([]),
+      BrightDataClient: { createFrom: sinon.stub().returns(brightDataClient) },
+      buildLocaleSearchUrl: sinon.stub().returns('https://example.com/uk'),
+      sleep: sinon.stub().resolves(),
+      updateAuditResult: sinon.stub().resolves(),
+      isCanonicalOrHreflangLink: () => false,
+    });
+
+    const context = {
+      log: {
+        info: sinon.stub(), warn: sinon.stub(), error: sinon.stub(), debug: sinon.stub(),
+      },
+      site: {
+        getId: () => 'site-1',
+        getBaseURL: () => 'https://example.com/uk',
+        getDeliveryType: () => 'aem_edge',
+        getConfig: () => ({
+          getHandlers: () => ({
+            'broken-internal-links': {
+              config: { mystiqueItemTypes: ['link'], validateBrightDataUrls: true },
+            },
+          }),
+          getIncludedURLs: () => [],
+        }),
+      },
+      finalUrl: 'https://example.com/uk',
+      sqs: { sendMessage: sinon.stub().resolves() },
+      env: { BRIGHT_DATA_API_KEY: 'key', BRIGHT_DATA_ZONE: 'zone' },
+      dataAccess: {
+        Suggestion: {
+          allByOpportunityIdAndStatus: sinon.stub().resolves([{
+            getData: () => ({
+              urlFrom: 'https://example.com/uk/source',
+              urlTo: 'https://example.com/uk/blog/seo-guide',
+              itemType: 'link',
+            }),
+            getId: () => 'suggestion-1',
+          }]),
+          findById,
+        },
+        SiteTopPage: {
+          allBySiteIdAndSourceAndGeo: sinon.stub().resolves([]),
+        },
+        Configuration: {
+          findLatest: sinon.stub().returns({
+            isHandlerEnabledForSite: sinon.stub().returns(true),
+          }),
+        },
+      },
+      audit: {
+        getId: () => 'audit-1',
+        getAuditResult: () => ({
+          brokenInternalLinks: [
+            { urlFrom: 'https://example.com/uk/source', urlTo: 'https://example.com/uk/blog/seo-guide', itemType: 'link' },
+          ],
+          success: true,
+        }),
+      },
+      updatedAuditResult: {
+        brokenInternalLinks: [
+          { urlFrom: 'https://example.com/uk/source', urlTo: 'https://example.com/uk/blog/seo-guide', itemType: 'link' },
+        ],
+        success: true,
+      },
+    };
+
+    const result = await step(context);
+
+    expect(result.status).to.equal('complete');
+    // Out-of-subpath SERP result is dropped before we ever look up the suggestion.
+    expect(findById).to.not.have.been.called;
+  });
+
   it('logs warning and skips when Suggestion.findById returns null after Bright Data resolve', async () => {
     const brightDataClient = {
       googleSearchWithFallback: sinon.stub().resolves({
@@ -735,6 +833,170 @@ describe('internal-links opportunity suggestions step', () => {
 
       expect(opportunity.setStatus).to.have.been.calledWith('RESOLVED');
       expect(bulkUpdateStatus).to.not.have.been.called;
+    });
+
+    // Same RESOLVED flow but with a crawl-coverage manifest present (crawl run).
+    // The manifest is reconstructed by loadScrapeResultPaths from an S3 read, so we
+    // stub s3Client.send to return the URL->key entries for the crawled pages.
+    async function runResolveFlowWithCoverage(existingSuggestions, crawledUrls, s3ClientOverride) {
+      const opportunity = {
+        getId: () => 'oppty-existing',
+        getType: () => 'broken-internal-links',
+        setStatus: sinon.stub().resolves(),
+        getSuggestions: sinon.stub().resolves(existingSuggestions),
+        setUpdatedBy: sinon.stub(),
+        save: sinon.stub().resolves(),
+      };
+      const Opportunity = {
+        allBySiteIdAndStatus: sinon.stub().resolves([opportunity]),
+      };
+      const bulkUpdateStatus = sinon.stub().resolves();
+      const manifestBody = JSON.stringify(crawledUrls.map((u) => [u, 'scrapes/x.json']));
+      const s3Client = s3ClientOverride || {
+        send: sinon.stub().resolves({
+          Body: { transformToString: async () => manifestBody },
+        }),
+      };
+
+      const step = createOpportunityAndSuggestionsStep({
+        auditType: 'broken-internal-links',
+        opptyStatuses: { NEW: 'NEW', RESOLVED: 'RESOLVED' },
+        suggestionStatuses,
+        isNonEmptyArray: (value) => Array.isArray(value) && value.length > 0,
+        createContextLogger: (log) => log,
+        calculateKpiDeltasForAudit: sinon.stub().returns({}),
+        convertToOpportunity: sinon.stub(),
+        createOpportunityData: sinon.stub(),
+        syncBrokenInternalLinksSuggestions: sinon.stub(),
+        filterByAuditScope: (pages) => pages,
+        extractPathPrefix: () => null,
+        isUnscrapeable: () => false,
+        filterBrokenSuggestedUrls: sinon.stub().resolves([]),
+        BrightDataClient: { createFrom: sinon.stub() },
+        buildLocaleSearchUrl: sinon.stub(),
+        sleep: sinon.stub().resolves(),
+        updateAuditResult: sinon.stub().resolves(),
+        isCanonicalOrHreflangLink: () => false,
+      });
+
+      const result = await step({
+        log: {
+          info: sinon.stub(),
+          warn: sinon.stub(),
+          error: sinon.stub(),
+          debug: sinon.stub(),
+        },
+        site: {
+          getId: () => 'site-1',
+          getConfig: () => ({ getHandlers: () => ({}) }),
+        },
+        audit: {
+          getId: () => 'audit-1',
+          getAuditResult: () => ({ success: true, brokenInternalLinks: [] }),
+        },
+        dataAccess: { Opportunity, Suggestion: { bulkUpdateStatus } },
+        env: { S3_SCRAPER_BUCKET_NAME: 'bucket' },
+        s3Client,
+      });
+
+      return { result, opportunity, bulkUpdateStatus };
+    }
+
+    const covSug = (status, urlFrom, id) => ({
+      getStatus: () => status,
+      getData: () => ({ urlFrom }),
+      id,
+    });
+
+    it('coverage-gates the RESOLVED path: outdates only crawled suggestions and holds the opportunity open when some pages were not crawled (SITES-49911)', async () => {
+      const suggestions = [
+        covSug(suggestionStatuses.NEW, 'https://example.com/crawled', 'covered-1'),
+        covSug(suggestionStatuses.NEW, 'https://example.com/not-crawled', 'uncovered-1'),
+      ];
+
+      const { opportunity, bulkUpdateStatus } = await runResolveFlowWithCoverage(
+        suggestions,
+        ['https://example.com/crawled'],
+      );
+
+      // Only the crawled suggestion is outdated.
+      expect(bulkUpdateStatus).to.have.been.calledOnce;
+      const [passed, target] = bulkUpdateStatus.firstCall.args;
+      expect(target).to.equal(suggestionStatuses.OUTDATED);
+      expect(passed.map((s) => s.id)).to.deep.equal(['covered-1']);
+      // An unconfirmed (uncrawled) suggestion remains -> opportunity is NOT resolved.
+      expect(opportunity.setStatus).to.not.have.been.called;
+      expect(opportunity.save).to.not.have.been.called;
+    });
+
+    it('resolves and outdates all suggestions when every page was crawled this run (SITES-49911)', async () => {
+      const suggestions = [
+        covSug(suggestionStatuses.NEW, 'https://example.com/a', 'a'),
+        covSug(suggestionStatuses.NEW, 'https://example.com/b', 'b'),
+      ];
+
+      const { opportunity, bulkUpdateStatus } = await runResolveFlowWithCoverage(
+        suggestions,
+        ['https://example.com/a', 'https://example.com/b'],
+      );
+
+      expect(bulkUpdateStatus).to.have.been.calledOnce;
+      expect(bulkUpdateStatus.firstCall.args[0].map((s) => s.id)).to.have.members(['a', 'b']);
+      expect(bulkUpdateStatus.firstCall.args[1]).to.equal(suggestionStatuses.OUTDATED);
+      expect(opportunity.setStatus).to.have.been.calledWith('RESOLVED');
+      expect(opportunity.save).to.have.been.called;
+    });
+
+    it('treats an empty crawl manifest as no coverage and preserves prior RESOLVED behavior (SITES-49911)', async () => {
+      const suggestions = [
+        covSug(suggestionStatuses.NEW, 'https://example.com/a', 'a'),
+        covSug(suggestionStatuses.SKIPPED, 'https://example.com/b', 'b'),
+      ];
+
+      const { opportunity, bulkUpdateStatus } = await runResolveFlowWithCoverage(
+        suggestions,
+        [],
+      );
+
+      // Empty manifest => no crawl coverage => prior behavior: resolve and outdate
+      // every non-frozen suggestion.
+      expect(bulkUpdateStatus).to.have.been.calledOnce;
+      expect(bulkUpdateStatus.firstCall.args[0].map((s) => s.id)).to.deep.equal(['a']);
+      expect(opportunity.setStatus).to.have.been.calledWith('RESOLVED');
+    });
+
+    it('holds the opportunity open and outdates nothing when no suggestion page was crawled (SITES-49911)', async () => {
+      const suggestions = [
+        covSug(suggestionStatuses.NEW, 'https://example.com/x', 'x'),
+        covSug(suggestionStatuses.NEW, 'https://example.com/y', 'y'),
+      ];
+
+      const { opportunity, bulkUpdateStatus } = await runResolveFlowWithCoverage(
+        suggestions,
+        ['https://example.com/unrelated'],
+      );
+
+      // Crawl run, but none of the suggestions' source pages were covered ->
+      // nothing is outdated and the opportunity is NOT resolved.
+      expect(bulkUpdateStatus).to.not.have.been.called;
+      expect(opportunity.setStatus).to.not.have.been.called;
+      expect(opportunity.save).to.not.have.been.called;
+    });
+
+    it('falls back to prior RESOLVED behavior when the crawl manifest read throws (SITES-49911)', async () => {
+      const suggestions = [covSug(suggestionStatuses.NEW, 'https://example.com/a', 'a')];
+      const throwingS3 = { send: sinon.stub().rejects(new Error('s3 down')) };
+
+      const { opportunity, bulkUpdateStatus } = await runResolveFlowWithCoverage(
+        suggestions,
+        [],
+        throwingS3,
+      );
+
+      // Manifest read error => treat as no coverage => prior resolve + outdate-all.
+      expect(opportunity.setStatus).to.have.been.calledWith('RESOLVED');
+      expect(bulkUpdateStatus).to.have.been.calledOnce;
+      expect(bulkUpdateStatus.firstCall.args[0].map((s) => s.id)).to.deep.equal(['a']);
     });
   });
 });

--- a/test/audits/internal-links/suggestions-generator.test.js
+++ b/test/audits/internal-links/suggestions-generator.test.js
@@ -1761,6 +1761,91 @@ describe('syncBrokenInternalLinksSuggestions', () => {
     );
   });
 
+  it('does NOT outdate a missing suggestion whose source page was not crawled this run (SITES-49911)', async () => {
+    // Coverage gap: urlFrom was not in the crawl set, so absence from newDataKeys is
+    // not evidence the link was fixed — the page simply was not re-examined this run.
+    const missingSuggestion = {
+      getData: testSandbox.stub().returns({
+        urlFrom: 'https://example.com/uncrawled-from',
+        urlTo: 'https://example.com/old-to',
+      }),
+      getStatus: testSandbox.stub().returns(SuggestionDataAccess.STATUSES.NEW),
+    };
+    testOpportunity.getSuggestions.resolves([missingSuggestion]);
+
+    await syncBrokenInternalLinksSuggestions({
+      opportunity: testOpportunity,
+      brokenInternalLinks: [{
+        urlFrom: 'https://example.com/new-from',
+        urlTo: 'https://example.com/new-to',
+      }],
+      context: testContext,
+      opportunityId: 'oppty-id-1',
+      crawledUrlFromSet: new Set(['https://example.com/new-from']),
+    });
+
+    expect(testContext.dataAccess.Suggestion.bulkUpdateStatus).to.not.have.been.called;
+  });
+
+  it('outdates a missing suggestion whose source page WAS crawled this run (SITES-49911)', async () => {
+    // Page was re-crawled and the broken link is gone from the new set -> genuine fix.
+    const missingSuggestion = {
+      getData: testSandbox.stub().returns({
+        urlFrom: 'https://example.com/crawled-from',
+        urlTo: 'https://example.com/old-to',
+      }),
+      getStatus: testSandbox.stub().returns(SuggestionDataAccess.STATUSES.NEW),
+    };
+    testOpportunity.getSuggestions.resolves([missingSuggestion]);
+
+    await syncBrokenInternalLinksSuggestions({
+      opportunity: testOpportunity,
+      brokenInternalLinks: [{
+        urlFrom: 'https://example.com/new-from',
+        urlTo: 'https://example.com/new-to',
+      }],
+      context: testContext,
+      opportunityId: 'oppty-id-1',
+      crawledUrlFromSet: new Set([
+        'https://example.com/crawled-from',
+        'https://example.com/new-from',
+      ]),
+    });
+
+    expect(testContext.dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledOnceWith(
+      [missingSuggestion],
+      SuggestionDataAccess.STATUSES.OUTDATED,
+    );
+  });
+
+  it('falls back to absence-only outdating when no crawl coverage set is provided (SITES-49911)', async () => {
+    // RUM-only runs pass no crawledUrlFromSet; prior behavior (outdate on absence) holds.
+    const missingSuggestion = {
+      getData: testSandbox.stub().returns({
+        urlFrom: 'https://example.com/old-from',
+        urlTo: 'https://example.com/old-to',
+      }),
+      getStatus: testSandbox.stub().returns(SuggestionDataAccess.STATUSES.NEW),
+    };
+    testOpportunity.getSuggestions.resolves([missingSuggestion]);
+
+    await syncBrokenInternalLinksSuggestions({
+      opportunity: testOpportunity,
+      brokenInternalLinks: [{
+        urlFrom: 'https://example.com/new-from',
+        urlTo: 'https://example.com/new-to',
+      }],
+      context: testContext,
+      opportunityId: 'oppty-id-1',
+      crawledUrlFromSet: new Set(),
+    });
+
+    expect(testContext.dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledOnceWith(
+      [missingSuggestion],
+      SuggestionDataAccess.STATUSES.OUTDATED,
+    );
+  });
+
   it('protects edited missing suggestions from OUTDATED on rerun (LLMO-6761)', async () => {
     // internal-links passes protectEditedFromOutdated:true, so a customer-edited
     // suggestion whose key is absent from the new set stays put rather than being


### PR DESCRIPTION
## Related Issues

Fixes SITES-49911 (child of SITES-49909 — the "verify-before-resolve, scope-guarded" thread).

## Problem

Broken-internal-links marked suggestions `OUTDATED` whenever a link pair was absent from the newest crawl, **without confirming the source page was actually re-examined this run**. A page that simply fell outside the run's crawl scope (or a run that scraped nothing) was therefore mistaken for a genuine fix — the "absence ≠ resolution" bug the ESE suggestion-status review flagged.

## Changes

- **Generalized coverage guard** — `handleOutdatedSuggestions` gains an optional `isWithinCoverage(data)` predicate that subsumes the single-URL `scrapedUrlsSet`. No-op when neither is supplied, so all existing callers are unchanged.
- **BIL sync path** — a broken-link pair is only eligible for `OUTDATED` when its source page (`urlFrom`) was actually crawled this run. The crawl-coverage set is reconstructed from the `scrape-result-paths` manifest (`loadScrapeResultPaths`). A non-empty manifest ⟺ a crawl run; RUM/LinkChecker-only runs (no manifest) keep prior absence-only behavior.
- **RESOLVED path (zero broken links) coverage-gated** — on a crawl run, outdate only crawled suggestions and flip the opportunity to `RESOLVED` **only when every non-frozen suggestion was crawled**; otherwise hold it open (unconfirmed links aren't treated as fixed). RUM-only runs retain prior resolve+outdate-all behavior. SKIPPED/REJECTED still protected (SITES-44646).
- **Suggestion-side subpath enforcement** — final `urlsSuggested` are hard-filtered through `isWithinAuditScope` in both the AI and Bright Data paths, so a broken `/uk/` link is never "fixed" with an out-of-subpath (`/us/`) URL. No-op on non-subpath sites.

Coverage is gated on `urlFrom` (the crawled source page) — the only signal reconstructable, and the correct granularity for a crawl (checked pairs aren't persisted; only broken pairs + crawled pages are).

## Testing

- +9 focused unit tests (sync guard, coverage-gated RESOLVED incl. partial/empty/throwing-manifest cases, subpath drop in the Bright Data path).
- New lines/branches fully covered; existing behavior preserved (RUM-only runs, edited/frozen suggestions).
- `npm test` green for the changed modules; full internal-links suite +9 passing, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```