### PR TITLE
feat(offsite): adopt phase-prefixed event names for offsite audit logging (LLMO-6973)

### DIFF
--- a/docs/decisions/002-offsite-structured-logging-taxonomy.md
+++ b/docs/decisions/002-offsite-structured-logging-taxonomy.md
@@ -45,13 +45,12 @@ silent-event gaps.
    post-processor. The field NAMES match the Mystique side so Splunk
    `stats ... by domain, audit, event, outcome` works across both sourcetypes.
 
-4. **`audit_persist` is logged via an offsite-only post-processor**, prepended/
-   appended to the offsite builders' `.withPostProcessors([...])`, rather than
-   editing the generic `common/base-audit.js`. Zero impact on the other ~100
-   audits.
+4. **`audit_persistence_run_recorded` is logged via an offsite-only post-processor**,
+   prepended/appended to the offsite builders' `.withPostProcessors([...])`, rather than
+   editing the generic `common/base-audit.js`. Zero impact on the other ~100 audits.
 
 5. **Silent failure modes are made loud, but behavior is unchanged.** e.g. the
-   guidance-handler DB-write failure now emits `opportunity_persist outcome=failure`
+   guidance-handler DB-write failure now emits `audit_persistence_opportunity_persisted outcome=failure`
    at error level, but the existing ack-without-retry control flow is left as-is
    (that is a separate correctness question, out of scope for this logging change).
 
@@ -76,14 +75,14 @@ silent-event gaps.
   `imsOrgId`). This keeps an `outcome=skip` Splunk query at a single level.
 - **Errors go through `errorField(err)`**, never interpolated into the free-text message, so the
   message stays injection-safe and `errorName`/`errorMessage` are queryable fields. The unclassified
-  catch-all `guidance_complete` failure additionally passes the raw Error to `failure(...)` for stack
+  catch-all `audit_persistence_completed` failure additionally passes the raw Error to `failure(...)` for stack
   capture in CloudWatch.
 
 ## Consequences
 
 - Splunk can `stats by audit, event, outcome, peer`, alert on
-  `event=opportunity_persist outcome=failure` and
-  `event=drs_poll outcome=failure reason=budget_exceeded`, and follow a run by
+  `event=audit_persistence_opportunity_persisted outcome=failure` and
+  `event=data_acquisition_scrape_job_status_polled outcome=failure reason=budget_exceeded`, and follow a run by
   `siteId`/`auditId` as extracted fields.
 - Shared/generic utils (`analysis-fetch.js`, `brand-resolver.js`,
   `base-audit.js`, `data-access.js`) are intentionally left untouched; offsite

--- a/docs/specs/2026-07-31-offsite-structured-logging.md
+++ b/docs/specs/2026-07-31-offsite-structured-logging.md
@@ -39,33 +39,44 @@ sink does not surface a second-arg object to Splunk — see ADR 002).
   `start/success/skip/failure/warn/debug(event, message, extra)` (each emits one
   string arg) and `.with(moreIds)`.
 - `withAuditPersistLog(audit)` — an offsite-only AuditBuilder post-processor that
-  logs `audit_persist` using the framework-set `context.audit` / `auditData.id`.
+  logs `audit_persistence_run_recorded` using the framework-set `context.audit` / `auditData.id`.
 
 ### Events (by component)
-- Collector `offsite-brand-presence/handler.js`: `audit_start`, `brand_data_load`,
-  `url_extract`, `url_store_write`, `drs_submit`, `drs_poll_schedule`,
-  `audit_complete`, `audit_persist`.
-- Poll `drs-status-handler.js`: `drs_poll`, `analysis_dispatch`,
-  `drs_poll_reschedule`, `poll_summary`, `cooldown_check`.
-- Analysis runners: `audit_start`, `config_resolve`, `url_store_read`,
-  `drs_availability`, `store_fetch_complete` (carries `status=`), `scrape_request`,
-  `url_limit_resolve`, `mystique_dispatch`, `audit_persist`.
-- Guidance handlers + `common/offsite-refresh.js`: `guidance_receive`,
-  `analysis_fetch`, `opportunity_persist`, `suggestion_sync`, `opportunity_retire`,
-  `opportunity_resolve`, `guidance_complete`.
+- Collector `offsite-brand-presence/handler.js`: `audit_orchestration_started`,
+  `data_acquisition_bp_data_source_selected`, `data_acquisition_bp_data_semrush_read`,
+  `data_acquisition_bp_data_urls_extracted_enriched`, `data_acquisition_store_urls_written`,
+  `data_acquisition_scrape_job_submitted`, `data_acquisition_scrape_job_poll_scheduled`,
+  `audit_orchestration_guideline_store_written`, `audit_orchestration_completed`,
+  `audit_persistence_run_recorded`.
+- Poll `drs-status-handler.js`: `data_acquisition_scrape_job_status_polled`,
+  `data_acquisition_analysis_request_handoff`, `data_acquisition_scrape_job_poll_rescheduled`,
+  `data_acquisition_scrape_job_poll_summary_notified`, `data_acquisition_cooldown_checked`.
+- Analysis runners: `audit_orchestration_started`, `audit_orchestration_brand_profile_resolved`,
+  `data_acquisition_store_urls_read`, `data_acquisition_scrape_job_status_polled`,
+  `data_acquisition_completed` (carries `status=`), `data_acquisition_scrape_job_submitted`,
+  `audit_analysis_url_limit_resolved`, `audit_analysis_mystique_request_handoff`,
+  `audit_persistence_run_recorded`.
+- Guidance handlers + `common/offsite-refresh.js`: `audit_analysis_completed`,
+  `audit_persistence_payload_fetched`, `audit_persistence_opportunity_persisted`,
+  `audit_persistence_suggestions_synced`, `audit_persistence_opportunity_retired`,
+  `audit_persistence_opportunity_resolved`, `audit_persistence_completed`.
 
 ### Gaps closed (P1–P4)
