### PR TITLE
feat(prerender): reconcile coveredByDomainWide against actual edge state (LLMO-7052)

### DIFF
--- a/src/prerender/domain-wide-reconciliation.js
+++ b/src/prerender/domain-wide-reconciliation.js
@@ -192,9 +192,13 @@ export async function syncCoveredByDomainWide(opportunity, context, successfulCo
     + `${!!domainWideSuggestion}, baseUrl=${baseUrl}`);
 
   // Pathname-only (not query-aware) is intentional here, unlike normalizePathnameWithQuery
-  // used for status.json/candidate dedup elsewhere: edge routing/deployment rules (a
-  // domain-wide /* rule or a path pattern) apply per-pathname, not per query-string variant,
-  // so two query-param variants of the same page are the same deployment unit for this check.
+  // used for status.json/candidate dedup elsewhere: coveredByDomainWide is assigned upstream
+  // by matching /*-suffixed allowedRegexPatterns against pathname only, ignoring the query
+  // string entirely (see buildUrlMatcher in spacecat-shared-tokowaka-client's
+  // src/utils/pattern-utils.js) — a domain-wide or path-level rule covers every query-param
+  // variant of a pathname identically. Reconciling at query-aware granularity would strand
+  // variants like /page?v=2 unreconciled forever unless that exact variant gets scraped,
+  // even though the routing rule that covers it doesn't distinguish query strings either.
   const deployedAtEdgePathnames = new Set();
   const notDeployedPathnames = new Set();
   successfulComparisons.forEach((r) => {

--- a/src/prerender/domain-wide-reconciliation.js
+++ b/src/prerender/domain-wide-reconciliation.js
@@ -10,12 +10,11 @@
  * governing permissions and limitations under the License.
  */
 
-import { Audit } from '@adobe/spacecat-shared-data-access';
+import { Audit, Suggestion } from '@adobe/spacecat-shared-data-access';
 import {
   isDomainWideSuggestionData,
   isPathSuggestionData,
   normalizePathnameWithQuery,
-  readSiteStatusJson,
   toPathname,
 } from './utils/utils.js';
 import { DOMAIN_WIDE_RECONCILIATION_BATCH_SIZE } from './utils/constants.js';
@@ -34,6 +33,19 @@ function isIndividualUrlSuggestionData(data) {
 }
 
 /**
+ * True when a suggestion is the active (non-OUTDATED) domain-wide suggestion with
+ * `edgeDeployed` set. Shared predicate for both the batch-selection lookup (which fetches
+ * its own suggestion list) and the write-back (which reuses an already-fetched list) so
+ * the "what counts as deployed" rule can't drift between them.
+ * @param {Object} s - Suggestion entity
+ * @returns {boolean}
+ */
+function isDeployedDomainWideSuggestion(s) {
+  return s.getStatus() === Suggestion.STATUSES.NEW
+    && isDomainWideSuggestionData(s.getData()) && !!s.getData()?.edgeDeployed;
+}
+
+/**
  * Finds the site's NEW prerender opportunity and, within it, the domain-wide
  * suggestion that currently has `edgeDeployed` set.
  * @param {Object} dataAccess - Data access layer
@@ -47,9 +59,7 @@ async function findDeployedDomainWide(dataAccess, siteId) {
     return null;
   }
   const suggestions = await opportunity.getSuggestions?.() ?? [];
-  const domainWide = suggestions.find(
-    (s) => isDomainWideSuggestionData(s.getData()) && !!s.getData()?.edgeDeployed,
-  );
+  const domainWide = suggestions.find(isDeployedDomainWideSuggestion);
   if (!domainWide) {
     return null;
   }
@@ -92,11 +102,13 @@ function hasPostDeployConfirmation(pageEntry, deployedAtMs) {
  * drops out of this selection once it gets any post-deploy scrape — no bookkeeping
  * needed to track "already handled".
  *
- * @param {Object} context - Audit context (dataAccess, log, s3Client, env)
+ * @param {Object} context - Audit context (dataAccess, log)
  * @param {string} siteId - Site ID
+ * @param {Object} siteStatus - The site's already-read status.json (caller fetches this
+ *   once via readSiteStatusJson and reuses it here rather than re-reading from S3)
  * @returns {Promise<string[]>} URLs to append to this run's scrape batch
  */
-export async function getDomainWideReconciliationCandidates(context, siteId) {
+export async function getDomainWideReconciliationCandidates(context, siteId, siteStatus) {
   const { dataAccess, log } = context;
   const found = await findDeployedDomainWide(dataAccess, siteId);
   if (!found) {
@@ -113,9 +125,8 @@ export async function getDomainWideReconciliationCandidates(context, siteId) {
     return [];
   }
 
-  const siteStatus = await readSiteStatusJson(siteId, context);
   const pageByPathname = new Map(
-    (siteStatus.pages ?? [])
+    (siteStatus?.pages ?? [])
       .filter((p) => p.url)
       .map((p) => [normalizePathnameWithQuery(p.url), p]),
   );
@@ -137,49 +148,95 @@ export async function getDomainWideReconciliationCandidates(context, siteId) {
 }
 
 /**
- * Clears `coveredByDomainWide` on any per-URL suggestion whose pathname was scraped
- * successfully this run and confirmed `isDeployedAtEdge: false` (LLMO-7052). Runs
- * against the full set of this run's successful comparisons, not just URLs pulled in by
- * getDomainWideReconciliationCandidates, so incidental confirmations from ordinary
- * organic/agentic/included rotation are caught too.
+ * Reconciles `coveredByDomainWide` against this run's confirmed edge state (LLMO-7052).
+ * One suggestion fetch, one save, covering both directions:
  *
- * No grace period: a single confirmed `isDeployedAtEdge: false` result clears the flag
- * immediately, symmetric with markDeployedUrlSuggestionsAsCovered, which already trusts
- * a single confirmed scrape to *set* it. If this fires before a still-propagating CDN
- * deploy has fully caught up, the next confirmed `isDeployedAtEdge: true` re-covers it
- * via that same add-side path.
+ *  - Add: when the domain-wide suggestion has `edgeDeployed`, NEW per-URL suggestions
+ *    whose pathname is confirmed deployed at edge this run get `coveredByDomainWide` set
+ *    (instead of moving to SKIPPED, so a domain-wide rollback naturally restores them to
+ *    the Current tab). NEW path-type suggestions are covered unconditionally while
+ *    domain-wide is active — they're redundant, not something to individually verify.
+ *  - Remove: any suggestion (any status) currently `coveredByDomainWide` whose pathname is
+ *    confirmed NOT deployed at edge this run has the flag cleared immediately — no grace
+ *    period, and independent of whether a domain-wide suggestion currently exists at all.
+ *
+ * Both directions read from a single `opportunity.getSuggestions()` fetch and write
+ * through a single `saveMany` call; the save is non-fatal on failure (logged, swallowed)
+ * so a transient DB error on this reconciliation step doesn't fail an otherwise-successful
+ * audit run — matching how other post-processing steps in this audit behave.
  *
  * @param {Object|null} opportunity - Opportunity entity (no-op if null)
- * @param {Object} context - Audit context (dataAccess, log)
+ * @param {Object} context - Audit context (dataAccess, log, site)
  * @param {Array} successfulComparisons - This run's non-error comparison results
  * @returns {Promise<void>}
  */
-export async function reconcileCoveredByDomainWide(opportunity, context, successfulComparisons) {
-  const { dataAccess, log } = context;
-  if (!opportunity || typeof opportunity.getSuggestions !== 'function') {
+export async function syncCoveredByDomainWide(opportunity, context, successfulComparisons) {
+  const { dataAccess, log, site } = context;
+  const SuggestionDA = dataAccess?.Suggestion;
+  if (!opportunity || typeof opportunity.getSuggestions !== 'function' || !SuggestionDA?.saveMany) {
     return;
   }
 
-  const notDeployedPathnames = new Set(
-    successfulComparisons
-      .filter((r) => !r.isDeployedAtEdge)
-      .map((r) => toPathname(r.url)),
-  );
-  if (notDeployedPathnames.size === 0) {
-    return;
-  }
+  const baseUrl = site?.getBaseURL?.() || '';
+  const siteId = site?.getId?.() || '';
 
   const suggestions = await opportunity.getSuggestions();
+
+  const domainWideSuggestion = suggestions.find(isDeployedDomainWideSuggestion) ?? null;
+  log.info(`${LOG_PREFIX} syncCoveredByDomainWide: isAllDomainDeployedAtEdge=`
+    + `${!!domainWideSuggestion}, baseUrl=${baseUrl}`);
+
+  const deployedAtEdgePathnames = new Set();
+  const notDeployedPathnames = new Set();
+  successfulComparisons.forEach((r) => {
+    (r.isDeployedAtEdge ? deployedAtEdgePathnames : notDeployedPathnames).add(toPathname(r.url));
+  });
+
+  const toCover = [];
+  if (domainWideSuggestion) {
+    const domainWideSuggestionId = domainWideSuggestion.getId();
+    // The domain-wide suggestion itself is always NEW and always in this list, so
+    // newSuggestions is never empty here — nothing further to guard on that front.
+    const newSuggestions = suggestions.filter((s) => s.getStatus() === Suggestion.STATUSES.NEW);
+
+    // Path and domain-wide suggestions have no url field — guard before calling toPathname.
+    const urlSuggestionsToCover = deployedAtEdgePathnames.size > 0
+      ? newSuggestions.filter((s) => {
+        const data = s.getData();
+        if (!data?.url) {
+          return false;
+        }
+        return deployedAtEdgePathnames.has(toPathname(data.url)) && !data?.edgeDeployed;
+      })
+      : [];
+
+    // Path suggestions are redundant while domain-wide (/*) is active — cover unconditionally.
+    const pathSuggestionsToCover = newSuggestions.filter((s) => {
+      const data = s.getData();
+      return isPathSuggestionData(data) && !data?.edgeDeployed && !data?.coveredByDomainWide;
+    });
+
+    toCover.push(...urlSuggestionsToCover, ...pathSuggestionsToCover);
+    if (toCover.length === 0) {
+      log.info(`${LOG_PREFIX} syncCoveredByDomainWide: no NEW suggestions to cover. `
+        + `baseUrl=${baseUrl}, siteId=${siteId}`);
+    } else {
+      toCover.forEach((s) => s.setData({
+        ...s.getData(),
+        coveredByDomainWide: domainWideSuggestionId,
+      }));
+      log.info(`${LOG_PREFIX} All domain deployed: marking ${urlSuggestionsToCover.length} `
+        + `per-URL and ${pathSuggestionsToCover.length} path suggestions as coveredByDomainWide. `
+        + `baseUrl=${baseUrl}, siteId=${siteId}`);
+    }
+  }
+
   const toClear = suggestions.filter((s) => {
     const data = s.getData();
     return !!data?.coveredByDomainWide
       && isIndividualUrlSuggestionData(data)
       && notDeployedPathnames.has(toPathname(data.url));
   });
-  if (toClear.length === 0) {
-    return;
-  }
-
   toClear.forEach((s) => {
     // eslint-disable-next-line no-unused-vars
     const { coveredByDomainWide, ...rest } = s.getData();
@@ -187,12 +244,19 @@ export async function reconcileCoveredByDomainWide(opportunity, context, success
     s.setUpdatedBy('system');
   });
 
+  const toSave = [...toCover, ...toClear];
+  if (toSave.length === 0) {
+    return;
+  }
+
   try {
-    await dataAccess.Suggestion.saveMany(toClear);
-    log.info(`${LOG_PREFIX} Domain-wide reconciliation: cleared coveredByDomainWide on `
-      + `${toClear.length} suggestion(s) confirmed not deployed at edge this run.`);
+    await SuggestionDA.saveMany(toSave);
+    if (toClear.length > 0) {
+      log.info(`${LOG_PREFIX} Domain-wide reconciliation: cleared coveredByDomainWide on `
+        + `${toClear.length} suggestion(s) confirmed not deployed at edge this run.`);
+    }
   } catch (e) {
-    log.error(`${LOG_PREFIX} Failed to clear coveredByDomainWide on ${toClear.length} `
+    log.error(`${LOG_PREFIX} Failed to save coveredByDomainWide changes for ${toSave.length} `
       + `suggestion(s): ${e.message}`);
   }
 }

--- a/src/prerender/domain-wide-reconciliation.js
+++ b/src/prerender/domain-wide-reconciliation.js
@@ -231,10 +231,13 @@ export async function syncCoveredByDomainWide(opportunity, context, successfulCo
       log.info(`${LOG_PREFIX} syncCoveredByDomainWide: no NEW suggestions to cover. `
         + `baseUrl=${baseUrl}, siteId=${siteId}`);
     } else {
-      toCover.forEach((s) => s.setData({
-        ...s.getData(),
-        coveredByDomainWide: domainWideSuggestionId,
-      }));
+      toCover.forEach((s) => {
+        s.setData({
+          ...s.getData(),
+          coveredByDomainWide: domainWideSuggestionId,
+        });
+        s.setUpdatedBy('system');
+      });
       log.info(`${LOG_PREFIX} All domain deployed: marking ${urlSuggestionsToCover.length} `
         + `per-URL and ${pathSuggestionsToCover.length} path suggestions as coveredByDomainWide. `
         + `baseUrl=${baseUrl}, siteId=${siteId}`);

--- a/src/prerender/domain-wide-reconciliation.js
+++ b/src/prerender/domain-wide-reconciliation.js
@@ -15,7 +15,6 @@ import {
   isDomainWideSuggestionData,
   isPathSuggestionData,
   normalizePathnameWithQuery,
-  toPathname,
 } from './utils/utils.js';
 import { DOMAIN_WIDE_RECONCILIATION_BATCH_SIZE } from './utils/constants.js';
 
@@ -157,13 +156,13 @@ export async function getDomainWideReconciliationCandidates(context, siteId, sit
  * One suggestion fetch, one save, covering both directions:
  *
  *  - Add: when the domain-wide suggestion has `edgeDeployed`, NEW per-URL suggestions
- *    whose pathname is confirmed deployed at edge this run get `coveredByDomainWide` set
- *    (instead of moving to SKIPPED, so a domain-wide rollback naturally restores them to
- *    the Current tab). NEW path-type suggestions are covered unconditionally while
+ *    confirmed deployed at edge this run (by their own exact URL) get `coveredByDomainWide`
+ *    set (instead of moving to SKIPPED, so a domain-wide rollback naturally restores them
+ *    to the Current tab). NEW path-type suggestions are covered unconditionally while
  *    domain-wide is active — they're redundant, not something to individually verify.
- *  - Remove: any suggestion (any status) currently `coveredByDomainWide` whose pathname is
- *    confirmed NOT deployed at edge this run has the flag cleared immediately — no grace
- *    period, and independent of whether a domain-wide suggestion currently exists at all.
+ *  - Remove: any suggestion (any status) currently `coveredByDomainWide` confirmed NOT
+ *    deployed at edge this run (by its own exact URL) has the flag cleared immediately —
+ *    no grace period, independent of whether a domain-wide suggestion currently exists.
  *
  * Both directions read from a single `opportunity.getSuggestions()` fetch and write
  * through a single `saveMany` call; the save is non-fatal on failure (logged, swallowed)
@@ -191,24 +190,15 @@ export async function syncCoveredByDomainWide(opportunity, context, successfulCo
   log.info(`${LOG_PREFIX} syncCoveredByDomainWide: isAllDomainDeployedAtEdge=`
     + `${!!domainWideSuggestion}, baseUrl=${baseUrl}`);
 
-  // Pathname-only (not query-aware) is intentional here, unlike normalizePathnameWithQuery
-  // used for status.json/candidate dedup elsewhere: coveredByDomainWide is assigned upstream
-  // by matching /*-suffixed allowedRegexPatterns against pathname only, ignoring the query
-  // string entirely (see buildUrlMatcher in spacecat-shared-tokowaka-client's
-  // src/utils/pattern-utils.js) — a domain-wide or path-level rule covers every query-param
-  // variant of a pathname identically. Reconciling at query-aware granularity would strand
-  // variants like /page?v=2 unreconciled forever unless that exact variant gets scraped,
-  // even though the routing rule that covers it doesn't distinguish query strings either.
-  const deployedAtEdgePathnames = new Set();
-  const notDeployedPathnames = new Set();
+  // Same key as buildSuggestionKey — each suggestion reconciled against its own result only.
+  const deployedAtEdgeKeys = new Set();
+  const notDeployedKeys = new Set();
   successfulComparisons.forEach((r) => {
-    (r.isDeployedAtEdge ? deployedAtEdgePathnames : notDeployedPathnames).add(toPathname(r.url));
+    (r.isDeployedAtEdge ? deployedAtEdgeKeys : notDeployedKeys)
+      .add(normalizePathnameWithQuery(r.url));
   });
-  // If two variants of the same pathname disagreed on isDeployedAtEdge this run (e.g.
-  // /page?v=1 confirmed deployed, /page?v=2 didn't), the positive confirmation wins —
-  // otherwise the same suggestion could match both toCover and toClear below and the
-  // second mutation would silently overwrite the first in the same saveMany call.
-  deployedAtEdgePathnames.forEach((pathname) => notDeployedPathnames.delete(pathname));
+  // On a same-key disagreement this run, positive confirmation wins.
+  deployedAtEdgeKeys.forEach((key) => notDeployedKeys.delete(key));
 
   const toCover = [];
   if (domainWideSuggestion) {
@@ -217,14 +207,14 @@ export async function syncCoveredByDomainWide(opportunity, context, successfulCo
     // newSuggestions is never empty here — nothing further to guard on that front.
     const newSuggestions = suggestions.filter((s) => s.getStatus() === Suggestion.STATUSES.NEW);
 
-    // Path and domain-wide suggestions have no url field — guard before calling toPathname.
-    const urlSuggestionsToCover = deployedAtEdgePathnames.size > 0
+    // Path and domain-wide suggestions have no url field — guard before normalizing.
+    const urlSuggestionsToCover = deployedAtEdgeKeys.size > 0
       ? newSuggestions.filter((s) => {
         const data = s.getData();
         if (!data?.url) {
           return false;
         }
-        return deployedAtEdgePathnames.has(toPathname(data.url))
+        return deployedAtEdgeKeys.has(normalizePathnameWithQuery(data.url))
           && !data?.edgeDeployed
           && !data?.coveredByDomainWide;
       })
@@ -255,7 +245,7 @@ export async function syncCoveredByDomainWide(opportunity, context, successfulCo
     const data = s.getData();
     return !!data?.coveredByDomainWide
       && isIndividualUrlSuggestionData(data)
-      && notDeployedPathnames.has(toPathname(data.url));
+      && notDeployedKeys.has(normalizePathnameWithQuery(data.url));
   });
   toClear.forEach((s) => {
     // eslint-disable-next-line no-unused-vars

--- a/src/prerender/domain-wide-reconciliation.js
+++ b/src/prerender/domain-wide-reconciliation.js
@@ -133,12 +133,107 @@ export async function getDomainWideReconciliationCandidates(context, siteId, sit
 }
 
 /**
+ * Partitions this run's comparisons into deployed/not-deployed identity keys (same key as
+ * buildSuggestionKey — each suggestion reconciled against its own result only). On a
+ * same-key disagreement this run, positive confirmation wins.
+ * @param {Array} successfulComparisons - This run's non-error comparison results
+ * @returns {{deployedAtEdgeKeys: Set<string>, notDeployedKeys: Set<string>}}
+ */
+function partitionComparisonResults(successfulComparisons) {
+  const deployedAtEdgeKeys = new Set();
+  const notDeployedKeys = new Set();
+  successfulComparisons.forEach((r) => {
+    (r.isDeployedAtEdge ? deployedAtEdgeKeys : notDeployedKeys)
+      .add(normalizePathnameWithQuery(r.url));
+  });
+  deployedAtEdgeKeys.forEach((key) => notDeployedKeys.delete(key));
+  return { deployedAtEdgeKeys, notDeployedKeys };
+}
+
+/**
+ * Add branch: NEW suggestions confirmed deployed at edge this run get `coveredByDomainWide`
+ * set. No-op (returns []) when no domain-wide suggestion is currently deployed.
+ * @param {Array} suggestions - All suggestions on the opportunity
+ * @param {Object|null} domainWideSuggestion - The active deployed domain-wide suggestion, if any
+ * @param {Set<string>} deployedAtEdgeKeys - Identity keys confirmed deployed this run
+ * @param {{log: Object, baseUrl: string, siteId: string}} logCtx
+ * @returns {Array} Suggestions mutated (and needing save)
+ */
+function computeSuggestionsToCover(suggestions, domainWideSuggestion, deployedAtEdgeKeys, {
+  log, baseUrl, siteId,
+}) {
+  if (!domainWideSuggestion) {
+    return [];
+  }
+  const domainWideSuggestionId = domainWideSuggestion.getId();
+  // Domain-wide suggestion is always NEW, so newSuggestions is never empty here.
+  const newSuggestions = suggestions.filter((s) => s.getStatus() === Suggestion.STATUSES.NEW);
+
+  // Path and domain-wide suggestions have no url field — guard before normalizing.
+  const urlSuggestionsToCover = deployedAtEdgeKeys.size > 0
+    ? newSuggestions.filter((s) => {
+      const data = s.getData();
+      if (!data?.url) {
+        return false;
+      }
+      return deployedAtEdgeKeys.has(normalizePathnameWithQuery(data.url))
+        && !data?.edgeDeployed
+        && !data?.coveredByDomainWide;
+    })
+    : [];
+
+  // Path suggestions are redundant while domain-wide (/*) is active — cover unconditionally.
+  const pathSuggestionsToCover = newSuggestions.filter((s) => {
+    const data = s.getData();
+    return isPathSuggestionData(data) && !data?.edgeDeployed && !data?.coveredByDomainWide;
+  });
+
+  const toCover = [...urlSuggestionsToCover, ...pathSuggestionsToCover];
+  if (toCover.length === 0) {
+    log.info(`${LOG_PREFIX} syncCoveredByDomainWide: no NEW suggestions to cover. `
+      + `baseUrl=${baseUrl}, siteId=${siteId}`);
+  } else {
+    toCover.forEach((s) => {
+      s.setData({
+        ...s.getData(),
+        coveredByDomainWide: domainWideSuggestionId,
+      });
+      s.setUpdatedBy('system');
+    });
+    log.info(`${LOG_PREFIX} All domain deployed: marking ${urlSuggestionsToCover.length} `
+      + `per-URL and ${pathSuggestionsToCover.length} path suggestions as coveredByDomainWide. `
+      + `baseUrl=${baseUrl}, siteId=${siteId}`);
+  }
+  return toCover;
+}
+
+/**
+ * Remove branch: any suggestion currently `coveredByDomainWide` and confirmed NOT deployed
+ * this run has the flag cleared — no grace period, any status.
+ * @param {Array} suggestions - All suggestions on the opportunity
+ * @param {Set<string>} notDeployedKeys - Identity keys confirmed not deployed this run
+ * @returns {Array} Suggestions mutated (and needing save)
+ */
+function computeSuggestionsToClear(suggestions, notDeployedKeys) {
+  const toClear = suggestions.filter((s) => {
+    const data = s.getData();
+    return !!data?.coveredByDomainWide
+      && isIndividualUrlSuggestionData(data)
+      && notDeployedKeys.has(normalizePathnameWithQuery(data.url));
+  });
+  toClear.forEach((s) => {
+    // eslint-disable-next-line no-unused-vars
+    const { coveredByDomainWide, ...rest } = s.getData();
+    s.setData(rest);
+    s.setUpdatedBy('system');
+  });
+  return toClear;
+}
+
+/**
  * Reconciles `coveredByDomainWide` against this run's confirmed edge state (LLMO-7052).
- * One fetch, one save:
- *  - Add: NEW suggestions confirmed deployed at edge this run get `coveredByDomainWide` set.
- *  - Remove: any suggestion confirmed NOT deployed this run has the flag cleared, no grace
- *    period.
- * Save failures are logged and swallowed — non-fatal, doesn't fail the audit run.
+ * One fetch, one save. Save failures are logged and swallowed — non-fatal, doesn't fail the
+ * audit run.
  * @param {Object|null} opportunity - Opportunity entity (no-op if null)
  * @param {Object} context - Audit context (dataAccess, log, site)
  * @param {Array} successfulComparisons - This run's non-error comparison results
@@ -160,71 +255,12 @@ export async function syncCoveredByDomainWide(opportunity, context, successfulCo
   log.info(`${LOG_PREFIX} syncCoveredByDomainWide: isAllDomainDeployedAtEdge=`
     + `${!!domainWideSuggestion}, baseUrl=${baseUrl}`);
 
-  // Same key as buildSuggestionKey — each suggestion reconciled against its own result only.
-  const deployedAtEdgeKeys = new Set();
-  const notDeployedKeys = new Set();
-  successfulComparisons.forEach((r) => {
-    (r.isDeployedAtEdge ? deployedAtEdgeKeys : notDeployedKeys)
-      .add(normalizePathnameWithQuery(r.url));
+  const { deployedAtEdgeKeys, notDeployedKeys } = partitionComparisonResults(successfulComparisons);
+
+  const toCover = computeSuggestionsToCover(suggestions, domainWideSuggestion, deployedAtEdgeKeys, {
+    log, baseUrl, siteId,
   });
-  // On a same-key disagreement this run, positive confirmation wins.
-  deployedAtEdgeKeys.forEach((key) => notDeployedKeys.delete(key));
-
-  const toCover = [];
-  if (domainWideSuggestion) {
-    const domainWideSuggestionId = domainWideSuggestion.getId();
-    // Domain-wide suggestion is always NEW, so newSuggestions is never empty here.
-    const newSuggestions = suggestions.filter((s) => s.getStatus() === Suggestion.STATUSES.NEW);
-
-    // Path and domain-wide suggestions have no url field — guard before normalizing.
-    const urlSuggestionsToCover = deployedAtEdgeKeys.size > 0
-      ? newSuggestions.filter((s) => {
-        const data = s.getData();
-        if (!data?.url) {
-          return false;
-        }
-        return deployedAtEdgeKeys.has(normalizePathnameWithQuery(data.url))
-          && !data?.edgeDeployed
-          && !data?.coveredByDomainWide;
-      })
-      : [];
-
-    // Path suggestions are redundant while domain-wide (/*) is active — cover unconditionally.
-    const pathSuggestionsToCover = newSuggestions.filter((s) => {
-      const data = s.getData();
-      return isPathSuggestionData(data) && !data?.edgeDeployed && !data?.coveredByDomainWide;
-    });
-
-    toCover.push(...urlSuggestionsToCover, ...pathSuggestionsToCover);
-    if (toCover.length === 0) {
-      log.info(`${LOG_PREFIX} syncCoveredByDomainWide: no NEW suggestions to cover. `
-        + `baseUrl=${baseUrl}, siteId=${siteId}`);
-    } else {
-      toCover.forEach((s) => {
-        s.setData({
-          ...s.getData(),
-          coveredByDomainWide: domainWideSuggestionId,
-        });
-        s.setUpdatedBy('system');
-      });
-      log.info(`${LOG_PREFIX} All domain deployed: marking ${urlSuggestionsToCover.length} `
-        + `per-URL and ${pathSuggestionsToCover.length} path suggestions as coveredByDomainWide. `
-        + `baseUrl=${baseUrl}, siteId=${siteId}`);
-    }
-  }
-
-  const toClear = suggestions.filter((s) => {
-    const data = s.getData();
-    return !!data?.coveredByDomainWide
-      && isIndividualUrlSuggestionData(data)
-      && notDeployedKeys.has(normalizePathnameWithQuery(data.url));
-  });
-  toClear.forEach((s) => {
-    // eslint-disable-next-line no-unused-vars
-    const { coveredByDomainWide, ...rest } = s.getData();
-    s.setData(rest);
-    s.setUpdatedBy('system');
-  });
+  const toClear = computeSuggestionsToClear(suggestions, notDeployedKeys);
 
   const toSave = [...toCover, ...toClear];
   if (toSave.length === 0) {

--- a/src/prerender/domain-wide-reconciliation.js
+++ b/src/prerender/domain-wide-reconciliation.js
@@ -32,10 +32,8 @@ function isIndividualUrlSuggestionData(data) {
 }
 
 /**
- * True when a suggestion is the active (non-OUTDATED) domain-wide suggestion with
- * `edgeDeployed` set. Shared predicate for both the batch-selection lookup (which fetches
- * its own suggestion list) and the write-back (which reuses an already-fetched list) so
- * the "what counts as deployed" rule can't drift between them.
+ * True when a suggestion is the active (NEW) domain-wide suggestion with `edgeDeployed` set.
+ * Shared by batch-selection and write-back so "deployed" can't drift between them.
  * @param {Object} s - Suggestion entity
  * @returns {boolean}
  */
@@ -66,18 +64,9 @@ async function findDeployedDomainWide(dataAccess, siteId) {
 }
 
 /**
- * True when a status.json page entry represents a genuine post-deploy confirmation:
- * a *successful* scrape that happened strictly after the domain-wide suggestion's own
- * `edgeDeployed` timestamp. Anything else — no entry, a failed/bot-blocked attempt
- * regardless of when, or a successful-but-pre-deploy entry — means we still don't know
- * this URL's current edge state relative to the deploy, so it stays eligible.
- *
- * Deliberately checks `scrapingStatus`, not just `scrapedAt`: uploadStatusSummaryToS3
- * stamps `scrapedAt` on every attempt regardless of outcome — `currentPages` sets it
- * unconditionally per result, and `missingPages` (bot-blocked/dropped scrapes) carries
- * `scrapingStatus: 'failed'` with its own `scrapedAt` too. A bare age comparison would
- * permanently retire a URL from the backlog after a single failed scrape, even though
- * it was never actually confirmed either way.
+ * True when a status.json page entry is a successful scrape strictly after `deployedAtMs`.
+ * Checks `scrapingStatus`, not just age, so a failed/bot-blocked scrape doesn't permanently
+ * retire a URL from the backlog.
  * @param {Object|undefined} pageEntry - status.json page entry for this URL, if any
  * @param {number} deployedAtMs - domain-wide suggestion's edgeDeployed, as epoch ms
  * @returns {boolean}
@@ -90,17 +79,9 @@ function hasPostDeployConfirmation(pageEntry, deployedAtMs) {
 }
 
 /**
- * Selects up to DOMAIN_WIDE_RECONCILIATION_BATCH_SIZE per-URL suggestions that are
- * currently `coveredByDomainWide` but have no genuine post-deploy scrape confirmation
- * yet (LLMO-7052). Intended to be appended *additively* to the daily scrape batch, on
- * top of DAILY_BATCH_SIZE, so reconciliation runs on a fixed cadence independent of
- * whether these URLs would otherwise be selected by organic/agentic/included ranking.
- *
- * Ordered oldest-`scrapedAt`-first (missing entries sort first) so the backlog drains
- * deterministically rather than resampling the same subset every run. A URL naturally
- * drops out of this selection once it gets any post-deploy scrape — no bookkeeping
- * needed to track "already handled".
- *
+ * Selects up to DOMAIN_WIDE_RECONCILIATION_BATCH_SIZE `coveredByDomainWide` suggestions
+ * with no post-deploy scrape confirmation yet (LLMO-7052), appended additively to the
+ * daily scrape batch. Ordered oldest-`scrapedAt`-first so the backlog drains deterministically.
  * @param {Object} context - Audit context (dataAccess, log)
  * @param {string} siteId - Site ID
  * @param {Object} siteStatus - The site's already-read status.json (caller fetches this
@@ -153,22 +134,11 @@ export async function getDomainWideReconciliationCandidates(context, siteId, sit
 
 /**
  * Reconciles `coveredByDomainWide` against this run's confirmed edge state (LLMO-7052).
- * One suggestion fetch, one save, covering both directions:
- *
- *  - Add: when the domain-wide suggestion has `edgeDeployed`, NEW per-URL suggestions
- *    confirmed deployed at edge this run (by their own exact URL) get `coveredByDomainWide`
- *    set (instead of moving to SKIPPED, so a domain-wide rollback naturally restores them
- *    to the Current tab). NEW path-type suggestions are covered unconditionally while
- *    domain-wide is active — they're redundant, not something to individually verify.
- *  - Remove: any suggestion (any status) currently `coveredByDomainWide` confirmed NOT
- *    deployed at edge this run (by its own exact URL) has the flag cleared immediately —
- *    no grace period, independent of whether a domain-wide suggestion currently exists.
- *
- * Both directions read from a single `opportunity.getSuggestions()` fetch and write
- * through a single `saveMany` call; the save is non-fatal on failure (logged, swallowed)
- * so a transient DB error on this reconciliation step doesn't fail an otherwise-successful
- * audit run — matching how other post-processing steps in this audit behave.
- *
+ * One fetch, one save:
+ *  - Add: NEW suggestions confirmed deployed at edge this run get `coveredByDomainWide` set.
+ *  - Remove: any suggestion confirmed NOT deployed this run has the flag cleared, no grace
+ *    period.
+ * Save failures are logged and swallowed — non-fatal, doesn't fail the audit run.
  * @param {Object|null} opportunity - Opportunity entity (no-op if null)
  * @param {Object} context - Audit context (dataAccess, log, site)
  * @param {Array} successfulComparisons - This run's non-error comparison results
@@ -203,8 +173,7 @@ export async function syncCoveredByDomainWide(opportunity, context, successfulCo
   const toCover = [];
   if (domainWideSuggestion) {
     const domainWideSuggestionId = domainWideSuggestion.getId();
-    // The domain-wide suggestion itself is always NEW and always in this list, so
-    // newSuggestions is never empty here — nothing further to guard on that front.
+    // Domain-wide suggestion is always NEW, so newSuggestions is never empty here.
     const newSuggestions = suggestions.filter((s) => s.getStatus() === Suggestion.STATUSES.NEW);
 
     // Path and domain-wide suggestions have no url field — guard before normalizing.

--- a/src/prerender/domain-wide-reconciliation.js
+++ b/src/prerender/domain-wide-reconciliation.js
@@ -116,6 +116,11 @@ export async function getDomainWideReconciliationCandidates(context, siteId, sit
   }
   const { suggestions, domainWide } = found;
   const deployedAtMs = new Date(domainWide.getData().edgeDeployed).getTime();
+  if (Number.isNaN(deployedAtMs)) {
+    log.warn(`${LOG_PREFIX} Domain-wide suggestion ${domainWide.getId()} has an unparseable `
+      + `edgeDeployed value; skipping reconciliation batch selection. siteId=${siteId}`);
+    return [];
+  }
 
   const covered = suggestions.filter((s) => {
     const data = s.getData();
@@ -186,11 +191,20 @@ export async function syncCoveredByDomainWide(opportunity, context, successfulCo
   log.info(`${LOG_PREFIX} syncCoveredByDomainWide: isAllDomainDeployedAtEdge=`
     + `${!!domainWideSuggestion}, baseUrl=${baseUrl}`);
 
+  // Pathname-only (not query-aware) is intentional here, unlike normalizePathnameWithQuery
+  // used for status.json/candidate dedup elsewhere: edge routing/deployment rules (a
+  // domain-wide /* rule or a path pattern) apply per-pathname, not per query-string variant,
+  // so two query-param variants of the same page are the same deployment unit for this check.
   const deployedAtEdgePathnames = new Set();
   const notDeployedPathnames = new Set();
   successfulComparisons.forEach((r) => {
     (r.isDeployedAtEdge ? deployedAtEdgePathnames : notDeployedPathnames).add(toPathname(r.url));
   });
+  // If two variants of the same pathname disagreed on isDeployedAtEdge this run (e.g.
+  // /page?v=1 confirmed deployed, /page?v=2 didn't), the positive confirmation wins —
+  // otherwise the same suggestion could match both toCover and toClear below and the
+  // second mutation would silently overwrite the first in the same saveMany call.
+  deployedAtEdgePathnames.forEach((pathname) => notDeployedPathnames.delete(pathname));
 
   const toCover = [];
   if (domainWideSuggestion) {
@@ -206,7 +220,9 @@ export async function syncCoveredByDomainWide(opportunity, context, successfulCo
         if (!data?.url) {
           return false;
         }
-        return deployedAtEdgePathnames.has(toPathname(data.url)) && !data?.edgeDeployed;
+        return deployedAtEdgePathnames.has(toPathname(data.url))
+          && !data?.edgeDeployed
+          && !data?.coveredByDomainWide;
       })
       : [];
 

--- a/src/prerender/domain-wide-reconciliation.js
+++ b/src/prerender/domain-wide-reconciliation.js
@@ -242,7 +242,7 @@ function computeSuggestionsToClear(suggestions, notDeployedKeys) {
 export async function syncCoveredByDomainWide(opportunity, context, successfulComparisons) {
   const { dataAccess, log, site } = context;
   const SuggestionDA = dataAccess?.Suggestion;
-  if (!opportunity || typeof opportunity.getSuggestions !== 'function' || !SuggestionDA?.saveMany) {
+  if (!opportunity) {
     return;
   }
 

--- a/src/prerender/domain-wide-reconciliation.js
+++ b/src/prerender/domain-wide-reconciliation.js
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { Audit } from '@adobe/spacecat-shared-data-access';
+import {
+  isDomainWideSuggestionData,
+  isPathSuggestionData,
+  normalizePathnameWithQuery,
+  readSiteStatusJson,
+  toPathname,
+} from './utils/utils.js';
+import { DOMAIN_WIDE_RECONCILIATION_BATCH_SIZE } from './utils/constants.js';
+
+const LOG_PREFIX = 'Prerender -';
+const AUDIT_TYPE = Audit.AUDIT_TYPES.PRERENDER;
+
+/**
+ * True when a suggestion's data represents an individual per-URL suggestion (not
+ * domain-wide, not path-type).
+ * @param {Object} data - Suggestion data
+ * @returns {boolean}
+ */
+function isIndividualUrlSuggestionData(data) {
+  return !!data?.url && !isDomainWideSuggestionData(data) && !isPathSuggestionData(data);
+}
+
+/**
+ * Finds the site's NEW prerender opportunity and, within it, the domain-wide
+ * suggestion that currently has `edgeDeployed` set.
+ * @param {Object} dataAccess - Data access layer
+ * @param {string} siteId - Site ID
+ * @returns {Promise<{suggestions: Array, domainWide: Object}|null>}
+ */
+async function findDeployedDomainWide(dataAccess, siteId) {
+  const opportunities = await dataAccess?.Opportunity?.allBySiteIdAndStatus?.(siteId, 'NEW') ?? [];
+  const opportunity = opportunities.find((o) => o.getType() === AUDIT_TYPE);
+  if (!opportunity) {
+    return null;
+  }
+  const suggestions = await opportunity.getSuggestions?.() ?? [];
+  const domainWide = suggestions.find(
+    (s) => isDomainWideSuggestionData(s.getData()) && !!s.getData()?.edgeDeployed,
+  );
+  if (!domainWide) {
+    return null;
+  }
+  return { suggestions, domainWide };
+}
+
+/**
+ * True when a status.json page entry represents a genuine post-deploy confirmation:
+ * a *successful* scrape that happened strictly after the domain-wide suggestion's own
+ * `edgeDeployed` timestamp. Anything else — no entry, a failed/bot-blocked attempt
+ * regardless of when, or a successful-but-pre-deploy entry — means we still don't know
+ * this URL's current edge state relative to the deploy, so it stays eligible.
+ *
+ * Deliberately checks `scrapingStatus`, not just `scrapedAt`: uploadStatusSummaryToS3
+ * stamps `scrapedAt` on every attempt regardless of outcome — `currentPages` sets it
+ * unconditionally per result, and `missingPages` (bot-blocked/dropped scrapes) carries
+ * `scrapingStatus: 'failed'` with its own `scrapedAt` too. A bare age comparison would
+ * permanently retire a URL from the backlog after a single failed scrape, even though
+ * it was never actually confirmed either way.
+ * @param {Object|undefined} pageEntry - status.json page entry for this URL, if any
+ * @param {number} deployedAtMs - domain-wide suggestion's edgeDeployed, as epoch ms
+ * @returns {boolean}
+ */
+function hasPostDeployConfirmation(pageEntry, deployedAtMs) {
+  if (!pageEntry?.scrapedAt || pageEntry.scrapingStatus !== 'success') {
+    return false;
+  }
+  return new Date(pageEntry.scrapedAt).getTime() > deployedAtMs;
+}
+
+/**
+ * Selects up to DOMAIN_WIDE_RECONCILIATION_BATCH_SIZE per-URL suggestions that are
+ * currently `coveredByDomainWide` but have no genuine post-deploy scrape confirmation
+ * yet (LLMO-7052). Intended to be appended *additively* to the daily scrape batch, on
+ * top of DAILY_BATCH_SIZE, so reconciliation runs on a fixed cadence independent of
+ * whether these URLs would otherwise be selected by organic/agentic/included ranking.
+ *
+ * Ordered oldest-`scrapedAt`-first (missing entries sort first) so the backlog drains
+ * deterministically rather than resampling the same subset every run. A URL naturally
+ * drops out of this selection once it gets any post-deploy scrape — no bookkeeping
+ * needed to track "already handled".
+ *
+ * @param {Object} context - Audit context (dataAccess, log, s3Client, env)
+ * @param {string} siteId - Site ID
+ * @returns {Promise<string[]>} URLs to append to this run's scrape batch
+ */
+export async function getDomainWideReconciliationCandidates(context, siteId) {
+  const { dataAccess, log } = context;
+  const found = await findDeployedDomainWide(dataAccess, siteId);
+  if (!found) {
+    return [];
+  }
+  const { suggestions, domainWide } = found;
+  const deployedAtMs = new Date(domainWide.getData().edgeDeployed).getTime();
+
+  const covered = suggestions.filter((s) => {
+    const data = s.getData();
+    return !!data?.coveredByDomainWide && isIndividualUrlSuggestionData(data);
+  });
+  if (covered.length === 0) {
+    return [];
+  }
+
+  const siteStatus = await readSiteStatusJson(siteId, context);
+  const pageByPathname = new Map(
+    (siteStatus.pages ?? [])
+      .filter((p) => p.url)
+      .map((p) => [normalizePathnameWithQuery(p.url), p]),
+  );
+
+  const backlog = covered.filter((s) => {
+    const pathname = normalizePathnameWithQuery(s.getData().url);
+    return !hasPostDeployConfirmation(pageByPathname.get(pathname), deployedAtMs);
+  });
+
+  const getScrapedAt = (s) => pageByPathname
+    .get(normalizePathnameWithQuery(s.getData().url))?.scrapedAt ?? '';
+  backlog.sort((a, b) => getScrapedAt(a).localeCompare(getScrapedAt(b)));
+
+  const selected = backlog.slice(0, DOMAIN_WIDE_RECONCILIATION_BATCH_SIZE);
+  log.info(`${LOG_PREFIX} Domain-wide reconciliation: ${covered.length} coveredByDomainWide `
+    + `suggestion(s), ${backlog.length} pending post-deploy confirmation, selecting `
+    + `${selected.length} for this run's batch. siteId=${siteId}`);
+  return selected.map((s) => s.getData().url);
+}
+
+/**
+ * Clears `coveredByDomainWide` on any per-URL suggestion whose pathname was scraped
+ * successfully this run and confirmed `isDeployedAtEdge: false` (LLMO-7052). Runs
+ * against the full set of this run's successful comparisons, not just URLs pulled in by
+ * getDomainWideReconciliationCandidates, so incidental confirmations from ordinary
+ * organic/agentic/included rotation are caught too.
+ *
+ * No grace period: a single confirmed `isDeployedAtEdge: false` result clears the flag
+ * immediately, symmetric with markDeployedUrlSuggestionsAsCovered, which already trusts
+ * a single confirmed scrape to *set* it. If this fires before a still-propagating CDN
+ * deploy has fully caught up, the next confirmed `isDeployedAtEdge: true` re-covers it
+ * via that same add-side path.
+ *
+ * @param {Object|null} opportunity - Opportunity entity (no-op if null)
+ * @param {Object} context - Audit context (dataAccess, log)
+ * @param {Array} successfulComparisons - This run's non-error comparison results
+ * @returns {Promise<void>}
+ */
+export async function reconcileCoveredByDomainWide(opportunity, context, successfulComparisons) {
+  const { dataAccess, log } = context;
+  if (!opportunity || typeof opportunity.getSuggestions !== 'function') {
+    return;
+  }
+
+  const notDeployedPathnames = new Set(
+    successfulComparisons
+      .filter((r) => !r.isDeployedAtEdge)
+      .map((r) => toPathname(r.url)),
+  );
+  if (notDeployedPathnames.size === 0) {
+    return;
+  }
+
+  const suggestions = await opportunity.getSuggestions();
+  const toClear = suggestions.filter((s) => {
+    const data = s.getData();
+    return !!data?.coveredByDomainWide
+      && isIndividualUrlSuggestionData(data)
+      && notDeployedPathnames.has(toPathname(data.url));
+  });
+  if (toClear.length === 0) {
+    return;
+  }
+
+  toClear.forEach((s) => {
+    // eslint-disable-next-line no-unused-vars
+    const { coveredByDomainWide, ...rest } = s.getData();
+    s.setData(rest);
+    s.setUpdatedBy('system');
+  });
+
+  try {
+    await dataAccess.Suggestion.saveMany(toClear);
+    log.info(`${LOG_PREFIX} Domain-wide reconciliation: cleared coveredByDomainWide on `
+      + `${toClear.length} suggestion(s) confirmed not deployed at edge this run.`);
+  } catch (e) {
+    log.error(`${LOG_PREFIX} Failed to clear coveredByDomainWide on ${toClear.length} `
+      + `suggestion(s): ${e.message}`);
+  }
+}

--- a/src/prerender/handler.js
+++ b/src/prerender/handler.js
@@ -39,7 +39,7 @@ import {
 } from './path-suggestions/main.js';
 import {
   getDomainWideReconciliationCandidates,
-  reconcileCoveredByDomainWide,
+  syncCoveredByDomainWide,
 } from './domain-wide-reconciliation.js';
 import {
   CONTENT_GAIN_THRESHOLD,
@@ -163,116 +163,6 @@ async function detectWrongEdgeDeployedStatus(dataAccess, siteId, auditUrl, log) 
   if (count > 0) {
     log.warn(`${LOG_PREFIX} Unexpected non-NEW suggestions with edgeDeployed set. baseUrl=${auditUrl}, siteId=${siteId}, nonNewEdgeDeployedCount=${count}`);
   }
-}
-
-/**
- * Checks if the domain-wide suggestion (isDomainWide=true) has edgeDeployed set.
- * @param {Object} opportunity - The opportunity object
- * @returns {Promise<boolean>}
- */
-async function getDomainWideSuggestionDeployedAtEdge(opportunity) {
-  if (!opportunity || typeof opportunity.getSuggestions !== 'function') {
-    return null;
-  }
-  const suggestions = await opportunity.getSuggestions();
-  return suggestions.find((s) => {
-    const d = s.getData();
-    return s.getStatus() === Suggestion.STATUSES.NEW
-      && isDomainWideSuggestionData(d) && !!d?.edgeDeployed;
-  }) ?? null;
-}
-
-/**
- * Sets coveredByDomainWide on NEW suggestions whose URLs are confirmed deployed at edge,
- * instead of moving them to SKIPPED. This allows rollback to naturally restore them to
- * the Current tab when the backend clears coveredByDomainWide on domain-wide rollback.
- * @param {Object} opportunity - The opportunity object
- * @param {Object} context - Audit context with dataAccess and log
- * @param {Set<string>} deployedAtEdgePathnames - Pathnames confirmed deployed at edge in this audit
- * @param {string} domainWideSuggestionId - ID of the deployed domain-wide suggestion
- * @returns {Promise<void>}
- */
-async function markDeployedUrlSuggestionsAsCovered(
-  opportunity,
-  context,
-  deployedAtEdgePathnames,
-  domainWideSuggestionId,
-) {
-  const { dataAccess, log, site } = context;
-  const SuggestionDA = dataAccess?.Suggestion;
-
-  const baseUrl = site?.getBaseURL?.() || '';
-  const siteId = site?.getId?.() || '';
-
-  if (!SuggestionDA?.allByOpportunityIdAndStatus || !SuggestionDA?.saveMany) {
-    return;
-  }
-
-  const newSuggestions = await SuggestionDA.allByOpportunityIdAndStatus(
-    opportunity.getId(),
-    Suggestion.STATUSES.NEW,
-  );
-
-  if (newSuggestions.length === 0) {
-    log.info(`${LOG_PREFIX} markDeployedUrlSuggestionsAsCovered: no NEW suggestions found. baseUrl=${baseUrl}, siteId=${siteId}`);
-    return;
-  }
-
-  // Mark per-URL suggestions whose pathnames are confirmed deployed at edge.
-  // Path and domain-wide suggestions have no url field — guard before calling toPathname.
-  const urlSuggestionsToCover = deployedAtEdgePathnames?.size > 0
-    ? newSuggestions.filter((s) => {
-      const data = s.getData();
-      if (!data?.url) {
-        return false;
-      }
-      return deployedAtEdgePathnames.has(toPathname(data.url)) && !data?.edgeDeployed;
-    })
-    : [];
-
-  // Mark path suggestions as covered by domain-wide (they're redundant while /* is active)
-  const pathSuggestionsToCover = newSuggestions.filter((s) => {
-    const data = s.getData();
-    return isPathSuggestionData(data) && !data?.edgeDeployed && !data?.coveredByDomainWide;
-  });
-
-  const allToCover = [...urlSuggestionsToCover, ...pathSuggestionsToCover];
-
-  if (allToCover.length === 0) {
-    log.info(`${LOG_PREFIX} markDeployedUrlSuggestionsAsCovered: no NEW suggestions to cover. baseUrl=${baseUrl}, siteId=${siteId}`);
-    return;
-  }
-
-  allToCover.forEach((s) => {
-    s.setData({ ...s.getData(), coveredByDomainWide: domainWideSuggestionId });
-  });
-
-  log.info(`${LOG_PREFIX} All domain deployed: marking ${urlSuggestionsToCover.length} per-URL and ${pathSuggestionsToCover.length} path suggestions as coveredByDomainWide. baseUrl=${baseUrl}, siteId=${siteId}`);
-  await SuggestionDA.saveMany(allToCover);
-}
-
-/**
- * Marks NEW suggestions as coveredByDomainWide when the domain-wide suggestion has edgeDeployed,
- * restricting to URLs confirmed deployed at edge in the current audit run.
- * @param {Object|null} opportunity - The opportunity object (no-op if null)
- * @param {Object} context - Audit context with dataAccess and log
- * @param {Set<string>} deployedAtEdgePathnames - Pathnames confirmed deployed at edge in this audit
- * @returns {Promise<void>}
- */
-async function markNewSuggestionsAsCovered(opportunity, context, deployedAtEdgePathnames) {
-  const { log, site } = context;
-  const baseUrl = site?.getBaseURL?.() || '';
-  const domainWideSuggestion = await getDomainWideSuggestionDeployedAtEdge(opportunity);
-  log.info(`${LOG_PREFIX} markNewSuggestionsAsCovered: isAllDomainDeployedAtEdge=${!!domainWideSuggestion}, baseUrl=${baseUrl}`);
-  if (!domainWideSuggestion) {
-    return;
-  }
-  await markDeployedUrlSuggestionsAsCovered(
-    opportunity,
-    context,
-    deployedAtEdgePathnames,
-    domainWideSuggestion.getId(),
-  );
 }
 
 /**
@@ -708,8 +598,9 @@ export async function submitForScraping(context) {
     // LLMO-7052: append the coveredByDomainWide reconciliation backlog additively, on top
     // of DAILY_BATCH_SIZE, so it runs on a fixed cadence rather than competing with
     // organic/agentic/included for the same slots.
-    const reconciliationUrls = (await getDomainWideReconciliationCandidates(context, siteId))
-      .map((url) => rebaseUrl(url, preferredBase, log));
+    const reconciliationUrls = (
+      await getDomainWideReconciliationCandidates(context, siteId, siteStatus)
+    ).map((url) => rebaseUrl(url, preferredBase, log));
     domainWideReconciliationCount = reconciliationUrls.length;
     const { urls: batchedUrlsWithReconciliation } = mergeAndGetUniqueHtmlUrls(
       [...batchedUrls, ...reconciliationUrls],
@@ -1593,18 +1484,12 @@ export async function processContentAndGenerateOpportunities(context) {
       }
     }
 
-    // When domain-wide suggestion has edgeDeployed, mark NEW suggestions as coveredByDomainWide
-    // Only mark suggestions for pathnames confirmed deployed at edge in this audit run
-    const deployedAtEdgePathnames = new Set(
-      successfulComparisons
-        .filter((r) => r.isDeployedAtEdge)
-        .map((r) => toPathname(r.url)),
-    );
-    await markNewSuggestionsAsCovered(opportunityWithSuggestions, context, deployedAtEdgePathnames);
-    // LLMO-7052: clear coveredByDomainWide on any suggestion this run's scrapes confirm is
-    // no longer deployed at edge — runs against all successfulComparisons, not just the
-    // reconciliation batch, so incidental confirmations from normal rotation are caught too.
-    await reconcileCoveredByDomainWide(opportunityWithSuggestions, context, successfulComparisons);
+    // LLMO-7052: reconcile coveredByDomainWide both ways against this run's confirmed edge
+    // state — add it to newly-deployed NEW suggestions, clear it from any suggestion (any
+    // status) whose pathname is confirmed no longer deployed. Runs against all
+    // successfulComparisons, not just the reconciliation batch, so incidental confirmations
+    // from normal organic/agentic/included rotation are caught too.
+    await syncCoveredByDomainWide(opportunityWithSuggestions, context, successfulComparisons);
 
     const endTime = process.hrtime(startTime);
     const elapsedSeconds = (endTime[0] + endTime[1] / 1e9).toFixed(2);

--- a/src/prerender/handler.js
+++ b/src/prerender/handler.js
@@ -38,6 +38,10 @@ import {
   mergePathSuggestionData,
 } from './path-suggestions/main.js';
 import {
+  getDomainWideReconciliationCandidates,
+  reconcileCoveredByDomainWide,
+} from './domain-wide-reconciliation.js';
+import {
   CONTENT_GAIN_THRESHOLD,
   DAILY_BATCH_SIZE,
   DOMAIN_WIDE_SUGGESTION_KEY,
@@ -623,6 +627,7 @@ export async function submitForScraping(context) {
   let isFirstRunOfCycle;
   let agenticNewThisCycle = 0;
   let edgeDeployedPathnames = new Set();
+  let domainWideReconciliationCount = 0;
 
   if (isSlackTriggered) {
     // Dedup each source independently: organic uses pathname-only dedup (tracking params stay
@@ -700,7 +705,18 @@ export async function submitForScraping(context) {
       (url) => !organicUrlSet.has(url) && !includedUrlSet.has(url),
     ).length;
 
-    finalUrls = batchedUrls;
+    // LLMO-7052: append the coveredByDomainWide reconciliation backlog additively, on top
+    // of DAILY_BATCH_SIZE, so it runs on a fixed cadence rather than competing with
+    // organic/agentic/included for the same slots.
+    const reconciliationUrls = (await getDomainWideReconciliationCandidates(context, siteId))
+      .map((url) => rebaseUrl(url, preferredBase, log));
+    domainWideReconciliationCount = reconciliationUrls.length;
+    const { urls: batchedUrlsWithReconciliation } = mergeAndGetUniqueHtmlUrls(
+      [...batchedUrls, ...reconciliationUrls],
+      { includeQueryParams: true },
+    );
+
+    finalUrls = batchedUrlsWithReconciliation;
   }
 
   log.info(`${LOG_PREFIX} prerender_submit_scraping_metrics:
@@ -716,6 +732,7 @@ export async function submitForScraping(context) {
     isFirstRunOfCycle=${isFirstRunOfCycle},
     agenticNewThisCycle=${agenticNewThisCycle},
     edgeDeployedUrls=${edgeDeployedPathnames.size},
+    domainWideReconciliationUrls=${domainWideReconciliationCount},
     baseUrl=${site.getBaseURL()},
     siteId=${siteId}`);
 
@@ -1584,6 +1601,10 @@ export async function processContentAndGenerateOpportunities(context) {
         .map((r) => toPathname(r.url)),
     );
     await markNewSuggestionsAsCovered(opportunityWithSuggestions, context, deployedAtEdgePathnames);
+    // LLMO-7052: clear coveredByDomainWide on any suggestion this run's scrapes confirm is
+    // no longer deployed at edge — runs against all successfulComparisons, not just the
+    // reconciliation batch, so incidental confirmations from normal rotation are caught too.
+    await reconcileCoveredByDomainWide(opportunityWithSuggestions, context, successfulComparisons);
 
     const endTime = process.hrtime(startTime);
     const elapsedSeconds = (endTime[0] + endTime[1] / 1e9).toFixed(2);

--- a/src/prerender/handler.js
+++ b/src/prerender/handler.js
@@ -595,9 +595,7 @@ export async function submitForScraping(context) {
       (url) => !organicUrlSet.has(url) && !includedUrlSet.has(url),
     ).length;
 
-    // LLMO-7052: append the coveredByDomainWide reconciliation backlog additively, on top
-    // of DAILY_BATCH_SIZE, so it runs on a fixed cadence rather than competing with
-    // organic/agentic/included for the same slots.
+    // LLMO-7052: reconciliation backlog, additive on top of DAILY_BATCH_SIZE.
     const reconciliationUrls = (
       await getDomainWideReconciliationCandidates(context, siteId, siteStatus)
     ).map((url) => rebaseUrl(url, preferredBase, log));
@@ -1484,11 +1482,7 @@ export async function processContentAndGenerateOpportunities(context) {
       }
     }
 
-    // LLMO-7052: reconcile coveredByDomainWide both ways against this run's confirmed edge
-    // state — add it to newly-deployed NEW suggestions, clear it from any suggestion (any
-    // status) whose pathname is confirmed no longer deployed. Runs against all
-    // successfulComparisons, not just the reconciliation batch, so incidental confirmations
-    // from normal organic/agentic/included rotation are caught too.
+    // LLMO-7052: reconcile coveredByDomainWide against this run's confirmed edge state.
     await syncCoveredByDomainWide(opportunityWithSuggestions, context, successfulComparisons);
 
     const endTime = process.hrtime(startTime);

--- a/src/prerender/utils/constants.js
+++ b/src/prerender/utils/constants.js
@@ -25,6 +25,12 @@ export const DOMAIN_WIDE_SUGGESTION_KEY = 'domain-wide-aggregate|prerender';
 export const MYSTIQUE_SUGGESTIONS_S3_PREFIX = 'prerender/mystique-suggestions';
 export const MYSTIQUE_BATCH_SIZE = DAILY_BATCH_SIZE;
 
+/**
+ * Daily cap on how many coveredByDomainWide suggestions get appended to the scrape
+ * batch for reconciliation (LLMO-7052), additive on top of DAILY_BATCH_SIZE.
+ */
+export const DOMAIN_WIDE_RECONCILIATION_BATCH_SIZE = 200;
+
 // Path-level prerender suggestion thresholds
 export const PATH_TYPE_MIN_URLS = 10;
 export const PATH_TYPE_MIN_VALUABLE_PCT = 33;

--- a/test/audits/prerender/behaviour/domain-wide-reconciliation.test.js
+++ b/test/audits/prerender/behaviour/domain-wide-reconciliation.test.js
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+
+/**
+ * Behavioural contracts: LLMO-7052 — coveredByDomainWide reconciliation.
+ *
+ * Written against the current (handler.js-resident) implementation of
+ * getDomainWideReconciliationCandidates / reconcileCoveredByDomainWide, using only the
+ * public step entry points (submitForScraping, processContentAndGenerateOpportunities)
+ * and external-dependency mocks (S3, dataAccess entities) — no internal functions are
+ * stubbed. These must keep passing unchanged once that logic is moved/merged elsewhere,
+ * since they assert on observable outcomes, not on which internal function ran them.
+ *
+ * BATCH SELECTION (submitForScraping):
+ *   - coveredByDomainWide suggestion with no post-deploy scrape confirmation → appended
+ *     to the returned scrape batch, additively.
+ *   - coveredByDomainWide suggestion already confirmed deployed after the deploy date →
+ *     not appended.
+ *   - No NEW prerender opportunity yet → no error, nothing extra appended.
+ *
+ * WRITE-BACK (processContentAndGenerateOpportunities):
+ *   - This run confirms isDeployedAtEdge: false for a coveredByDomainWide suggestion's
+ *     URL → the flag is cleared and the suggestion is saved.
+ *   - This run confirms isDeployedAtEdge: true → left unchanged.
+ *   - This run's scrape for that URL errors → left unchanged (no false-negative clear).
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import {
+  submitForScraping,
+  processContentAndGenerateOpportunities,
+} from '../../../../src/prerender/handler.js';
+import {
+  buildContext,
+  buildSite,
+  buildS3Client,
+  buildDataAccess,
+  buildOpportunity,
+  buildSuggestion,
+  buildUrlS3Content,
+  statusKey,
+  buildStatus,
+} from './helpers.js';
+
+use(sinonChai);
+
+const SITE_ID = 'test-site-id';
+const BASE_URL = 'https://example.com';
+
+describe('Prerender behaviour — LLMO-7052 coveredByDomainWide reconciliation', () => {
+  let sandbox;
+
+  beforeEach(() => { sandbox = sinon.createSandbox(); });
+  afterEach(() => { sandbox.restore(); });
+
+  describe('batch selection (submitForScraping)', () => {
+    function buildBatchSelectionContext(overrides) {
+      return buildContext(sandbox, {
+        site: buildSite({ id: SITE_ID, baseUrl: BASE_URL }),
+        s3Client: buildS3Client(sandbox, { [statusKey(SITE_ID)]: buildStatus() }),
+        ...overrides,
+      });
+    }
+
+    it('appends a coveredByDomainWide URL with no post-deploy scrape confirmation, additively', async () => {
+      const deployedAt = Date.now() - (60 * 60 * 1000);
+      const url = `${BASE_URL}/covered-page`;
+      const domainWide = buildSuggestion(sandbox, {
+        id: 'dw-1',
+        data: { isDomainWide: true, edgeDeployed: deployedAt },
+      });
+      const covered = buildSuggestion(sandbox, {
+        id: 'covered-1',
+        data: { url, coveredByDomainWide: 'dw-1' },
+      });
+      const opportunity = buildOpportunity(sandbox, { suggestions: [domainWide, covered] });
+
+      const ctx = buildBatchSelectionContext({
+        dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+      });
+
+      const result = await submitForScraping(ctx);
+
+      expect(result.urls).to.deep.include({ url });
+    });
+
+    it('excludes a coveredByDomainWide URL already confirmed deployed after the deploy date', async () => {
+      const deployedAt = Date.now() - (60 * 60 * 1000);
+      const url = `${BASE_URL}/confirmed-page`;
+      const domainWide = buildSuggestion(sandbox, {
+        id: 'dw-1',
+        data: { isDomainWide: true, edgeDeployed: deployedAt },
+      });
+      const covered = buildSuggestion(sandbox, {
+        id: 'covered-1',
+        data: { url, coveredByDomainWide: 'dw-1' },
+      });
+      const opportunity = buildOpportunity(sandbox, { suggestions: [domainWide, covered] });
+
+      const ctx = buildBatchSelectionContext({
+        s3Client: buildS3Client(sandbox, {
+          [statusKey(SITE_ID)]: buildStatus({
+            pages: [{
+              url,
+              scrapingStatus: 'success',
+              scrapedAt: new Date(deployedAt + 1000).toISOString(),
+            }],
+          }),
+        }),
+        dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+      });
+
+      const result = await submitForScraping(ctx);
+
+      expect(result.urls).to.deep.equal([]);
+    });
+
+    it('does not error and appends nothing when there is no NEW prerender opportunity yet', async () => {
+      const ctx = buildBatchSelectionContext({
+        dataAccess: buildDataAccess(sandbox, { opportunities: [] }),
+      });
+
+      const result = await submitForScraping(ctx);
+
+      expect(result.urls).to.deep.equal([]);
+    });
+  });
+
+  describe('write-back (processContentAndGenerateOpportunities)', () => {
+    const scrapeJobId = 'job-1';
+
+    function buildWriteBackContext(url, opportunity, { isDeployedAtEdge, s3Error } = {}) {
+      const dataAccess = buildDataAccess(sandbox, {
+        opportunities: [opportunity],
+        scrapeUrls: [url],
+      });
+      const s3Client = s3Error
+        ? { send: sandbox.stub().rejects(s3Error) }
+        : buildS3Client(sandbox, {
+          [statusKey(SITE_ID)]: buildStatus(),
+          ...buildUrlS3Content(scrapeJobId, url, { scrapeJson: { isDeployedAtEdge } }),
+        });
+      return buildContext(sandbox, {
+        site: buildSite({ id: SITE_ID, baseUrl: BASE_URL }),
+        s3Client,
+        dataAccess,
+        scrapeResultPaths: new Map([[url, {}]]),
+        auditContext: { scrapeJobId },
+      });
+    }
+
+    it('clears coveredByDomainWide when this run confirms isDeployedAtEdge: false', async () => {
+      const url = `${BASE_URL}/covered-page`;
+      const covered = buildSuggestion(sandbox, {
+        id: 'covered-1',
+        data: { url, coveredByDomainWide: 'dw-1' },
+      });
+      const opportunity = buildOpportunity(sandbox, { suggestions: [covered] });
+      const ctx = buildWriteBackContext(url, opportunity, { isDeployedAtEdge: false });
+
+      await processContentAndGenerateOpportunities(ctx);
+
+      expect(covered.setData).to.have.been.calledWith(sinon.match((d) => !('coveredByDomainWide' in d)));
+      expect(ctx.dataAccess.Suggestion.saveMany).to.have.been.calledWith([covered]);
+    });
+
+    it('leaves coveredByDomainWide unchanged when this run confirms isDeployedAtEdge: true', async () => {
+      const url = `${BASE_URL}/covered-page`;
+      const covered = buildSuggestion(sandbox, {
+        id: 'covered-1',
+        data: { url, coveredByDomainWide: 'dw-1' },
+      });
+      const opportunity = buildOpportunity(sandbox, { suggestions: [covered] });
+      const ctx = buildWriteBackContext(url, opportunity, { isDeployedAtEdge: true });
+
+      await processContentAndGenerateOpportunities(ctx);
+
+      expect(covered.setData).to.not.have.been.called;
+      expect(ctx.dataAccess.Suggestion.saveMany).to.not.have.been.called;
+    });
+
+    it("leaves coveredByDomainWide unchanged when this run's scrape for that URL errors", async () => {
+      const url = `${BASE_URL}/covered-page`;
+      const covered = buildSuggestion(sandbox, {
+        id: 'covered-1',
+        data: { url, coveredByDomainWide: 'dw-1' },
+      });
+      const opportunity = buildOpportunity(sandbox, { suggestions: [covered] });
+      const ctx = buildWriteBackContext(url, opportunity, {
+        s3Error: Object.assign(new Error('S3 unavailable'), { name: 'S3Error' }),
+      });
+
+      await processContentAndGenerateOpportunities(ctx);
+
+      expect(covered.setData).to.not.have.been.called;
+      expect(ctx.dataAccess.Suggestion.saveMany).to.not.have.been.called;
+    });
+  });
+});

--- a/test/audits/prerender/domain-wide-reconciliation.test.js
+++ b/test/audits/prerender/domain-wide-reconciliation.test.js
@@ -586,6 +586,51 @@ describe('domain-wide-reconciliation', () => {
       expect(context.log.info).to.have.been.calledWith(sinon.match(/isAllDomainDeployedAtEdge=true/));
     });
 
+    it('does not cover a NEW per-URL suggestion when only a different query-param sibling was confirmed deployed', async () => {
+      const domainWide = domainWideSuggestion(sandbox);
+      const uncovered = buildSuggestion(sandbox, {
+        id: 'url-1',
+        data: { url: 'https://example.com/promo?v=2' },
+      });
+      const opportunity = buildOpportunity(sandbox, { suggestions: [domainWide, uncovered] });
+      const context = buildContext(sandbox);
+
+      await syncCoveredByDomainWide(
+        opportunity,
+        context,
+        [{ url: 'https://example.com/promo?v=1', isDeployedAtEdge: true }],
+      );
+
+      expect(uncovered.setData).to.not.have.been.called;
+      expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
+    });
+
+    it('covers and clears two suggestions sharing a pathname but different query strings, independently, when both are scraped this run', async () => {
+      const domainWide = domainWideSuggestion(sandbox);
+      const newlyDeployed = buildSuggestion(sandbox, {
+        id: 'url-1',
+        data: { url: 'https://example.com/promo?v=1' },
+      });
+      const rolledBack = coveredSuggestion(sandbox, { id: 'url-2', url: 'https://example.com/promo?v=2' });
+      const opportunity = buildOpportunity(sandbox, {
+        suggestions: [domainWide, newlyDeployed, rolledBack],
+      });
+      const context = buildContext(sandbox);
+
+      await syncCoveredByDomainWide(
+        opportunity,
+        context,
+        [
+          { url: 'https://example.com/promo?v=1', isDeployedAtEdge: true },
+          { url: 'https://example.com/promo?v=2', isDeployedAtEdge: false },
+        ],
+      );
+
+      expect(newlyDeployed.setData).to.have.been.calledWith(sinon.match({ coveredByDomainWide: 'domain-wide-id' }));
+      expect(rolledBack.setData).to.have.been.calledWith({ url: 'https://example.com/promo?v=2' });
+      expect(context.dataAccess.Suggestion.saveMany).to.have.been.calledWith([newlyDeployed, rolledBack]);
+    });
+
     it('does not cover an already edgeDeployed per-URL suggestion or an already-covered path suggestion', async () => {
       const domainWide = domainWideSuggestion(sandbox);
       const alreadyDeployed = buildSuggestion(sandbox, {

--- a/test/audits/prerender/domain-wide-reconciliation.test.js
+++ b/test/audits/prerender/domain-wide-reconciliation.test.js
@@ -455,7 +455,7 @@ describe('domain-wide-reconciliation', () => {
       expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
     });
 
-    it('clears coveredByDomainWide on a suggestion confirmed not deployed at edge, matching by pathname regardless of query params', async () => {
+    it('does not clear a suggestion when only a different query-param sibling was scraped', async () => {
       const suggestion = coveredSuggestion(sandbox, { id: 's1', url: 'https://example.com/a?x=1' });
       const opportunity = buildOpportunity(sandbox, { suggestions: [suggestion] });
       const context = buildContext(sandbox);
@@ -466,16 +466,11 @@ describe('domain-wide-reconciliation', () => {
         [{ url: 'https://example.com/a?y=2', isDeployedAtEdge: false }],
       );
 
-      expect(suggestion.setData).to.have.been.calledWith({ url: 'https://example.com/a?x=1' });
-      expect(suggestion.setUpdatedBy).to.have.been.calledWith('system');
-      expect(context.dataAccess.Suggestion.saveMany).to.have.been.calledWith([suggestion]);
+      expect(suggestion.setData).to.not.have.been.called;
+      expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
     });
 
-    it('does not clear a suggestion when two query-param variants of its pathname disagree this run — the positive confirmation wins', async () => {
-      // /a?x=1 confirmed deployed, /a?y=2 confirmed not deployed, same pathname /a.
-      // Without de-duplication this suggestion would match both toCover and toClear and
-      // the toClear mutation (running second) would silently win, clearing the flag even
-      // though at least one variant confirmed it's actually deployed.
+    it('clears a suggestion confirmed not deployed by its own exact URL result', async () => {
       const suggestion = coveredSuggestion(sandbox, { id: 's1', url: 'https://example.com/a?x=1' });
       const opportunity = buildOpportunity(sandbox, { suggestions: [suggestion] });
       const context = buildContext(sandbox);
@@ -483,9 +478,26 @@ describe('domain-wide-reconciliation', () => {
       await syncCoveredByDomainWide(
         opportunity,
         context,
+        [{ url: 'https://example.com/a?x=1', isDeployedAtEdge: false }],
+      );
+
+      expect(suggestion.setData).to.have.been.calledWith({ url: 'https://example.com/a?x=1' });
+      expect(suggestion.setUpdatedBy).to.have.been.calledWith('system');
+      expect(context.dataAccess.Suggestion.saveMany).to.have.been.calledWith([suggestion]);
+    });
+
+    it('does not clear a suggestion when two comparisons normalize to the same key and disagree — the positive confirmation wins', async () => {
+      // ?gclid=... is a stripped tracking param, so both normalize to the same key.
+      const suggestion = coveredSuggestion(sandbox, { id: 's1', url: 'https://example.com/a?gclid=1' });
+      const opportunity = buildOpportunity(sandbox, { suggestions: [suggestion] });
+      const context = buildContext(sandbox);
+
+      await syncCoveredByDomainWide(
+        opportunity,
+        context,
         [
-          { url: 'https://example.com/a?x=1', isDeployedAtEdge: true },
-          { url: 'https://example.com/a?y=2', isDeployedAtEdge: false },
+          { url: 'https://example.com/a?gclid=1', isDeployedAtEdge: true },
+          { url: 'https://example.com/a?gclid=2', isDeployedAtEdge: false },
         ],
       );
 

--- a/test/audits/prerender/domain-wide-reconciliation.test.js
+++ b/test/audits/prerender/domain-wide-reconciliation.test.js
@@ -155,6 +155,23 @@ describe('domain-wide-reconciliation', () => {
       expect(result).to.deep.equal([]);
     });
 
+    it('returns [] when the domain-wide suggestion has an unparseable edgeDeployed value', async () => {
+      const opportunity = buildOpportunity(sandbox, {
+        suggestions: [
+          domainWideSuggestion(sandbox, { edgeDeployed: 'not-a-valid-date' }),
+          coveredSuggestion(sandbox, { id: 's1', url: 'https://example.com/a' }),
+        ],
+      });
+      const context = buildContext(sandbox, {
+        dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+      });
+
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID, statusWithPages([]));
+
+      expect(result).to.deep.equal([]);
+      expect(context.log.warn).to.have.been.calledWith(sinon.match(/unparseable/));
+    });
+
     it('returns [] when no suggestions are coveredByDomainWide', async () => {
       const opportunity = buildOpportunity(sandbox, {
         suggestions: [
@@ -452,6 +469,44 @@ describe('domain-wide-reconciliation', () => {
       expect(suggestion.setData).to.have.been.calledWith({ url: 'https://example.com/a?x=1' });
       expect(suggestion.setUpdatedBy).to.have.been.calledWith('system');
       expect(context.dataAccess.Suggestion.saveMany).to.have.been.calledWith([suggestion]);
+    });
+
+    it('does not clear a suggestion when two query-param variants of its pathname disagree this run — the positive confirmation wins', async () => {
+      // /a?x=1 confirmed deployed, /a?y=2 confirmed not deployed, same pathname /a.
+      // Without de-duplication this suggestion would match both toCover and toClear and
+      // the toClear mutation (running second) would silently win, clearing the flag even
+      // though at least one variant confirmed it's actually deployed.
+      const suggestion = coveredSuggestion(sandbox, { id: 's1', url: 'https://example.com/a?x=1' });
+      const opportunity = buildOpportunity(sandbox, { suggestions: [suggestion] });
+      const context = buildContext(sandbox);
+
+      await syncCoveredByDomainWide(
+        opportunity,
+        context,
+        [
+          { url: 'https://example.com/a?x=1', isDeployedAtEdge: true },
+          { url: 'https://example.com/a?y=2', isDeployedAtEdge: false },
+        ],
+      );
+
+      expect(suggestion.setData).to.not.have.been.called;
+      expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
+    });
+
+    it('does not re-cover (redundant write) a NEW per-URL suggestion that is already coveredByDomainWide', async () => {
+      const domainWide = domainWideSuggestion(sandbox);
+      const alreadyCovered = coveredSuggestion(sandbox, { id: 'url-1', url: 'https://example.com/page1' });
+      const opportunity = buildOpportunity(sandbox, { suggestions: [domainWide, alreadyCovered] });
+      const context = buildContext(sandbox);
+
+      await syncCoveredByDomainWide(
+        opportunity,
+        context,
+        [{ url: 'https://example.com/page1', isDeployedAtEdge: true }],
+      );
+
+      expect(alreadyCovered.setData).to.not.have.been.called;
+      expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
     });
 
     it('clears multiple matching suggestions in a single saveMany call', async () => {

--- a/test/audits/prerender/domain-wide-reconciliation.test.js
+++ b/test/audits/prerender/domain-wide-reconciliation.test.js
@@ -580,6 +580,8 @@ describe('domain-wide-reconciliation', () => {
 
       expect(urlSuggestion.setData).to.have.been.calledWith(sinon.match({ coveredByDomainWide: 'domain-wide-id' }));
       expect(pathSuggestion.setData).to.have.been.calledWith(sinon.match({ coveredByDomainWide: 'domain-wide-id' }));
+      expect(urlSuggestion.setUpdatedBy).to.have.been.calledWith('system');
+      expect(pathSuggestion.setUpdatedBy).to.have.been.calledWith('system');
       expect(context.dataAccess.Suggestion.saveMany).to.have.been.calledWith([urlSuggestion, pathSuggestion]);
       expect(context.log.info).to.have.been.calledWith(sinon.match(/isAllDomainDeployedAtEdge=true/));
     });

--- a/test/audits/prerender/domain-wide-reconciliation.test.js
+++ b/test/audits/prerender/domain-wide-reconciliation.test.js
@@ -16,16 +16,14 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import {
   getDomainWideReconciliationCandidates,
-  reconcileCoveredByDomainWide,
+  syncCoveredByDomainWide,
 } from '../../../src/prerender/domain-wide-reconciliation.js';
 import { DOMAIN_WIDE_RECONCILIATION_BATCH_SIZE } from '../../../src/prerender/utils/constants.js';
 import {
   buildContext,
   buildDataAccess,
   buildOpportunity,
-  buildS3Client,
   buildSuggestion,
-  statusKey,
 } from './behaviour/helpers.js';
 
 use(sinonChai);
@@ -33,9 +31,10 @@ use(sinonChai);
 const SITE_ID = 'test-site-id';
 const DEPLOYED_AT = new Date('2026-08-01T00:00:00.000Z').getTime();
 
-function domainWideSuggestion(sandbox, { edgeDeployed = DEPLOYED_AT } = {}) {
+function domainWideSuggestion(sandbox, { status = 'NEW', edgeDeployed = DEPLOYED_AT } = {}) {
   return buildSuggestion(sandbox, {
     id: 'domain-wide-id',
+    status,
     data: { isDomainWide: true, ...(edgeDeployed !== undefined && { edgeDeployed }) },
   });
 }
@@ -62,7 +61,7 @@ describe('domain-wide-reconciliation', () => {
     it('returns [] when dataAccess has no Opportunity entity at all', async () => {
       const context = buildContext(sandbox, { dataAccess: {} });
 
-      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID, statusWithPages([]));
 
       expect(result).to.deep.equal([]);
     });
@@ -73,22 +72,21 @@ describe('domain-wide-reconciliation', () => {
         dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
       });
 
-      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID, statusWithPages([]));
 
       expect(result).to.deep.equal([]);
     });
 
-    it('treats a missing status.json (no pages key at all) the same as an empty page list', async () => {
+    it('treats a missing/undefined siteStatus the same as an empty page list', async () => {
       const url = 'https://example.com/no-status-json';
       const opportunity = buildOpportunity(sandbox, {
         suggestions: [domainWideSuggestion(sandbox), coveredSuggestion(sandbox, { id: 's1', url })],
       });
       const context = buildContext(sandbox, {
         dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
-        s3Client: buildS3Client(sandbox, {}),
       });
 
-      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID, undefined);
 
       expect(result).to.deep.equal([url]);
     });
@@ -98,7 +96,7 @@ describe('domain-wide-reconciliation', () => {
         dataAccess: buildDataAccess(sandbox, { opportunities: [] }),
       });
 
-      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID, statusWithPages([]));
 
       expect(result).to.deep.equal([]);
     });
@@ -109,7 +107,7 @@ describe('domain-wide-reconciliation', () => {
         dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
       });
 
-      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID, statusWithPages([]));
 
       expect(result).to.deep.equal([]);
     });
@@ -122,7 +120,7 @@ describe('domain-wide-reconciliation', () => {
         dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
       });
 
-      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID, statusWithPages([]));
 
       expect(result).to.deep.equal([]);
     });
@@ -135,7 +133,24 @@ describe('domain-wide-reconciliation', () => {
         dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
       });
 
-      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID, statusWithPages([]));
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('returns [] when the only domain-wide suggestion with edgeDeployed is OUTDATED', async () => {
+      // Bug fix: an OUTDATED domain-wide suggestion that still carries a stale edgeDeployed
+      // must not be treated as currently deployed — mirrors the NEW-status guard that
+      // getDomainWideSuggestionDeployedAtEdge already enforced pre-merge.
+      const outdatedWithEdge = domainWideSuggestion(sandbox, { status: 'OUTDATED' });
+      const opportunity = buildOpportunity(sandbox, {
+        suggestions: [outdatedWithEdge, coveredSuggestion(sandbox, { id: 's1', url: 'https://example.com/a' })],
+      });
+      const context = buildContext(sandbox, {
+        dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+      });
+
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID, statusWithPages([]));
 
       expect(result).to.deep.equal([]);
     });
@@ -151,7 +166,7 @@ describe('domain-wide-reconciliation', () => {
         dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
       });
 
-      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID, statusWithPages([]));
 
       expect(result).to.deep.equal([]);
     });
@@ -172,7 +187,7 @@ describe('domain-wide-reconciliation', () => {
         dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
       });
 
-      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID, statusWithPages([]));
 
       expect(result).to.deep.equal([]);
     });
@@ -184,10 +199,9 @@ describe('domain-wide-reconciliation', () => {
       });
       const context = buildContext(sandbox, {
         dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
-        s3Client: buildS3Client(sandbox, { [statusKey(SITE_ID)]: statusWithPages([]) }),
       });
 
-      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID, statusWithPages([]));
 
       expect(result).to.deep.equal([url]);
     });
@@ -199,16 +213,14 @@ describe('domain-wide-reconciliation', () => {
       });
       const context = buildContext(sandbox, {
         dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
-        s3Client: buildS3Client(sandbox, {
-          [statusKey(SITE_ID)]: statusWithPages([{
-            url,
-            scrapingStatus: 'success',
-            scrapedAt: new Date(DEPLOYED_AT - 1000).toISOString(),
-          }]),
-        }),
       });
+      const siteStatus = statusWithPages([{
+        url,
+        scrapingStatus: 'success',
+        scrapedAt: new Date(DEPLOYED_AT - 1000).toISOString(),
+      }]);
 
-      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID, siteStatus);
 
       expect(result).to.deep.equal([url]);
     });
@@ -220,16 +232,14 @@ describe('domain-wide-reconciliation', () => {
       });
       const context = buildContext(sandbox, {
         dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
-        s3Client: buildS3Client(sandbox, {
-          [statusKey(SITE_ID)]: statusWithPages([{
-            url,
-            scrapingStatus: 'success',
-            scrapedAt: new Date(DEPLOYED_AT + 1000).toISOString(),
-          }]),
-        }),
       });
+      const siteStatus = statusWithPages([{
+        url,
+        scrapingStatus: 'success',
+        scrapedAt: new Date(DEPLOYED_AT + 1000).toISOString(),
+      }]);
 
-      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID, siteStatus);
 
       expect(result).to.deep.equal([]);
     });
@@ -241,16 +251,14 @@ describe('domain-wide-reconciliation', () => {
       });
       const context = buildContext(sandbox, {
         dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
-        s3Client: buildS3Client(sandbox, {
-          [statusKey(SITE_ID)]: statusWithPages([{
-            url,
-            scrapingStatus: 'error',
-            scrapedAt: new Date(DEPLOYED_AT + 1000).toISOString(),
-          }]),
-        }),
       });
+      const siteStatus = statusWithPages([{
+        url,
+        scrapingStatus: 'error',
+        scrapedAt: new Date(DEPLOYED_AT + 1000).toISOString(),
+      }]);
 
-      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID, siteStatus);
 
       expect(result).to.deep.equal([url]);
     });
@@ -262,16 +270,14 @@ describe('domain-wide-reconciliation', () => {
       });
       const context = buildContext(sandbox, {
         dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
-        s3Client: buildS3Client(sandbox, {
-          [statusKey(SITE_ID)]: statusWithPages([{
-            url,
-            scrapingStatus: 'failed',
-            scrapedAt: new Date(DEPLOYED_AT + 1000).toISOString(),
-          }]),
-        }),
       });
+      const siteStatus = statusWithPages([{
+        url,
+        scrapingStatus: 'failed',
+        scrapedAt: new Date(DEPLOYED_AT + 1000).toISOString(),
+      }]);
 
-      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID, siteStatus);
 
       expect(result).to.deep.equal([url]);
     });
@@ -283,12 +289,10 @@ describe('domain-wide-reconciliation', () => {
       });
       const context = buildContext(sandbox, {
         dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
-        s3Client: buildS3Client(sandbox, {
-          [statusKey(SITE_ID)]: statusWithPages([{ scrapingStatus: 'success' }]),
-        }),
       });
+      const siteStatus = statusWithPages([{ scrapingStatus: 'success' }]);
 
-      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID, siteStatus);
 
       expect(result).to.deep.equal([url]);
     });
@@ -307,15 +311,13 @@ describe('domain-wide-reconciliation', () => {
       });
       const context = buildContext(sandbox, {
         dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
-        s3Client: buildS3Client(sandbox, {
-          [statusKey(SITE_ID)]: statusWithPages([
-            { url: urlNew, scrapingStatus: 'error', scrapedAt: new Date(DEPLOYED_AT - 1000).toISOString() },
-            { url: urlOld, scrapingStatus: 'error', scrapedAt: new Date(DEPLOYED_AT - 5000).toISOString() },
-          ]),
-        }),
       });
+      const siteStatus = statusWithPages([
+        { url: urlNew, scrapingStatus: 'error', scrapedAt: new Date(DEPLOYED_AT - 1000).toISOString() },
+        { url: urlOld, scrapingStatus: 'error', scrapedAt: new Date(DEPLOYED_AT - 5000).toISOString() },
+      ]);
 
-      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID, siteStatus);
 
       expect(result).to.deep.equal([urlMissing, urlOld, urlNew]);
     });
@@ -331,20 +333,33 @@ describe('domain-wide-reconciliation', () => {
       });
       const context = buildContext(sandbox, {
         dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
-        s3Client: buildS3Client(sandbox, { [statusKey(SITE_ID)]: statusWithPages([]) }),
       });
 
-      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID, statusWithPages([]));
 
       expect(result).to.have.length(DOMAIN_WIDE_RECONCILIATION_BATCH_SIZE);
     });
   });
 
-  describe('reconcileCoveredByDomainWide', () => {
+  describe('syncCoveredByDomainWide', () => {
+    it('falls back to empty string for baseUrl/siteId when site getBaseURL/getId are missing', async () => {
+      const suggestion = coveredSuggestion(sandbox, { id: 's1', url: 'https://example.com/a' });
+      const opportunity = buildOpportunity(sandbox, { suggestions: [suggestion] });
+      const context = buildContext(sandbox, { site: { getBaseURL: () => '', getId: () => '' } });
+
+      await syncCoveredByDomainWide(
+        opportunity,
+        context,
+        [{ url: 'https://example.com/a', isDeployedAtEdge: false }],
+      );
+
+      expect(context.dataAccess.Suggestion.saveMany).to.have.been.calledWith([suggestion]);
+    });
+
     it('no-ops when opportunity is null', async () => {
       const context = buildContext(sandbox);
 
-      await reconcileCoveredByDomainWide(null, context, [{ url: 'https://example.com/a', isDeployedAtEdge: false }]);
+      await syncCoveredByDomainWide(null, context, [{ url: 'https://example.com/a', isDeployedAtEdge: false }]);
 
       expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
     });
@@ -352,24 +367,39 @@ describe('domain-wide-reconciliation', () => {
     it('no-ops when opportunity has no getSuggestions function', async () => {
       const context = buildContext(sandbox);
 
-      await reconcileCoveredByDomainWide({}, context, [{ url: 'https://example.com/a', isDeployedAtEdge: false }]);
+      await syncCoveredByDomainWide({}, context, [{ url: 'https://example.com/a', isDeployedAtEdge: false }]);
 
       expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
     });
 
-    it('no-ops when every successful comparison confirms isDeployedAtEdge: true', async () => {
+    it('no-ops when dataAccess.Suggestion.saveMany is missing', async () => {
+      const opportunity = buildOpportunity(sandbox, {
+        suggestions: [coveredSuggestion(sandbox, { id: 's1', url: 'https://example.com/a' })],
+      });
+      const context = buildContext(sandbox, { dataAccess: { Suggestion: {} } });
+
+      await syncCoveredByDomainWide(
+        opportunity,
+        context,
+        [{ url: 'https://example.com/a', isDeployedAtEdge: false }],
+      );
+
+      // Should not throw — guard returns before touching getSuggestions at all.
+      expect(opportunity.getSuggestions).to.not.have.been.called;
+    });
+
+    it('does not save when every successful comparison confirms isDeployedAtEdge: true and there is no domain-wide suggestion', async () => {
       const opportunity = buildOpportunity(sandbox, {
         suggestions: [coveredSuggestion(sandbox, { id: 's1', url: 'https://example.com/a' })],
       });
       const context = buildContext(sandbox);
 
-      await reconcileCoveredByDomainWide(
+      await syncCoveredByDomainWide(
         opportunity,
         context,
         [{ url: 'https://example.com/a', isDeployedAtEdge: true }],
       );
 
-      expect(opportunity.getSuggestions).to.not.have.been.called;
       expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
     });
 
@@ -378,7 +408,7 @@ describe('domain-wide-reconciliation', () => {
       const opportunity = buildOpportunity(sandbox, { suggestions: [suggestion] });
       const context = buildContext(sandbox);
 
-      await reconcileCoveredByDomainWide(
+      await syncCoveredByDomainWide(
         opportunity,
         context,
         [{ url: 'https://example.com/a', isDeployedAtEdge: false }],
@@ -399,7 +429,7 @@ describe('domain-wide-reconciliation', () => {
       const opportunity = buildOpportunity(sandbox, { suggestions: [pathSuggestion, dwSuggestion] });
       const context = buildContext(sandbox);
 
-      await reconcileCoveredByDomainWide(
+      await syncCoveredByDomainWide(
         opportunity,
         context,
         [{ url: 'https://example.com/blog', isDeployedAtEdge: false }],
@@ -413,7 +443,7 @@ describe('domain-wide-reconciliation', () => {
       const opportunity = buildOpportunity(sandbox, { suggestions: [suggestion] });
       const context = buildContext(sandbox);
 
-      await reconcileCoveredByDomainWide(
+      await syncCoveredByDomainWide(
         opportunity,
         context,
         [{ url: 'https://example.com/a?y=2', isDeployedAtEdge: false }],
@@ -431,7 +461,7 @@ describe('domain-wide-reconciliation', () => {
       const opportunity = buildOpportunity(sandbox, { suggestions: [s1, s2, stillDeployed] });
       const context = buildContext(sandbox);
 
-      await reconcileCoveredByDomainWide(
+      await syncCoveredByDomainWide(
         opportunity,
         context,
         [
@@ -451,13 +481,106 @@ describe('domain-wide-reconciliation', () => {
       const context = buildContext(sandbox);
       context.dataAccess.Suggestion.saveMany.rejects(new Error('db unavailable'));
 
-      await reconcileCoveredByDomainWide(
+      await syncCoveredByDomainWide(
         opportunity,
         context,
         [{ url: 'https://example.com/a', isDeployedAtEdge: false }],
       );
 
       expect(context.log.error).to.have.been.called;
+    });
+
+    it('covers NEW per-URL and path suggestions when the domain-wide suggestion is deployed', async () => {
+      const domainWide = domainWideSuggestion(sandbox);
+      const urlSuggestion = buildSuggestion(sandbox, {
+        id: 'url-1',
+        data: { url: 'https://example.com/page1' },
+      });
+      const pathSuggestion = buildSuggestion(sandbox, {
+        id: 'path-1',
+        data: { allowedRegexPatterns: ['/blog/*'] },
+      });
+      const opportunity = buildOpportunity(sandbox, {
+        suggestions: [domainWide, urlSuggestion, pathSuggestion],
+      });
+      const context = buildContext(sandbox);
+
+      await syncCoveredByDomainWide(
+        opportunity,
+        context,
+        [{ url: 'https://example.com/page1', isDeployedAtEdge: true }],
+      );
+
+      expect(urlSuggestion.setData).to.have.been.calledWith(sinon.match({ coveredByDomainWide: 'domain-wide-id' }));
+      expect(pathSuggestion.setData).to.have.been.calledWith(sinon.match({ coveredByDomainWide: 'domain-wide-id' }));
+      expect(context.dataAccess.Suggestion.saveMany).to.have.been.calledWith([urlSuggestion, pathSuggestion]);
+      expect(context.log.info).to.have.been.calledWith(sinon.match(/isAllDomainDeployedAtEdge=true/));
+    });
+
+    it('does not cover an already edgeDeployed per-URL suggestion or an already-covered path suggestion', async () => {
+      const domainWide = domainWideSuggestion(sandbox);
+      const alreadyDeployed = buildSuggestion(sandbox, {
+        id: 'url-1',
+        data: { url: 'https://example.com/page1', edgeDeployed: 111 },
+      });
+      const alreadyCoveredPath = buildSuggestion(sandbox, {
+        id: 'path-1',
+        data: { allowedRegexPatterns: ['/blog/*'], coveredByDomainWide: 'dw-old' },
+      });
+      const opportunity = buildOpportunity(sandbox, {
+        suggestions: [domainWide, alreadyDeployed, alreadyCoveredPath],
+      });
+      const context = buildContext(sandbox);
+
+      await syncCoveredByDomainWide(
+        opportunity,
+        context,
+        [{ url: 'https://example.com/page1', isDeployedAtEdge: true }],
+      );
+
+      expect(alreadyDeployed.setData).to.not.have.been.called;
+      expect(alreadyCoveredPath.setData).to.not.have.been.called;
+      expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
+      expect(context.log.info).to.have.been.calledWith(sinon.match(/no NEW suggestions to cover/));
+    });
+
+    it('logs "no NEW suggestions to cover" when the domain-wide suggestion is deployed but no other NEW suggestions exist', async () => {
+      // The domain-wide suggestion itself is always NEW but never a coverage candidate
+      // (no url, and isPathSuggestionData excludes anything with isDomainWide) — so with
+      // no other suggestions in the opportunity, toCover is empty.
+      const domainWide = domainWideSuggestion(sandbox);
+      const opportunity = buildOpportunity(sandbox, { suggestions: [domainWide] });
+      const context = buildContext(sandbox);
+
+      await syncCoveredByDomainWide(opportunity, context, []);
+
+      expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
+      expect(context.log.info).to.have.been.calledWith(sinon.match(/no NEW suggestions to cover/));
+    });
+
+    it('covers and clears in the same run via a single saveMany call', async () => {
+      const domainWide = domainWideSuggestion(sandbox);
+      const toCover = buildSuggestion(sandbox, {
+        id: 'url-1',
+        data: { url: 'https://example.com/newly-deployed' },
+      });
+      const toClear = coveredSuggestion(sandbox, { id: 'url-2', url: 'https://example.com/rolled-back' });
+      const opportunity = buildOpportunity(sandbox, { suggestions: [domainWide, toCover, toClear] });
+      const context = buildContext(sandbox);
+
+      await syncCoveredByDomainWide(
+        opportunity,
+        context,
+        [
+          { url: 'https://example.com/newly-deployed', isDeployedAtEdge: true },
+          { url: 'https://example.com/rolled-back', isDeployedAtEdge: false },
+        ],
+      );
+
+      expect(context.dataAccess.Suggestion.saveMany).to.have.been.calledOnce;
+      const saved = context.dataAccess.Suggestion.saveMany.firstCall.args[0];
+      expect(saved).to.include(toCover);
+      expect(saved).to.include(toClear);
     });
   });
 });

--- a/test/audits/prerender/domain-wide-reconciliation.test.js
+++ b/test/audits/prerender/domain-wide-reconciliation.test.js
@@ -381,30 +381,6 @@ describe('domain-wide-reconciliation', () => {
       expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
     });
 
-    it('no-ops when opportunity has no getSuggestions function', async () => {
-      const context = buildContext(sandbox);
-
-      await syncCoveredByDomainWide({}, context, [{ url: 'https://example.com/a', isDeployedAtEdge: false }]);
-
-      expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
-    });
-
-    it('no-ops when dataAccess.Suggestion.saveMany is missing', async () => {
-      const opportunity = buildOpportunity(sandbox, {
-        suggestions: [coveredSuggestion(sandbox, { id: 's1', url: 'https://example.com/a' })],
-      });
-      const context = buildContext(sandbox, { dataAccess: { Suggestion: {} } });
-
-      await syncCoveredByDomainWide(
-        opportunity,
-        context,
-        [{ url: 'https://example.com/a', isDeployedAtEdge: false }],
-      );
-
-      // Should not throw — guard returns before touching getSuggestions at all.
-      expect(opportunity.getSuggestions).to.not.have.been.called;
-    });
-
     it('does not save when every successful comparison confirms isDeployedAtEdge: true and there is no domain-wide suggestion', async () => {
       const opportunity = buildOpportunity(sandbox, {
         suggestions: [coveredSuggestion(sandbox, { id: 's1', url: 'https://example.com/a' })],

--- a/test/audits/prerender/domain-wide-reconciliation.test.js
+++ b/test/audits/prerender/domain-wide-reconciliation.test.js
@@ -1,0 +1,463 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import {
+  getDomainWideReconciliationCandidates,
+  reconcileCoveredByDomainWide,
+} from '../../../src/prerender/domain-wide-reconciliation.js';
+import { DOMAIN_WIDE_RECONCILIATION_BATCH_SIZE } from '../../../src/prerender/utils/constants.js';
+import {
+  buildContext,
+  buildDataAccess,
+  buildOpportunity,
+  buildS3Client,
+  buildSuggestion,
+  statusKey,
+} from './behaviour/helpers.js';
+
+use(sinonChai);
+
+const SITE_ID = 'test-site-id';
+const DEPLOYED_AT = new Date('2026-08-01T00:00:00.000Z').getTime();
+
+function domainWideSuggestion(sandbox, { edgeDeployed = DEPLOYED_AT } = {}) {
+  return buildSuggestion(sandbox, {
+    id: 'domain-wide-id',
+    data: { isDomainWide: true, ...(edgeDeployed !== undefined && { edgeDeployed }) },
+  });
+}
+
+function coveredSuggestion(sandbox, { id, url, coveredByDomainWide = 'domain-wide-id' } = {}) {
+  return buildSuggestion(sandbox, {
+    id,
+    data: { url, coveredByDomainWide },
+  });
+}
+
+function statusWithPages(pages) {
+  return { pages };
+}
+
+describe('domain-wide-reconciliation', () => {
+  const sandbox = sinon.createSandbox();
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  describe('getDomainWideReconciliationCandidates', () => {
+    it('returns [] when dataAccess has no Opportunity entity at all', async () => {
+      const context = buildContext(sandbox, { dataAccess: {} });
+
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('returns [] when the matched opportunity has no getSuggestions function', async () => {
+      const opportunity = { getType: () => 'prerender' };
+      const context = buildContext(sandbox, {
+        dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+      });
+
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('treats a missing status.json (no pages key at all) the same as an empty page list', async () => {
+      const url = 'https://example.com/no-status-json';
+      const opportunity = buildOpportunity(sandbox, {
+        suggestions: [domainWideSuggestion(sandbox), coveredSuggestion(sandbox, { id: 's1', url })],
+      });
+      const context = buildContext(sandbox, {
+        dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+        s3Client: buildS3Client(sandbox, {}),
+      });
+
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+
+      expect(result).to.deep.equal([url]);
+    });
+
+    it('returns [] when there is no NEW prerender opportunity', async () => {
+      const context = buildContext(sandbox, {
+        dataAccess: buildDataAccess(sandbox, { opportunities: [] }),
+      });
+
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('returns [] when the only NEW opportunity is not a prerender opportunity', async () => {
+      const opportunity = buildOpportunity(sandbox, { type: 'other-audit-type' });
+      const context = buildContext(sandbox, {
+        dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+      });
+
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('returns [] when the opportunity has no domain-wide suggestion', async () => {
+      const opportunity = buildOpportunity(sandbox, {
+        suggestions: [coveredSuggestion(sandbox, { id: 's1', url: 'https://example.com/a' })],
+      });
+      const context = buildContext(sandbox, {
+        dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+      });
+
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('returns [] when the domain-wide suggestion has no edgeDeployed set', async () => {
+      const opportunity = buildOpportunity(sandbox, {
+        suggestions: [domainWideSuggestion(sandbox, { edgeDeployed: undefined })],
+      });
+      const context = buildContext(sandbox, {
+        dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+      });
+
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('returns [] when no suggestions are coveredByDomainWide', async () => {
+      const opportunity = buildOpportunity(sandbox, {
+        suggestions: [
+          domainWideSuggestion(sandbox),
+          buildSuggestion(sandbox, { id: 's1', data: { url: 'https://example.com/a' } }),
+        ],
+      });
+      const context = buildContext(sandbox, {
+        dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+      });
+
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('excludes domain-wide and path-type suggestions even if coveredByDomainWide is set', async () => {
+      const pathSuggestion = buildSuggestion(sandbox, {
+        id: 'path-1',
+        data: { allowedRegexPatterns: ['/blog/*'], coveredByDomainWide: 'domain-wide-id' },
+      });
+      const otherDomainWide = buildSuggestion(sandbox, {
+        id: 'dw-2',
+        data: { isDomainWide: true, coveredByDomainWide: 'domain-wide-id' },
+      });
+      const opportunity = buildOpportunity(sandbox, {
+        suggestions: [domainWideSuggestion(sandbox), pathSuggestion, otherDomainWide],
+      });
+      const context = buildContext(sandbox, {
+        dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+      });
+
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('includes a covered URL with no status.json entry at all (never scraped)', async () => {
+      const url = 'https://example.com/never-scraped';
+      const opportunity = buildOpportunity(sandbox, {
+        suggestions: [domainWideSuggestion(sandbox), coveredSuggestion(sandbox, { id: 's1', url })],
+      });
+      const context = buildContext(sandbox, {
+        dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+        s3Client: buildS3Client(sandbox, { [statusKey(SITE_ID)]: statusWithPages([]) }),
+      });
+
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+
+      expect(result).to.deep.equal([url]);
+    });
+
+    it('includes a covered URL scraped successfully before the deploy date', async () => {
+      const url = 'https://example.com/pre-deploy';
+      const opportunity = buildOpportunity(sandbox, {
+        suggestions: [domainWideSuggestion(sandbox), coveredSuggestion(sandbox, { id: 's1', url })],
+      });
+      const context = buildContext(sandbox, {
+        dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+        s3Client: buildS3Client(sandbox, {
+          [statusKey(SITE_ID)]: statusWithPages([{
+            url,
+            scrapingStatus: 'success',
+            scrapedAt: new Date(DEPLOYED_AT - 1000).toISOString(),
+          }]),
+        }),
+      });
+
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+
+      expect(result).to.deep.equal([url]);
+    });
+
+    it('excludes a covered URL confirmed successfully scraped after the deploy date', async () => {
+      const url = 'https://example.com/confirmed';
+      const opportunity = buildOpportunity(sandbox, {
+        suggestions: [domainWideSuggestion(sandbox), coveredSuggestion(sandbox, { id: 's1', url })],
+      });
+      const context = buildContext(sandbox, {
+        dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+        s3Client: buildS3Client(sandbox, {
+          [statusKey(SITE_ID)]: statusWithPages([{
+            url,
+            scrapingStatus: 'success',
+            scrapedAt: new Date(DEPLOYED_AT + 1000).toISOString(),
+          }]),
+        }),
+      });
+
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+
+      expect(result).to.deep.equal([]);
+    });
+
+    it('includes a covered URL whose only post-deploy attempt errored (does not retire it)', async () => {
+      const url = 'https://example.com/errored';
+      const opportunity = buildOpportunity(sandbox, {
+        suggestions: [domainWideSuggestion(sandbox), coveredSuggestion(sandbox, { id: 's1', url })],
+      });
+      const context = buildContext(sandbox, {
+        dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+        s3Client: buildS3Client(sandbox, {
+          [statusKey(SITE_ID)]: statusWithPages([{
+            url,
+            scrapingStatus: 'error',
+            scrapedAt: new Date(DEPLOYED_AT + 1000).toISOString(),
+          }]),
+        }),
+      });
+
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+
+      expect(result).to.deep.equal([url]);
+    });
+
+    it('includes a covered URL whose only post-deploy attempt was a bot-blocked/missing "failed" entry', async () => {
+      const url = 'https://example.com/bot-blocked';
+      const opportunity = buildOpportunity(sandbox, {
+        suggestions: [domainWideSuggestion(sandbox), coveredSuggestion(sandbox, { id: 's1', url })],
+      });
+      const context = buildContext(sandbox, {
+        dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+        s3Client: buildS3Client(sandbox, {
+          [statusKey(SITE_ID)]: statusWithPages([{
+            url,
+            scrapingStatus: 'failed',
+            scrapedAt: new Date(DEPLOYED_AT + 1000).toISOString(),
+          }]),
+        }),
+      });
+
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+
+      expect(result).to.deep.equal([url]);
+    });
+
+    it('ignores status.json page entries with no url field', async () => {
+      const url = 'https://example.com/never-scraped';
+      const opportunity = buildOpportunity(sandbox, {
+        suggestions: [domainWideSuggestion(sandbox), coveredSuggestion(sandbox, { id: 's1', url })],
+      });
+      const context = buildContext(sandbox, {
+        dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+        s3Client: buildS3Client(sandbox, {
+          [statusKey(SITE_ID)]: statusWithPages([{ scrapingStatus: 'success' }]),
+        }),
+      });
+
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+
+      expect(result).to.deep.equal([url]);
+    });
+
+    it('sorts the backlog ascending by scrapedAt, missing entries first', async () => {
+      const urlNew = 'https://example.com/newer';
+      const urlOld = 'https://example.com/older';
+      const urlMissing = 'https://example.com/missing-entry';
+      const opportunity = buildOpportunity(sandbox, {
+        suggestions: [
+          domainWideSuggestion(sandbox),
+          coveredSuggestion(sandbox, { id: 's-new', url: urlNew }),
+          coveredSuggestion(sandbox, { id: 's-old', url: urlOld }),
+          coveredSuggestion(sandbox, { id: 's-missing', url: urlMissing }),
+        ],
+      });
+      const context = buildContext(sandbox, {
+        dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+        s3Client: buildS3Client(sandbox, {
+          [statusKey(SITE_ID)]: statusWithPages([
+            { url: urlNew, scrapingStatus: 'error', scrapedAt: new Date(DEPLOYED_AT - 1000).toISOString() },
+            { url: urlOld, scrapingStatus: 'error', scrapedAt: new Date(DEPLOYED_AT - 5000).toISOString() },
+          ]),
+        }),
+      });
+
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+
+      expect(result).to.deep.equal([urlMissing, urlOld, urlNew]);
+    });
+
+    it(`caps the batch at DOMAIN_WIDE_RECONCILIATION_BATCH_SIZE (${DOMAIN_WIDE_RECONCILIATION_BATCH_SIZE})`, async () => {
+      const total = DOMAIN_WIDE_RECONCILIATION_BATCH_SIZE + 5;
+      const suggestions = Array.from({ length: total }, (_, i) => coveredSuggestion(sandbox, {
+        id: `s-${i}`,
+        url: `https://example.com/page-${i}`,
+      }));
+      const opportunity = buildOpportunity(sandbox, {
+        suggestions: [domainWideSuggestion(sandbox), ...suggestions],
+      });
+      const context = buildContext(sandbox, {
+        dataAccess: buildDataAccess(sandbox, { opportunities: [opportunity] }),
+        s3Client: buildS3Client(sandbox, { [statusKey(SITE_ID)]: statusWithPages([]) }),
+      });
+
+      const result = await getDomainWideReconciliationCandidates(context, SITE_ID);
+
+      expect(result).to.have.length(DOMAIN_WIDE_RECONCILIATION_BATCH_SIZE);
+    });
+  });
+
+  describe('reconcileCoveredByDomainWide', () => {
+    it('no-ops when opportunity is null', async () => {
+      const context = buildContext(sandbox);
+
+      await reconcileCoveredByDomainWide(null, context, [{ url: 'https://example.com/a', isDeployedAtEdge: false }]);
+
+      expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
+    });
+
+    it('no-ops when opportunity has no getSuggestions function', async () => {
+      const context = buildContext(sandbox);
+
+      await reconcileCoveredByDomainWide({}, context, [{ url: 'https://example.com/a', isDeployedAtEdge: false }]);
+
+      expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
+    });
+
+    it('no-ops when every successful comparison confirms isDeployedAtEdge: true', async () => {
+      const opportunity = buildOpportunity(sandbox, {
+        suggestions: [coveredSuggestion(sandbox, { id: 's1', url: 'https://example.com/a' })],
+      });
+      const context = buildContext(sandbox);
+
+      await reconcileCoveredByDomainWide(
+        opportunity,
+        context,
+        [{ url: 'https://example.com/a', isDeployedAtEdge: true }],
+      );
+
+      expect(opportunity.getSuggestions).to.not.have.been.called;
+      expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
+    });
+
+    it('no-ops when no suggestion is coveredByDomainWide', async () => {
+      const suggestion = buildSuggestion(sandbox, { id: 's1', data: { url: 'https://example.com/a' } });
+      const opportunity = buildOpportunity(sandbox, { suggestions: [suggestion] });
+      const context = buildContext(sandbox);
+
+      await reconcileCoveredByDomainWide(
+        opportunity,
+        context,
+        [{ url: 'https://example.com/a', isDeployedAtEdge: false }],
+      );
+
+      expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
+    });
+
+    it('does not clear domain-wide or path-type suggestions even if their pathname matches', async () => {
+      const pathSuggestion = buildSuggestion(sandbox, {
+        id: 'path-1',
+        data: { allowedRegexPatterns: ['/blog/*'], coveredByDomainWide: 'dw-1', url: 'https://example.com/blog' },
+      });
+      const dwSuggestion = buildSuggestion(sandbox, {
+        id: 'dw-1',
+        data: { isDomainWide: true, coveredByDomainWide: 'dw-1', url: 'https://example.com/blog' },
+      });
+      const opportunity = buildOpportunity(sandbox, { suggestions: [pathSuggestion, dwSuggestion] });
+      const context = buildContext(sandbox);
+
+      await reconcileCoveredByDomainWide(
+        opportunity,
+        context,
+        [{ url: 'https://example.com/blog', isDeployedAtEdge: false }],
+      );
+
+      expect(context.dataAccess.Suggestion.saveMany).to.not.have.been.called;
+    });
+
+    it('clears coveredByDomainWide on a suggestion confirmed not deployed at edge, matching by pathname regardless of query params', async () => {
+      const suggestion = coveredSuggestion(sandbox, { id: 's1', url: 'https://example.com/a?x=1' });
+      const opportunity = buildOpportunity(sandbox, { suggestions: [suggestion] });
+      const context = buildContext(sandbox);
+
+      await reconcileCoveredByDomainWide(
+        opportunity,
+        context,
+        [{ url: 'https://example.com/a?y=2', isDeployedAtEdge: false }],
+      );
+
+      expect(suggestion.setData).to.have.been.calledWith({ url: 'https://example.com/a?x=1' });
+      expect(suggestion.setUpdatedBy).to.have.been.calledWith('system');
+      expect(context.dataAccess.Suggestion.saveMany).to.have.been.calledWith([suggestion]);
+    });
+
+    it('clears multiple matching suggestions in a single saveMany call', async () => {
+      const s1 = coveredSuggestion(sandbox, { id: 's1', url: 'https://example.com/a' });
+      const s2 = coveredSuggestion(sandbox, { id: 's2', url: 'https://example.com/b' });
+      const stillDeployed = coveredSuggestion(sandbox, { id: 's3', url: 'https://example.com/c' });
+      const opportunity = buildOpportunity(sandbox, { suggestions: [s1, s2, stillDeployed] });
+      const context = buildContext(sandbox);
+
+      await reconcileCoveredByDomainWide(
+        opportunity,
+        context,
+        [
+          { url: 'https://example.com/a', isDeployedAtEdge: false },
+          { url: 'https://example.com/b', isDeployedAtEdge: false },
+          { url: 'https://example.com/c', isDeployedAtEdge: true },
+        ],
+      );
+
+      expect(context.dataAccess.Suggestion.saveMany).to.have.been.calledWith([s1, s2]);
+      expect(stillDeployed.setData).to.not.have.been.called;
+    });
+
+    it('logs and swallows an error from saveMany without throwing', async () => {
+      const suggestion = coveredSuggestion(sandbox, { id: 's1', url: 'https://example.com/a' });
+      const opportunity = buildOpportunity(sandbox, { suggestions: [suggestion] });
+      const context = buildContext(sandbox);
+      context.dataAccess.Suggestion.saveMany.rejects(new Error('db unavailable'));
+
+      await reconcileCoveredByDomainWide(
+        opportunity,
+        context,
+        [{ url: 'https://example.com/a', isDeployedAtEdge: false }],
+      );
+
+      expect(context.log.error).to.have.been.called;
+    });
+  });
+});

--- a/test/audits/prerender/handler.test.js
+++ b/test/audits/prerender/handler.test.js
@@ -5366,8 +5366,9 @@ describe('Prerender Audit', () => {
       const res = await mockHandler.submitForScraping(ctx);
 
       expect(res.urls).to.deep.equal([{ url: 'http://[invalid' }]);
-      // Four calls: one per source (organic, included, agentic) + one cross-source dedup
-      expect(mergeAndGetUniqueHtmlUrlsStub).to.have.callCount(4);
+      // Five calls: one per source (organic, included, agentic) + one cross-source dedup
+      // + one merge with the (empty) domain-wide reconciliation batch (LLMO-7052).
+      expect(mergeAndGetUniqueHtmlUrlsStub).to.have.callCount(5);
     });
 
     it('should use catch-path sheet fallback and hit toPath catch in fallback', async () => {

--- a/test/audits/prerender/handler.test.js
+++ b/test/audits/prerender/handler.test.js
@@ -9176,7 +9176,7 @@ describe('Prerender Audit', () => {
     });
   });
 
-  describe('skipNewSuggestionsWhenDomainDeployed / markDeployedUrlSuggestionsAsCovered', () => {
+  describe('LLMO-7052: syncCoveredByDomainWide (add + remove, merged)', () => {
     // HTML pair that produces contentGainRatio > CONTENT_GAIN_THRESHOLD (1.1) so prerender is detected
     const serverHtml = '<html><body><p>Short</p></body></html>';
     const clientHtml = '<html><body><p>Short</p><p>Much more dynamic content loaded by JavaScript making the page significantly longer than the server-side render and pushing the content gain ratio well above the threshold</p></body></html>';
@@ -9219,8 +9219,10 @@ describe('Prerender Audit', () => {
       let currentData = { ...data };
       return {
         getId: () => id,
+        getStatus: () => 'NEW',
         getData: () => currentData,
         setData: (newData) => { currentData = newData; },
+        setUpdatedBy: () => {},
       };
     };
 
@@ -9231,20 +9233,21 @@ describe('Prerender Audit', () => {
       const pathSuggestion = buildSuggestionWithSetData('ps1', { allowedRegexPatterns: ['/products/*'], pathScore: 2.5 });
 
       const saveManyStub = sandbox.stub().resolves();
-      const allByOpportunityIdAndStatusStub = sandbox.stub().resolves([newSuggestion1, newSuggestion2, pathSuggestion]);
 
-      const mockHandler = await buildMockHandler(sandbox, [domainWideSuggestion]);
+      const mockHandler = await buildMockHandler(
+        sandbox,
+        [domainWideSuggestion, newSuggestion1, newSuggestion2, pathSuggestion],
+      );
       const context = buildContext(sandbox, {
         dataAccess: {
           SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([]) },
           LatestAudit: { updateByKeys: sandbox.stub().resolves() },
-          Suggestion: { allByOpportunityIdAndStatus: allByOpportunityIdAndStatusStub, saveMany: saveManyStub },
+          Suggestion: { saveMany: saveManyStub },
         },
       });
 
       await mockHandler.processContentAndGenerateOpportunities(context);
 
-      expect(allByOpportunityIdAndStatusStub).to.have.been.calledOnce;
       expect(saveManyStub).to.have.been.calledOnce;
       expect(newSuggestion1.getData().coveredByDomainWide).to.equal('dw-1');
       expect(newSuggestion2.getData().coveredByDomainWide).to.equal('dw-1');
@@ -9253,26 +9256,26 @@ describe('Prerender Audit', () => {
       expect(context.log.info).to.have.been.calledWith(sinon.match(/All domain deployed: marking.*per-URL and.*path suggestions as coveredByDomainWide/));
     });
 
-    it('should skip saveMany when no NEW suggestions exist', async () => {
+    it('should skip saveMany when there are no other NEW suggestions to cover', async () => {
+      // The domain-wide suggestion itself is always NEW but is never a coverage candidate
+      // (no url, and isPathSuggestionData excludes anything with isDomainWide=true).
       const domainWideSuggestion = { getStatus: () => 'NEW', getId: () => 'dw-1', getData: () => ({ isDomainWide: true, edgeDeployed: 1234567890 }) };
 
       const saveManyStub = sandbox.stub().resolves();
-      const allByOpportunityIdAndStatusStub = sandbox.stub().resolves([]);
 
       const mockHandler = await buildMockHandler(sandbox, [domainWideSuggestion]);
       const context = buildContext(sandbox, {
         dataAccess: {
           SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([]) },
           LatestAudit: { updateByKeys: sandbox.stub().resolves() },
-          Suggestion: { allByOpportunityIdAndStatus: allByOpportunityIdAndStatusStub, saveMany: saveManyStub },
+          Suggestion: { saveMany: saveManyStub },
         },
       });
 
       await mockHandler.processContentAndGenerateOpportunities(context);
 
-      expect(allByOpportunityIdAndStatusStub).to.have.been.calledOnce;
       expect(saveManyStub).to.not.have.been.called;
-      expect(context.log.info).to.have.been.calledWith(sinon.match(/markDeployedUrlSuggestionsAsCovered: no NEW suggestions found/));
+      expect(context.log.info).to.have.been.calledWith(sinon.match(/no NEW suggestions to cover/));
     });
 
     it('should only set coveredByDomainWide on the deployed-URL suggestion, preserving the non-deployed one', async () => {
@@ -9283,14 +9286,16 @@ describe('Prerender Audit', () => {
       const nonDeployedSuggestion = buildSuggestionWithSetData('s-not-deployed', { url: 'https://example.com/other-page' });
 
       const saveManyStub = sandbox.stub().resolves();
-      const allByOpportunityIdAndStatusStub = sandbox.stub().resolves([deployedSuggestion, nonDeployedSuggestion]);
 
-      const mockHandler = await buildMockHandler(sandbox, [domainWideSuggestion]);
+      const mockHandler = await buildMockHandler(
+        sandbox,
+        [domainWideSuggestion, deployedSuggestion, nonDeployedSuggestion],
+      );
       const context = buildContext(sandbox, {
         dataAccess: {
           SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([]) },
           LatestAudit: { updateByKeys: sandbox.stub().resolves() },
-          Suggestion: { allByOpportunityIdAndStatus: allByOpportunityIdAndStatusStub, saveMany: saveManyStub },
+          Suggestion: { saveMany: saveManyStub },
         },
       });
 
@@ -9310,14 +9315,16 @@ describe('Prerender Audit', () => {
       const normalSuggestion = buildSuggestionWithSetData('s-normal', { url: 'https://example.com/page1' });
 
       const saveManyStub = sandbox.stub().resolves();
-      const allByOpportunityIdAndStatusStub = sandbox.stub().resolves([alreadyDeployedSuggestion, normalSuggestion]);
 
-      const mockHandler = await buildMockHandler(sandbox, [domainWideSuggestion]);
+      const mockHandler = await buildMockHandler(
+        sandbox,
+        [domainWideSuggestion, alreadyDeployedSuggestion, normalSuggestion],
+      );
       const context = buildContext(sandbox, {
         dataAccess: {
           SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([]) },
           LatestAudit: { updateByKeys: sandbox.stub().resolves() },
-          Suggestion: { allByOpportunityIdAndStatus: allByOpportunityIdAndStatusStub, saveMany: saveManyStub },
+          Suggestion: { saveMany: saveManyStub },
         },
       });
 
@@ -9334,20 +9341,18 @@ describe('Prerender Audit', () => {
       const newSuggestion = buildSuggestionWithSetData('s1', { url: 'https://other.com/page' });
 
       const saveManyStub = sandbox.stub().resolves();
-      const allByOpportunityIdAndStatusStub = sandbox.stub().resolves([newSuggestion]);
 
-      const mockHandler = await buildMockHandler(sandbox, [domainWideSuggestion]);
+      const mockHandler = await buildMockHandler(sandbox, [domainWideSuggestion, newSuggestion]);
       const context = buildContext(sandbox, {
         dataAccess: {
           SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([]) },
           LatestAudit: { updateByKeys: sandbox.stub().resolves() },
-          Suggestion: { allByOpportunityIdAndStatus: allByOpportunityIdAndStatusStub, saveMany: saveManyStub },
+          Suggestion: { saveMany: saveManyStub },
         },
       });
 
       await mockHandler.processContentAndGenerateOpportunities(context);
 
-      expect(allByOpportunityIdAndStatusStub).to.have.been.calledOnce;
       expect(saveManyStub).to.not.have.been.called;
       expect(context.log.info).to.have.been.calledWith(sinon.match(/no NEW suggestions to cover/));
     });
@@ -9359,7 +9364,6 @@ describe('Prerender Audit', () => {
       const newSuggestion = buildSuggestionWithSetData('s1', { url: 'https://example.com/page1' });
 
       const saveManyStub = sandbox.stub().resolves();
-      const allByOpportunityIdAndStatusStub = sandbox.stub().resolves([newSuggestion]);
 
       const s3ClientNoEdge = {
         send: sandbox.stub().callsFake((command) => {
@@ -9372,13 +9376,13 @@ describe('Prerender Audit', () => {
         }),
       };
 
-      const mockHandler = await buildMockHandler(sandbox, [domainWideSuggestion]);
+      const mockHandler = await buildMockHandler(sandbox, [domainWideSuggestion, newSuggestion]);
       const context = buildContext(sandbox, {
         s3Client: s3ClientNoEdge,
         dataAccess: {
           SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([]) },
           LatestAudit: { updateByKeys: sandbox.stub().resolves() },
-          Suggestion: { allByOpportunityIdAndStatus: allByOpportunityIdAndStatusStub, saveMany: saveManyStub },
+          Suggestion: { saveMany: saveManyStub },
         },
       });
 
@@ -9418,18 +9422,17 @@ describe('Prerender Audit', () => {
       const newSuggestion = buildSuggestionWithSetData('s1', { url: 'https://example.com/page1' });
 
       const saveManyStub = sandbox.stub().resolves();
-      const allByOpportunityIdAndStatusStub = sandbox.stub().resolves([newSuggestion]);
 
       // OUTDATED suggestions appear before the deployed one — this is the real-world order
       const mockHandler = await buildMockHandler(
         sandbox,
-        [outdatedDomainWide1, outdatedDomainWide2, deployedDomainWide],
+        [outdatedDomainWide1, outdatedDomainWide2, deployedDomainWide, newSuggestion],
       );
       const context = buildContext(sandbox, {
         dataAccess: {
           SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([]) },
           LatestAudit: { updateByKeys: sandbox.stub().resolves() },
-          Suggestion: { allByOpportunityIdAndStatus: allByOpportunityIdAndStatusStub, saveMany: saveManyStub },
+          Suggestion: { saveMany: saveManyStub },
         },
       });
 
@@ -9486,7 +9489,7 @@ describe('Prerender Audit', () => {
       expect(saveManyStub).to.not.have.been.called;
     });
 
-    it('should skip when SuggestionDA methods are missing', async () => {
+    it('should skip when SuggestionDA.saveMany is missing', async () => {
       const domainWideSuggestion = { getStatus: () => 'NEW', getId: () => 'dw-1', getData: () => ({ isDomainWide: true, edgeDeployed: 1234567890 }) };
 
       const mockHandler = await buildMockHandler(sandbox, [domainWideSuggestion]);
@@ -9494,7 +9497,7 @@ describe('Prerender Audit', () => {
         dataAccess: {
           SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([]) },
           LatestAudit: { updateByKeys: sandbox.stub().resolves() },
-          Suggestion: {}, // methods intentionally absent
+          Suggestion: {}, // saveMany intentionally absent
         },
       });
 
@@ -9505,18 +9508,17 @@ describe('Prerender Audit', () => {
 
     it('should handle invalid suggestion URLs gracefully in coveredByDomainWide matching', async () => {
       const domainWideSuggestion = { getStatus: () => 'NEW', getId: () => 'dw-1', getData: () => ({ isDomainWide: true, edgeDeployed: 1234567890 }) };
-      // Suggestion with an unparseable URL — triggers the catch branch in markDeployedUrlSuggestionsAsCovered
+      // Suggestion with an unparseable URL — triggers the catch branch in the add-side filter
       const invalidUrlSuggestion = buildSuggestionWithSetData('s-invalid', { url: 'not-a-valid-url' });
 
       const saveManyStub = sandbox.stub().resolves();
-      const allByOpportunityIdAndStatusStub = sandbox.stub().resolves([invalidUrlSuggestion]);
 
-      const mockHandler = await buildMockHandler(sandbox, [domainWideSuggestion]);
+      const mockHandler = await buildMockHandler(sandbox, [domainWideSuggestion, invalidUrlSuggestion]);
       const context = buildContext(sandbox, {
         dataAccess: {
           SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([]) },
           LatestAudit: { updateByKeys: sandbox.stub().resolves() },
-          Suggestion: { allByOpportunityIdAndStatus: allByOpportunityIdAndStatusStub, saveMany: saveManyStub },
+          Suggestion: { saveMany: saveManyStub },
         },
       });
 
@@ -9537,18 +9539,18 @@ describe('Prerender Audit', () => {
       const pathUncovered = buildSuggestionWithSetData('ps-plain', { allowedRegexPatterns: ['/news/*'], pathScore: 2 });
 
       const saveManyStub = sandbox.stub().resolves();
-      const allByOpportunityIdAndStatusStub = sandbox.stub().resolves([
+
+      const mockHandler = await buildMockHandler(sandbox, [
+        domainWideSuggestion,
         pathWithEdgeDeployed,
         pathAlreadyCovered,
         pathUncovered,
       ]);
-
-      const mockHandler = await buildMockHandler(sandbox, [domainWideSuggestion]);
       const context = buildContext(sandbox, {
         dataAccess: {
           SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([]) },
           LatestAudit: { updateByKeys: sandbox.stub().resolves() },
-          Suggestion: { allByOpportunityIdAndStatus: allByOpportunityIdAndStatusStub, saveMany: saveManyStub },
+          Suggestion: { saveMany: saveManyStub },
         },
       });
 
@@ -9562,22 +9564,20 @@ describe('Prerender Audit', () => {
     });
 
     it('should use empty string fallback for baseUrl/siteId when site getBaseURL/getId return empty', async () => {
-      // Covers the || '' branches on lines 98-99 and 126
       const domainWideSuggestion = { getStatus: () => 'NEW', getId: () => 'dw-1', getData: () => ({ isDomainWide: true, edgeDeployed: 1234567890 }) };
       // scrapeResultPaths has 'https://example.com/page1' — suggestion URL must match
       const newSuggestion = buildSuggestionWithSetData('s1', { url: 'https://example.com/page1' });
 
       const saveManyStub = sandbox.stub().resolves();
-      const allByOpportunityIdAndStatusStub = sandbox.stub().resolves([newSuggestion]);
 
-      const mockHandler = await buildMockHandler(sandbox, [domainWideSuggestion]);
+      const mockHandler = await buildMockHandler(sandbox, [domainWideSuggestion, newSuggestion]);
       const context = buildContext(sandbox, {
-        // getBaseURL and getId return '' — triggers the || '' fallback on lines 98-99 and 126
+        // getBaseURL and getId return '' — triggers the || '' fallback
         site: { getId: () => '', getBaseURL: () => '' },
         dataAccess: {
           SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([]) },
           LatestAudit: { updateByKeys: sandbox.stub().resolves() },
-          Suggestion: { allByOpportunityIdAndStatus: allByOpportunityIdAndStatusStub, saveMany: saveManyStub },
+          Suggestion: { saveMany: saveManyStub },
         },
       });
 


### PR DESCRIPTION
## Summary
- `coveredByDomainWide` is set immediately and unverified when a domain-wide/path suggestion is deployed (pure pattern match in `spacecat-shared-tokowaka-client`), and the only existing self-heal (`clearStaleCoverageRefs`) only clears it on a *full* domain-wide rollback — never based on a specific URL's own edge truth.
- Adds deploy-date-relative reconciliation in `src/prerender/domain-wide-reconciliation.js`, independent of Problems 1/2 (LLMO-7038/LLMO-6638, still unmerged/blocked on team decisioning):
  - `getDomainWideReconciliationCandidates` — additive daily batch (capped at `DOMAIN_WIDE_RECONCILIATION_BATCH_SIZE=200`) selecting `coveredByDomainWide` suggestions with no post-deploy scrape confirmation yet, appended on top of `DAILY_BATCH_SIZE` in `submitForScraping`.
  - `syncCoveredByDomainWide` — single-fetch/single-save write-back in `processContentAndGenerateOpportunities`, merged with the pre-existing add-side logic (previously `markNewSuggestionsAsCovered` in `handler.js`): covers newly-deployed NEW suggestions and clears the flag off any suggestion this run's scrapes confirm `isDeployedAtEdge: false` — no grace period.
  - Matching is by exact suggestion identity (`normalizePathnameWithQuery`, the same key `buildSuggestionKey` uses for suggestion identity elsewhere in this audit) — each suggestion is reconciled against its own scrape result only, never inferred from a sibling query-param variant's result. An earlier iteration matched by pathname only; changed after confirming with the edge-deploy team that their pattern matcher (`buildUrlMatcher` in `spacecat-shared-tokowaka-client`) also only matches on pathname, which raised the question of whether that pathname-only behavior should itself be revisited on the deploy side (raised separately in #project-tokowaka-scrum-updates) — this reconciliation logic now stays consistent with the rest of the audit's suggestion-identity model instead of assuming that.
  - Explicit guard against a scrape-failure edge case: `status.json` stamps `scrapedAt` on every attempt regardless of success/failure, so eligibility checks `scrapingStatus === 'success'`, not just the timestamp — a bot-blocked/failed scrape never permanently retires a URL from the reconciliation backlog.
- Design discussed and iterated in the [Prerender Audit Enhancement Requests wiki](https://wiki.corp.adobe.com/spaces/~anujmaha/pages/4016155947/Prerender+Audit+Enhancement+Requests), Problem 3.

## Test plan
- [x] `test/audits/prerender/domain-wide-reconciliation.test.js` — 36 tests, 100% lines/branches/functions on the module.
- [x] `test/audits/prerender/behaviour/domain-wide-reconciliation.test.js` — 6 public-entry-point behaviour tests, unchanged since the initial implementation; used to validate the later move/merge refactor was behavior-preserving.
- [x] Full `test/audits/prerender/` suite passes (685/685), no regressions.
- [x] Full repo suite: pre-existing ~9-10 unrelated failures reproduce identically on clean `main` (cited-analysis, CWV, broken-internal-links, product-metatags, sitemap, meta-tags).
- [x] Lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
