### PR TITLE
feat(summarization): publish Mysticat observations

### DIFF
--- a/docs/specs/2026-08-21-summarization-mysticat-observation.md
+++ b/docs/specs/2026-08-21-summarization-mysticat-observation.md
@@ -1,0 +1,110 @@
+# Summarization Mysticat Observation
+
+**Status:** Implemented in audit-worker; downstream ingestion and projection pending
+
+## Problem
+
+The summarization audit currently sends `guidance:summarization` to Mystique and waits for a
+callback containing a presigned result URL. Audit-worker then creates the opportunity and
+synchronizes summary and key-point suggestions. Mysticat's blackboard model instead needs a
+source observation that identifies the pages to process and lets downstream services own agent
+execution and projection.
+
+## Goals
+
+- Publish the pages already selected, scraped, and filtered by audit-worker.
+- Include enough information for downstream processing to locate each scrape result.
+- Run beside the legacy guidance path for shadow validation.
+- Prevent shadow-path failures from failing or retrying the legacy audit flow.
+- Bound the message below the SQS 256 KB maximum.
+
+## Non-Goals
+
+- Implement the Mysticat ingestion task, agent, or projector in this repository.
+- Change ownership of production summarization opportunities or suggestions.
+- Remove `guidance:summarization` or its callback handler.
+- Enable the observation path by default.
+
+## Audit-Worker Flow
+
+The existing `send-to-mystique` step remains the controlling path:
+
+1. Verify at least 50% of submitted URLs have scrape results.
+2. Remove dynamic pages, pages with existing summary and key points, and unchanged pages.
+3. Limit the result to 100 pages and persist the sent URLs and content hashes on the audit.
+4. Send the legacy `guidance:summarization` message.
+5. When `OBSERVATION_SUMMARIZATION_ENABLED=true`, send the shadow observation.
+
+The observation send is wrapped in its own error boundary. An oversized message or SQS failure is
+logged and does not change the successful result of the legacy path.
+
+## Message Contract
+
+The observation uses the existing `QUEUE_SPACECAT_TO_MYSTIQUE` queue:
+
+```json
+{
+  "type": "observation:summarization",
+  "siteId": "site-id-123",
+  "auditId": "audit-id-456",
+  "baseURL": "https://example.com",
+  "deliveryType": "aem",
+  "time": "2026-08-21T12:00:00.000Z",
+  "data": {
+    "pages": [
+      {
+        "url": "https://example.com/page",
+        "scrapeResultPath": "scrapes/site-id-123/page/scrape.json",
+        "contentHash": "sha256-value-or-null"
+      }
+    ],
+    "generatePrompts": false
+  }
+}
+```
+
+Constraints:
+
+- `data.pages` contains at most 100 entries.
+- Every page has a URL and scraper result path.
+- `contentHash` is `null` when scraper content inspection is not configured.
+- Serialized observations above 200 KB are skipped.
+- The feature flag must equal the string `true` to publish.
+
+## Downstream Work
+
+Before enabling the flag, the Mystique/Mysticat repositories must:
+
+1. Register and validate `observation:summarization`.
+2. Read scrape objects using `scrapeResultPath` and the configured scraper bucket.
+3. Run the summarization agent for each page.
+4. Project one `summarization` opportunity per site scope.
+5. Project summary and key-point suggestions with stable, idempotent keys.
+6. Preserve edited, deployed, and in-progress suggestions according to the current worker rules.
+7. Scope OUTDATED transitions to URLs processed by the observation.
+
+## Rollout
+
+1. Deploy downstream ingestion and projection with contract tests.
+2. Enable `OBSERVATION_SUMMARIZATION_ENABLED=true` for shadow sites.
+3. Compare selected URLs, generated content, stable keys, and suggestion lifecycle behavior.
+4. Add a per-site engine selector before making Mysticat the persistence owner.
+5. For blackboard-owned sites, stop the legacy guidance send and worker-owned suggestion sync.
+6. Remove the legacy callback only after in-flight messages have drained.
+
+## Alternatives
+
+- **Move URL discovery into Mysticat:** rejected for the migration because audit-worker already owns
+  SEO, agentic, included-URL, scrape-availability, and unchanged-content filtering.
+- **Replace the legacy path immediately:** rejected because downstream ingestion and projector
+  behavior must be validated before persistence ownership changes.
+- **Send only URLs:** rejected because explicit scraper paths avoid duplicating scrape-object lookup
+  conventions downstream.
+
+## Success Criteria
+
+- Disabled mode sends only the existing guidance message.
+- Enabled mode sends one guidance and one observation message.
+- Observation failures never fail a successful legacy send.
+- The handler and observation branches retain 100% focused test coverage.
+- Downstream processing is idempotent before production ownership is transferred.