-- P1: `drs_submit` skip/failure reasons (no_ims_org, not_configured, submit_rejected);
-  loud `drs_poll_schedule` failure + `no_jobs` skip; `drs_poll_reschedule` failure
-  (re-throw preserved); per-source `drs_poll outcome=failure reason=budget_exceeded|scrape_failed`
-  at deadline; per-iteration `drs_poll outcome=start` snapshot.
-- P2: `brand_data_load` success/failure/skip with `source`/`rows`; `url_store_read`
-  failure; self-heal `scrape_request` (un-prefixed lines fixed); `store_fetch_complete`
-  status token; `analysis_dispatch` failure + `cooldown` skip.
-- P3: `mystique_dispatch` success/failure.
-- P4: `audit_persist` (via post-processor); `opportunity_persist` success **and** the
-  previously-silent DB-write failure made loud; `analysis_fetch` success/failure;
-  `suggestion_sync`; `opportunity_retire`.
+- P1: `data_acquisition_scrape_job_submitted` skip/failure reasons (no_ims_org,
+  not_configured, submit_rejected); loud `data_acquisition_scrape_job_poll_scheduled`
+  failure + `no_jobs` skip; `data_acquisition_scrape_job_poll_rescheduled` failure
+  (re-throw preserved); per-source `data_acquisition_scrape_job_status_polled
+  outcome=failure reason=budget_exceeded|scrape_failed` at deadline; per-iteration
+  `data_acquisition_scrape_job_status_polled outcome=start` snapshot.
+- P2: `data_acquisition_bp_data_*` success/failure/skip with `source`/`rows`;
+  `data_acquisition_store_urls_read` failure; self-heal `data_acquisition_scrape_job_submitted`
+  (un-prefixed lines fixed); `data_acquisition_completed` status token;
+  `data_acquisition_analysis_request_handoff` failure + `data_acquisition_cooldown_checked` skip.
+- P3: `audit_analysis_mystique_request_handoff` success/failure.
+- P4: `audit_persistence_run_recorded` (via post-processor);
+  `audit_persistence_opportunity_persisted` success **and** the previously-silent
+  DB-write failure made loud; `audit_persistence_payload_fetched` success/failure;
+  `audit_persistence_suggestions_synced`; `audit_persistence_opportunity_retired`.
 
 ### Scope boundaries
 Offsite-only files were converted (collector, poll, analysis + guidance handlers,
@@ -84,6 +95,6 @@ runId threading).
 
 - `npm test` green with the 100% coverage gate.
 - In Splunk (`service=audit-worker domain=offsite`): `stats count by audit, event,
-  outcome, peer` returns rows; `event=opportunity_persist outcome=failure` and
-  `event=drs_poll outcome=failure reason=budget_exceeded` are alertable;
-  `siteId`/`auditId`/`opportunityId`/`drsJobId` appear as extracted fields.
+  outcome, peer` returns rows; `event=audit_persistence_opportunity_persisted outcome=failure`
+  and `event=data_acquisition_scrape_job_status_polled outcome=failure reason=budget_exceeded`
+  are alertable; `siteId`/`auditId`/`opportunityId`/`drsJobId` appear as extracted fields.

--- a/src/cited-analysis/guidance-handler.js
+++ b/src/cited-analysis/guidance-handler.js
@@ -46,7 +46,8 @@ const AUDIT_TYPE = Audit.AUDIT_TYPES.CITED_ANALYSIS;
 const HUMAN_PREFIX = `[offsite:${AUDIT.CITED}]`;
 
 /**
- * Classifies a presigned-analysis-fetch failure for the `analysis_fetch` reason token:
+ * Classifies a presigned-analysis-fetch failure for the `audit_persistence_payload_fetched`
+ * event's reason token:
  * URL/SSRF/shape and body-shape rejections are `validation`; network / non-2xx / timeout
  * failures are `fetch`. The messages come from analysis-fetch.js / assertPresignedUrl.
  *
@@ -75,12 +76,12 @@ export default async function handler(message, context) {
 
   const olog = createOffsiteLogger(log, { audit: AUDIT.CITED, siteId, auditId });
 
-  olog.start('guidance_receive', `Received cited analysis guidance for siteId: ${siteId}, auditId: ${auditId}`, {
+  olog.start('audit_analysis_completed', `Received cited analysis guidance for siteId: ${siteId}, auditId: ${auditId}`, {
     peer: PEER.MYSTIQUE, direction: 'inbound',
   });
 
   if (data?.error) {
-    olog.failure('guidance_receive', `Mystique returned an error for siteId: ${siteId}, auditId: ${auditId}`, {
+    olog.failure('audit_analysis_completed', `Mystique returned an error for siteId: ${siteId}, auditId: ${auditId}`, {
       peer: PEER.MYSTIQUE, direction: 'inbound', reason: 'mystique_error', mystiqueError: data.errorMessage,
     });
     return noContent();
@@ -95,11 +96,11 @@ export default async function handler(message, context) {
         log,
         prefix: HUMAN_PREFIX,
       });
-      olog.success('analysis_fetch', 'Fetched analysis from presigned URL', {
+      olog.success('audit_persistence_payload_fetched', 'Fetched analysis from presigned URL', {
         peer: PEER.S3, direction: 'inbound',
       });
     } catch (error) {
-      olog.failure('analysis_fetch', 'Error fetching from presigned URL', {
+      olog.failure('audit_persistence_payload_fetched', 'Error fetching from presigned URL', {
         peer: PEER.S3, direction: 'inbound', reason: classifyFetchFailure(error), ...errorField(error),
       });
       return badRequest(`Error fetching analysis data: ${error.message}`);
@@ -109,20 +110,20 @@ export default async function handler(message, context) {
   }
 
   if (!analysisData) {
-    olog.failure('guidance_complete', 'No analysis data provided in message', { reason: 'no_analysis_data' });
+    olog.failure('audit_persistence_completed', 'No analysis data provided in message', { reason: 'no_analysis_data' });
     return badRequest('Analysis data is required');
   }
 
   const site = await Site.findById(siteId);
   if (!site) {
-    olog.failure('guidance_complete', `Site not found for siteId: ${siteId}`, { reason: 'site_not_found' });
+    olog.failure('audit_persistence_completed', `Site not found for siteId: ${siteId}`, { reason: 'site_not_found' });
     return notFound('Site not found');
   }
 
   if (auditId) {
     const audit = await AuditModel.findById(auditId);
     if (!audit) {
-      olog.failure('guidance_complete', `Audit not found for auditId: ${auditId}`, { reason: 'audit_not_found' });
+      olog.failure('audit_persistence_completed', `Audit not found for auditId: ${auditId}`, { reason: 'audit_not_found' });
       return notFound('Audit not found');
     }
   }
@@ -134,11 +135,11 @@ export default async function handler(message, context) {
     const opportunityData = analysisData.opportunity || {};
 
     if (suggestions.length === 0) {
-      olog.skip('guidance_complete', 'No suggestions found in analysis', { reason: 'no_suggestions' });
+      olog.skip('audit_persistence_completed', 'No suggestions found in analysis', { reason: 'no_suggestions' });
       return noContent();
     }
 
-    olog.debug('guidance_receive', `Processing ${suggestions.length} suggestions`, {
+    olog.debug('audit_analysis_completed', `Processing ${suggestions.length} suggestions`, {
       count: suggestions.length, companyName,
     });
 
@@ -148,7 +149,7 @@ export default async function handler(message, context) {
 
     // Validate before mutating the evergreen opportunity.
     if (!isValidOffsiteAnalysis(analysisData, auditType)) {
-      olog.failure('guidance_complete', `Malformed analysis payload for siteId: ${siteId}; skipping update`, { reason: 'malformed_payload' });
+      olog.failure('audit_persistence_completed', `Malformed analysis payload for siteId: ${siteId}; skipping update`, { reason: 'malformed_payload' });
       return badRequest('Malformed analysis payload');
     }
 
@@ -212,17 +213,17 @@ export default async function handler(message, context) {
           data: suggestion.data,
         }),
       });
-      ologOpp.success('suggestion_sync', `Synced ${suggestions.length} suggestions`, {
+      ologOpp.success('audit_persistence_suggestions_synced', `Synced ${suggestions.length} suggestions`, {
         peer: PEER.POSTGRES, direction: 'outbound', count: suggestions.length,
       });
     } catch (error) {
-      ologOpp.failure('suggestion_sync', 'Failed to sync suggestions', {
+      ologOpp.failure('audit_persistence_suggestions_synced', 'Failed to sync suggestions', {
         peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
       });
       throw error;
     }
 
-    ologOpp.success('guidance_complete', `Successfully processed cited analysis for site: ${siteId}, company: ${companyName}, ${suggestions.length} suggestions`, {
+    ologOpp.success('audit_persistence_completed', `Successfully processed cited analysis for site: ${siteId}, company: ${companyName}, ${suggestions.length} suggestions`, {
       count: suggestions.length,
     });
     logOffsiteLlmUsage(log, HUMAN_PREFIX, siteId, opportunityData.llmUsage);
@@ -233,7 +234,7 @@ export default async function handler(message, context) {
         dataAccess, opportunity, siteId, auditType, log,
       });
     } catch (error) {
-      ologOpp.failure('outdated_suggestion_delete', `Unexpected expired OUTDATED suggestion deletion failure for auditType ${auditType}`, {
+      ologOpp.failure('audit_housekeeping_suggestions_removed', `Unexpected expired OUTDATED suggestion deletion failure for auditType ${auditType}`, {
         peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
       }, error);
     }
@@ -244,7 +245,7 @@ export default async function handler(message, context) {
         dataAccess, siteId, auditType, log,
       });
     } catch (error) {
-      ologOpp.failure('retention_delete', `Unexpected retention failure for auditType ${auditType}`, {
+      ologOpp.failure('audit_housekeeping_opportunities_removed', `Unexpected retention failure for auditType ${auditType}`, {
         peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
       }, error);
     }
@@ -283,9 +284,10 @@ export default async function handler(message, context) {
 
     return ok();
   } catch (error) {
-    // Intentional drill-down: a failure already logged by an inner event (e.g. suggestion_sync)
-    // will also surface here as guidance_complete outcome=failure - the terminal, per-run marker.
-    olog.failure('guidance_complete', 'Error processing cited analysis', { ...errorField(error) }, error);
+    // Intentional drill-down: a failure already logged by an inner event (e.g.
+    // audit_persistence_suggestions_synced) will also surface here as
+    // audit_persistence_completed outcome=failure - the terminal, per-run marker.
+    olog.failure('audit_persistence_completed', 'Error processing cited analysis', { ...errorField(error) }, error);
     return badRequest(`Error processing analysis: ${error.message}`);
   }
 }

--- a/src/cited-analysis/handler.js
+++ b/src/cited-analysis/handler.js
@@ -149,7 +149,7 @@ function partitionExcludedUrls(urls, brandTokens, olog) {
     const reason = host && isExcludedCitedHost(host, brandTokens);
     if (reason) {
       droppedCount += 1;
-      olog.debug('url_store_read', 'Excluding URL', {
+      olog.debug('data_acquisition_store_urls_read', 'Excluding URL', {
         peer: PEER.URL_STORE, direction: 'inbound', url: entry.url, reason,
       });
     } else {
@@ -171,12 +171,12 @@ async function fetchStoreData(siteId, context, site) {
   const olog = createOffsiteLogger(log, { audit: AUDIT.CITED, siteId });
   const storeClient = StoreClient.createFrom(context);
 
-  olog.start('url_store_read', `Fetching data from stores for siteId: ${siteId}`, {
+  olog.start('data_acquisition_store_urls_read', `Fetching data from stores for siteId: ${siteId}`, {
     peer: PEER.URL_STORE, direction: 'inbound',
   });
 
   const rawUrls = await storeClient.getUrls(siteId, URL_TYPES.CITED, { sortBy: 'createdAt', sortOrder: 'desc' });
-  olog.success('url_store_read', `Retrieved ${rawUrls.length} cited URLs from URL Store`, {
+  olog.success('data_acquisition_store_urls_read', `Retrieved ${rawUrls.length} cited URLs from URL Store`, {
     peer: PEER.URL_STORE, direction: 'inbound', count: rawUrls.length,
   });
 
@@ -191,7 +191,7 @@ async function fetchStoreData(siteId, context, site) {
   );
   if (ownedDroppedCount > 0) {
     olog.debug(
-      'url_store_read',
+      'data_acquisition_store_urls_read',
       `Excluded ${ownedDroppedCount} owned-domain URLs (cited analysis is 3rd-party earned only)`,
       { peer: PEER.URL_STORE, direction: 'inbound', droppedOwned: ownedDroppedCount },
     );
@@ -209,7 +209,7 @@ async function fetchStoreData(siteId, context, site) {
   );
   if (nonEarnedDroppedCount > 0) {
     olog.debug(
-      'url_store_read',
+      'data_acquisition_store_urls_read',
       `Excluded ${nonEarnedDroppedCount} non-earned/branded URLs `
       + '(social, search, deal-aggregator, or brand-owned lookalike)',
       { peer: PEER.URL_STORE, direction: 'inbound', droppedNonEarned: nonEarnedDroppedCount },
@@ -225,15 +225,15 @@ async function fetchStoreData(siteId, context, site) {
     drsClient,
     olog,
   );
-  olog.success('drs_availability', `${urls.length} cited URLs available in DRS${formatDrsExtras(counts)}`, {
+  olog.success('data_acquisition_scrape_job_status_polled', `${urls.length} cited URLs available in DRS${formatDrsExtras(counts)}`, {
     peer: PEER.DRS, direction: 'outbound', available: urls.length,
   });
 
   const topics = await computeTopicsFromBrandPresence(siteId, context, site);
-  olog.debug('topics_load', `Computed ${topics.length} topics from brand presence data`, {
+  olog.debug('audit_orchestration_brand_topics_resolved', `Computed ${topics.length} topics from brand presence data`, {
     count: topics.length,
   });
-  olog.debug('topics_load', `Brand-presence topics payload: ${JSON.stringify(topics)}`);
+  olog.debug('audit_orchestration_brand_topics_resolved', `Brand-presence topics payload: ${JSON.stringify(topics)}`);
 
   let guidelines = [];
   try {
@@ -241,7 +241,7 @@ async function fetchStoreData(siteId, context, site) {
     guidelines = sentimentConfig.guidelines ?? [];
   } catch (error) {
     if (error instanceof StoreEmptyError) {
-      olog.skip('guideline_read', 'No guidelines configured for cited-analysis, proceeding without', {
+      olog.skip('audit_orchestration_brand_guidelines_resolved', 'No guidelines configured for cited-analysis, proceeding without', {
         peer: PEER.URL_STORE, direction: 'inbound', reason: 'no_guidelines',
       });
     } else {
@@ -249,7 +249,7 @@ async function fetchStoreData(siteId, context, site) {
     }
   }
 
-  olog.success('guideline_read', `Retrieved ${guidelines.length} guidelines`, {
+  olog.success('audit_orchestration_brand_guidelines_resolved', `Retrieved ${guidelines.length} guidelines`, {
     peer: PEER.URL_STORE, direction: 'inbound', count: guidelines.length,
   });
 
@@ -278,8 +278,8 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
   // handler to report DRS / Mystique / total durations.
   const analysisStartedAt = Date.now();
 
-  olog.start('audit_start', `Starting Cited analysis audit for site: ${siteId}`);
-  olog.debug('audit_start', `auditContext: ${JSON.stringify(auditContext)}`);
+  olog.start('audit_orchestration_started', `Starting Cited analysis audit for site: ${siteId}`);
+  olog.debug('audit_orchestration_started', `auditContext: ${JSON.stringify(auditContext)}`);
 
   const enableBrandProfile = resolveEnableBrandProfile(auditContext, log, HUMAN_PREFIX);
   const forwardedUrlLimit = resolveForwardedUrlLimit(auditContext, log, HUMAN_PREFIX);
@@ -289,7 +289,7 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
     const citedConfig = getCitedConfig(site);
 
     if (!citedConfig.companyName) {
-      olog.warn('config_resolve', 'No company name configured for site, skipping audit', {
+      olog.warn('audit_orchestration_brand_profile_resolved', 'No company name configured for site, skipping audit', {
         outcome: OUTCOME.SKIP, reason: 'no_company_name',
       });
       return {
@@ -301,7 +301,7 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
       };
     }
 
-    olog.success('config_resolve', `Config: ${citedConfig.competitors.length} competitor(s)`, {
+    olog.success('audit_orchestration_brand_profile_resolved', `Config: ${citedConfig.competitors.length} competitor(s)`, {
       companyName: citedConfig.companyName,
       website: citedConfig.companyWebsite,
       competitors: citedConfig.competitors.length,
@@ -310,7 +310,7 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
       // Surfaces the misconfiguration before the SQS hop to Mystique. With an
       // empty list Mystique will only count the primary brand in Share of Voice
       // (no hardcoded fallback) — see LLMO-4909 / cited_sentiment_flow.py.
-      olog.warn('config_resolve', `No competitors configured for site ${siteId}; Share of Voice will only include the primary brand`, {
+      olog.warn('audit_orchestration_brand_profile_resolved', `No competitors configured for site ${siteId}; Share of Voice will only include the primary brand`, {
         outcome: OUTCOME.SKIP, reason: 'no_competitors',
       });
     }
@@ -321,7 +321,7 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
     // reads as a coherent sequence rather than a contradictory "no scrape needed".
     const scrapedNow = scrapedThisCycle(auditContext);
     olog.success(
-      'store_fetch_complete',
+      'data_acquisition_completed',
       scrapedNow
         ? `DRS scrape finished this cycle; ${storeData.urls.length} URL(s) ready, proceeding to Mystique`
         : `Reusing previously scraped DRS content for ${storeData.urls.length} URL(s); no new scrape needed, proceeding to Mystique`,
@@ -371,7 +371,7 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
       // A scoped scrape already ran and the store is STILL empty → the brand has no
       // cited URLs to analyze. Report a terminal message instead of looping.
       if (auditContext.drsScrapeRequested) {
-        olog.failure('url_store_read', 'URL store still empty after scrape', {
+        olog.failure('data_acquisition_store_urls_read', 'URL store still empty after scrape', {
           peer: PEER.URL_STORE, direction: 'inbound', reason: 'empty_after_scrape', ...errorField(error),
         });
         await postMessageOptional(
@@ -388,7 +388,7 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
       // First individual run with an empty store: collect + scrape just this bucket via a
       // domain-scoped offsite-brand-presence run, which re-triggers this analysis when DRS
       // completes — no need to run offsite-brand-presence for all buckets manually.
-      olog.skip('store_fetch_complete', 'URL store empty, requesting a scoped scrape for top-cited', {
+      olog.skip('data_acquisition_completed', 'URL store empty, requesting a scoped scrape for top-cited', {
         status: 'pending_scrape', peer: PEER.URL_STORE, direction: 'inbound', reason: 'empty_store',
       });
       await postMessageOptional(
@@ -419,7 +419,7 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
       const { channelId, threadTs } = slackContext || {};
       if (auditContext.drsScrapeRequested) {
         // A scrape already ran this cycle and DRS still reports no scraped content → terminal.
-        olog.failure('drs_availability', 'No DRS content available after scraping', {
+        olog.failure('data_acquisition_scrape_job_status_polled', 'No DRS content available after scraping', {
           peer: PEER.DRS, direction: 'outbound', reason: 'no_content_after_scrape', ...errorField(error),
         });
         await postMessageOptional(
@@ -433,7 +433,7 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
           fullAuditRef: url,
         };
       }
-      olog.skip('store_fetch_complete', 'URLs stored but not scraped in DRS yet, requesting a scrape for top-cited', {
+      olog.skip('data_acquisition_completed', 'URLs stored but not scraped in DRS yet, requesting a scrape for top-cited', {
         status: 'pending_scrape', peer: PEER.DRS, direction: 'outbound', reason: 'no_drs_content',
       });
       await postMessageOptional(
@@ -459,7 +459,7 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
       };
     }
 
-    olog.failure('audit_start', 'Audit failed', { ...errorField(error) });
+    olog.failure('audit_orchestration_started', 'Audit failed', { ...errorField(error) });
     return {
       auditResult: {
         success: false,
@@ -485,14 +485,14 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
   const olog = createOffsiteLogger(log, { audit: AUDIT.CITED, siteId, auditId: audit?.getId() });
 
   if (!auditResult.success) {
-    olog.skip('mystique_dispatch', 'Audit failed, skipping Mystique message', {
+    olog.skip('audit_analysis_mystique_request_handoff', 'Audit failed, skipping Mystique message', {
       peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'audit_failed',
     });
     return auditData;
   }
 
   if (!sqs || !env?.QUEUE_SPACECAT_TO_MYSTIQUE) {
-    olog.warn('mystique_dispatch', 'SQS or Mystique queue not configured, skipping message', {
+    olog.warn('audit_analysis_mystique_request_handoff', 'SQS or Mystique queue not configured, skipping message', {
       outcome: OUTCOME.SKIP, peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'not_configured',
     });
     return auditData;
@@ -502,7 +502,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     const { Site } = dataAccess;
     const site = await Site.findById(siteId);
     if (!site) {
-      olog.warn('mystique_dispatch', 'Site not found, skipping Mystique message', {
+      olog.warn('audit_analysis_mystique_request_handoff', 'Site not found, skipping Mystique message', {
         outcome: OUTCOME.SKIP, peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'site_not_found',
       });
       return auditData;
@@ -510,7 +510,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
 
     const { config, storeData } = auditResult;
     const urlLimit = config?.urlLimit ?? MYSTIQUE_URLS_LIMIT;
-    olog.success('url_limit_resolve', `urlLimit=${urlLimit} (URLs sent to Mystique)`);
+    olog.success('audit_analysis_url_limit_resolved', `urlLimit=${urlLimit} (URLs sent to Mystique)`);
 
     const { urls, sentimentConfig } = storeData;
     // Project only the fields Mystique reads (url, categories, prompts,
@@ -556,7 +556,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     try {
       brand = await resolveBrandForSite(context, site);
     } catch (brandError) {
-      olog.warn('mystique_dispatch', 'Brand resolution failed unexpectedly; proceeding without scope', {
+      olog.warn('audit_analysis_scope_resolved', 'Brand resolution failed unexpectedly; proceeding without scope', {
         peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'brand_resolution', ...errorField(brandError),
       });
     }
@@ -578,7 +578,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
       sentUrlCount -= 1;
       message.data.urls = enrichedUrls.slice(0, sentUrlCount);
       olog.warn(
-        'mystique_dispatch',
+        'audit_analysis_mystique_request_built',
         `Message size ${bytes} bytes exceeds budget; reducing to ${sentUrlCount} URLs`,
         { peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'sqs_budget' },
       );
@@ -590,7 +590,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
       const bytes = Buffer.byteLength(JSON.stringify(message), 'utf8');
       if (bytes > SQS_MAX_SAFE_BYTES) {
         olog.warn(
-          'mystique_dispatch',
+          'audit_analysis_mystique_request_built',
           `Single-URL payload (${bytes} bytes) still exceeds budget; stripping prompts`,
           { peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'sqs_budget_single' },
         );
@@ -603,12 +603,12 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
       }
     }
 
-    olog.debug('mystique_dispatch', `Built Mystique message type ${message.type}`, {
+    olog.debug('audit_analysis_mystique_request_built', `Built Mystique message type ${message.type}`, {
       peer: PEER.MYSTIQUE, direction: 'outbound',
     });
     await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, message);
     olog.success(
-      'mystique_dispatch',
+      'audit_analysis_mystique_request_handoff',
       `Queued Cited analysis request to Mystique with ${message.data.urls.length} URLs`,
       {
         peer: PEER.MYSTIQUE,
@@ -620,7 +620,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     );
     return auditData;
   } catch (error) {
-    olog.failure('mystique_dispatch', 'Failed to send Mystique message', {
+    olog.failure('audit_analysis_mystique_request_handoff', 'Failed to send Mystique message', {
       peer: PEER.MYSTIQUE, direction: 'outbound', ...errorField(error),
     });
     // Notify the Slack thread that triggered this audit so the operator knows

--- a/src/common/offsite-refresh.js
+++ b/src/common/offsite-refresh.js
@@ -112,7 +112,7 @@ export async function persistOffsiteOpportunity(
         data: mappedOpportunity.data,
         ...(mappedOpportunity.status ? { status: mappedOpportunity.status } : {}),
       });
-      olog.success('opportunity_persist', `Created ${auditType} opportunity`, {
+      olog.success('audit_persistence_opportunity_persisted', `Created ${auditType} opportunity`, {
         peer: PEER.POSTGRES,
         direction: 'outbound',
         opportunityId: created.getId(),
@@ -126,7 +126,7 @@ export async function persistOffsiteOpportunity(
     opportunityToUpdate.setUpdatedBy('system');
     await opportunityToUpdate.save();
 
-    olog.success('opportunity_persist', `Refreshed evergreen ${auditType} opportunity`, {
+    olog.success('audit_persistence_opportunity_persisted', `Refreshed evergreen ${auditType} opportunity`, {
       peer: PEER.POSTGRES,
       direction: 'outbound',
       opportunityId: opportunityToUpdate.getId(),
@@ -136,7 +136,7 @@ export async function persistOffsiteOpportunity(
   } catch (error) {
     // The sharpest edge: a silent DB write failure here strands the run. Log loudly and
     // structured, THEN rethrow unchanged so the caller's error handling is preserved.
-    olog.failure('opportunity_persist', `Failed to persist opportunity for siteId ${auditData.siteId}, auditId ${auditData.id}`, {
+    olog.failure('audit_persistence_opportunity_persisted', `Failed to persist opportunity for siteId ${auditData.siteId}, auditId ${auditData.id}`, {
       peer: PEER.POSTGRES,
       direction: 'outbound',
       reason: 'db_write',
@@ -168,7 +168,7 @@ export async function resolveEvergreenOffsiteOpportunity({
   try {
     opportunities = await Opportunity.allBySiteIdAndStatus(siteId, Oppty.STATUSES.NEW);
   } catch (e) {
-    olog.failure('opportunity_resolve', `Failed to fetch opportunities for siteId ${siteId}`, {
+    olog.failure('audit_persistence_opportunity_resolved', `Failed to fetch opportunities for siteId ${siteId}`, {
       peer: PEER.POSTGRES, direction: 'inbound', reason: 'lookup', ...errorField(e),
     });
     throw e;
@@ -187,7 +187,7 @@ export async function resolveEvergreenOffsiteOpportunity({
     (a, b) => new Date(b.getUpdatedAt()) - new Date(a.getUpdatedAt()),
   );
 
-  olog.success('opportunity_retire', `Found ${matchingOpportunities.length} NEW ${auditType} opportunities for siteId ${siteId}; retiring ${duplicates.length} duplicate(s), keeping ${evergreenOpportunity.getId()} as the evergreen opportunity`, {
+  olog.success('audit_persistence_opportunity_retired', `Found ${matchingOpportunities.length} NEW ${auditType} opportunities for siteId ${siteId}; retiring ${duplicates.length} duplicate(s), keeping ${evergreenOpportunity.getId()} as the evergreen opportunity`, {
     peer: PEER.POSTGRES, direction: 'outbound', retired: duplicates.length, kept: evergreenOpportunity.getId(),
   });
 

--- a/src/common/offsite-retention.js
+++ b/src/common/offsite-retention.js
@@ -47,7 +47,7 @@ export async function findExpiredSnapshots({
     ignoredOpportunities = await Opportunity
       .allBySiteIdAndStatus(siteId, Oppty.STATUSES.IGNORED);
   } catch (error) {
-    olog.failure('retention_lookup', `Failed to find snapshots for auditType ${auditType}`, {
+    olog.failure('audit_housekeeping_opportunities_found', `Failed to find snapshots for auditType ${auditType}`, {
       peer: PEER.POSTGRES, direction: 'inbound', ...errorField(error),
     });
     return [];
@@ -107,7 +107,7 @@ export async function deleteExpiredSnapshots({
   const snapshotIds = expiredSnapshots.map((snapshot) => snapshot.getId());
   await Opportunity.removeByIds(snapshotIds);
 
-  olog.success('retention_delete', `Deleted ${snapshotIds.length} expired snapshot(s) for auditType ${auditType}`, {
+  olog.success('audit_housekeeping_opportunities_removed', `Deleted ${snapshotIds.length} expired snapshot(s) for auditType ${auditType}`, {
     peer: PEER.POSTGRES, direction: 'outbound', eligible: allExpiredSnapshots.length, deleted: snapshotIds.length,
   });
 
@@ -165,7 +165,7 @@ export async function deleteExpiredOutdatedSuggestions({
   try {
     opportunitySuggestions = await opportunity.getSuggestions() || [];
   } catch (error) {
-    olog.failure('outdated_suggestion_lookup', `Failed to read suggestions for expired OUTDATED suggestion deletion, auditType ${auditType}`, {
+    olog.failure('audit_housekeeping_suggestions_found', `Failed to read suggestions for expired OUTDATED suggestion deletion, auditType ${auditType}`, {
       peer: PEER.POSTGRES, direction: 'inbound', ...errorField(error),
     });
     return emptyRetentionSummary;
@@ -185,12 +185,12 @@ export async function deleteExpiredOutdatedSuggestions({
       try {
         // Dependent fix-entity rows cascade-delete with their suggestions.
         await Suggestion.removeByIds(suggestionIds);
-        olog.success('outdated_suggestion_delete', `Deleted ${suggestionIds.length} expired OUTDATED suggestion(s) for auditType ${auditType}`, {
+        olog.success('audit_housekeeping_suggestions_removed', `Deleted ${suggestionIds.length} expired OUTDATED suggestion(s) for auditType ${auditType}`, {
           peer: PEER.POSTGRES, direction: 'outbound', suggestionIds,
         });
         return { deleted: suggestionBatch.length, failed: 0 };
       } catch (error) {
-        olog.failure('outdated_suggestion_delete', `Failed to delete ${suggestionBatch.length} expired OUTDATED suggestion(s), auditType ${auditType}`, {
+        olog.failure('audit_housekeeping_suggestions_removed', `Failed to delete ${suggestionBatch.length} expired OUTDATED suggestion(s), auditType ${auditType}`, {
           peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
         });
         return { deleted: 0, failed: suggestionBatch.length };
@@ -219,9 +219,9 @@ export async function deleteExpiredOutdatedSuggestions({
     failed: retentionSummary.failed,
   };
   if (retentionSummary.failed > 0) {
-    olog.failure('outdated_suggestion_retention_summary', `Expired OUTDATED suggestion deletion summary for auditType ${auditType}`, summaryFields);
+    olog.failure('audit_housekeeping_suggestions_removal_summary', `Expired OUTDATED suggestion deletion summary for auditType ${auditType}`, summaryFields);
   } else {
-    olog.success('outdated_suggestion_retention_summary', `Expired OUTDATED suggestion deletion summary for auditType ${auditType}`, summaryFields);
+    olog.success('audit_housekeeping_suggestions_removal_summary', `Expired OUTDATED suggestion deletion summary for auditType ${auditType}`, summaryFields);
   }
 
   return retentionSummary;

--- a/src/common/offsite-snapshot.js
+++ b/src/common/offsite-snapshot.js
@@ -57,7 +57,7 @@ export async function findSnapshotByTriggerAuditId({
   try {
     opportunities = await Opportunity.allBySiteIdAndStatus(siteId, Oppty.STATUSES.IGNORED);
   } catch (e) {
-    olog.failure('snapshot_lookup', `Failed to look up existing auditType ${auditType} snapshots`, {
+    olog.failure('audit_persistence_snapshot_resolved', `Failed to look up existing auditType ${auditType} snapshots`, {
       peer: PEER.POSTGRES, direction: 'inbound', ...errorField(e),
     });
     throw e;
@@ -121,7 +121,7 @@ export async function prepareSuppressedRunSnapshot({
   };
 
   if (!triggerAuditId) {
-    olog.warn('snapshot_prepare', 'Missing auditId; snapshot idempotency and traceability are unavailable', {
+    olog.warn('audit_persistence_snapshot_prepared', 'Missing auditId; snapshot idempotency and traceability are unavailable', {
       reason: 'missing_audit_id',
     });
   }
@@ -135,13 +135,13 @@ export async function prepareSuppressedRunSnapshot({
   if (existingSuppressedRunSnapshot) {
     // triggerAuditId is provably truthy here: existingSuppressedRunSnapshot can only be set
     // by the lookup above, which only runs when triggerAuditId is truthy.
-    olog.success('snapshot_prepare', `Reusing suppressed-refresh snapshot ${existingSuppressedRunSnapshot.getId()}`, {
+    olog.success('audit_persistence_snapshot_prepared', `Reusing suppressed-refresh snapshot ${existingSuppressedRunSnapshot.getId()}`, {
       peer: PEER.POSTGRES,
       snapshotId: existingSuppressedRunSnapshot.getId(),
       triggerAuditId,
     });
   } else {
-    olog.start('snapshot_prepare', 'Preparing new suppressed-refresh snapshot', {
+    olog.start('audit_persistence_snapshot_prepared', 'Preparing new suppressed-refresh snapshot', {
       triggerAuditId: triggerAuditId || undefined,
     });
   }
@@ -168,12 +168,12 @@ export async function prepareSupersededRunSnapshot({
 
   if (!evergreenOpportunity) {
     // First surfaced run: there is no previous evergreen state to preserve.
-    olog.debug('snapshot_prepare', 'No evergreen opportunity exists; no superseded-refresh snapshot is needed');
+    olog.debug('audit_persistence_snapshot_prepared', 'No evergreen opportunity exists; no superseded-refresh snapshot is needed');
     return { opportunityData, opportunityToUpdate: null };
   }
 
   if (!triggerAuditId) {
-    olog.warn('snapshot_prepare', 'Missing auditId; snapshot idempotency and traceability are unavailable', {
+    olog.warn('audit_persistence_snapshot_prepared', 'Missing auditId; snapshot idempotency and traceability are unavailable', {
       reason: 'missing_audit_id',
     });
   }
@@ -187,7 +187,7 @@ export async function prepareSupersededRunSnapshot({
   if (existingSupersededRunSnapshot) {
     // triggerAuditId is provably truthy here: existingSupersededRunSnapshot can only be set
     // by the lookup above, which only runs when triggerAuditId is truthy.
-    olog.success('snapshot_prepare', `Reusing superseded-refresh snapshot ${existingSupersededRunSnapshot.getId()}`, {
+    olog.success('audit_persistence_snapshot_prepared', `Reusing superseded-refresh snapshot ${existingSupersededRunSnapshot.getId()}`, {
       peer: PEER.POSTGRES,
       snapshotId: existingSupersededRunSnapshot.getId(),
       triggerAuditId,
@@ -235,20 +235,20 @@ export async function prepareSupersededRunSnapshot({
           ...(suggestion.getSkipDetail() ? { skipDetail: suggestion.getSkipDetail() } : {}),
         })));
         if (errorItems?.length > 0) {
-          olog.failure('snapshot_copy_suggestions', `${errorItems.length} suggestion(s) failed to copy onto snapshot ${snapshot.getId()}`, {
+          olog.failure('audit_persistence_snapshot_suggestions_copied', `${errorItems.length} suggestion(s) failed to copy onto snapshot ${snapshot.getId()}`, {
             peer: PEER.POSTGRES, opportunityId: snapshot.getId(),
           });
         }
       } catch (err) {
         // addSuggestions threw entirely — the snapshot record already exists but has no
         // suggestions. Delete the orphan so the next delivery recreates the snapshot cleanly.
-        olog.failure('snapshot_copy_suggestions', `addSuggestions threw for snapshot ${snapshot.getId()}; deleting orphan and rethrowing`, {
+        olog.failure('audit_persistence_snapshot_suggestions_copied', `addSuggestions threw for snapshot ${snapshot.getId()}; deleting orphan and rethrowing`, {
           peer: PEER.POSTGRES, opportunityId: snapshot.getId(), ...errorField(err),
         });
         try {
           await snapshot.remove();
         } catch (removeErr) {
-          olog.failure('snapshot_cleanup', `Failed to delete orphan snapshot ${snapshot.getId()}`, {
+          olog.failure('audit_persistence_snapshot_cleaned_up', `Failed to delete orphan snapshot ${snapshot.getId()}`, {
             peer: PEER.POSTGRES, opportunityId: snapshot.getId(), ...errorField(removeErr),
           });
         }
@@ -256,7 +256,7 @@ export async function prepareSupersededRunSnapshot({
       }
     }
 
-    olog.success('snapshot_prepare', `Created superseded-refresh snapshot ${snapshot.getId()} from evergreen opportunity ${evergreenOpportunity.getId()}`, {
+    olog.success('audit_persistence_snapshot_prepared', `Created superseded-refresh snapshot ${snapshot.getId()} from evergreen opportunity ${evergreenOpportunity.getId()}`, {
       peer: PEER.POSTGRES,
       opportunityId: snapshot.getId(),
       triggerAuditId: triggerAuditId || undefined,

--- a/src/offsite-brand-presence/drs-status-handler.js
+++ b/src/offsite-brand-presence/drs-status-handler.js
@@ -75,7 +75,7 @@ async function hasRecentAudit(siteId, auditType, dataAccess, log) {
     const auditedAt = new Date(latest.getAuditedAt()).getTime();
     return (Date.now() - auditedAt) < AUDIT_TRIGGER_COOLDOWN_MS;
   } catch (err) {
-    olog.warn('cooldown_check', `Failed to check recent ${auditType} audit for site ${siteId}`, {
+    olog.warn('data_acquisition_cooldown_checked', `Failed to check recent ${auditType} audit for site ${siteId}`, {
       peer: PEER.SPACECAT, direction: 'inbound', auditType, ...errorField(err),
     });
     return false;
@@ -230,7 +230,7 @@ async function triggerAnalysisAudits(
     try {
       // eslint-disable-next-line no-await-in-loop
       if (await hasRecentAudit(siteId, type, dataAccess, log)) {
-        olog.skip('analysis_dispatch', `Skipping ${type} for site ${siteId} — recent audit exists`, {
+        olog.skip('data_acquisition_analysis_request_handoff', `Skipping ${type} for site ${siteId} — recent audit exists`, {
           peer: PEER.SQS, direction: 'outbound', reason: 'cooldown', auditType: type,
         });
         handled.push(type);
@@ -256,12 +256,12 @@ async function triggerAnalysisAudits(
           ...(Object.keys(messageData).length > 0 && { messageData }),
         },
       });
-      olog.success('analysis_dispatch', `Triggered ${type} for site ${siteId}`, {
+      olog.success('data_acquisition_analysis_request_handoff', `Triggered ${type} for site ${siteId}`, {
         peer: PEER.SQS, direction: 'outbound', auditType: type,
       });
       handled.push(type);
     } catch (err) {
-      olog.warn('analysis_dispatch', `Failed to trigger ${type} analysis audit for site ${siteId}`, {
+      olog.warn('data_acquisition_analysis_request_handoff', `Failed to trigger ${type} analysis audit for site ${siteId}`, {
         peer: PEER.SQS, direction: 'outbound', auditType: type, ...errorField(err),
       });
     }
@@ -338,7 +338,7 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
   if (jobs.length === 0) {
     // ADR convention: "no jobs to poll" is the canonical .skip() case (info level,
     // outcome=skip) — not a warning. See scheduleDrsStatusPoll's analogous skip.
-    olog.skip('drs_poll', `No jobs to poll, skipping (site ${siteId})`, {
+    olog.skip('data_acquisition_scrape_job_status_polled', `No jobs to poll, skipping (site ${siteId})`, {
       peer: PEER.DRS, reason: 'no_jobs',
     });
     return ok();
@@ -356,7 +356,7 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
       const result = await drsClient.getJob(job.jobId);
       return { ...job, status: result?.status, error: result?.error_message };
     } catch (err) {
-      olog.warn('drs_poll', `getJob failed for ${job.jobId}`, {
+      olog.warn('data_acquisition_scrape_job_status_polled', `getJob failed for ${job.jobId}`, {
         peer: PEER.DRS, drsJobId: job.jobId, ...errorField(err),
       });
       return { ...job, status: undefined, error: undefined };
@@ -370,7 +370,7 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
 
   // P1-7: per-poll visibility. Emit a snapshot of terminal/total after resolving statuses
   // so the wait is observable in Splunk (previously nothing was logged on a normal poll).
-  olog.start('drs_poll', `DRS poll for ${baseURL}: ${terminalCount}/${statuses.length} jobs terminal`, {
+  olog.start('data_acquisition_scrape_job_status_polled', `DRS poll for ${baseURL}: ${terminalCount}/${statuses.length} jobs terminal`, {
     peer: PEER.DRS, terminal: terminalCount, total: statuses.length,
   });
 
@@ -392,7 +392,7 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
       enableSemrush,
     );
   } catch (err) {
-    olog.warn('analysis_dispatch', `Failed to trigger analysis audits for ${baseURL}`, {
+    olog.warn('data_acquisition_analysis_request_handoff', `Failed to trigger analysis audits for ${baseURL}`, {
       peer: PEER.SQS, direction: 'outbound', ...errorField(err),
     });
   }
@@ -422,12 +422,12 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
     try {
       await sqs.sendMessage(configuration.getQueues().audits, nextMessage, null, delaySeconds);
     } catch (err) {
-      olog.failure('drs_poll_reschedule', `Failed to re-enqueue DRS status poll for ${baseURL}`, {
+      olog.failure('data_acquisition_scrape_job_poll_rescheduled', `Failed to re-enqueue DRS status poll for ${baseURL}`, {
         peer: PEER.SQS, direction: 'outbound', ...errorField(err),
       });
       throw err;
     }
-    olog.success('drs_poll_reschedule', `${terminalCount}/${statuses.length} jobs terminal for ${baseURL}, re-polling in ${delaySeconds}s`, {
+    olog.success('data_acquisition_scrape_job_poll_rescheduled', `${terminalCount}/${statuses.length} jobs terminal for ${baseURL}, re-polling in ${delaySeconds}s`, {
       peer: PEER.SQS, direction: 'outbound', terminal: terminalCount, total: statuses.length, delaySeconds,
     });
     return ok();
@@ -445,14 +445,14 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
   // dropped source (was previously visible only as prose in the Slack summary).
   const dropped = computeDroppedAuditTypes(statuses, new Set(nextTriggered));
   for (const { auditType, reason } of dropped) {
-    olog.failure('drs_poll', `Dropping ${auditType} for ${baseURL}: no DRS success (${reason})`, {
+    olog.failure('data_acquisition_scrape_job_status_polled', `Dropping ${auditType} for ${baseURL}: no DRS success (${reason})`, {
       peer: PEER.DRS, reason, auditType,
     });
   }
 
   const summary = buildSummary(baseURL, statuses, drsStartedAt, nextTriggered);
   await postMessageOptional(context, channelId, summary, { threadTs });
-  olog.success('poll_summary', `Posted completion summary for ${baseURL} (${statuses.length} jobs)`, {
+  olog.success('data_acquisition_scrape_job_poll_summary_notified', `Posted completion summary for ${baseURL} (${statuses.length} jobs)`, {
     peer: PEER.SLACK, direction: 'outbound', jobs: statuses.length,
   });
 

--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -198,7 +198,7 @@ function classifyAndNormalize(rawUrl, siteHostname, brandTokens, olog) {
   // analysis measures earned, non-branded, non-social citations only.
   const exclusionReason = isExcludedCitedHost(hostname, brandTokens);
   if (exclusionReason) {
-    olog.debug('url_extract', 'Excluding URL', { url: rawUrl, reason: exclusionReason });
+    olog.debug('data_acquisition_bp_data_urls_extracted', 'Excluding URL', { url: rawUrl, reason: exclusionReason });
     return null;
   }
 
@@ -311,7 +311,7 @@ function extractUrlsAndTopics(data, allUrls, topicMap, olog, siteHostname, brand
     }
   }
 
-  olog.debug('url_extract', `Found ${allUrls.size} unique source URLs`, { count: allUrls.size });
+  olog.debug('data_acquisition_bp_data_urls_extracted', `Found ${allUrls.size} unique source URLs`, { count: allUrls.size });
 }
 
 /**
@@ -336,13 +336,13 @@ async function addUrlsToUrlStore(siteId, topByDomain, topCited, dataAccess, log)
     for (const url of urls) {
       entries.push({ url, audits: [config.auditType] });
     }
-    olog.debug('url_store_write', `Selected top ${urls.length} ${domain} URLs (limit ${DRS_URLS_LIMIT})`, { peer: PEER.URL_STORE, direction: 'outbound', bucket: domain });
+    olog.debug('data_acquisition_store_urls_written', `Selected top ${urls.length} ${domain} URLs (limit ${DRS_URLS_LIMIT})`, { peer: PEER.URL_STORE, direction: 'outbound', bucket: domain });
   }
   for (const url of topCited) {
     entries.push({ url, audits: [CITED_ANALYSIS_DRS_CONFIG.auditType] });
   }
-  olog.debug('url_store_write', `Selected top ${topCited.length} cited URLs excluding offsite domains (limit ${DRS_URLS_LIMIT})`, { peer: PEER.URL_STORE, direction: 'outbound', bucket: 'top-cited' });
-  olog.start('url_store_write', `Adding ${entries.length} URLs to URL store`, { peer: PEER.URL_STORE, direction: 'outbound', total: entries.length });
+  olog.debug('data_acquisition_store_urls_written', `Selected top ${topCited.length} cited URLs excluding offsite domains (limit ${DRS_URLS_LIMIT})`, { peer: PEER.URL_STORE, direction: 'outbound', bucket: 'top-cited' });
+  olog.start('data_acquisition_store_urls_written', `Adding ${entries.length} URLs to URL store`, { peer: PEER.URL_STORE, direction: 'outbound', total: entries.length });
 
   let existingUrlSet;
   try {
@@ -350,7 +350,7 @@ async function addUrlsToUrlStore(siteId, topByDomain, topCited, dataAccess, log)
     const { data: existingUrls } = await AuditUrl.batchGetByKeys(keys);
     existingUrlSet = new Set(existingUrls.map((u) => u.getUrl()));
   } catch (error) {
-    olog.failure('url_store_write', 'Failed to check existing URLs', { peer: PEER.URL_STORE, direction: 'outbound', ...errorField(error) });
+    olog.failure('data_acquisition_store_urls_written', 'Failed to check existing URLs', { peer: PEER.URL_STORE, direction: 'outbound', ...errorField(error) });
     return {};
   }
 
@@ -370,7 +370,7 @@ async function addUrlsToUrlStore(siteId, topByDomain, topCited, dataAccess, log)
         });
         return entry.url;
       } catch (createError) {
-        olog.warn('url_store_write', 'Failed to add URL to store', {
+        olog.warn('data_acquisition_store_urls_written', 'Failed to add URL to store', {
           peer: PEER.URL_STORE, direction: 'outbound', url: entry.url, ...errorField(createError),
         });
         return null;
@@ -383,7 +383,7 @@ async function addUrlsToUrlStore(siteId, topByDomain, topCited, dataAccess, log)
   const createdCount = storedUrls.size - existingCount;
   const failCount = entries.length - storedUrls.size;
 
-  olog.success('url_store_write', `URL store complete: ${createdCount} created, ${existingCount} already existed, ${failCount} failed`, {
+  olog.success('data_acquisition_store_urls_written', `URL store complete: ${createdCount} created, ${existingCount} already existed, ${failCount} failed`, {
     peer: PEER.URL_STORE, direction: 'outbound', created: createdCount, existing: existingCount, failed: failCount,
   });
 
@@ -441,7 +441,7 @@ async function addTopicsToGuidelineStore(siteId, topicMap, allUrls, dataAccess, 
   const existingByName = await fetchExistingTopicsByName(siteId, SentimentTopic);
 
   const entries = [...topicMap.entries()];
-  olog.start('guideline_store_write', `Persisting ${entries.length} topics to guideline store (${existingByName.size} existing)`, { peer: PEER.SPACECAT, direction: 'outbound', total: entries.length });
+  olog.start('audit_orchestration_guideline_store_written', `Persisting ${entries.length} topics to guideline store (${existingByName.size} existing)`, { peer: PEER.SPACECAT, direction: 'outbound', total: entries.length });
 
   const results = await Promise.all(
     entries.map(async ([name, topicData]) => {
@@ -474,7 +474,7 @@ async function addTopicsToGuidelineStore(siteId, topicMap, allUrls, dataAccess, 
         });
         return 'created';
       } catch (error) {
-        olog.warn('guideline_store_write', `Failed to save topic ${name}`, { peer: PEER.SPACECAT, direction: 'outbound', ...errorField(error) });
+        olog.warn('audit_orchestration_guideline_store_written', `Failed to save topic ${name}`, { peer: PEER.SPACECAT, direction: 'outbound', ...errorField(error) });
         return 'error';
       }
     }),
@@ -484,7 +484,7 @@ async function addTopicsToGuidelineStore(siteId, topicMap, allUrls, dataAccess, 
   const updated = results.filter((r) => r === 'updated').length;
   const failed = results.filter((r) => r === 'error').length;
 
-  olog.success('guideline_store_write', `Guideline store complete: ${created} created, ${updated} updated, ${failed} failed`, {
+  olog.success('audit_orchestration_guideline_store_written', `Guideline store complete: ${created} created, ${updated} updated, ${failed} failed`, {
     peer: PEER.SPACECAT, direction: 'outbound', created, updated, failed,
   });
 }
@@ -526,7 +526,7 @@ async function submitWithRetry({ domain, datasetId, params }, submitFn, olog) {
       const start = Date.now();
       // eslint-disable-next-line no-await-in-loop
       const result = await submitFn(params);
-      olog.success('drs_submit', `DRS job created for ${jobDataset} (${Date.now() - start}ms)`, {
+      olog.success('data_acquisition_scrape_job_submitted', `DRS job created for ${jobDataset} (${Date.now() - start}ms)`, {
         peer: PEER.DRS, direction: 'outbound', jobDataset, drsJobId: result?.job_id,
       });
       return {
@@ -534,7 +534,7 @@ async function submitWithRetry({ domain, datasetId, params }, submitFn, olog) {
       };
     } catch (err) {
       if (attempt === 0 && isRetriable(err)) {
-        olog.warn('drs_submit', `DRS job for ${jobDataset} failed (attempt 1), retrying in ${RETRY_DELAY_MS}ms`, {
+        olog.warn('data_acquisition_scrape_job_submitted', `DRS job for ${jobDataset} failed (attempt 1), retrying in ${RETRY_DELAY_MS}ms`, {
           peer: PEER.DRS, direction: 'outbound', jobDataset, retry: 1, ...errorField(err),
         });
         // eslint-disable-next-line no-await-in-loop
@@ -543,7 +543,7 @@ async function submitWithRetry({ domain, datasetId, params }, submitFn, olog) {
         });
       } else {
         const label = attempt === 0 ? '' : ' after retry';
-        olog.failure('drs_submit', `DRS job failed for ${jobDataset}${label}`, {
+        olog.failure('data_acquisition_scrape_job_submitted', `DRS job failed for ${jobDataset}${label}`, {
           peer: PEER.DRS, direction: 'outbound', jobDataset, reason: 'submit_rejected', ...errorField(err),
         });
         return {
@@ -603,7 +603,7 @@ async function triggerDrsScraping(
   const drsClient = DrsClient.createFrom(context);
 
   if (!drsClient.isConfigured()) {
-    olog.failure('drs_submit', 'DRS_API_URL or DRS_API_KEY not configured, skipping DRS scraping', {
+    olog.failure('data_acquisition_scrape_job_submitted', 'DRS_API_URL or DRS_API_KEY not configured, skipping DRS scraping', {
       peer: PEER.DRS, direction: 'outbound', reason: 'not_configured',
     });
     return { skipped: 'DRS is not configured (DRS_API_URL/DRS_API_KEY missing)', results: [] };
@@ -614,7 +614,7 @@ async function triggerDrsScraping(
   // imsOrgId set. Resolve it here as a faithful pre-flight check: if it is
   // missing we skip rather than fire jobs that are guaranteed to fail.
   if (!imsOrgId) {
-    olog.warn('drs_submit', `Site ${siteId} organization has no imsOrgId, skipping DRS scraping. Populate imsOrgId on the SpaceCat organization to enable offsite brand presence scraping.`, {
+    olog.warn('data_acquisition_scrape_job_submitted', `Site ${siteId} organization has no imsOrgId, skipping DRS scraping. Populate imsOrgId on the SpaceCat organization to enable offsite brand presence scraping.`, {
       outcome: OUTCOME.SKIP, peer: PEER.DRS, direction: 'outbound', reason: 'no_ims_org',
     });
     return {
@@ -655,7 +655,7 @@ async function triggerDrsScraping(
   }
 
   const orgSuffix = spacecatOrgId ? ` (with spacecat_org_id: ${spacecatOrgId})` : '';
-  olog.start('drs_submit', `Submitting ${jobs.length} DRS scrape jobs${orgSuffix}`, { peer: PEER.DRS, direction: 'outbound', jobs: jobs.length });
+  olog.start('data_acquisition_scrape_job_submitted', `Submitting ${jobs.length} DRS scrape jobs${orgSuffix}`, { peer: PEER.DRS, direction: 'outbound', jobs: jobs.length });
 
   const results = [];
   for (const job of jobs) {
@@ -835,7 +835,7 @@ async function scheduleDrsStatusPoll(
     .map((r) => ({ domain: r.domain, datasetId: r.datasetId, jobId: r.response.job_id }));
 
   if (jobs.length === 0) {
-    olog.skip('drs_poll_schedule', `No successfully submitted DRS jobs for ${baseURL}, not scheduling status poll`, {
+    olog.skip('data_acquisition_scrape_job_poll_scheduled', `No successfully submitted DRS jobs for ${baseURL}, not scheduling status poll`, {
       peer: PEER.SQS, direction: 'outbound', reason: 'no_jobs',
     });
     return;
@@ -860,7 +860,7 @@ async function scheduleDrsStatusPoll(
     },
   }, null, pollIntervalSeconds);
 
-  olog.success('drs_poll_schedule', `Scheduled DRS status poll for ${baseURL} (${jobs.length} jobs, every ${pollIntervalSeconds}s)`, {
+  olog.success('data_acquisition_scrape_job_poll_scheduled', `Scheduled DRS status poll for ${baseURL} (${jobs.length} jobs, every ${pollIntervalSeconds}s)`, {
     peer: PEER.SQS, direction: 'outbound', jobs: jobs.length, intervalSeconds: pollIntervalSeconds,
   });
 }
@@ -903,7 +903,7 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
   // Fail fast on an unrecognized scope: scoping to an unknown bucket would silently
   // empty every bucket and produce a no-op scrape → poll → re-trigger chain.
   if (domainScope && !VALID_DOMAIN_SCOPES.has(domainScope)) {
-    olog.failure('audit_start', `Unknown domainScope '${domainScope}', aborting run`, { reason: 'unknown_scope', domainScope });
+    olog.failure('audit_orchestration_started', `Unknown domainScope '${domainScope}', aborting run`, { reason: 'unknown_scope', domainScope });
     return {
       auditResult: { success: false, error: `Unknown domainScope: ${domainScope}` },
       fullAuditRef: finalUrl,
@@ -917,13 +917,13 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
     .map(({ week, year }) => `w${String(week).padStart(2, '0')}-${year}`)
     .join(', ');
 
-  olog.start('audit_start', `Starting audit for site: ${siteId} (${baseURL}), weeks: ${weekLabels}`);
+  olog.start('audit_orchestration_started', `Starting audit for site: ${siteId} (${baseURL}), weeks: ${weekLabels}`);
 
   let siteHostname;
   try {
     siteHostname = new URL(baseURL).hostname.replace(/^www\./, '');
   } catch {
-    olog.warn('audit_start', `Could not parse baseURL "${baseURL}", skipping site URL filter`, { outcome: OUTCOME.SKIP, reason: 'unparseable_base_url' });
+    olog.warn('audit_orchestration_started', `Could not parse baseURL "${baseURL}", skipping site URL filter`, { outcome: OUTCOME.SKIP, reason: 'unparseable_base_url' });
   }
 
   // Brand tokens drop social/search domains and brand-owned lookalikes
@@ -951,7 +951,7 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
   // Logged unconditionally (including the off case) so a Splunk search on siteId
   // alone shows whether this run even attempted Semrush and, if so, which knob
   // decided that (Slack per-run override vs the env var) — the two can disagree.
-  olog.success('data_source_select', `Semrush source ${semrushEnabled ? 'enabled' : 'disabled'} for this run`, {
+  olog.success('data_acquisition_bp_data_source_selected', `Semrush source ${semrushEnabled ? 'enabled' : 'disabled'} for this run`, {
     source: 'semrush',
     semrushEnabled,
     decidedBy: enableSemrushOverride !== undefined ? 'slack-override' : 'env-var',
@@ -989,7 +989,7 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
       const isEntitlementSkip = SEMRUSH_ENTITLEMENT_SKIP_REASONS.has(reason);
       if (hardStopOnFailure && !isEntitlementSkip) {
         // enableSemrush:true forced this run — surface the failure, no fallback.
-        olog.failure('brand_data_load', `Semrush source failed (${reason}); hard stop — no legacy fallback (enableSemrush:true)`, {
+        olog.failure('data_acquisition_bp_data_semrush_read', `Semrush source failed (${reason}); hard stop — no legacy fallback (enableSemrush:true)`, {
           peer: PEER.SEMRUSH, direction: 'inbound', source: 'semrush', reason,
         });
         await postMessageOptional(
@@ -1014,11 +1014,11 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
       // An entitlement-based skip is expected scoping, not a failure — log it at
       // info/outcome=skip; a genuine technical failure stays warn/outcome=failure.
       if (isEntitlementSkip) {
-        olog.skip('brand_data_load', `Semrush skipped (${reason}); falling back to PostgREST/SharePoint`, {
+        olog.skip('data_acquisition_bp_data_semrush_read', `Semrush skipped (${reason}); falling back to PostgREST/SharePoint`, {
           peer: PEER.SEMRUSH, direction: 'inbound', source: 'semrush', reason,
         });
       } else {
-        olog.warn('brand_data_load', `Semrush source failed (${reason}); falling back to PostgREST/SharePoint`, {
+        olog.warn('data_acquisition_bp_data_semrush_read', `Semrush source failed (${reason}); falling back to PostgREST/SharePoint`, {
           peer: PEER.SEMRUSH, direction: 'inbound', source: 'semrush', reason,
         });
       }
@@ -1027,7 +1027,7 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
         allUrls.set(url, info);
       }
       usedSemrush = true;
-      olog.success('brand_data_load', `Loaded ${semrushUrls.size} cited URL(s) from Semrush`, {
+      olog.success('data_acquisition_bp_data_semrush_read', `Loaded ${semrushUrls.size} cited URL(s) from Semrush`, {
         peer: PEER.SEMRUSH, direction: 'inbound', source: 'semrush', count: semrushUrls.size,
       });
     }
@@ -1054,7 +1054,7 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
     }
   }
 
-  olog.success('url_extract', `Total unique source URLs found: ${allUrls.size}`, { count: allUrls.size });
+  olog.success('data_acquisition_bp_data_urls_extracted', `Total unique source URLs found: ${allUrls.size}`, { count: allUrls.size });
 
   // Compute per-domain counts for audit result
   const urlCounts = {};
@@ -1068,7 +1068,7 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
   }
 
   if (allUrls.size === 0) {
-    olog.success('audit_complete', 'No offsite URLs found, audit complete', { reason: 'no_urls' });
+    olog.success('audit_orchestration_completed', 'No offsite URLs found, audit complete', { reason: 'no_urls' });
     await postMessageOptional(
       context,
       channelId,
@@ -1094,7 +1094,7 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
 
   if (domainScope) {
     ({ topByDomain, topCited } = scopeBucketsToDomain(topByDomain, topCited, domainScope));
-    olog.debug('url_extract', `Scoped run to '${domainScope}'`, { domainScope });
+    olog.debug('data_acquisition_bp_data_urls_extracted', `Scoped run to '${domainScope}'`, { domainScope });
   }
 
   const storedByDomain = await addUrlsToUrlStore(siteId, topByDomain, topCited, dataAccess, log);
@@ -1136,7 +1136,7 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
       // its notification, so a transient SQS/Configuration hiccup scheduling the follow-up
       // poll is non-fatal and must not page. outcome=failure is retained (warn defaults to
       // it) so Splunk still counts it, without the error/paging severity.
-      olog.warn('drs_poll_schedule', 'Failed to schedule DRS status poll', {
+      olog.warn('data_acquisition_scrape_job_poll_scheduled', 'Failed to schedule DRS status poll', {
         peer: PEER.SQS, direction: 'outbound', ...errorField(err),
       });
     }
@@ -1147,7 +1147,7 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
   //   await addTopicsToGuidelineStore(siteId, topicMap, allUrls, dataAccess, log);
   // }
 
-  olog.success('audit_complete', `Audit complete for site ${siteId}: ${allUrls.size} URLs processed, ${drsResults.length} DRS jobs triggered`, {
+  olog.success('audit_orchestration_completed', `Audit complete for site ${siteId}: ${allUrls.size} URLs processed, ${drsResults.length} DRS jobs triggered`, {
     urls: allUrls.size, drsJobs: drsResults.length,
   });
 

--- a/src/reddit-analysis/guidance-handler.js
+++ b/src/reddit-analysis/guidance-handler.js
@@ -46,7 +46,8 @@ const AUDIT_TYPE = Audit.AUDIT_TYPES.REDDIT_ANALYSIS;
 const HUMAN_PREFIX = `[offsite:${AUDIT.REDDIT}]`;
 
 /**
- * Classifies a presigned-analysis-fetch failure for the `analysis_fetch` reason token:
+ * Classifies a presigned-analysis-fetch failure for the `audit_persistence_payload_fetched`
+ * event's reason token:
  * URL/SSRF/shape and body-shape rejections are `validation`; network / non-2xx / timeout
  * failures are `fetch`. The messages come from analysis-fetch.js / assertPresignedUrl.
  *
@@ -75,12 +76,12 @@ export default async function handler(message, context) {
 
   const olog = createOffsiteLogger(log, { audit: AUDIT.REDDIT, siteId, auditId });
 
-  olog.start('guidance_receive', `Received Reddit analysis guidance for siteId: ${siteId}, auditId: ${auditId}`, {
+  olog.start('audit_analysis_completed', `Received Reddit analysis guidance for siteId: ${siteId}, auditId: ${auditId}`, {
     peer: PEER.MYSTIQUE, direction: 'inbound',
   });
 
   if (data?.error) {
-    olog.failure('guidance_receive', `Mystique returned an error for siteId: ${siteId}, auditId: ${auditId}`, {
+    olog.failure('audit_analysis_completed', `Mystique returned an error for siteId: ${siteId}, auditId: ${auditId}`, {
       peer: PEER.MYSTIQUE, direction: 'inbound', reason: 'mystique_error', mystiqueError: data.errorMessage,
     });
     return noContent();
@@ -95,11 +96,11 @@ export default async function handler(message, context) {
         log,
         prefix: HUMAN_PREFIX,
       });
-      olog.success('analysis_fetch', 'Fetched analysis from presigned URL', {
+      olog.success('audit_persistence_payload_fetched', 'Fetched analysis from presigned URL', {
         peer: PEER.S3, direction: 'inbound',
       });
     } catch (error) {
-      olog.failure('analysis_fetch', 'Error fetching from presigned URL', {
+      olog.failure('audit_persistence_payload_fetched', 'Error fetching from presigned URL', {
         peer: PEER.S3, direction: 'inbound', reason: classifyFetchFailure(error), ...errorField(error),
       });
       return badRequest(`Error fetching analysis data: ${error.message}`);
@@ -109,20 +110,20 @@ export default async function handler(message, context) {
   }
 
   if (!analysisData) {
-    olog.failure('guidance_complete', 'No analysis data provided in message', { reason: 'no_analysis_data' });
+    olog.failure('audit_persistence_completed', 'No analysis data provided in message', { reason: 'no_analysis_data' });
     return badRequest('Analysis data is required');
   }
 
   const site = await Site.findById(siteId);
   if (!site) {
-    olog.failure('guidance_complete', `Site not found for siteId: ${siteId}`, { reason: 'site_not_found' });
+    olog.failure('audit_persistence_completed', `Site not found for siteId: ${siteId}`, { reason: 'site_not_found' });
     return notFound('Site not found');
   }
 
   if (auditId) {
     const audit = await AuditModel.findById(auditId);
     if (!audit) {
-      olog.failure('guidance_complete', `Audit not found for auditId: ${auditId}`, { reason: 'audit_not_found' });
+      olog.failure('audit_persistence_completed', `Audit not found for auditId: ${auditId}`, { reason: 'audit_not_found' });
       return notFound('Audit not found');
     }
   }
@@ -134,11 +135,11 @@ export default async function handler(message, context) {
     const opportunityData = analysisData.opportunity || {};
 
     if (suggestions.length === 0) {
-      olog.skip('guidance_complete', 'No suggestions found in analysis', { reason: 'no_suggestions' });
+      olog.skip('audit_persistence_completed', 'No suggestions found in analysis', { reason: 'no_suggestions' });
       return noContent();
     }
 
-    olog.debug('guidance_receive', `Processing ${suggestions.length} suggestions`, {
+    olog.debug('audit_analysis_completed', `Processing ${suggestions.length} suggestions`, {
       count: suggestions.length, companyName,
     });
 
@@ -148,7 +149,7 @@ export default async function handler(message, context) {
 
     // Validate before mutating the evergreen opportunity.
     if (!isValidOffsiteAnalysis(analysisData, auditType)) {
-      olog.failure('guidance_complete', `Malformed analysis payload for siteId: ${siteId}; skipping update`, { reason: 'malformed_payload' });
+      olog.failure('audit_persistence_completed', `Malformed analysis payload for siteId: ${siteId}; skipping update`, { reason: 'malformed_payload' });
       return badRequest('Malformed analysis payload');
     }
 
@@ -212,17 +213,17 @@ export default async function handler(message, context) {
           data: suggestion.data,
         }),
       });
-      ologOpp.success('suggestion_sync', `Synced ${suggestions.length} suggestions`, {
+      ologOpp.success('audit_persistence_suggestions_synced', `Synced ${suggestions.length} suggestions`, {
         peer: PEER.POSTGRES, direction: 'outbound', count: suggestions.length,
       });
     } catch (error) {
-      ologOpp.failure('suggestion_sync', 'Failed to sync suggestions', {
+      ologOpp.failure('audit_persistence_suggestions_synced', 'Failed to sync suggestions', {
         peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
       });
       throw error;
     }
 
-    ologOpp.success('guidance_complete', `Successfully processed Reddit analysis for site: ${siteId}, company: ${companyName}, ${suggestions.length} suggestions`, {
+    ologOpp.success('audit_persistence_completed', `Successfully processed Reddit analysis for site: ${siteId}, company: ${companyName}, ${suggestions.length} suggestions`, {
       count: suggestions.length,
     });
     logOffsiteLlmUsage(log, HUMAN_PREFIX, siteId, opportunityData.llmUsage);
@@ -233,7 +234,7 @@ export default async function handler(message, context) {
         dataAccess, opportunity, siteId, auditType, log,
       });
     } catch (error) {
-      ologOpp.failure('outdated_suggestion_delete', `Unexpected expired OUTDATED suggestion deletion failure for auditType ${auditType}`, {
+      ologOpp.failure('audit_housekeeping_suggestions_removed', `Unexpected expired OUTDATED suggestion deletion failure for auditType ${auditType}`, {
         peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
       }, error);
     }
@@ -244,7 +245,7 @@ export default async function handler(message, context) {
         dataAccess, siteId, auditType, log,
       });
     } catch (error) {
-      ologOpp.failure('retention_delete', `Unexpected retention failure for auditType ${auditType}`, {
+      ologOpp.failure('audit_housekeeping_opportunities_removed', `Unexpected retention failure for auditType ${auditType}`, {
         peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
       }, error);
     }
@@ -281,9 +282,10 @@ export default async function handler(message, context) {
 
     return ok();
   } catch (error) {
-    // Intentional drill-down: a failure already logged by an inner event (e.g. suggestion_sync)
-    // will also surface here as guidance_complete outcome=failure — the terminal, per-run marker.
-    olog.failure('guidance_complete', 'Error processing Reddit analysis', { ...errorField(error) }, error);
+    // Intentional drill-down: a failure already logged by an inner event (e.g.
+    // audit_persistence_suggestions_synced) will also surface here as
+    // audit_persistence_completed outcome=failure — the terminal, per-run marker.
+    olog.failure('audit_persistence_completed', 'Error processing Reddit analysis', { ...errorField(error) }, error);
     return badRequest(`Error processing analysis: ${error.message}`);
   }
 }

--- a/src/reddit-analysis/handler.js
+++ b/src/reddit-analysis/handler.js
@@ -91,12 +91,12 @@ async function fetchStoreData(siteId, context, site) {
   const olog = createOffsiteLogger(log, { audit: AUDIT.REDDIT, siteId });
   const storeClient = StoreClient.createFrom(context);
 
-  olog.start('url_store_read', `Fetching data from stores for siteId: ${siteId}`, {
+  olog.start('data_acquisition_store_urls_read', `Fetching data from stores for siteId: ${siteId}`, {
     peer: PEER.URL_STORE, direction: 'inbound',
   });
 
   const rawUrls = await storeClient.getUrls(siteId, URL_TYPES.REDDIT, { sortBy: 'createdAt', sortOrder: 'desc' });
-  olog.success('url_store_read', `Retrieved ${rawUrls.length} Reddit URLs from URL Store`, {
+  olog.success('data_acquisition_store_urls_read', `Retrieved ${rawUrls.length} Reddit URLs from URL Store`, {
     peer: PEER.URL_STORE, direction: 'inbound', count: rawUrls.length,
   });
 
@@ -109,15 +109,15 @@ async function fetchStoreData(siteId, context, site) {
     drsClient,
     olog,
   );
-  olog.success('drs_availability', `${urls.length} Reddit URLs available in DRS${formatDrsExtras(counts)}`, {
+  olog.success('data_acquisition_scrape_job_status_polled', `${urls.length} Reddit URLs available in DRS${formatDrsExtras(counts)}`, {
     peer: PEER.DRS, direction: 'outbound', available: urls.length,
   });
 
   const topics = await computeTopicsFromBrandPresence(siteId, context, site);
-  olog.debug('topics_load', `Computed ${topics.length} topics from brand presence data`, {
+  olog.debug('audit_orchestration_brand_topics_resolved', `Computed ${topics.length} topics from brand presence data`, {
     count: topics.length,
   });
-  olog.debug('topics_load', `Brand-presence topics payload: ${JSON.stringify(topics)}`);
+  olog.debug('audit_orchestration_brand_topics_resolved', `Brand-presence topics payload: ${JSON.stringify(topics)}`);
 
   let guidelines = [];
   try {
@@ -128,7 +128,7 @@ async function fetchStoreData(siteId, context, site) {
     guidelines = sentimentConfig.guidelines ?? [];
   } catch (error) {
     if (error instanceof StoreEmptyError) {
-      olog.skip('guideline_read', 'No guidelines configured for reddit-analysis, proceeding without', {
+      olog.skip('audit_orchestration_brand_guidelines_resolved', 'No guidelines configured for reddit-analysis, proceeding without', {
         peer: PEER.URL_STORE, direction: 'inbound', reason: 'no_guidelines',
       });
     } else {
@@ -136,7 +136,7 @@ async function fetchStoreData(siteId, context, site) {
     }
   }
 
-  olog.success('guideline_read', `Retrieved ${guidelines.length} guidelines`, {
+  olog.success('audit_orchestration_brand_guidelines_resolved', `Retrieved ${guidelines.length} guidelines`, {
     peer: PEER.URL_STORE, direction: 'inbound', count: guidelines.length,
   });
 
@@ -165,8 +165,8 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
   // handler to report DRS / Mystique / total durations.
   const analysisStartedAt = Date.now();
 
-  olog.start('audit_start', `Starting Reddit analysis audit for site: ${siteId}`);
-  olog.debug('audit_start', `auditContext: ${JSON.stringify(auditContext)}`);
+  olog.start('audit_orchestration_started', `Starting Reddit analysis audit for site: ${siteId}`);
+  olog.debug('audit_orchestration_started', `auditContext: ${JSON.stringify(auditContext)}`);
 
   const enableBrandProfile = resolveEnableBrandProfile(auditContext, log, HUMAN_PREFIX);
   const forwardedUrlLimit = resolveForwardedUrlLimit(auditContext, log, HUMAN_PREFIX);
@@ -176,7 +176,7 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
     const redditConfig = getRedditConfig(site);
 
     if (!redditConfig.companyName) {
-      olog.warn('config_resolve', 'No company name configured for site, skipping audit', {
+      olog.warn('audit_orchestration_brand_profile_resolved', 'No company name configured for site, skipping audit', {
         outcome: OUTCOME.SKIP, reason: 'no_company_name',
       });
       return {
@@ -188,7 +188,7 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
       };
     }
 
-    olog.success('config_resolve', 'Resolved Reddit config', {
+    olog.success('audit_orchestration_brand_profile_resolved', 'Resolved Reddit config', {
       companyName: redditConfig.companyName,
       website: redditConfig.companyWebsite,
     });
@@ -199,7 +199,7 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
     // reads as a coherent sequence rather than a contradictory "no scrape needed".
     const scrapedNow = scrapedThisCycle(auditContext);
     olog.success(
-      'store_fetch_complete',
+      'data_acquisition_completed',
       scrapedNow
         ? `DRS scrape finished this cycle; ${storeData.urls.length} URL(s) ready, proceeding to Mystique`
         : `Reusing previously scraped DRS content for ${storeData.urls.length} URL(s); no new scrape needed, proceeding to Mystique`,
@@ -249,7 +249,7 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
       // A scoped scrape already ran and the store is STILL empty → the brand has no
       // Reddit URLs to analyze. Report a terminal message instead of looping.
       if (auditContext.drsScrapeRequested) {
-        olog.failure('url_store_read', 'URL store still empty after scrape', {
+        olog.failure('data_acquisition_store_urls_read', 'URL store still empty after scrape', {
           peer: PEER.URL_STORE, direction: 'inbound', reason: 'empty_after_scrape', ...errorField(error),
         });
         await postMessageOptional(
@@ -266,7 +266,7 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
       // First individual run with an empty store: collect + scrape just this bucket via a
       // domain-scoped offsite-brand-presence run, which re-triggers this analysis when DRS
       // completes — no need to run offsite-brand-presence for all buckets manually.
-      olog.skip('store_fetch_complete', 'URL store empty, requesting a scoped scrape for reddit.com', {
+      olog.skip('data_acquisition_completed', 'URL store empty, requesting a scoped scrape for reddit.com', {
         status: 'pending_scrape', peer: PEER.URL_STORE, direction: 'inbound', reason: 'empty_store',
       });
       await postMessageOptional(
@@ -297,7 +297,7 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
       const { channelId, threadTs } = slackContext || {};
       if (auditContext.drsScrapeRequested) {
         // A scrape already ran this cycle and DRS still reports no scraped content → terminal.
-        olog.failure('drs_availability', 'No DRS content available after scraping', {
+        olog.failure('data_acquisition_scrape_job_status_polled', 'No DRS content available after scraping', {
           peer: PEER.DRS, direction: 'outbound', reason: 'no_content_after_scrape', ...errorField(error),
         });
         await postMessageOptional(
@@ -311,7 +311,7 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
           fullAuditRef: url,
         };
       }
-      olog.skip('store_fetch_complete', 'URLs stored but not scraped in DRS yet, requesting a scrape for reddit.com', {
+      olog.skip('data_acquisition_completed', 'URLs stored but not scraped in DRS yet, requesting a scrape for reddit.com', {
         status: 'pending_scrape', peer: PEER.DRS, direction: 'outbound', reason: 'no_drs_content',
       });
       await postMessageOptional(
@@ -337,7 +337,7 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
       };
     }
 
-    olog.failure('audit_start', 'Audit failed', { ...errorField(error) });
+    olog.failure('audit_orchestration_started', 'Audit failed', { ...errorField(error) });
     return {
       auditResult: {
         success: false,
@@ -363,14 +363,14 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
   const olog = createOffsiteLogger(log, { audit: AUDIT.REDDIT, siteId, auditId: audit?.getId() });
 
   if (!auditResult.success) {
-    olog.skip('mystique_dispatch', 'Audit failed, skipping Mystique message', {
+    olog.skip('audit_analysis_mystique_request_handoff', 'Audit failed, skipping Mystique message', {
       peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'audit_failed',
     });
     return auditData;
   }
 
   if (!sqs || !env?.QUEUE_SPACECAT_TO_MYSTIQUE) {
-    olog.warn('mystique_dispatch', 'SQS or Mystique queue not configured, skipping message', {
+    olog.warn('audit_analysis_mystique_request_handoff', 'SQS or Mystique queue not configured, skipping message', {
       outcome: OUTCOME.SKIP, peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'not_configured',
     });
     return auditData;
@@ -380,7 +380,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     const { Site } = dataAccess;
     const site = await Site.findById(siteId);
     if (!site) {
-      olog.warn('mystique_dispatch', 'Site not found, skipping Mystique message', {
+      olog.warn('audit_analysis_mystique_request_handoff', 'Site not found, skipping Mystique message', {
         outcome: OUTCOME.SKIP, peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'site_not_found',
       });
       return auditData;
@@ -388,7 +388,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
 
     const { config, storeData } = auditResult;
     const urlLimit = config?.urlLimit ?? MYSTIQUE_URLS_LIMIT;
-    olog.success('url_limit_resolve', `urlLimit=${urlLimit} (URLs sent to Mystique)`);
+    olog.success('audit_analysis_url_limit_resolved', `urlLimit=${urlLimit} (URLs sent to Mystique)`);
 
     const { urls, sentimentConfig } = storeData;
     const enrichedUrls = enrichUrlsWithTopicData(urls, sentimentConfig.topics)
@@ -418,18 +418,18 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     try {
       brand = await resolveBrandForSite(context, site);
     } catch (brandError) {
-      olog.warn('mystique_dispatch', 'Brand resolution failed unexpectedly; proceeding without scope', {
+      olog.warn('audit_analysis_scope_resolved', 'Brand resolution failed unexpectedly; proceeding without scope', {
         peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'brand_resolution', ...errorField(brandError),
       });
     }
     const message = applyBrandScope(baseMessage, brand);
 
-    olog.debug('mystique_dispatch', `Built Mystique message type ${message.type}`, {
+    olog.debug('audit_analysis_mystique_request_built', `Built Mystique message type ${message.type}`, {
       peer: PEER.MYSTIQUE, direction: 'outbound',
     });
     await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, message);
     olog.success(
-      'mystique_dispatch',
+      'audit_analysis_mystique_request_handoff',
       `Queued Reddit analysis request to Mystique with ${enrichedUrls.length} URLs`,
       {
         peer: PEER.MYSTIQUE,
@@ -441,7 +441,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     );
     return auditData;
   } catch (error) {
-    olog.failure('mystique_dispatch', 'Failed to send Mystique message', {
+    olog.failure('audit_analysis_mystique_request_handoff', 'Failed to send Mystique message', {
       peer: PEER.MYSTIQUE, direction: 'outbound', ...errorField(error),
     });
     throw error;

--- a/src/utils/offsite-audit-utils.js
+++ b/src/utils/offsite-audit-utils.js
@@ -281,7 +281,8 @@ export function isExcludedCitedHost(hostname, brandTokens) {
  *
  * @param {object} [auditContext]
  * @param {number|string} [auditContext.messageData.urlLimit]
- * @param {object} [olog] - bound offsite logger (createOffsiteLogger); emits `url_limit_resolve`
+ * @param {object} [olog] - bound offsite logger (createOffsiteLogger);
+ *   emits `audit_analysis_url_limit_resolved`
  * @returns {number}
  */
 /**
@@ -426,14 +427,15 @@ export function scrapedThisCycle(auditContext) {
  *   (e.g. ['reddit_posts', 'reddit_comments'])
  * @param {string} siteId - Site ID required by the DRS lookup API
  * @param {object|null} drsClient - Configured DrsClient instance (or null / unconfigured)
- * @param {object} [olog] - bound offsite logger (see createOffsiteLogger); emits `drs_availability`
+ * @param {object} [olog] - bound offsite logger (see createOffsiteLogger);
+ *   emits `data_acquisition_scrape_job_status_polled`
  * @returns {Promise<{urls: Array<{url: string}>, counts: {total: number, available: number,
  *   scraping: number, notFound: number, determined: boolean}}>}
  * @throws {DrsNoContentAvailableError} When DRS responded but no URLs are available yet
  */
 export async function filterUrlsByDrsStatus(urls, datasetIds, siteId, drsClient, olog) {
   if (!drsClient || !drsClient.isConfigured()) {
-    olog?.skip('drs_availability', 'DRS client not configured, skipping availability filter', {
+    olog?.skip('data_acquisition_scrape_job_status_polled', 'DRS client not configured, skipping availability filter', {
       peer: PEER.DRS, direction: 'outbound', reason: 'not_configured',
     });
     return { urls, counts: undeterminedDrsCounts(urls.length) };
@@ -449,7 +451,7 @@ export async function filterUrlsByDrsStatus(urls, datasetIds, siteId, drsClient,
       // eslint-disable-next-line no-await-in-loop
       const response = await drsClient.lookupScrapeResults({ datasetId, siteId, urls: rawUrls });
       if (!response) {
-        olog?.warn('drs_availability', `DRS lookup returned null for datasetId=${datasetId}, skipping`, {
+        olog?.warn('data_acquisition_scrape_job_status_polled', `DRS lookup returned null for datasetId=${datasetId}, skipping`, {
           peer: PEER.DRS, direction: 'outbound', datasetId, reason: 'null_response',
         });
         // eslint-disable-next-line no-continue
@@ -464,21 +466,21 @@ export async function filterUrlsByDrsStatus(urls, datasetIds, siteId, drsClient,
         }
       }
       olog?.debug(
-        'drs_availability',
+        'data_acquisition_scrape_job_status_polled',
         `DRS lookup datasetId=${datasetId}: `
         + `${response.summary?.available ?? 0}/${response.summary?.total ?? rawUrls.length} available, `
         + `${response.summary?.scraping ?? 0} scraping, ${response.summary?.not_found ?? 0} not-found`,
         { peer: PEER.DRS, direction: 'outbound', datasetId },
       );
     } catch (error) {
-      olog?.warn('drs_availability', `DRS lookup failed for datasetId=${datasetId}, skipping`, {
+      olog?.warn('data_acquisition_scrape_job_status_polled', `DRS lookup failed for datasetId=${datasetId}, skipping`, {
         peer: PEER.DRS, direction: 'outbound', datasetId, ...errorField(error),
       });
     }
   }
 
   if (!atLeastOneLookupSucceeded) {
-    olog?.warn('drs_availability', `All DRS lookups failed or returned null for datasets [${datasetIds.join(', ')}], skipping availability filter`, {
+    olog?.warn('data_acquisition_scrape_job_status_polled', `All DRS lookups failed or returned null for datasets [${datasetIds.join(', ')}], skipping availability filter`, {
       peer: PEER.DRS, direction: 'outbound', reason: 'all_failed',
     });
     return { urls, counts: undeterminedDrsCounts(urls.length) };
@@ -504,7 +506,7 @@ export async function filterUrlsByDrsStatus(urls, datasetIds, siteId, drsClient,
   const filtered = urls.filter((item) => availableUrls.has(item.url));
   const removed = total - filtered.length;
   if (removed > 0) {
-    olog?.debug('drs_availability', `DRS availability filter: removed ${removed} URL(s) not yet scraped (${scraping} scraping, ${notFound} not-found), ${filtered.length} remaining`, {
+    olog?.debug('data_acquisition_scrape_job_status_polled', `DRS availability filter: removed ${removed} URL(s) not yet scraped (${scraping} scraping, ${notFound} not-found), ${filtered.length} remaining`, {
       peer: PEER.DRS, direction: 'outbound', removed, remaining: filtered.length,
     });
   }
@@ -520,14 +522,14 @@ export function resolveMystiqueUrlLimit(auditContext, olog) {
   const n = Number(raw);
   if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1) {
     olog?.warn(
-      'url_limit_resolve',
+      'audit_analysis_url_limit_resolved',
       `Invalid urlLimit in auditContext (${JSON.stringify(raw)}), using default ${MYSTIQUE_URLS_LIMIT}`,
       { reason: 'invalid', urlLimit: MYSTIQUE_URLS_LIMIT },
     );
     return MYSTIQUE_URLS_LIMIT;
   }
   if (n > MYSTIQUE_URLS_LIMIT) {
-    olog?.debug('url_limit_resolve', `urlLimit ${n} exceeds cap ${MYSTIQUE_URLS_LIMIT}, using ${MYSTIQUE_URLS_LIMIT}`, {
+    olog?.debug('audit_analysis_url_limit_resolved', `urlLimit ${n} exceeds cap ${MYSTIQUE_URLS_LIMIT}, using ${MYSTIQUE_URLS_LIMIT}`, {
       requested: n, cap: MYSTIQUE_URLS_LIMIT, urlLimit: MYSTIQUE_URLS_LIMIT,
     });
     return MYSTIQUE_URLS_LIMIT;
@@ -646,7 +648,8 @@ export function resolveForwardedUrlLimit(auditContext, log, logPrefix) {
  * @param {boolean} [enableSemrush] - Forwarded so this scoped offsite-brand-presence run honors
  *   the same `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED` override originally requested on Slack for
  *   the analysis audit that triggered it, instead of falling back to the plain env var.
- * @param {object} [olog] - bound offsite logger (see createOffsiteLogger); emits `scrape_request`
+ * @param {object} [olog] - bound offsite logger (see createOffsiteLogger);
+ *   emits `data_acquisition_scrape_job_submitted`
  *   with `reason=self_heal`. Threaded from the analysis-handler caller so the audit slug/ids are
  *   bound (this generic util does not know which analysis triggered the self-heal).
  *
@@ -682,11 +685,11 @@ export async function requestOffsiteScrape(
         messageData: { domainScope, ...overrides },
       },
     });
-    olog?.success('scrape_request', `Requested DRS scrape for '${domainScope}' (site ${siteId})`, {
+    olog?.success('data_acquisition_scrape_job_submitted', `Requested DRS scrape for '${domainScope}' (site ${siteId})`, {
       peer: PEER.SQS, direction: 'outbound', reason: 'self_heal', domainScope, ...overrides,
     });
   } catch (error) {
-    olog?.warn('scrape_request', `Failed to request DRS scrape for '${domainScope}' (site ${siteId})`, {
+    olog?.warn('data_acquisition_scrape_job_submitted', `Failed to request DRS scrape for '${domainScope}' (site ${siteId})`, {
       peer: PEER.SQS, direction: 'outbound', reason: 'self_heal', domainScope, ...overrides, ...errorField(error),
     });
   }

--- a/src/utils/offsite-brand-presence-enrichment.js
+++ b/src/utils/offsite-brand-presence-enrichment.js
@@ -103,7 +103,7 @@ async function readQueryIndexPaths(site, sharepointClient, log) {
   const dataFolder = site.getConfig?.()?.getLlmoDataFolder?.();
   if (!dataFolder) {
     log.warn(enrich('No LLMO data folder configured for site', {
-      event: 'brand_data_load', outcome: OUTCOME.SKIP, peer: PEER.SHAREPOINT, direction: 'inbound', reason: 'no_data_folder',
+      event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.SKIP, peer: PEER.SHAREPOINT, direction: 'inbound', reason: 'no_data_folder',
     }));
     return null;
   }
@@ -362,7 +362,7 @@ function extractUrlsAndTopics(data, allUrls, topicMap, log, siteHostname) {
   }
 
   log.info(enrich(`Found ${allUrls.size} unique source URLs`, {
-    event: 'url_extract', outcome: OUTCOME.SUCCESS, count: allUrls.size,
+    event: 'data_acquisition_bp_data_urls_extracted_enriched', outcome: OUTCOME.SUCCESS, count: allUrls.size,
   }));
 }
 
@@ -396,7 +396,7 @@ export async function loadBrandPresenceData({
 
   if (isBrandalfOrg === null) {
     log.warn(enrich(`Brandalf flag state unknown for org ${organizationId}; skipping legacy file fetch for site ${siteId}`, {
-      event: 'brand_data_load', outcome: OUTCOME.SKIP, reason: 'brandalf_unknown',
+      event: 'data_acquisition_bp_data_source_selected', outcome: OUTCOME.SKIP, reason: 'brandalf_unknown',
     }));
     return null;
   }
@@ -413,12 +413,12 @@ export async function loadBrandPresenceData({
     if (dbData) {
       // P2-1: the PostgREST success path previously returned unlogged at the enrichment level.
       log.info(enrich(`Loaded ${dbData.data.length} brand presence rows from PostgREST for site ${siteId}`, {
-        event: 'brand_data_load', outcome: OUTCOME.SUCCESS, peer: PEER.POSTGRES, direction: 'inbound', source: 'postgrest', rows: dbData.data.length,
+        event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SUCCESS, peer: PEER.POSTGRES, direction: 'inbound', source: 'postgrest', rows: dbData.data.length,
       }));
       return dbData;
     }
     log.info(enrich(`No PostgREST data for brandalf-enabled site ${siteId}, falling back to SharePoint file fetch`, {
-      event: 'brand_data_load', outcome: OUTCOME.SKIP, peer: PEER.POSTGRES, direction: 'inbound', source: 'postgrest', reason: 'no_rows',
+      event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SKIP, peer: PEER.POSTGRES, direction: 'inbound', source: 'postgrest', reason: 'no_rows',
     }));
   }
 
@@ -428,7 +428,7 @@ export async function loadBrandPresenceData({
   }
   if (!resolvedSite) {
     log.warn(enrich(`Cannot resolve site for ${siteId}, skipping SharePoint fetch`, {
-      event: 'brand_data_load', outcome: OUTCOME.SKIP, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', reason: 'no_site',
+      event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.SKIP, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', reason: 'no_site',
     }));
     return null;
   }
@@ -440,14 +440,14 @@ export async function loadBrandPresenceData({
     queryResult = await readQueryIndexPaths(resolvedSite, sharepointClient, log);
   } catch (error) {
     log.error(enrich(`Error reading query-index from SharePoint: ${error.message}`, {
-      event: 'brand_data_load', outcome: OUTCOME.FAILURE, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', reason: 'query_index', errorName: error.name,
+      event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.FAILURE, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', reason: 'query_index', errorName: error.name,
     }));
     return null;
   }
 
   if (!queryResult || queryResult.paths.length === 0) {
     log.warn(enrich(`Failed to read query-index for site ${siteId}`, {
-      event: 'brand_data_load', outcome: OUTCOME.SKIP, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', reason: 'empty_query_index',
+      event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.SKIP, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', reason: 'empty_query_index',
     }));
     return null;
   }
@@ -462,12 +462,12 @@ export async function loadBrandPresenceData({
     ({ week, year }) => filterBrandPresenceFiles(paths, week, year),
   );
   log.info(enrich(`Found ${matchedFiles.length} brand presence files for weeks ${weekLabels}`, {
-    event: 'brand_data_load', outcome: OUTCOME.START, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', files: matchedFiles.length,
+    event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.START, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', files: matchedFiles.length,
   }));
 
   if (matchedFiles.length === 0) {
     log.info(enrich(`No matching brand presence files for site ${siteId}`, {
-      event: 'brand_data_load', outcome: OUTCOME.SKIP, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', count: 0,
+      event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.SKIP, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', count: 0,
     }));
     return null;
   }
@@ -484,19 +484,19 @@ export async function loadBrandPresenceData({
       allRows.push(...data.data);
     } catch (err) {
       log.error(enrich(`Error reading brand presence sheet ${sheetName}: ${err.message}`, {
-        event: 'brand_data_load', outcome: OUTCOME.FAILURE, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', reason: 'sheet_read', errorName: err.name,
+        event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.FAILURE, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', reason: 'sheet_read', errorName: err.name,
       }));
     }
   }
 
   if (allRows.length === 0) {
     log.info(enrich(`No usable brand presence rows from SharePoint for site ${siteId}`, {
-      event: 'brand_data_load', outcome: OUTCOME.SKIP, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', count: 0,
+      event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.SKIP, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', count: 0,
     }));
     return null;
   }
   log.info(enrich(`Loaded ${allRows.length} brand presence rows from SharePoint for site ${siteId}`, {
-    event: 'brand_data_load', outcome: OUTCOME.SUCCESS, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', rows: allRows.length,
+    event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.SUCCESS, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', rows: allRows.length,
   }));
   return { data: allRows };
 }
@@ -541,7 +541,7 @@ export async function computeTopicsFromBrandPresence(siteId, context, site) {
     .map(({ week, year }) => `w${String(week).padStart(2, '0')}-${year}`)
     .join(', ');
   log.info(enrich(`Processing weeks: ${weekLabels}`, {
-    event: 'brand_data_load', outcome: OUTCOME.START,
+    event: 'data_acquisition_bp_data_source_selected', outcome: OUTCOME.START,
   }));
 
   const brandPresenceData = await loadBrandPresenceData({
@@ -558,7 +558,7 @@ export async function computeTopicsFromBrandPresence(siteId, context, site) {
       siteHostname = new URL(baseURL).hostname.replace(/^www\./, '');
     } catch {
       log.warn(enrich(`Could not parse baseURL "${baseURL}", skipping site URL filter`, {
-        event: 'url_extract', outcome: OUTCOME.SKIP, reason: 'unparseable_base_url',
+        event: 'data_acquisition_bp_data_urls_extracted_enriched', outcome: OUTCOME.SKIP, reason: 'unparseable_base_url',
       }));
     }
   }

--- a/src/utils/offsite-brand-presence-postgrest.js
+++ b/src/utils/offsite-brand-presence-postgrest.js
@@ -92,7 +92,7 @@ async function fetchExecutionsWithSources(postgrestClient, {
   while (true) {
     if (pageCount >= MAX_EXECUTION_FETCH_PAGES) {
       log.warn(bp(`Exceeded maximum brand_presence_executions pages (${MAX_EXECUTION_FETCH_PAGES}), processing ${rows.length} rows fetched so far`, {
-        event: 'brand_data_load', outcome: OUTCOME.SUCCESS, peer: PEER.POSTGRES, direction: 'inbound', reason: 'max_pages', pages: MAX_EXECUTION_FETCH_PAGES, rows: rows.length,
+        event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SUCCESS, peer: PEER.POSTGRES, direction: 'inbound', reason: 'max_pages', pages: MAX_EXECUTION_FETCH_PAGES, rows: rows.length,
       }));
       break;
     }
@@ -128,7 +128,7 @@ async function fetchExecutionsWithSources(postgrestClient, {
     const batch = data || [];
     rows.push(...batch);
     log?.info(bp(`Fetched batch: ${batch.length} rows (total: ${rows.length})`, {
-      event: 'brand_data_load', outcome: OUTCOME.START, peer: PEER.POSTGRES, direction: 'inbound', rows: batch.length,
+      event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.START, peer: PEER.POSTGRES, direction: 'inbound', rows: batch.length,
     }));
 
     if (batch.length < EXECUTION_FETCH_BATCH_SIZE) {
@@ -191,7 +191,7 @@ export async function loadBrandPresenceDataFromPostgrest({
 
     if (executions.length === 0) {
       log?.info(bp(`No execution rows found for site ${siteId}`, {
-        event: 'brand_data_load', outcome: OUTCOME.SKIP, peer: PEER.POSTGRES, direction: 'inbound', count: 0, reason: 'no_executions',
+        event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SKIP, peer: PEER.POSTGRES, direction: 'inbound', count: 0, reason: 'no_executions',
       }));
       return null;
     }
@@ -199,18 +199,18 @@ export async function loadBrandPresenceDataFromPostgrest({
     const rows = mapExecutionsToLegacyBrandPresenceRows(executions);
     if (rows.length === 0) {
       log?.info(bp(`No usable rows found for site ${siteId}`, {
-        event: 'brand_data_load', outcome: OUTCOME.SKIP, peer: PEER.POSTGRES, direction: 'inbound', count: 0, reason: 'no_usable_rows',
+        event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SKIP, peer: PEER.POSTGRES, direction: 'inbound', count: 0, reason: 'no_usable_rows',
       }));
       return null;
     }
 
     log?.info(bp(`Loaded ${rows.length} legacy-shaped rows from PostgREST for site ${siteId}`, {
-      event: 'brand_data_load', outcome: OUTCOME.SUCCESS, peer: PEER.POSTGRES, direction: 'inbound', rows: rows.length,
+      event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SUCCESS, peer: PEER.POSTGRES, direction: 'inbound', rows: rows.length,
     }));
     return { data: rows };
   } catch (error) {
     log?.warn(bp(`PostgREST query failed for site ${siteId}: ${error.message}`, {
-      event: 'brand_data_load', outcome: OUTCOME.FAILURE, peer: PEER.POSTGRES, direction: 'inbound', reason: 'query', errorName: error.name,
+      event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.FAILURE, peer: PEER.POSTGRES, direction: 'inbound', reason: 'query', errorName: error.name,
     }));
     return null;
   }

--- a/src/utils/offsite-brand-presence-semrush.js
+++ b/src/utils/offsite-brand-presence-semrush.js
@@ -136,7 +136,7 @@ async function fetchDomainUrls(url, headers, olog, pageSize) {
   try {
     response = await fetch(url, { headers, timeout: FETCH_TIMEOUT_MS });
   } catch (error) {
-    olog.failure('domain_urls_fetch', 'Fetch failed for domain-urls', {
+    olog.failure('data_acquisition_bp_data_semrush_read', 'Fetch failed for domain-urls', {
       peer: PEER.SEMRUSH, direction: 'inbound', durationMs: Date.now() - startedAt, ...errorField(error),
     }, error);
     return {
@@ -156,9 +156,9 @@ async function fetchDomainUrls(url, headers, olog, pageSize) {
     if (authFailure) {
       // Distinct branch so a rejected service token is visible instead of being
       // masked as "Semrush returned nothing" (LLMO-6709 verification).
-      olog.failure('domain_urls_fetch', `Service token rejected for domain-urls (HTTP ${response.status}) — verify the IMS service token is authorized by the Semrush proxy (LLMO-6709)`, logFields);
+      olog.failure('data_acquisition_bp_data_semrush_read', `Service token rejected for domain-urls (HTTP ${response.status}) — verify the IMS service token is authorized by the Semrush proxy (LLMO-6709)`, logFields);
     } else {
-      olog.failure('domain_urls_fetch', `domain-urls returned HTTP ${response.status}`, logFields);
+      olog.failure('data_acquisition_bp_data_semrush_read', `domain-urls returned HTTP ${response.status}`, logFields);
     }
     return {
       rows: [], ok: false, authFailure, truncated: false,
@@ -169,7 +169,7 @@ async function fetchDomainUrls(url, headers, olog, pageSize) {
   try {
     body = await response.json();
   } catch (error) {
-    olog.failure('domain_urls_fetch', 'Could not parse domain-urls response', {
+    olog.failure('data_acquisition_bp_data_semrush_read', 'Could not parse domain-urls response', {
       peer: PEER.SEMRUSH, direction: 'inbound', durationMs: Date.now() - startedAt, ...errorField(error),
     }, error);
     return {
@@ -182,7 +182,7 @@ async function fetchDomainUrls(url, headers, olog, pageSize) {
   if (truncated) {
     // A full page is a successful response with a caveat (possible starvation), not a
     // failure — override the default outcome so this doesn't pollute failure-based alerts.
-    olog.warn('domain_urls_fetch', `domain-urls returned a full page (${raw.length} >= ${pageSize}); response may be truncated`, {
+    olog.warn('data_acquisition_bp_data_semrush_read', `domain-urls returned a full page (${raw.length} >= ${pageSize}); response may be truncated`, {
       peer: PEER.SEMRUSH, direction: 'inbound', rowCount: raw.length, pageSize, outcome: OUTCOME.SUCCESS,
     });
   }
@@ -298,7 +298,7 @@ export async function loadCitedUrlsFromSemrush({
     try {
       await onProgress(text);
     } catch (error) {
-      olog.warn('brand_data_load', 'Failed to post Semrush progress update', {
+      olog.warn('data_acquisition_bp_data_semrush_read', 'Failed to post Semrush progress update', {
         peer: PEER.SLACK, direction: 'outbound', ...errorField(error),
       });
     }
@@ -309,12 +309,12 @@ export async function loadCitedUrlsFromSemrush({
     }
   };
 
-  olog.start('brand_data_load', 'Starting Semrush source attempt', { peer: PEER.SEMRUSH, direction: 'inbound', baseUrl });
+  olog.start('data_acquisition_bp_data_semrush_read', 'Starting Semrush source attempt', { peer: PEER.SEMRUSH, direction: 'inbound', baseUrl });
   await notify(':mag: Starting Semrush URL-Inspector lookup...');
 
   const spaceCatId = site?.getOrganizationId?.();
   if (!spaceCatId) {
-    olog.warn('brand_data_load', 'Site has no organization id; skipping Semrush source', {
+    olog.warn('data_acquisition_bp_data_semrush_read', 'Site has no organization id; skipping Semrush source', {
       peer: PEER.SEMRUSH, direction: 'inbound', durationMs: elapsed(), reason: 'no-organization-id', outcome: OUTCOME.SKIP,
     });
     await notify(':warning: Site has no organization id — falling back to the legacy source.');
@@ -327,13 +327,13 @@ export async function loadCitedUrlsFromSemrush({
   const { brand, resolved } = await resolveBrandResultForSite(context, site);
   if (!brand?.brandId) {
     if (resolved) {
-      olog.skip('brand_data_load', `No active brand for org ${spaceCatId}; skipping Semrush source`, {
+      olog.skip('data_acquisition_bp_data_semrush_read', `No active brand for org ${spaceCatId}; skipping Semrush source`, {
         peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, durationMs: elapsed(), reason: 'no-active-brand',
       });
       await notify(':information_source: No active brand configured for this org — falling back to the legacy source.');
       setDiagnostics({ fallbackReason: 'no-active-brand' });
     } else {
-      olog.warn('brand_data_load', `Brand resolution failed (transient) for org ${spaceCatId}; using legacy fallback`, {
+      olog.warn('data_acquisition_bp_data_semrush_read', `Brand resolution failed (transient) for org ${spaceCatId}; using legacy fallback`, {
         peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, durationMs: elapsed(), reason: 'brand-resolution-failed',
       });
       await notify(':warning: Brand resolution failed (transient) — falling back to the legacy source.');
@@ -353,7 +353,7 @@ export async function loadCitedUrlsFromSemrush({
   });
   if (!entitlement.entitled) {
     if (entitlement.resolved) {
-      olog.skip('brand_data_load', `Brand not entitled for Semrush (${entitlement.reason}) for org ${spaceCatId}; skipping Semrush source`, {
+      olog.skip('data_acquisition_bp_data_semrush_read', `Brand not entitled for Semrush (${entitlement.reason}) for org ${spaceCatId}; skipping Semrush source`, {
         peer: PEER.SEMRUSH,
         direction: 'inbound',
         orgId: spaceCatId,
@@ -373,7 +373,7 @@ export async function loadCitedUrlsFromSemrush({
         entitlementReason: entitlement.reason,
       });
     } else {
-      olog.warn('brand_data_load', `Semrush entitlement check failed (transient) for org ${spaceCatId}; using legacy fallback`, {
+      olog.warn('data_acquisition_bp_data_semrush_read', `Semrush entitlement check failed (transient) for org ${spaceCatId}; using legacy fallback`, {
         peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, brandId: brand.brandId, durationMs: elapsed(),
       });
       await notify(':warning: Could not verify Semrush entitlement (transient) — falling back to the legacy source.');
@@ -387,7 +387,7 @@ export async function loadCitedUrlsFromSemrush({
 
   const dateWindow = getDateWindowForPreviousWeeks(previousWeeks);
   if (!dateWindow) {
-    olog.warn('brand_data_load', 'Could not derive a date window; skipping Semrush source', {
+    olog.warn('data_acquisition_bp_data_semrush_read', 'Could not derive a date window; skipping Semrush source', {
       peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, brandId: brand.brandId, durationMs: elapsed(), outcome: OUTCOME.SKIP,
     });
     await notify(':warning: Could not derive a date window — falling back to the legacy source.');
@@ -400,7 +400,7 @@ export async function loadCitedUrlsFromSemrush({
   try {
     authorization = await getAuthorizationHeader(context);
   } catch (error) {
-    olog.failure('brand_data_load', 'Failed to obtain IMS service token', {
+    olog.failure('data_acquisition_bp_data_semrush_read', 'Failed to obtain IMS service token', {
       peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, brandId: brand.brandId, durationMs: elapsed(), ...errorField(error),
     }, error);
     await notify(`:x: Failed to obtain an IMS service token (\`${error.message}\`) — falling back to the legacy source.`);
