### PR TITLE
fix(toc): exclude accessibility skip-navigation lists from hasTocInDom

### DIFF
--- a/src/toc/handler.js
+++ b/src/toc/handler.js
@@ -110,6 +110,40 @@ export const TOPPAGES_CHECK = {
   explanation: 'No URLs found for audit',
 };
 
+// Accessibility "skip navigation" links (e.g. <a href="#main">Skip to main content</a>) are
+// a near-universal WCAG pattern, almost always shipped as a 2+ item list in shared header
+// markup — which satisfies Signal 1 below on every single page of a site, without being a
+// TOC. Confirmed live on canadiantire.ca: `<ul class="nl-accessibility-links">` linking to
+// `#main`/`#secondary-navigation` with text "Skip to main content" / "Skip to navigation"
+// caused hasTocInDom to report true on 100% of 191 sampled pages, masking genuine TOC gaps
+// site-wide. Matched by anchor TEXT rather than by class/id, since the class naming
+// ("nl-accessibility-links" here) is site/design-system-specific and won't generalize, while
+// the "Skip to ..." / "Skip ..." / "Jump to ..." phrasing is standard a11y copy independent
+// of markup conventions.
+//
+// French equivalent included because canadiantire.ca itself is bilingual and re-triggers the
+// exact same false positive on its /fr/ pages via the localized skip-nav copy ("passer au
+// contenu principal" / "passer à la navigation") — confirmed live, same nl-accessibility-links
+// list, just localized text. Other locales are not yet covered; extend this pattern (or move
+// to a per-locale phrase list) if another site surfaces the same gap in a different language.
+const SKIP_NAV_TEXT_RE = /^(skip\s+(to\s+)?(the\s+)?(main\s+)?(content|navigation|nav|footer|search|links?)\b|jump\s+to\s+(the\s+)?(main\s+)?content\b|(passer|aller|sauter)\s+(au|à\s+la|directement\s+au)\s+(contenu(\s+principal)?|navigation)\b)/i;
+
+/**
+ * True when every internal anchor link in the list reads as an accessibility skip-navigation
+ * link (see SKIP_NAV_TEXT_RE above), i.e. the list is skip-nav boilerplate, not a TOC.
+ * A list containing links that are NOT all skip-nav text is left for the normal Signal 1
+ * count check (e.g. a real TOC could coincidentally sit next to a lone skip-nav link outside
+ * this list; this only excludes lists that are entirely skip-nav).
+ * @param {CheerioAPI} $ - The Cheerio instance
+ * @param {Object[]} internalLinks - Array of internal anchor <a> elements from one list
+ * @returns {boolean}
+ */
+function isSkipNavigationList($, internalLinks) {
+  return internalLinks.length > 0 && internalLinks.every(
+    (a) => SKIP_NAV_TEXT_RE.test($(a).text().trim()),
+  );
+}
+
 /**
  * Detect TOC presence in DOM using heuristic signals, without AI.
  * Checks for:
@@ -122,9 +156,12 @@ export function hasTocInDom($) {
   // Signal 1: list (ul/ol) with 2+ internal anchor links (href="#section-id").
   // Exclude bare href="#" (JavaScript tab/nav placeholders) — only count links
   // with a non-empty fragment so search menus and tab widgets don't false-positive.
+  // Also exclude lists that are entirely accessibility skip-navigation links (see
+  // isSkipNavigationList above) — those are boilerplate, not a TOC.
   let anchorListFound = false;
   $('ul, ol').each((_, listEl) => {
-    if ($(listEl).find('a[href^="#"]:not([href="#"])').length >= 2) {
+    const internalLinks = $(listEl).find('a[href^="#"]:not([href="#"])').toArray();
+    if (internalLinks.length >= 2 && !isSkipNavigationList($, internalLinks)) {
       anchorListFound = true;
       return false; // break the each loop
     }

--- a/test/audits/toc.test.js
+++ b/test/audits/toc.test.js
@@ -3176,6 +3176,57 @@ describe('TOC (Table of Contents) Audit', () => {
         expect(hasTocInDom($)).to.equal(false);
       });
 
+      it('returns false for a skip-navigation accessibility link list (canadiantire.ca-style)', () => {
+        const $ = cheerioLoad(
+          '<ul class="nl-accessibility-links">'
+          + '<li><a href="#main">Skip to main content</a></li>'
+          + '<li><a href="#secondary-navigation">Skip to navigation</a></li>'
+          + '</ul>',
+        );
+        expect(hasTocInDom($)).to.equal(false);
+      });
+
+      it('returns false for a skip-navigation list regardless of surrounding whitespace in link text', () => {
+        const $ = cheerioLoad(
+          '<ul>'
+          + '<li><a href="#content">\n                Skip to main content            \n</a></li>'
+          + '<li><a href="#nav">\n                        Skip to navigation            \n</a></li>'
+          + '</ul>',
+        );
+        expect(hasTocInDom($)).to.equal(false);
+      });
+
+      it('returns false for a "Skip navigation" / "Jump to main content" style skip-nav list', () => {
+        const $ = cheerioLoad(
+          '<ol>'
+          + '<li><a href="#footer">Skip navigation</a></li>'
+          + '<li><a href="#body">Jump to main content</a></li>'
+          + '</ol>',
+        );
+        expect(hasTocInDom($)).to.equal(false);
+      });
+
+      it('returns false for the French-language canadiantire.ca/fr skip-navigation list', () => {
+        const $ = cheerioLoad(
+          '<ul class="nl-accessibility-links">'
+          + '<li><a href="#main">passer au contenu principal</a></li>'
+          + '<li><a href="#secondary-navigation">passer à la navigation</a></li>'
+          + '</ul>',
+        );
+        expect(hasTocInDom($)).to.equal(false);
+      });
+
+      it('returns true when a list mixes a skip-nav link with genuine TOC section links', () => {
+        const $ = cheerioLoad(
+          '<ul>'
+          + '<li><a href="#main">Skip to main content</a></li>'
+          + '<li><a href="#s1">Section 1</a></li>'
+          + '<li><a href="#s2">Section 2</a></li>'
+          + '</ul>',
+        );
+        expect(hasTocInDom($)).to.equal(true);
+      });
+
       it('returns false when nav menu has links without # anchors', () => {
         const $ = cheerioLoad(
           '<nav><ul>'


### PR DESCRIPTION
## Problem

`hasTocInDom`'s Signal 1 ("a list with 2+ internal anchor links") false-positives on accessibility "skip to content" link lists, which are near-universal WCAG boilerplate in a site's shared header markup:

```html
<ul class="nl-accessibility-links">
  <a href="#main">Skip to main content</a>
  <a href="#secondary-navigation">Skip to navigation</a>
</ul>
```

**Confirmed live on canadiantire.ca**: this exact pattern caused the DOM heuristic to report "TOC present" on **100% of 191 sampled pages** (verified by re-running the audit's own detection logic locally against real scrape data pulled from S3), independently masking genuine TOC gaps site-wide — the audit would never have surfaced a single TOC opportunity for this site even with a healthy scrape pipeline.

The first pass of this fix (English-only) still missed the site's `/fr/` pages, which carry the identical list with localized text ("passer au contenu principal" / "passer à la navigation") — added French phrasing too since the site itself is bilingual.

## Fix

Exclude a list from Signal 1 when **every** internal anchor link in it reads as a skip-navigation link (matched by anchor **text**, not class/id — skip-nav class naming is site/design-system-specific and won't generalize, while "Skip to ..."/"Jump to ..." phrasing is standard a11y copy). A list containing a mix of skip-nav and real section links is still correctly detected as a TOC (covered by a dedicated test).

## Testing

- 5 new `hasTocInDom` unit tests: the reported false positive, a whitespace variant, alternate English phrasing ("Skip navigation" / "Jump to main content"), the French case, and the mixed-list case.
- Full existing `test/audits/toc.test.js` suite passes (204/204 on this branch).
- `eslint` clean.
- Locally re-ran the audit's real detection logic (this fixed `hasTocInDom`, plus the existing heading-extraction/placement utilities) against 191 real `scrape.json` files pulled from `s3://spacecat-prod-scraper` for canadiantire.ca's most recent TOC audit job. Before this fix: 191/191 pages falsely reported "TOC present." After: 1 genuine TOC found (a real `id="toc"` anchor), 186 pages correctly flagged missing, 4 skipped for too few headings.

## Not in scope for this PR

- Only English and French skip-nav phrasing are covered (proven necessary on this bilingual site); other locales aren't handled yet — flagged in a code comment for whoever hits it next.
- A separate, unrelated issue also found during this investigation — intermittent `ECONNRESET`/socket hang-up errors reading scrape.json from S3 (`spacecat-prod-scraper`), seen at scale (~4,600 occurrences/24h across many audits) — is not addressed here and is being raised separately with the platform team.