### PR TITLE
refactor(offsite): rework log messages for readability (LLMO-6973)

### DIFF
--- a/src/cited-analysis/guidance-handler.js
+++ b/src/cited-analysis/guidance-handler.js
@@ -76,12 +76,12 @@ export default async function handler(message, context) {
 
   const olog = createOffsiteLogger(log, { audit: AUDIT.CITED, siteId, auditId });
 
-  olog.start('audit_analysis_completed', `Received cited analysis guidance for siteId: ${siteId}, auditId: ${auditId}`, {
+  olog.start('audit_analysis_completed', 'Guidance received', {
     peer: PEER.MYSTIQUE, direction: 'inbound',
   });
 
   if (data?.error) {
-    olog.failure('audit_analysis_completed', `Mystique returned an error for siteId: ${siteId}, auditId: ${auditId}`, {
+    olog.failure('audit_analysis_completed', 'Mystique returned an error', {
       peer: PEER.MYSTIQUE, direction: 'inbound', reason: 'mystique_error', mystiqueError: data.errorMessage,
     });
     return noContent();
@@ -116,14 +116,14 @@ export default async function handler(message, context) {
 
   const site = await Site.findById(siteId);
   if (!site) {
-    olog.failure('audit_persistence_completed', `Site not found for siteId: ${siteId}`, { reason: 'site_not_found' });
+    olog.failure('audit_persistence_completed', 'Site not found', { reason: 'site_not_found' });
     return notFound('Site not found');
   }
 
   if (auditId) {
     const audit = await AuditModel.findById(auditId);
     if (!audit) {
-      olog.failure('audit_persistence_completed', `Audit not found for auditId: ${auditId}`, { reason: 'audit_not_found' });
+      olog.failure('audit_persistence_completed', 'Audit not found', { reason: 'audit_not_found' });
       return notFound('Audit not found');
     }
   }
@@ -139,7 +139,7 @@ export default async function handler(message, context) {
       return noContent();
     }
 
-    olog.debug('audit_analysis_completed', `Processing ${suggestions.length} suggestions`, {
+    olog.debug('audit_analysis_completed', 'Processing suggestions', {
       count: suggestions.length, companyName,
     });
 
@@ -149,7 +149,7 @@ export default async function handler(message, context) {
 
     // Validate before mutating the evergreen opportunity.
     if (!isValidOffsiteAnalysis(analysisData, auditType)) {
-      olog.failure('audit_persistence_completed', `Malformed analysis payload for siteId: ${siteId}; skipping update`, { reason: 'malformed_payload' });
+      olog.failure('audit_persistence_completed', 'Malformed analysis payload; skipping update', { reason: 'malformed_payload' });
       return badRequest('Malformed analysis payload');
     }
 
@@ -223,8 +223,8 @@ export default async function handler(message, context) {
       throw error;
     }
 
-    ologOpp.success('audit_persistence_completed', `Successfully processed cited analysis for site: ${siteId}, company: ${companyName}, ${suggestions.length} suggestions`, {
-      count: suggestions.length,
+    ologOpp.success('audit_persistence_completed', 'Run processed successfully', {
+      count: suggestions.length, companyName,
     });
     logOffsiteLlmUsage(log, HUMAN_PREFIX, siteId, opportunityData.llmUsage);
 
@@ -234,8 +234,8 @@ export default async function handler(message, context) {
         dataAccess, opportunity, siteId, auditType, log,
       });
     } catch (error) {
-      ologOpp.failure('audit_housekeeping_suggestions_removed', `Unexpected expired OUTDATED suggestion deletion failure for auditType ${auditType}`, {
-        peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
+      ologOpp.failure('audit_housekeeping_suggestions_removed', 'OUTDATED suggestion deletion failed', {
+        peer: PEER.POSTGRES, direction: 'outbound', auditType, ...errorField(error),
       }, error);
     }
 
@@ -245,8 +245,8 @@ export default async function handler(message, context) {
         dataAccess, siteId, auditType, log,
       });
     } catch (error) {
-      ologOpp.failure('audit_housekeeping_opportunities_removed', `Unexpected retention failure for auditType ${auditType}`, {
-        peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
+      ologOpp.failure('audit_housekeeping_opportunities_removed', 'Snapshot retention failed', {
+        peer: PEER.POSTGRES, direction: 'outbound', auditType, ...errorField(error),
       }, error);
     }
 
@@ -287,7 +287,7 @@ export default async function handler(message, context) {
     // Intentional drill-down: a failure already logged by an inner event (e.g.
     // audit_persistence_suggestions_synced) will also surface here as
     // audit_persistence_completed outcome=failure - the terminal, per-run marker.
-    olog.failure('audit_persistence_completed', 'Error processing cited analysis', { ...errorField(error) }, error);
+    olog.failure('audit_persistence_completed', 'Error processing analysis', { ...errorField(error) }, error);
     return badRequest(`Error processing analysis: ${error.message}`);
   }
 }

--- a/src/cited-analysis/handler.js
+++ b/src/cited-analysis/handler.js
@@ -171,12 +171,12 @@ async function fetchStoreData(siteId, context, site) {
   const olog = createOffsiteLogger(log, { audit: AUDIT.CITED, siteId });
   const storeClient = StoreClient.createFrom(context);
 
-  olog.start('data_acquisition_store_urls_read', `Fetching data from stores for siteId: ${siteId}`, {
+  olog.start('data_acquisition_store_urls_read', 'Fetching data from stores', {
     peer: PEER.URL_STORE, direction: 'inbound',
   });
 
   const rawUrls = await storeClient.getUrls(siteId, URL_TYPES.CITED, { sortBy: 'createdAt', sortOrder: 'desc' });
-  olog.success('data_acquisition_store_urls_read', `Retrieved ${rawUrls.length} cited URLs from URL Store`, {
+  olog.success('data_acquisition_store_urls_read', 'Retrieved URLs from URL Store', {
     peer: PEER.URL_STORE, direction: 'inbound', count: rawUrls.length,
   });
 
@@ -192,7 +192,7 @@ async function fetchStoreData(siteId, context, site) {
   if (ownedDroppedCount > 0) {
     olog.debug(
       'data_acquisition_store_urls_read',
-      `Excluded ${ownedDroppedCount} owned-domain URLs (cited analysis is 3rd-party earned only)`,
+      'Excluded owned-domain URLs (cited analysis is 3rd-party earned only)',
       { peer: PEER.URL_STORE, direction: 'inbound', droppedOwned: ownedDroppedCount },
     );
   }
@@ -210,8 +210,7 @@ async function fetchStoreData(siteId, context, site) {
   if (nonEarnedDroppedCount > 0) {
     olog.debug(
       'data_acquisition_store_urls_read',
-      `Excluded ${nonEarnedDroppedCount} non-earned/branded URLs `
-      + '(social, search, deal-aggregator, or brand-owned lookalike)',
+      'Excluded non-earned/branded URLs (social, search, deal-aggregator, or brand-owned lookalike)',
       { peer: PEER.URL_STORE, direction: 'inbound', droppedNonEarned: nonEarnedDroppedCount },
     );
   }
@@ -230,10 +229,9 @@ async function fetchStoreData(siteId, context, site) {
   });
 
   const topics = await computeTopicsFromBrandPresence(siteId, context, site);
-  olog.debug('audit_orchestration_brand_topics_resolved', `Computed ${topics.length} topics from brand presence data`, {
+  olog.debug('audit_orchestration_brand_topics_resolved', 'Computed topics from brand presence data', {
     count: topics.length,
   });
-  olog.debug('audit_orchestration_brand_topics_resolved', `Brand-presence topics payload: ${JSON.stringify(topics)}`);
 
   let guidelines = [];
   try {
@@ -278,8 +276,7 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
   // handler to report DRS / Mystique / total durations.
   const analysisStartedAt = Date.now();
 
-  olog.start('audit_orchestration_started', `Starting Cited analysis audit for site: ${siteId}`);
-  olog.debug('audit_orchestration_started', `auditContext: ${JSON.stringify(auditContext)}`);
+  olog.start('audit_orchestration_started', 'Audit started');
 
   const enableBrandProfile = resolveEnableBrandProfile(auditContext, log, HUMAN_PREFIX);
   const forwardedUrlLimit = resolveForwardedUrlLimit(auditContext, log, HUMAN_PREFIX);
@@ -301,7 +298,7 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
       };
     }
 
-    olog.success('audit_orchestration_brand_profile_resolved', `Config: ${citedConfig.competitors.length} competitor(s)`, {
+    olog.success('audit_orchestration_brand_profile_resolved', 'Brand profile resolved', {
       companyName: citedConfig.companyName,
       website: citedConfig.companyWebsite,
       competitors: citedConfig.competitors.length,
@@ -310,7 +307,7 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
       // Surfaces the misconfiguration before the SQS hop to Mystique. With an
       // empty list Mystique will only count the primary brand in Share of Voice
       // (no hardcoded fallback) — see LLMO-4909 / cited_sentiment_flow.py.
-      olog.warn('audit_orchestration_brand_profile_resolved', `No competitors configured for site ${siteId}; Share of Voice will only include the primary brand`, {
+      olog.warn('audit_orchestration_brand_profile_resolved', 'No competitors configured; Share of Voice will only include the primary brand', {
         outcome: OUTCOME.SKIP, reason: 'no_competitors',
       });
     }
@@ -323,8 +320,8 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
     olog.success(
       'data_acquisition_completed',
       scrapedNow
-        ? `DRS scrape finished this cycle; ${storeData.urls.length} URL(s) ready, proceeding to Mystique`
-        : `Reusing previously scraped DRS content for ${storeData.urls.length} URL(s); no new scrape needed, proceeding to Mystique`,
+        ? 'DRS scrape finished this cycle; proceeding to Mystique'
+        : 'Reusing previously scraped DRS content; no new scrape needed, proceeding to Mystique',
       { status: 'pending_analysis', urls: storeData.urls.length, scrapedNow },
     );
 
@@ -510,7 +507,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
 
     const { config, storeData } = auditResult;
     const urlLimit = config?.urlLimit ?? MYSTIQUE_URLS_LIMIT;
-    olog.success('audit_analysis_url_limit_resolved', `urlLimit=${urlLimit} (URLs sent to Mystique)`);
+    olog.success('audit_analysis_url_limit_resolved', 'URL limit resolved', { urlLimit });
 
     const { urls, sentimentConfig } = storeData;
     // Project only the fields Mystique reads (url, categories, prompts,
@@ -609,7 +606,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, message);
     olog.success(
       'audit_analysis_mystique_request_handoff',
-      `Queued Cited analysis request to Mystique with ${message.data.urls.length} URLs`,
+      'Queued analysis request to Mystique',
       {
         peer: PEER.MYSTIQUE,
         direction: 'outbound',

--- a/src/common/offsite-refresh.js
+++ b/src/common/offsite-refresh.js
@@ -112,10 +112,11 @@ export async function persistOffsiteOpportunity(
         data: mappedOpportunity.data,
         ...(mappedOpportunity.status ? { status: mappedOpportunity.status } : {}),
       });
-      olog.success('audit_persistence_opportunity_persisted', `Created ${auditType} opportunity`, {
+      olog.success('audit_persistence_opportunity_persisted', 'Created opportunity', {
         peer: PEER.POSTGRES,
         direction: 'outbound',
         opportunityId: created.getId(),
+        auditType,
         status: mappedOpportunity.status,
       });
       return created;
@@ -126,17 +127,18 @@ export async function persistOffsiteOpportunity(
     opportunityToUpdate.setUpdatedBy('system');
     await opportunityToUpdate.save();
 
-    olog.success('audit_persistence_opportunity_persisted', `Refreshed evergreen ${auditType} opportunity`, {
+    olog.success('audit_persistence_opportunity_persisted', 'Refreshed evergreen opportunity', {
       peer: PEER.POSTGRES,
       direction: 'outbound',
       opportunityId: opportunityToUpdate.getId(),
+      auditType,
       status: mappedOpportunity.status,
     });
     return opportunityToUpdate;
   } catch (error) {
     // The sharpest edge: a silent DB write failure here strands the run. Log loudly and
     // structured, THEN rethrow unchanged so the caller's error handling is preserved.
-    olog.failure('audit_persistence_opportunity_persisted', `Failed to persist opportunity for siteId ${auditData.siteId}, auditId ${auditData.id}`, {
+    olog.failure('audit_persistence_opportunity_persisted', 'Failed to persist opportunity', {
       peer: PEER.POSTGRES,
       direction: 'outbound',
       reason: 'db_write',
@@ -168,7 +170,7 @@ export async function resolveEvergreenOffsiteOpportunity({
   try {
     opportunities = await Opportunity.allBySiteIdAndStatus(siteId, Oppty.STATUSES.NEW);
   } catch (e) {
-    olog.failure('audit_persistence_opportunity_resolved', `Failed to fetch opportunities for siteId ${siteId}`, {
+    olog.failure('audit_persistence_opportunity_resolved', 'Failed to fetch opportunities', {
       peer: PEER.POSTGRES, direction: 'inbound', reason: 'lookup', ...errorField(e),
     });
     throw e;
@@ -187,8 +189,8 @@ export async function resolveEvergreenOffsiteOpportunity({
     (a, b) => new Date(b.getUpdatedAt()) - new Date(a.getUpdatedAt()),
   );
 
-  olog.success('audit_persistence_opportunity_retired', `Found ${matchingOpportunities.length} NEW ${auditType} opportunities for siteId ${siteId}; retiring ${duplicates.length} duplicate(s), keeping ${evergreenOpportunity.getId()} as the evergreen opportunity`, {
-    peer: PEER.POSTGRES, direction: 'outbound', retired: duplicates.length, kept: evergreenOpportunity.getId(),
+  olog.success('audit_persistence_opportunity_retired', 'Duplicate opportunities found; retiring extras', {
+    peer: PEER.POSTGRES, direction: 'outbound', found: matchingOpportunities.length, retired: duplicates.length, kept: evergreenOpportunity.getId(),
   });
 
   duplicates.forEach((duplicate) => {

--- a/src/common/offsite-retention.js
+++ b/src/common/offsite-retention.js
@@ -47,8 +47,8 @@ export async function findExpiredSnapshots({
     ignoredOpportunities = await Opportunity
       .allBySiteIdAndStatus(siteId, Oppty.STATUSES.IGNORED);
   } catch (error) {
-    olog.failure('audit_housekeeping_opportunities_found', `Failed to find snapshots for auditType ${auditType}`, {
-      peer: PEER.POSTGRES, direction: 'inbound', ...errorField(error),
+    olog.failure('audit_housekeeping_opportunities_found', 'Failed to find snapshots', {
+      peer: PEER.POSTGRES, direction: 'inbound', auditType, ...errorField(error),
     });
     return [];
   }
@@ -107,8 +107,8 @@ export async function deleteExpiredSnapshots({
   const snapshotIds = expiredSnapshots.map((snapshot) => snapshot.getId());
   await Opportunity.removeByIds(snapshotIds);
 
-  olog.success('audit_housekeeping_opportunities_removed', `Deleted ${snapshotIds.length} expired snapshot(s) for auditType ${auditType}`, {
-    peer: PEER.POSTGRES, direction: 'outbound', eligible: allExpiredSnapshots.length, deleted: snapshotIds.length,
+  olog.success('audit_housekeeping_opportunities_removed', 'Deleted expired snapshots', {
+    peer: PEER.POSTGRES, direction: 'outbound', auditType, eligible: allExpiredSnapshots.length, deleted: snapshotIds.length,
   });
 
   return snapshotIds.length;
@@ -165,8 +165,8 @@ export async function deleteExpiredOutdatedSuggestions({
   try {
     opportunitySuggestions = await opportunity.getSuggestions() || [];
   } catch (error) {
-    olog.failure('audit_housekeeping_suggestions_found', `Failed to read suggestions for expired OUTDATED suggestion deletion, auditType ${auditType}`, {
-      peer: PEER.POSTGRES, direction: 'inbound', ...errorField(error),
+    olog.failure('audit_housekeeping_suggestions_found', 'Failed to read suggestions for expired OUTDATED suggestion deletion', {
+      peer: PEER.POSTGRES, direction: 'inbound', auditType, ...errorField(error),
     });
     return emptyRetentionSummary;
   }
@@ -185,13 +185,13 @@ export async function deleteExpiredOutdatedSuggestions({
       try {
         // Dependent fix-entity rows cascade-delete with their suggestions.
         await Suggestion.removeByIds(suggestionIds);
-        olog.success('audit_housekeeping_suggestions_removed', `Deleted ${suggestionIds.length} expired OUTDATED suggestion(s) for auditType ${auditType}`, {
-          peer: PEER.POSTGRES, direction: 'outbound', suggestionIds,
+        olog.success('audit_housekeeping_suggestions_removed', 'Deleted expired OUTDATED suggestions', {
+          peer: PEER.POSTGRES, direction: 'outbound', auditType, suggestionIds,
         });
         return { deleted: suggestionBatch.length, failed: 0 };
       } catch (error) {
-        olog.failure('audit_housekeeping_suggestions_removed', `Failed to delete ${suggestionBatch.length} expired OUTDATED suggestion(s), auditType ${auditType}`, {
-          peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
+        olog.failure('audit_housekeeping_suggestions_removed', 'Failed to delete expired OUTDATED suggestion batch', {
+          peer: PEER.POSTGRES, direction: 'outbound', auditType, batchSize: suggestionBatch.length, ...errorField(error),
         });
         return { deleted: 0, failed: suggestionBatch.length };
       }
@@ -213,15 +213,16 @@ export async function deleteExpiredOutdatedSuggestions({
   const summaryFields = {
     peer: PEER.POSTGRES,
     direction: 'outbound',
+    auditType,
     scanned: retentionSummary.scanned,
     eligible: retentionSummary.eligible,
     deleted: retentionSummary.deleted,
     failed: retentionSummary.failed,
   };
   if (retentionSummary.failed > 0) {
-    olog.failure('audit_housekeeping_suggestions_removal_summary', `Expired OUTDATED suggestion deletion summary for auditType ${auditType}`, summaryFields);
+    olog.failure('audit_housekeeping_suggestions_removal_summary', 'Expired OUTDATED suggestion deletion summary', summaryFields);
   } else {
-    olog.success('audit_housekeeping_suggestions_removal_summary', `Expired OUTDATED suggestion deletion summary for auditType ${auditType}`, summaryFields);
+    olog.success('audit_housekeeping_suggestions_removal_summary', 'Expired OUTDATED suggestion deletion summary', summaryFields);
   }
 
   return retentionSummary;

--- a/src/common/offsite-snapshot.js
+++ b/src/common/offsite-snapshot.js
@@ -57,8 +57,8 @@ export async function findSnapshotByTriggerAuditId({
   try {
     opportunities = await Opportunity.allBySiteIdAndStatus(siteId, Oppty.STATUSES.IGNORED);
   } catch (e) {
-    olog.failure('audit_persistence_snapshot_resolved', `Failed to look up existing auditType ${auditType} snapshots`, {
-      peer: PEER.POSTGRES, direction: 'inbound', ...errorField(e),
+    olog.failure('audit_persistence_snapshot_resolved', 'Failed to look up existing snapshots', {
+      peer: PEER.POSTGRES, direction: 'inbound', auditType, ...errorField(e),
     });
     throw e;
   }
@@ -135,7 +135,7 @@ export async function prepareSuppressedRunSnapshot({
   if (existingSuppressedRunSnapshot) {
     // triggerAuditId is provably truthy here: existingSuppressedRunSnapshot can only be set
     // by the lookup above, which only runs when triggerAuditId is truthy.
-    olog.success('audit_persistence_snapshot_prepared', `Reusing suppressed-refresh snapshot ${existingSuppressedRunSnapshot.getId()}`, {
+    olog.success('audit_persistence_snapshot_prepared', 'Reusing suppressed-refresh snapshot', {
       peer: PEER.POSTGRES,
       snapshotId: existingSuppressedRunSnapshot.getId(),
       triggerAuditId,
@@ -187,7 +187,7 @@ export async function prepareSupersededRunSnapshot({
   if (existingSupersededRunSnapshot) {
     // triggerAuditId is provably truthy here: existingSupersededRunSnapshot can only be set
     // by the lookup above, which only runs when triggerAuditId is truthy.
-    olog.success('audit_persistence_snapshot_prepared', `Reusing superseded-refresh snapshot ${existingSupersededRunSnapshot.getId()}`, {
+    olog.success('audit_persistence_snapshot_prepared', 'Reusing superseded-refresh snapshot', {
       peer: PEER.POSTGRES,
       snapshotId: existingSupersededRunSnapshot.getId(),
       triggerAuditId,
@@ -235,20 +235,20 @@ export async function prepareSupersededRunSnapshot({
           ...(suggestion.getSkipDetail() ? { skipDetail: suggestion.getSkipDetail() } : {}),
         })));
         if (errorItems?.length > 0) {
-          olog.failure('audit_persistence_snapshot_suggestions_copied', `${errorItems.length} suggestion(s) failed to copy onto snapshot ${snapshot.getId()}`, {
-            peer: PEER.POSTGRES, opportunityId: snapshot.getId(),
+          olog.failure('audit_persistence_snapshot_suggestions_copied', 'Suggestions failed to copy onto snapshot', {
+            peer: PEER.POSTGRES, opportunityId: snapshot.getId(), failed: errorItems.length,
           });
         }
       } catch (err) {
         // addSuggestions threw entirely — the snapshot record already exists but has no
         // suggestions. Delete the orphan so the next delivery recreates the snapshot cleanly.
-        olog.failure('audit_persistence_snapshot_suggestions_copied', `addSuggestions threw for snapshot ${snapshot.getId()}; deleting orphan and rethrowing`, {
+        olog.failure('audit_persistence_snapshot_suggestions_copied', 'addSuggestions threw for snapshot; deleting orphan and rethrowing', {
           peer: PEER.POSTGRES, opportunityId: snapshot.getId(), ...errorField(err),
         });
         try {
           await snapshot.remove();
         } catch (removeErr) {
-          olog.failure('audit_persistence_snapshot_cleaned_up', `Failed to delete orphan snapshot ${snapshot.getId()}`, {
+          olog.failure('audit_persistence_snapshot_cleaned_up', 'Failed to delete orphan snapshot', {
             peer: PEER.POSTGRES, opportunityId: snapshot.getId(), ...errorField(removeErr),
           });
         }
@@ -256,9 +256,10 @@ export async function prepareSupersededRunSnapshot({
       }
     }
 
-    olog.success('audit_persistence_snapshot_prepared', `Created superseded-refresh snapshot ${snapshot.getId()} from evergreen opportunity ${evergreenOpportunity.getId()}`, {
+    olog.success('audit_persistence_snapshot_prepared', 'Created superseded-refresh snapshot from evergreen opportunity', {
       peer: PEER.POSTGRES,
       opportunityId: snapshot.getId(),
+      evergreenOpportunityId: evergreenOpportunity.getId(),
       triggerAuditId: triggerAuditId || undefined,
     });
   }

--- a/src/offsite-brand-presence/drs-status-handler.js
+++ b/src/offsite-brand-presence/drs-status-handler.js
@@ -75,7 +75,7 @@ async function hasRecentAudit(siteId, auditType, dataAccess, log) {
     const auditedAt = new Date(latest.getAuditedAt()).getTime();
     return (Date.now() - auditedAt) < AUDIT_TRIGGER_COOLDOWN_MS;
   } catch (err) {
-    olog.warn('data_acquisition_cooldown_checked', `Failed to check recent ${auditType} audit for site ${siteId}`, {
+    olog.warn('data_acquisition_cooldown_checked', 'Failed to check recent audit', {
       peer: PEER.SPACECAT, direction: 'inbound', auditType, ...errorField(err),
     });
     return false;
@@ -230,7 +230,7 @@ async function triggerAnalysisAudits(
     try {
       // eslint-disable-next-line no-await-in-loop
       if (await hasRecentAudit(siteId, type, dataAccess, log)) {
-        olog.skip('data_acquisition_analysis_request_handoff', `Skipping ${type} for site ${siteId} — recent audit exists`, {
+        olog.skip('data_acquisition_analysis_request_handoff', 'Skipping analysis dispatch; recent audit exists', {
           peer: PEER.SQS, direction: 'outbound', reason: 'cooldown', auditType: type,
         });
         handled.push(type);
@@ -256,12 +256,12 @@ async function triggerAnalysisAudits(
           ...(Object.keys(messageData).length > 0 && { messageData }),
         },
       });
-      olog.success('data_acquisition_analysis_request_handoff', `Triggered ${type} for site ${siteId}`, {
+      olog.success('data_acquisition_analysis_request_handoff', 'Analysis audit dispatched', {
         peer: PEER.SQS, direction: 'outbound', auditType: type,
       });
       handled.push(type);
     } catch (err) {
-      olog.warn('data_acquisition_analysis_request_handoff', `Failed to trigger ${type} analysis audit for site ${siteId}`, {
+      olog.warn('data_acquisition_analysis_request_handoff', 'Failed to dispatch analysis audit', {
         peer: PEER.SQS, direction: 'outbound', auditType: type, ...errorField(err),
       });
     }
@@ -338,7 +338,7 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
   if (jobs.length === 0) {
     // ADR convention: "no jobs to poll" is the canonical .skip() case (info level,
     // outcome=skip) — not a warning. See scheduleDrsStatusPoll's analogous skip.
-    olog.skip('data_acquisition_scrape_job_status_polled', `No jobs to poll, skipping (site ${siteId})`, {
+    olog.skip('data_acquisition_scrape_job_status_polled', 'No jobs to poll, skipping', {
       peer: PEER.DRS, reason: 'no_jobs',
     });
     return ok();
@@ -356,7 +356,7 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
       const result = await drsClient.getJob(job.jobId);
       return { ...job, status: result?.status, error: result?.error_message };
     } catch (err) {
-      olog.warn('data_acquisition_scrape_job_status_polled', `getJob failed for ${job.jobId}`, {
+      olog.warn('data_acquisition_scrape_job_status_polled', 'DRS getJob call failed', {
         peer: PEER.DRS, drsJobId: job.jobId, ...errorField(err),
       });
       return { ...job, status: undefined, error: undefined };
@@ -370,7 +370,7 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
 
   // P1-7: per-poll visibility. Emit a snapshot of terminal/total after resolving statuses
   // so the wait is observable in Splunk (previously nothing was logged on a normal poll).
-  olog.start('data_acquisition_scrape_job_status_polled', `DRS poll for ${baseURL}: ${terminalCount}/${statuses.length} jobs terminal`, {
+  olog.start('data_acquisition_scrape_job_status_polled', 'DRS poll in progress', {
     peer: PEER.DRS, terminal: terminalCount, total: statuses.length,
   });
 
@@ -392,7 +392,7 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
       enableSemrush,
     );
   } catch (err) {
-    olog.warn('data_acquisition_analysis_request_handoff', `Failed to trigger analysis audits for ${baseURL}`, {
+    olog.warn('data_acquisition_analysis_request_handoff', 'Failed to dispatch analysis audits', {
       peer: PEER.SQS, direction: 'outbound', ...errorField(err),
     });
   }
@@ -422,12 +422,12 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
     try {
       await sqs.sendMessage(configuration.getQueues().audits, nextMessage, null, delaySeconds);
     } catch (err) {
-      olog.failure('data_acquisition_scrape_job_poll_rescheduled', `Failed to re-enqueue DRS status poll for ${baseURL}`, {
+      olog.failure('data_acquisition_scrape_job_poll_rescheduled', 'Failed to re-enqueue DRS status poll', {
         peer: PEER.SQS, direction: 'outbound', ...errorField(err),
       });
       throw err;
     }
-    olog.success('data_acquisition_scrape_job_poll_rescheduled', `${terminalCount}/${statuses.length} jobs terminal for ${baseURL}, re-polling in ${delaySeconds}s`, {
+    olog.success('data_acquisition_scrape_job_poll_rescheduled', 'Re-polling DRS status', {
       peer: PEER.SQS, direction: 'outbound', terminal: terminalCount, total: statuses.length, delaySeconds,
     });
     return ok();
@@ -445,14 +445,14 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
   // dropped source (was previously visible only as prose in the Slack summary).
   const dropped = computeDroppedAuditTypes(statuses, new Set(nextTriggered));
   for (const { auditType, reason } of dropped) {
-    olog.failure('data_acquisition_scrape_job_status_polled', `Dropping ${auditType} for ${baseURL}: no DRS success (${reason})`, {
+    olog.failure('data_acquisition_scrape_job_status_polled', 'Dropping analysis audit type; no DRS success', {
       peer: PEER.DRS, reason, auditType,
     });
   }
 
   const summary = buildSummary(baseURL, statuses, drsStartedAt, nextTriggered);
   await postMessageOptional(context, channelId, summary, { threadTs });
-  olog.success('data_acquisition_scrape_job_poll_summary_notified', `Posted completion summary for ${baseURL} (${statuses.length} jobs)`, {
+  olog.success('data_acquisition_scrape_job_poll_summary_notified', 'Posted DRS completion summary', {
     peer: PEER.SLACK, direction: 'outbound', jobs: statuses.length,
   });
 

--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -383,7 +383,7 @@ async function addUrlsToUrlStore(siteId, topByDomain, topCited, dataAccess, log)
   const createdCount = storedUrls.size - existingCount;
   const failCount = entries.length - storedUrls.size;
 
-  olog.success('data_acquisition_store_urls_written', `URL store complete: ${createdCount} created, ${existingCount} already existed, ${failCount} failed`, {
+  olog.success('data_acquisition_store_urls_written', 'URL store write complete', {
     peer: PEER.URL_STORE, direction: 'outbound', created: createdCount, existing: existingCount, failed: failCount,
   });
 
@@ -484,7 +484,7 @@ async function addTopicsToGuidelineStore(siteId, topicMap, allUrls, dataAccess, 
   const updated = results.filter((r) => r === 'updated').length;
   const failed = results.filter((r) => r === 'error').length;
 
-  olog.success('audit_orchestration_guideline_store_written', `Guideline store complete: ${created} created, ${updated} updated, ${failed} failed`, {
+  olog.success('audit_orchestration_guideline_store_written', 'Guideline store write complete', {
     peer: PEER.SPACECAT, direction: 'outbound', created, updated, failed,
   });
 }
@@ -526,24 +526,23 @@ async function submitWithRetry({ domain, datasetId, params }, submitFn, olog) {
       const start = Date.now();
       // eslint-disable-next-line no-await-in-loop
       const result = await submitFn(params);
-      olog.success('data_acquisition_scrape_job_submitted', `DRS job created for ${jobDataset} (${Date.now() - start}ms)`, {
-        peer: PEER.DRS, direction: 'outbound', jobDataset, drsJobId: result?.job_id,
+      olog.success('data_acquisition_scrape_job_submitted', 'DRS job created', {
+        peer: PEER.DRS, direction: 'outbound', jobDataset, drsJobId: result?.job_id, durationMs: Date.now() - start,
       });
       return {
         domain, datasetId, status: 'success', response: result,
       };
     } catch (err) {
       if (attempt === 0 && isRetriable(err)) {
-        olog.warn('data_acquisition_scrape_job_submitted', `DRS job for ${jobDataset} failed (attempt 1), retrying in ${RETRY_DELAY_MS}ms`, {
-          peer: PEER.DRS, direction: 'outbound', jobDataset, retry: 1, ...errorField(err),
+        olog.warn('data_acquisition_scrape_job_submitted', 'DRS job submission failed; retrying', {
+          peer: PEER.DRS, direction: 'outbound', jobDataset, retry: 1, delayMs: RETRY_DELAY_MS, ...errorField(err),
         });
         // eslint-disable-next-line no-await-in-loop
         await new Promise((resolve) => {
           setTimeout(resolve, RETRY_DELAY_MS);
         });
       } else {
-        const label = attempt === 0 ? '' : ' after retry';
-        olog.failure('data_acquisition_scrape_job_submitted', `DRS job failed for ${jobDataset}${label}`, {
+        olog.failure('data_acquisition_scrape_job_submitted', attempt === 0 ? 'DRS job submission failed' : 'DRS job submission failed after retry', {
           peer: PEER.DRS, direction: 'outbound', jobDataset, reason: 'submit_rejected', ...errorField(err),
         });
         return {
@@ -614,7 +613,7 @@ async function triggerDrsScraping(
   // imsOrgId set. Resolve it here as a faithful pre-flight check: if it is
   // missing we skip rather than fire jobs that are guaranteed to fail.
   if (!imsOrgId) {
-    olog.warn('data_acquisition_scrape_job_submitted', `Site ${siteId} organization has no imsOrgId, skipping DRS scraping. Populate imsOrgId on the SpaceCat organization to enable offsite brand presence scraping.`, {
+    olog.warn('data_acquisition_scrape_job_submitted', 'Organization has no imsOrgId; skipping DRS scraping. Populate imsOrgId on the SpaceCat organization to enable offsite brand presence scraping.', {
       outcome: OUTCOME.SKIP, peer: PEER.DRS, direction: 'outbound', reason: 'no_ims_org',
     });
     return {
@@ -655,7 +654,7 @@ async function triggerDrsScraping(
   }
 
   const orgSuffix = spacecatOrgId ? ` (with spacecat_org_id: ${spacecatOrgId})` : '';
-  olog.start('data_acquisition_scrape_job_submitted', `Submitting ${jobs.length} DRS scrape jobs${orgSuffix}`, { peer: PEER.DRS, direction: 'outbound', jobs: jobs.length });
+  olog.start('data_acquisition_scrape_job_submitted', `Submitting DRS scrape jobs${orgSuffix}`, { peer: PEER.DRS, direction: 'outbound', jobs: jobs.length });
 
   const results = [];
   for (const job of jobs) {
@@ -835,7 +834,7 @@ async function scheduleDrsStatusPoll(
     .map((r) => ({ domain: r.domain, datasetId: r.datasetId, jobId: r.response.job_id }));
 
   if (jobs.length === 0) {
-    olog.skip('data_acquisition_scrape_job_poll_scheduled', `No successfully submitted DRS jobs for ${baseURL}, not scheduling status poll`, {
+    olog.skip('data_acquisition_scrape_job_poll_scheduled', 'No successfully submitted DRS jobs; not scheduling status poll', {
       peer: PEER.SQS, direction: 'outbound', reason: 'no_jobs',
     });
     return;
@@ -860,7 +859,7 @@ async function scheduleDrsStatusPoll(
     },
   }, null, pollIntervalSeconds);
 
-  olog.success('data_acquisition_scrape_job_poll_scheduled', `Scheduled DRS status poll for ${baseURL} (${jobs.length} jobs, every ${pollIntervalSeconds}s)`, {
+  olog.success('data_acquisition_scrape_job_poll_scheduled', 'Scheduled DRS status poll', {
     peer: PEER.SQS, direction: 'outbound', jobs: jobs.length, intervalSeconds: pollIntervalSeconds,
   });
 }
@@ -903,7 +902,7 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
   // Fail fast on an unrecognized scope: scoping to an unknown bucket would silently
   // empty every bucket and produce a no-op scrape → poll → re-trigger chain.
   if (domainScope && !VALID_DOMAIN_SCOPES.has(domainScope)) {
-    olog.failure('audit_orchestration_started', `Unknown domainScope '${domainScope}', aborting run`, { reason: 'unknown_scope', domainScope });
+    olog.failure('audit_orchestration_started', 'Unknown domainScope; aborting run', { reason: 'unknown_scope', domainScope });
     return {
       auditResult: { success: false, error: `Unknown domainScope: ${domainScope}` },
       fullAuditRef: finalUrl,
@@ -917,7 +916,7 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
     .map(({ week, year }) => `w${String(week).padStart(2, '0')}-${year}`)
     .join(', ');
 
-  olog.start('audit_orchestration_started', `Starting audit for site: ${siteId} (${baseURL}), weeks: ${weekLabels}`);
+  olog.start('audit_orchestration_started', 'Audit started', { weeks: weekLabels });
 
   let siteHostname;
   try {
@@ -1054,7 +1053,7 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
     }
   }
 
-  olog.success('data_acquisition_bp_data_urls_extracted', `Total unique source URLs found: ${allUrls.size}`, { count: allUrls.size });
+  olog.success('data_acquisition_bp_data_urls_extracted', 'Unique source URLs collected', { count: allUrls.size });
 
   // Compute per-domain counts for audit result
   const urlCounts = {};
@@ -1147,7 +1146,7 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
   //   await addTopicsToGuidelineStore(siteId, topicMap, allUrls, dataAccess, log);
   // }
 
-  olog.success('audit_orchestration_completed', `Audit complete for site ${siteId}: ${allUrls.size} URLs processed, ${drsResults.length} DRS jobs triggered`, {
+  olog.success('audit_orchestration_completed', 'Audit complete', {
     urls: allUrls.size, drsJobs: drsResults.length,
   });
 

--- a/src/reddit-analysis/guidance-handler.js
+++ b/src/reddit-analysis/guidance-handler.js
@@ -76,12 +76,12 @@ export default async function handler(message, context) {
 
   const olog = createOffsiteLogger(log, { audit: AUDIT.REDDIT, siteId, auditId });
 
-  olog.start('audit_analysis_completed', `Received Reddit analysis guidance for siteId: ${siteId}, auditId: ${auditId}`, {
+  olog.start('audit_analysis_completed', 'Guidance received', {
     peer: PEER.MYSTIQUE, direction: 'inbound',
   });
 
   if (data?.error) {
-    olog.failure('audit_analysis_completed', `Mystique returned an error for siteId: ${siteId}, auditId: ${auditId}`, {
+    olog.failure('audit_analysis_completed', 'Mystique returned an error', {
       peer: PEER.MYSTIQUE, direction: 'inbound', reason: 'mystique_error', mystiqueError: data.errorMessage,
     });
     return noContent();
@@ -116,14 +116,14 @@ export default async function handler(message, context) {
 
   const site = await Site.findById(siteId);
   if (!site) {
-    olog.failure('audit_persistence_completed', `Site not found for siteId: ${siteId}`, { reason: 'site_not_found' });
+    olog.failure('audit_persistence_completed', 'Site not found', { reason: 'site_not_found' });
     return notFound('Site not found');
   }
 
   if (auditId) {
     const audit = await AuditModel.findById(auditId);
     if (!audit) {
-      olog.failure('audit_persistence_completed', `Audit not found for auditId: ${auditId}`, { reason: 'audit_not_found' });
+      olog.failure('audit_persistence_completed', 'Audit not found', { reason: 'audit_not_found' });
       return notFound('Audit not found');
     }
   }
@@ -139,7 +139,7 @@ export default async function handler(message, context) {
       return noContent();
     }
 
-    olog.debug('audit_analysis_completed', `Processing ${suggestions.length} suggestions`, {
+    olog.debug('audit_analysis_completed', 'Processing suggestions', {
       count: suggestions.length, companyName,
     });
 
@@ -149,7 +149,7 @@ export default async function handler(message, context) {
 
     // Validate before mutating the evergreen opportunity.
     if (!isValidOffsiteAnalysis(analysisData, auditType)) {
-      olog.failure('audit_persistence_completed', `Malformed analysis payload for siteId: ${siteId}; skipping update`, { reason: 'malformed_payload' });
+      olog.failure('audit_persistence_completed', 'Malformed analysis payload; skipping update', { reason: 'malformed_payload' });
       return badRequest('Malformed analysis payload');
     }
 
@@ -223,8 +223,8 @@ export default async function handler(message, context) {
       throw error;
     }
 
-    ologOpp.success('audit_persistence_completed', `Successfully processed Reddit analysis for site: ${siteId}, company: ${companyName}, ${suggestions.length} suggestions`, {
-      count: suggestions.length,
+    ologOpp.success('audit_persistence_completed', 'Run processed successfully', {
+      count: suggestions.length, companyName,
     });
     logOffsiteLlmUsage(log, HUMAN_PREFIX, siteId, opportunityData.llmUsage);
 
@@ -234,8 +234,8 @@ export default async function handler(message, context) {
         dataAccess, opportunity, siteId, auditType, log,
       });
     } catch (error) {
-      ologOpp.failure('audit_housekeeping_suggestions_removed', `Unexpected expired OUTDATED suggestion deletion failure for auditType ${auditType}`, {
-        peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
+      ologOpp.failure('audit_housekeeping_suggestions_removed', 'OUTDATED suggestion deletion failed', {
+        peer: PEER.POSTGRES, direction: 'outbound', auditType, ...errorField(error),
       }, error);
     }
 
@@ -245,8 +245,8 @@ export default async function handler(message, context) {
         dataAccess, siteId, auditType, log,
       });
     } catch (error) {
-      ologOpp.failure('audit_housekeeping_opportunities_removed', `Unexpected retention failure for auditType ${auditType}`, {
-        peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
+      ologOpp.failure('audit_housekeeping_opportunities_removed', 'Snapshot retention failed', {
+        peer: PEER.POSTGRES, direction: 'outbound', auditType, ...errorField(error),
       }, error);
     }
 
@@ -285,7 +285,7 @@ export default async function handler(message, context) {
     // Intentional drill-down: a failure already logged by an inner event (e.g.
     // audit_persistence_suggestions_synced) will also surface here as
     // audit_persistence_completed outcome=failure — the terminal, per-run marker.
-    olog.failure('audit_persistence_completed', 'Error processing Reddit analysis', { ...errorField(error) }, error);
+    olog.failure('audit_persistence_completed', 'Error processing analysis', { ...errorField(error) }, error);
     return badRequest(`Error processing analysis: ${error.message}`);
   }
 }

--- a/src/reddit-analysis/handler.js
+++ b/src/reddit-analysis/handler.js
@@ -91,12 +91,12 @@ async function fetchStoreData(siteId, context, site) {
   const olog = createOffsiteLogger(log, { audit: AUDIT.REDDIT, siteId });
   const storeClient = StoreClient.createFrom(context);
 
-  olog.start('data_acquisition_store_urls_read', `Fetching data from stores for siteId: ${siteId}`, {
+  olog.start('data_acquisition_store_urls_read', 'Fetching data from stores', {
     peer: PEER.URL_STORE, direction: 'inbound',
   });
 
   const rawUrls = await storeClient.getUrls(siteId, URL_TYPES.REDDIT, { sortBy: 'createdAt', sortOrder: 'desc' });
-  olog.success('data_acquisition_store_urls_read', `Retrieved ${rawUrls.length} Reddit URLs from URL Store`, {
+  olog.success('data_acquisition_store_urls_read', 'Retrieved URLs from URL Store', {
     peer: PEER.URL_STORE, direction: 'inbound', count: rawUrls.length,
   });
 
@@ -114,10 +114,9 @@ async function fetchStoreData(siteId, context, site) {
   });
 
   const topics = await computeTopicsFromBrandPresence(siteId, context, site);
-  olog.debug('audit_orchestration_brand_topics_resolved', `Computed ${topics.length} topics from brand presence data`, {
+  olog.debug('audit_orchestration_brand_topics_resolved', 'Computed topics from brand presence data', {
     count: topics.length,
   });
-  olog.debug('audit_orchestration_brand_topics_resolved', `Brand-presence topics payload: ${JSON.stringify(topics)}`);
 
   let guidelines = [];
   try {
@@ -165,8 +164,7 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
   // handler to report DRS / Mystique / total durations.
   const analysisStartedAt = Date.now();
 
-  olog.start('audit_orchestration_started', `Starting Reddit analysis audit for site: ${siteId}`);
-  olog.debug('audit_orchestration_started', `auditContext: ${JSON.stringify(auditContext)}`);
+  olog.start('audit_orchestration_started', 'Audit started');
 
   const enableBrandProfile = resolveEnableBrandProfile(auditContext, log, HUMAN_PREFIX);
   const forwardedUrlLimit = resolveForwardedUrlLimit(auditContext, log, HUMAN_PREFIX);
@@ -188,7 +186,7 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
       };
     }
 
-    olog.success('audit_orchestration_brand_profile_resolved', 'Resolved Reddit config', {
+    olog.success('audit_orchestration_brand_profile_resolved', 'Brand profile resolved', {
       companyName: redditConfig.companyName,
       website: redditConfig.companyWebsite,
     });
@@ -201,8 +199,8 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
     olog.success(
       'data_acquisition_completed',
       scrapedNow
-        ? `DRS scrape finished this cycle; ${storeData.urls.length} URL(s) ready, proceeding to Mystique`
-        : `Reusing previously scraped DRS content for ${storeData.urls.length} URL(s); no new scrape needed, proceeding to Mystique`,
+        ? 'DRS scrape finished this cycle; proceeding to Mystique'
+        : 'Reusing previously scraped DRS content; no new scrape needed, proceeding to Mystique',
       { status: 'pending_analysis', urls: storeData.urls.length, scrapedNow },
     );
 
@@ -388,7 +386,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
 
     const { config, storeData } = auditResult;
     const urlLimit = config?.urlLimit ?? MYSTIQUE_URLS_LIMIT;
-    olog.success('audit_analysis_url_limit_resolved', `urlLimit=${urlLimit} (URLs sent to Mystique)`);
+    olog.success('audit_analysis_url_limit_resolved', 'URL limit resolved', { urlLimit });
 
     const { urls, sentimentConfig } = storeData;
     const enrichedUrls = enrichUrlsWithTopicData(urls, sentimentConfig.topics)
@@ -430,7 +428,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, message);
     olog.success(
       'audit_analysis_mystique_request_handoff',
-      `Queued Reddit analysis request to Mystique with ${enrichedUrls.length} URLs`,
+      'Queued analysis request to Mystique',
       {
         peer: PEER.MYSTIQUE,
         direction: 'outbound',

--- a/src/utils/offsite-audit-utils.js
+++ b/src/utils/offsite-audit-utils.js
@@ -451,7 +451,7 @@ export async function filterUrlsByDrsStatus(urls, datasetIds, siteId, drsClient,
       // eslint-disable-next-line no-await-in-loop
       const response = await drsClient.lookupScrapeResults({ datasetId, siteId, urls: rawUrls });
       if (!response) {
-        olog?.warn('data_acquisition_scrape_job_status_polled', `DRS lookup returned null for datasetId=${datasetId}, skipping`, {
+        olog?.warn('data_acquisition_scrape_job_status_polled', 'DRS lookup returned null; skipping dataset', {
           peer: PEER.DRS, direction: 'outbound', datasetId, reason: 'null_response',
         });
         // eslint-disable-next-line no-continue
@@ -467,21 +467,27 @@ export async function filterUrlsByDrsStatus(urls, datasetIds, siteId, drsClient,
       }
       olog?.debug(
         'data_acquisition_scrape_job_status_polled',
-        `DRS lookup datasetId=${datasetId}: `
-        + `${response.summary?.available ?? 0}/${response.summary?.total ?? rawUrls.length} available, `
-        + `${response.summary?.scraping ?? 0} scraping, ${response.summary?.not_found ?? 0} not-found`,
-        { peer: PEER.DRS, direction: 'outbound', datasetId },
+        'DRS lookup dataset summary',
+        {
+          peer: PEER.DRS,
+          direction: 'outbound',
+          datasetId,
+          available: response.summary?.available ?? 0,
+          total: response.summary?.total ?? rawUrls.length,
+          scraping: response.summary?.scraping ?? 0,
+          notFound: response.summary?.not_found ?? 0,
+        },
       );
     } catch (error) {
-      olog?.warn('data_acquisition_scrape_job_status_polled', `DRS lookup failed for datasetId=${datasetId}, skipping`, {
+      olog?.warn('data_acquisition_scrape_job_status_polled', 'DRS lookup failed; skipping dataset', {
         peer: PEER.DRS, direction: 'outbound', datasetId, ...errorField(error),
       });
     }
   }
 
   if (!atLeastOneLookupSucceeded) {
-    olog?.warn('data_acquisition_scrape_job_status_polled', `All DRS lookups failed or returned null for datasets [${datasetIds.join(', ')}], skipping availability filter`, {
-      peer: PEER.DRS, direction: 'outbound', reason: 'all_failed',
+    olog?.warn('data_acquisition_scrape_job_status_polled', 'All DRS lookups failed or returned null; skipping availability filter', {
+      peer: PEER.DRS, direction: 'outbound', reason: 'all_failed', datasetIds,
     });
     return { urls, counts: undeterminedDrsCounts(urls.length) };
   }
@@ -506,8 +512,8 @@ export async function filterUrlsByDrsStatus(urls, datasetIds, siteId, drsClient,
   const filtered = urls.filter((item) => availableUrls.has(item.url));
   const removed = total - filtered.length;
   if (removed > 0) {
-    olog?.debug('data_acquisition_scrape_job_status_polled', `DRS availability filter: removed ${removed} URL(s) not yet scraped (${scraping} scraping, ${notFound} not-found), ${filtered.length} remaining`, {
-      peer: PEER.DRS, direction: 'outbound', removed, remaining: filtered.length,
+    olog?.debug('data_acquisition_scrape_job_status_polled', 'DRS availability filter removed URLs not yet scraped', {
+      peer: PEER.DRS, direction: 'outbound', removed, remaining: filtered.length, scraping, notFound,
     });
   }
   return { urls: filtered, counts };
@@ -523,13 +529,13 @@ export function resolveMystiqueUrlLimit(auditContext, olog) {
   if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1) {
     olog?.warn(
       'audit_analysis_url_limit_resolved',
-      `Invalid urlLimit in auditContext (${JSON.stringify(raw)}), using default ${MYSTIQUE_URLS_LIMIT}`,
-      { reason: 'invalid', urlLimit: MYSTIQUE_URLS_LIMIT },
+      'Invalid urlLimit in auditContext; using default',
+      { reason: 'invalid', raw: JSON.stringify(raw), urlLimit: MYSTIQUE_URLS_LIMIT },
     );
     return MYSTIQUE_URLS_LIMIT;
   }
   if (n > MYSTIQUE_URLS_LIMIT) {
-    olog?.debug('audit_analysis_url_limit_resolved', `urlLimit ${n} exceeds cap ${MYSTIQUE_URLS_LIMIT}, using ${MYSTIQUE_URLS_LIMIT}`, {
+    olog?.debug('audit_analysis_url_limit_resolved', 'urlLimit exceeds cap; using cap', {
       requested: n, cap: MYSTIQUE_URLS_LIMIT, urlLimit: MYSTIQUE_URLS_LIMIT,
     });
     return MYSTIQUE_URLS_LIMIT;
@@ -571,7 +577,7 @@ function makeResolveOverride(fieldName) {
     // or forge a second key=value. (This helper is audit-agnostic, so it takes the
     // platform `log`, not an `olog`; the value must still be field-rendered, never
     // interpolated raw into the message.)
-    log?.warn(appendFields(`${prefix} Invalid ${fieldName} in auditContext, omitting`, {
+    log?.warn(appendFields(`${prefix} Invalid override value in auditContext, omitting`, {
       reason: 'invalid_override',
       field: fieldName,
       raw: JSON.stringify(raw).slice(0, 100),
@@ -685,11 +691,11 @@ export async function requestOffsiteScrape(
         messageData: { domainScope, ...overrides },
       },
     });
-    olog?.success('data_acquisition_scrape_job_submitted', `Requested DRS scrape for '${domainScope}' (site ${siteId})`, {
+    olog?.success('data_acquisition_scrape_job_submitted', 'Requested DRS scrape for domain scope', {
       peer: PEER.SQS, direction: 'outbound', reason: 'self_heal', domainScope, ...overrides,
     });
   } catch (error) {
-    olog?.warn('data_acquisition_scrape_job_submitted', `Failed to request DRS scrape for '${domainScope}' (site ${siteId})`, {
+    olog?.warn('data_acquisition_scrape_job_submitted', 'Failed to request DRS scrape for domain scope', {
       peer: PEER.SQS, direction: 'outbound', reason: 'self_heal', domainScope, ...overrides, ...errorField(error),
     });
   }

--- a/src/utils/offsite-brand-presence-enrichment.js
+++ b/src/utils/offsite-brand-presence-enrichment.js
@@ -361,7 +361,7 @@ function extractUrlsAndTopics(data, allUrls, topicMap, log, siteHostname) {
     }
   }
 
-  log.info(enrich(`Found ${allUrls.size} unique source URLs`, {
+  log.info(enrich('Found unique source URLs', {
     event: 'data_acquisition_bp_data_urls_extracted_enriched', outcome: OUTCOME.SUCCESS, count: allUrls.size,
   }));
 }
@@ -395,8 +395,8 @@ export async function loadBrandPresenceData({
     : false;
 
   if (isBrandalfOrg === null) {
-    log.warn(enrich(`Brandalf flag state unknown for org ${organizationId}; skipping legacy file fetch for site ${siteId}`, {
-      event: 'data_acquisition_bp_data_source_selected', outcome: OUTCOME.SKIP, reason: 'brandalf_unknown',
+    log.warn(enrich('Brandalf flag state unknown; skipping legacy file fetch', {
+      event: 'data_acquisition_bp_data_source_selected', outcome: OUTCOME.SKIP, reason: 'brandalf_unknown', orgId: organizationId, siteId,
     }));
     return null;
   }
@@ -412,13 +412,13 @@ export async function loadBrandPresenceData({
     });
     if (dbData) {
       // P2-1: the PostgREST success path previously returned unlogged at the enrichment level.
-      log.info(enrich(`Loaded ${dbData.data.length} brand presence rows from PostgREST for site ${siteId}`, {
-        event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SUCCESS, peer: PEER.POSTGRES, direction: 'inbound', source: 'postgrest', rows: dbData.data.length,
+      log.info(enrich('Loaded brand presence rows from PostgREST', {
+        event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SUCCESS, peer: PEER.POSTGRES, direction: 'inbound', source: 'postgrest', siteId, rows: dbData.data.length,
       }));
       return dbData;
     }
-    log.info(enrich(`No PostgREST data for brandalf-enabled site ${siteId}, falling back to SharePoint file fetch`, {
-      event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SKIP, peer: PEER.POSTGRES, direction: 'inbound', source: 'postgrest', reason: 'no_rows',
+    log.info(enrich('No PostgREST data for brandalf-enabled site; falling back to SharePoint file fetch', {
+      event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SKIP, peer: PEER.POSTGRES, direction: 'inbound', source: 'postgrest', reason: 'no_rows', siteId,
     }));
   }
 
@@ -427,8 +427,8 @@ export async function loadBrandPresenceData({
     resolvedSite = await context.dataAccess?.Site?.findById(siteId);
   }
   if (!resolvedSite) {
-    log.warn(enrich(`Cannot resolve site for ${siteId}, skipping SharePoint fetch`, {
-      event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.SKIP, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', reason: 'no_site',
+    log.warn(enrich('Cannot resolve site; skipping SharePoint fetch', {
+      event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.SKIP, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', reason: 'no_site', siteId,
     }));
     return null;
   }
@@ -439,15 +439,15 @@ export async function loadBrandPresenceData({
     sharepointClient = await createLLMOSharepointClient(context);
     queryResult = await readQueryIndexPaths(resolvedSite, sharepointClient, log);
   } catch (error) {
-    log.error(enrich(`Error reading query-index from SharePoint: ${error.message}`, {
-      event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.FAILURE, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', reason: 'query_index', errorName: error.name,
+    log.error(enrich('Error reading query-index from SharePoint', {
+      event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.FAILURE, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', reason: 'query_index', errorName: error.name, errorMessage: error.message,
     }));
     return null;
   }
 
   if (!queryResult || queryResult.paths.length === 0) {
-    log.warn(enrich(`Failed to read query-index for site ${siteId}`, {
-      event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.SKIP, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', reason: 'empty_query_index',
+    log.warn(enrich('Failed to read query-index', {
+      event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.SKIP, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', reason: 'empty_query_index', siteId,
     }));
     return null;
   }
@@ -461,13 +461,13 @@ export async function loadBrandPresenceData({
   const matchedFiles = previousWeeks.flatMap(
     ({ week, year }) => filterBrandPresenceFiles(paths, week, year),
   );
-  log.info(enrich(`Found ${matchedFiles.length} brand presence files for weeks ${weekLabels}`, {
-    event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.START, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', files: matchedFiles.length,
+  log.info(enrich('Found brand presence files', {
+    event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.START, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', files: matchedFiles.length, weeks: weekLabels,
   }));
 
   if (matchedFiles.length === 0) {
-    log.info(enrich(`No matching brand presence files for site ${siteId}`, {
-      event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.SKIP, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', count: 0,
+    log.info(enrich('No matching brand presence files', {
+      event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.SKIP, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', count: 0, siteId,
     }));
     return null;
   }
@@ -483,20 +483,20 @@ export async function loadBrandPresenceData({
       }
       allRows.push(...data.data);
     } catch (err) {
-      log.error(enrich(`Error reading brand presence sheet ${sheetName}: ${err.message}`, {
-        event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.FAILURE, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', reason: 'sheet_read', errorName: err.name,
+      log.error(enrich('Error reading brand presence sheet', {
+        event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.FAILURE, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', reason: 'sheet_read', sheetName, errorName: err.name, errorMessage: err.message,
       }));
     }
   }
 
   if (allRows.length === 0) {
-    log.info(enrich(`No usable brand presence rows from SharePoint for site ${siteId}`, {
-      event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.SKIP, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', count: 0,
+    log.info(enrich('No usable brand presence rows from SharePoint', {
+      event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.SKIP, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', count: 0, siteId,
     }));
     return null;
   }
-  log.info(enrich(`Loaded ${allRows.length} brand presence rows from SharePoint for site ${siteId}`, {
-    event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.SUCCESS, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', rows: allRows.length,
+  log.info(enrich('Loaded brand presence rows from SharePoint', {
+    event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.SUCCESS, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', siteId, rows: allRows.length,
   }));
   return { data: allRows };
 }
@@ -540,8 +540,8 @@ export async function computeTopicsFromBrandPresence(siteId, context, site) {
   const weekLabels = previousWeeks
     .map(({ week, year }) => `w${String(week).padStart(2, '0')}-${year}`)
     .join(', ');
-  log.info(enrich(`Processing weeks: ${weekLabels}`, {
-    event: 'data_acquisition_bp_data_source_selected', outcome: OUTCOME.START,
+  log.info(enrich('Processing weeks', {
+    event: 'data_acquisition_bp_data_source_selected', outcome: OUTCOME.START, weeks: weekLabels,
   }));
 
   const brandPresenceData = await loadBrandPresenceData({
@@ -557,8 +557,8 @@ export async function computeTopicsFromBrandPresence(siteId, context, site) {
     try {
       siteHostname = new URL(baseURL).hostname.replace(/^www\./, '');
     } catch {
-      log.warn(enrich(`Could not parse baseURL "${baseURL}", skipping site URL filter`, {
-        event: 'data_acquisition_bp_data_urls_extracted_enriched', outcome: OUTCOME.SKIP, reason: 'unparseable_base_url',
+      log.warn(enrich('Could not parse baseURL; skipping site URL filter', {
+        event: 'data_acquisition_bp_data_urls_extracted_enriched', outcome: OUTCOME.SKIP, reason: 'unparseable_base_url', baseURL,
       }));
     }
   }

--- a/src/utils/offsite-brand-presence-postgrest.js
+++ b/src/utils/offsite-brand-presence-postgrest.js
@@ -91,7 +91,7 @@ async function fetchExecutionsWithSources(postgrestClient, {
   // eslint-disable-next-line no-constant-condition
   while (true) {
     if (pageCount >= MAX_EXECUTION_FETCH_PAGES) {
-      log.warn(bp(`Exceeded maximum brand_presence_executions pages (${MAX_EXECUTION_FETCH_PAGES}), processing ${rows.length} rows fetched so far`, {
+      log.warn(bp('Exceeded maximum brand_presence_executions pages; processing rows fetched so far', {
         event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SUCCESS, peer: PEER.POSTGRES, direction: 'inbound', reason: 'max_pages', pages: MAX_EXECUTION_FETCH_PAGES, rows: rows.length,
       }));
       break;
@@ -127,8 +127,8 @@ async function fetchExecutionsWithSources(postgrestClient, {
 
     const batch = data || [];
     rows.push(...batch);
-    log?.info(bp(`Fetched batch: ${batch.length} rows (total: ${rows.length})`, {
-      event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.START, peer: PEER.POSTGRES, direction: 'inbound', rows: batch.length,
+    log?.info(bp('Fetched batch', {
+      event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.START, peer: PEER.POSTGRES, direction: 'inbound', rows: batch.length, total: rows.length,
     }));
 
     if (batch.length < EXECUTION_FETCH_BATCH_SIZE) {
@@ -190,27 +190,27 @@ export async function loadBrandPresenceDataFromPostgrest({
     });
 
     if (executions.length === 0) {
-      log?.info(bp(`No execution rows found for site ${siteId}`, {
-        event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SKIP, peer: PEER.POSTGRES, direction: 'inbound', count: 0, reason: 'no_executions',
+      log?.info(bp('No execution rows found', {
+        event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SKIP, peer: PEER.POSTGRES, direction: 'inbound', count: 0, reason: 'no_executions', siteId,
       }));
       return null;
     }
 
     const rows = mapExecutionsToLegacyBrandPresenceRows(executions);
     if (rows.length === 0) {
-      log?.info(bp(`No usable rows found for site ${siteId}`, {
-        event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SKIP, peer: PEER.POSTGRES, direction: 'inbound', count: 0, reason: 'no_usable_rows',
+      log?.info(bp('No usable rows found', {
+        event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SKIP, peer: PEER.POSTGRES, direction: 'inbound', count: 0, reason: 'no_usable_rows', siteId,
       }));
       return null;
     }
 
-    log?.info(bp(`Loaded ${rows.length} legacy-shaped rows from PostgREST for site ${siteId}`, {
-      event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SUCCESS, peer: PEER.POSTGRES, direction: 'inbound', rows: rows.length,
+    log?.info(bp('Loaded legacy-shaped rows from PostgREST', {
+      event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SUCCESS, peer: PEER.POSTGRES, direction: 'inbound', siteId, rows: rows.length,
     }));
     return { data: rows };
   } catch (error) {
-    log?.warn(bp(`PostgREST query failed for site ${siteId}: ${error.message}`, {
-      event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.FAILURE, peer: PEER.POSTGRES, direction: 'inbound', reason: 'query', errorName: error.name,
+    log?.warn(bp('PostgREST query failed', {
+      event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.FAILURE, peer: PEER.POSTGRES, direction: 'inbound', reason: 'query', siteId, errorName: error.name, errorMessage: error.message,
     }));
     return null;
   }

--- a/src/utils/offsite-brand-presence-semrush.js
+++ b/src/utils/offsite-brand-presence-semrush.js
@@ -156,9 +156,9 @@ async function fetchDomainUrls(url, headers, olog, pageSize) {
     if (authFailure) {
       // Distinct branch so a rejected service token is visible instead of being
       // masked as "Semrush returned nothing" (LLMO-6709 verification).
-      olog.failure('data_acquisition_bp_data_semrush_read', `Service token rejected for domain-urls (HTTP ${response.status}) — verify the IMS service token is authorized by the Semrush proxy (LLMO-6709)`, logFields);
+      olog.failure('data_acquisition_bp_data_semrush_read', 'Service token rejected for domain-urls; verify the IMS service token is authorized by the Semrush proxy (LLMO-6709)', logFields);
     } else {
-      olog.failure('data_acquisition_bp_data_semrush_read', `domain-urls returned HTTP ${response.status}`, logFields);
+      olog.failure('data_acquisition_bp_data_semrush_read', 'domain-urls returned a non-2xx status', logFields);
     }
     return {
       rows: [], ok: false, authFailure, truncated: false,
@@ -182,7 +182,7 @@ async function fetchDomainUrls(url, headers, olog, pageSize) {
   if (truncated) {
     // A full page is a successful response with a caveat (possible starvation), not a
     // failure — override the default outcome so this doesn't pollute failure-based alerts.
-    olog.warn('data_acquisition_bp_data_semrush_read', `domain-urls returned a full page (${raw.length} >= ${pageSize}); response may be truncated`, {
+    olog.warn('data_acquisition_bp_data_semrush_read', 'domain-urls returned a full page; response may be truncated', {
       peer: PEER.SEMRUSH, direction: 'inbound', rowCount: raw.length, pageSize, outcome: OUTCOME.SUCCESS,
     });
   }
@@ -327,13 +327,13 @@ export async function loadCitedUrlsFromSemrush({
   const { brand, resolved } = await resolveBrandResultForSite(context, site);
   if (!brand?.brandId) {
     if (resolved) {
-      olog.skip('data_acquisition_bp_data_semrush_read', `No active brand for org ${spaceCatId}; skipping Semrush source`, {
+      olog.skip('data_acquisition_bp_data_semrush_read', 'No active brand; skipping Semrush source', {
         peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, durationMs: elapsed(), reason: 'no-active-brand',
       });
       await notify(':information_source: No active brand configured for this org — falling back to the legacy source.');
       setDiagnostics({ fallbackReason: 'no-active-brand' });
     } else {
-      olog.warn('data_acquisition_bp_data_semrush_read', `Brand resolution failed (transient) for org ${spaceCatId}; using legacy fallback`, {
+      olog.warn('data_acquisition_bp_data_semrush_read', 'Brand resolution failed (transient); using legacy fallback', {
         peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, durationMs: elapsed(), reason: 'brand-resolution-failed',
       });
       await notify(':warning: Brand resolution failed (transient) — falling back to the legacy source.');
@@ -353,7 +353,7 @@ export async function loadCitedUrlsFromSemrush({
   });
   if (!entitlement.entitled) {
     if (entitlement.resolved) {
-      olog.skip('data_acquisition_bp_data_semrush_read', `Brand not entitled for Semrush (${entitlement.reason}) for org ${spaceCatId}; skipping Semrush source`, {
+      olog.skip('data_acquisition_bp_data_semrush_read', 'Brand not entitled for Semrush; skipping Semrush source', {
         peer: PEER.SEMRUSH,
         direction: 'inbound',
         orgId: spaceCatId,
@@ -373,7 +373,7 @@ export async function loadCitedUrlsFromSemrush({
         entitlementReason: entitlement.reason,
       });
     } else {
-      olog.warn('data_acquisition_bp_data_semrush_read', `Semrush entitlement check failed (transient) for org ${spaceCatId}; using legacy fallback`, {
+      olog.warn('data_acquisition_bp_data_semrush_read', 'Semrush entitlement check failed (transient); using legacy fallback', {
         peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, brandId: brand.brandId, durationMs: elapsed(),
       });
       await notify(':warning: Could not verify Semrush entitlement (transient) — falling back to the legacy source.');
@@ -480,7 +480,7 @@ export async function loadCitedUrlsFromSemrush({
   });
   await notify(`:package: Loaded ${bucketCounts['youtube.com']} \`youtube.com\`, ${bucketCounts['reddit.com']} \`reddit.com\`, and ${bucketCounts.cited} cited (third-party) URL(s).`);
 
-  olog.success('data_acquisition_bp_data_semrush_read', `Collected ${allUrls.size} cited URLs from Semrush`, {
+  olog.success('data_acquisition_bp_data_semrush_read', 'Collected cited URLs from Semrush', {
     peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, brandId: brand.brandId, urlCount: allUrls.size, durationMs: elapsed(),
   });
   await notify(`:tada: Semrush source succeeded — *${allUrls.size}* total cited URL(s) in ${elapsed()}ms.`);

--- a/src/utils/store-client.js
+++ b/src/utils/store-client.js
@@ -215,7 +215,7 @@ export default class StoreClient {
     const { sortBy = 'createdAt', sortOrder = 'desc' } = queryParams;
     const { AuditUrl } = this.dataAccess;
 
-    this.log.info(sc(`Fetching ${auditType} URLs for siteId: ${siteId}`, {
+    this.log.info(sc('Fetching URLs from URL Store', {
       event: 'data_acquisition_store_urls_read', outcome: OUTCOME.START, peer: PEER.URL_STORE, direction: 'inbound', siteId, auditType,
     }));
 
@@ -236,8 +236,8 @@ export default class StoreClient {
         },
       ));
     } catch (error) {
-      this.log.error(sc(`Failed to read ${auditType} URLs for siteId: ${siteId}: ${error.message}`, {
-        event: 'data_acquisition_store_urls_read', outcome: OUTCOME.FAILURE, peer: PEER.URL_STORE, direction: 'inbound', siteId, auditType, errorName: error.name,
+      this.log.error(sc('Failed to read URLs from URL Store', {
+        event: 'data_acquisition_store_urls_read', outcome: OUTCOME.FAILURE, peer: PEER.URL_STORE, direction: 'inbound', siteId, auditType, errorName: error.name, errorMessage: error.message,
       }));
       throw error;
     }
@@ -247,7 +247,7 @@ export default class StoreClient {
     }
 
     const urls = items.map(toAuditUrlJson);
-    this.log.info(sc(`Found ${urls.length} ${auditType} URLs for siteId: ${siteId}`, {
+    this.log.info(sc('Found URLs in URL Store', {
       event: 'data_acquisition_store_urls_read', outcome: OUTCOME.SUCCESS, peer: PEER.URL_STORE, direction: 'inbound', siteId, auditType, count: urls.length,
     }));
     return urls;
@@ -267,7 +267,7 @@ export default class StoreClient {
     this.#ensureConfigured(['SentimentTopic', 'SentimentGuideline']);
     const { SentimentTopic, SentimentGuideline } = this.dataAccess;
 
-    this.log.info(sc(`Fetching sentiment config for siteId: ${siteId}, audit: ${auditType}`, {
+    this.log.info(sc('Fetching sentiment config', {
       event: 'audit_orchestration_brand_guidelines_resolved', outcome: OUTCOME.START, peer: PEER.URL_STORE, direction: 'inbound', siteId, auditType,
     }));
 
@@ -289,7 +289,7 @@ export default class StoreClient {
       throw new StoreEmptyError('guidelinesStore', siteId, `No guidelines found for audit type: ${auditType}`);
     }
 
-    this.log.info(sc(`Found ${topics.length} topics and ${guidelines.length} guidelines for siteId: ${siteId}`, {
+    this.log.info(sc('Found topics and guidelines', {
       event: 'audit_orchestration_brand_guidelines_resolved', outcome: OUTCOME.SUCCESS, peer: PEER.URL_STORE, direction: 'inbound', siteId, auditType, topics: topics.length, guidelines: guidelines.length,
     }));
     return { topics, guidelines };

--- a/src/wikipedia-analysis/guidance-handler.js
+++ b/src/wikipedia-analysis/guidance-handler.js
@@ -133,13 +133,13 @@ export default async function handler(message, context) {
 
   const olog = createOffsiteLogger(log, { audit: AUDIT.WIKIPEDIA, siteId, auditId });
 
-  olog.start('audit_analysis_completed', `Received Wikipedia analysis guidance for siteId: ${siteId}, auditId: ${auditId}`, {
+  olog.start('audit_analysis_completed', 'Guidance received', {
     peer: PEER.MYSTIQUE, direction: 'inbound',
   });
 
   const site = await Site.findById(siteId);
   if (!site) {
-    olog.failure('audit_persistence_completed', `Site not found for siteId: ${siteId}`, { reason: 'site_not_found' });
+    olog.failure('audit_persistence_completed', 'Site not found', { reason: 'site_not_found' });
     return notFound('Site not found');
   }
   const baseUrl = site.getBaseURL();
@@ -147,7 +147,7 @@ export default async function handler(message, context) {
   // Mystique couldn't complete the analysis (e.g. an upstream producer/service
   // failure). Report it to the Slack thread instead of failing silently, then stop.
   if (data?.error) {
-    olog.failure('audit_analysis_completed', `Mystique returned an error for siteId: ${siteId}, auditId: ${auditId}`, {
+    olog.failure('audit_analysis_completed', 'Mystique returned an error', {
       peer: PEER.MYSTIQUE, direction: 'inbound', reason: 'mystique_error', mystiqueError: data.errorMessage,
     });
     await postWikipediaOutcomeToSlack(
@@ -189,7 +189,7 @@ export default async function handler(message, context) {
   if (auditId) {
     const audit = await AuditModel.findById(auditId);
     if (!audit) {
-      olog.failure('audit_persistence_completed', `Audit not found for auditId: ${auditId}`, { reason: 'audit_not_found' });
+      olog.failure('audit_persistence_completed', 'Audit not found', { reason: 'audit_not_found' });
       return notFound('Audit not found');
     }
   }
@@ -213,7 +213,7 @@ export default async function handler(message, context) {
       return noContent();
     }
 
-    olog.debug('audit_analysis_completed', `Processing ${suggestions.length} suggestions`, {
+    olog.debug('audit_analysis_completed', 'Processing suggestions', {
       count: suggestions.length, company,
     });
 
@@ -273,8 +273,8 @@ export default async function handler(message, context) {
       throw error;
     }
 
-    ologOpp.success('audit_persistence_completed', `Successfully processed Wikipedia analysis for site: ${siteId}, company: ${company}, ${suggestions.length} suggestions`, {
-      count: suggestions.length,
+    ologOpp.success('audit_persistence_completed', 'Run processed successfully', {
+      count: suggestions.length, company,
     });
 
     await postWikipediaOutcomeToSlack(
@@ -289,7 +289,7 @@ export default async function handler(message, context) {
     // Intentional drill-down: a failure already logged by an inner event (e.g.
     // audit_persistence_suggestions_synced) will also surface here as
     // audit_persistence_completed outcome=failure — the terminal, per-run marker.
-    olog.failure('audit_persistence_completed', 'Error processing Wikipedia analysis', { ...errorField(error) }, error);
+    olog.failure('audit_persistence_completed', 'Error processing analysis', { ...errorField(error) }, error);
     return badRequest(`Error processing analysis: ${error.message}`);
   }
 }

--- a/src/wikipedia-analysis/handler.js
+++ b/src/wikipedia-analysis/handler.js
@@ -235,7 +235,7 @@ async function runWikipediaAnalysisAudit(url, context, site, auditContext = {}) 
   const siteId = site.getId();
   const olog = createOffsiteLogger(log, { audit: AUDIT.WIKIPEDIA, siteId });
 
-  olog.start('audit_orchestration_started', `Starting Wikipedia analysis audit for site: ${siteId}`);
+  olog.start('audit_orchestration_started', 'Audit started');
 
   try {
     const wikipediaConfig = getWikipediaConfig(site);
@@ -264,7 +264,7 @@ async function runWikipediaAnalysisAudit(url, context, site, auditContext = {}) 
       };
     }
 
-    olog.success('audit_orchestration_brand_profile_resolved', 'Resolved Wikipedia config', {
+    olog.success('audit_orchestration_brand_profile_resolved', 'Brand profile resolved', {
       companyName: wikipediaConfig.companyName,
       website: wikipediaConfig.companyWebsite,
       wikipediaUrl: wikipediaConfig.wikipediaUrl,
@@ -363,7 +363,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
 
     olog.success(
       'audit_analysis_mystique_request_handoff',
-      'Queued Wikipedia analysis request to Mystique',
+      'Queued analysis request to Mystique',
       {
         peer: PEER.MYSTIQUE,
         direction: 'outbound',

--- a/src/youtube-analysis/guidance-handler.js
+++ b/src/youtube-analysis/guidance-handler.js
@@ -74,12 +74,12 @@ export default async function handler(message, context) {
 
   const olog = createOffsiteLogger(log, { audit: AUDIT.YOUTUBE, siteId, auditId });
 
-  olog.start('audit_analysis_completed', `Received YouTube analysis guidance for siteId: ${siteId}, auditId: ${auditId}`, {
+  olog.start('audit_analysis_completed', 'Guidance received', {
     peer: PEER.MYSTIQUE, direction: 'inbound',
   });
 
   if (data?.error) {
-    olog.failure('audit_analysis_completed', `Mystique returned an error for siteId: ${siteId}, auditId: ${auditId}`, {
+    olog.failure('audit_analysis_completed', 'Mystique returned an error', {
       peer: PEER.MYSTIQUE, direction: 'inbound', reason: 'mystique_error', mystiqueError: data.errorMessage,
     });
     return noContent();
@@ -114,14 +114,14 @@ export default async function handler(message, context) {
 
   const site = await Site.findById(siteId);
   if (!site) {
-    olog.failure('audit_persistence_completed', `Site not found for siteId: ${siteId}`, { reason: 'site_not_found' });
+    olog.failure('audit_persistence_completed', 'Site not found', { reason: 'site_not_found' });
     return notFound('Site not found');
   }
 
   if (auditId) {
     const audit = await AuditModel.findById(auditId);
     if (!audit) {
-      olog.failure('audit_persistence_completed', `Audit not found for auditId: ${auditId}`, { reason: 'audit_not_found' });
+      olog.failure('audit_persistence_completed', 'Audit not found', { reason: 'audit_not_found' });
       return notFound('Audit not found');
     }
   }
@@ -137,7 +137,7 @@ export default async function handler(message, context) {
       return noContent();
     }
 
-    olog.debug('audit_analysis_completed', `Processing ${suggestions.length} suggestions`, {
+    olog.debug('audit_analysis_completed', 'Processing suggestions', {
       count: suggestions.length, companyName,
     });
 
@@ -147,7 +147,7 @@ export default async function handler(message, context) {
 
     // Validate before mutating the evergreen opportunity.
     if (!isValidOffsiteAnalysis(analysisData, auditType)) {
-      olog.failure('audit_persistence_completed', `Malformed analysis payload for siteId: ${siteId}; skipping update`, { reason: 'malformed_payload' });
+      olog.failure('audit_persistence_completed', 'Malformed analysis payload; skipping update', { reason: 'malformed_payload' });
       return badRequest('Malformed analysis payload');
     }
 
@@ -221,8 +221,8 @@ export default async function handler(message, context) {
       throw error;
     }
 
-    ologOpp.success('audit_persistence_completed', `Successfully processed YouTube analysis for site: ${siteId}, company: ${companyName}, ${suggestions.length} suggestions`, {
-      count: suggestions.length,
+    ologOpp.success('audit_persistence_completed', 'Run processed successfully', {
+      count: suggestions.length, companyName,
     });
     logOffsiteLlmUsage(log, HUMAN_PREFIX, siteId, opportunityData.llmUsage);
 
@@ -232,8 +232,8 @@ export default async function handler(message, context) {
         dataAccess, opportunity, siteId, auditType, log,
       });
     } catch (error) {
-      ologOpp.failure('audit_housekeeping_suggestions_removed', `Unexpected expired OUTDATED suggestion deletion failure for auditType ${auditType}`, {
-        peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
+      ologOpp.failure('audit_housekeeping_suggestions_removed', 'OUTDATED suggestion deletion failed', {
+        peer: PEER.POSTGRES, direction: 'outbound', auditType, ...errorField(error),
       }, error);
     }
 
@@ -243,8 +243,8 @@ export default async function handler(message, context) {
         dataAccess, siteId, auditType, log,
       });
     } catch (error) {
-      ologOpp.failure('audit_housekeeping_opportunities_removed', `Unexpected retention failure for auditType ${auditType}`, {
-        peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
+      ologOpp.failure('audit_housekeeping_opportunities_removed', 'Snapshot retention failed', {
+        peer: PEER.POSTGRES, direction: 'outbound', auditType, ...errorField(error),
       }, error);
     }
 
@@ -283,7 +283,7 @@ export default async function handler(message, context) {
     // Intentional drill-down: a failure already logged by an inner event (e.g.
     // audit_persistence_suggestions_synced) will also surface here as
     // audit_persistence_completed outcome=failure — the terminal, per-run marker.
-    olog.failure('audit_persistence_completed', 'Error processing YouTube analysis', { ...errorField(error) }, error);
+    olog.failure('audit_persistence_completed', 'Error processing analysis', { ...errorField(error) }, error);
     return badRequest(`Error processing analysis: ${error.message}`);
   }
 }

--- a/src/youtube-analysis/handler.js
+++ b/src/youtube-analysis/handler.js
@@ -91,12 +91,12 @@ async function fetchStoreData(siteId, context, site) {
   const olog = createOffsiteLogger(log, { audit: AUDIT.YOUTUBE, siteId });
   const storeClient = StoreClient.createFrom(context);
 
-  olog.start('data_acquisition_store_urls_read', `Fetching data from stores for siteId: ${siteId}`, {
+  olog.start('data_acquisition_store_urls_read', 'Fetching data from stores', {
     peer: PEER.URL_STORE, direction: 'inbound',
   });
 
   const rawUrls = await storeClient.getUrls(siteId, URL_TYPES.YOUTUBE, { sortBy: 'createdAt', sortOrder: 'desc' });
-  olog.success('data_acquisition_store_urls_read', `Retrieved ${rawUrls.length} YouTube URLs from URL Store`, {
+  olog.success('data_acquisition_store_urls_read', 'Retrieved URLs from URL Store', {
     peer: PEER.URL_STORE, direction: 'inbound', count: rawUrls.length,
   });
 
@@ -114,10 +114,9 @@ async function fetchStoreData(siteId, context, site) {
   });
 
   const topics = await computeTopicsFromBrandPresence(siteId, context, site);
-  olog.debug('audit_orchestration_brand_topics_resolved', `Computed ${topics.length} topics from brand presence data`, {
+  olog.debug('audit_orchestration_brand_topics_resolved', 'Computed topics from brand presence data', {
     count: topics.length,
   });
-  olog.debug('audit_orchestration_brand_topics_resolved', `Brand-presence topics payload: ${JSON.stringify(topics)}`);
 
   let guidelines = [];
   try {
@@ -165,8 +164,7 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
   // handler to report DRS / Mystique / total durations.
   const analysisStartedAt = Date.now();
 
-  olog.start('audit_orchestration_started', `Starting YouTube analysis audit for site: ${siteId}`);
-  olog.debug('audit_orchestration_started', `auditContext: ${JSON.stringify(auditContext)}`);
+  olog.start('audit_orchestration_started', 'Audit started');
 
   const enableBrandProfile = resolveEnableBrandProfile(auditContext, log, HUMAN_PREFIX);
   const forwardedUrlLimit = resolveForwardedUrlLimit(auditContext, log, HUMAN_PREFIX);
@@ -188,7 +186,7 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
       };
     }
 
-    olog.success('audit_orchestration_brand_profile_resolved', 'Resolved YouTube config', {
+    olog.success('audit_orchestration_brand_profile_resolved', 'Brand profile resolved', {
       companyName: youtubeConfig.companyName,
       website: youtubeConfig.companyWebsite,
     });
@@ -201,8 +199,8 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
     olog.success(
       'data_acquisition_completed',
       scrapedNow
-        ? `DRS scrape finished this cycle; ${storeData.urls.length} URL(s) ready, proceeding to Mystique`
-        : `Reusing previously scraped DRS content for ${storeData.urls.length} URL(s); no new scrape needed, proceeding to Mystique`,
+        ? 'DRS scrape finished this cycle; proceeding to Mystique'
+        : 'Reusing previously scraped DRS content; no new scrape needed, proceeding to Mystique',
       { status: 'pending_analysis', urls: storeData.urls.length, scrapedNow },
     );
 
@@ -388,7 +386,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
 
     const { config, storeData } = auditResult;
     const urlLimit = config?.urlLimit ?? MYSTIQUE_URLS_LIMIT;
-    olog.success('audit_analysis_url_limit_resolved', `urlLimit=${urlLimit} (URLs sent to Mystique)`);
+    olog.success('audit_analysis_url_limit_resolved', 'URL limit resolved', { urlLimit });
 
     const { urls, sentimentConfig } = storeData;
     const enrichedUrls = enrichUrlsWithTopicData(urls, sentimentConfig.topics)
@@ -430,7 +428,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, message);
     olog.success(
       'audit_analysis_mystique_request_handoff',
-      `Queued YouTube analysis request to Mystique with ${enrichedUrls.length} URLs`,
+      'Queued analysis request to Mystique',
       {
         peer: PEER.MYSTIQUE,
         direction: 'outbound',

--- a/test/audits/cited-analysis/guidance-handler.test.js
+++ b/test/audits/cited-analysis/guidance-handler.test.js
@@ -232,7 +232,7 @@ describe('Cited Analysis Guidance Handler', () => {
       expect(mockOpportunity.save).to.have.been.called;
       expect(mockOpportunity.save).to.have.been.calledBefore(syncSuggestionsStub);
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/Successfully processed cited analysis/)
+        sinon.match(/Run processed successfully/)
           .and(sinon.match(/event=audit_persistence_completed/))
           .and(sinon.match(/outcome=success/)),
       );
@@ -963,7 +963,7 @@ describe('Cited Analysis Guidance Handler', () => {
       // (errorName/errorMessage tokens) and passes the raw error as a genuine second arg
       // purely for stack capture (Fix B).
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/Error processing cited analysis/)
+        sinon.match(/Error processing analysis/)
           .and(sinon.match(/event=audit_persistence_completed/))
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/errorName=Error/)),
@@ -1003,7 +1003,7 @@ describe('Cited Analysis Guidance Handler', () => {
       );
       // ...and the outer catch converts it into a terminal audit_persistence_completed failure.
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/Error processing cited analysis/).and(sinon.match(/event=audit_persistence_completed/)),
+        sinon.match(/Error processing analysis/).and(sinon.match(/event=audit_persistence_completed/)),
       );
     });
 
@@ -1148,7 +1148,7 @@ describe('Cited Analysis Guidance Handler', () => {
       await handler.default(message, context);
 
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/Received cited analysis guidance for siteId/)
+        sinon.match(/Guidance received/)
           .and(sinon.match(/event=audit_analysis_completed/))
           .and(sinon.match(/outcome=start/)),
       );

--- a/test/audits/cited-analysis/handler.test.js
+++ b/test/audits/cited-analysis/handler.test.js
@@ -251,9 +251,6 @@ describe('Cited Analysis Handler', function () {
       );
 
       expect(result.auditResult.config.urlLimit).to.equal(7);
-      expect(context.log.debug).to.have.been.calledWith(
-        sinon.match('auditContext: {"messageData":{"urlLimit":"7"}}'),
-      );
     });
 
     it('should set config.enableBrandProfile on auditResult from messageData.enableBrandProfile', async () => {
@@ -271,7 +268,7 @@ describe('Cited Analysis Handler', function () {
       await citedAnalysisHandler.default.runner(baseURL, context, mockSite);
 
       expect(context.log.debug).to.have.been.calledWith(
-        sinon.match(`Brand-presence topics payload: ${JSON.stringify(mockComputedTopics)}`),
+        sinon.match(`count=${mockComputedTopics.length}`),
       );
     });
 
@@ -388,7 +385,7 @@ describe('Cited Analysis Handler', function () {
       const result = await citedAnalysisHandler.default.runner(baseURL, context, mockSite);
 
       expect(result.auditResult.success).to.be.true;
-      expect(context.log.debug).to.have.been.calledWith(sinon.match('Brand-presence topics payload: []'));
+      expect(context.log.debug).to.have.been.calledWith(sinon.match('count=0'));
     });
 
     it('should re-throw non-StoreEmptyError from getGuidelines', async () => {
@@ -474,7 +471,7 @@ describe('Cited Analysis Handler', function () {
           .and(sinon.match('companyName=https://bmw.com'))
           .and(sinon.match('website=https://bmw.com')),
       );
-      expect(context.log.warn).to.have.been.calledWithMatch(/No competitors configured for site/);
+      expect(context.log.warn).to.have.been.calledWithMatch(/No competitors configured/);
       expect(result.auditResult.success).to.be.true;
     });
 
@@ -489,7 +486,7 @@ describe('Cited Analysis Handler', function () {
           .and(sinon.match('companyName=https://test-company.com'))
           .and(sinon.match('website=https://test-company.com')),
       );
-      expect(context.log.warn).to.have.been.calledWithMatch(/No competitors configured for site/);
+      expect(context.log.warn).to.have.been.calledWithMatch(/No competitors configured/);
       expect(result.auditResult.success).to.be.true;
     });
 
@@ -622,7 +619,7 @@ describe('Cited Analysis Handler', function () {
       const filtered = mockFilterUrlsByDrsStatus.firstCall.args[0];
       const hosts = filtered.map((u) => new URL(u.url).hostname).sort();
       expect(hosts).to.deep.equal(['caranddriver.com', 'motortrend.com']);
-      expect(context.log.debug).to.have.been.calledWithMatch(/Excluded 3 owned-domain URLs/);
+      expect(context.log.debug).to.have.been.calledWithMatch(/Excluded owned-domain URLs.*droppedOwned=3/);
     });
 
     it('drops owned-domain lookalikes that contain the brand token, keeps neutral hosts', async () => {
@@ -642,7 +639,7 @@ describe('Cited Analysis Handler', function () {
       const filtered = mockFilterUrlsByDrsStatus.firstCall.args[0];
       const hosts = filtered.map((u) => new URL(u.url).hostname);
       expect(hosts).to.deep.equal(['caranddriver.com']);
-      expect(context.log.debug).to.have.been.calledWithMatch(/Excluded 2 non-earned\/branded URLs/);
+      expect(context.log.debug).to.have.been.calledWithMatch(/Excluded non-earned\/branded URLs.*droppedNonEarned=2/);
     });
 
     it('is a no-op when baseURL is whitespace-only and no brand keywords configured', async () => {
@@ -719,7 +716,7 @@ describe('Cited Analysis Handler', function () {
       const filtered = mockFilterUrlsByDrsStatus.firstCall.args[0];
       const hosts = filtered.map((u) => new URL(u.url).hostname);
       expect(hosts).to.deep.equal(['caranddriver.com']);
-      expect(context.log.debug).to.have.been.calledWithMatch(/Excluded 4 non-earned\/branded URLs/);
+      expect(context.log.debug).to.have.been.calledWithMatch(/Excluded non-earned\/branded URLs.*droppedNonEarned=4/);
     });
 
     it('drops brand-owned lookalike domains via configured brand keywords', async () => {
@@ -798,7 +795,7 @@ describe('Cited Analysis Handler', function () {
       expect(sentMessage.data.urls[0].url).to.equal(mockUrls[0].url);
       expect(sentMessage.data).to.not.have.property('enableBrandProfile');
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(`urlLimit=${MYSTIQUE_URLS_LIMIT} (URLs sent to Mystique)`),
+        sinon.match(`urlLimit=${MYSTIQUE_URLS_LIMIT}`),
       );
       expect(context.log.info).to.have.been.calledWith(
         sinon.match(/event=audit_analysis_mystique_request_handoff/)
@@ -847,7 +844,7 @@ describe('Cited Analysis Handler', function () {
       const postProcessor = citedAnalysisHandler.default.postProcessors[0];
       await postProcessor(baseURL, auditData, context);
 
-      expect(context.log.info).to.have.been.calledWith(sinon.match('urlLimit=1 (URLs sent to Mystique)'));
+      expect(context.log.info).to.have.been.calledWith(sinon.match('urlLimit=1'));
       const sentMessage = context.sqs.sendMessage.firstCall.args[1];
       expect(sentMessage.data.urls).to.have.lengthOf(1);
     });
@@ -927,7 +924,7 @@ describe('Cited Analysis Handler', function () {
       const sentMessage = context.sqs.sendMessage.firstCall.args[1];
       expect(sentMessage.data.urls).to.have.lengthOf(MYSTIQUE_URLS_LIMIT);
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(`urlLimit=${MYSTIQUE_URLS_LIMIT} (URLs sent to Mystique)`),
+        sinon.match(`urlLimit=${MYSTIQUE_URLS_LIMIT}`),
       );
     });
 

--- a/test/audits/offsite-brand-presence-drs-status.test.js
+++ b/test/audits/offsite-brand-presence-drs-status.test.js
@@ -254,7 +254,7 @@ describe('offsite-brand-presence DRS status handler', function () {
     const sentTypes = context.sqs.sendMessage.getCalls().map((c) => c.args[1].type);
     expect(sentTypes).to.include('reddit-analysis');
     expect(sentTypes).to.include('offsite-brand-presence-drs-status');
-    expect(log.warn).to.have.been.calledWithMatch(/getJob failed for job-2/);
+    expect(log.warn).to.have.been.calledWithMatch(/DRS getJob call failed.*drsJobId=job-2/);
   });
 
   it('reports a job as still running when getJob errors past the deadline', async () => {
@@ -514,7 +514,7 @@ describe('offsite-brand-presence DRS status handler', function () {
 
       expect(result.status).to.equal(200);
       expect(mockPostMessageOptional).to.have.been.calledOnce;
-      expect(log.warn).to.have.been.calledWithMatch(/Failed to trigger .* analysis audit for site/);
+      expect(log.warn).to.have.been.calledWithMatch(/Failed to dispatch analysis audit/);
     });
 
     it('skips an audit type when a recent audit exists within the cooldown window', async () => {
@@ -530,7 +530,7 @@ describe('offsite-brand-presence DRS status handler', function () {
       const types = context.sqs.sendMessage.getCalls().map((c) => c.args[1].type);
       expect(types).to.include('youtube-analysis');
       expect(types).to.not.include('reddit-analysis');
-      expect(log.info).to.have.been.calledWithMatch(/Skipping reddit-analysis.*recent audit exists/);
+      expect(log.info).to.have.been.calledWithMatch(/Skipping analysis dispatch; recent audit exists.*auditType=reddit-analysis/);
     });
 
     it('triggers within the cooldown when the recent audit is a pending_scrape run', async () => {
@@ -639,7 +639,7 @@ describe('offsite-brand-presence DRS status handler', function () {
 
       expect(result.status).to.equal(200);
       expect(mockPostMessageOptional).to.have.been.calledOnce;
-      expect(log.warn).to.have.been.calledWithMatch(/Failed to trigger analysis audits for/);
+      expect(log.warn).to.have.been.calledWithMatch(/Failed to dispatch analysis audits/);
     });
 
     it('dispatches with partial data at the deadline if a dataset is still running', async () => {

--- a/test/audits/offsite-brand-presence.test.js
+++ b/test/audits/offsite-brand-presence.test.js
@@ -423,7 +423,7 @@ describe('Offsite Brand Presence Handler', function () {
 
       expect(result.auditResult.success).to.be.true;
       expect(mockLoadCitedUrlsFromSemrush).to.have.been.calledOnce;
-      expect(log.warn).to.have.been.calledWithMatch(/Invalid enableSemrush/);
+      expect(log.warn).to.have.been.calledWithMatch(/Invalid override value in auditContext/);
     });
 
     it('env-enabled fallback surfaces dataSource+fallbackReason even when legacy also yields nothing', async () => {
@@ -888,7 +888,7 @@ describe('Offsite Brand Presence Handler', function () {
       expect(dataAccess.AuditUrl.create).to.not.have.been.called;
       expect(result.auditResult.success).to.be.true;
       expect(log.info).to.have.been.calledWith(
-        sinon.match(/0 created, 1 already existed, 0 failed/),
+        sinon.match(/created=0 existing=1 failed=0/),
       );
 
       const videosCall = mockSubmitScrapeJob.getCalls().find(
@@ -926,7 +926,7 @@ describe('Offsite Brand Presence Handler', function () {
         sinon.match(/Failed to add URL to store/),
       );
       expect(log.info).to.have.been.calledWith(
-        sinon.match(/0 created, 0 already existed, 1 failed/),
+        sinon.match(/created=0 existing=0 failed=1/),
       );
     });
 
@@ -940,7 +940,7 @@ describe('Offsite Brand Presence Handler', function () {
 
       expect(result.auditResult.success).to.be.true;
       expect(log.info).to.have.been.calledWith(
-        sinon.match(/2 created, 0 already existed, 1 failed/),
+        sinon.match(/created=2 existing=0 failed=1/),
       );
 
       const videosCall = mockSubmitScrapeJob.getCalls().find(
@@ -1619,7 +1619,7 @@ describe('Offsite Brand Presence Handler', function () {
       expect(result.auditResult.drsJobs[0].status).to.equal('error');
       expect(result.auditResult.drsJobs[0].error).to.include('503');
       expect(log.error).to.have.been.calledWith(
-        sinon.match(/DRS job failed/),
+        sinon.match(/DRS job submission failed/),
       );
     });
 
@@ -1638,7 +1638,7 @@ describe('Offsite Brand Presence Handler', function () {
       expect(result.auditResult.drsJobs[0].status).to.equal('success');
       expect(result.auditResult.drsJobs[0].response.job_id).to.equal('retry-ok');
       expect(log.warn).to.have.been.calledWith(
-        sinon.match(/failed \(attempt 1\), retrying in 500ms/),
+        sinon.match(/DRS job submission failed; retrying/).and(sinon.match(/delayMs=500/)),
       );
     });
 
@@ -1745,7 +1745,7 @@ describe('Offsite Brand Presence Handler', function () {
 
       expect(result.auditResult.drsJobs[0].status).to.equal('success');
       expect(result.auditResult.drsJobs[0].response.job_id).to.equal('retry-ok');
-      expect(log.warn).to.have.been.calledWith(sinon.match(/failed \(attempt 1\), retrying in 500ms/));
+      expect(log.warn).to.have.been.calledWith(sinon.match(/DRS job submission failed; retrying/).and(sinon.match(/delayMs=500/)));
     });
 
     it('should not retry on 400 and fail immediately', async () => {
@@ -1777,7 +1777,7 @@ describe('Offsite Brand Presence Handler', function () {
 
       expect(result.auditResult.drsJobs[0].status).to.equal('success');
       expect(result.auditResult.drsJobs[0].response.job_id).to.equal('net-retry-ok');
-      expect(log.warn).to.have.been.calledWith(sinon.match(/failed \(attempt 1\), retrying in 500ms/));
+      expect(log.warn).to.have.been.calledWith(sinon.match(/DRS job submission failed; retrying/).and(sinon.match(/delayMs=500/)));
     });
 
     it('should record error when both attempts fail with 503', async () => {
@@ -1791,7 +1791,7 @@ describe('Offsite Brand Presence Handler', function () {
         expect(job.status).to.equal('error');
         expect(job.error).to.include('503');
       }
-      expect(log.error).to.have.been.calledWith(sinon.match(/DRS job failed.*after retry/));
+      expect(log.error).to.have.been.calledWith(sinon.match(/DRS job submission failed after retry/));
     });
 
     it('should not retry on 422 and fail immediately', async () => {

--- a/test/audits/reddit-analysis/guidance-handler.test.js
+++ b/test/audits/reddit-analysis/guidance-handler.test.js
@@ -228,7 +228,7 @@ describe('Reddit Analysis Guidance Handler', () => {
       expect(mockOpportunity.setStatus).to.have.been.calledWith('NEW');
       expect(mockOpportunity.setData).to.have.been.called;
       expect(mockOpportunity.save).to.have.been.called;
-      expect(context.log.info).to.have.been.calledWith(sinon.match(/Successfully processed Reddit analysis/));
+      expect(context.log.info).to.have.been.calledWith(sinon.match(/Run processed successfully/));
     });
 
     it('should pass opportunityData from BO JSON to persistOffsiteOpportunity', async () => {
@@ -829,7 +829,7 @@ describe('Reddit Analysis Guidance Handler', () => {
       // (errorName/errorMessage tokens) and passes the raw error as a genuine second arg
       // purely for stack capture (Fix B).
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/Error processing Reddit analysis/)
+        sinon.match(/Error processing analysis/)
           .and(sinon.match(/event=audit_persistence_completed/))
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/errorName=Error/)),
@@ -988,7 +988,7 @@ describe('Reddit Analysis Guidance Handler', () => {
       await handler.default(message, context);
 
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/Received Reddit analysis guidance for siteId/),
+        sinon.match(/Guidance received/),
       );
     });
 

--- a/test/audits/reddit-analysis/handler.test.js
+++ b/test/audits/reddit-analysis/handler.test.js
@@ -253,9 +253,6 @@ describe('Reddit Analysis Handler', function () {
       );
 
       expect(result.auditResult.config.urlLimit).to.equal(3);
-      expect(context.log.debug).to.have.been.calledWith(
-        sinon.match('auditContext: {"messageData":{"urlLimit":"3"}}'),
-      );
     });
 
     it('should set config.enableBrandProfile on auditResult from messageData.enableBrandProfile', async () => {
@@ -273,7 +270,7 @@ describe('Reddit Analysis Handler', function () {
       await redditAnalysisHandler.default.runner(baseURL, context, mockSite);
 
       expect(context.log.debug).to.have.been.calledWith(
-        sinon.match(`Brand-presence topics payload: ${JSON.stringify(mockComputedTopics)}`),
+        sinon.match(`count=${mockComputedTopics.length}`),
       );
     });
 
@@ -401,7 +398,7 @@ describe('Reddit Analysis Handler', function () {
       const result = await redditAnalysisHandler.default.runner(baseURL, context, mockSite);
 
       expect(result.auditResult.success).to.be.true;
-      expect(context.log.debug).to.have.been.calledWith(sinon.match('Brand-presence topics payload: []'));
+      expect(context.log.debug).to.have.been.calledWith(sinon.match('count=0'));
     });
 
     it('should proceed without guidelines when guidelinesStore returns empty', async () => {
@@ -617,7 +614,7 @@ describe('Reddit Analysis Handler', function () {
       expect(sentMessage.data.urls[0].url).to.equal(mockUrls[0].url);
       expect(sentMessage.data).to.not.have.property('enableBrandProfile');
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(`urlLimit=${MYSTIQUE_URLS_LIMIT} (URLs sent to Mystique)`),
+        sinon.match(`urlLimit=${MYSTIQUE_URLS_LIMIT}`),
       );
       expect(context.log.info).to.have.been.calledWith(
         sinon.match(/event=audit_analysis_mystique_request_handoff/)
@@ -666,7 +663,7 @@ describe('Reddit Analysis Handler', function () {
       const postProcessor = redditAnalysisHandler.default.postProcessors[0];
       await postProcessor(baseURL, auditData, context);
 
-      expect(context.log.info).to.have.been.calledWith(sinon.match('urlLimit=1 (URLs sent to Mystique)'));
+      expect(context.log.info).to.have.been.calledWith(sinon.match('urlLimit=1'));
       const sentMessage = context.sqs.sendMessage.firstCall.args[1];
       expect(sentMessage.data.urls).to.have.lengthOf(1);
       expect(context.log.info).to.have.been.calledWith(
@@ -725,7 +722,7 @@ describe('Reddit Analysis Handler', function () {
       const postProcessor = redditAnalysisHandler.default.postProcessors[0];
       await postProcessor(baseURL, auditData, context);
 
-      expect(context.log.info).to.have.been.calledWith(sinon.match('urlLimit=4 (URLs sent to Mystique)'));
+      expect(context.log.info).to.have.been.calledWith(sinon.match('urlLimit=4'));
       const sentMessage = context.sqs.sendMessage.firstCall.args[1];
       expect(sentMessage.data.urls).to.have.lengthOf(4);
       expect(context.log.info).to.have.been.calledWith(
@@ -758,7 +755,7 @@ describe('Reddit Analysis Handler', function () {
       const sentMessage = context.sqs.sendMessage.firstCall.args[1];
       expect(sentMessage.data.urls).to.have.lengthOf(MYSTIQUE_URLS_LIMIT);
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(`urlLimit=${MYSTIQUE_URLS_LIMIT} (URLs sent to Mystique)`),
+        sinon.match(`urlLimit=${MYSTIQUE_URLS_LIMIT}`),
       );
     });
 

--- a/test/audits/wikipedia-analysis/guidance-handler.test.js
+++ b/test/audits/wikipedia-analysis/guidance-handler.test.js
@@ -153,7 +153,7 @@ describe('Wikipedia Analysis Guidance Handler', function () {
       expect(syncSuggestionsStub).to.have.been.calledOnce;
       expect(mockOpportunity.setData).to.have.been.called;
       expect(mockOpportunity.save).to.have.been.called;
-      expect(context.log.info).to.have.been.calledWith(sinon.match(/Successfully processed Wikipedia analysis/));
+      expect(context.log.info).to.have.been.calledWith(sinon.match(/Run processed successfully/));
     });
 
     it('should create guidance with industry analysis', async () => {
@@ -463,7 +463,7 @@ describe('Wikipedia Analysis Guidance Handler', function () {
       // (errorName/errorMessage tokens) and passes the raw error as a genuine second arg
       // purely for stack capture.
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/Error processing Wikipedia analysis/)
+        sinon.match(/Error processing analysis/)
           .and(sinon.match(/event=audit_persistence_completed/))
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/errorName=Error/)),
@@ -566,7 +566,7 @@ describe('Wikipedia Analysis Guidance Handler', function () {
       await handler.default(message, context);
 
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/Received Wikipedia analysis guidance for siteId/),
+        sinon.match(/Guidance received/),
       );
     });
 

--- a/test/audits/youtube-analysis/guidance-handler.test.js
+++ b/test/audits/youtube-analysis/guidance-handler.test.js
@@ -686,7 +686,7 @@ describe('YouTube Analysis Guidance Handler', () => {
       // (errorName/errorMessage tokens) and passes the raw error as a genuine second arg
       // purely for stack capture (Fix B).
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/Error processing YouTube analysis/)
+        sinon.match(/Error processing analysis/)
           .and(sinon.match(/event=audit_persistence_completed/))
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/errorName=Error/)),
@@ -977,7 +977,7 @@ describe('YouTube Analysis Guidance Handler', () => {
       expect(mockOpportunity.save).to.have.been.calledOnce;
       expect(response.status).to.equal(200);
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/Successfully processed YouTube analysis/),
+        sinon.match(/Run processed successfully/),
       );
     });
   });

--- a/test/audits/youtube-analysis/handler.test.js
+++ b/test/audits/youtube-analysis/handler.test.js
@@ -246,9 +246,6 @@ describe('YouTube Analysis Handler', function () {
       );
 
       expect(result.auditResult.config.urlLimit).to.equal(7);
-      expect(context.log.debug).to.have.been.calledWith(
-        sinon.match('auditContext: {"messageData":{"urlLimit":"7"}}'),
-      );
     });
 
     it('should set config.enableBrandProfile on auditResult from messageData.enableBrandProfile', async () => {
@@ -266,7 +263,7 @@ describe('YouTube Analysis Handler', function () {
       await youtubeAnalysisHandler.default.runner(baseURL, context, mockSite);
 
       expect(context.log.debug).to.have.been.calledWith(
-        sinon.match(`Brand-presence topics payload: ${JSON.stringify(mockComputedTopics)}`),
+        sinon.match(`count=${mockComputedTopics.length}`),
       );
     });
 
@@ -401,7 +398,7 @@ describe('YouTube Analysis Handler', function () {
       const result = await youtubeAnalysisHandler.default.runner(baseURL, context, mockSite);
 
       expect(result.auditResult.success).to.be.true;
-      expect(context.log.debug).to.have.been.calledWith(sinon.match('Brand-presence topics payload: []'));
+      expect(context.log.debug).to.have.been.calledWith(sinon.match('count=0'));
     });
 
     it('should rethrow non-StoreEmptyError from getGuidelines', async () => {
@@ -599,7 +596,7 @@ describe('YouTube Analysis Handler', function () {
       expect(sentMessage.data.urls[0].url).to.equal(mockUrls[0].url);
       expect(sentMessage.data).to.not.have.property('enableBrandProfile');
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(`urlLimit=${MYSTIQUE_URLS_LIMIT} (URLs sent to Mystique)`),
+        sinon.match(`urlLimit=${MYSTIQUE_URLS_LIMIT}`),
       );
       expect(context.log.info).to.have.been.calledWith(
         sinon.match(/event=audit_analysis_mystique_request_handoff/)
@@ -648,7 +645,7 @@ describe('YouTube Analysis Handler', function () {
       const postProcessor = youtubeAnalysisHandler.default.postProcessors[0];
       await postProcessor(baseURL, auditData, context);
 
-      expect(context.log.info).to.have.been.calledWith(sinon.match('urlLimit=1 (URLs sent to Mystique)'));
+      expect(context.log.info).to.have.been.calledWith(sinon.match('urlLimit=1'));
       const sentMessage = context.sqs.sendMessage.firstCall.args[1];
       expect(sentMessage.data.urls).to.have.lengthOf(1);
     });
@@ -705,7 +702,7 @@ describe('YouTube Analysis Handler', function () {
       const sentMessage = context.sqs.sendMessage.firstCall.args[1];
       expect(sentMessage.data.urls).to.have.lengthOf(MYSTIQUE_URLS_LIMIT);
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(`urlLimit=${MYSTIQUE_URLS_LIMIT} (URLs sent to Mystique)`),
+        sinon.match(`urlLimit=${MYSTIQUE_URLS_LIMIT}`),
       );
     });
 

--- a/test/common/offsite-retention.test.js
+++ b/test/common/offsite-retention.test.js
@@ -524,7 +524,8 @@ describe('offsite-retention', () => {
         failed: suggestionCount - OUTDATED_SUGGESTION_DELETE_BATCH_SIZE,
       });
       expect(log.error).to.have.been.calledWith(
-        sinon.match(/Failed to delete 5 expired OUTDATED suggestion\(s\)/)
+        sinon.match(/Failed to delete expired OUTDATED suggestion batch/)
+          .and(sinon.match(/batchSize=5/))
           .and(sinon.match(/errorMessage="batch DELETE failed"/)),
       );
       expect(log.info).to.not.have.been.calledWith(
@@ -559,7 +560,7 @@ describe('offsite-retention', () => {
       });
       expect(removeByIds).to.have.been.calledBefore(log.info);
       expect(log.info).to.have.been.calledWith(
-        sinon.match(/Deleted 1 expired OUTDATED suggestion\(s\)/)
+        sinon.match(/Deleted expired OUTDATED suggestions/)
           .and(sinon.match(/event=audit_housekeeping_suggestions_removed/))
           .and(sinon.match(/outcome=success/))
           .and(sinon.match(/opportunityId=evergreen-1/))

--- a/test/common/offsite-snapshot.test.js
+++ b/test/common/offsite-snapshot.test.js
@@ -157,7 +157,7 @@ describe('offsite-snapshot', () => {
         dataAccess, siteId: 'site-1', auditType: 'cited-analysis', triggerAuditId: 'audit-1', log,
       })).to.be.rejectedWith('DB down');
       expect(log.error).to.have.been.calledWith(
-        sinon.match(/Failed to look up existing auditType cited-analysis snapshots/),
+        sinon.match(/Failed to look up existing snapshots/).and(sinon.match(/auditType=cited-analysis/)),
       );
     });
 
@@ -283,7 +283,7 @@ describe('offsite-snapshot', () => {
         tags: ['custom-tag'],
         data: { qa: 'suppressed' },
       });
-      expect(log.info).to.have.been.calledWith(sinon.match(/Reusing suppressed-refresh snapshot snapshot-1/));
+      expect(log.info).to.have.been.calledWith(sinon.match(/Reusing suppressed-refresh snapshot/).and(sinon.match(/snapshotId=snapshot-1/)));
     });
 
     it('builds a managed snapshot without lookup when triggerAuditId is missing', async () => {
@@ -394,7 +394,7 @@ describe('offsite-snapshot', () => {
         opportunityToUpdate: evergreenOpportunity,
       });
       expect(create).to.not.have.been.called;
-      expect(log.info).to.have.been.calledWith(sinon.match(/Reusing superseded-refresh snapshot snapshot-1/));
+      expect(log.info).to.have.been.calledWith(sinon.match(/Reusing superseded-refresh snapshot/).and(sinon.match(/snapshotId=snapshot-1/)));
     });
 
     it('creates an IGNORED managed snapshot preserving fields, scope, and data', async () => {
@@ -451,7 +451,9 @@ describe('offsite-snapshot', () => {
         },
       });
       expect(log.info).to.have.been.calledWith(
-        sinon.match(/Created superseded-refresh snapshot snapshot-1 from evergreen opportunity evergreen-1/),
+        sinon.match(/Created superseded-refresh snapshot from evergreen opportunity/)
+          .and(sinon.match(/opportunityId=snapshot-1/))
+          .and(sinon.match(/evergreenOpportunityId=evergreen-1/)),
       );
     });
 
@@ -648,7 +650,7 @@ describe('offsite-snapshot', () => {
         log,
       });
 
-      expect(log.error).to.have.been.calledWith(sinon.match(/1 suggestion\(s\) failed to copy/));
+      expect(log.error).to.have.been.calledWith(sinon.match(/Suggestions failed to copy onto snapshot/).and(sinon.match(/failed=1/)));
     });
 
     it('deletes the orphan snapshot and rethrows when addSuggestions fully rejects', async () => {

--- a/test/utils/offsite-audit-utils.test.js
+++ b/test/utils/offsite-audit-utils.test.js
@@ -187,7 +187,7 @@ describe('offsite-audit-utils', () => {
       });
       expect(olog.debug).to.have.been.calledWith(
         'data_acquisition_scrape_job_status_polled',
-        'DRS availability filter: removed 1 URL(s) not yet scraped (0 scraping, 1 not-found), 2 remaining',
+        'DRS availability filter removed URLs not yet scraped',
         sinon.match({ peer: PEER.DRS, removed: 1, remaining: 2 }),
       );
     });
@@ -208,8 +208,10 @@ describe('offsite-audit-utils', () => {
 
       expect(olog.debug).to.have.been.calledWith(
         'data_acquisition_scrape_job_status_polled',
-        'DRS lookup datasetId=ds1: 1/3 available, 0 scraping, 2 not-found',
-        sinon.match({ peer: PEER.DRS, datasetId: 'ds1' }),
+        'DRS lookup dataset summary',
+        sinon.match({
+          peer: PEER.DRS, datasetId: 'ds1', available: 1, total: 3,
+        }),
       );
     });
 
@@ -237,7 +239,7 @@ describe('offsite-audit-utils', () => {
       });
       expect(olog.debug).to.have.been.calledWith(
         'data_acquisition_scrape_job_status_polled',
-        'DRS availability filter: removed 2 URL(s) not yet scraped (1 scraping, 1 not-found), 1 remaining',
+        'DRS availability filter removed URLs not yet scraped',
         sinon.match({ peer: PEER.DRS, removed: 2, remaining: 1 }),
       );
     });
@@ -293,7 +295,7 @@ describe('offsite-audit-utils', () => {
 
       expect(result.urls).to.deep.equal(urls);
       expect(result.counts.determined).to.equal(false);
-      expect(olog.warn).to.have.been.calledWith('data_acquisition_scrape_job_status_polled', sinon.match(/DRS lookup failed for datasetId=ds1/), sinon.match({
+      expect(olog.warn).to.have.been.calledWith('data_acquisition_scrape_job_status_polled', sinon.match(/DRS lookup failed; skipping dataset/), sinon.match({
         peer: PEER.DRS, datasetId: 'ds1', errorName: 'Error', errorMessage: 'network error',
       }));
       expect(olog.warn).to.have.been.calledWith('data_acquisition_scrape_job_status_polled', sinon.match(/All DRS lookups failed or returned null/), sinon.match({ peer: PEER.DRS, reason: 'all_failed' }));
@@ -350,8 +352,10 @@ describe('offsite-audit-utils', () => {
 
       expect(olog.debug).to.have.been.calledWith(
         'data_acquisition_scrape_job_status_polled',
-        `DRS lookup datasetId=ds1: 0/${urls.length} available, 0 scraping, 0 not-found`,
-        sinon.match({ peer: PEER.DRS, datasetId: 'ds1' }),
+        'DRS lookup dataset summary',
+        sinon.match({
+          peer: PEER.DRS, datasetId: 'ds1', available: 0, total: urls.length,
+        }),
       );
     });
   });

--- a/test/utils/offsite-brand-presence-enrichment.test.js
+++ b/test/utils/offsite-brand-presence-enrichment.test.js
@@ -391,7 +391,7 @@ describe('offsite-brand-presence-enrichment', function () {
       const site = makeSite();
       const result = await computeTopicsFromBrandPresence(SITE_ID, { log }, site);
       expect(result).to.deep.equal([]);
-      expect(log.warn).to.have.been.calledWithMatch(/Failed to read query-index for site/);
+      expect(log.warn).to.have.been.calledWithMatch(/Failed to read query-index/);
     });
 
     it('aggregates topics from brand presence rows (US, reddit URL, topic)', async () => {
@@ -876,7 +876,7 @@ describe('offsite-brand-presence-enrichment', function () {
       });
 
       expect(result).to.be.null;
-      expect(log.info).to.have.been.calledWithMatch(/Found 0 brand presence files/);
+      expect(log.info).to.have.been.calledWithMatch(/Found brand presence files.*files=0/);
     });
 
     it('skips a brand-presence sheet whose workbook has no worksheets', async () => {

--- a/test/utils/offsite-brand-presence-postgrest.test.js
+++ b/test/utils/offsite-brand-presence-postgrest.test.js
@@ -475,7 +475,7 @@ describe('offsite-brand-presence-postgrest', () => {
 
       expect(await loadWith({ postgrestClient })).to.equal(null);
       expect(log.warn).to.have.been.calledWithMatch(
-        '[offsite:brand-presence-postgrest] PostgREST query failed for site site-123: Failed to fetch brand_presence_executions: query failed',
+        '[offsite:brand-presence-postgrest] PostgREST query failed',
       );
     });
 
@@ -496,7 +496,7 @@ describe('offsite-brand-presence-postgrest', () => {
       expect(result).to.not.equal(null);
       expect(result.data).to.have.length.greaterThan(0);
       expect(log.warn).to.have.been.calledWithMatch(
-        `Exceeded maximum brand_presence_executions pages (${MAX_EXECUTION_FETCH_PAGES})`,
+        'Exceeded maximum brand_presence_executions pages; processing rows fetched so far',
       );
     });
   });

--- a/test/utils/offsite-brand-presence-semrush.test.js
+++ b/test/utils/offsite-brand-presence-semrush.test.js
@@ -466,7 +466,7 @@ describe('offsite-brand-presence-semrush', function () {
     expect(diagnostics.entitlementReason).to.equal(SEMRUSH_ENTITLEMENT_REASONS.NO_WORKSPACE);
     expect(fetchStub).to.not.have.been.called;
     expect(getServiceAccessToken).to.not.have.been.called;
-    expect(log.info).to.have.been.calledWithMatch(/not entitled for Semrush \(no-workspace\)/);
+    expect(log.info).to.have.been.calledWithMatch(/Brand not entitled for Semrush.*entitlementReason=no-workspace/);
     expect(onProgress).to.have.been.calledWith(
       ':information_source: Brand is not entitled for Semrush — falling back to the legacy source.',
     );

--- a/test/utils/store-client.test.js
+++ b/test/utils/store-client.test.js
@@ -420,7 +420,7 @@ describe('StoreClient', () => {
       await storeClient.getGuidelines(siteId, 'test');
 
       expect(mockLog.info).to.have.been.calledWith(
-        sinon.match(/2 topics and 1 guidelines/),
+        sinon.match(/topics=2/).and(sinon.match(/guidelines=1/)),
       );
     });
   });


### PR DESCRIPTION
## Summary 

Drops IDs/counts from message prose that are already carried as structured fields, removes raw JSON/debug dumps, routes error text through errorField instead of interpolating it, and standardizes phrasing across the cited/reddit/ youtube/wikipedia analysis flows and their guidance handlers so similar events read consistently in Splunk.