@@ -423,14 +423,14 @@ export async function loadCitedUrlsFromSemrush({
   const url = buildDomainUrlsUrl({
     baseUrl, spaceCatId, brandId: brand.brandId, startDate, endDate, pageSize: PAGE_SIZE,
   });
-  olog.start('brand_data_load', 'Querying domain-urls (all hosts, all platforms)', {
+  olog.start('data_acquisition_bp_data_semrush_read', 'Querying domain-urls (all hosts, all platforms)', {
     peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, brandId: brand.brandId, pageSize: PAGE_SIZE,
   });
   await notify(':satellite: Querying `domain-urls` (all hosts, all platforms) in a single request...');
 
   const result = await fetchDomainUrls(url, headers, olog, PAGE_SIZE);
   if (!result.ok) {
-    olog.warn('brand_data_load', 'domain-urls request failed; using legacy fallback', {
+    olog.warn('data_acquisition_bp_data_semrush_read', 'domain-urls request failed; using legacy fallback', {
       peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, durationMs: elapsed(),
     });
     await notify(':x: `domain-urls` request failed — falling back to the legacy source.');
@@ -466,7 +466,7 @@ export async function loadCitedUrlsFromSemrush({
     }
   }
 
-  olog.success('url_extract', 'Bucketed domain-urls response', {
+  olog.success('data_acquisition_bp_data_semrush_read', 'Bucketed domain-urls response', {
     peer: PEER.SEMRUSH,
     direction: 'inbound',
     orgId: spaceCatId,
@@ -480,7 +480,7 @@ export async function loadCitedUrlsFromSemrush({
   });
   await notify(`:package: Loaded ${bucketCounts['youtube.com']} \`youtube.com\`, ${bucketCounts['reddit.com']} \`reddit.com\`, and ${bucketCounts.cited} cited (third-party) URL(s).`);
 
-  olog.success('brand_data_load', `Collected ${allUrls.size} cited URLs from Semrush`, {
+  olog.success('data_acquisition_bp_data_semrush_read', `Collected ${allUrls.size} cited URLs from Semrush`, {
     peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, brandId: brand.brandId, urlCount: allUrls.size, durationMs: elapsed(),
   });
   await notify(`:tada: Semrush source succeeded — *${allUrls.size}* total cited URL(s) in ${elapsed()}ms.`);

--- a/src/utils/offsite-logging.js
+++ b/src/utils/offsite-logging.js
@@ -198,7 +198,7 @@ export function createOffsiteLogger(log, bound = {}) {
 }
 
 /**
- * Build an offsite `audit_persist` post-processor for an AuditBuilder.
+ * Build an offsite `audit_persistence_run_recorded` post-processor for an AuditBuilder.
  *
  * The framework persists the Audit record silently (`defaultPersister` -> `Audit.create`) and
  * sets `context.audit` before post-processors run, so this post-processor makes the persist
@@ -215,7 +215,7 @@ export function withAuditPersistLog(audit) {
       audit,
       siteId: auditData?.siteId,
       auditId: auditData?.id ?? context.audit?.getId?.(),
-    }).success('audit_persist', 'Audit persisted', {
+    }).success('audit_persistence_run_recorded', 'Audit persisted', {
       peer: PEER.POSTGRES,
       direction: 'outbound',
       auditType: auditData?.auditType,

--- a/src/utils/store-client.js
+++ b/src/utils/store-client.js
@@ -216,13 +216,13 @@ export default class StoreClient {
     const { AuditUrl } = this.dataAccess;
 
     this.log.info(sc(`Fetching ${auditType} URLs for siteId: ${siteId}`, {
-      event: 'url_store_read', outcome: OUTCOME.START, peer: PEER.URL_STORE, direction: 'inbound', siteId, auditType,
+      event: 'data_acquisition_store_urls_read', outcome: OUTCOME.START, peer: PEER.URL_STORE, direction: 'inbound', siteId, auditType,
     }));
 
-    // P2-3: wrap the DB read so a genuine read error is a distinct, alertable
-    // `url_store_read outcome=failure` rather than surfacing only as the generic
-    // "Audit failed". The empty-store case below stays a StoreEmptyError (a normal
-    // "no URLs yet" signal the callers self-heal on), not a read failure.
+    // Wraps the DB read so a genuine read error is a distinct, alertable
+    // `data_acquisition_store_urls_read outcome=failure` rather than surfacing only as
+    // the generic "Audit failed". The empty-store case below stays a StoreEmptyError (a
+    // normal "no URLs yet" signal the callers self-heal on), not a read failure.
     let items;
     try {
       items = await this.#fetchAllPages((cursor) => AuditUrl.allBySiteIdAndAuditType(
@@ -237,7 +237,7 @@ export default class StoreClient {
       ));
     } catch (error) {
       this.log.error(sc(`Failed to read ${auditType} URLs for siteId: ${siteId}: ${error.message}`, {
-        event: 'url_store_read', outcome: OUTCOME.FAILURE, peer: PEER.URL_STORE, direction: 'inbound', siteId, auditType, errorName: error.name,
+        event: 'data_acquisition_store_urls_read', outcome: OUTCOME.FAILURE, peer: PEER.URL_STORE, direction: 'inbound', siteId, auditType, errorName: error.name,
       }));
       throw error;
     }
@@ -248,7 +248,7 @@ export default class StoreClient {
 
     const urls = items.map(toAuditUrlJson);
     this.log.info(sc(`Found ${urls.length} ${auditType} URLs for siteId: ${siteId}`, {
-      event: 'url_store_read', outcome: OUTCOME.SUCCESS, peer: PEER.URL_STORE, direction: 'inbound', siteId, auditType, count: urls.length,
+      event: 'data_acquisition_store_urls_read', outcome: OUTCOME.SUCCESS, peer: PEER.URL_STORE, direction: 'inbound', siteId, auditType, count: urls.length,
     }));
     return urls;
   }
@@ -268,7 +268,7 @@ export default class StoreClient {
     const { SentimentTopic, SentimentGuideline } = this.dataAccess;
 
     this.log.info(sc(`Fetching sentiment config for siteId: ${siteId}, audit: ${auditType}`, {
-      event: 'guideline_read', outcome: OUTCOME.START, peer: PEER.URL_STORE, direction: 'inbound', siteId, auditType,
+      event: 'audit_orchestration_brand_guidelines_resolved', outcome: OUTCOME.START, peer: PEER.URL_STORE, direction: 'inbound', siteId, auditType,
     }));
 
     const topicItems = await this.#fetchAllPages(
@@ -290,7 +290,7 @@ export default class StoreClient {
     }
 
     this.log.info(sc(`Found ${topics.length} topics and ${guidelines.length} guidelines for siteId: ${siteId}`, {
-      event: 'guideline_read', outcome: OUTCOME.SUCCESS, peer: PEER.URL_STORE, direction: 'inbound', siteId, auditType, topics: topics.length, guidelines: guidelines.length,
+      event: 'audit_orchestration_brand_guidelines_resolved', outcome: OUTCOME.SUCCESS, peer: PEER.URL_STORE, direction: 'inbound', siteId, auditType, topics: topics.length, guidelines: guidelines.length,
     }));
     return { topics, guidelines };
   }

--- a/src/wikipedia-analysis/guidance-handler.js
+++ b/src/wikipedia-analysis/guidance-handler.js
@@ -31,7 +31,8 @@ const AUDIT_TYPE = Audit.AUDIT_TYPES.WIKIPEDIA_ANALYSIS;
 const HUMAN_PREFIX = `[offsite:${AUDIT.WIKIPEDIA}]`;
 
 /**
- * Classifies a presigned-analysis-fetch failure for the `analysis_fetch` reason token:
+ * Classifies a presigned-analysis-fetch failure for the `audit_persistence_payload_fetched`
+ * event's reason token:
  * URL/SSRF/shape and body-shape rejections are `validation`; network / non-2xx / timeout
  * failures are `fetch`. The messages come from analysis-fetch.js / assertPresignedUrl.
  *
@@ -132,13 +133,13 @@ export default async function handler(message, context) {
 
   const olog = createOffsiteLogger(log, { audit: AUDIT.WIKIPEDIA, siteId, auditId });
 
-  olog.start('guidance_receive', `Received Wikipedia analysis guidance for siteId: ${siteId}, auditId: ${auditId}`, {
+  olog.start('audit_analysis_completed', `Received Wikipedia analysis guidance for siteId: ${siteId}, auditId: ${auditId}`, {
     peer: PEER.MYSTIQUE, direction: 'inbound',
   });
 
   const site = await Site.findById(siteId);
   if (!site) {
-    olog.failure('guidance_complete', `Site not found for siteId: ${siteId}`, { reason: 'site_not_found' });
+    olog.failure('audit_persistence_completed', `Site not found for siteId: ${siteId}`, { reason: 'site_not_found' });
     return notFound('Site not found');
   }
   const baseUrl = site.getBaseURL();
@@ -146,7 +147,7 @@ export default async function handler(message, context) {
   // Mystique couldn't complete the analysis (e.g. an upstream producer/service
   // failure). Report it to the Slack thread instead of failing silently, then stop.
   if (data?.error) {
-    olog.failure('guidance_receive', `Mystique returned an error for siteId: ${siteId}, auditId: ${auditId}`, {
+    olog.failure('audit_analysis_completed', `Mystique returned an error for siteId: ${siteId}, auditId: ${auditId}`, {
       peer: PEER.MYSTIQUE, direction: 'inbound', reason: 'mystique_error', mystiqueError: data.errorMessage,
     });
     await postWikipediaOutcomeToSlack(
@@ -167,11 +168,11 @@ export default async function handler(message, context) {
         log,
         prefix: HUMAN_PREFIX,
       });
-      olog.success('analysis_fetch', 'Fetched analysis from presigned URL', {
+      olog.success('audit_persistence_payload_fetched', 'Fetched analysis from presigned URL', {
         peer: PEER.S3, direction: 'inbound',
       });
     } catch (error) {
-      olog.failure('analysis_fetch', 'Error fetching from presigned URL', {
+      olog.failure('audit_persistence_payload_fetched', 'Error fetching from presigned URL', {
         peer: PEER.S3, direction: 'inbound', reason: classifyFetchFailure(error), ...errorField(error),
       });
       return badRequest(`Error fetching analysis data: ${error.message}`);
@@ -180,7 +181,7 @@ export default async function handler(message, context) {
 
   // Validate analysis data
   if (!analysisData) {
-    olog.failure('guidance_complete', 'No analysis data provided in message', { reason: 'no_analysis_data' });
+    olog.failure('audit_persistence_completed', 'No analysis data provided in message', { reason: 'no_analysis_data' });
     return badRequest('Analysis data is required');
   }
 
@@ -188,7 +189,7 @@ export default async function handler(message, context) {
   if (auditId) {
     const audit = await AuditModel.findById(auditId);
     if (!audit) {
-      olog.failure('guidance_complete', `Audit not found for auditId: ${auditId}`, { reason: 'audit_not_found' });
+      olog.failure('audit_persistence_completed', `Audit not found for auditId: ${auditId}`, { reason: 'audit_not_found' });
       return notFound('Audit not found');
     }
   }
@@ -203,7 +204,7 @@ export default async function handler(message, context) {
     // was analyzed but had nothing to improve. Report the outcome to Slack — this
     // path used to return silently, so a Slack-triggered run showed only the trigger.
     if (suggestions.length === 0) {
-      olog.skip('guidance_complete', 'No suggestions found in analysis', { reason: 'no_suggestions' });
+      olog.skip('audit_persistence_completed', 'No suggestions found in analysis', { reason: 'no_suggestions' });
       const outcomeMessage = wikipediaUrl
         ? `:white_check_mark: *wikipedia-analysis* audit finished for *${baseUrl}*\n`
           + '• Wikipedia page analyzed — no improvement suggestions found'
@@ -212,7 +213,7 @@ export default async function handler(message, context) {
       return noContent();
     }
 
-    olog.debug('guidance_receive', `Processing ${suggestions.length} suggestions`, {
+    olog.debug('audit_analysis_completed', `Processing ${suggestions.length} suggestions`, {
       count: suggestions.length, company,
     });
 
@@ -245,7 +246,7 @@ export default async function handler(message, context) {
       fullAnalysis: analysisData,
     });
     await opportunity.save();
-    ologOpp.success('opportunity_persist', 'Opportunity persisted', {
+    ologOpp.success('audit_persistence_opportunity_persisted', 'Opportunity persisted', {
       peer: PEER.POSTGRES, direction: 'outbound',
     });
 
@@ -262,17 +263,17 @@ export default async function handler(message, context) {
           data: suggestion,
         }),
       });
-      ologOpp.success('suggestion_sync', `Synced ${suggestions.length} suggestions`, {
+      ologOpp.success('audit_persistence_suggestions_synced', `Synced ${suggestions.length} suggestions`, {
         peer: PEER.POSTGRES, direction: 'outbound', count: suggestions.length,
       });
     } catch (error) {
-      ologOpp.failure('suggestion_sync', 'Failed to sync suggestions', {
+      ologOpp.failure('audit_persistence_suggestions_synced', 'Failed to sync suggestions', {
         peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
       });
       throw error;
     }
 
-    ologOpp.success('guidance_complete', `Successfully processed Wikipedia analysis for site: ${siteId}, company: ${company}, ${suggestions.length} suggestions`, {
+    ologOpp.success('audit_persistence_completed', `Successfully processed Wikipedia analysis for site: ${siteId}, company: ${company}, ${suggestions.length} suggestions`, {
       count: suggestions.length,
     });
 
@@ -285,9 +286,10 @@ export default async function handler(message, context) {
 
     return ok();
   } catch (error) {
-    // Intentional drill-down: a failure already logged by an inner event (e.g. suggestion_sync)
-    // will also surface here as guidance_complete outcome=failure — the terminal, per-run marker.
-    olog.failure('guidance_complete', 'Error processing Wikipedia analysis', { ...errorField(error) }, error);
+    // Intentional drill-down: a failure already logged by an inner event (e.g.
+    // audit_persistence_suggestions_synced) will also surface here as
+    // audit_persistence_completed outcome=failure — the terminal, per-run marker.
+    olog.failure('audit_persistence_completed', 'Error processing Wikipedia analysis', { ...errorField(error) }, error);
     return badRequest(`Error processing analysis: ${error.message}`);
   }
 }

--- a/src/wikipedia-analysis/handler.js
+++ b/src/wikipedia-analysis/handler.js
@@ -101,26 +101,26 @@ function unwrapSlackMrkdwnLink(raw) {
 function resolveWikipediaUrlOverride(auditContext, olog) {
   const md = auditContext?.messageData;
   if (!md) {
-    olog?.debug('url_override', 'No messageData on audit context', { reason: 'no_message_data' });
+    olog?.debug('audit_orchestration_url_override_resolved', 'No messageData on audit context', { reason: 'no_message_data' });
     return undefined;
   }
 
   const wikiVal = md.wikiUrl;
   const wikipediaVal = md.wikipediaUrl;
 
-  olog?.debug('url_override', 'Resolving Wikipedia URL override from messageData', {
+  olog?.debug('audit_orchestration_url_override_resolved', 'Resolving Wikipedia URL override from messageData', {
     wikiUrl: wikiVal, wikipediaUrl: wikipediaVal,
   });
 
   const rawOverride = wikiVal || wikipediaVal;
 
   if (rawOverride === undefined || rawOverride === null || rawOverride === '') {
-    olog?.debug('url_override', 'No usable wikiUrl/wikipediaUrl override', { reason: 'no_override_value' });
+    olog?.debug('audit_orchestration_url_override_resolved', 'No usable wikiUrl/wikipediaUrl override', { reason: 'no_override_value' });
     return undefined;
   }
 
   if (typeof rawOverride !== 'string') {
-    olog?.debug('url_override', 'Override rejected: expected a string value', {
+    olog?.debug('audit_orchestration_url_override_resolved', 'Override rejected: expected a string value', {
       reason: 'non_string', valueType: typeof rawOverride,
     });
     return undefined;
@@ -128,20 +128,20 @@ function resolveWikipediaUrlOverride(auditContext, olog) {
 
   const normalized = unwrapSlackMrkdwnLink(rawOverride);
   if (!normalized) {
-    olog?.debug('url_override', 'Override rejected: empty after Slack/mrkdwn normalization', {
+    olog?.debug('audit_orchestration_url_override_resolved', 'Override rejected: empty after Slack/mrkdwn normalization', {
       reason: 'empty_after_normalize',
     });
     return undefined;
   }
 
   if (!isValidUrl(normalized)) {
-    olog?.debug('url_override', 'Override rejected: not a valid URL', {
+    olog?.debug('audit_orchestration_url_override_resolved', 'Override rejected: not a valid URL', {
       reason: 'invalid_url', value: normalized,
     });
     return { invalid: true, value: normalized };
   }
 
-  olog?.debug('url_override', 'Override accepted', { url: normalized });
+  olog?.debug('audit_orchestration_url_override_resolved', 'Override accepted', { url: normalized });
 
   return { url: normalized };
 }
@@ -235,26 +235,26 @@ async function runWikipediaAnalysisAudit(url, context, site, auditContext = {}) 
   const siteId = site.getId();
   const olog = createOffsiteLogger(log, { audit: AUDIT.WIKIPEDIA, siteId });
 
-  olog.start('audit_start', `Starting Wikipedia analysis audit for site: ${siteId}`);
+  olog.start('audit_orchestration_started', `Starting Wikipedia analysis audit for site: ${siteId}`);
 
   try {
     const wikipediaConfig = getWikipediaConfig(site);
 
     const wikipediaUrlOverride = resolveWikipediaUrlOverride(auditContext, olog);
     if (wikipediaUrlOverride?.invalid) {
-      olog.warn('config_resolve', 'Ignoring invalid wikipedia URL override', {
+      olog.warn('audit_orchestration_brand_profile_resolved', 'Ignoring invalid wikipedia URL override', {
         reason: 'invalid_url_override', value: wikipediaUrlOverride.value,
       });
     } else if (wikipediaUrlOverride?.url) {
       wikipediaConfig.wikipediaUrl = wikipediaUrlOverride.url;
-      olog.debug('config_resolve', 'Using Wikipedia URL override from audit message', {
+      olog.debug('audit_orchestration_brand_profile_resolved', 'Using Wikipedia URL override from audit message', {
         url: wikipediaUrlOverride.url,
       });
     }
 
     // Validate that we have a company name
     if (!wikipediaConfig.companyName) {
-      olog.warn('config_resolve', 'No company name configured for site, skipping audit', { reason: 'no_company_name' });
+      olog.warn('audit_orchestration_brand_profile_resolved', 'No company name configured for site, skipping audit', { reason: 'no_company_name' });
       return {
         auditResult: {
           success: false,
@@ -264,7 +264,7 @@ async function runWikipediaAnalysisAudit(url, context, site, auditContext = {}) 
       };
     }
 
-    olog.success('config_resolve', 'Resolved Wikipedia config', {
+    olog.success('audit_orchestration_brand_profile_resolved', 'Resolved Wikipedia config', {
       companyName: wikipediaConfig.companyName,
       website: wikipediaConfig.companyWebsite,
       wikipediaUrl: wikipediaConfig.wikipediaUrl,
@@ -282,7 +282,7 @@ async function runWikipediaAnalysisAudit(url, context, site, auditContext = {}) 
       fullAuditRef: url,
     };
   } catch (error) {
-    olog.failure('audit_start', 'Audit failed', { ...errorField(error) });
+    olog.failure('audit_orchestration_started', 'Audit failed', { ...errorField(error) });
     return {
       auditResult: {
         success: false,
@@ -312,12 +312,12 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
 
   // Skip if audit failed
   if (!auditResult.success) {
-    olog.skip('mystique_dispatch', 'Audit failed, skipping Mystique message', { reason: 'audit_failed' });
+    olog.skip('audit_analysis_mystique_request_handoff', 'Audit failed, skipping Mystique message', { reason: 'audit_failed' });
     return auditData;
   }
 
   if (!sqs || !env?.QUEUE_SPACECAT_TO_MYSTIQUE) {
-    olog.warn('mystique_dispatch', 'SQS or Mystique queue not configured, skipping message', { reason: 'not_configured' });
+    olog.warn('audit_analysis_mystique_request_handoff', 'SQS or Mystique queue not configured, skipping message', { reason: 'not_configured' });
     return auditData;
   }
 
@@ -326,7 +326,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     const { Site } = dataAccess;
     const site = await Site.findById(siteId);
     if (!site) {
-      olog.warn('mystique_dispatch', 'Site not found, skipping Mystique message', { reason: 'site_not_found' });
+      olog.warn('audit_analysis_mystique_request_handoff', 'Site not found, skipping Mystique message', { reason: 'site_not_found' });
       return auditData;
     }
 
@@ -352,7 +352,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     try {
       brand = await resolveBrandForSite(context, site);
     } catch (brandError) {
-      olog.warn('mystique_dispatch', 'Brand resolution failed unexpectedly; proceeding without scope', { ...errorField(brandError) });
+      olog.warn('audit_analysis_scope_resolved', 'Brand resolution failed unexpectedly; proceeding without scope', { ...errorField(brandError) });
     }
     const message = applyBrandScope(baseMessage, brand);
 
@@ -362,7 +362,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
       : '(empty → auto-detect)';
 
     olog.success(
-      'mystique_dispatch',
+      'audit_analysis_mystique_request_handoff',
       'Queued Wikipedia analysis request to Mystique',
       {
         peer: PEER.MYSTIQUE,
@@ -373,7 +373,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
       },
     );
   } catch (error) {
-    olog.failure('mystique_dispatch', 'Failed to send Mystique message', { peer: PEER.MYSTIQUE, direction: 'outbound', ...errorField(error) }, error);
+    olog.failure('audit_analysis_mystique_request_handoff', 'Failed to send Mystique message', { peer: PEER.MYSTIQUE, direction: 'outbound', ...errorField(error) }, error);
     // Re-throw to fail the audit if we can't send to Mystique
     throw error;
   }

--- a/src/youtube-analysis/guidance-handler.js
+++ b/src/youtube-analysis/guidance-handler.js
@@ -44,7 +44,8 @@ const AUDIT_TYPE = Audit.AUDIT_TYPES.YOUTUBE_ANALYSIS;
 const HUMAN_PREFIX = `[offsite:${AUDIT.YOUTUBE}]`;
 
 /**
- * Classifies a presigned-analysis-fetch failure for the `analysis_fetch` reason token:
+ * Classifies a presigned-analysis-fetch failure for the `audit_persistence_payload_fetched`
+ * event's reason token:
  * URL/SSRF/shape and body-shape rejections are `validation`; network / non-2xx / timeout
  * failures are `fetch`. The messages come from analysis-fetch.js / assertPresignedUrl.
  *
@@ -73,12 +74,12 @@ export default async function handler(message, context) {
 
   const olog = createOffsiteLogger(log, { audit: AUDIT.YOUTUBE, siteId, auditId });
 
-  olog.start('guidance_receive', `Received YouTube analysis guidance for siteId: ${siteId}, auditId: ${auditId}`, {
+  olog.start('audit_analysis_completed', `Received YouTube analysis guidance for siteId: ${siteId}, auditId: ${auditId}`, {
     peer: PEER.MYSTIQUE, direction: 'inbound',
   });
 
   if (data?.error) {
-    olog.failure('guidance_receive', `Mystique returned an error for siteId: ${siteId}, auditId: ${auditId}`, {
+    olog.failure('audit_analysis_completed', `Mystique returned an error for siteId: ${siteId}, auditId: ${auditId}`, {
       peer: PEER.MYSTIQUE, direction: 'inbound', reason: 'mystique_error', mystiqueError: data.errorMessage,
     });
     return noContent();
@@ -93,11 +94,11 @@ export default async function handler(message, context) {
         log,
         prefix: HUMAN_PREFIX,
       });
-      olog.success('analysis_fetch', 'Fetched analysis from presigned URL', {
+      olog.success('audit_persistence_payload_fetched', 'Fetched analysis from presigned URL', {
         peer: PEER.S3, direction: 'inbound',
       });
     } catch (error) {
-      olog.failure('analysis_fetch', 'Error fetching from presigned URL', {
+      olog.failure('audit_persistence_payload_fetched', 'Error fetching from presigned URL', {
         peer: PEER.S3, direction: 'inbound', reason: classifyFetchFailure(error), ...errorField(error),
       });
       return badRequest(`Error fetching analysis data: ${error.message}`);
@@ -107,20 +108,20 @@ export default async function handler(message, context) {
   }
 
   if (!analysisData) {
-    olog.failure('guidance_complete', 'No analysis data provided in message', { reason: 'no_analysis_data' });
+    olog.failure('audit_persistence_completed', 'No analysis data provided in message', { reason: 'no_analysis_data' });
     return badRequest('Analysis data is required');
   }
 
   const site = await Site.findById(siteId);
   if (!site) {
-    olog.failure('guidance_complete', `Site not found for siteId: ${siteId}`, { reason: 'site_not_found' });
+    olog.failure('audit_persistence_completed', `Site not found for siteId: ${siteId}`, { reason: 'site_not_found' });
     return notFound('Site not found');
   }
 
   if (auditId) {
     const audit = await AuditModel.findById(auditId);
     if (!audit) {
-      olog.failure('guidance_complete', `Audit not found for auditId: ${auditId}`, { reason: 'audit_not_found' });
+      olog.failure('audit_persistence_completed', `Audit not found for auditId: ${auditId}`, { reason: 'audit_not_found' });
       return notFound('Audit not found');
     }
   }
@@ -132,11 +133,11 @@ export default async function handler(message, context) {
     const opportunityData = analysisData.opportunity || {};
 
     if (suggestions.length === 0) {
-      olog.skip('guidance_complete', 'No suggestions found in analysis', { reason: 'no_suggestions' });
+      olog.skip('audit_persistence_completed', 'No suggestions found in analysis', { reason: 'no_suggestions' });
       return noContent();
     }
 
-    olog.debug('guidance_receive', `Processing ${suggestions.length} suggestions`, {
+    olog.debug('audit_analysis_completed', `Processing ${suggestions.length} suggestions`, {
       count: suggestions.length, companyName,
     });
 
@@ -146,7 +147,7 @@ export default async function handler(message, context) {
 
     // Validate before mutating the evergreen opportunity.
     if (!isValidOffsiteAnalysis(analysisData, auditType)) {
-      olog.failure('guidance_complete', `Malformed analysis payload for siteId: ${siteId}; skipping update`, { reason: 'malformed_payload' });
+      olog.failure('audit_persistence_completed', `Malformed analysis payload for siteId: ${siteId}; skipping update`, { reason: 'malformed_payload' });
       return badRequest('Malformed analysis payload');
     }
 
@@ -210,17 +211,17 @@ export default async function handler(message, context) {
           data: suggestion.data,
         }),
       });
-      ologOpp.success('suggestion_sync', `Synced ${suggestions.length} suggestions`, {
+      ologOpp.success('audit_persistence_suggestions_synced', `Synced ${suggestions.length} suggestions`, {
         peer: PEER.POSTGRES, direction: 'outbound', count: suggestions.length,
       });
     } catch (error) {
-      ologOpp.failure('suggestion_sync', 'Failed to sync suggestions', {
+      ologOpp.failure('audit_persistence_suggestions_synced', 'Failed to sync suggestions', {
         peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
       });
       throw error;
     }
 
-    ologOpp.success('guidance_complete', `Successfully processed YouTube analysis for site: ${siteId}, company: ${companyName}, ${suggestions.length} suggestions`, {
+    ologOpp.success('audit_persistence_completed', `Successfully processed YouTube analysis for site: ${siteId}, company: ${companyName}, ${suggestions.length} suggestions`, {
       count: suggestions.length,
     });
     logOffsiteLlmUsage(log, HUMAN_PREFIX, siteId, opportunityData.llmUsage);
@@ -231,7 +232,7 @@ export default async function handler(message, context) {
         dataAccess, opportunity, siteId, auditType, log,
       });
     } catch (error) {
-      ologOpp.failure('outdated_suggestion_delete', `Unexpected expired OUTDATED suggestion deletion failure for auditType ${auditType}`, {
+      ologOpp.failure('audit_housekeeping_suggestions_removed', `Unexpected expired OUTDATED suggestion deletion failure for auditType ${auditType}`, {
         peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
       }, error);
     }
@@ -242,7 +243,7 @@ export default async function handler(message, context) {
         dataAccess, siteId, auditType, log,
       });
     } catch (error) {
-      ologOpp.failure('retention_delete', `Unexpected retention failure for auditType ${auditType}`, {
+      ologOpp.failure('audit_housekeeping_opportunities_removed', `Unexpected retention failure for auditType ${auditType}`, {
         peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
       }, error);
     }
@@ -279,9 +280,10 @@ export default async function handler(message, context) {
 
     return ok();
   } catch (error) {
-    // Intentional drill-down: a failure already logged by an inner event (e.g. suggestion_sync)
-    // will also surface here as guidance_complete outcome=failure — the terminal, per-run marker.
-    olog.failure('guidance_complete', 'Error processing YouTube analysis', { ...errorField(error) }, error);
+    // Intentional drill-down: a failure already logged by an inner event (e.g.
+    // audit_persistence_suggestions_synced) will also surface here as
+    // audit_persistence_completed outcome=failure — the terminal, per-run marker.
+    olog.failure('audit_persistence_completed', 'Error processing YouTube analysis', { ...errorField(error) }, error);
     return badRequest(`Error processing analysis: ${error.message}`);
   }
 }

--- a/src/youtube-analysis/handler.js
+++ b/src/youtube-analysis/handler.js
@@ -91,12 +91,12 @@ async function fetchStoreData(siteId, context, site) {
   const olog = createOffsiteLogger(log, { audit: AUDIT.YOUTUBE, siteId });
   const storeClient = StoreClient.createFrom(context);
 
-  olog.start('url_store_read', `Fetching data from stores for siteId: ${siteId}`, {
+  olog.start('data_acquisition_store_urls_read', `Fetching data from stores for siteId: ${siteId}`, {
     peer: PEER.URL_STORE, direction: 'inbound',
   });
 
   const rawUrls = await storeClient.getUrls(siteId, URL_TYPES.YOUTUBE, { sortBy: 'createdAt', sortOrder: 'desc' });
-  olog.success('url_store_read', `Retrieved ${rawUrls.length} YouTube URLs from URL Store`, {
+  olog.success('data_acquisition_store_urls_read', `Retrieved ${rawUrls.length} YouTube URLs from URL Store`, {
     peer: PEER.URL_STORE, direction: 'inbound', count: rawUrls.length,
   });
 
@@ -109,15 +109,15 @@ async function fetchStoreData(siteId, context, site) {
     drsClient,
     olog,
   );
-  olog.success('drs_availability', `${urls.length} YouTube URLs available in DRS${formatDrsExtras(counts)}`, {
+  olog.success('data_acquisition_scrape_job_status_polled', `${urls.length} YouTube URLs available in DRS${formatDrsExtras(counts)}`, {
     peer: PEER.DRS, direction: 'outbound', available: urls.length,
   });
 
   const topics = await computeTopicsFromBrandPresence(siteId, context, site);
-  olog.debug('topics_load', `Computed ${topics.length} topics from brand presence data`, {
+  olog.debug('audit_orchestration_brand_topics_resolved', `Computed ${topics.length} topics from brand presence data`, {
     count: topics.length,
   });
-  olog.debug('topics_load', `Brand-presence topics payload: ${JSON.stringify(topics)}`);
+  olog.debug('audit_orchestration_brand_topics_resolved', `Brand-presence topics payload: ${JSON.stringify(topics)}`);
 
   let guidelines = [];
   try {
@@ -128,7 +128,7 @@ async function fetchStoreData(siteId, context, site) {
     guidelines = sentimentConfig.guidelines ?? [];
   } catch (error) {
     if (error instanceof StoreEmptyError) {
-      olog.skip('guideline_read', 'No guidelines configured for youtube-analysis, proceeding without', {
+      olog.skip('audit_orchestration_brand_guidelines_resolved', 'No guidelines configured for youtube-analysis, proceeding without', {
         peer: PEER.URL_STORE, direction: 'inbound', reason: 'no_guidelines',
       });
     } else {
@@ -136,7 +136,7 @@ async function fetchStoreData(siteId, context, site) {
     }
   }
 
-  olog.success('guideline_read', `Retrieved ${guidelines.length} guidelines`, {
+  olog.success('audit_orchestration_brand_guidelines_resolved', `Retrieved ${guidelines.length} guidelines`, {
     peer: PEER.URL_STORE, direction: 'inbound', count: guidelines.length,
   });
 
@@ -165,8 +165,8 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
   // handler to report DRS / Mystique / total durations.
   const analysisStartedAt = Date.now();
 
-  olog.start('audit_start', `Starting YouTube analysis audit for site: ${siteId}`);
-  olog.debug('audit_start', `auditContext: ${JSON.stringify(auditContext)}`);
+  olog.start('audit_orchestration_started', `Starting YouTube analysis audit for site: ${siteId}`);
+  olog.debug('audit_orchestration_started', `auditContext: ${JSON.stringify(auditContext)}`);
 
   const enableBrandProfile = resolveEnableBrandProfile(auditContext, log, HUMAN_PREFIX);
   const forwardedUrlLimit = resolveForwardedUrlLimit(auditContext, log, HUMAN_PREFIX);
@@ -176,7 +176,7 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
     const youtubeConfig = getYouTubeConfig(site);
 
     if (!youtubeConfig.companyName) {
-      olog.warn('config_resolve', 'No company name configured for site, skipping audit', {
+      olog.warn('audit_orchestration_brand_profile_resolved', 'No company name configured for site, skipping audit', {
         outcome: OUTCOME.SKIP, reason: 'no_company_name',
       });
       return {
@@ -188,7 +188,7 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
       };
     }
 
-    olog.success('config_resolve', 'Resolved YouTube config', {
+    olog.success('audit_orchestration_brand_profile_resolved', 'Resolved YouTube config', {
       companyName: youtubeConfig.companyName,
       website: youtubeConfig.companyWebsite,
     });
@@ -199,7 +199,7 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
     // reads as a coherent sequence rather than a contradictory "no scrape needed".
     const scrapedNow = scrapedThisCycle(auditContext);
     olog.success(
-      'store_fetch_complete',
+      'data_acquisition_completed',
       scrapedNow
         ? `DRS scrape finished this cycle; ${storeData.urls.length} URL(s) ready, proceeding to Mystique`
         : `Reusing previously scraped DRS content for ${storeData.urls.length} URL(s); no new scrape needed, proceeding to Mystique`,
@@ -249,7 +249,7 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
       // A scoped scrape already ran and the store is STILL empty → the brand has no
       // YouTube URLs to analyze. Report a terminal message instead of looping.
       if (auditContext.drsScrapeRequested) {
-        olog.failure('url_store_read', 'URL store still empty after scrape', {
+        olog.failure('data_acquisition_store_urls_read', 'URL store still empty after scrape', {
           peer: PEER.URL_STORE, direction: 'inbound', reason: 'empty_after_scrape', ...errorField(error),
         });
         await postMessageOptional(
@@ -266,7 +266,7 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
       // First individual run with an empty store: collect + scrape just this bucket via a
       // domain-scoped offsite-brand-presence run, which re-triggers this analysis when DRS
       // completes — no need to run offsite-brand-presence for all buckets manually.
-      olog.skip('store_fetch_complete', 'URL store empty, requesting a scoped scrape for youtube.com', {
+      olog.skip('data_acquisition_completed', 'URL store empty, requesting a scoped scrape for youtube.com', {
         status: 'pending_scrape', peer: PEER.URL_STORE, direction: 'inbound', reason: 'empty_store',
       });
       await postMessageOptional(
@@ -297,7 +297,7 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
       const { channelId, threadTs } = slackContext || {};
       if (auditContext.drsScrapeRequested) {
         // A scrape already ran this cycle and DRS still reports no scraped content → terminal.
-        olog.failure('drs_availability', 'No DRS content available after scraping', {
+        olog.failure('data_acquisition_scrape_job_status_polled', 'No DRS content available after scraping', {
           peer: PEER.DRS, direction: 'outbound', reason: 'no_content_after_scrape', ...errorField(error),
         });
         await postMessageOptional(
@@ -311,7 +311,7 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
           fullAuditRef: url,
         };
       }
-      olog.skip('store_fetch_complete', 'URLs stored but not scraped in DRS yet, requesting a scrape for youtube.com', {
+      olog.skip('data_acquisition_completed', 'URLs stored but not scraped in DRS yet, requesting a scrape for youtube.com', {
         status: 'pending_scrape', peer: PEER.DRS, direction: 'outbound', reason: 'no_drs_content',
       });
       await postMessageOptional(
@@ -337,7 +337,7 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
       };
     }
 
-    olog.failure('audit_start', 'Audit failed', { ...errorField(error) });
+    olog.failure('audit_orchestration_started', 'Audit failed', { ...errorField(error) });
     return {
       auditResult: {
         success: false,
@@ -363,14 +363,14 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
   const olog = createOffsiteLogger(log, { audit: AUDIT.YOUTUBE, siteId, auditId: audit?.getId() });
 
   if (!auditResult.success) {
-    olog.skip('mystique_dispatch', 'Audit failed, skipping Mystique message', {
+    olog.skip('audit_analysis_mystique_request_handoff', 'Audit failed, skipping Mystique message', {
       peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'audit_failed',
     });
     return auditData;
   }
 
   if (!sqs || !env?.QUEUE_SPACECAT_TO_MYSTIQUE) {
-    olog.warn('mystique_dispatch', 'SQS or Mystique queue not configured, skipping message', {
+    olog.warn('audit_analysis_mystique_request_handoff', 'SQS or Mystique queue not configured, skipping message', {
       outcome: OUTCOME.SKIP, peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'not_configured',
     });
     return auditData;
@@ -380,7 +380,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     const { Site } = dataAccess;
     const site = await Site.findById(siteId);
     if (!site) {
-      olog.warn('mystique_dispatch', 'Site not found, skipping Mystique message', {
+      olog.warn('audit_analysis_mystique_request_handoff', 'Site not found, skipping Mystique message', {
         outcome: OUTCOME.SKIP, peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'site_not_found',
       });
       return auditData;
@@ -388,7 +388,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
 
     const { config, storeData } = auditResult;
     const urlLimit = config?.urlLimit ?? MYSTIQUE_URLS_LIMIT;
-    olog.success('url_limit_resolve', `urlLimit=${urlLimit} (URLs sent to Mystique)`);
+    olog.success('audit_analysis_url_limit_resolved', `urlLimit=${urlLimit} (URLs sent to Mystique)`);
 
     const { urls, sentimentConfig } = storeData;
     const enrichedUrls = enrichUrlsWithTopicData(urls, sentimentConfig.topics)
@@ -418,18 +418,18 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     try {
       brand = await resolveBrandForSite(context, site);
     } catch (brandError) {
-      olog.warn('mystique_dispatch', 'Brand resolution failed unexpectedly; proceeding without scope', {
+      olog.warn('audit_analysis_scope_resolved', 'Brand resolution failed unexpectedly; proceeding without scope', {
         peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'brand_resolution', ...errorField(brandError),
       });
     }
     const message = applyBrandScope(baseMessage, brand);
 
-    olog.debug('mystique_dispatch', `Built Mystique message type ${message.type}`, {
+    olog.debug('audit_analysis_mystique_request_built', `Built Mystique message type ${message.type}`, {
       peer: PEER.MYSTIQUE, direction: 'outbound',
     });
     await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, message);
     olog.success(
-      'mystique_dispatch',
+      'audit_analysis_mystique_request_handoff',
       `Queued YouTube analysis request to Mystique with ${enrichedUrls.length} URLs`,
       {
         peer: PEER.MYSTIQUE,
@@ -441,7 +441,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     );
     return auditData;
   } catch (error) {
-    olog.failure('mystique_dispatch', 'Failed to send Mystique message', {
+    olog.failure('audit_analysis_mystique_request_handoff', 'Failed to send Mystique message', {
       peer: PEER.MYSTIQUE, direction: 'outbound', ...errorField(error),
     });
     throw error;

--- a/test/audits/cited-analysis/guidance-handler.test.js
+++ b/test/audits/cited-analysis/guidance-handler.test.js
@@ -233,7 +233,7 @@ describe('Cited Analysis Guidance Handler', () => {
       expect(mockOpportunity.save).to.have.been.calledBefore(syncSuggestionsStub);
       expect(context.log.info).to.have.been.calledWith(
         sinon.match(/Successfully processed cited analysis/)
-          .and(sinon.match(/event=guidance_complete/))
+          .and(sinon.match(/event=audit_persistence_completed/))
           .and(sinon.match(/outcome=success/)),
       );
     });
@@ -399,7 +399,7 @@ describe('Cited Analysis Guidance Handler', () => {
       expect(result.status).to.equal(204);
       expect(convertToOpportunityStub).to.not.have.been.called;
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/No suggestions found in analysis/).and(sinon.match(/event=guidance_complete/)).and(sinon.match(/outcome=skip/)),
+        sinon.match(/No suggestions found in analysis/).and(sinon.match(/event=audit_persistence_completed/)).and(sinon.match(/outcome=skip/)),
       );
     });
 
@@ -438,7 +438,7 @@ describe('Cited Analysis Guidance Handler', () => {
       expect(context.log.error).to.have.been.calledWith(
         sinon.match(/Mystique returned an error/)
           .and(sinon.match(/mystiqueError="HTTP error.*400 Bad Request"/))
-          .and(sinon.match(/event=guidance_receive/))
+          .and(sinon.match(/event=audit_analysis_completed/))
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/peer=mystique/)),
       );
@@ -456,7 +456,7 @@ describe('Cited Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(400);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/No analysis data provided in message/).and(sinon.match(/event=guidance_complete/)),
+        sinon.match(/No analysis data provided in message/).and(sinon.match(/event=audit_persistence_completed/)),
       );
     });
 
@@ -522,7 +522,7 @@ describe('Cited Analysis Guidance Handler', () => {
       expect(convertToOpportunityStub).to.have.been.calledOnce;
       // P4-4: successful S3 fetch is now logged (peer=s3, inbound).
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=analysis_fetch/).and(sinon.match(/outcome=success/)).and(sinon.match(/peer=s3/)),
+        sinon.match(/event=audit_persistence_payload_fetched/).and(sinon.match(/outcome=success/)).and(sinon.match(/peer=s3/)),
       );
 
       const propsArg = convertToOpportunityStub.firstCall.args[5];
@@ -567,7 +567,7 @@ describe('Cited Analysis Guidance Handler', () => {
       // An SSRF/URL-shape rejection is classified reason=validation.
       expect(context.log.error).to.have.been.calledWith(
         sinon.match(/hostname is not an allowlisted/)
-          .and(sinon.match(/event=analysis_fetch/))
+          .and(sinon.match(/event=audit_persistence_payload_fetched/))
           .and(sinon.match(/reason=validation/)),
       );
     });
@@ -590,7 +590,7 @@ describe('Cited Analysis Guidance Handler', () => {
       // A transport error is classified reason=fetch.
       expect(context.log.error).to.have.been.calledWith(
         sinon.match(/Error fetching from presigned URL/)
-          .and(sinon.match(/event=analysis_fetch/))
+          .and(sinon.match(/event=audit_persistence_payload_fetched/))
           .and(sinon.match(/reason=fetch/)),
       );
     });
@@ -959,17 +959,17 @@ describe('Cited Analysis Guidance Handler', () => {
       const result = await handler.default(message, context);
 
       expect(result.status).to.equal(400);
-      // The outer catch folds the error into a structured guidance_complete failure line
+      // The outer catch folds the error into a structured audit_persistence_completed failure line
       // (errorName/errorMessage tokens) and passes the raw error as a genuine second arg
       // purely for stack capture (Fix B).
       expect(context.log.error).to.have.been.calledWith(
         sinon.match(/Error processing cited analysis/)
-          .and(sinon.match(/event=guidance_complete/))
+          .and(sinon.match(/event=audit_persistence_completed/))
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/errorName=Error/)),
       );
       const outerCatchCall = context.log.error.getCalls().find(
-        (c) => /event=guidance_complete/.test(String(c.args[0])),
+        (c) => /event=audit_persistence_completed/.test(String(c.args[0])),
       );
       expect(outerCatchCall.args).to.have.lengthOf(2);
       expect(outerCatchCall.args[1]).to.be.an('error');
@@ -996,14 +996,14 @@ describe('Cited Analysis Guidance Handler', () => {
       // Behavior is unchanged: the outer catch still acks with badRequest.
       expect(result.status).to.equal(400);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/event=suggestion_sync/)
+        sinon.match(/event=audit_persistence_suggestions_synced/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/peer=postgres/))
           .and(sinon.match(/errorName=Error/)),
       );
-      // ...and the outer catch converts it into a terminal guidance_complete failure.
+      // ...and the outer catch converts it into a terminal audit_persistence_completed failure.
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/Error processing cited analysis/).and(sinon.match(/event=guidance_complete/)),
+        sinon.match(/Error processing cited analysis/).and(sinon.match(/event=audit_persistence_completed/)),
       );
     });
 
@@ -1024,7 +1024,7 @@ describe('Cited Analysis Guidance Handler', () => {
       await handler.default(message, context);
 
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=suggestion_sync/)
+        sinon.match(/event=audit_persistence_suggestions_synced/)
           .and(sinon.match(/outcome=success/))
           .and(sinon.match(/peer=postgres/))
           .and(sinon.match(/opportunityId=opp-123/)),
@@ -1078,7 +1078,7 @@ describe('Cited Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(400);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/No analysis data provided in message/).and(sinon.match(/event=guidance_complete/)),
+        sinon.match(/No analysis data provided in message/).and(sinon.match(/event=audit_persistence_completed/)),
       );
     });
 
@@ -1149,7 +1149,7 @@ describe('Cited Analysis Guidance Handler', () => {
 
       expect(context.log.info).to.have.been.calledWith(
         sinon.match(/Received cited analysis guidance for siteId/)
-          .and(sinon.match(/event=guidance_receive/))
+          .and(sinon.match(/event=audit_analysis_completed/))
           .and(sinon.match(/outcome=start/)),
       );
     });
@@ -1790,7 +1790,7 @@ describe('Cited Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(200);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/event=retention_delete/)
+        sinon.match(/event=audit_housekeeping_opportunities_removed/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/errorMessage="retention blew up"/)),
       );
@@ -1879,7 +1879,7 @@ describe('Cited Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(200);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/event=outdated_suggestion_delete/)
+        sinon.match(/event=audit_housekeeping_suggestions_removed/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/errorMessage="retention blew up"/)),
       );

--- a/test/audits/cited-analysis/handler.test.js
+++ b/test/audits/cited-analysis/handler.test.js
@@ -470,7 +470,7 @@ describe('Cited Analysis Handler', function () {
       const result = await citedAnalysisHandler.default.runner('https://bmw.com', context, mockSite);
 
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=config_resolve/)
+        sinon.match(/event=audit_orchestration_brand_profile_resolved/)
           .and(sinon.match('companyName=https://bmw.com'))
           .and(sinon.match('website=https://bmw.com')),
       );
@@ -485,7 +485,7 @@ describe('Cited Analysis Handler', function () {
       const result = await citedAnalysisHandler.default.runner('https://test-company.com', context, mockSite);
 
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=config_resolve/)
+        sinon.match(/event=audit_orchestration_brand_profile_resolved/)
           .and(sinon.match('companyName=https://test-company.com'))
           .and(sinon.match('website=https://test-company.com')),
       );
@@ -500,7 +500,7 @@ describe('Cited Analysis Handler', function () {
       expect(result.auditResult.success).to.be.true;
       expect(context.log.warn).to.not.have.been.calledWithMatch(/No competitors configured/);
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=config_resolve/)
+        sinon.match(/event=audit_orchestration_brand_profile_resolved/)
           .and(sinon.match('companyName="Example Corp"'))
           .and(sinon.match(`website=${baseURL}`))
           .and(sinon.match('competitors=2')),
@@ -801,7 +801,7 @@ describe('Cited Analysis Handler', function () {
         sinon.match(`urlLimit=${MYSTIQUE_URLS_LIMIT} (URLs sent to Mystique)`),
       );
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=mystique_dispatch/)
+        sinon.match(/event=audit_analysis_mystique_request_handoff/)
           .and(sinon.match('companyName="Example Corp"'))
           .and(sinon.match('urls=2')),
       );
@@ -898,7 +898,7 @@ describe('Cited Analysis Handler', function () {
       const sentMessage = context.sqs.sendMessage.firstCall.args[1];
       expect(sentMessage.data.urls).to.have.lengthOf(MYSTIQUE_URLS_LIMIT);
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=mystique_dispatch/)
+        sinon.match(/event=audit_analysis_mystique_request_handoff/)
           .and(sinon.match('companyName=Test'))
           .and(sinon.match(`urls=${MYSTIQUE_URLS_LIMIT}`)),
       );
@@ -1271,7 +1271,7 @@ describe('Cited Analysis Handler', function () {
       expect(sentMessage.siteId).to.equal(siteId);
       // brandId is now a structured field on the mystique_dispatch success line.
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=mystique_dispatch/).and(sinon.match(/brandId=brand-4/)),
+        sinon.match(/event=audit_analysis_mystique_request_handoff/).and(sinon.match(/brandId=brand-4/)),
       );
     });
 

--- a/test/audits/offsite-brand-presence-drs-status.test.js
+++ b/test/audits/offsite-brand-presence-drs-status.test.js
@@ -201,7 +201,7 @@ describe('offsite-brand-presence DRS status handler', function () {
     expect(thrown.message).to.equal('SQS reschedule down');
     expect(log.error).to.have.been.calledWith(
       sinon.match(/Failed to re-enqueue DRS status poll/)
-        .and(sinon.match(/event=drs_poll_reschedule/))
+        .and(sinon.match(/event=data_acquisition_scrape_job_poll_rescheduled/))
         .and(sinon.match(/outcome=failure/)),
     );
   });
@@ -235,7 +235,7 @@ describe('offsite-brand-presence DRS status handler', function () {
     // P1-6: the youtube bucket (still running at the deadline) is dropped with a
     // structured, alertable failure instead of only appearing in the Slack prose.
     expect(log.error).to.have.been.calledWith(
-      sinon.match(/event=drs_poll/)
+      sinon.match(/event=data_acquisition_scrape_job_status_polled/)
         .and(sinon.match(/outcome=failure/))
         .and(sinon.match(/reason=budget_exceeded/))
         .and(sinon.match(/auditType=youtube-analysis/)),
@@ -485,7 +485,7 @@ describe('offsite-brand-presence DRS status handler', function () {
       // P1-6: both buckets failed their scrape (all terminal, no success) → dropped with
       // reason=scrape_failed rather than budget_exceeded.
       expect(log.error).to.have.been.calledWith(
-        sinon.match(/event=drs_poll/)
+        sinon.match(/event=data_acquisition_scrape_job_status_polled/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/reason=scrape_failed/))
           .and(sinon.match(/auditType=reddit-analysis/)),

--- a/test/audits/offsite-brand-presence.test.js
+++ b/test/audits/offsite-brand-presence.test.js
@@ -286,7 +286,7 @@ describe('Offsite Brand Presence Handler', function () {
       // The happy-path load emits a structured success with the loaded URL count.
       expect(log.info).to.have.been.calledWith(
         sinon.match(/Loaded 1 cited URL\(s\) from Semrush/)
-          .and(sinon.match(/event=brand_data_load/))
+          .and(sinon.match(/event=data_acquisition_bp_data_semrush_read/))
           .and(sinon.match(/outcome=success/))
           .and(sinon.match(/peer=semrush/))
           .and(sinon.match(/count=1/)),
@@ -332,7 +332,7 @@ describe('Offsite Brand Presence Handler', function () {
       expect(mockLoadBrandPresenceData).to.not.have.been.called; // no legacy fallback
       expect(log.error).to.have.been.calledWith(
         sinon.match(/Semrush source failed/)
-          .and(sinon.match(/event=brand_data_load/))
+          .and(sinon.match(/event=data_acquisition_bp_data_semrush_read/))
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/peer=semrush/))
           .and(sinon.match(/reason=semrush-failed/)),
@@ -353,7 +353,7 @@ describe('Offsite Brand Presence Handler', function () {
       expect(result.auditResult.urlCounts['youtube.com']).to.equal(1);
       expect(log.warn).to.have.been.calledWith(
         sinon.match(/falling back to PostgREST\/SharePoint/)
-          .and(sinon.match(/event=brand_data_load/))
+          .and(sinon.match(/event=data_acquisition_bp_data_semrush_read/))
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/peer=semrush/))
           .and(sinon.match(/reason=semrush-failed/)),
@@ -1656,7 +1656,7 @@ describe('Offsite Brand Presence Handler', function () {
       // level (outcome=failure) rather than a warn/skip — see Fix C.
       expect(log.error).to.have.been.calledWith(
         sinon.match(/DRS_API_URL or DRS_API_KEY not configured/)
-          .and(sinon.match(/event=drs_submit/))
+          .and(sinon.match(/event=data_acquisition_scrape_job_submitted/))
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/reason=not_configured/)),
       );
@@ -1945,7 +1945,7 @@ describe('Offsite Brand Presence Handler', function () {
       expect(context.sqs.sendMessage).to.not.have.been.called;
       // P1-4: the previously-silent empty-jobs early return now logs a structured skip.
       expect(log.info).to.have.been.calledWith(
-        sinon.match(/event=drs_poll_schedule/)
+        sinon.match(/event=data_acquisition_scrape_job_poll_scheduled/)
           .and(sinon.match(/outcome=skip/))
           .and(sinon.match(/reason=no_jobs/)),
       );
@@ -1964,7 +1964,7 @@ describe('Offsite Brand Presence Handler', function () {
       // transient SQS hiccup here must not page.
       expect(log.warn).to.have.been.calledWith(
         sinon.match(/Failed to schedule DRS status poll/)
-          .and(sinon.match(/event=drs_poll_schedule/))
+          .and(sinon.match(/event=data_acquisition_scrape_job_poll_scheduled/))
           .and(sinon.match(/outcome=failure/)),
       );
     });

--- a/test/audits/reddit-analysis/guidance-handler.test.js
+++ b/test/audits/reddit-analysis/guidance-handler.test.js
@@ -316,7 +316,7 @@ describe('Reddit Analysis Guidance Handler', () => {
       expect(result.status).to.equal(204);
       expect(convertToOpportunityStub).to.not.have.been.called;
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/No suggestions found in analysis/).and(sinon.match(/event=guidance_complete/)).and(sinon.match(/outcome=skip/)),
+        sinon.match(/No suggestions found in analysis/).and(sinon.match(/event=audit_persistence_completed/)).and(sinon.match(/outcome=skip/)),
       );
     });
 
@@ -370,7 +370,7 @@ describe('Reddit Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(400);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/No analysis data provided in message/).and(sinon.match(/event=guidance_complete/)),
+        sinon.match(/No analysis data provided in message/).and(sinon.match(/event=audit_persistence_completed/)),
       );
     });
 
@@ -825,17 +825,17 @@ describe('Reddit Analysis Guidance Handler', () => {
       const result = await handler.default(message, context);
 
       expect(result.status).to.equal(400);
-      // The outer catch folds the error into a structured guidance_complete failure line
+      // The outer catch folds the error into a structured audit_persistence_completed failure line
       // (errorName/errorMessage tokens) and passes the raw error as a genuine second arg
       // purely for stack capture (Fix B).
       expect(context.log.error).to.have.been.calledWith(
         sinon.match(/Error processing Reddit analysis/)
-          .and(sinon.match(/event=guidance_complete/))
+          .and(sinon.match(/event=audit_persistence_completed/))
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/errorName=Error/)),
       );
       const outerCatchCall = context.log.error.getCalls().find(
-        (c) => /event=guidance_complete/.test(String(c.args[0])),
+        (c) => /event=audit_persistence_completed/.test(String(c.args[0])),
       );
       expect(outerCatchCall.args).to.have.lengthOf(2);
       expect(outerCatchCall.args[1]).to.be.an('error');
@@ -861,7 +861,7 @@ describe('Reddit Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(400);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/event=suggestion_sync/)
+        sinon.match(/event=audit_persistence_suggestions_synced/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/peer=postgres/))
           .and(sinon.match(/errorName=Error/)),
@@ -885,7 +885,7 @@ describe('Reddit Analysis Guidance Handler', () => {
       await handler.default(message, context);
 
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=suggestion_sync/)
+        sinon.match(/event=audit_persistence_suggestions_synced/)
           .and(sinon.match(/outcome=success/))
           .and(sinon.match(/peer=postgres/))
           .and(sinon.match(/opportunityId=opp-123/)),
@@ -918,7 +918,7 @@ describe('Reddit Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(400);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/No analysis data provided in message/).and(sinon.match(/event=guidance_complete/)),
+        sinon.match(/No analysis data provided in message/).and(sinon.match(/event=audit_persistence_completed/)),
       );
     });
 
@@ -1598,7 +1598,7 @@ describe('Reddit Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(200);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/event=retention_delete/)
+        sinon.match(/event=audit_housekeeping_opportunities_removed/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/errorMessage="retention blew up"/)),
       );
@@ -1687,7 +1687,7 @@ describe('Reddit Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(200);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/event=outdated_suggestion_delete/)
+        sinon.match(/event=audit_housekeeping_suggestions_removed/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/errorMessage="retention blew up"/)),
       );

--- a/test/audits/reddit-analysis/handler.test.js
+++ b/test/audits/reddit-analysis/handler.test.js
@@ -483,7 +483,7 @@ describe('Reddit Analysis Handler', function () {
       const result = await redditAnalysisHandler.default.runner('https://bmw.com', context, mockSite);
 
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=config_resolve/)
+        sinon.match(/event=audit_orchestration_brand_profile_resolved/)
           .and(sinon.match('companyName=https://bmw.com'))
           .and(sinon.match('website=https://bmw.com')),
       );
@@ -497,7 +497,7 @@ describe('Reddit Analysis Handler', function () {
       const result = await redditAnalysisHandler.default.runner('https://test-company.com', context, mockSite);
 
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=config_resolve/)
+        sinon.match(/event=audit_orchestration_brand_profile_resolved/)
           .and(sinon.match('companyName=https://test-company.com'))
           .and(sinon.match('website=https://test-company.com')),
       );
@@ -620,7 +620,7 @@ describe('Reddit Analysis Handler', function () {
         sinon.match(`urlLimit=${MYSTIQUE_URLS_LIMIT} (URLs sent to Mystique)`),
       );
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=mystique_dispatch/)
+        sinon.match(/event=audit_analysis_mystique_request_handoff/)
           .and(sinon.match('companyName="Example Corp"'))
           .and(sinon.match('urls=2')),
       );
@@ -670,7 +670,7 @@ describe('Reddit Analysis Handler', function () {
       const sentMessage = context.sqs.sendMessage.firstCall.args[1];
       expect(sentMessage.data.urls).to.have.lengthOf(1);
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=mystique_dispatch/)
+        sinon.match(/event=audit_analysis_mystique_request_handoff/)
           .and(sinon.match('companyName=Test'))
           .and(sinon.match('urls=1')),
       );
@@ -699,7 +699,7 @@ describe('Reddit Analysis Handler', function () {
       const sentMessage = context.sqs.sendMessage.firstCall.args[1];
       expect(sentMessage.data.urls).to.have.lengthOf(MYSTIQUE_URLS_LIMIT);
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=mystique_dispatch/)
+        sinon.match(/event=audit_analysis_mystique_request_handoff/)
           .and(sinon.match('companyName=Test'))
           .and(sinon.match(`urls=${MYSTIQUE_URLS_LIMIT}`)),
       );
@@ -729,7 +729,7 @@ describe('Reddit Analysis Handler', function () {
       const sentMessage = context.sqs.sendMessage.firstCall.args[1];
       expect(sentMessage.data.urls).to.have.lengthOf(4);
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=mystique_dispatch/)
+        sinon.match(/event=audit_analysis_mystique_request_handoff/)
           .and(sinon.match('companyName=Test'))
           .and(sinon.match('urls=4')),
       );
@@ -893,7 +893,7 @@ describe('Reddit Analysis Handler', function () {
       expect(sentMessage.siteId).to.equal(siteId);
       // brandId is now a structured field on the mystique_dispatch success line.
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=mystique_dispatch/).and(sinon.match(/brandId=brand-3/)),
+        sinon.match(/event=audit_analysis_mystique_request_handoff/).and(sinon.match(/brandId=brand-3/)),
       );
     });
 

--- a/test/audits/wikipedia-analysis/guidance-handler.test.js
+++ b/test/audits/wikipedia-analysis/guidance-handler.test.js
@@ -459,17 +459,17 @@ describe('Wikipedia Analysis Guidance Handler', function () {
       const result = await handler.default(message, context);
 
       expect(result.status).to.equal(400);
-      // The outer catch folds the error into a structured guidance_complete failure line
+      // The outer catch folds the error into a structured audit_persistence_completed failure line
       // (errorName/errorMessage tokens) and passes the raw error as a genuine second arg
       // purely for stack capture.
       expect(context.log.error).to.have.been.calledWith(
         sinon.match(/Error processing Wikipedia analysis/)
-          .and(sinon.match(/event=guidance_complete/))
+          .and(sinon.match(/event=audit_persistence_completed/))
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/errorName=Error/)),
       );
       const outerCatchCall = context.log.error.getCalls().find(
-        (c) => /event=guidance_complete/.test(String(c.args[0])),
+        (c) => /event=audit_persistence_completed/.test(String(c.args[0])),
       );
       expect(outerCatchCall.args).to.have.lengthOf(2);
       expect(outerCatchCall.args[1]).to.be.an('error');
@@ -496,7 +496,7 @@ describe('Wikipedia Analysis Guidance Handler', function () {
       // Inner catch logs the failed sync event, then rethrows into the outer catch (badRequest).
       expect(result.status).to.equal(400);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/event=suggestion_sync outcome=failure/),
+        sinon.match(/event=audit_persistence_suggestions_synced outcome=failure/),
       );
     });
 
@@ -777,7 +777,7 @@ describe('Wikipedia Analysis Guidance Handler', function () {
       expect(context.log.error).to.have.been.calledWith(
         sinon.match(/Mystique returned an error/)
           .and(sinon.match(/mystiqueError="Wikipedia analysis failed"/))
-          .and(sinon.match(/event=guidance_receive/))
+          .and(sinon.match(/event=audit_analysis_completed/))
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/peer=mystique/)),
       );

--- a/test/audits/wikipedia-analysis/handler.test.js
+++ b/test/audits/wikipedia-analysis/handler.test.js
@@ -213,7 +213,7 @@ describe('Wikipedia Analysis Handler', () => {
       expect(result.auditResult.success).to.be.true;
       expect(result.auditResult.config.wikipediaUrl).to.equal(override);
       expect(context.log.debug).to.have.been.calledWith(
-        sinon.match(/event=config_resolve/).and(sinon.match(`url=${override}`)),
+        sinon.match(/event=audit_orchestration_brand_profile_resolved/).and(sinon.match(`url=${override}`)),
       );
     });
 
@@ -287,7 +287,7 @@ describe('Wikipedia Analysis Handler', () => {
 
       expect(result.auditResult.config.wikipediaUrl).to.equal('https://en.wikipedia.org/wiki/Example_Corp');
       expect(context.log.debug).to.have.been.calledWith(
-        sinon.match(/event=url_override/).and(sinon.match(/after Slack\/mrkdwn normalization/)),
+        sinon.match(/event=audit_orchestration_url_override_resolved/).and(sinon.match(/after Slack\/mrkdwn normalization/)),
       );
     });
 
@@ -340,7 +340,7 @@ describe('Wikipedia Analysis Handler', () => {
 
       expect(result.auditResult.config.wikipediaUrl).to.equal('https://en.wikipedia.org/wiki/Example_Corp');
       expect(context.log.warn).to.have.been.calledWith(
-        sinon.match(/event=config_resolve/)
+        sinon.match(/event=audit_orchestration_brand_profile_resolved/)
           .and(sinon.match(/reason=invalid_url_override/))
           .and(sinon.match('value=not-a-valid-url')),
       );
@@ -412,7 +412,7 @@ describe('Wikipedia Analysis Handler', () => {
       expect(context.log.debug).to.have.been.calledWith(
         sinon.match(
           (msg) => typeof msg === 'string'
-            && msg.includes('event=url_override')
+            && msg.includes('event=audit_orchestration_url_override_resolved')
             && msg.includes(`wikiUrl=${path}`),
         ),
       );
@@ -475,7 +475,7 @@ describe('Wikipedia Analysis Handler', () => {
         }),
       );
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=mystique_dispatch/)
+        sinon.match(/event=audit_analysis_mystique_request_handoff/)
           .and(sinon.match('companyName="Example Corp"'))
           .and(sinon.match('wikipediaUrl=https://en.wikipedia.org/wiki/Example_Corp')),
       );
@@ -501,7 +501,7 @@ describe('Wikipedia Analysis Handler', () => {
       await postProcessor(baseURL, auditData, context);
 
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=mystique_dispatch/)
+        sinon.match(/event=audit_analysis_mystique_request_handoff/)
           .and(sinon.match('wikipediaUrl="(empty → auto-detect)"')),
       );
     });
@@ -634,7 +634,7 @@ describe('Wikipedia Analysis Handler', () => {
       expect(sentMessage.brandId).to.equal('brand-1');
       expect(sentMessage.siteId).to.equal(siteId);
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/brandId=brand-1/).and(sinon.match(/event=mystique_dispatch/)),
+        sinon.match(/brandId=brand-1/).and(sinon.match(/event=audit_analysis_mystique_request_handoff/)),
       );
     });
 

--- a/test/audits/youtube-analysis/guidance-handler.test.js
+++ b/test/audits/youtube-analysis/guidance-handler.test.js
@@ -682,17 +682,17 @@ describe('YouTube Analysis Guidance Handler', () => {
       const response = await guidanceHandler.default(message, context);
 
       expect(response.status).to.equal(400);
-      // The outer catch folds the error into a structured guidance_complete failure line
+      // The outer catch folds the error into a structured audit_persistence_completed failure line
       // (errorName/errorMessage tokens) and passes the raw error as a genuine second arg
       // purely for stack capture (Fix B).
       expect(context.log.error).to.have.been.calledWith(
         sinon.match(/Error processing YouTube analysis/)
-          .and(sinon.match(/event=guidance_complete/))
+          .and(sinon.match(/event=audit_persistence_completed/))
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/errorName=Error/)),
       );
       const outerCatchCall = context.log.error.getCalls().find(
-        (c) => /event=guidance_complete/.test(String(c.args[0])),
+        (c) => /event=audit_persistence_completed/.test(String(c.args[0])),
       );
       expect(outerCatchCall.args).to.have.lengthOf(2);
       expect(outerCatchCall.args[1]).to.be.an('error');
@@ -714,7 +714,7 @@ describe('YouTube Analysis Guidance Handler', () => {
 
       expect(response.status).to.equal(400);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/event=suggestion_sync/)
+        sinon.match(/event=audit_persistence_suggestions_synced/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/peer=postgres/))
           .and(sinon.match(/errorName=Error/)),
@@ -734,7 +734,7 @@ describe('YouTube Analysis Guidance Handler', () => {
       await guidanceHandler.default(message, context);
 
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=suggestion_sync/)
+        sinon.match(/event=audit_persistence_suggestions_synced/)
           .and(sinon.match(/outcome=success/))
           .and(sinon.match(/peer=postgres/))
           .and(sinon.match(/opportunityId=opportunity-123/)),
@@ -1589,7 +1589,7 @@ describe('YouTube Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(200);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/event=retention_delete/)
+        sinon.match(/event=audit_housekeeping_opportunities_removed/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/errorMessage="retention blew up"/)),
       );
@@ -1678,7 +1678,7 @@ describe('YouTube Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(200);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/event=outdated_suggestion_delete/)
+        sinon.match(/event=audit_housekeeping_suggestions_removed/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/errorMessage="retention blew up"/)),
       );

--- a/test/audits/youtube-analysis/handler.test.js
+++ b/test/audits/youtube-analysis/handler.test.js
@@ -465,7 +465,7 @@ describe('YouTube Analysis Handler', function () {
       const result = await youtubeAnalysisHandler.default.runner('https://bmw.com', context, mockSite);
 
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=config_resolve/)
+        sinon.match(/event=audit_orchestration_brand_profile_resolved/)
           .and(sinon.match('companyName=https://bmw.com'))
           .and(sinon.match('website=https://bmw.com')),
       );
@@ -479,7 +479,7 @@ describe('YouTube Analysis Handler', function () {
       const result = await youtubeAnalysisHandler.default.runner('https://test-company.com', context, mockSite);
 
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=config_resolve/)
+        sinon.match(/event=audit_orchestration_brand_profile_resolved/)
           .and(sinon.match('companyName=https://test-company.com'))
           .and(sinon.match('website=https://test-company.com')),
       );
@@ -602,7 +602,7 @@ describe('YouTube Analysis Handler', function () {
         sinon.match(`urlLimit=${MYSTIQUE_URLS_LIMIT} (URLs sent to Mystique)`),
       );
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=mystique_dispatch/)
+        sinon.match(/event=audit_analysis_mystique_request_handoff/)
           .and(sinon.match('companyName="Example Corp"'))
           .and(sinon.match('urls=2')),
       );
@@ -676,7 +676,7 @@ describe('YouTube Analysis Handler', function () {
       const sentMessage = context.sqs.sendMessage.firstCall.args[1];
       expect(sentMessage.data.urls).to.have.lengthOf(MYSTIQUE_URLS_LIMIT);
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=mystique_dispatch/)
+        sinon.match(/event=audit_analysis_mystique_request_handoff/)
           .and(sinon.match('companyName=Test'))
           .and(sinon.match(`urls=${MYSTIQUE_URLS_LIMIT}`)),
       );
@@ -838,7 +838,7 @@ describe('YouTube Analysis Handler', function () {
       expect(sentMessage.brandId).to.equal('brand-2');
       expect(sentMessage.siteId).to.equal(siteId);
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=mystique_dispatch/).and(sinon.match(/brandId=brand-2/)),
+        sinon.match(/event=audit_analysis_mystique_request_handoff/).and(sinon.match(/brandId=brand-2/)),
       );
     });
 

--- a/test/common/offsite-refresh.test.js
+++ b/test/common/offsite-refresh.test.js
@@ -132,7 +132,7 @@ describe('offsite-refresh', () => {
 
       expect(log.error).to.have.been.calledWith(
         sinon.match(/DB down/)
-          .and(sinon.match(/event=opportunity_resolve/))
+          .and(sinon.match(/event=audit_persistence_opportunity_resolved/))
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/audit=cited/)),
       );
@@ -148,7 +148,7 @@ describe('offsite-refresh', () => {
       })).to.be.rejectedWith('DB down');
 
       expect(log.error).to.have.been.calledWith(
-        sinon.match(/event=opportunity_resolve/).and(sinon.match(/audit=unknown/)),
+        sinon.match(/event=audit_persistence_opportunity_resolved/).and(sinon.match(/audit=unknown/)),
       );
     });
 
@@ -221,7 +221,7 @@ describe('offsite-refresh', () => {
       expect(newest.setStatus).to.not.have.been.called;
       // P4-7: retirement is now a structured opportunity_retire line.
       expect(log.info).to.have.been.calledWith(
-        sinon.match(/event=opportunity_retire/)
+        sinon.match(/event=audit_persistence_opportunity_retired/)
           .and(sinon.match(/outcome=success/))
           .and(sinon.match(/retired=2/))
           .and(sinon.match(/kept=newest/)),
@@ -307,7 +307,7 @@ describe('offsite-refresh', () => {
       );
 
       expect(log.info).to.have.been.calledWith(
-        sinon.match(/event=opportunity_persist/)
+        sinon.match(/event=audit_persistence_opportunity_persisted/)
           .and(sinon.match(/outcome=success/))
           .and(sinon.match(/peer=postgres/))
           .and(sinon.match(/audit=reddit/))
@@ -341,7 +341,7 @@ describe('offsite-refresh', () => {
       );
 
       expect(log.info).to.have.been.calledWith(
-        sinon.match(/event=opportunity_persist/)
+        sinon.match(/event=audit_persistence_opportunity_persisted/)
           .and(sinon.match(/outcome=success/))
           .and(sinon.match(/opportunityId=evergreen-1/)),
       );
@@ -363,7 +363,7 @@ describe('offsite-refresh', () => {
       )).to.be.rejectedWith('db exploded');
 
       expect(log.error).to.have.been.calledWith(
-        sinon.match(/event=opportunity_persist/)
+        sinon.match(/event=audit_persistence_opportunity_persisted/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/reason=db_write/))
           .and(sinon.match(/errorName=Error/))

--- a/test/common/offsite-retention.test.js
+++ b/test/common/offsite-retention.test.js
@@ -346,7 +346,7 @@ describe('offsite-retention', () => {
       expect(retentionSummary.deleted).to.equal(0);
       expect(retentionSummary.scanned).to.equal(0);
       expect(log.info).to.have.been.calledWith(
-        sinon.match(/event=outdated_suggestion_retention_summary/)
+        sinon.match(/event=audit_housekeeping_suggestions_removal_summary/)
           .and(sinon.match(/outcome=success/))
           .and(sinon.match(/scanned=0/))
           .and(sinon.match(/eligible=0/))
@@ -380,7 +380,7 @@ describe('offsite-retention', () => {
         scanned: 0, eligible: 0, deleted: 0, failed: 0,
       });
       expect(log.error).to.have.been.calledWith(
-        sinon.match(/event=outdated_suggestion_lookup/)
+        sinon.match(/event=audit_housekeeping_suggestions_found/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/opportunityId=evergreen-1/))
           .and(sinon.match(/siteId=site-1/))
@@ -407,7 +407,7 @@ describe('offsite-retention', () => {
         scanned: 1, eligible: 1, deleted: 0, failed: 1,
       });
       expect(log.error).to.have.been.calledWith(
-        sinon.match(/event=outdated_suggestion_delete/)
+        sinon.match(/event=audit_housekeeping_suggestions_removed/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/opportunityId=evergreen-1/))
           .and(sinon.match(/siteId=site-1/))
@@ -533,7 +533,7 @@ describe('offsite-retention', () => {
       // A partial failure must surface at outcome=failure on the summary, not success — an
       // alerting query keyed on outcome=failure must not miss a partial-batch failure.
       expect(log.error).to.have.been.calledWith(
-        sinon.match(/event=outdated_suggestion_retention_summary/)
+        sinon.match(/event=audit_housekeeping_suggestions_removal_summary/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(`failed=${suggestionCount - OUTDATED_SUGGESTION_DELETE_BATCH_SIZE}`)),
       );
@@ -560,7 +560,7 @@ describe('offsite-retention', () => {
       expect(removeByIds).to.have.been.calledBefore(log.info);
       expect(log.info).to.have.been.calledWith(
         sinon.match(/Deleted 1 expired OUTDATED suggestion\(s\)/)
-          .and(sinon.match(/event=outdated_suggestion_delete/))
+          .and(sinon.match(/event=audit_housekeeping_suggestions_removed/))
           .and(sinon.match(/outcome=success/))
           .and(sinon.match(/opportunityId=evergreen-1/))
           .and(sinon.match(/siteId=site-1/))
@@ -568,7 +568,7 @@ describe('offsite-retention', () => {
       );
       expect(log.info).to.have.been.calledWith(
         sinon.match(/Expired OUTDATED suggestion deletion summary/)
-          .and(sinon.match(/event=outdated_suggestion_retention_summary/))
+          .and(sinon.match(/event=audit_housekeeping_suggestions_removal_summary/))
           .and(sinon.match(/outcome=success/))
           .and(sinon.match(/opportunityId=evergreen-1/))
           .and(sinon.match(/siteId=site-1/))
@@ -635,7 +635,7 @@ describe('offsite-retention', () => {
 
       expect(expiredSnapshots).to.deep.equal([]);
       expect(log.error).to.have.been.calledWith(
-        sinon.match(/event=retention_lookup/)
+        sinon.match(/event=audit_housekeeping_opportunities_found/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/audit=cited/))
           .and(sinon.match(/errorMessage="DB down"/)),
@@ -783,7 +783,7 @@ describe('offsite-retention', () => {
       expect(removeByIdsSuggestion).to.have.been.calledOnceWith(['sugg-2', 'sugg-1']);
       expect(removeByIdsOpportunity).to.have.been.calledOnceWith(['second-expired', 'first-expired']);
       expect(log.info).to.have.been.calledWith(
-        sinon.match(/event=retention_delete/)
+        sinon.match(/event=audit_housekeeping_opportunities_removed/)
           .and(sinon.match(/outcome=success/))
           .and(sinon.match(/eligible=2/))
           .and(sinon.match(/deleted=2/)),

--- a/test/utils/offsite-audit-utils.test.js
+++ b/test/utils/offsite-audit-utils.test.js
@@ -140,7 +140,7 @@ describe('offsite-audit-utils', () => {
       expect(result.urls).to.deep.equal(urls);
       expect(result.counts.determined).to.equal(false);
       expect(olog.skip).to.have.been.calledWith(
-        'drs_availability',
+        'data_acquisition_scrape_job_status_polled',
         'DRS client not configured, skipping availability filter',
         sinon.match({ reason: 'not_configured' }),
       );
@@ -186,7 +186,7 @@ describe('offsite-audit-utils', () => {
         total: 3, available: 2, scraping: 0, notFound: 1, determined: true,
       });
       expect(olog.debug).to.have.been.calledWith(
-        'drs_availability',
+        'data_acquisition_scrape_job_status_polled',
         'DRS availability filter: removed 1 URL(s) not yet scraped (0 scraping, 1 not-found), 2 remaining',
         sinon.match({ peer: PEER.DRS, removed: 1, remaining: 2 }),
       );
@@ -207,7 +207,7 @@ describe('offsite-audit-utils', () => {
       await filterUrlsByDrsStatus(urls, ['ds1'], siteId, drsClient, olog);
 
       expect(olog.debug).to.have.been.calledWith(
-        'drs_availability',
+        'data_acquisition_scrape_job_status_polled',
         'DRS lookup datasetId=ds1: 1/3 available, 0 scraping, 2 not-found',
         sinon.match({ peer: PEER.DRS, datasetId: 'ds1' }),
       );
@@ -236,7 +236,7 @@ describe('offsite-audit-utils', () => {
         total: 3, available: 1, scraping: 1, notFound: 1, determined: true,
       });
       expect(olog.debug).to.have.been.calledWith(
-        'drs_availability',
+        'data_acquisition_scrape_job_status_polled',
         'DRS availability filter: removed 2 URL(s) not yet scraped (1 scraping, 1 not-found), 1 remaining',
         sinon.match({ peer: PEER.DRS, removed: 2, remaining: 1 }),
       );
@@ -278,8 +278,8 @@ describe('offsite-audit-utils', () => {
 
       expect(result.urls).to.deep.equal(urls);
       expect(result.counts.determined).to.equal(false);
-      expect(olog.warn).to.have.been.calledWith('drs_availability', sinon.match(/DRS lookup returned null/), sinon.match({ peer: PEER.DRS, datasetId: 'ds1', reason: 'null_response' }));
-      expect(olog.warn).to.have.been.calledWith('drs_availability', sinon.match(/All DRS lookups failed or returned null/), sinon.match({ peer: PEER.DRS, reason: 'all_failed' }));
+      expect(olog.warn).to.have.been.calledWith('data_acquisition_scrape_job_status_polled', sinon.match(/DRS lookup returned null/), sinon.match({ peer: PEER.DRS, datasetId: 'ds1', reason: 'null_response' }));
+      expect(olog.warn).to.have.been.calledWith('data_acquisition_scrape_job_status_polled', sinon.match(/All DRS lookups failed or returned null/), sinon.match({ peer: PEER.DRS, reason: 'all_failed' }));
     });
 
     it('falls back to full list when all lookups throw', async () => {
@@ -293,10 +293,10 @@ describe('offsite-audit-utils', () => {
 
       expect(result.urls).to.deep.equal(urls);
       expect(result.counts.determined).to.equal(false);
-      expect(olog.warn).to.have.been.calledWith('drs_availability', sinon.match(/DRS lookup failed for datasetId=ds1/), sinon.match({
+      expect(olog.warn).to.have.been.calledWith('data_acquisition_scrape_job_status_polled', sinon.match(/DRS lookup failed for datasetId=ds1/), sinon.match({
         peer: PEER.DRS, datasetId: 'ds1', errorName: 'Error', errorMessage: 'network error',
       }));
-      expect(olog.warn).to.have.been.calledWith('drs_availability', sinon.match(/All DRS lookups failed or returned null/), sinon.match({ peer: PEER.DRS, reason: 'all_failed' }));
+      expect(olog.warn).to.have.been.calledWith('data_acquisition_scrape_job_status_polled', sinon.match(/All DRS lookups failed or returned null/), sinon.match({ peer: PEER.DRS, reason: 'all_failed' }));
     });
 
     it('does not log removed count when all URLs pass the filter', async () => {
@@ -317,7 +317,7 @@ describe('offsite-audit-utils', () => {
       expect(result.counts).to.deep.equal({
         total: 3, available: 3, scraping: 0, notFound: 0, determined: true,
       });
-      expect(olog.debug).to.not.have.been.calledWith('drs_availability', sinon.match(/DRS availability filter: removed/));
+      expect(olog.debug).to.not.have.been.calledWith('data_acquisition_scrape_job_status_polled', sinon.match(/DRS availability filter: removed/));
     });
 
     it('works without log or logPrefix', async () => {
@@ -349,7 +349,7 @@ describe('offsite-audit-utils', () => {
       await filterUrlsByDrsStatus(urls, ['ds1'], siteId, drsClient, olog);
 
       expect(olog.debug).to.have.been.calledWith(
-        'drs_availability',
+        'data_acquisition_scrape_job_status_polled',
         `DRS lookup datasetId=ds1: 0/${urls.length} available, 0 scraping, 0 not-found`,
         sinon.match({ peer: PEER.DRS, datasetId: 'ds1' }),
       );
@@ -491,7 +491,7 @@ describe('offsite-audit-utils', () => {
         { messageData: { urlLimit: MYSTIQUE_URLS_LIMIT + 10 } },
         olog,
       )).to.equal(MYSTIQUE_URLS_LIMIT);
-      expect(olog.debug).to.have.been.calledOnceWith('url_limit_resolve', sinon.match(/exceeds cap/), sinon.match({ requested: MYSTIQUE_URLS_LIMIT + 10, cap: MYSTIQUE_URLS_LIMIT, urlLimit: MYSTIQUE_URLS_LIMIT }));
+      expect(olog.debug).to.have.been.calledOnceWith('audit_analysis_url_limit_resolved', sinon.match(/exceeds cap/), sinon.match({ requested: MYSTIQUE_URLS_LIMIT + 10, cap: MYSTIQUE_URLS_LIMIT, urlLimit: MYSTIQUE_URLS_LIMIT }));
     });
 
     it('returns default and warns when urlLimit is invalid', () => {
@@ -502,7 +502,7 @@ describe('offsite-audit-utils', () => {
       expect(fractional).to.equal(MYSTIQUE_URLS_LIMIT);
       expect(olog.warn).to.have.been.calledTwice;
       expect(olog.warn).to.have.been.calledWith(
-        'url_limit_resolve',
+        'audit_analysis_url_limit_resolved',
         sinon.match(/Invalid urlLimit/),
         sinon.match({ reason: 'invalid' }),
       );
@@ -646,7 +646,7 @@ describe('offsite-audit-utils', () => {
         },
       });
       expect(olog.success).to.have.been.calledWith(
-        'scrape_request',
+        'data_acquisition_scrape_job_submitted',
         sinon.match(/Requested DRS scrape/),
         sinon.match({ reason: 'self_heal', domainScope: 'top-cited' }),
       );
@@ -710,7 +710,7 @@ describe('offsite-audit-utils', () => {
       await requestOffsiteScrape(context, 'site-1', 'top-cited', undefined, true, undefined, undefined, olog);
 
       expect(olog.warn).to.have.been.calledWith(
-        'scrape_request',
+        'data_acquisition_scrape_job_submitted',
         sinon.match(/Failed to request DRS scrape/),
         sinon.match({ reason: 'self_heal' }),
       );

--- a/test/utils/offsite-logging.test.js
+++ b/test/utils/offsite-logging.test.js
@@ -242,7 +242,7 @@ describe('offsite-logging helper', () => {
   });
 
   describe('withAuditPersistLog', () => {
-    it('is a post-processor that logs audit_persist success from the persisted audit data', async () => {
+    it('is a post-processor that logs audit_persistence_run_recorded success from the persisted audit data', async () => {
       const pp = withAuditPersistLog(AUDIT.CITED);
       const auditData = { siteId: 's1', id: 'a1', auditType: 'cited-analysis' };
 
@@ -251,7 +251,7 @@ describe('offsite-logging helper', () => {
       // returns the accumulator unchanged so the post-processor chain is transparent
       expect(result).to.equal(auditData);
       expect(log.info).to.have.been.calledOnceWithExactly(
-        '[offsite:cited] Audit persisted domain=offsite audit=cited event=audit_persist '
+        '[offsite:cited] Audit persisted domain=offsite audit=cited event=audit_persistence_run_recorded '
         + 'outcome=success peer=postgres direction=outbound siteId=s1 auditId=a1 auditType=cited-analysis',
       );
     });
@@ -264,7 +264,7 @@ describe('offsite-logging helper', () => {
       await pp('https://example.com', auditData, context, {}, {});
 
       expect(log.info).to.have.been.calledOnceWithExactly(
-        '[offsite:brand-presence] Audit persisted domain=offsite audit=brand-presence event=audit_persist '
+        '[offsite:brand-presence] Audit persisted domain=offsite audit=brand-presence event=audit_persistence_run_recorded '
         + 'outcome=success peer=postgres direction=outbound siteId=s2 auditId=a2 auditType=offsite-brand-presence',
       );
     });

--- a/test/utils/store-client.test.js
+++ b/test/utils/store-client.test.js
@@ -285,10 +285,11 @@ describe('StoreClient', () => {
       await expect(storeClient.getUrls(siteId, URL_TYPES.WIKIPEDIA))
         .to.be.rejectedWith('dynamo exploded');
       expect(dataAccess.AuditUrl.allBySiteIdAndAuditType).to.have.been.calledTwice;
-      // P2-3: a genuine read error is logged as a distinct, alertable url_store_read failure
-      // before it is re-thrown (rather than surfacing only as the generic "Audit failed").
+      // A genuine read error is logged as a distinct, alertable
+      // data_acquisition_store_urls_read failure before it is re-thrown (rather than
+      // surfacing only as the generic "Audit failed").
       expect(mockLog.error).to.have.been.calledWith(
-        sinon.match(/event=url_store_read/)
+        sinon.match(/event=data_acquisition_store_urls_read/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/dynamo exploded/)),
       );


### PR DESCRIPTION
## Summary

Replace all short/generic event-name strings in the offsite audit pipeline with descriptive, phase-prefixed names following a consistent taxonomy:

- \`audit_orchestration_*\` — P1: site config, brand profile, topics, guidelines
- \`data_acquisition_*\` — P2: DRS scrape lifecycle, brand-presence data
- \`audit_analysis_*\` — P3: Mystique handoff and guidance receipt
- \`audit_persistence_*\` — P4: payload fetch, opportunity/snapshot persistence
- \`audit_housekeeping_*\` — P5: retention and cleanup

## What changed

Pure string-literal substitution at every call site across 18 source files and all corresponding test files. No method changes, no outcome/level changes, no new fields, no behavioral changes.

## Test plan

- [x] All 912 offsite-related tests pass
- [x] Full repo: 9,792 passing, 9 failing (9 pre-existing failures in unrelated audits — confirmed on \`main\`)
- [x] 100% line/branch/statement coverage maintained on all touched files
- [x] Lint clean

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```