### PR TITLE
fix(preflight): surface a scrape-failure signal instead of a silent false-clean pass

### DIFF
--- a/src/common/async-job-runner.js
+++ b/src/common/async-job-runner.js
@@ -69,7 +69,7 @@ export class AsyncJobRunner extends StepAudit {
     const { stepNames } = this;
     const { log } = context;
     const {
-      type, jobId, auditContext = {},
+      type, jobId, auditContext = {}, scrapeResults,
     } = message;
     try {
       const job = await this.jobProvider(auditContext.jobId || jobId, context);
@@ -94,7 +94,7 @@ export class AsyncJobRunner extends StepAudit {
       const step = this.getStep(stepName);
 
       const updatedStepContext = {
-        ...context, site, job, type, auditContext,
+        ...context, site, job, type, auditContext, scrapeResults,
       };
 
       updatedStepContext.finalUrl = await this.urlResolver(site, context);

--- a/src/preflight/accessibility.js
+++ b/src/preflight/accessibility.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-import { isNonEmptyArray } from '@adobe/spacecat-shared-utils';
+import { isNonEmptyArray, stripTrailingSlash } from '@adobe/spacecat-shared-utils';
 import { DeleteObjectsCommand } from '@aws-sdk/client-s3';
 
 import { saveIntermediateResults, formatStructuredAuditLog } from './utils.js';
@@ -18,6 +18,7 @@ import { sleep } from '../support/utils.js';
 import { accessibilityOpportunitiesMap } from '../accessibility/utils/constants.js';
 import { getObjectFromKey, getObjectKeysUsingPrefix } from '../utils/s3-utils.js';
 import { formatWcagRule } from '../accessibility/utils/generate-individual-opportunities.js';
+import { PreflightError } from './error-constants.js';
 
 export const PREFLIGHT_ACCESSIBILITY = 'accessibility';
 
@@ -74,6 +75,7 @@ export async function scrapeAccessibilityData(context, auditContext) {
     previewUrls,
     step,
     audits,
+    failedScrapes = new Map(),
   } = auditContext;
 
   const siteId = site.getId();
@@ -93,18 +95,29 @@ export async function scrapeAccessibilityData(context, auditContext) {
 
   log.debug(`[preflight-audit] site: ${site.getId()}, job: ${jobId}, step: ${step}. Step 1: Preparing accessibility scrape`);
 
-  // Create accessibility audit entries for all pages
+  // Create accessibility audit entries for all pages. Pages whose main page scrape already
+  // failed outright (403/DNS/timeout) get a status: 'error' entry now and are excluded below from
+  // both the accessibility scrape request and the poll - their result file will never appear.
   previewUrls.forEach((url) => {
     const pageResult = audits.get(url);
     if (pageResult) {
-      pageResult.audits.push({ name: PREFLIGHT_ACCESSIBILITY, type: 'a11y', opportunities: [] });
+      const scrapeError = failedScrapes.get(stripTrailingSlash(url));
+      pageResult.audits.push({
+        name: PREFLIGHT_ACCESSIBILITY,
+        type: 'a11y',
+        opportunities: [],
+        ...(scrapeError ? { status: 'error', error: scrapeError } : {}),
+      });
     } else {
       log.warn(`[preflight-audit] No audit entry found for URL: ${url}`);
     }
   });
 
-  // Use the URLs from the preflight job request directly
-  const urlsToScrape = previewUrls.map((url) => ({ url }));
+  // Use the URLs from the preflight job request directly, excluding ones already known to have
+  // failed their main scrape - no point sending them on for accessibility processing too.
+  const urlsToScrape = previewUrls
+    .filter((url) => !failedScrapes.has(stripTrailingSlash(url)))
+    .map((url) => ({ url }));
   log.debug(`[preflight-audit] Using preview URLs for accessibility audit: ${JSON.stringify(urlsToScrape, null, 2)}`);
 
   // Force re-scrape all URLs regardless of existing data
@@ -182,6 +195,7 @@ export async function processAccessibilityOpportunities(context, auditContext) {
     step,
     audits,
     auditsResult,
+    failedScrapes = new Map(),
     timeExecutionBreakdown,
   } = auditContext;
 
@@ -204,7 +218,11 @@ export async function processAccessibilityOpportunities(context, auditContext) {
   let pagesWithData = 0;
   let pageErrors = 0;
 
-  for (const url of previewUrls) {
+  // Pages whose main scrape already failed were marked status: 'error' and never sent on for
+  // accessibility scraping (scrapeAccessibilityData) - there's no result file to look up for them.
+  const scannedUrls = previewUrls.filter((url) => !failedScrapes.has(stripTrailingSlash(url)));
+
+  for (const url of scannedUrls) {
     try {
       // Generate the expected filename for this URL
       const filename = generateAccessibilityFilename(url);
@@ -218,7 +236,19 @@ export async function processAccessibilityOpportunities(context, auditContext) {
 
       if (!accessibilityData) {
         log.warn(`[preflight-audit] No accessibility data found for ${url} at key: ${fileKey}`);
-        // Skip to next URL if no data found
+        // No result file ever showed up (scrape timeout) - surface that instead of leaving a
+        // silent "clean" result.
+        const pageResult = audits.get(url);
+        const accessibilityAudit = pageResult.audits.find(
+          (a) => a.name === PREFLIGHT_ACCESSIBILITY,
+        );
+        if (accessibilityAudit) {
+          accessibilityAudit.status = 'error';
+          accessibilityAudit.error = {
+            code: PreflightError.SCRAPE_TIMEOUT.code,
+            message: PreflightError.SCRAPE_TIMEOUT.message,
+          };
+        }
       } else {
         pagesWithData += 1;
         log.debug(`[preflight-audit] Successfully loaded accessibility data for ${url}`);
@@ -363,7 +393,7 @@ export async function processAccessibilityOpportunities(context, auditContext) {
  * Accessibility preflight handler
  */
 export default async function accessibility(context, auditContext) {
-  const { previewUrls, timeExecutionBreakdown } = auditContext;
+  const { previewUrls, timeExecutionBreakdown, failedScrapes = new Map() } = auditContext;
   const { log, site, job } = context;
 
   // Check if we have URLs to process
@@ -395,8 +425,12 @@ export default async function accessibility(context, auditContext) {
   // 1 second poll interval
   const pollInterval = 1 * 1000;
 
-  // Generate expected filenames based on preview URLs
-  const expectedFiles = previewUrls.map((url) => generateAccessibilityFilename(url));
+  // Generate expected filenames based on preview URLs, excluding ones already known to have
+  // failed their main scrape - no accessibility result file will ever be produced for those, so
+  // waiting on them would just burn the full maxWaitTime for nothing.
+  const expectedFiles = previewUrls
+    .filter((url) => !failedScrapes.has(stripTrailingSlash(url)))
+    .map((url) => generateAccessibilityFilename(url));
 
   log.debug(`[preflight-audit] Expected files: ${JSON.stringify(expectedFiles)}`);
 

--- a/src/preflight/canonical.js
+++ b/src/preflight/canonical.js
@@ -116,6 +116,7 @@ export default async function canonical(context, auditContext) {
     auditsResult,
     previewBaseURL,
     scrapedObjects,
+    failedScrapes = new Map(),
     timeExecutionBreakdown,
   } = auditContext;
 
@@ -126,10 +127,12 @@ export default async function canonical(context, auditContext) {
 
   try {
     previewUrls.forEach((url) => {
+      const scrapeError = failedScrapes.get(stripTrailingSlash(url));
       audits.get(url).audits.push({
         name: PREFLIGHT_CANONICAL,
         type: 'seo',
         opportunities: [],
+        ...(scrapeError ? { status: 'error', error: scrapeError } : {}),
       });
     });
 

--- a/src/preflight/error-constants.js
+++ b/src/preflight/error-constants.js
@@ -18,6 +18,10 @@ export const PreflightErrorClassification = Object.freeze({
   // Site/org configuration prevents the audit from running (e.g. handler disabled,
   // missing entitlement). Not transient - retrying the job won't help.
   CONFIG_ERROR: 'CONFIG_ERROR',
+
+  // The content-scraper could not fetch the page (403, DNS, timeout, etc.). Transient -
+  // re-running the audit may succeed once the underlying access/availability issue clears.
+  SCRAPE_ERROR: 'SCRAPE_ERROR',
 });
 
 /**
@@ -34,5 +38,23 @@ export const PreflightError = Object.freeze({
     message: 'The Preflight audit is not enabled for this site.',
     description: 'The preflight handler is disabled in the site configuration.',
     classification: PreflightErrorClassification.CONFIG_ERROR,
+  }),
+  SCRAPE_FORBIDDEN: Object.freeze({
+    code: 'PREFLIGHT-101',
+    message: 'This page could not be accessed. Confirm you have permission to view it.',
+    description: 'The content-scraper received an HTTP 401/403 response for the page.',
+    classification: PreflightErrorClassification.SCRAPE_ERROR,
+  }),
+  SCRAPE_TIMEOUT: Object.freeze({
+    code: 'PREFLIGHT-102',
+    message: 'This page took too long to load and could not be checked.',
+    description: 'The content-scraper timed out navigating to or rendering the page.',
+    classification: PreflightErrorClassification.SCRAPE_ERROR,
+  }),
+  SCRAPE_FAILED: Object.freeze({
+    code: 'PREFLIGHT-103',
+    message: 'This page could not be checked.',
+    description: 'The content-scraper failed to fetch the page for a reason other than an access denial or timeout (e.g. DNS failure).',
+    classification: PreflightErrorClassification.SCRAPE_ERROR,
   }),
 });

--- a/src/preflight/form-accessibility.js
+++ b/src/preflight/form-accessibility.js
@@ -11,7 +11,7 @@
  */
 
 import { createHash } from 'crypto';
-import { isNonEmptyArray } from '@adobe/spacecat-shared-utils';
+import { isNonEmptyArray, stripTrailingSlash } from '@adobe/spacecat-shared-utils';
 import { load as cheerioLoad } from 'cheerio';
 
 import { saveIntermediateResults, formatStructuredAuditLog } from './utils.js';
@@ -19,6 +19,7 @@ import { sleep } from '../support/utils.js';
 import { getObjectFromKey, getObjectMetadataUsingPrefix } from '../utils/s3-utils.js';
 import { generateAccessibilityFilename } from './accessibility.js';
 import { getDomElementSelector } from './utils/dom-selector.js';
+import { PreflightError } from './error-constants.js';
 
 export const PREFLIGHT_FORM_ACCESSIBILITY = 'form-accessibility';
 
@@ -130,6 +131,7 @@ export async function detectFormAccessibility(context, auditContext) {
     previewUrls,
     step,
     audits,
+    failedScrapes = new Map(),
   } = auditContext;
 
   const siteId = site.getId();
@@ -149,11 +151,20 @@ export async function detectFormAccessibility(context, auditContext) {
 
   log.debug(`[preflight-audit] ${siteId}, job: ${jobId}, step: ${step}. Step 1: Preparing form accessibility scrape`);
 
-  // Create form accessibility audit entries for all pages
+  // Create form accessibility audit entries for all pages. Pages whose main page scrape already
+  // failed outright (403/DNS/timeout) get a status: 'error' entry now and are excluded below from
+  // form detection - there's no scraped HTML to find <form> elements in, and nothing useful to
+  // send to Mystique.
   previewUrls.forEach((url) => {
     const pageResult = audits.get(url);
     if (pageResult) {
-      pageResult.audits.push({ name: PREFLIGHT_FORM_ACCESSIBILITY, type: 'form-a11y', opportunities: [] });
+      const scrapeError = failedScrapes.get(stripTrailingSlash(url));
+      pageResult.audits.push({
+        name: PREFLIGHT_FORM_ACCESSIBILITY,
+        type: 'form-a11y',
+        opportunities: [],
+        ...(scrapeError ? { status: 'error', error: scrapeError } : {}),
+      });
     } else {
       log.warn(`[preflight-audit] ${siteId}, No audit entry found for URL: ${url}`);
     }
@@ -164,7 +175,9 @@ export async function detectFormAccessibility(context, auditContext) {
   // just the first <form> in DOM order (e.g. a header search widget ahead of
   // the actual content form) — see SITES-48703.
   const entriesPerPage = await Promise.all(
-    previewUrls.map((url) => findFormsOnPage(url, s3Client, bucketName, siteId, log)),
+    previewUrls
+      .filter((url) => !failedScrapes.has(stripTrailingSlash(url)))
+      .map((url) => findFormsOnPage(url, s3Client, bucketName, siteId, log)),
   );
   const urlsToDetect = entriesPerPage.flat();
 
@@ -242,6 +255,7 @@ export async function processFormAccessibilityOpportunities(
     step,
     audits,
     auditsResult,
+    failedScrapes = new Map(),
     timeExecutionBreakdown,
   } = auditContext;
 
@@ -261,8 +275,12 @@ export async function processFormAccessibilityOpportunities(
   // Falls back to one generic entry per URL when the caller didn't pass the
   // detected entries (e.g. this function called standalone) — preserves the
   // original one-file-per-URL behavior in that case.
-  const resolvedFormEntries = formEntries
-    || previewUrls.map((url) => ({ form: url, formSource: 'form' }));
+  // Pages whose main scrape already failed were marked status: 'error' and never looked at for
+  // forms (detectFormAccessibility) - exclude them here too, including in the standalone-call
+  // fallback below, so there's no result file lookup attempted for them.
+  const resolvedFormEntries = (formEntries
+    || previewUrls.map((url) => ({ form: url, formSource: 'form' })))
+    .filter(({ form: url }) => !failedScrapes.has(stripTrailingSlash(url)));
 
   try {
     // When invoked from the main runner we get the freshness threshold the poll used.
@@ -317,7 +335,19 @@ export async function processFormAccessibilityOpportunities(
 
         if (!accessibilityData) {
           log.warn(`[preflight-audit] ${siteId} No form accessibility data found for ${url} at key: ${fileKey}`);
-          // Skip to next URL if no data found
+          // No result file ever showed up (Mystique round-trip timeout) - surface that instead of
+          // leaving a silent "clean" result.
+          const pageResult = audits.get(url);
+          const accessibilityAudit = pageResult.audits.find(
+            (a) => a.name === PREFLIGHT_FORM_ACCESSIBILITY,
+          );
+          if (accessibilityAudit) {
+            accessibilityAudit.status = 'error';
+            accessibilityAudit.error = {
+              code: PreflightError.SCRAPE_TIMEOUT.code,
+              message: PreflightError.SCRAPE_TIMEOUT.message,
+            };
+          }
         } else {
           formsWithData += 1;
           log.info(`[preflight-audit] ${siteId} Successfully loaded form accessibility data for ${url}`);

--- a/src/preflight/handler.js
+++ b/src/preflight/handler.js
@@ -19,6 +19,7 @@ import { isAuditEnabledForSite, noopPersister, noopUrlResolver } from '../common
 import { getObjectKeysUsingPrefix, getObjectFromKey } from '../utils/s3-utils.js';
 import {
   getPrefixedPageAuthToken, isValidUrls, saveIntermediateResults, formatStructuredAuditLog,
+  buildFailedScrapesMap,
 } from './utils.js';
 import { getDomElementSelector, toElementTargets } from './utils/dom-selector.js';
 import { PreflightError } from './error-constants.js';
@@ -120,7 +121,7 @@ export const preflightAudit = async (context) => {
   const startTimestamp = new Date().toISOString();
 
   const {
-    site, job, s3Client, log, dataAccess,
+    site, job, s3Client, log, dataAccess, scrapeResults,
   } = context;
   const { AsyncJob: AsyncJobEntity } = dataAccess;
   const { S3_SCRAPER_BUCKET_NAME } = context.env;
@@ -251,6 +252,10 @@ export const preflightAudit = async (context) => {
         })),
     );
 
+    // URLs whose scrape failed outright (403/DNS/timeout) - no scrape record will ever show up
+    // for these in scrapedObjects, so checks must not fall through to a silent "clean" default.
+    const failedScrapes = buildFailedScrapesMap(scrapeResults, log);
+
     // Initialize results
     const auditsResult = previewUrls.map((url) => ({
       pageUrl: url,
@@ -272,14 +277,22 @@ export const preflightAudit = async (context) => {
       try {
         previewUrls.forEach((url) => {
           const pageResult = audits.get(url);
+          const scrapeError = failedScrapes.get(stripTrailingSlash(url));
+          const errorFields = scrapeError ? { status: 'error', error: scrapeError } : {};
           if (bodySizeEnabled) {
-            pageResult.audits.push({ name: AUDIT_BODY_SIZE, type: 'seo', opportunities: [] });
+            pageResult.audits.push({
+              name: AUDIT_BODY_SIZE, type: 'seo', opportunities: [], ...errorFields,
+            });
           }
           if (loremIpsumEnabled) {
-            pageResult.audits.push({ name: AUDIT_LOREM_IPSUM, type: 'seo', opportunities: [] });
+            pageResult.audits.push({
+              name: AUDIT_LOREM_IPSUM, type: 'seo', opportunities: [], ...errorFields,
+            });
           }
           if (h1CountEnabled) {
-            pageResult.audits.push({ name: AUDIT_H1_COUNT, type: 'seo', opportunities: [] });
+            pageResult.audits.push({
+              name: AUDIT_H1_COUNT, type: 'seo', opportunities: [], ...errorFields,
+            });
           }
         });
 
@@ -429,6 +442,7 @@ export const preflightAudit = async (context) => {
           auditsResult,
           s3Keys,
           scrapedObjects,
+          failedScrapes,
           pageAuthToken,
           urls,
           timeExecutionBreakdown,

--- a/src/preflight/headings.js
+++ b/src/preflight/headings.js
@@ -190,6 +190,7 @@ export default async function headings(context, auditContext) {
     audits,
     auditsResult,
     scrapedObjects,
+    failedScrapes = new Map(),
     timeExecutionBreakdown,
   } = auditContext;
 
@@ -201,7 +202,13 @@ export default async function headings(context, auditContext) {
   // Create headings audit entries for all pages
   previewUrls.forEach((url) => {
     const pageResult = audits.get(url);
-    pageResult.audits.push({ name: PREFLIGHT_HEADINGS, type: 'seo', opportunities: [] });
+    const scrapeError = failedScrapes.get(stripTrailingSlash(url));
+    pageResult.audits.push({
+      name: PREFLIGHT_HEADINGS,
+      type: 'seo',
+      opportunities: [],
+      ...(scrapeError ? { status: 'error', error: scrapeError } : {}),
+    });
   });
 
   log.debug(`[preflight-audit] site: ${site.getId()}, job: ${job.getId()}, step: ${step}. Starting headings audit`);

--- a/src/preflight/links.js
+++ b/src/preflight/links.js
@@ -66,6 +66,7 @@ export default async function links(context, auditContext) {
     audits,
     auditsResult,
     scrapedObjects,
+    failedScrapes = new Map(),
     urls,
     pageAuthToken,
     timeExecutionBreakdown,
@@ -74,7 +75,13 @@ export default async function links(context, auditContext) {
   // Create links audit entries for all pages
   previewUrls.forEach((url) => {
     const pageResult = audits.get(url);
-    pageResult.audits.push({ name: PREFLIGHT_LINKS, type: 'seo', opportunities: [] });
+    const scrapeError = failedScrapes.get(stripTrailingSlash(url));
+    pageResult.audits.push({
+      name: PREFLIGHT_LINKS,
+      type: 'seo',
+      opportunities: [],
+      ...(scrapeError ? { status: 'error', error: scrapeError } : {}),
+    });
   });
 
   // Pre-index PREFLIGHT_LINKS audits for O(1) lookups

--- a/src/preflight/metatags.js
+++ b/src/preflight/metatags.js
@@ -59,6 +59,7 @@ export default async function metatags(context, auditContext) {
     audits,
     auditsResult,
     scrapedObjects,
+    failedScrapes = new Map(),
     timeExecutionBreakdown,
   } = auditContext;
 
@@ -69,7 +70,13 @@ export default async function metatags(context, auditContext) {
   // Create metatags audit entries for all pages
   previewUrls.forEach((url) => {
     const pageResult = audits.get(url);
-    pageResult.audits.push({ name: PREFLIGHT_METATAGS, type: 'seo', opportunities: [] });
+    const scrapeError = failedScrapes.get(stripTrailingSlash(url));
+    pageResult.audits.push({
+      name: PREFLIGHT_METATAGS,
+      type: 'seo',
+      opportunities: [],
+      ...(scrapeError ? { status: 'error', error: scrapeError } : {}),
+    });
   });
 
   // Workaround for the updated meta-tags audit which requires a map of URL to S3 key

--- a/src/preflight/utils.js
+++ b/src/preflight/utils.js
@@ -10,7 +10,8 @@
  * governing permissions and limitations under the License.
  */
 import { Site } from '@adobe/spacecat-shared-data-access';
-import { isNonEmptyArray, isValidUrl } from '@adobe/spacecat-shared-utils';
+import { isNonEmptyArray, isValidUrl, stripTrailingSlash } from '@adobe/spacecat-shared-utils';
+import { PreflightError } from './error-constants.js';
 
 export async function saveIntermediateResults(context, result, auditName) {
   const {
@@ -33,6 +34,47 @@ export function isValidUrls(urls) {
     isNonEmptyArray(urls)
     && urls.every((url) => isValidUrl(url))
   );
+}
+
+/**
+ * Builds a lookup of URLs whose page scrape failed outright (e.g. 401/403, DNS, timeout), from
+ * the content-scraper's completion message. A failed scrape never writes a scrape record to S3,
+ * so without this signal a check has no way to distinguish "genuinely clean page" from "page was
+ * never actually analyzed" - it would silently report the pre-initialized empty/"clean" result.
+ * @param {Array<{ metadata?: { url?: string, status?: string, reason?: string } }>} scrapeResults
+ *   - The content-scraper completion message's per-URL results.
+ * @param {object} log
+ * @returns {Map<string, { code: string, message: string }>} Keyed by `stripTrailingSlash(url)`
+ *   to match the normalization already used when matching scraped pages back to their preview URL.
+ */
+export function buildFailedScrapesMap(scrapeResults, log) {
+  const failedScrapes = new Map();
+
+  if (!isNonEmptyArray(scrapeResults)) {
+    return failedScrapes;
+  }
+
+  scrapeResults.forEach((result) => {
+    const { url, status, reason } = result?.metadata || {};
+    if (status !== 'FAILED' || !isValidUrl(url)) {
+      return;
+    }
+
+    let preflightError = PreflightError.SCRAPE_FAILED;
+    if (/HTTP 40[13]/.test(reason || '')) {
+      preflightError = PreflightError.SCRAPE_FORBIDDEN;
+    } else if (/timeout/i.test(reason || '')) {
+      preflightError = PreflightError.SCRAPE_TIMEOUT;
+    }
+
+    log.warn(`[preflight-audit] Scrape failed for ${url}, reason: ${reason}. Marking checks with ${preflightError.code}.`);
+    failedScrapes.set(stripTrailingSlash(url), {
+      code: preflightError.code,
+      message: preflightError.message,
+    });
+  });
+
+  return failedScrapes;
 }
 
 export function getPrefixedPageAuthToken(site, token, options) {

--- a/test/audits/preflight-canonical.test.js
+++ b/test/audits/preflight-canonical.test.js
@@ -143,7 +143,7 @@ describe('Preflight Canonical Audit', () => {
 
     it('surfaces every canonical tag selector for canonical-tag-multiple, not just the first', async () => {
       // Protects: the whole point of this check is "there is more than one" — surfacing only
-      // one tag's selector would hide the rest from the author (SITES-48646 follow-up).
+      // one tag's selector would hide the rest from the author ( follow-up).
       const ctx = buildContext();
       const rawBody = `<html><head>
         <link rel="canonical" href="${PAGE_URL}">

--- a/test/audits/preflight-form-accessibility.test.js
+++ b/test/audits/preflight-form-accessibility.test.js
@@ -16,6 +16,7 @@ import chaiAsPromised from 'chai-as-promised';
 import sinon from 'sinon';
 import esmock from 'esmock';
 import { isValidUrls } from '../../src/preflight/utils.js';
+import { PreflightError } from '../../src/preflight/error-constants.js';
 
 use(sinonChai);
 use(chaiAsPromised);
@@ -206,6 +207,31 @@ describe('Preflight Form Accessibility Audit', () => {
           type: 'form-a11y',
           opportunities: [],
         });
+      });
+
+      it('marks a page whose main scrape already failed with status: error and excludes it from form detection (SITES-48986)', async () => {
+        const { detectFormAccessibility } = await import('../../src/preflight/form-accessibility.js');
+
+        auditContext.failedScrapes = new Map([
+          ['https://example.com/page1', { code: 'PREFLIGHT-101', message: 'This page could not be accessed. Confirm you have permission to view it.' }],
+        ]);
+        auditContext.audits.get('https://example.com/page1').audits = [];
+        auditContext.audits.get('https://example.com/page2').audits = [];
+
+        const urlsToDetect = await detectFormAccessibility(context, auditContext);
+
+        const page1Audit = auditContext.audits.get('https://example.com/page1').audits[0];
+        expect(page1Audit.status).to.equal('error');
+        expect(page1Audit.error).to.deep.equal({
+          code: 'PREFLIGHT-101',
+          message: 'This page could not be accessed. Confirm you have permission to view it.',
+        });
+
+        const page2Audit = auditContext.audits.get('https://example.com/page2').audits[0];
+        expect(page2Audit.status).to.be.undefined;
+
+        // The failed page is never looked at for forms and never sent to Mystique.
+        expect(urlsToDetect).to.deep.equal([{ form: 'https://example.com/page2', formSource: 'form' }]);
       });
 
       it('should handle missing audit entry for URL', async () => {
@@ -589,6 +615,43 @@ describe('Preflight Form Accessibility Audit', () => {
         expect(log.warn).to.have.been.calledWith(
           '[preflight-audit] site-123 No form accessibility data found for https://example.com/page1 at key: form-accessibility-preflight/site-123/example_com_page1.json',
         );
+
+        // No result file ever showed up for a URL that wasn't already known to have failed its
+        // main scrape - this is a genuine Mystique round-trip timeout, so it must be surfaced as
+        // an error rather than left as a silent "clean" empty result (SITES-49360).
+        const page1Audit = auditContext.audits.get('https://example.com/page1').audits
+          .find((a) => a.name === 'form-accessibility');
+        expect(page1Audit.status).to.equal('error');
+        expect(page1Audit.error).to.deep.equal({
+          code: PreflightError.SCRAPE_TIMEOUT.code,
+          message: PreflightError.SCRAPE_TIMEOUT.message,
+        });
+      });
+
+      it('skips the result-file lookup entirely for a page whose main scrape already failed (SITES-48986)', async () => {
+        const { processFormAccessibilityOpportunities } = await import('../../src/preflight/form-accessibility.js');
+
+        auditContext.failedScrapes = new Map([
+          ['https://example.com/page1', { code: 'PREFLIGHT-101', message: 'This page could not be accessed. Confirm you have permission to view it.' }],
+        ]);
+
+        s3Client.send.callsFake((command) => {
+          if (command.constructor.name === 'GetObjectCommand') {
+            return Promise.resolve({
+              Body: { transformToString: sinon.stub().resolves(JSON.stringify({ a11yIssues: [] })) },
+            });
+          }
+          return Promise.resolve({});
+        });
+
+        await processFormAccessibilityOpportunities(context, auditContext);
+
+        expect(log.warn).to.not.have.been.calledWith(
+          '[preflight-audit] site-123 No form accessibility data found for https://example.com/page1 at key: form-accessibility-preflight/site-123/example_com_page1.json',
+        );
+        const page2Audit = auditContext.audits.get('https://example.com/page2').audits
+          .find((a) => a.name === 'form-accessibility');
+        expect(page2Audit.status).to.be.undefined;
       });
 
       it('skips a stale result file (freshness gate) instead of serving previous-run data (SITES-49003)', async () => {
@@ -1867,21 +1930,14 @@ describe('Preflight Form Accessibility Audit', () => {
     it('should have empty urlsToDetect after mapping', async () => {
       const { detectFormAccessibility } = await import('../../src/preflight/form-accessibility.js');
 
-      // Create a scenario where previewUrls exists but map results in empty urlsToScrape
-      // This is a rare edge case but needed for coverage
+      // Create a scenario where previewUrls exists but every URL already failed its main
+      // scrape, so urlsToDetect is empty after filtering out known-failed URLs.
       auditContext.previewUrls = [''];
-      // Mock map only on this instance to return an empty array
-      auditContext.previewUrls.map = function mockMap() {
-        return [];
-      };
+      auditContext.failedScrapes = new Map([['', { code: 'PREFLIGHT-103', message: 'This page could not be checked.' }]]);
 
-      try {
-        await detectFormAccessibility(context, auditContext);
-        expect(log.info).to.have.been.calledWith('[preflight-audit] site-123  No URLs to detect for form accessibility audit');
-        expect(context.sqs.sendMessage).to.not.have.been.called;
-      } finally {
-        // No need to restore map since we only mocked the instance
-      }
+      await detectFormAccessibility(context, auditContext);
+      expect(log.info).to.have.been.calledWith('[preflight-audit] site-123  No URLs to detect for form accessibility audit');
+      expect(context.sqs.sendMessage).to.not.have.been.called;
     });
 
     it('should handle error during individual file processing and add form-accessibility-error opportunity', async () => {

--- a/test/audits/preflight.test.js
+++ b/test/audits/preflight.test.js
@@ -31,6 +31,7 @@ import { suggestionData } from '../fixtures/preflight/preflight-suggest.js';
 import identifyData from '../fixtures/preflight/preflight-identify.json' with { type: 'json' };
 import readabilityData from '../fixtures/preflight/preflight-identify-readability.json' with { type: 'json' };
 import { getPrefixedPageAuthToken, isValidUrls, saveIntermediateResults } from '../../src/preflight/utils.js';
+import { PreflightError } from '../../src/preflight/error-constants.js';
 
 use(sinonChai);
 use(chaiAsPromised);
@@ -1351,6 +1352,65 @@ describe('Preflight Audit', () => {
       })));
     });
 
+    it('marks every check with status: error when the content-scraper reports the page scrape as FAILED (SITES-48986)', async function () {
+      this.timeout(10000);
+
+      // No scrape.json exists for this URL - the content-scraper never wrote one because the
+      // scrape itself failed (this is the actual production signature of a 403/DNS/timeout).
+      s3Client.send.callsFake((command) => {
+        if (command.input?.Prefix) {
+          return Promise.resolve({ Contents: [], IsTruncated: false });
+        }
+        return Promise.resolve({});
+      });
+
+      // The completion message that triggered this step reports the scrape as FAILED for the
+      // one URL in this job - this is the signal AsyncJobRunner now threads through onto context.
+      context.scrapeResults = [
+        {
+          metadata: {
+            url: 'https://main--example--page.aem.page/page1',
+            status: 'FAILED',
+            reason: 'HTTP 403 error for URL: https://main--example--page.aem.page/page1',
+          },
+        },
+      ];
+
+      job.getMetadata = () => ({
+        payload: {
+          step: PREFLIGHT_STEP_IDENTIFY,
+          urls: ['https://main--example--page.aem.page/page1'],
+          enableAuthentication: false,
+        },
+      });
+
+      configuration.isHandlerEnabledForSite.returns(true);
+
+      await preflightAuditFunction(context);
+
+      const jobEntityCalls = context.dataAccess.AsyncJob.findById.returnValues;
+      const finalJobEntity = await jobEntityCalls[jobEntityCalls.length - 1];
+      const actualResult = finalJobEntity.setResult.getCall(0).args[0];
+
+      expect(actualResult).to.have.lengthOf(1);
+      const [pageResult] = actualResult;
+      // readability is a separate audit family untouched by this fix (not part of the
+      // scrapedObjects.forEach blind spot these tickets cover) - accessibility/form-accessibility
+      // are esmocked out in this describe block's setup and covered by their own test files.
+      const checksUnderTest = pageResult.audits.filter((audit) => audit.name !== 'readability');
+      expect(checksUnderTest.map((audit) => audit.name)).to.include.members([
+        AUDIT_BODY_SIZE, AUDIT_LOREM_IPSUM, AUDIT_H1_COUNT, 'canonical', 'metatags', 'headings', 'links',
+      ]);
+      checksUnderTest.forEach((audit) => {
+        expect(audit.status, `expected ${audit.name} to be marked as failed`).to.equal('error');
+        expect(audit.error).to.deep.equal({
+          code: PreflightError.SCRAPE_FORBIDDEN.code,
+          message: PreflightError.SCRAPE_FORBIDDEN.message,
+        });
+        expect(audit.opportunities).to.deep.equal([]);
+      });
+    });
+
     // eslint-disable-next-line func-names
     it('handles invalid http:// URLs gracefully in insecure link detection', async function () {
       this.timeout(10000);
@@ -2379,6 +2439,35 @@ describe('Preflight Audit', () => {
         );
       });
 
+      it('marks a page whose main scrape already failed with status: error and excludes it from the scrape request (SITES-48986)', async () => {
+        const { scrapeAccessibilityData } = await import('../../src/preflight/accessibility.js');
+
+        auditContext.failedScrapes = new Map([
+          ['https://example.com/page1', { code: 'PREFLIGHT-101', message: 'This page could not be accessed. Confirm you have permission to view it.' }],
+        ]);
+        // Start from a clean slate - scrapeAccessibilityData pushes a new entry rather than
+        // replacing, so the pre-seeded beforeEach entry would otherwise sit at index 0.
+        auditContext.audits.get('https://example.com/page1').audits = [];
+        auditContext.audits.get('https://example.com/page2').audits = [];
+
+        await scrapeAccessibilityData(context, auditContext);
+
+        const page1Audit = auditContext.audits.get('https://example.com/page1').audits[0];
+        expect(page1Audit.status).to.equal('error');
+        expect(page1Audit.error).to.deep.equal({
+          code: 'PREFLIGHT-101',
+          message: 'This page could not be accessed. Confirm you have permission to view it.',
+        });
+
+        const page2Audit = auditContext.audits.get('https://example.com/page2').audits[0];
+        expect(page2Audit.status).to.be.undefined;
+
+        // Only the non-failed URL is sent on for accessibility scraping.
+        expect(sqs.sendMessage).to.have.been.calledOnce;
+        const message = sqs.sendMessage.getCall(0).args[1];
+        expect(message.urls).to.deep.equal([{ url: 'https://example.com/page2' }]);
+      });
+
       it('should handle missing S3 bucket configuration', async () => {
         const { scrapeAccessibilityData } = await import('../../src/preflight/accessibility.js');
 
@@ -2858,6 +2947,49 @@ describe('Preflight Audit', () => {
         expect(log.warn).to.have.been.calledWith(
           '[preflight-audit] No accessibility data found for https://example.com/page1 at key: accessibility-preflight/site-123/example_com_page1.json',
         );
+
+        // No result file ever showed up for a URL that wasn't already known to have failed its
+        // main scrape - this is a genuine poll timeout, so it must be surfaced as an error rather
+        // than left as a silent "clean" empty result (SITES-49360).
+        const page1Audit = auditContext.audits.get('https://example.com/page1').audits[0];
+        expect(page1Audit.status).to.equal('error');
+        expect(page1Audit.error).to.deep.equal({
+          code: PreflightError.SCRAPE_TIMEOUT.code,
+          message: PreflightError.SCRAPE_TIMEOUT.message,
+        });
+      });
+
+      it('skips the S3 lookup entirely for a page whose main scrape already failed (SITES-48986)', async () => {
+        const { processAccessibilityOpportunities } = await import('../../src/preflight/accessibility.js');
+
+        auditContext.failedScrapes = new Map([
+          ['https://example.com/page1', { code: 'PREFLIGHT-101', message: 'This page could not be accessed. Confirm you have permission to view it.' }],
+        ]);
+
+        s3Client.send.callsFake((command) => {
+          if (command.constructor.name === 'GetObjectCommand') {
+            return Promise.resolve({
+              Body: { transformToString: sinon.stub().resolves(JSON.stringify({ violations: {} })) },
+            });
+          }
+          return Promise.resolve({});
+        });
+
+        await processAccessibilityOpportunities(context, auditContext);
+
+        // The known-failed page is skipped entirely - no S3 lookup, no "no data found" warning,
+        // and its (already error-tagged, by scrapeAccessibilityData in the real flow) audit entry
+        // is left alone rather than being overwritten with a timeout error or violation data.
+        expect(log.warn).to.not.have.been.calledWith(
+          '[preflight-audit] No accessibility data found for https://example.com/page1 at key: accessibility-preflight/site-123/example_com_page1.json',
+        );
+        const page1Audit = auditContext.audits.get('https://example.com/page1').audits[0];
+        expect(page1Audit.opportunities).to.deep.equal([]);
+
+        // The non-failed page is processed normally.
+        const page2Audit = auditContext.audits.get('https://example.com/page2').audits[0];
+        expect(page2Audit.status).to.be.undefined;
+        expect(page2Audit.opportunities).to.deep.equal([]);
       });
 
       it('should add timing information to execution breakdown', async () => {
@@ -4120,23 +4252,16 @@ describe('Preflight Audit', () => {
     it('should have empty urlsToScrape after mapping', async () => {
       const { scrapeAccessibilityData } = await import('../../src/preflight/accessibility.js');
 
-      // Create a scenario where previewUrls exists but map results in empty urlsToScrape
-      // This is a rare edge case but needed for coverage
+      // Create a scenario where previewUrls exists but every URL already failed its main
+      // scrape, so urlsToScrape is empty after filtering out known-failed URLs.
       auditContext.previewUrls = [''];
-      // Mock map only on this instance to return an empty array
-      auditContext.previewUrls.map = function mockMap() {
-        return [];
-      };
+      auditContext.failedScrapes = new Map([['', { code: 'PREFLIGHT-103', message: 'This page could not be checked.' }]]);
 
-      try {
-        await scrapeAccessibilityData(context, auditContext);
+      await scrapeAccessibilityData(context, auditContext);
 
-        // Should log the "No URLs to scrape" message from line 126
-        expect(log.info).to.have.been.calledWith('[preflight-audit] No URLs to scrape');
-        expect(context.sqs.sendMessage).to.not.have.been.called;
-      } finally {
-        // No need to restore map since we only mocked the instance
-      }
+      // Should log the "No URLs to scrape" message
+      expect(log.info).to.have.been.calledWith('[preflight-audit] No URLs to scrape');
+      expect(context.sqs.sendMessage).to.not.have.been.called;
     });
 
     it('should handle error during individual file processing and add accessibility-error opportunity', async () => {

--- a/test/preflight/utils.test.js
+++ b/test/preflight/utils.test.js
@@ -12,7 +12,10 @@
 
 import { expect } from 'chai';
 
-import { formatStructuredAuditLog, PREFLIGHT_METRIC_MARKER } from '../../src/preflight/utils.js';
+import {
+  formatStructuredAuditLog, PREFLIGHT_METRIC_MARKER, buildFailedScrapesMap,
+} from '../../src/preflight/utils.js';
+import { PreflightError } from '../../src/preflight/error-constants.js';
 
 describe('preflight/utils formatStructuredAuditLog', () => {
   it('leads with the rare pfauditmetric marker (the Splunk query anchor)', () => {
@@ -97,5 +100,97 @@ describe('preflight/utils formatStructuredAuditLog', () => {
     });
 
     expect(out).to.include('error="Error: kaboom"');
+  });
+});
+
+describe('preflight/utils buildFailedScrapesMap', () => {
+  let log;
+
+  beforeEach(() => {
+    log = {
+      warnCalls: [],
+      warn(...args) {
+        this.warnCalls.push(args);
+      },
+    };
+  });
+
+  it('returns an empty map when scrapeResults is not a non-empty array', () => {
+    expect(buildFailedScrapesMap(undefined, log).size).to.equal(0);
+    expect(buildFailedScrapesMap([], log).size).to.equal(0);
+  });
+
+  it('ignores entries that are not FAILED', () => {
+    const result = buildFailedScrapesMap([
+      { metadata: { url: 'https://example.com/page', status: 'COMPLETE' } },
+    ], log);
+
+    expect(result.size).to.equal(0);
+  });
+
+  it('ignores FAILED entries with a missing or invalid url', () => {
+    const result = buildFailedScrapesMap([
+      { metadata: { status: 'FAILED', reason: 'HTTP 403 error' } },
+      { metadata: { url: 'not-a-url', status: 'FAILED', reason: 'HTTP 403 error' } },
+    ], log);
+
+    expect(result.size).to.equal(0);
+  });
+
+  it('ignores entries with no metadata at all', () => {
+    const result = buildFailedScrapesMap([{}], log);
+
+    expect(result.size).to.equal(0);
+  });
+
+  it('classifies a 401/403 reason as SCRAPE_FORBIDDEN, keyed by the trailing-slash-stripped url', () => {
+    const result = buildFailedScrapesMap([
+      {
+        metadata: {
+          url: 'https://example.com/',
+          status: 'FAILED',
+          reason: 'HTTP 403 error for URL: https://example.com/',
+        },
+      },
+    ], log);
+
+    // stripTrailingSlash only strips a bare-origin trailing slash (matching the same
+    // normalization applied to previewUrls elsewhere in handler.js), so the map key here
+    // drops the trailing slash while a deeper path like '/page/' would not.
+    expect(result.get('https://example.com')).to.deep.equal({
+      code: PreflightError.SCRAPE_FORBIDDEN.code,
+      message: PreflightError.SCRAPE_FORBIDDEN.message,
+    });
+    expect(log.warnCalls).to.have.lengthOf(1);
+  });
+
+  it('classifies a timeout reason as SCRAPE_TIMEOUT', () => {
+    const result = buildFailedScrapesMap([
+      { metadata: { url: 'https://example.com/slow', status: 'FAILED', reason: 'Navigation Timeout Exceeded' } },
+    ], log);
+
+    expect(result.get('https://example.com/slow')).to.deep.equal({
+      code: PreflightError.SCRAPE_TIMEOUT.code,
+      message: PreflightError.SCRAPE_TIMEOUT.message,
+    });
+  });
+
+  it('falls back to SCRAPE_FAILED for any other terminal failure reason', () => {
+    const result = buildFailedScrapesMap([
+      { metadata: { url: 'https://example.com/dns', status: 'FAILED', reason: 'net::ERR_NAME_NOT_RESOLVED' } },
+    ], log);
+
+    expect(result.get('https://example.com/dns')).to.deep.equal({
+      code: PreflightError.SCRAPE_FAILED.code,
+      message: PreflightError.SCRAPE_FAILED.message,
+    });
+  });
+
+  it('falls back to SCRAPE_FAILED when reason is missing entirely', () => {
+    const result = buildFailedScrapesMap([
+      { metadata: { url: 'https://example.com/unknown', status: 'FAILED' } },
+    ], log);
+
+    expect(result.get('https://example.com/unknown').code).to.equal(PreflightError.SCRAPE_FAILED.code);
   });
 });


### PR DESCRIPTION
When the content-scraper fails to fetch a preflight page (403/DNS/timeout), every DOM/SEO/accessibility check reported a clean pass instead of an error, because the completion message's per-URL FAILED status was received but discarded before reaching the check logic - which then inferred "no issues" purely from a scrape record's absence in S3. Thread that signal through AsyncJobRunner and use it to mark the affected checks with a stable error code from the PreflightError catalog, and skip/short-circuit the accessibility and form-accessibility polls for pages already known to have failed their main scrape.

Fixes SITES-48986 (closed duplicates: SITES-49360, SITES-49871).

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