--- a/src/summarization/handler.js
+++ b/src/summarization/handler.js
@@ -24,8 +24,47 @@ const AUDIT_CONTEXT_URLS_KEY = 'summarizationUrls';
 const SCRAPE_AVAILABILITY_THRESHOLD = 0.5; // 50%
 const MAX_TOP_PAGES = 200;
 const MAX_PAGES_TO_MYSTIQUE = 100;
+const OBSERVATION_MAX_MESSAGE_BYTES = 200 * 1024;
 // Summarization opportunities remain in NEW status while active/unresolved.
 const ACTIVE_OPPORTUNITY_STATUS = 'NEW';
+
+async function publishSummarizationObservation({
+  site, audit, urls, scrapeResultPaths, urlToContentHash, generatePrompts, sqs, env, log,
+}) {
+  if (env?.OBSERVATION_SUMMARIZATION_ENABLED !== 'true') {
+    return;
+  }
+
+  try {
+    const message = {
+      type: 'observation:summarization',
+      siteId: site.getId(),
+      auditId: audit.getId(),
+      baseURL: site.getBaseURL(),
+      deliveryType: site.getDeliveryType(),
+      time: new Date().toISOString(),
+      data: {
+        pages: urls.map((url) => ({
+          url,
+          scrapeResultPath: scrapeResultPaths.get(url),
+          contentHash: urlToContentHash[url] ?? null,
+        })),
+        generatePrompts,
+      },
+    };
+
+    const serialized = JSON.stringify(message);
+    if (serialized.length > OBSERVATION_MAX_MESSAGE_BYTES) {
+      log.warn(`[SUMMARIZATION] observation:summarization payload size ${serialized.length} bytes exceeds budget ${OBSERVATION_MAX_MESSAGE_BYTES}; skipping publish`);
+      return;
+    }
+
+    await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, message);
+    log.info(`[SUMMARIZATION] Sent observation:summarization with ${urls.length} pages for site ${site.getId()}`);
+  } catch (error) {
+    log.error(`[SUMMARIZATION] Failed to publish observation:summarization shadow message: ${error.message}`);
+  }
+}
 
 function parseGeneratePromptsFlag(data, log) {
   try {
@@ -347,6 +386,18 @@ export async function sendToMystique(context) {
 
   await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, message);
   log.info(`[SUMMARIZATION] Sent ${topPagesPayload.length} pages to Mystique for site ${site.getId()}`);
+
+  await publishSummarizationObservation({
+    site,
+    audit,
+    urls: urlsToSend,
+    scrapeResultPaths,
+    urlToContentHash,
+    generatePrompts,
+    sqs,
+    env,
+    log,
+  });
 
   return {
     status: 'complete',

--- a/test/audits/summarization/handler.test.js
+++ b/test/audits/summarization/handler.test.js
@@ -361,6 +361,72 @@ describe('Summarization Handler', () => {
       );
     });
 
+    it('should publish a summarization observation when enabled', async () => {
+      context.env.OBSERVATION_SUMMARIZATION_ENABLED = 'true';
+
+      const result = await sendToMystique(context);
+
+      expect(result).to.deep.equal({ status: 'complete' });
+      expect(sqs.sendMessage).to.have.been.calledTwice;
+      const observation = sqs.sendMessage.secondCall.args[1];
+      expect(observation).to.include({
+        type: 'observation:summarization',
+        siteId: 'site-id-123',
+        auditId: 'audit-id-456',
+        baseURL: 'https://adobe.com',
+        deliveryType: 'aem',
+      });
+      expect(observation.time).to.be.a('string');
+      expect(observation.data).to.deep.include({ generatePrompts: false });
+      expect(observation.data.pages).to.deep.equal([
+        {
+          url: 'https://adobe.com/page1',
+          scrapeResultPath: 'scrapes/site-id-123/page1/scrape.json',
+          contentHash: null,
+        },
+        {
+          url: 'https://adobe.com/page2',
+          scrapeResultPath: 'scrapes/site-id-123/page2/scrape.json',
+          contentHash: null,
+        },
+        {
+          url: 'https://adobe.com/page3',
+          scrapeResultPath: 'scrapes/site-id-123/page3/scrape.json',
+          contentHash: null,
+        },
+      ]);
+      expect(log.info).to.have.been.calledWith(
+        '[SUMMARIZATION] Sent observation:summarization with 3 pages for site site-id-123',
+      );
+    });
+
+    it('should skip an oversized summarization observation', async () => {
+      context.env.OBSERVATION_SUMMARIZATION_ENABLED = 'true';
+      context.scrapeResultPaths.set('https://adobe.com/page1', 'x'.repeat(205 * 1024));
+
+      const result = await sendToMystique(context);
+
+      expect(result).to.deep.equal({ status: 'complete' });
+      expect(sqs.sendMessage).to.have.been.calledOnce;
+      expect(log.warn).to.have.been.calledWith(
+        sinon.match(/observation:summarization payload size .* exceeds budget 204800/),
+      );
+    });
+
+    it('should isolate summarization observation publish failures', async () => {
+      context.env.OBSERVATION_SUMMARIZATION_ENABLED = 'true';
+      sqs.sendMessage.onFirstCall().resolves({});
+      sqs.sendMessage.onSecondCall().rejects(new Error('shadow queue failure'));
+
+      const result = await sendToMystique(context);
+
+      expect(result).to.deep.equal({ status: 'complete' });
+      expect(sqs.sendMessage).to.have.been.calledTwice;
+      expect(log.error).to.have.been.calledWith(
+        '[SUMMARIZATION] Failed to publish observation:summarization shadow message: shadow queue failure',
+      );
+    });
+
     it('should propagate generatePrompts=true from auditContext into Mystique payload', async () => {
       context.auditContext = {
         ...context.auditContext,


### PR DESCRIPTION
## Related Issues

None linked.

## Summary

- publish an opt-in `observation:summarization` shadow message after the legacy Mystique guidance message
- include filtered page URLs, scraper object paths, content hashes, and `generatePrompts`
- enforce a 200 KB payload budget and isolate shadow-publish failures from the legacy audit
- document the wire contract, rollout boundary, and required downstream Mysticat ingestion/projector work in a dedicated spec

## Testing

- `npx mocha -i -g 'Post-Deploy' test/audits/summarization/handler.test.js` (54 passing)\n- `npx eslint src/summarization/handler.js`\n- `git diff --check`\n- focused coverage for `src/summarization/handler.js`: 100% lines, branches, functions, and statements\n\nThe broader summarization glob currently has 17 pre-existing failures in `guidance-handler.test.js` caused by `DATA_SOURCES.SITE` being undefined; this change does not touch that path.\n\n## Rollout\n\nKeep `OBSERVATION_SUMMARIZATION_ENABLED` disabled until the downstream Mystique/Mysticat ingestion task and projector support `observation:summarization`. The existing guidance callback remains the production persistence owner during shadow validation.\n\nThanks for contributing!