### PR TITLE
refactor(offsite): event & reason logging taxonomy cleanup (LLMO-6973)

### DIFF
--- a/docs/decisions/002-offsite-structured-logging-taxonomy.md
+++ b/docs/decisions/002-offsite-structured-logging-taxonomy.md
@@ -1,7 +1,8 @@
 # 002 — Offsite Audits: Structured Logging Taxonomy
 
-- **Status:** Accepted
+- **Status:** Superseded
 - **Date:** 2026-07-31
+- **Superseded by:** ADR [003 — Offsite Event Taxonomy: Phase Boundaries](003-offsite-event-taxonomy-phase-boundaries.md)
 
 ## Context
 

--- a/docs/decisions/003-offsite-event-taxonomy-phase-boundaries.md
+++ b/docs/decisions/003-offsite-event-taxonomy-phase-boundaries.md
@@ -147,7 +147,6 @@ helper, the offsite-only post-processor pattern for the audit-persist log, and t
 - `reasonCategory=config` vs `infra` vs `expected` becomes the primary alerting split going
   forward: infra-tagged failures should page, config-tagged ones should route to an operator
   worklist, expected-tagged ones should never alert regardless of log level.
-- The authoritative reference for exact current event names, fields, and example log lines is
-  `05-logging.md` in the operational knowledge base; this ADR documents the *decision* (why the
-  phases and mergers look the way they do), not a field-by-field spec, to avoid the two documents
-  drifting out of sync on the same details.
+- This ADR documents the *decision* (why the phases and mergers look the way they do), not a
+  field-by-field spec of every event's exact fields and example log lines, to avoid drifting out
+  of sync with the implementation's own detail over time.

--- a/docs/decisions/003-offsite-event-taxonomy-phase-boundaries.md
+++ b/docs/decisions/003-offsite-event-taxonomy-phase-boundaries.md
@@ -1,0 +1,153 @@
+# 003 — Offsite Event Taxonomy: Phase Boundaries
+
+- **Status:** Accepted
+- **Date:** 2026-08-25
+- **Supersedes:** the event-naming section of ADR [002](002-offsite-structured-logging-taxonomy.md)
+
+## Context
+
+ADR 002 established the `key=value` taxonomy (`domain`/`audit`/`event`/`outcome`/`peer`/`direction`
+plus ids) and closed the original silent-event gaps. In practice the event names it introduced
+grew organically, one gap at a time, rather than from a single map of the pipeline's phases. That
+produced three recurring problems:
+
+1. **Inconsistent or missing phase boundaries.** Some phases had a clear `_started`/`_completed`
+   pair (`audit_orchestration_started` / `audit_orchestration_completed`); others had none
+   (`data_acquisition`, `audit_persistence`, `audit_housekeeping` had no unconditional start
+   marker at all), so "did this phase even begin?" wasn't always answerable from the logs alone.
+2. **One event, several unrelated questions.** Names like `data_acquisition_analysis_dispatched`
+   and `data_acquisition_cooldown_checked` described two different, tightly-coupled steps of the
+   same control-plane decision (dispatch a content type's analysis once its scrape is ready) as if
+   they were separate events, while genuinely distinct outcomes of a single step (e.g. every way a
+   scrape submission can succeed, retry, or fail) were sometimes split across several names.
+3. **Control-plane decisions attributed to the wrong phase.** Some events that decide *whether and
+   when* to move an audit forward (brand scope resolution, the URL-limit override, the
+   analysis-request dispatch) were named as if they belonged to data acquisition or analysis,
+   purely because of where in the code they happened to fire, rather than what kind of decision
+   they represent.
+
+None of this was a correctness bug — the events fired, and outcome/reason fields were present —
+but it made the taxonomy harder to teach, harder to alert on consistently, and harder for an
+on-call engineer or an agent to reconstruct "which of the five phases got how far" for a given run
+without already knowing the code.
+
+## Decision
+
+We re-partitioned the offsite event taxonomy into five phases — `audit_orchestration`,
+`data_acquisition`, `audit_analysis`, `audit_persistence`, `audit_housekeeping` — each with a real,
+unconditional `_start`/`_end` boundary pair, and reassigned/merged events along phase and
+question boundaries rather than code-location boundaries.
+
+1. **Every phase gets an unconditional `_start` and `_end`, with no exceptions.** Even phases that
+   previously had no explicit start marker (`data_acquisition`, `audit_persistence`,
+   `audit_housekeeping`) now emit one unconditionally, as the first line of that phase's work. This
+   makes "how far did this run get" a single grep across five event names, independent of audit
+   type or outcome, instead of inferring phase boundaries from whichever event happened to fire
+   next.
+
+2. **Control-plane decisions live in `audit_orchestration`, regardless of when they fire at
+   runtime.** Brand scope resolution (`audit_orchestration_brand_scope_resolved`), the
+   analysis-request URL-limit resolution (`audit_orchestration_analysis_url_limit_resolved`), and
+   the analysis-request dispatch (`audit_orchestration_analysis_request_dispatched`) are all
+   orchestration decisions — they decide *whether/how* an analysis proceeds — even though the
+   dispatch physically fires from the DRS status poll once a scrape reaches a terminal state, well
+   after the phase's own `_start` line. Naming by decision-kind rather than call-site keeps every
+   "should this run happen, and with what scope/limit" question in one place, instead of splitting
+   it between orchestration and data-acquisition depending on which function happened to contain
+   the check.
+
+3. **`audit_analysis` stays deliberately thin.** It carries only `audit_analysis_start` (assemble
+   and send the Mystique request) and `audit_analysis_end` (the completed result comes back).
+   Mystique owns everything in between — validation, its own content lookup, the LLM call, the
+   quality gate — and audit-worker has no visibility into any of it. Adding intermediate events
+   here would either be fabricated (audit-worker doesn't know what's happening on the Mystique
+   side) or would require cross-service correlation we explicitly deferred in ADR 002. The phase's
+   job is to bracket the hand-off, not narrate it.
+
+4. **Events that answered overlapping questions were merged under one event name**, distinguished
+   by `reason` and, where a single lifecycle has multiple checkpoint-like states, `snapshotAction`
+   — instead of minting a new event name per checkpoint. For example:
+   - `data_acquisition_scrape_job_poll_scheduled` and `data_acquisition_scrape_job_poll_rescheduled`
+     answered the same underlying question ("was the next status check successfully queued?") for
+     the initial schedule and every subsequent reschedule; they merged into
+     `data_acquisition_scrape_job_poll_request_dispatched`, with a `firstSchedule` boolean telling
+     the two cases apart instead of two event names.
+   - `audit_persistence_snapshot_prepared`, `audit_persistence_snapshot_suggestions_copied`, and
+     `audit_persistence_snapshot_cleaned_up` were three names for one lifecycle (decide
+     reuse-vs-create a preserved copy, copy its recommendations, clean up if that copy failed
+     outright); they merged into `audit_persistence_snapshot_opportunity_write`, with
+     `snapshotAction` (`reused`|`creating`|`created`|`skipped`) tracking the prepare/reuse/create
+     decision and `reason` (`suggestions_copy_failed`|`orphan_cleanup_failed`) distinguishing the
+     two ways the recommendation-copy step can fail.
+   - `audit_persistence_opportunity_persisted` and `audit_persistence_suggestions_persisted`
+     covered the two halves of the same save (the opportunity record, its recommendations) that
+     always happen back to back for the same result; they merged into
+     `audit_persistence_evergreen_opportunity_write`, with `reason=opportunity_write_failed` vs.
+     `reason=suggestions_write_failed` keeping the two failure modes unmistakable despite sharing
+     an event name.
+
+   This keeps the event-name count proportional to the number of distinct *questions* an operator
+   or dashboard asks ("did the poll get rescheduled", "did the save land"), not to the number of
+   code paths that can produce an answer.
+
+5. **`reasonCategory` classifies every `reason`.** Every `reason` code now carries a
+   `reasonCategory` of `config` (a customer/site/org misconfiguration or eligibility gap, e.g.
+   `no_ims_org`, `no_company_name`), `infra` (a technical/system failure, transient or not, e.g.
+   `opportunity_write_failed`, `brand_resolution_failed`), or `expected` (a deliberate, working-as-
+   designed no-op, e.g. `cooldown`, `no_suggestions`). This is additive to ADR 002's existing
+   `reason` field, not a replacement for it, and lets a single Splunk query or alert separate "an
+   operator needs to fix a customer's setup" from "on-call needs to look at infrastructure" from
+   "nothing is actually wrong here" — the three questions that previously required knowing, per
+   `reason` code, which bucket it fell into.
+
+6. **New events with no prior form** were added where a phase genuinely had no unconditional start
+   before: `data_acquisition_start`, `audit_persistence_start`, `audit_housekeeping_start`.
+
+This decision supersedes ADR 002's event-naming section (the specific event names it introduced
+for orchestration, data acquisition, analysis, persistence, and housekeeping). ADR 002's other
+decisions — the `key=value`-in-message-string taxonomy shape, the shared `offsite-logging.js`
+helper, the offsite-only post-processor pattern for the audit-persist log, and the
+`skip`-vs-`warn` / `errorField()` conventions — are unaffected and remain in force.
+
+## Alternatives Considered
+
+- **Keep the original per-gap event names and only add the missing `_start` markers.** Rejected:
+  it would have closed problem #1 above but left the overlapping-question and
+  wrong-phase-attribution problems in place, so the taxonomy would still require reading code to
+  know which events belong together.
+- **One event per code path (status quo direction).** Rejected: this is how the taxonomy accreted
+  its inconsistencies in the first place — every new gap or edge case got its own event name,
+  which scales with the number of `if` branches in the code rather than with the number of
+  questions an operator actually asks. `reason`/`snapshotAction` scale with questions instead.
+- **Name events by call site instead of by decision-kind.** Rejected for the control-plane events
+  (brand scope, URL limit, dispatch): naming `audit_orchestration_analysis_request_dispatched` as
+  a `data_acquisition_*` event because it fires from the DRS poll handler would optimize for "easy
+  to find in the code" over "easy to reason about as a decision" — and the code that emits an event
+  changes far more often than the phase it conceptually belongs to.
+- **Give `audit_analysis` intermediate events by inferring Mystique's internal steps from timing
+  gaps.** Rejected: audit-worker has no ground truth for what Mystique is doing between the request
+  and the result; fabricating intermediate checkpoints would be guesswork dressed up as
+  observability. If Mystique's own internal steps need visibility, that belongs in Mystique's own
+  logging, correlated by `auditId`/request id — not invented on the audit-worker side.
+- **A `severity` field instead of `reasonCategory`.** Rejected: severity (info/warn/error) is
+  already carried by the log level and by `outcome`. `reasonCategory` answers a different question
+  — *whose problem is this* (customer config, our infra, or nobody's) — which doesn't map onto log
+  level (a `config` gap is often logged at `warn`, an `expected` no-op sometimes at `error` for
+  visibility, e.g. `data_acquisition_url_store_read`'s `store_empty_after_scrape`).
+
+## Consequences
+
+- Every offsite run now has exactly five `_start`/`_end` boundary pairs to check, regardless of
+  audit type or how far the run got — `stats count by audit, event` where `event` ends in `_start`
+  or `_end` gives a phase-completion funnel for free.
+- Dashboards and alerts built against ADR 002's original event names (e.g.
+  `audit_persistence_opportunity_persisted`, `data_acquisition_scrape_job_submitted`) must be
+  updated to the current names; there is no dual-emission period — the rename happened in the same
+  change as the phase re-partitioning to avoid a window where two names mean the same thing.
+- `reasonCategory=config` vs `infra` vs `expected` becomes the primary alerting split going
+  forward: infra-tagged failures should page, config-tagged ones should route to an operator
+  worklist, expected-tagged ones should never alert regardless of log level.
+- The authoritative reference for exact current event names, fields, and example log lines is
+  `05-logging.md` in the operational knowledge base; this ADR documents the *decision* (why the
+  phases and mergers look the way they do), not a field-by-field spec, to avoid the two documents
+  drifting out of sync on the same details.

--- a/docs/specs/2026-07-31-offsite-structured-logging.md
+++ b/docs/specs/2026-07-31-offsite-structured-logging.md
@@ -47,7 +47,7 @@ sink does not surface a second-arg object to Splunk — see ADR 002).
   `data_acquisition_bp_data_semrush_read`, `data_acquisition_bp_data_urls_enriched`,
   `data_acquisition_url_store_write`, `data_acquisition_scrape_job_request_dispatched`,
   `data_acquisition_scrape_job_poll_request_dispatched`,
-  `audit_orchestration_guideline_store_written`, `audit_orchestration_end`,
+  `audit_orchestration_guideline_store_write`, `audit_orchestration_end`,
   `audit_persistence_start`, `audit_persistence_run_write`.
 - Poll `drs-status-handler.js`: `data_acquisition_scrape_job_poll_checked`,
   `audit_orchestration_analysis_request_dispatched`,

--- a/docs/specs/2026-07-31-offsite-structured-logging.md
+++ b/docs/specs/2026-07-31-offsite-structured-logging.md
@@ -39,44 +39,51 @@ sink does not surface a second-arg object to Splunk — see ADR 002).
   `start/success/skip/failure/warn/debug(event, message, extra)` (each emits one
   string arg) and `.with(moreIds)`.
 - `withAuditPersistLog(audit)` — an offsite-only AuditBuilder post-processor that
-  logs `audit_persistence_run_recorded` using the framework-set `context.audit` / `auditData.id`.
+  logs `audit_persistence_run_write` using the framework-set `context.audit` / `auditData.id`.
 
 ### Events (by component)
-- Collector `offsite-brand-presence/handler.js`: `audit_orchestration_started`,
-  `data_acquisition_bp_data_source_selected`, `data_acquisition_bp_data_semrush_read`,
-  `data_acquisition_bp_data_urls_extracted_enriched`, `data_acquisition_store_urls_written`,
-  `data_acquisition_scrape_job_submitted`, `data_acquisition_scrape_job_poll_scheduled`,
-  `audit_orchestration_guideline_store_written`, `audit_orchestration_completed`,
-  `audit_persistence_run_recorded`.
-- Poll `drs-status-handler.js`: `data_acquisition_scrape_job_status_polled`,
-  `data_acquisition_analysis_request_handoff`, `data_acquisition_scrape_job_poll_rescheduled`,
-  `data_acquisition_scrape_job_poll_summary_notified`, `data_acquisition_cooldown_checked`.
-- Analysis runners: `audit_orchestration_started`, `audit_orchestration_brand_profile_resolved`,
-  `data_acquisition_store_urls_read`, `data_acquisition_scrape_job_status_polled`,
-  `data_acquisition_completed` (carries `status=`), `data_acquisition_scrape_job_submitted`,
-  `audit_analysis_url_limit_resolved`, `audit_analysis_mystique_request_handoff`,
-  `audit_persistence_run_recorded`.
-- Guidance handlers + `common/offsite-refresh.js`: `audit_analysis_completed`,
-  `audit_persistence_payload_fetched`, `audit_persistence_opportunity_persisted`,
-  `audit_persistence_suggestions_synced`, `audit_persistence_opportunity_retired`,
-  `audit_persistence_opportunity_resolved`, `audit_persistence_completed`.
+- Collector `offsite-brand-presence/handler.js`: `audit_orchestration_start`,
+  `data_acquisition_start`, `data_acquisition_bp_data_source_selected`,
+  `data_acquisition_bp_data_semrush_read`, `data_acquisition_bp_data_urls_enriched`,
+  `data_acquisition_url_store_write`, `data_acquisition_scrape_job_request_dispatched`,
+  `data_acquisition_scrape_job_poll_request_dispatched`,
+  `audit_orchestration_guideline_store_written`, `audit_orchestration_end`,
+  `audit_persistence_start`, `audit_persistence_run_write`.
+- Poll `drs-status-handler.js`: `data_acquisition_scrape_job_poll_checked`,
+  `audit_orchestration_analysis_request_dispatched`,
+  `data_acquisition_scrape_job_poll_request_dispatched`,
+  `data_acquisition_scrape_job_poll_end`.
+- Analysis runners: `audit_orchestration_start`, `audit_orchestration_brand_profile_resolved`,
+  `data_acquisition_start`, `data_acquisition_url_store_read`,
+  `data_acquisition_scrape_job_poll_checked`, `data_acquisition_end` (carries `status=`),
+  `data_acquisition_scrape_job_request_dispatched`,
+  `audit_orchestration_analysis_url_limit_resolved`, `audit_analysis_start`,
+  `audit_persistence_start`, `audit_persistence_run_write`.
+- Guidance handlers + `common/offsite-refresh.js`: `audit_analysis_end`,
+  `audit_persistence_start`, `audit_persistence_mystique_payload_read`,
+  `audit_persistence_evergreen_opportunity_write`, `audit_persistence_opportunity_retired`,
+  `audit_persistence_evergreen_opportunity_read`, `audit_persistence_end`,
+  `audit_housekeeping_start`, `audit_housekeeping_outdated_opportunities_read`,
+  `audit_housekeeping_outdated_opportunities_deleted`,
+  `audit_housekeeping_outdated_suggestions_read`,
+  `audit_housekeeping_outdated_suggestions_deleted`, `audit_housekeeping_end`.
 
 ### Gaps closed (P1–P4)
-- P1: `data_acquisition_scrape_job_submitted` skip/failure reasons (no_ims_org,
-  not_configured, submit_rejected); loud `data_acquisition_scrape_job_poll_scheduled`
-  failure + `no_jobs` skip; `data_acquisition_scrape_job_poll_rescheduled` failure
-  (re-throw preserved); per-source `data_acquisition_scrape_job_status_polled
+- P1: `data_acquisition_scrape_job_request_dispatched` skip/failure reasons (no_ims_org,
+  not_configured, submit_rejected); loud `data_acquisition_scrape_job_poll_request_dispatched`
+  failure + `no_jobs` skip; reschedule failure on the same event
+  (re-throw preserved); per-source `data_acquisition_scrape_job_poll_checked
   outcome=failure reason=budget_exceeded|scrape_failed` at deadline; per-iteration
-  `data_acquisition_scrape_job_status_polled outcome=start` snapshot.
+  `data_acquisition_scrape_job_poll_checked outcome=start` snapshot.
 - P2: `data_acquisition_bp_data_*` success/failure/skip with `source`/`rows`;
-  `data_acquisition_store_urls_read` failure; self-heal `data_acquisition_scrape_job_submitted`
-  (un-prefixed lines fixed); `data_acquisition_completed` status token;
-  `data_acquisition_analysis_request_handoff` failure + `data_acquisition_cooldown_checked` skip.
-- P3: `audit_analysis_mystique_request_handoff` success/failure.
-- P4: `audit_persistence_run_recorded` (via post-processor);
-  `audit_persistence_opportunity_persisted` success **and** the previously-silent
-  DB-write failure made loud; `audit_persistence_payload_fetched` success/failure;
-  `audit_persistence_suggestions_synced`; `audit_persistence_opportunity_retired`.
+  `data_acquisition_url_store_read` failure; self-heal `data_acquisition_scrape_job_request_dispatched`
+  (un-prefixed lines fixed); `data_acquisition_end` status token;
+  `audit_orchestration_analysis_request_dispatched` failure + cooldown skip on the same event.
+- P3: `audit_analysis_start` success/failure.
+- P4: `audit_persistence_run_write` (via post-processor);
+  `audit_persistence_evergreen_opportunity_write` success **and** the previously-silent
+  DB-write failure made loud; `audit_persistence_mystique_payload_read` success/failure;
+  `audit_persistence_evergreen_opportunity_write` (suggestions half); `audit_persistence_opportunity_retired`.
 
 ### Scope boundaries
 Offsite-only files were converted (collector, poll, analysis + guidance handlers,
@@ -95,6 +102,6 @@ runId threading).
 
 - `npm test` green with the 100% coverage gate.
 - In Splunk (`service=audit-worker domain=offsite`): `stats count by audit, event,
-  outcome, peer` returns rows; `event=audit_persistence_opportunity_persisted outcome=failure`
-  and `event=data_acquisition_scrape_job_status_polled outcome=failure reason=budget_exceeded`
+  outcome, peer` returns rows; `event=audit_persistence_evergreen_opportunity_write outcome=failure`
+  and `event=data_acquisition_scrape_job_poll_checked outcome=failure reason=budget_exceeded`
   are alertable; `siteId`/`auditId`/`opportunityId`/`drsJobId` appear as extracted fields.

--- a/src/cited-analysis/guidance-handler.js
+++ b/src/cited-analysis/guidance-handler.js
@@ -46,7 +46,7 @@ const AUDIT_TYPE = Audit.AUDIT_TYPES.CITED_ANALYSIS;
 const HUMAN_PREFIX = `[offsite:${AUDIT.CITED}]`;
 
 /**
- * Classifies a presigned-analysis-fetch failure for the `audit_persistence_payload_fetched`
+ * Classifies a presigned-analysis-fetch failure for the `audit_persistence_mystique_payload_read`
  * event's reason token:
  * URL/SSRF/shape and body-shape rejections are `validation`; network / non-2xx / timeout
  * failures are `fetch`. The messages come from analysis-fetch.js / assertPresignedUrl.
@@ -76,13 +76,14 @@ export default async function handler(message, context) {
 
   const olog = createOffsiteLogger(log, { audit: AUDIT.CITED, siteId, auditId });
 
-  olog.start('audit_analysis_completed', 'Guidance received', {
+  olog.start('audit_analysis_end', 'Guidance received', {
     peer: PEER.MYSTIQUE, direction: 'inbound',
   });
+  olog.start('audit_persistence_start', 'Persistence started');
 
   if (data?.error) {
-    olog.failure('audit_analysis_completed', 'Mystique returned an error', {
-      peer: PEER.MYSTIQUE, direction: 'inbound', reason: 'mystique_error', mystiqueError: data.errorMessage,
+    olog.failure('audit_analysis_end', 'Mystique returned an error', {
+      peer: PEER.MYSTIQUE, direction: 'inbound', reason: 'mystique_error', reasonCategory: 'infra', mystiqueError: data.errorMessage,
     });
     return noContent();
   }
@@ -96,12 +97,12 @@ export default async function handler(message, context) {
         log,
         prefix: HUMAN_PREFIX,
       });
-      olog.success('audit_persistence_payload_fetched', 'Fetched analysis from presigned URL', {
+      olog.success('audit_persistence_mystique_payload_read', 'Fetched analysis from presigned URL', {
         peer: PEER.S3, direction: 'inbound',
       });
     } catch (error) {
-      olog.failure('audit_persistence_payload_fetched', 'Error fetching from presigned URL', {
-        peer: PEER.S3, direction: 'inbound', reason: classifyFetchFailure(error), ...errorField(error),
+      olog.failure('audit_persistence_mystique_payload_read', 'Error fetching from presigned URL', {
+        peer: PEER.S3, direction: 'inbound', reason: classifyFetchFailure(error), reasonCategory: 'infra', ...errorField(error),
       });
       return badRequest(`Error fetching analysis data: ${error.message}`);
     }
@@ -110,20 +111,20 @@ export default async function handler(message, context) {
   }
 
   if (!analysisData) {
-    olog.failure('audit_persistence_completed', 'No analysis data provided in message', { reason: 'no_analysis_data' });
+    olog.failure('audit_persistence_end', 'No analysis data provided in message', { reason: 'no_analysis_data', reasonCategory: 'infra' });
     return badRequest('Analysis data is required');
   }
 
   const site = await Site.findById(siteId);
   if (!site) {
-    olog.failure('audit_persistence_completed', 'Site not found', { reason: 'site_not_found' });
+    olog.failure('audit_persistence_end', 'Site not found', { reason: 'site_not_found_at_persist', reasonCategory: 'infra' });
     return notFound('Site not found');
   }
 
   if (auditId) {
     const audit = await AuditModel.findById(auditId);
     if (!audit) {
-      olog.failure('audit_persistence_completed', 'Audit not found', { reason: 'audit_not_found' });
+      olog.failure('audit_persistence_end', 'Audit not found', { reason: 'audit_not_found', reasonCategory: 'infra' });
       return notFound('Audit not found');
     }
   }
@@ -135,11 +136,11 @@ export default async function handler(message, context) {
     const opportunityData = analysisData.opportunity || {};
 
     if (suggestions.length === 0) {
-      olog.skip('audit_persistence_completed', 'No suggestions found in analysis', { reason: 'no_suggestions' });
+      olog.skip('audit_persistence_end', 'No suggestions found in analysis', { reason: 'no_suggestions', reasonCategory: 'expected' });
       return noContent();
     }
 
-    olog.debug('audit_analysis_completed', 'Processing suggestions', {
+    olog.debug('audit_analysis_end', 'Processing suggestions', {
       count: suggestions.length, companyName,
     });
 
@@ -149,7 +150,7 @@ export default async function handler(message, context) {
 
     // Validate before mutating the evergreen opportunity.
     if (!isValidOffsiteAnalysis(analysisData, auditType)) {
-      olog.failure('audit_persistence_completed', 'Malformed analysis payload; skipping update', { reason: 'malformed_payload' });
+      olog.failure('audit_persistence_end', 'Malformed analysis payload; skipping update', { reason: 'malformed_payload', reasonCategory: 'infra' });
       return badRequest('Malformed analysis payload');
     }
 
@@ -213,20 +214,22 @@ export default async function handler(message, context) {
           data: suggestion.data,
         }),
       });
-      ologOpp.success('audit_persistence_suggestions_synced', `Synced ${suggestions.length} suggestions`, {
+      ologOpp.success('audit_persistence_evergreen_opportunity_write', `Synced ${suggestions.length} suggestions`, {
         peer: PEER.POSTGRES, direction: 'outbound', count: suggestions.length,
       });
     } catch (error) {
-      ologOpp.failure('audit_persistence_suggestions_synced', 'Failed to sync suggestions', {
-        peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
+      ologOpp.failure('audit_persistence_evergreen_opportunity_write', 'Failed to sync suggestions', {
+        peer: PEER.POSTGRES, direction: 'outbound', reason: 'suggestions_write_failed', reasonCategory: 'infra', ...errorField(error),
       });
       throw error;
     }
 
-    ologOpp.success('audit_persistence_completed', 'Run processed successfully', {
+    ologOpp.success('audit_persistence_end', 'Run processed successfully', {
       count: suggestions.length, companyName,
     });
     logOffsiteLlmUsage(log, HUMAN_PREFIX, siteId, opportunityData.llmUsage);
+
+    ologOpp.start('audit_housekeeping_start', 'Housekeeping started');
 
     // Expired suggestion deletion must not fail an otherwise successful refresh.
     try {
@@ -234,7 +237,7 @@ export default async function handler(message, context) {
         dataAccess, opportunity, siteId, auditType, log,
       });
     } catch (error) {
-      ologOpp.failure('audit_housekeeping_suggestions_removed', 'OUTDATED suggestion deletion failed', {
+      ologOpp.failure('audit_housekeeping_outdated_suggestions_deleted', 'OUTDATED suggestion deletion failed', {
         peer: PEER.POSTGRES, direction: 'outbound', auditType, ...errorField(error),
       }, error);
     }
@@ -245,7 +248,7 @@ export default async function handler(message, context) {
         dataAccess, siteId, auditType, log,
       });
     } catch (error) {
-      ologOpp.failure('audit_housekeeping_opportunities_removed', 'Snapshot retention failed', {
+      ologOpp.failure('audit_housekeeping_outdated_opportunities_deleted', 'Snapshot retention failed', {
         peer: PEER.POSTGRES, direction: 'outbound', auditType, ...errorField(error),
       }, error);
     }
@@ -285,9 +288,9 @@ export default async function handler(message, context) {
     return ok();
   } catch (error) {
     // Intentional drill-down: a failure already logged by an inner event (e.g.
-    // audit_persistence_suggestions_synced) will also surface here as
-    // audit_persistence_completed outcome=failure - the terminal, per-run marker.
-    olog.failure('audit_persistence_completed', 'Error processing analysis', { ...errorField(error) }, error);
+    // audit_persistence_evergreen_opportunity_write) will also surface here as
+    // audit_persistence_end outcome=failure - the terminal, per-run marker.
+    olog.failure('audit_persistence_end', 'Error processing analysis', { ...errorField(error) }, error);
     return badRequest(`Error processing analysis: ${error.message}`);
   }
 }

--- a/src/cited-analysis/guidance-handler.js
+++ b/src/cited-analysis/guidance-handler.js
@@ -290,7 +290,7 @@ export default async function handler(message, context) {
     // Intentional drill-down: a failure already logged by an inner event (e.g.
     // audit_persistence_evergreen_opportunity_write) will also surface here as
     // audit_persistence_end outcome=failure - the terminal, per-run marker.
-    olog.failure('audit_persistence_end', 'Error processing analysis', { ...errorField(error) }, error);
+    olog.failure('audit_persistence_end', 'Error processing analysis', { reason: 'unexpected_error', reasonCategory: 'infra', ...errorField(error) }, error);
     return badRequest(`Error processing analysis: ${error.message}`);
   }
 }

--- a/src/cited-analysis/handler.js
+++ b/src/cited-analysis/handler.js
@@ -149,7 +149,7 @@ function partitionExcludedUrls(urls, brandTokens, olog) {
     const reason = host && isExcludedCitedHost(host, brandTokens);
     if (reason) {
       droppedCount += 1;
-      olog.debug('data_acquisition_store_urls_read', 'Excluding URL', {
+      olog.debug('data_acquisition_url_store_read', 'Excluding URL', {
         peer: PEER.URL_STORE, direction: 'inbound', url: entry.url, reason,
       });
     } else {
@@ -171,12 +171,12 @@ async function fetchStoreData(siteId, context, site) {
   const olog = createOffsiteLogger(log, { audit: AUDIT.CITED, siteId });
   const storeClient = StoreClient.createFrom(context);
 
-  olog.start('data_acquisition_store_urls_read', 'Fetching data from stores', {
+  olog.start('data_acquisition_url_store_read', 'Fetching data from stores', {
     peer: PEER.URL_STORE, direction: 'inbound',
   });
 
   const rawUrls = await storeClient.getUrls(siteId, URL_TYPES.CITED, { sortBy: 'createdAt', sortOrder: 'desc' });
-  olog.success('data_acquisition_store_urls_read', 'Retrieved URLs from URL Store', {
+  olog.success('data_acquisition_url_store_read', 'Retrieved URLs from URL Store', {
     peer: PEER.URL_STORE, direction: 'inbound', count: rawUrls.length,
   });
 
@@ -191,7 +191,7 @@ async function fetchStoreData(siteId, context, site) {
   );
   if (ownedDroppedCount > 0) {
     olog.debug(
-      'data_acquisition_store_urls_read',
+      'data_acquisition_url_store_read',
       'Excluded owned-domain URLs (cited analysis is 3rd-party earned only)',
       { peer: PEER.URL_STORE, direction: 'inbound', droppedOwned: ownedDroppedCount },
     );
@@ -209,7 +209,7 @@ async function fetchStoreData(siteId, context, site) {
   );
   if (nonEarnedDroppedCount > 0) {
     olog.debug(
-      'data_acquisition_store_urls_read',
+      'data_acquisition_url_store_read',
       'Excluded non-earned/branded URLs (social, search, deal-aggregator, or brand-owned lookalike)',
       { peer: PEER.URL_STORE, direction: 'inbound', droppedNonEarned: nonEarnedDroppedCount },
     );
@@ -224,7 +224,7 @@ async function fetchStoreData(siteId, context, site) {
     drsClient,
     olog,
   );
-  olog.success('data_acquisition_scrape_job_status_polled', `${urls.length} cited URLs available in DRS${formatDrsExtras(counts)}`, {
+  olog.success('data_acquisition_scrape_content_checked', `${urls.length} cited URLs available in DRS${formatDrsExtras(counts)}`, {
     peer: PEER.DRS, direction: 'outbound', available: urls.length,
   });
 
@@ -240,7 +240,7 @@ async function fetchStoreData(siteId, context, site) {
   } catch (error) {
     if (error instanceof StoreEmptyError) {
       olog.skip('audit_orchestration_brand_guidelines_resolved', 'No guidelines configured for cited-analysis, proceeding without', {
-        peer: PEER.URL_STORE, direction: 'inbound', reason: 'no_guidelines',
+        peer: PEER.URL_STORE, direction: 'inbound', reason: 'no_guidelines', reasonCategory: 'expected',
       });
     } else {
       throw error;
@@ -276,7 +276,7 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
   // handler to report DRS / Mystique / total durations.
   const analysisStartedAt = Date.now();
 
-  olog.start('audit_orchestration_started', 'Audit started');
+  olog.start('audit_orchestration_start', 'Audit started');
 
   const enableBrandProfile = resolveEnableBrandProfile(auditContext, log, HUMAN_PREFIX);
   const forwardedUrlLimit = resolveForwardedUrlLimit(auditContext, log, HUMAN_PREFIX);
@@ -287,7 +287,7 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
 
     if (!citedConfig.companyName) {
       olog.warn('audit_orchestration_brand_profile_resolved', 'No company name configured for site, skipping audit', {
-        outcome: OUTCOME.SKIP, reason: 'no_company_name',
+        outcome: OUTCOME.SKIP, reason: 'no_company_name', reasonCategory: 'config',
       });
       return {
         auditResult: {
@@ -308,17 +308,18 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
       // empty list Mystique will only count the primary brand in Share of Voice
       // (no hardcoded fallback) — see LLMO-4909 / cited_sentiment_flow.py.
       olog.warn('audit_orchestration_brand_profile_resolved', 'No competitors configured; Share of Voice will only include the primary brand', {
-        outcome: OUTCOME.SKIP, reason: 'no_competitors',
+        outcome: OUTCOME.SKIP, reason: 'no_competitors', reasonCategory: 'config',
       });
     }
 
+    olog.start('data_acquisition_start', 'Fetching URLs and readiness signals from stores/DRS');
     const storeData = await fetchStoreData(siteId, context, site);
     // Whether this run's DRS scrape produced the content (poll-dispatched) or we are reusing
     // a prior scrape (direct/scheduled run) changes the log and Slack wording so the thread
     // reads as a coherent sequence rather than a contradictory "no scrape needed".
     const scrapedNow = scrapedThisCycle(auditContext);
     olog.success(
-      'data_acquisition_completed',
+      'data_acquisition_end',
       scrapedNow
         ? 'DRS scrape finished this cycle; proceeding to Mystique'
         : 'Reusing previously scraped DRS content; no new scrape needed, proceeding to Mystique',
@@ -346,6 +347,8 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
       { threadTs: slackContext?.threadTs },
     );
 
+    olog.success('audit_orchestration_end', 'Audit complete', { status: 'pending_analysis' });
+
     return {
       auditResult: {
         success: true,
@@ -368,8 +371,8 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
       // A scoped scrape already ran and the store is STILL empty → the brand has no
       // cited URLs to analyze. Report a terminal message instead of looping.
       if (auditContext.drsScrapeRequested) {
-        olog.failure('data_acquisition_store_urls_read', 'URL store still empty after scrape', {
-          peer: PEER.URL_STORE, direction: 'inbound', reason: 'empty_after_scrape', ...errorField(error),
+        olog.failure('data_acquisition_url_store_read', 'URL store still empty after scrape', {
+          peer: PEER.URL_STORE, direction: 'inbound', reason: 'store_empty_after_scrape', reasonCategory: 'infra', ...errorField(error),
         });
         await postMessageOptional(
           context,
@@ -385,8 +388,8 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
       // First individual run with an empty store: collect + scrape just this bucket via a
       // domain-scoped offsite-brand-presence run, which re-triggers this analysis when DRS
       // completes — no need to run offsite-brand-presence for all buckets manually.
-      olog.skip('data_acquisition_completed', 'URL store empty, requesting a scoped scrape for top-cited', {
-        status: 'pending_scrape', peer: PEER.URL_STORE, direction: 'inbound', reason: 'empty_store',
+      olog.skip('data_acquisition_end', 'URL store empty, requesting a scoped scrape for top-cited', {
+        status: 'pending_scrape', peer: PEER.URL_STORE, direction: 'inbound', reason: 'store_empty_first_attempt', reasonCategory: 'expected',
       });
       await postMessageOptional(
         context,
@@ -416,8 +419,8 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
       const { channelId, threadTs } = slackContext || {};
       if (auditContext.drsScrapeRequested) {
         // A scrape already ran this cycle and DRS still reports no scraped content → terminal.
-        olog.failure('data_acquisition_scrape_job_status_polled', 'No DRS content available after scraping', {
-          peer: PEER.DRS, direction: 'outbound', reason: 'no_content_after_scrape', ...errorField(error),
+        olog.failure('data_acquisition_scrape_content_checked', 'No DRS content available after scraping', {
+          peer: PEER.DRS, direction: 'outbound', reason: 'content_not_scraped_after_retry', reasonCategory: 'infra', ...errorField(error),
         });
         await postMessageOptional(
           context,
@@ -430,8 +433,8 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
           fullAuditRef: url,
         };
       }
-      olog.skip('data_acquisition_completed', 'URLs stored but not scraped in DRS yet, requesting a scrape for top-cited', {
-        status: 'pending_scrape', peer: PEER.DRS, direction: 'outbound', reason: 'no_drs_content',
+      olog.skip('data_acquisition_end', 'URLs stored but not scraped in DRS yet, requesting a scrape for top-cited', {
+        status: 'pending_scrape', peer: PEER.DRS, direction: 'outbound', reason: 'content_not_scraped_first_attempt', reasonCategory: 'expected',
       });
       await postMessageOptional(
         context,
@@ -456,7 +459,7 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
       };
     }
 
-    olog.failure('audit_orchestration_started', 'Audit failed', { ...errorField(error) });
+    olog.failure('audit_orchestration_end', 'Audit failed', { ...errorField(error) });
     return {
       auditResult: {
         success: false,
@@ -482,15 +485,15 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
   const olog = createOffsiteLogger(log, { audit: AUDIT.CITED, siteId, auditId: audit?.getId() });
 
   if (!auditResult.success) {
-    olog.skip('audit_analysis_mystique_request_handoff', 'Audit failed, skipping Mystique message', {
-      peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'audit_failed',
+    olog.skip('audit_analysis_start', 'Audit failed, skipping Mystique message', {
+      peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'audit_failed', reasonCategory: 'expected',
     });
     return auditData;
   }
 
   if (!sqs || !env?.QUEUE_SPACECAT_TO_MYSTIQUE) {
-    olog.warn('audit_analysis_mystique_request_handoff', 'SQS or Mystique queue not configured, skipping message', {
-      outcome: OUTCOME.SKIP, peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'not_configured',
+    olog.warn('audit_analysis_start', 'SQS or Mystique queue not configured, skipping message', {
+      outcome: OUTCOME.SKIP, peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'mystique_not_configured', reasonCategory: 'infra',
     });
     return auditData;
   }
@@ -499,15 +502,15 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     const { Site } = dataAccess;
     const site = await Site.findById(siteId);
     if (!site) {
-      olog.warn('audit_analysis_mystique_request_handoff', 'Site not found, skipping Mystique message', {
-        outcome: OUTCOME.SKIP, peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'site_not_found',
+      olog.warn('audit_analysis_start', 'Site not found, skipping Mystique message', {
+        outcome: OUTCOME.SKIP, peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'site_not_found_at_dispatch', reasonCategory: 'infra',
       });
       return auditData;
     }
 
     const { config, storeData } = auditResult;
     const urlLimit = config?.urlLimit ?? MYSTIQUE_URLS_LIMIT;
-    olog.success('audit_analysis_url_limit_resolved', 'URL limit resolved', { urlLimit });
+    olog.success('audit_orchestration_analysis_url_limit_resolved', 'URL limit resolved', { urlLimit });
 
     const { urls, sentimentConfig } = storeData;
     // Project only the fields Mystique reads (url, categories, prompts,
@@ -553,8 +556,8 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     try {
       brand = await resolveBrandForSite(context, site);
     } catch (brandError) {
-      olog.warn('audit_analysis_scope_resolved', 'Brand resolution failed unexpectedly; proceeding without scope', {
-        peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'brand_resolution', ...errorField(brandError),
+      olog.warn('audit_orchestration_brand_scope_resolved', 'Brand resolution failed unexpectedly; proceeding without scope', {
+        peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'brand_resolution', reasonCategory: 'infra', ...errorField(brandError),
       });
     }
     const message = applyBrandScope(baseMessage, brand);
@@ -575,9 +578,11 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
       sentUrlCount -= 1;
       message.data.urls = enrichedUrls.slice(0, sentUrlCount);
       olog.warn(
-        'audit_analysis_mystique_request_built',
+        'audit_analysis_start',
         `Message size ${bytes} bytes exceeds budget; reducing to ${sentUrlCount} URLs`,
-        { peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'sqs_budget' },
+        {
+          peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'sqs_budget', reasonCategory: 'expected',
+        },
       );
     }
 
@@ -587,9 +592,11 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
       const bytes = Buffer.byteLength(JSON.stringify(message), 'utf8');
       if (bytes > SQS_MAX_SAFE_BYTES) {
         olog.warn(
-          'audit_analysis_mystique_request_built',
+          'audit_analysis_start',
           `Single-URL payload (${bytes} bytes) still exceeds budget; stripping prompts`,
-          { peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'sqs_budget_single' },
+          {
+            peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'sqs_budget_single', reasonCategory: 'expected',
+          },
         );
         const [singleUrl] = message.data.urls;
         message.data.urls = [{
@@ -600,24 +607,24 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
       }
     }
 
-    olog.debug('audit_analysis_mystique_request_built', `Built Mystique message type ${message.type}`, {
-      peer: PEER.MYSTIQUE, direction: 'outbound',
-    });
+    const finalBytes = Buffer.byteLength(JSON.stringify(message), 'utf8');
     await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, message);
     olog.success(
-      'audit_analysis_mystique_request_handoff',
+      'audit_analysis_start',
       'Queued analysis request to Mystique',
       {
         peer: PEER.MYSTIQUE,
         direction: 'outbound',
         companyName: config.companyName,
         urls: message.data.urls.length,
+        messageType: message.type,
+        bytes: finalBytes,
         ...(brand && { brandId: brand.brandId }),
       },
     );
     return auditData;
   } catch (error) {
-    olog.failure('audit_analysis_mystique_request_handoff', 'Failed to send Mystique message', {
+    olog.failure('audit_analysis_start', 'Failed to send Mystique message', {
       peer: PEER.MYSTIQUE, direction: 'outbound', ...errorField(error),
     });
     // Notify the Slack thread that triggered this audit so the operator knows

--- a/src/cited-analysis/handler.js
+++ b/src/cited-analysis/handler.js
@@ -581,7 +581,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
         'audit_analysis_start',
         `Message size ${bytes} bytes exceeds budget; reducing to ${sentUrlCount} URLs`,
         {
-          peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'sqs_budget', reasonCategory: 'expected',
+          outcome: OUTCOME.SUCCESS, peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'sqs_budget', reasonCategory: 'expected',
         },
       );
     }
@@ -595,7 +595,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
           'audit_analysis_start',
           `Single-URL payload (${bytes} bytes) still exceeds budget; stripping prompts`,
           {
-            peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'sqs_budget_single', reasonCategory: 'expected',
+            outcome: OUTCOME.SUCCESS, peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'sqs_budget_single', reasonCategory: 'expected',
           },
         );
         const [singleUrl] = message.data.urls;
@@ -625,7 +625,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     return auditData;
   } catch (error) {
     olog.failure('audit_analysis_start', 'Failed to send Mystique message', {
-      peer: PEER.MYSTIQUE, direction: 'outbound', ...errorField(error),
+      peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'unexpected_error', reasonCategory: 'infra', ...errorField(error),
     });
     // Notify the Slack thread that triggered this audit so the operator knows
     // Mystique was never reached and doesn't wait for results that won't come.

--- a/src/cited-analysis/handler.js
+++ b/src/cited-analysis/handler.js
@@ -459,7 +459,7 @@ async function runCitedAnalysisAudit(url, context, site, auditContext = {}) {
       };
     }
 
-    olog.failure('audit_orchestration_end', 'Audit failed', { ...errorField(error) });
+    olog.failure('audit_orchestration_end', 'Audit failed', { reason: 'unexpected_error', reasonCategory: 'infra', ...errorField(error) });
     return {
       auditResult: {
         success: false,

--- a/src/common/offsite-refresh.js
+++ b/src/common/offsite-refresh.js
@@ -112,7 +112,7 @@ export async function persistOffsiteOpportunity(
         data: mappedOpportunity.data,
         ...(mappedOpportunity.status ? { status: mappedOpportunity.status } : {}),
       });
-      olog.success('audit_persistence_opportunity_persisted', 'Created opportunity', {
+      olog.success('audit_persistence_evergreen_opportunity_write', 'Created opportunity', {
         peer: PEER.POSTGRES,
         direction: 'outbound',
         opportunityId: created.getId(),
@@ -127,7 +127,7 @@ export async function persistOffsiteOpportunity(
     opportunityToUpdate.setUpdatedBy('system');
     await opportunityToUpdate.save();
 
-    olog.success('audit_persistence_opportunity_persisted', 'Refreshed evergreen opportunity', {
+    olog.success('audit_persistence_evergreen_opportunity_write', 'Refreshed evergreen opportunity', {
       peer: PEER.POSTGRES,
       direction: 'outbound',
       opportunityId: opportunityToUpdate.getId(),
@@ -138,10 +138,11 @@ export async function persistOffsiteOpportunity(
   } catch (error) {
     // The sharpest edge: a silent DB write failure here strands the run. Log loudly and
     // structured, THEN rethrow unchanged so the caller's error handling is preserved.
-    olog.failure('audit_persistence_opportunity_persisted', 'Failed to persist opportunity', {
+    olog.failure('audit_persistence_evergreen_opportunity_write', 'Failed to persist opportunity', {
       peer: PEER.POSTGRES,
       direction: 'outbound',
-      reason: 'db_write',
+      reason: 'opportunity_write_failed',
+      reasonCategory: 'infra',
       ...errorField(error),
     });
     throw error;
@@ -170,8 +171,8 @@ export async function resolveEvergreenOffsiteOpportunity({
   try {
     opportunities = await Opportunity.allBySiteIdAndStatus(siteId, Oppty.STATUSES.NEW);
   } catch (e) {
-    olog.failure('audit_persistence_opportunity_resolved', 'Failed to fetch opportunities', {
-      peer: PEER.POSTGRES, direction: 'inbound', reason: 'lookup', ...errorField(e),
+    olog.failure('audit_persistence_evergreen_opportunity_read', 'Failed to fetch opportunities', {
+      peer: PEER.POSTGRES, direction: 'inbound', reason: 'lookup', reasonCategory: 'infra', ...errorField(e),
     });
     throw e;
   }

--- a/src/common/offsite-retention.js
+++ b/src/common/offsite-retention.js
@@ -47,8 +47,8 @@ export async function findExpiredSnapshots({
     ignoredOpportunities = await Opportunity
       .allBySiteIdAndStatus(siteId, Oppty.STATUSES.IGNORED);
   } catch (error) {
-    olog.failure('audit_housekeeping_opportunities_found', 'Failed to find snapshots', {
-      peer: PEER.POSTGRES, direction: 'inbound', auditType, ...errorField(error),
+    olog.failure('audit_housekeeping_outdated_opportunities_read', 'Failed to find snapshots', {
+      peer: PEER.POSTGRES, direction: 'inbound', auditType, reason: 'lookup', reasonCategory: 'infra', ...errorField(error),
     });
     return [];
   }
@@ -107,7 +107,7 @@ export async function deleteExpiredSnapshots({
   const snapshotIds = expiredSnapshots.map((snapshot) => snapshot.getId());
   await Opportunity.removeByIds(snapshotIds);
 
-  olog.success('audit_housekeeping_opportunities_removed', 'Deleted expired snapshots', {
+  olog.success('audit_housekeeping_outdated_opportunities_deleted', 'Deleted expired snapshots', {
     peer: PEER.POSTGRES, direction: 'outbound', auditType, eligible: allExpiredSnapshots.length, deleted: snapshotIds.length,
   });
 
@@ -165,8 +165,8 @@ export async function deleteExpiredOutdatedSuggestions({
   try {
     opportunitySuggestions = await opportunity.getSuggestions() || [];
   } catch (error) {
-    olog.failure('audit_housekeeping_suggestions_found', 'Failed to read suggestions for expired OUTDATED suggestion deletion', {
-      peer: PEER.POSTGRES, direction: 'inbound', auditType, ...errorField(error),
+    olog.failure('audit_housekeeping_outdated_suggestions_read', 'Failed to read suggestions for expired OUTDATED suggestion deletion', {
+      peer: PEER.POSTGRES, direction: 'inbound', auditType, reason: 'lookup', reasonCategory: 'infra', ...errorField(error),
     });
     return emptyRetentionSummary;
   }
@@ -185,12 +185,12 @@ export async function deleteExpiredOutdatedSuggestions({
       try {
         // Dependent fix-entity rows cascade-delete with their suggestions.
         await Suggestion.removeByIds(suggestionIds);
-        olog.success('audit_housekeeping_suggestions_removed', 'Deleted expired OUTDATED suggestions', {
+        olog.success('audit_housekeeping_outdated_suggestions_deleted', 'Deleted expired OUTDATED suggestions', {
           peer: PEER.POSTGRES, direction: 'outbound', auditType, suggestionIds,
         });
         return { deleted: suggestionBatch.length, failed: 0 };
       } catch (error) {
-        olog.failure('audit_housekeeping_suggestions_removed', 'Failed to delete expired OUTDATED suggestion batch', {
+        olog.failure('audit_housekeeping_outdated_suggestions_deleted', 'Failed to delete expired OUTDATED suggestion batch', {
           peer: PEER.POSTGRES, direction: 'outbound', auditType, batchSize: suggestionBatch.length, ...errorField(error),
         });
         return { deleted: 0, failed: suggestionBatch.length };
@@ -220,9 +220,9 @@ export async function deleteExpiredOutdatedSuggestions({
     failed: retentionSummary.failed,
   };
   if (retentionSummary.failed > 0) {
-    olog.failure('audit_housekeeping_suggestions_removal_summary', 'Expired OUTDATED suggestion deletion summary', summaryFields);
+    olog.failure('audit_housekeeping_end', 'Expired OUTDATED suggestion deletion summary', summaryFields);
   } else {
-    olog.success('audit_housekeeping_suggestions_removal_summary', 'Expired OUTDATED suggestion deletion summary', summaryFields);
+    olog.success('audit_housekeeping_end', 'Expired OUTDATED suggestion deletion summary', summaryFields);
   }
 
   return retentionSummary;

--- a/src/common/offsite-snapshot.js
+++ b/src/common/offsite-snapshot.js
@@ -57,7 +57,7 @@ export async function findSnapshotByTriggerAuditId({
   try {
     opportunities = await Opportunity.allBySiteIdAndStatus(siteId, Oppty.STATUSES.IGNORED);
   } catch (e) {
-    olog.failure('audit_persistence_snapshot_resolved', 'Failed to look up existing snapshots', {
+    olog.failure('audit_persistence_snapshot_opportunity_read', 'Failed to look up existing snapshots', {
       peer: PEER.POSTGRES, direction: 'inbound', auditType, ...errorField(e),
     });
     throw e;
@@ -121,8 +121,9 @@ export async function prepareSuppressedRunSnapshot({
   };
 
   if (!triggerAuditId) {
-    olog.warn('audit_persistence_snapshot_prepared', 'Missing auditId; snapshot idempotency and traceability are unavailable', {
+    olog.warn('audit_persistence_snapshot_opportunity_write', 'Missing auditId; snapshot idempotency and traceability are unavailable', {
       reason: 'missing_audit_id',
+      reasonCategory: 'infra',
     });
   }
 
@@ -135,14 +136,16 @@ export async function prepareSuppressedRunSnapshot({
   if (existingSuppressedRunSnapshot) {
     // triggerAuditId is provably truthy here: existingSuppressedRunSnapshot can only be set
     // by the lookup above, which only runs when triggerAuditId is truthy.
-    olog.success('audit_persistence_snapshot_prepared', 'Reusing suppressed-refresh snapshot', {
+    olog.success('audit_persistence_snapshot_opportunity_write', 'Reusing suppressed-refresh snapshot', {
       peer: PEER.POSTGRES,
       snapshotId: existingSuppressedRunSnapshot.getId(),
       triggerAuditId,
+      snapshotAction: 'reused',
     });
   } else {
-    olog.start('audit_persistence_snapshot_prepared', 'Preparing new suppressed-refresh snapshot', {
+    olog.start('audit_persistence_snapshot_opportunity_write', 'Preparing new suppressed-refresh snapshot', {
       triggerAuditId: triggerAuditId || undefined,
+      snapshotAction: 'creating',
     });
   }
 
@@ -168,13 +171,16 @@ export async function prepareSupersededRunSnapshot({
 
   if (!evergreenOpportunity) {
     // First surfaced run: there is no previous evergreen state to preserve.
-    olog.debug('audit_persistence_snapshot_prepared', 'No evergreen opportunity exists; no superseded-refresh snapshot is needed');
+    olog.debug('audit_persistence_snapshot_opportunity_write', 'No evergreen opportunity exists; no superseded-refresh snapshot is needed', {
+      snapshotAction: 'skipped',
+    });
     return { opportunityData, opportunityToUpdate: null };
   }
 
   if (!triggerAuditId) {
-    olog.warn('audit_persistence_snapshot_prepared', 'Missing auditId; snapshot idempotency and traceability are unavailable', {
+    olog.warn('audit_persistence_snapshot_opportunity_write', 'Missing auditId; snapshot idempotency and traceability are unavailable', {
       reason: 'missing_audit_id',
+      reasonCategory: 'infra',
     });
   }
 
@@ -187,10 +193,11 @@ export async function prepareSupersededRunSnapshot({
   if (existingSupersededRunSnapshot) {
     // triggerAuditId is provably truthy here: existingSupersededRunSnapshot can only be set
     // by the lookup above, which only runs when triggerAuditId is truthy.
-    olog.success('audit_persistence_snapshot_prepared', 'Reusing superseded-refresh snapshot', {
+    olog.success('audit_persistence_snapshot_opportunity_write', 'Reusing superseded-refresh snapshot', {
       peer: PEER.POSTGRES,
       snapshotId: existingSupersededRunSnapshot.getId(),
       triggerAuditId,
+      snapshotAction: 'reused',
     });
   }
 
@@ -235,32 +242,45 @@ export async function prepareSupersededRunSnapshot({
           ...(suggestion.getSkipDetail() ? { skipDetail: suggestion.getSkipDetail() } : {}),
         })));
         if (errorItems?.length > 0) {
-          olog.failure('audit_persistence_snapshot_suggestions_copied', 'Suggestions failed to copy onto snapshot', {
-            peer: PEER.POSTGRES, opportunityId: snapshot.getId(), failed: errorItems.length,
+          olog.failure('audit_persistence_snapshot_opportunity_write', 'Suggestions failed to copy onto snapshot', {
+            peer: PEER.POSTGRES,
+            opportunityId: snapshot.getId(),
+            failed: errorItems.length,
+            reason: 'suggestions_copy_failed',
+            reasonCategory: 'infra',
           });
         }
       } catch (err) {
         // addSuggestions threw entirely — the snapshot record already exists but has no
         // suggestions. Delete the orphan so the next delivery recreates the snapshot cleanly.
-        olog.failure('audit_persistence_snapshot_suggestions_copied', 'addSuggestions threw for snapshot; deleting orphan and rethrowing', {
-          peer: PEER.POSTGRES, opportunityId: snapshot.getId(), ...errorField(err),
+        olog.failure('audit_persistence_snapshot_opportunity_write', 'addSuggestions threw for snapshot; deleting orphan and rethrowing', {
+          peer: PEER.POSTGRES,
+          opportunityId: snapshot.getId(),
+          reason: 'suggestions_copy_failed',
+          reasonCategory: 'infra',
+          ...errorField(err),
         });
         try {
           await snapshot.remove();
         } catch (removeErr) {
-          olog.failure('audit_persistence_snapshot_cleaned_up', 'Failed to delete orphan snapshot', {
-            peer: PEER.POSTGRES, opportunityId: snapshot.getId(), ...errorField(removeErr),
+          olog.failure('audit_persistence_snapshot_opportunity_write', 'Failed to delete orphan snapshot', {
+            peer: PEER.POSTGRES,
+            opportunityId: snapshot.getId(),
+            reason: 'orphan_cleanup_failed',
+            reasonCategory: 'infra',
+            ...errorField(removeErr),
           });
         }
         throw err;
       }
     }
 
-    olog.success('audit_persistence_snapshot_prepared', 'Created superseded-refresh snapshot from evergreen opportunity', {
+    olog.success('audit_persistence_snapshot_opportunity_write', 'Created superseded-refresh snapshot from evergreen opportunity', {
       peer: PEER.POSTGRES,
       opportunityId: snapshot.getId(),
       evergreenOpportunityId: evergreenOpportunity.getId(),
       triggerAuditId: triggerAuditId || undefined,
+      snapshotAction: 'created',
     });
   }
 

--- a/src/offsite-brand-presence/drs-status-handler.js
+++ b/src/offsite-brand-presence/drs-status-handler.js
@@ -69,13 +69,16 @@ async function hasRecentAudit(siteId, auditType, dataAccess, log) {
     // (Without this, an individual analysis run that self-heals an empty URL store never
     // reaches Mystique: its pending_scrape audit trips the cooldown for the whole hour.)
     // Only a real completed/in-progress analysis within the window dedupes redelivered polls.
+    olog.debug('audit_orchestration_analysis_request_dispatched', 'Recent-audit cooldown check succeeded', {
+      peer: PEER.SPACECAT, direction: 'inbound', auditType,
+    });
     if (latest.getAuditResult?.()?.status === 'pending_scrape') {
       return false;
     }
     const auditedAt = new Date(latest.getAuditedAt()).getTime();
     return (Date.now() - auditedAt) < AUDIT_TRIGGER_COOLDOWN_MS;
   } catch (err) {
-    olog.warn('data_acquisition_cooldown_checked', 'Failed to check recent audit', {
+    olog.warn('audit_orchestration_analysis_request_dispatched', 'Failed to check recent audit', {
       peer: PEER.SPACECAT, direction: 'inbound', auditType, ...errorField(err),
     });
     return false;
@@ -144,7 +147,8 @@ function computeReadyAuditTypes(statuses, deadlineReached, alreadyTriggered) {
  *
  * @param {Array<{domain: string, status: string|undefined}>} statuses - Per-job statuses
  * @param {Set<string>} triggered - Audit types already dispatched (this + prior polls)
- * @returns {Array<{auditType: string, reason: string}>} Dropped audit types with a reason
+ * @returns {Array<{auditType: string, reason: string, reasonCategory: string}>} Dropped
+ *   audit types with a reason
  */
 function computeDroppedAuditTypes(statuses, triggered) {
   const groups = new Map();
@@ -172,7 +176,11 @@ function computeDroppedAuditTypes(statuses, triggered) {
       continue;
     }
     const allGroupTerminal = groupJobs.every((s) => DRS_TERMINAL_STATUSES.has(s.status));
-    dropped.push({ auditType, reason: allGroupTerminal ? 'scrape_failed' : 'budget_exceeded' });
+    dropped.push({
+      auditType,
+      reason: allGroupTerminal ? 'scrape_failed' : 'budget_exceeded',
+      reasonCategory: 'infra',
+    });
   }
   return dropped;
 }
@@ -230,8 +238,8 @@ async function triggerAnalysisAudits(
     try {
       // eslint-disable-next-line no-await-in-loop
       if (await hasRecentAudit(siteId, type, dataAccess, log)) {
-        olog.skip('data_acquisition_analysis_request_handoff', 'Skipping analysis dispatch; recent audit exists', {
-          peer: PEER.SQS, direction: 'outbound', reason: 'cooldown', auditType: type,
+        olog.skip('audit_orchestration_analysis_request_dispatched', 'Skipping analysis dispatch; recent audit exists', {
+          peer: PEER.SQS, direction: 'outbound', reason: 'cooldown', reasonCategory: 'expected', auditType: type,
         });
         handled.push(type);
         // eslint-disable-next-line no-continue
@@ -256,12 +264,12 @@ async function triggerAnalysisAudits(
           ...(Object.keys(messageData).length > 0 && { messageData }),
         },
       });
-      olog.success('data_acquisition_analysis_request_handoff', 'Analysis audit dispatched', {
+      olog.success('audit_orchestration_analysis_request_dispatched', 'Analysis audit dispatched', {
         peer: PEER.SQS, direction: 'outbound', auditType: type,
       });
       handled.push(type);
     } catch (err) {
-      olog.warn('data_acquisition_analysis_request_handoff', 'Failed to dispatch analysis audit', {
+      olog.warn('audit_orchestration_analysis_request_dispatched', 'Failed to dispatch analysis audit', {
         peer: PEER.SQS, direction: 'outbound', auditType: type, ...errorField(err),
       });
     }
@@ -338,8 +346,8 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
   if (jobs.length === 0) {
     // ADR convention: "no jobs to poll" is the canonical .skip() case (info level,
     // outcome=skip) — not a warning. See scheduleDrsStatusPoll's analogous skip.
-    olog.skip('data_acquisition_scrape_job_status_polled', 'No jobs to poll, skipping', {
-      peer: PEER.DRS, reason: 'no_jobs',
+    olog.skip('data_acquisition_scrape_job_poll_checked', 'No jobs to poll, skipping', {
+      peer: PEER.DRS, reason: 'no_jobs', reasonCategory: 'expected',
     });
     return ok();
   }
@@ -356,7 +364,7 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
       const result = await drsClient.getJob(job.jobId);
       return { ...job, status: result?.status, error: result?.error_message };
     } catch (err) {
-      olog.warn('data_acquisition_scrape_job_status_polled', 'DRS getJob call failed', {
+      olog.warn('data_acquisition_scrape_job_poll_checked', 'DRS getJob call failed', {
         peer: PEER.DRS, drsJobId: job.jobId, ...errorField(err),
       });
       return { ...job, status: undefined, error: undefined };
@@ -370,7 +378,7 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
 
   // P1-7: per-poll visibility. Emit a snapshot of terminal/total after resolving statuses
   // so the wait is observable in Splunk (previously nothing was logged on a normal poll).
-  olog.start('data_acquisition_scrape_job_status_polled', 'DRS poll in progress', {
+  olog.start('data_acquisition_scrape_job_poll_checked', 'DRS poll in progress', {
     peer: PEER.DRS, terminal: terminalCount, total: statuses.length,
   });
 
@@ -392,7 +400,7 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
       enableSemrush,
     );
   } catch (err) {
-    olog.warn('data_acquisition_analysis_request_handoff', 'Failed to dispatch analysis audits', {
+    olog.warn('audit_orchestration_analysis_request_dispatched', 'Failed to dispatch analysis audits', {
       peer: PEER.SQS, direction: 'outbound', ...errorField(err),
     });
   }
@@ -422,13 +430,13 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
     try {
       await sqs.sendMessage(configuration.getQueues().audits, nextMessage, null, delaySeconds);
     } catch (err) {
-      olog.failure('data_acquisition_scrape_job_poll_rescheduled', 'Failed to re-enqueue DRS status poll', {
-        peer: PEER.SQS, direction: 'outbound', ...errorField(err),
+      olog.failure('data_acquisition_scrape_job_poll_request_dispatched', 'Failed to re-enqueue DRS status poll', {
+        peer: PEER.SQS, direction: 'outbound', firstSchedule: false, ...errorField(err),
       });
       throw err;
     }
-    olog.success('data_acquisition_scrape_job_poll_rescheduled', 'Re-polling DRS status', {
-      peer: PEER.SQS, direction: 'outbound', terminal: terminalCount, total: statuses.length, delaySeconds,
+    olog.success('data_acquisition_scrape_job_poll_request_dispatched', 'Re-polling DRS status', {
+      peer: PEER.SQS, direction: 'outbound', terminal: terminalCount, total: statuses.length, delaySeconds, firstSchedule: false,
     });
     return ok();
   }
@@ -444,16 +452,20 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
   // DRS success is dropped here with no dispatch. Emit one structured, alertable failure per
   // dropped source (was previously visible only as prose in the Slack summary).
   const dropped = computeDroppedAuditTypes(statuses, new Set(nextTriggered));
-  for (const { auditType, reason } of dropped) {
-    olog.failure('data_acquisition_scrape_job_status_polled', 'Dropping analysis audit type; no DRS success', {
-      peer: PEER.DRS, reason, auditType,
+  for (const { auditType, reason, reasonCategory } of dropped) {
+    olog.failure('data_acquisition_scrape_job_poll_checked', 'Dropping analysis audit type; no DRS success', {
+      peer: PEER.DRS, reason, reasonCategory, auditType,
     });
   }
 
   const summary = buildSummary(baseURL, statuses, drsStartedAt, nextTriggered);
   await postMessageOptional(context, channelId, summary, { threadTs });
-  olog.success('data_acquisition_scrape_job_poll_summary_notified', 'Posted DRS completion summary', {
-    peer: PEER.SLACK, direction: 'outbound', jobs: statuses.length,
+  olog.success('data_acquisition_scrape_job_poll_completed', 'Posted DRS completion summary', {
+    peer: PEER.SLACK,
+    direction: 'outbound',
+    jobs: statuses.length,
+    dropped: dropped.length,
+    ...(dropped.length > 0 && { reason: 'budget_exceeded', reasonCategory: 'infra' }),
   });
 
   return ok();

--- a/src/offsite-brand-presence/drs-status-handler.js
+++ b/src/offsite-brand-presence/drs-status-handler.js
@@ -460,12 +460,12 @@ export default async function offsiteBrandPresenceDrsStatusHandler(message, cont
 
   const summary = buildSummary(baseURL, statuses, drsStartedAt, nextTriggered);
   await postMessageOptional(context, channelId, summary, { threadTs });
-  olog.success('data_acquisition_scrape_job_poll_completed', 'Posted DRS completion summary', {
+  olog.success('data_acquisition_scrape_job_poll_end', 'Posted DRS completion summary', {
     peer: PEER.SLACK,
     direction: 'outbound',
     jobs: statuses.length,
     dropped: dropped.length,
-    ...(dropped.length > 0 && { reason: 'budget_exceeded', reasonCategory: 'infra' }),
+    ...(dropped.length > 0 && { reason: 'partial_drop', reasonCategory: 'infra' }),
   });
 
   return ok();

--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -336,13 +336,13 @@ async function addUrlsToUrlStore(siteId, topByDomain, topCited, dataAccess, log)
     for (const url of urls) {
       entries.push({ url, audits: [config.auditType] });
     }
-    olog.debug('data_acquisition_store_urls_written', `Selected top ${urls.length} ${domain} URLs (limit ${DRS_URLS_LIMIT})`, { peer: PEER.URL_STORE, direction: 'outbound', bucket: domain });
+    olog.debug('data_acquisition_url_store_write', `Selected top ${urls.length} ${domain} URLs (limit ${DRS_URLS_LIMIT})`, { peer: PEER.URL_STORE, direction: 'outbound', bucket: domain });
   }
   for (const url of topCited) {
     entries.push({ url, audits: [CITED_ANALYSIS_DRS_CONFIG.auditType] });
   }
-  olog.debug('data_acquisition_store_urls_written', `Selected top ${topCited.length} cited URLs excluding offsite domains (limit ${DRS_URLS_LIMIT})`, { peer: PEER.URL_STORE, direction: 'outbound', bucket: 'top-cited' });
-  olog.start('data_acquisition_store_urls_written', `Adding ${entries.length} URLs to URL store`, { peer: PEER.URL_STORE, direction: 'outbound', total: entries.length });
+  olog.debug('data_acquisition_url_store_write', `Selected top ${topCited.length} cited URLs excluding offsite domains (limit ${DRS_URLS_LIMIT})`, { peer: PEER.URL_STORE, direction: 'outbound', bucket: 'top-cited' });
+  olog.start('data_acquisition_url_store_write', `Adding ${entries.length} URLs to URL store`, { peer: PEER.URL_STORE, direction: 'outbound', total: entries.length });
 
   let existingUrlSet;
   try {
@@ -350,7 +350,7 @@ async function addUrlsToUrlStore(siteId, topByDomain, topCited, dataAccess, log)
     const { data: existingUrls } = await AuditUrl.batchGetByKeys(keys);
     existingUrlSet = new Set(existingUrls.map((u) => u.getUrl()));
   } catch (error) {
-    olog.failure('data_acquisition_store_urls_written', 'Failed to check existing URLs', { peer: PEER.URL_STORE, direction: 'outbound', ...errorField(error) });
+    olog.failure('data_acquisition_url_store_write', 'Failed to check existing URLs', { peer: PEER.URL_STORE, direction: 'outbound', ...errorField(error) });
     return {};
   }
 
@@ -370,7 +370,7 @@ async function addUrlsToUrlStore(siteId, topByDomain, topCited, dataAccess, log)
         });
         return entry.url;
       } catch (createError) {
-        olog.warn('data_acquisition_store_urls_written', 'Failed to add URL to store', {
+        olog.warn('data_acquisition_url_store_write', 'Failed to add URL to store', {
           peer: PEER.URL_STORE, direction: 'outbound', url: entry.url, ...errorField(createError),
         });
         return null;
@@ -383,7 +383,7 @@ async function addUrlsToUrlStore(siteId, topByDomain, topCited, dataAccess, log)
   const createdCount = storedUrls.size - existingCount;
   const failCount = entries.length - storedUrls.size;
 
-  olog.success('data_acquisition_store_urls_written', 'URL store write complete', {
+  olog.success('data_acquisition_url_store_write', 'URL store write complete', {
     peer: PEER.URL_STORE, direction: 'outbound', created: createdCount, existing: existingCount, failed: failCount,
   });
 
@@ -441,7 +441,7 @@ async function addTopicsToGuidelineStore(siteId, topicMap, allUrls, dataAccess, 
   const existingByName = await fetchExistingTopicsByName(siteId, SentimentTopic);
 
   const entries = [...topicMap.entries()];
-  olog.start('audit_orchestration_guideline_store_written', `Persisting ${entries.length} topics to guideline store (${existingByName.size} existing)`, { peer: PEER.SPACECAT, direction: 'outbound', total: entries.length });
+  olog.start('audit_orchestration_guideline_store_write', `Persisting ${entries.length} topics to guideline store (${existingByName.size} existing)`, { peer: PEER.SPACECAT, direction: 'outbound', total: entries.length });
 
   const results = await Promise.all(
     entries.map(async ([name, topicData]) => {
@@ -474,7 +474,7 @@ async function addTopicsToGuidelineStore(siteId, topicMap, allUrls, dataAccess, 
         });
         return 'created';
       } catch (error) {
-        olog.warn('audit_orchestration_guideline_store_written', `Failed to save topic ${name}`, { peer: PEER.SPACECAT, direction: 'outbound', ...errorField(error) });
+        olog.warn('audit_orchestration_guideline_store_write', `Failed to save topic ${name}`, { peer: PEER.SPACECAT, direction: 'outbound', ...errorField(error) });
         return 'error';
       }
     }),
@@ -484,7 +484,7 @@ async function addTopicsToGuidelineStore(siteId, topicMap, allUrls, dataAccess, 
   const updated = results.filter((r) => r === 'updated').length;
   const failed = results.filter((r) => r === 'error').length;
 
-  olog.success('audit_orchestration_guideline_store_written', 'Guideline store write complete', {
+  olog.success('audit_orchestration_guideline_store_write', 'Guideline store write complete', {
     peer: PEER.SPACECAT, direction: 'outbound', created, updated, failed,
   });
 }
@@ -526,7 +526,7 @@ async function submitWithRetry({ domain, datasetId, params }, submitFn, olog) {
       const start = Date.now();
       // eslint-disable-next-line no-await-in-loop
       const result = await submitFn(params);
-      olog.success('data_acquisition_scrape_job_submitted', 'DRS job created', {
+      olog.success('data_acquisition_scrape_job_request_dispatched', 'DRS job created', {
         peer: PEER.DRS, direction: 'outbound', jobDataset, drsJobId: result?.job_id, durationMs: Date.now() - start,
       });
       return {
@@ -534,7 +534,7 @@ async function submitWithRetry({ domain, datasetId, params }, submitFn, olog) {
       };
     } catch (err) {
       if (attempt === 0 && isRetriable(err)) {
-        olog.warn('data_acquisition_scrape_job_submitted', 'DRS job submission failed; retrying', {
+        olog.warn('data_acquisition_scrape_job_request_dispatched', 'DRS job submission failed; retrying', {
           peer: PEER.DRS, direction: 'outbound', jobDataset, retry: 1, delayMs: RETRY_DELAY_MS, ...errorField(err),
         });
         // eslint-disable-next-line no-await-in-loop
@@ -542,8 +542,8 @@ async function submitWithRetry({ domain, datasetId, params }, submitFn, olog) {
           setTimeout(resolve, RETRY_DELAY_MS);
         });
       } else {
-        olog.failure('data_acquisition_scrape_job_submitted', attempt === 0 ? 'DRS job submission failed' : 'DRS job submission failed after retry', {
-          peer: PEER.DRS, direction: 'outbound', jobDataset, reason: 'submit_rejected', ...errorField(err),
+        olog.failure('data_acquisition_scrape_job_request_dispatched', attempt === 0 ? 'DRS job submission failed' : 'DRS job submission failed after retry', {
+          peer: PEER.DRS, direction: 'outbound', jobDataset, reason: 'submit_rejected', reasonCategory: 'infra', ...errorField(err),
         });
         return {
           domain, datasetId, status: 'error', error: err.message,
@@ -602,8 +602,8 @@ async function triggerDrsScraping(
   const drsClient = DrsClient.createFrom(context);
 
   if (!drsClient.isConfigured()) {
-    olog.failure('data_acquisition_scrape_job_submitted', 'DRS_API_URL or DRS_API_KEY not configured, skipping DRS scraping', {
-      peer: PEER.DRS, direction: 'outbound', reason: 'not_configured',
+    olog.failure('data_acquisition_scrape_job_request_dispatched', 'DRS_API_URL or DRS_API_KEY not configured, skipping DRS scraping', {
+      peer: PEER.DRS, direction: 'outbound', reason: 'drs_not_configured', reasonCategory: 'infra',
     });
     return { skipped: 'DRS is not configured (DRS_API_URL/DRS_API_KEY missing)', results: [] };
   }
@@ -613,8 +613,8 @@ async function triggerDrsScraping(
   // imsOrgId set. Resolve it here as a faithful pre-flight check: if it is
   // missing we skip rather than fire jobs that are guaranteed to fail.
   if (!imsOrgId) {
-    olog.warn('data_acquisition_scrape_job_submitted', 'Organization has no imsOrgId; skipping DRS scraping. Populate imsOrgId on the SpaceCat organization to enable offsite brand presence scraping.', {
-      outcome: OUTCOME.SKIP, peer: PEER.DRS, direction: 'outbound', reason: 'no_ims_org',
+    olog.warn('data_acquisition_scrape_job_request_dispatched', 'Organization has no imsOrgId; skipping DRS scraping. Populate imsOrgId on the SpaceCat organization to enable offsite brand presence scraping.', {
+      outcome: OUTCOME.SKIP, peer: PEER.DRS, direction: 'outbound', reason: 'no_ims_org', reasonCategory: 'config',
     });
     return {
       skipped: 'organization has no imsOrgId — populate imsOrgId on the SpaceCat organization to enable scraping',
@@ -654,7 +654,7 @@ async function triggerDrsScraping(
   }
 
   const orgSuffix = spacecatOrgId ? ` (with spacecat_org_id: ${spacecatOrgId})` : '';
-  olog.start('data_acquisition_scrape_job_submitted', `Submitting DRS scrape jobs${orgSuffix}`, { peer: PEER.DRS, direction: 'outbound', jobs: jobs.length });
+  olog.start('data_acquisition_scrape_job_request_dispatched', `Submitting DRS scrape jobs${orgSuffix}`, { peer: PEER.DRS, direction: 'outbound', jobs: jobs.length });
 
   const results = [];
   for (const job of jobs) {
@@ -834,8 +834,8 @@ async function scheduleDrsStatusPoll(
     .map((r) => ({ domain: r.domain, datasetId: r.datasetId, jobId: r.response.job_id }));
 
   if (jobs.length === 0) {
-    olog.skip('data_acquisition_scrape_job_poll_scheduled', 'No successfully submitted DRS jobs; not scheduling status poll', {
-      peer: PEER.SQS, direction: 'outbound', reason: 'no_jobs',
+    olog.skip('data_acquisition_scrape_job_poll_request_dispatched', 'No successfully submitted DRS jobs; not scheduling status poll', {
+      peer: PEER.SQS, direction: 'outbound', reason: 'no_jobs', reasonCategory: 'expected', firstSchedule: true,
     });
     return;
   }
@@ -859,8 +859,8 @@ async function scheduleDrsStatusPoll(
     },
   }, null, pollIntervalSeconds);
 
-  olog.success('data_acquisition_scrape_job_poll_scheduled', 'Scheduled DRS status poll', {
-    peer: PEER.SQS, direction: 'outbound', jobs: jobs.length, intervalSeconds: pollIntervalSeconds,
+  olog.success('data_acquisition_scrape_job_poll_request_dispatched', 'Scheduled DRS status poll', {
+    peer: PEER.SQS, direction: 'outbound', jobs: jobs.length, intervalSeconds: pollIntervalSeconds, firstSchedule: true,
   });
 }
 
@@ -902,7 +902,7 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
   // Fail fast on an unrecognized scope: scoping to an unknown bucket would silently
   // empty every bucket and produce a no-op scrape → poll → re-trigger chain.
   if (domainScope && !VALID_DOMAIN_SCOPES.has(domainScope)) {
-    olog.failure('audit_orchestration_started', 'Unknown domainScope; aborting run', { reason: 'unknown_scope', domainScope });
+    olog.failure('audit_orchestration_start', 'Unknown domainScope; aborting run', { reason: 'unknown_scope', reasonCategory: 'infra', domainScope });
     return {
       auditResult: { success: false, error: `Unknown domainScope: ${domainScope}` },
       fullAuditRef: finalUrl,
@@ -916,19 +916,24 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
     .map(({ week, year }) => `w${String(week).padStart(2, '0')}-${year}`)
     .join(', ');
 
-  olog.start('audit_orchestration_started', 'Audit started', { weeks: weekLabels });
+  olog.start('audit_orchestration_start', 'Audit started', { weeks: weekLabels });
 
   let siteHostname;
   try {
     siteHostname = new URL(baseURL).hostname.replace(/^www\./, '');
   } catch {
-    olog.warn('audit_orchestration_started', `Could not parse baseURL "${baseURL}", skipping site URL filter`, { outcome: OUTCOME.SKIP, reason: 'unparseable_base_url' });
+    olog.warn('audit_orchestration_start', `Could not parse baseURL "${baseURL}", skipping site URL filter`, { outcome: OUTCOME.SKIP, reason: 'unparseable_base_url', reasonCategory: 'config' });
   }
 
   // Brand tokens drop social/search domains and brand-owned lookalikes
   // (e.g. lovedbylovesac.com) from the cited URLs before they are stored.
   const brandKeywords = site.getConfig?.()?.getBrandKeywords?.() || [];
   const brandTokens = computeBrandTokens(siteHostname, brandKeywords);
+
+  // Unconditional marker for the real beginning of the data-acquisition phase (P2):
+  // everything above is orchestration setup (brand/topic resolution); everything from
+  // here on acquires the data (Semrush or legacy/SharePoint) that feeds URL selection.
+  olog.start('data_acquisition_start', 'Data acquisition started', {});
 
   const allUrls = new Map();
   let usedSemrush = false;
@@ -975,11 +980,11 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
       ),
     });
     // A `null` return means the Semrush source FAILED (auth / no-brand /
-    // no-date-window / outage / whole-surface-zero — see the loader's
+    // no_date_window / outage / whole-surface-zero — see the loader's
     // diagnostics.fallbackReason). A genuinely-empty-but-successful result (Map
     // with size 0) is NOT a failure and continues as a normal zero-URL run.
     if (semrushUrls === null) {
-      const reason = semrushDiagnostics.fallbackReason ?? 'semrush-failed';
+      const reason = semrushDiagnostics.fallbackReason ?? 'semrush_failed';
       // A deliberate entitlement-based skip is never a hard stop, even when this run
       // explicitly forced Semrush on via enableSemrush:true — "no wasted calls, no
       // errors" for a non-entitled brand must hold regardless of how Semrush was
@@ -1032,11 +1037,11 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
     }
   }
   const dataSource = usedSemrush ? 'semrush' : 'legacy';
-  // Granular cause behind an entitlement-based `fallbackReason` (`flag-disabled` |
-  // `no-workspace` | `no-client` | `check-failed`) — set only on the two entitlement
+  // Granular cause behind an entitlement-based `fallbackReason` (`flag_disabled` |
+  // `no_workspace` | `no_client` | `check_failed`) — set only on the two entitlement
   // skip reasons (see the loader). Kept separate from `fallbackReason` so a wiring
-  // bug (`no-client`) stays distinguishable from a one-off transient blip
-  // (`check-failed`) without changing the coarse-grained hard-stop-exemption contract.
+  // bug (`no_client`) stays distinguishable from a one-off transient blip
+  // (`check_failed`) without changing the coarse-grained hard-stop-exemption contract.
   const entitlementReason = semrushDiagnostics?.entitlementReason;
 
   // Legacy source: runs when the flag is off, OR when Semrush was env-enabled but
@@ -1067,7 +1072,7 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
   }
 
   if (allUrls.size === 0) {
-    olog.success('audit_orchestration_completed', 'No offsite URLs found, audit complete', { reason: 'no_urls' });
+    olog.success('audit_orchestration_end', 'No offsite URLs found, audit complete', { reason: 'no_urls', reasonCategory: 'expected' });
     await postMessageOptional(
       context,
       channelId,
@@ -1135,8 +1140,8 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
       // its notification, so a transient SQS/Configuration hiccup scheduling the follow-up
       // poll is non-fatal and must not page. outcome=failure is retained (warn defaults to
       // it) so Splunk still counts it, without the error/paging severity.
-      olog.warn('data_acquisition_scrape_job_poll_scheduled', 'Failed to schedule DRS status poll', {
-        peer: PEER.SQS, direction: 'outbound', ...errorField(err),
+      olog.warn('data_acquisition_scrape_job_poll_request_dispatched', 'Failed to schedule DRS status poll', {
+        peer: PEER.SQS, direction: 'outbound', firstSchedule: true, ...errorField(err),
       });
     }
   }
@@ -1146,7 +1151,7 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
   //   await addTopicsToGuidelineStore(siteId, topicMap, allUrls, dataAccess, log);
   // }
 
-  olog.success('audit_orchestration_completed', 'Audit complete', {
+  olog.success('audit_orchestration_end', 'Audit complete', {
     urls: allUrls.size, drsJobs: drsResults.length,
   });
 

--- a/src/reddit-analysis/guidance-handler.js
+++ b/src/reddit-analysis/guidance-handler.js
@@ -46,7 +46,7 @@ const AUDIT_TYPE = Audit.AUDIT_TYPES.REDDIT_ANALYSIS;
 const HUMAN_PREFIX = `[offsite:${AUDIT.REDDIT}]`;
 
 /**
- * Classifies a presigned-analysis-fetch failure for the `audit_persistence_payload_fetched`
+ * Classifies a presigned-analysis-fetch failure for the `audit_persistence_mystique_payload_read`
  * event's reason token:
  * URL/SSRF/shape and body-shape rejections are `validation`; network / non-2xx / timeout
  * failures are `fetch`. The messages come from analysis-fetch.js / assertPresignedUrl.
@@ -76,13 +76,15 @@ export default async function handler(message, context) {
 
   const olog = createOffsiteLogger(log, { audit: AUDIT.REDDIT, siteId, auditId });
 
-  olog.start('audit_analysis_completed', 'Guidance received', {
+  olog.start('audit_persistence_start', 'Persisting guidance', {});
+
+  olog.start('audit_analysis_end', 'Guidance received', {
     peer: PEER.MYSTIQUE, direction: 'inbound',
   });
 
   if (data?.error) {
-    olog.failure('audit_analysis_completed', 'Mystique returned an error', {
-      peer: PEER.MYSTIQUE, direction: 'inbound', reason: 'mystique_error', mystiqueError: data.errorMessage,
+    olog.failure('audit_analysis_end', 'Mystique returned an error', {
+      peer: PEER.MYSTIQUE, direction: 'inbound', reason: 'mystique_error', reasonCategory: 'infra', mystiqueError: data.errorMessage,
     });
     return noContent();
   }
@@ -96,12 +98,12 @@ export default async function handler(message, context) {
         log,
         prefix: HUMAN_PREFIX,
       });
-      olog.success('audit_persistence_payload_fetched', 'Fetched analysis from presigned URL', {
+      olog.success('audit_persistence_mystique_payload_read', 'Fetched analysis from presigned URL', {
         peer: PEER.S3, direction: 'inbound',
       });
     } catch (error) {
-      olog.failure('audit_persistence_payload_fetched', 'Error fetching from presigned URL', {
-        peer: PEER.S3, direction: 'inbound', reason: classifyFetchFailure(error), ...errorField(error),
+      olog.failure('audit_persistence_mystique_payload_read', 'Error fetching from presigned URL', {
+        peer: PEER.S3, direction: 'inbound', reason: classifyFetchFailure(error), reasonCategory: 'infra', ...errorField(error),
       });
       return badRequest(`Error fetching analysis data: ${error.message}`);
     }
@@ -110,20 +112,20 @@ export default async function handler(message, context) {
   }
 
   if (!analysisData) {
-    olog.failure('audit_persistence_completed', 'No analysis data provided in message', { reason: 'no_analysis_data' });
+    olog.failure('audit_persistence_end', 'No analysis data provided in message', { reason: 'no_analysis_data', reasonCategory: 'infra' });
     return badRequest('Analysis data is required');
   }
 
   const site = await Site.findById(siteId);
   if (!site) {
-    olog.failure('audit_persistence_completed', 'Site not found', { reason: 'site_not_found' });
+    olog.failure('audit_persistence_end', 'Site not found', { reason: 'site_not_found_at_persist', reasonCategory: 'infra' });
     return notFound('Site not found');
   }
 
   if (auditId) {
     const audit = await AuditModel.findById(auditId);
     if (!audit) {
-      olog.failure('audit_persistence_completed', 'Audit not found', { reason: 'audit_not_found' });
+      olog.failure('audit_persistence_end', 'Audit not found', { reason: 'audit_not_found', reasonCategory: 'infra' });
       return notFound('Audit not found');
     }
   }
@@ -135,11 +137,11 @@ export default async function handler(message, context) {
     const opportunityData = analysisData.opportunity || {};
 
     if (suggestions.length === 0) {
-      olog.skip('audit_persistence_completed', 'No suggestions found in analysis', { reason: 'no_suggestions' });
+      olog.skip('audit_persistence_end', 'No suggestions found in analysis', { reason: 'no_suggestions', reasonCategory: 'expected' });
       return noContent();
     }
 
-    olog.debug('audit_analysis_completed', 'Processing suggestions', {
+    olog.debug('audit_analysis_end', 'Processing suggestions', {
       count: suggestions.length, companyName,
     });
 
@@ -149,7 +151,7 @@ export default async function handler(message, context) {
 
     // Validate before mutating the evergreen opportunity.
     if (!isValidOffsiteAnalysis(analysisData, auditType)) {
-      olog.failure('audit_persistence_completed', 'Malformed analysis payload; skipping update', { reason: 'malformed_payload' });
+      olog.failure('audit_persistence_end', 'Malformed analysis payload; skipping update', { reason: 'malformed_payload', reasonCategory: 'infra' });
       return badRequest('Malformed analysis payload');
     }
 
@@ -213,20 +215,22 @@ export default async function handler(message, context) {
           data: suggestion.data,
         }),
       });
-      ologOpp.success('audit_persistence_suggestions_synced', `Synced ${suggestions.length} suggestions`, {
+      ologOpp.success('audit_persistence_evergreen_opportunity_write', `Synced ${suggestions.length} suggestions`, {
         peer: PEER.POSTGRES, direction: 'outbound', count: suggestions.length,
       });
     } catch (error) {
-      ologOpp.failure('audit_persistence_suggestions_synced', 'Failed to sync suggestions', {
-        peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
+      ologOpp.failure('audit_persistence_evergreen_opportunity_write', 'Failed to sync suggestions', {
+        peer: PEER.POSTGRES, direction: 'outbound', reason: 'suggestions_write_failed', reasonCategory: 'infra', ...errorField(error),
       });
       throw error;
     }
 
-    ologOpp.success('audit_persistence_completed', 'Run processed successfully', {
+    ologOpp.success('audit_persistence_end', 'Run processed successfully', {
       count: suggestions.length, companyName,
     });
     logOffsiteLlmUsage(log, HUMAN_PREFIX, siteId, opportunityData.llmUsage);
+
+    olog.start('audit_housekeeping_start', 'Starting outdated suggestion/opportunity cleanup', {});
 
     // Expired suggestion deletion must not fail an otherwise successful refresh.
     try {
@@ -234,7 +238,7 @@ export default async function handler(message, context) {
         dataAccess, opportunity, siteId, auditType, log,
       });
     } catch (error) {
-      ologOpp.failure('audit_housekeeping_suggestions_removed', 'OUTDATED suggestion deletion failed', {
+      ologOpp.failure('audit_housekeeping_outdated_suggestions_deleted', 'OUTDATED suggestion deletion failed', {
         peer: PEER.POSTGRES, direction: 'outbound', auditType, ...errorField(error),
       }, error);
     }
@@ -245,7 +249,7 @@ export default async function handler(message, context) {
         dataAccess, siteId, auditType, log,
       });
     } catch (error) {
-      ologOpp.failure('audit_housekeeping_opportunities_removed', 'Snapshot retention failed', {
+      ologOpp.failure('audit_housekeeping_outdated_opportunities_deleted', 'Snapshot retention failed', {
         peer: PEER.POSTGRES, direction: 'outbound', auditType, ...errorField(error),
       }, error);
     }
@@ -283,9 +287,9 @@ export default async function handler(message, context) {
     return ok();
   } catch (error) {
     // Intentional drill-down: a failure already logged by an inner event (e.g.
-    // audit_persistence_suggestions_synced) will also surface here as
-    // audit_persistence_completed outcome=failure — the terminal, per-run marker.
-    olog.failure('audit_persistence_completed', 'Error processing analysis', { ...errorField(error) }, error);
+    // audit_persistence_evergreen_opportunity_write) will also surface here as
+    // audit_persistence_end outcome=failure — the terminal, per-run marker.
+    olog.failure('audit_persistence_end', 'Error processing analysis', { ...errorField(error) }, error);
     return badRequest(`Error processing analysis: ${error.message}`);
   }
 }

--- a/src/reddit-analysis/guidance-handler.js
+++ b/src/reddit-analysis/guidance-handler.js
@@ -289,7 +289,7 @@ export default async function handler(message, context) {
     // Intentional drill-down: a failure already logged by an inner event (e.g.
     // audit_persistence_evergreen_opportunity_write) will also surface here as
     // audit_persistence_end outcome=failure — the terminal, per-run marker.
-    olog.failure('audit_persistence_end', 'Error processing analysis', { ...errorField(error) }, error);
+    olog.failure('audit_persistence_end', 'Error processing analysis', { reason: 'unexpected_error', reasonCategory: 'infra', ...errorField(error) }, error);
     return badRequest(`Error processing analysis: ${error.message}`);
   }
 }

--- a/src/reddit-analysis/guidance-handler.js
+++ b/src/reddit-analysis/guidance-handler.js
@@ -76,11 +76,11 @@ export default async function handler(message, context) {
 
   const olog = createOffsiteLogger(log, { audit: AUDIT.REDDIT, siteId, auditId });
 
-  olog.start('audit_persistence_start', 'Persisting guidance', {});
-
   olog.start('audit_analysis_end', 'Guidance received', {
     peer: PEER.MYSTIQUE, direction: 'inbound',
   });
+
+  olog.start('audit_persistence_start', 'Persisting guidance', {});
 
   if (data?.error) {
     olog.failure('audit_analysis_end', 'Mystique returned an error', {

--- a/src/reddit-analysis/handler.js
+++ b/src/reddit-analysis/handler.js
@@ -339,7 +339,7 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
       };
     }
 
-    olog.failure('audit_orchestration_end', 'Audit failed', { ...errorField(error) });
+    olog.failure('audit_orchestration_end', 'Audit failed', { reason: 'unexpected_error', reasonCategory: 'infra', ...errorField(error) });
     return {
       auditResult: {
         success: false,

--- a/src/reddit-analysis/handler.js
+++ b/src/reddit-analysis/handler.js
@@ -91,12 +91,12 @@ async function fetchStoreData(siteId, context, site) {
   const olog = createOffsiteLogger(log, { audit: AUDIT.REDDIT, siteId });
   const storeClient = StoreClient.createFrom(context);
 
-  olog.start('data_acquisition_store_urls_read', 'Fetching data from stores', {
+  olog.start('data_acquisition_url_store_read', 'Fetching data from stores', {
     peer: PEER.URL_STORE, direction: 'inbound',
   });
 
   const rawUrls = await storeClient.getUrls(siteId, URL_TYPES.REDDIT, { sortBy: 'createdAt', sortOrder: 'desc' });
-  olog.success('data_acquisition_store_urls_read', 'Retrieved URLs from URL Store', {
+  olog.success('data_acquisition_url_store_read', 'Retrieved URLs from URL Store', {
     peer: PEER.URL_STORE, direction: 'inbound', count: rawUrls.length,
   });
 
@@ -109,7 +109,7 @@ async function fetchStoreData(siteId, context, site) {
     drsClient,
     olog,
   );
-  olog.success('data_acquisition_scrape_job_status_polled', `${urls.length} Reddit URLs available in DRS${formatDrsExtras(counts)}`, {
+  olog.success('data_acquisition_scrape_content_checked', `${urls.length} Reddit URLs available in DRS${formatDrsExtras(counts)}`, {
     peer: PEER.DRS, direction: 'outbound', available: urls.length,
   });
 
@@ -128,7 +128,7 @@ async function fetchStoreData(siteId, context, site) {
   } catch (error) {
     if (error instanceof StoreEmptyError) {
       olog.skip('audit_orchestration_brand_guidelines_resolved', 'No guidelines configured for reddit-analysis, proceeding without', {
-        peer: PEER.URL_STORE, direction: 'inbound', reason: 'no_guidelines',
+        peer: PEER.URL_STORE, direction: 'inbound', reason: 'no_guidelines', reasonCategory: 'expected',
       });
     } else {
       throw error;
@@ -164,7 +164,7 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
   // handler to report DRS / Mystique / total durations.
   const analysisStartedAt = Date.now();
 
-  olog.start('audit_orchestration_started', 'Audit started');
+  olog.start('audit_orchestration_start', 'Audit started');
 
   const enableBrandProfile = resolveEnableBrandProfile(auditContext, log, HUMAN_PREFIX);
   const forwardedUrlLimit = resolveForwardedUrlLimit(auditContext, log, HUMAN_PREFIX);
@@ -175,7 +175,7 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
 
     if (!redditConfig.companyName) {
       olog.warn('audit_orchestration_brand_profile_resolved', 'No company name configured for site, skipping audit', {
-        outcome: OUTCOME.SKIP, reason: 'no_company_name',
+        outcome: OUTCOME.SKIP, reason: 'no_company_name', reasonCategory: 'config',
       });
       return {
         auditResult: {
@@ -191,13 +191,15 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
       website: redditConfig.companyWebsite,
     });
 
+    olog.start('data_acquisition_start', 'Starting data acquisition', {});
+
     const storeData = await fetchStoreData(siteId, context, site);
     // Whether this run's DRS scrape produced the content (poll-dispatched) or we are reusing
     // a prior scrape (direct/scheduled run) changes the log and Slack wording so the thread
     // reads as a coherent sequence rather than a contradictory "no scrape needed".
     const scrapedNow = scrapedThisCycle(auditContext);
     olog.success(
-      'data_acquisition_completed',
+      'data_acquisition_end',
       scrapedNow
         ? 'DRS scrape finished this cycle; proceeding to Mystique'
         : 'Reusing previously scraped DRS content; no new scrape needed, proceeding to Mystique',
@@ -225,6 +227,8 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
       { threadTs: slackContext?.threadTs },
     );
 
+    olog.success('audit_orchestration_end', 'Audit complete', { status: 'pending_analysis' });
+
     return {
       auditResult: {
         success: true,
@@ -247,8 +251,8 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
       // A scoped scrape already ran and the store is STILL empty → the brand has no
       // Reddit URLs to analyze. Report a terminal message instead of looping.
       if (auditContext.drsScrapeRequested) {
-        olog.failure('data_acquisition_store_urls_read', 'URL store still empty after scrape', {
-          peer: PEER.URL_STORE, direction: 'inbound', reason: 'empty_after_scrape', ...errorField(error),
+        olog.failure('data_acquisition_url_store_read', 'URL store still empty after scrape', {
+          peer: PEER.URL_STORE, direction: 'inbound', reason: 'store_empty_after_scrape', reasonCategory: 'infra', ...errorField(error),
         });
         await postMessageOptional(
           context,
@@ -264,8 +268,8 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
       // First individual run with an empty store: collect + scrape just this bucket via a
       // domain-scoped offsite-brand-presence run, which re-triggers this analysis when DRS
       // completes — no need to run offsite-brand-presence for all buckets manually.
-      olog.skip('data_acquisition_completed', 'URL store empty, requesting a scoped scrape for reddit.com', {
-        status: 'pending_scrape', peer: PEER.URL_STORE, direction: 'inbound', reason: 'empty_store',
+      olog.skip('data_acquisition_end', 'URL store empty, requesting a scoped scrape for reddit.com', {
+        status: 'pending_scrape', peer: PEER.URL_STORE, direction: 'inbound', reason: 'store_empty_first_attempt', reasonCategory: 'expected',
       });
       await postMessageOptional(
         context,
@@ -295,8 +299,8 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
       const { channelId, threadTs } = slackContext || {};
       if (auditContext.drsScrapeRequested) {
         // A scrape already ran this cycle and DRS still reports no scraped content → terminal.
-        olog.failure('data_acquisition_scrape_job_status_polled', 'No DRS content available after scraping', {
-          peer: PEER.DRS, direction: 'outbound', reason: 'no_content_after_scrape', ...errorField(error),
+        olog.failure('data_acquisition_scrape_content_checked', 'No DRS content available after scraping', {
+          peer: PEER.DRS, direction: 'outbound', reason: 'content_not_scraped_after_retry', reasonCategory: 'infra', ...errorField(error),
         });
         await postMessageOptional(
           context,
@@ -309,8 +313,8 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
           fullAuditRef: url,
         };
       }
-      olog.skip('data_acquisition_completed', 'URLs stored but not scraped in DRS yet, requesting a scrape for reddit.com', {
-        status: 'pending_scrape', peer: PEER.DRS, direction: 'outbound', reason: 'no_drs_content',
+      olog.skip('data_acquisition_end', 'URLs stored but not scraped in DRS yet, requesting a scrape for reddit.com', {
+        status: 'pending_scrape', peer: PEER.DRS, direction: 'outbound', reason: 'content_not_scraped_first_attempt', reasonCategory: 'expected',
       });
       await postMessageOptional(
         context,
@@ -335,7 +339,7 @@ async function runRedditAnalysisAudit(url, context, site, auditContext = {}) {
       };
     }
 
-    olog.failure('audit_orchestration_started', 'Audit failed', { ...errorField(error) });
+    olog.failure('audit_orchestration_end', 'Audit failed', { ...errorField(error) });
     return {
       auditResult: {
         success: false,
@@ -361,15 +365,15 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
   const olog = createOffsiteLogger(log, { audit: AUDIT.REDDIT, siteId, auditId: audit?.getId() });
 
   if (!auditResult.success) {
-    olog.skip('audit_analysis_mystique_request_handoff', 'Audit failed, skipping Mystique message', {
-      peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'audit_failed',
+    olog.skip('audit_analysis_start', 'Audit failed, skipping Mystique message', {
+      peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'audit_failed', reasonCategory: 'expected',
     });
     return auditData;
   }
 
   if (!sqs || !env?.QUEUE_SPACECAT_TO_MYSTIQUE) {
-    olog.warn('audit_analysis_mystique_request_handoff', 'SQS or Mystique queue not configured, skipping message', {
-      outcome: OUTCOME.SKIP, peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'not_configured',
+    olog.warn('audit_analysis_start', 'SQS or Mystique queue not configured, skipping message', {
+      outcome: OUTCOME.SKIP, peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'mystique_not_configured', reasonCategory: 'infra',
     });
     return auditData;
   }
@@ -378,15 +382,15 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     const { Site } = dataAccess;
     const site = await Site.findById(siteId);
     if (!site) {
-      olog.warn('audit_analysis_mystique_request_handoff', 'Site not found, skipping Mystique message', {
-        outcome: OUTCOME.SKIP, peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'site_not_found',
+      olog.warn('audit_analysis_start', 'Site not found, skipping Mystique message', {
+        outcome: OUTCOME.SKIP, peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'site_not_found_at_dispatch', reasonCategory: 'infra',
       });
       return auditData;
     }
 
     const { config, storeData } = auditResult;
     const urlLimit = config?.urlLimit ?? MYSTIQUE_URLS_LIMIT;
-    olog.success('audit_analysis_url_limit_resolved', 'URL limit resolved', { urlLimit });
+    olog.success('audit_orchestration_analysis_url_limit_resolved', 'URL limit resolved', { urlLimit });
 
     const { urls, sentimentConfig } = storeData;
     const enrichedUrls = enrichUrlsWithTopicData(urls, sentimentConfig.topics)
@@ -416,19 +420,16 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     try {
       brand = await resolveBrandForSite(context, site);
     } catch (brandError) {
-      olog.warn('audit_analysis_scope_resolved', 'Brand resolution failed unexpectedly; proceeding without scope', {
-        peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'brand_resolution', ...errorField(brandError),
+      olog.warn('audit_orchestration_brand_scope_resolved', 'Brand resolution failed unexpectedly; proceeding without scope', {
+        peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'brand_resolution', reasonCategory: 'infra', ...errorField(brandError),
       });
     }
     const message = applyBrandScope(baseMessage, brand);
 
-    olog.debug('audit_analysis_mystique_request_built', `Built Mystique message type ${message.type}`, {
-      peer: PEER.MYSTIQUE, direction: 'outbound',
-    });
     await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, message);
     olog.success(
-      'audit_analysis_mystique_request_handoff',
-      'Queued analysis request to Mystique',
+      'audit_analysis_start',
+      `Queued analysis request to Mystique (message type ${message.type})`,
       {
         peer: PEER.MYSTIQUE,
         direction: 'outbound',
@@ -439,7 +440,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     );
     return auditData;
   } catch (error) {
-    olog.failure('audit_analysis_mystique_request_handoff', 'Failed to send Mystique message', {
+    olog.failure('audit_analysis_start', 'Failed to send Mystique message', {
       peer: PEER.MYSTIQUE, direction: 'outbound', ...errorField(error),
     });
     throw error;

--- a/src/reddit-analysis/handler.js
+++ b/src/reddit-analysis/handler.js
@@ -441,7 +441,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     return auditData;
   } catch (error) {
     olog.failure('audit_analysis_start', 'Failed to send Mystique message', {
-      peer: PEER.MYSTIQUE, direction: 'outbound', ...errorField(error),
+      peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'unexpected_error', reasonCategory: 'infra', ...errorField(error),
     });
     throw error;
   }

--- a/src/utils/offsite-audit-utils.js
+++ b/src/utils/offsite-audit-utils.js
@@ -282,7 +282,7 @@ export function isExcludedCitedHost(hostname, brandTokens) {
  * @param {object} [auditContext]
  * @param {number|string} [auditContext.messageData.urlLimit]
  * @param {object} [olog] - bound offsite logger (createOffsiteLogger);
- *   emits `audit_analysis_url_limit_resolved`
+ *   emits `audit_orchestration_analysis_url_limit_resolved`
  * @returns {number}
  */
 /**
@@ -428,15 +428,15 @@ export function scrapedThisCycle(auditContext) {
  * @param {string} siteId - Site ID required by the DRS lookup API
  * @param {object|null} drsClient - Configured DrsClient instance (or null / unconfigured)
  * @param {object} [olog] - bound offsite logger (see createOffsiteLogger);
- *   emits `data_acquisition_scrape_job_status_polled`
+ *   emits `data_acquisition_scrape_content_checked`
  * @returns {Promise<{urls: Array<{url: string}>, counts: {total: number, available: number,
  *   scraping: number, notFound: number, determined: boolean}}>}
  * @throws {DrsNoContentAvailableError} When DRS responded but no URLs are available yet
  */
 export async function filterUrlsByDrsStatus(urls, datasetIds, siteId, drsClient, olog) {
   if (!drsClient || !drsClient.isConfigured()) {
-    olog?.skip('data_acquisition_scrape_job_status_polled', 'DRS client not configured, skipping availability filter', {
-      peer: PEER.DRS, direction: 'outbound', reason: 'not_configured',
+    olog?.skip('data_acquisition_scrape_content_checked', 'DRS client not configured, skipping availability filter', {
+      peer: PEER.DRS, direction: 'outbound', reason: 'drs_not_configured', reasonCategory: 'infra',
     });
     return { urls, counts: undeterminedDrsCounts(urls.length) };
   }
@@ -451,8 +451,8 @@ export async function filterUrlsByDrsStatus(urls, datasetIds, siteId, drsClient,
       // eslint-disable-next-line no-await-in-loop
       const response = await drsClient.lookupScrapeResults({ datasetId, siteId, urls: rawUrls });
       if (!response) {
-        olog?.warn('data_acquisition_scrape_job_status_polled', 'DRS lookup returned null; skipping dataset', {
-          peer: PEER.DRS, direction: 'outbound', datasetId, reason: 'null_response',
+        olog?.warn('data_acquisition_scrape_content_checked', 'DRS lookup returned null; skipping dataset', {
+          peer: PEER.DRS, direction: 'outbound', datasetId, reason: 'null_response', reasonCategory: 'infra',
         });
         // eslint-disable-next-line no-continue
         continue;
@@ -466,7 +466,7 @@ export async function filterUrlsByDrsStatus(urls, datasetIds, siteId, drsClient,
         }
       }
       olog?.debug(
-        'data_acquisition_scrape_job_status_polled',
+        'data_acquisition_scrape_content_checked',
         'DRS lookup dataset summary',
         {
           peer: PEER.DRS,
@@ -479,15 +479,15 @@ export async function filterUrlsByDrsStatus(urls, datasetIds, siteId, drsClient,
         },
       );
     } catch (error) {
-      olog?.warn('data_acquisition_scrape_job_status_polled', 'DRS lookup failed; skipping dataset', {
+      olog?.warn('data_acquisition_scrape_content_checked', 'DRS lookup failed; skipping dataset', {
         peer: PEER.DRS, direction: 'outbound', datasetId, ...errorField(error),
       });
     }
   }
 
   if (!atLeastOneLookupSucceeded) {
-    olog?.warn('data_acquisition_scrape_job_status_polled', 'All DRS lookups failed or returned null; skipping availability filter', {
-      peer: PEER.DRS, direction: 'outbound', reason: 'all_failed', datasetIds,
+    olog?.warn('data_acquisition_scrape_content_checked', 'All DRS lookups failed or returned null; skipping availability filter', {
+      peer: PEER.DRS, direction: 'outbound', reason: 'all_failed', reasonCategory: 'infra', datasetIds,
     });
     return { urls, counts: undeterminedDrsCounts(urls.length) };
   }
@@ -512,7 +512,7 @@ export async function filterUrlsByDrsStatus(urls, datasetIds, siteId, drsClient,
   const filtered = urls.filter((item) => availableUrls.has(item.url));
   const removed = total - filtered.length;
   if (removed > 0) {
-    olog?.debug('data_acquisition_scrape_job_status_polled', 'DRS availability filter removed URLs not yet scraped', {
+    olog?.debug('data_acquisition_scrape_content_checked', 'DRS availability filter removed URLs not yet scraped', {
       peer: PEER.DRS, direction: 'outbound', removed, remaining: filtered.length, scraping, notFound,
     });
   }
@@ -528,14 +528,16 @@ export function resolveMystiqueUrlLimit(auditContext, olog) {
   const n = Number(raw);
   if (!Number.isFinite(n) || !Number.isInteger(n) || n < 1) {
     olog?.warn(
-      'audit_analysis_url_limit_resolved',
+      'audit_orchestration_analysis_url_limit_resolved',
       'Invalid urlLimit in auditContext; using default',
-      { reason: 'invalid', raw: JSON.stringify(raw), urlLimit: MYSTIQUE_URLS_LIMIT },
+      {
+        reason: 'invalid', reasonCategory: 'config', raw: JSON.stringify(raw), urlLimit: MYSTIQUE_URLS_LIMIT,
+      },
     );
     return MYSTIQUE_URLS_LIMIT;
   }
   if (n > MYSTIQUE_URLS_LIMIT) {
-    olog?.debug('audit_analysis_url_limit_resolved', 'urlLimit exceeds cap; using cap', {
+    olog?.debug('audit_orchestration_analysis_url_limit_resolved', 'urlLimit exceeds cap; using cap', {
       requested: n, cap: MYSTIQUE_URLS_LIMIT, urlLimit: MYSTIQUE_URLS_LIMIT,
     });
     return MYSTIQUE_URLS_LIMIT;
@@ -579,6 +581,7 @@ function makeResolveOverride(fieldName) {
     // interpolated raw into the message.)
     log?.warn(appendFields(`${prefix} Invalid override value in auditContext, omitting`, {
       reason: 'invalid_override',
+      reasonCategory: 'config',
       field: fieldName,
       raw: JSON.stringify(raw).slice(0, 100),
     }));
@@ -655,7 +658,7 @@ export function resolveForwardedUrlLimit(auditContext, log, logPrefix) {
  *   the same `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED` override originally requested on Slack for
  *   the analysis audit that triggered it, instead of falling back to the plain env var.
  * @param {object} [olog] - bound offsite logger (see createOffsiteLogger);
- *   emits `data_acquisition_scrape_job_submitted`
+ *   emits `data_acquisition_scrape_job_request_dispatched`
  *   with `reason=self_heal`. Threaded from the analysis-handler caller so the audit slug/ids are
  *   bound (this generic util does not know which analysis triggered the self-heal).
  *
@@ -691,12 +694,12 @@ export async function requestOffsiteScrape(
         messageData: { domainScope, ...overrides },
       },
     });
-    olog?.success('data_acquisition_scrape_job_submitted', 'Requested DRS scrape for domain scope', {
-      peer: PEER.SQS, direction: 'outbound', reason: 'self_heal', domainScope, ...overrides,
+    olog?.success('data_acquisition_scrape_job_request_dispatched', 'Requested DRS scrape for domain scope', {
+      peer: PEER.SQS, direction: 'outbound', reason: 'self_heal', reasonCategory: 'expected', domainScope, ...overrides,
     });
   } catch (error) {
-    olog?.warn('data_acquisition_scrape_job_submitted', 'Failed to request DRS scrape for domain scope', {
-      peer: PEER.SQS, direction: 'outbound', reason: 'self_heal', domainScope, ...overrides, ...errorField(error),
+    olog?.warn('data_acquisition_scrape_job_request_dispatched', 'Failed to request DRS scrape for domain scope', {
+      peer: PEER.SQS, direction: 'outbound', reason: 'self_heal', reasonCategory: 'expected', domainScope, ...overrides, ...errorField(error),
     });
   }
 }

--- a/src/utils/offsite-audit-utils.js
+++ b/src/utils/offsite-audit-utils.js
@@ -699,7 +699,7 @@ export async function requestOffsiteScrape(
     });
   } catch (error) {
     olog?.warn('data_acquisition_scrape_job_request_dispatched', 'Failed to request DRS scrape for domain scope', {
-      peer: PEER.SQS, direction: 'outbound', reason: 'self_heal', reasonCategory: 'expected', domainScope, ...overrides, ...errorField(error),
+      peer: PEER.SQS, direction: 'outbound', reason: 'self_heal_failed', reasonCategory: 'infra', domainScope, ...overrides, ...errorField(error),
     });
   }
 }

--- a/src/utils/offsite-brand-presence-enrichment.js
+++ b/src/utils/offsite-brand-presence-enrichment.js
@@ -103,7 +103,7 @@ async function readQueryIndexPaths(site, sharepointClient, log) {
   const dataFolder = site.getConfig?.()?.getLlmoDataFolder?.();
   if (!dataFolder) {
     log.warn(enrich('No LLMO data folder configured for site', {
-      event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.SKIP, peer: PEER.SHAREPOINT, direction: 'inbound', reason: 'no_data_folder',
+      event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.SKIP, peer: PEER.SHAREPOINT, direction: 'inbound', reason: 'no_data_folder', reasonCategory: 'config',
     }));
     return null;
   }
@@ -362,7 +362,7 @@ function extractUrlsAndTopics(data, allUrls, topicMap, log, siteHostname) {
   }
 
   log.info(enrich('Found unique source URLs', {
-    event: 'data_acquisition_bp_data_urls_extracted_enriched', outcome: OUTCOME.SUCCESS, count: allUrls.size,
+    event: 'data_acquisition_bp_data_urls_enriched', outcome: OUTCOME.SUCCESS, count: allUrls.size,
   }));
 }
 
@@ -396,7 +396,7 @@ export async function loadBrandPresenceData({
 
   if (isBrandalfOrg === null) {
     log.warn(enrich('Brandalf flag state unknown; skipping legacy file fetch', {
-      event: 'data_acquisition_bp_data_source_selected', outcome: OUTCOME.SKIP, reason: 'brandalf_unknown', orgId: organizationId, siteId,
+      event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SKIP, reason: 'brandalf_unknown', reasonCategory: 'infra', orgId: organizationId, siteId,
     }));
     return null;
   }
@@ -418,7 +418,7 @@ export async function loadBrandPresenceData({
       return dbData;
     }
     log.info(enrich('No PostgREST data for brandalf-enabled site; falling back to SharePoint file fetch', {
-      event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SKIP, peer: PEER.POSTGRES, direction: 'inbound', source: 'postgrest', reason: 'no_rows', siteId,
+      event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SKIP, peer: PEER.POSTGRES, direction: 'inbound', source: 'postgrest', reason: 'no_rows', reasonCategory: 'config', siteId,
     }));
   }
 
@@ -428,7 +428,7 @@ export async function loadBrandPresenceData({
   }
   if (!resolvedSite) {
     log.warn(enrich('Cannot resolve site; skipping SharePoint fetch', {
-      event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.SKIP, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', reason: 'no_site', siteId,
+      event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.SKIP, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', reason: 'no_site', reasonCategory: 'config', siteId,
     }));
     return null;
   }
@@ -440,14 +440,14 @@ export async function loadBrandPresenceData({
     queryResult = await readQueryIndexPaths(resolvedSite, sharepointClient, log);
   } catch (error) {
     log.error(enrich('Error reading query-index from SharePoint', {
-      event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.FAILURE, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', reason: 'query_index', errorName: error.name, errorMessage: error.message,
+      event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.FAILURE, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', reason: 'query_index', reasonCategory: 'infra', errorName: error.name, errorMessage: error.message,
     }));
     return null;
   }
 
   if (!queryResult || queryResult.paths.length === 0) {
     log.warn(enrich('Failed to read query-index', {
-      event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.SKIP, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', reason: 'empty_query_index', siteId,
+      event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.SKIP, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', reason: 'empty_query_index', reasonCategory: 'config', siteId,
     }));
     return null;
   }
@@ -484,7 +484,7 @@ export async function loadBrandPresenceData({
       allRows.push(...data.data);
     } catch (err) {
       log.error(enrich('Error reading brand presence sheet', {
-        event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.FAILURE, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', reason: 'sheet_read', sheetName, errorName: err.name, errorMessage: err.message,
+        event: 'data_acquisition_bp_data_sharepoint_read', outcome: OUTCOME.FAILURE, peer: PEER.SHAREPOINT, direction: 'inbound', source: 'sharepoint', reason: 'sheet_read', reasonCategory: 'infra', sheetName, errorName: err.name, errorMessage: err.message,
       }));
     }
   }
@@ -558,7 +558,7 @@ export async function computeTopicsFromBrandPresence(siteId, context, site) {
       siteHostname = new URL(baseURL).hostname.replace(/^www\./, '');
     } catch {
       log.warn(enrich('Could not parse baseURL; skipping site URL filter', {
-        event: 'data_acquisition_bp_data_urls_extracted_enriched', outcome: OUTCOME.SKIP, reason: 'unparseable_base_url', baseURL,
+        event: 'data_acquisition_bp_data_urls_enriched', outcome: OUTCOME.SKIP, reason: 'unparseable_base_url', reasonCategory: 'config', baseURL,
       }));
     }
   }

--- a/src/utils/offsite-brand-presence-postgrest.js
+++ b/src/utils/offsite-brand-presence-postgrest.js
@@ -92,7 +92,7 @@ async function fetchExecutionsWithSources(postgrestClient, {
   while (true) {
     if (pageCount >= MAX_EXECUTION_FETCH_PAGES) {
       log.warn(bp('Exceeded maximum brand_presence_executions pages; processing rows fetched so far', {
-        event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SUCCESS, peer: PEER.POSTGRES, direction: 'inbound', reason: 'max_pages', pages: MAX_EXECUTION_FETCH_PAGES, rows: rows.length,
+        event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SUCCESS, peer: PEER.POSTGRES, direction: 'inbound', reason: 'max_pages', reasonCategory: 'infra', pages: MAX_EXECUTION_FETCH_PAGES, rows: rows.length,
       }));
       break;
     }
@@ -191,7 +191,7 @@ export async function loadBrandPresenceDataFromPostgrest({
 
     if (executions.length === 0) {
       log?.info(bp('No execution rows found', {
-        event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SKIP, peer: PEER.POSTGRES, direction: 'inbound', count: 0, reason: 'no_executions', siteId,
+        event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SKIP, peer: PEER.POSTGRES, direction: 'inbound', count: 0, reason: 'no_executions', reasonCategory: 'config', siteId,
       }));
       return null;
     }
@@ -199,7 +199,7 @@ export async function loadBrandPresenceDataFromPostgrest({
     const rows = mapExecutionsToLegacyBrandPresenceRows(executions);
     if (rows.length === 0) {
       log?.info(bp('No usable rows found', {
-        event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SKIP, peer: PEER.POSTGRES, direction: 'inbound', count: 0, reason: 'no_usable_rows', siteId,
+        event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.SKIP, peer: PEER.POSTGRES, direction: 'inbound', count: 0, reason: 'no_usable_rows', reasonCategory: 'config', siteId,
       }));
       return null;
     }
@@ -210,7 +210,7 @@ export async function loadBrandPresenceDataFromPostgrest({
     return { data: rows };
   } catch (error) {
     log?.warn(bp('PostgREST query failed', {
-      event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.FAILURE, peer: PEER.POSTGRES, direction: 'inbound', reason: 'query', siteId, errorName: error.name, errorMessage: error.message,
+      event: 'data_acquisition_bp_data_postgres_read', outcome: OUTCOME.FAILURE, peer: PEER.POSTGRES, direction: 'inbound', reason: 'query', reasonCategory: 'infra', siteId, errorName: error.name, errorMessage: error.message,
     }));
     return null;
   }

--- a/src/utils/offsite-brand-presence-semrush.js
+++ b/src/utils/offsite-brand-presence-semrush.js
@@ -270,13 +270,13 @@ function classifyRow(row, siteHostname, brandTokens) {
  *   without a Slack dependency; a failure here is logged and swallowed, never thrown — a Slack
  *   outage must not affect the Semrush attempt itself.
  * @param {object} [params.diagnostics] - Optional out-param, mutated in place. On a null
- *   return, set to `{ fallbackReason }` with a specific code (`no-organization-id`,
- *   `no-active-brand`, `brand-resolution-failed`, `not-entitled`, `entitlement-check-failed`,
- *   `no-date-window`, `ims-token-failed`, `domain-urls-auth-failed`, or `domain-urls-failed`).
+ *   return, set to `{ fallbackReason }` with a specific code (`no_organization_id`,
+ *   `no_active_brand`, `brand_resolution_failed`, `not_entitled`, `entitlement_check_failed`,
+ *   `no_date_window`, `ims_token_failed`, `domain_urls_auth_failed`, or `domain_urls_failed`).
  *   The two entitlement reasons additionally set `entitlementReason` to the granular cause
- *   from `resolveSemrushEntitlement` (`flag-disabled` | `no-workspace` | `no-client` |
- *   `check-failed`) — `fallbackReason` alone cannot distinguish a confirmed non-entitlement
- *   from a wiring bug (`no-client`) vs a transient blip (`check-failed`). On a successful
+ *   from `resolveSemrushEntitlement` (`flag_disabled` | `no_workspace` | `no_client` |
+ *   `check_failed`) — `fallbackReason` alone cannot distinguish a confirmed non-entitlement
+ *   from a wiring bug (`no_client`) vs a transient blip (`check_failed`). On a successful
  *   return, set to `{ truncated }` — true when the response came back at `PAGE_SIZE`, so a
  *   bucket may be starved (LLMO-6711 shadow-run parity signal).
  * @returns {Promise<Map<string, {count:number, domain:string|null}> | null>}
@@ -315,10 +315,10 @@ export async function loadCitedUrlsFromSemrush({
   const spaceCatId = site?.getOrganizationId?.();
   if (!spaceCatId) {
     olog.warn('data_acquisition_bp_data_semrush_read', 'Site has no organization id; skipping Semrush source', {
-      peer: PEER.SEMRUSH, direction: 'inbound', durationMs: elapsed(), reason: 'no-organization-id', outcome: OUTCOME.SKIP,
+      peer: PEER.SEMRUSH, direction: 'inbound', durationMs: elapsed(), reason: 'no_organization_id', reasonCategory: 'config', outcome: OUTCOME.SKIP,
     });
     await notify(':warning: Site has no organization id — falling back to the legacy source.');
-    setDiagnostics({ fallbackReason: 'no-organization-id' });
+    setDiagnostics({ fallbackReason: 'no_organization_id', reasonCategory: 'config' });
     return null;
   }
 
@@ -328,16 +328,16 @@ export async function loadCitedUrlsFromSemrush({
   if (!brand?.brandId) {
     if (resolved) {
       olog.skip('data_acquisition_bp_data_semrush_read', 'No active brand; skipping Semrush source', {
-        peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, durationMs: elapsed(), reason: 'no-active-brand',
+        peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, durationMs: elapsed(), reason: 'no_active_brand', reasonCategory: 'config',
       });
       await notify(':information_source: No active brand configured for this org — falling back to the legacy source.');
-      setDiagnostics({ fallbackReason: 'no-active-brand' });
+      setDiagnostics({ fallbackReason: 'no_active_brand', reasonCategory: 'config' });
     } else {
       olog.warn('data_acquisition_bp_data_semrush_read', 'Brand resolution failed (transient); using legacy fallback', {
-        peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, durationMs: elapsed(), reason: 'brand-resolution-failed',
+        peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, durationMs: elapsed(), reason: 'brand_resolution_failed', reasonCategory: 'infra',
       });
       await notify(':warning: Brand resolution failed (transient) — falling back to the legacy source.');
-      setDiagnostics({ fallbackReason: 'brand-resolution-failed' });
+      setDiagnostics({ fallbackReason: 'brand_resolution_failed', reasonCategory: 'infra' });
     }
     return null;
   }
@@ -360,16 +360,18 @@ export async function loadCitedUrlsFromSemrush({
         brandId: brand.brandId,
         entitlementReason: entitlement.reason,
         durationMs: elapsed(),
-        reason: 'not-entitled',
+        reason: 'not_entitled',
+        reasonCategory: 'config',
       });
       await notify(':information_source: Brand is not entitled for Semrush — falling back to the legacy source.');
       // fallbackReason is the coarse, contract-level signal the handler's hard-stop
       // exemption keys off (SEMRUSH_ENTITLEMENT_SKIP_REASONS); entitlementReason keeps
-      // the granular cause (`flag-disabled` | `no-workspace` | `no-client` |
-      // `check-failed`) visible in diagnostics/auditResult without changing that
+      // the granular cause (`flag_disabled` | `no_workspace` | `no_client` |
+      // `check_failed`) visible in diagnostics/auditResult without changing that
       // contract — see ADR 002, Decision 7.
       setDiagnostics({
         fallbackReason: SEMRUSH_NOT_ENTITLED_REASON,
+        reasonCategory: 'config',
         entitlementReason: entitlement.reason,
       });
     } else {
@@ -379,6 +381,7 @@ export async function loadCitedUrlsFromSemrush({
       await notify(':warning: Could not verify Semrush entitlement (transient) — falling back to the legacy source.');
       setDiagnostics({
         fallbackReason: SEMRUSH_ENTITLEMENT_CHECK_FAILED_REASON,
+        reasonCategory: 'infra',
         entitlementReason: entitlement.reason,
       });
     }
@@ -391,7 +394,7 @@ export async function loadCitedUrlsFromSemrush({
       peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, brandId: brand.brandId, durationMs: elapsed(), outcome: OUTCOME.SKIP,
     });
     await notify(':warning: Could not derive a date window — falling back to the legacy source.');
-    setDiagnostics({ fallbackReason: 'no-date-window' });
+    setDiagnostics({ fallbackReason: 'no_date_window', reasonCategory: 'config' });
     return null;
   }
   const { startDate, endDate } = dateWindow;
@@ -404,7 +407,7 @@ export async function loadCitedUrlsFromSemrush({
       peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, brandId: brand.brandId, durationMs: elapsed(), ...errorField(error),
     }, error);
     await notify(`:x: Failed to obtain an IMS service token (\`${error.message}\`) — falling back to the legacy source.`);
-    setDiagnostics({ fallbackReason: 'ims-token-failed' });
+    setDiagnostics({ fallbackReason: 'ims_token_failed', reasonCategory: 'infra' });
     return null;
   }
 
@@ -434,7 +437,10 @@ export async function loadCitedUrlsFromSemrush({
       peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, durationMs: elapsed(),
     });
     await notify(':x: `domain-urls` request failed — falling back to the legacy source.');
-    setDiagnostics({ fallbackReason: result.authFailure ? 'domain-urls-auth-failed' : 'domain-urls-failed' });
+    setDiagnostics({
+      fallbackReason: result.authFailure ? 'domain_urls_auth_failed' : 'domain_urls_failed',
+      reasonCategory: 'infra',
+    });
     return null;
   }
   setDiagnostics({ truncated: result.truncated });

--- a/src/utils/offsite-logging.js
+++ b/src/utils/offsite-logging.js
@@ -198,7 +198,7 @@ export function createOffsiteLogger(log, bound = {}) {
 }
 
 /**
- * Build an offsite `audit_persistence_run_recorded` post-processor for an AuditBuilder.
+ * Build an offsite `audit_persistence_run_write` post-processor for an AuditBuilder.
  *
  * The framework persists the Audit record silently (`defaultPersister` -> `Audit.create`) and
  * sets `context.audit` before post-processors run, so this post-processor makes the persist
@@ -215,7 +215,7 @@ export function withAuditPersistLog(audit) {
       audit,
       siteId: auditData?.siteId,
       auditId: auditData?.id ?? context.audit?.getId?.(),
-    }).success('audit_persistence_run_recorded', 'Audit persisted', {
+    }).success('audit_persistence_run_write', 'Audit persisted', {
       peer: PEER.POSTGRES,
       direction: 'outbound',
       auditType: auditData?.auditType,

--- a/src/utils/semrush-entitlement.js
+++ b/src/utils/semrush-entitlement.js
@@ -55,14 +55,14 @@ const SERENITY_FLAG_NAME = 'serenity';
  * check (`offsite-brand-presence/handler.js`) share one literal instead of two
  * independently-typed copies that could drift.
  */
-export const SEMRUSH_NOT_ENTITLED_REASON = 'not-entitled';
+export const SEMRUSH_NOT_ENTITLED_REASON = 'not_entitled';
 
 /**
  * Reason code the loader sets on `diagnostics.fallbackReason` when the entitlement
  * check itself could not complete (`resolved:false` — see `entitlementReason` on the
- * same diagnostics object for the granular cause: `no-client` vs `check-failed`).
+ * same diagnostics object for the granular cause: `no_client` vs `check_failed`).
  */
-export const SEMRUSH_ENTITLEMENT_CHECK_FAILED_REASON = 'entitlement-check-failed';
+export const SEMRUSH_ENTITLEMENT_CHECK_FAILED_REASON = 'entitlement_check_failed';
 
 /**
  * Both entitlement-based skip reasons — a deliberate skip (confirmed or
@@ -82,11 +82,11 @@ export const SEMRUSH_ENTITLEMENT_SKIP_REASONS = Object.freeze(
  */
 export const SEMRUSH_ENTITLEMENT_REASONS = Object.freeze({
   ENTITLED: 'entitled',
-  FLAG_DISABLED: 'flag-disabled',
-  NO_WORKSPACE: 'no-workspace',
-  MISSING_INPUT: 'missing-input',
-  NO_CLIENT: 'no-client',
-  CHECK_FAILED: 'check-failed',
+  FLAG_DISABLED: 'flag_disabled',
+  NO_WORKSPACE: 'no_workspace',
+  MISSING_INPUT: 'missing_input',
+  NO_CLIENT: 'no_client',
+  CHECK_FAILED: 'check_failed',
 });
 
 /**
@@ -97,7 +97,7 @@ export const SEMRUSH_ENTITLEMENT_REASONS = Object.freeze({
  * `Organization.findById`, `Brand.findById`) all run CONCURRENTLY via `Promise.all`, so
  * the critical path here is one round-trip deep, not two — the same budget is, if
  * anything, more generous for this shape. Re-validate against real p99s post-rollout
- * if `check-failed` volume looks high (a symptom the timeout is too tight for
+ * if `check_failed` volume looks high (a symptom the timeout is too tight for
  * `Organization`/`Brand`'s data-access-layer overhead vs a raw PostgREST query).
  */
 export const SEMRUSH_ENTITLEMENT_TIMEOUT_MS = 300;

--- a/src/utils/store-client.js
+++ b/src/utils/store-client.js
@@ -216,11 +216,11 @@ export default class StoreClient {
     const { AuditUrl } = this.dataAccess;
 
     this.log.info(sc('Fetching URLs from URL Store', {
-      event: 'data_acquisition_store_urls_read', outcome: OUTCOME.START, peer: PEER.URL_STORE, direction: 'inbound', siteId, auditType,
+      event: 'data_acquisition_url_store_read', outcome: OUTCOME.START, peer: PEER.URL_STORE, direction: 'inbound', siteId, auditType,
     }));
 
     // Wraps the DB read so a genuine read error is a distinct, alertable
-    // `data_acquisition_store_urls_read outcome=failure` rather than surfacing only as
+    // `data_acquisition_url_store_read outcome=failure` rather than surfacing only as
     // the generic "Audit failed". The empty-store case below stays a StoreEmptyError (a
     // normal "no URLs yet" signal the callers self-heal on), not a read failure.
     let items;
@@ -237,7 +237,7 @@ export default class StoreClient {
       ));
     } catch (error) {
       this.log.error(sc('Failed to read URLs from URL Store', {
-        event: 'data_acquisition_store_urls_read', outcome: OUTCOME.FAILURE, peer: PEER.URL_STORE, direction: 'inbound', siteId, auditType, errorName: error.name, errorMessage: error.message,
+        event: 'data_acquisition_url_store_read', outcome: OUTCOME.FAILURE, peer: PEER.URL_STORE, direction: 'inbound', siteId, auditType, errorName: error.name, errorMessage: error.message,
       }));
       throw error;
     }
@@ -248,7 +248,7 @@ export default class StoreClient {
 
     const urls = items.map(toAuditUrlJson);
     this.log.info(sc('Found URLs in URL Store', {
-      event: 'data_acquisition_store_urls_read', outcome: OUTCOME.SUCCESS, peer: PEER.URL_STORE, direction: 'inbound', siteId, auditType, count: urls.length,
+      event: 'data_acquisition_url_store_read', outcome: OUTCOME.SUCCESS, peer: PEER.URL_STORE, direction: 'inbound', siteId, auditType, count: urls.length,
     }));
     return urls;
   }

--- a/src/wikipedia-analysis/guidance-handler.js
+++ b/src/wikipedia-analysis/guidance-handler.js
@@ -31,7 +31,7 @@ const AUDIT_TYPE = Audit.AUDIT_TYPES.WIKIPEDIA_ANALYSIS;
 const HUMAN_PREFIX = `[offsite:${AUDIT.WIKIPEDIA}]`;
 
 /**
- * Classifies a presigned-analysis-fetch failure for the `audit_persistence_payload_fetched`
+ * Classifies a presigned-analysis-fetch failure for the `audit_persistence_mystique_payload_read`
  * event's reason token:
  * URL/SSRF/shape and body-shape rejections are `validation`; network / non-2xx / timeout
  * failures are `fetch`. The messages come from analysis-fetch.js / assertPresignedUrl.
@@ -133,13 +133,15 @@ export default async function handler(message, context) {
 
   const olog = createOffsiteLogger(log, { audit: AUDIT.WIKIPEDIA, siteId, auditId });
 
-  olog.start('audit_analysis_completed', 'Guidance received', {
+  olog.start('audit_persistence_start', 'Persistence started', {});
+
+  olog.start('audit_analysis_end', 'Guidance received', {
     peer: PEER.MYSTIQUE, direction: 'inbound',
   });
 
   const site = await Site.findById(siteId);
   if (!site) {
-    olog.failure('audit_persistence_completed', 'Site not found', { reason: 'site_not_found' });
+    olog.failure('audit_persistence_end', 'Site not found', { reason: 'site_not_found_at_persist', reasonCategory: 'infra' });
     return notFound('Site not found');
   }
   const baseUrl = site.getBaseURL();
@@ -147,8 +149,8 @@ export default async function handler(message, context) {
   // Mystique couldn't complete the analysis (e.g. an upstream producer/service
   // failure). Report it to the Slack thread instead of failing silently, then stop.
   if (data?.error) {
-    olog.failure('audit_analysis_completed', 'Mystique returned an error', {
-      peer: PEER.MYSTIQUE, direction: 'inbound', reason: 'mystique_error', mystiqueError: data.errorMessage,
+    olog.failure('audit_analysis_end', 'Mystique returned an error', {
+      peer: PEER.MYSTIQUE, direction: 'inbound', reason: 'mystique_error', reasonCategory: 'infra', mystiqueError: data.errorMessage,
     });
     await postWikipediaOutcomeToSlack(
       context,
@@ -168,12 +170,12 @@ export default async function handler(message, context) {
         log,
         prefix: HUMAN_PREFIX,
       });
-      olog.success('audit_persistence_payload_fetched', 'Fetched analysis from presigned URL', {
+      olog.success('audit_persistence_mystique_payload_read', 'Fetched analysis from presigned URL', {
         peer: PEER.S3, direction: 'inbound',
       });
     } catch (error) {
-      olog.failure('audit_persistence_payload_fetched', 'Error fetching from presigned URL', {
-        peer: PEER.S3, direction: 'inbound', reason: classifyFetchFailure(error), ...errorField(error),
+      olog.failure('audit_persistence_mystique_payload_read', 'Error fetching from presigned URL', {
+        peer: PEER.S3, direction: 'inbound', reason: classifyFetchFailure(error), reasonCategory: 'infra', ...errorField(error),
       });
       return badRequest(`Error fetching analysis data: ${error.message}`);
     }
@@ -181,7 +183,7 @@ export default async function handler(message, context) {
 
   // Validate analysis data
   if (!analysisData) {
-    olog.failure('audit_persistence_completed', 'No analysis data provided in message', { reason: 'no_analysis_data' });
+    olog.failure('audit_persistence_end', 'No analysis data provided in message', { reason: 'no_analysis_data', reasonCategory: 'infra' });
     return badRequest('Analysis data is required');
   }
 
@@ -189,7 +191,7 @@ export default async function handler(message, context) {
   if (auditId) {
     const audit = await AuditModel.findById(auditId);
     if (!audit) {
-      olog.failure('audit_persistence_completed', 'Audit not found', { reason: 'audit_not_found' });
+      olog.failure('audit_persistence_end', 'Audit not found', { reason: 'audit_not_found', reasonCategory: 'infra' });
       return notFound('Audit not found');
     }
   }
@@ -204,7 +206,7 @@ export default async function handler(message, context) {
     // was analyzed but had nothing to improve. Report the outcome to Slack — this
     // path used to return silently, so a Slack-triggered run showed only the trigger.
     if (suggestions.length === 0) {
-      olog.skip('audit_persistence_completed', 'No suggestions found in analysis', { reason: 'no_suggestions' });
+      olog.skip('audit_persistence_end', 'No suggestions found in analysis', { reason: 'no_suggestions', reasonCategory: 'expected' });
       const outcomeMessage = wikipediaUrl
         ? `:white_check_mark: *wikipedia-analysis* audit finished for *${baseUrl}*\n`
           + '• Wikipedia page analyzed — no improvement suggestions found'
@@ -213,7 +215,7 @@ export default async function handler(message, context) {
       return noContent();
     }
 
-    olog.debug('audit_analysis_completed', 'Processing suggestions', {
+    olog.debug('audit_analysis_end', 'Processing suggestions', {
       count: suggestions.length, company,
     });
 
@@ -246,7 +248,7 @@ export default async function handler(message, context) {
       fullAnalysis: analysisData,
     });
     await opportunity.save();
-    ologOpp.success('audit_persistence_opportunity_persisted', 'Opportunity persisted', {
+    ologOpp.success('audit_persistence_evergreen_opportunity_write', 'Opportunity persisted', {
       peer: PEER.POSTGRES, direction: 'outbound',
     });
 
@@ -263,17 +265,17 @@ export default async function handler(message, context) {
           data: suggestion,
         }),
       });
-      ologOpp.success('audit_persistence_suggestions_synced', `Synced ${suggestions.length} suggestions`, {
+      ologOpp.success('audit_persistence_evergreen_opportunity_write', `Synced ${suggestions.length} suggestions`, {
         peer: PEER.POSTGRES, direction: 'outbound', count: suggestions.length,
       });
     } catch (error) {
-      ologOpp.failure('audit_persistence_suggestions_synced', 'Failed to sync suggestions', {
-        peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
+      ologOpp.failure('audit_persistence_evergreen_opportunity_write', 'Failed to sync suggestions', {
+        peer: PEER.POSTGRES, direction: 'outbound', reason: 'suggestions_write_failed', reasonCategory: 'infra', ...errorField(error),
       });
       throw error;
     }
 
-    ologOpp.success('audit_persistence_completed', 'Run processed successfully', {
+    ologOpp.success('audit_persistence_end', 'Run processed successfully', {
       count: suggestions.length, company,
     });
 
@@ -287,9 +289,9 @@ export default async function handler(message, context) {
     return ok();
   } catch (error) {
     // Intentional drill-down: a failure already logged by an inner event (e.g.
-    // audit_persistence_suggestions_synced) will also surface here as
-    // audit_persistence_completed outcome=failure — the terminal, per-run marker.
-    olog.failure('audit_persistence_completed', 'Error processing analysis', { ...errorField(error) }, error);
+    // audit_persistence_evergreen_opportunity_write) will also surface here as
+    // audit_persistence_end outcome=failure — the terminal, per-run marker.
+    olog.failure('audit_persistence_end', 'Error processing analysis', { ...errorField(error) }, error);
     return badRequest(`Error processing analysis: ${error.message}`);
   }
 }

--- a/src/wikipedia-analysis/guidance-handler.js
+++ b/src/wikipedia-analysis/guidance-handler.js
@@ -291,7 +291,7 @@ export default async function handler(message, context) {
     // Intentional drill-down: a failure already logged by an inner event (e.g.
     // audit_persistence_evergreen_opportunity_write) will also surface here as
     // audit_persistence_end outcome=failure — the terminal, per-run marker.
-    olog.failure('audit_persistence_end', 'Error processing analysis', { ...errorField(error) }, error);
+    olog.failure('audit_persistence_end', 'Error processing analysis', { reason: 'unexpected_error', reasonCategory: 'infra', ...errorField(error) }, error);
     return badRequest(`Error processing analysis: ${error.message}`);
   }
 }

--- a/src/wikipedia-analysis/guidance-handler.js
+++ b/src/wikipedia-analysis/guidance-handler.js
@@ -133,11 +133,11 @@ export default async function handler(message, context) {
 
   const olog = createOffsiteLogger(log, { audit: AUDIT.WIKIPEDIA, siteId, auditId });
 
-  olog.start('audit_persistence_start', 'Persistence started', {});
-
   olog.start('audit_analysis_end', 'Guidance received', {
     peer: PEER.MYSTIQUE, direction: 'inbound',
   });
+
+  olog.start('audit_persistence_start', 'Persistence started', {});
 
   const site = await Site.findById(siteId);
   if (!site) {

--- a/src/wikipedia-analysis/handler.js
+++ b/src/wikipedia-analysis/handler.js
@@ -235,7 +235,7 @@ async function runWikipediaAnalysisAudit(url, context, site, auditContext = {}) 
   const siteId = site.getId();
   const olog = createOffsiteLogger(log, { audit: AUDIT.WIKIPEDIA, siteId });
 
-  olog.start('audit_orchestration_started', 'Audit started');
+  olog.start('audit_orchestration_start', 'Audit started');
 
   try {
     const wikipediaConfig = getWikipediaConfig(site);
@@ -243,7 +243,7 @@ async function runWikipediaAnalysisAudit(url, context, site, auditContext = {}) 
     const wikipediaUrlOverride = resolveWikipediaUrlOverride(auditContext, olog);
     if (wikipediaUrlOverride?.invalid) {
       olog.warn('audit_orchestration_brand_profile_resolved', 'Ignoring invalid wikipedia URL override', {
-        reason: 'invalid_url_override', value: wikipediaUrlOverride.value,
+        reason: 'invalid_url_override', reasonCategory: 'config', value: wikipediaUrlOverride.value,
       });
     } else if (wikipediaUrlOverride?.url) {
       wikipediaConfig.wikipediaUrl = wikipediaUrlOverride.url;
@@ -254,7 +254,7 @@ async function runWikipediaAnalysisAudit(url, context, site, auditContext = {}) 
 
     // Validate that we have a company name
     if (!wikipediaConfig.companyName) {
-      olog.warn('audit_orchestration_brand_profile_resolved', 'No company name configured for site, skipping audit', { reason: 'no_company_name' });
+      olog.warn('audit_orchestration_brand_profile_resolved', 'No company name configured for site, skipping audit', { reason: 'no_company_name', reasonCategory: 'config' });
       return {
         auditResult: {
           success: false,
@@ -272,6 +272,8 @@ async function runWikipediaAnalysisAudit(url, context, site, auditContext = {}) 
 
     const slackContext = auditContext?.slackContext;
 
+    olog.success('audit_orchestration_end', 'Audit complete', { status: 'pending_analysis' });
+
     return {
       auditResult: {
         success: true,
@@ -282,7 +284,7 @@ async function runWikipediaAnalysisAudit(url, context, site, auditContext = {}) 
       fullAuditRef: url,
     };
   } catch (error) {
-    olog.failure('audit_orchestration_started', 'Audit failed', { ...errorField(error) });
+    olog.failure('audit_orchestration_end', 'Audit failed', { ...errorField(error) });
     return {
       auditResult: {
         success: false,
@@ -312,12 +314,12 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
 
   // Skip if audit failed
   if (!auditResult.success) {
-    olog.skip('audit_analysis_mystique_request_handoff', 'Audit failed, skipping Mystique message', { reason: 'audit_failed' });
+    olog.skip('audit_analysis_start', 'Audit failed, skipping Mystique message', { reason: 'audit_failed', reasonCategory: 'expected' });
     return auditData;
   }
 
   if (!sqs || !env?.QUEUE_SPACECAT_TO_MYSTIQUE) {
-    olog.warn('audit_analysis_mystique_request_handoff', 'SQS or Mystique queue not configured, skipping message', { reason: 'not_configured' });
+    olog.warn('audit_analysis_start', 'SQS or Mystique queue not configured, skipping message', { reason: 'mystique_not_configured', reasonCategory: 'infra' });
     return auditData;
   }
 
@@ -326,7 +328,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     const { Site } = dataAccess;
     const site = await Site.findById(siteId);
     if (!site) {
-      olog.warn('audit_analysis_mystique_request_handoff', 'Site not found, skipping Mystique message', { reason: 'site_not_found' });
+      olog.warn('audit_analysis_start', 'Site not found, skipping Mystique message', { reason: 'site_not_found_at_dispatch', reasonCategory: 'infra' });
       return auditData;
     }
 
@@ -352,7 +354,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     try {
       brand = await resolveBrandForSite(context, site);
     } catch (brandError) {
-      olog.warn('audit_analysis_scope_resolved', 'Brand resolution failed unexpectedly; proceeding without scope', { ...errorField(brandError) });
+      olog.warn('audit_orchestration_brand_scope_resolved', 'Brand resolution failed unexpectedly; proceeding without scope', { reason: 'brand_resolution', reasonCategory: 'infra', ...errorField(brandError) });
     }
     const message = applyBrandScope(baseMessage, brand);
 
@@ -362,7 +364,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
       : '(empty → auto-detect)';
 
     olog.success(
-      'audit_analysis_mystique_request_handoff',
+      'audit_analysis_start',
       'Queued analysis request to Mystique',
       {
         peer: PEER.MYSTIQUE,
@@ -373,7 +375,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
       },
     );
   } catch (error) {
-    olog.failure('audit_analysis_mystique_request_handoff', 'Failed to send Mystique message', { peer: PEER.MYSTIQUE, direction: 'outbound', ...errorField(error) }, error);
+    olog.failure('audit_analysis_start', 'Failed to send Mystique message', { peer: PEER.MYSTIQUE, direction: 'outbound', ...errorField(error) }, error);
     // Re-throw to fail the audit if we can't send to Mystique
     throw error;
   }

--- a/src/wikipedia-analysis/handler.js
+++ b/src/wikipedia-analysis/handler.js
@@ -284,7 +284,7 @@ async function runWikipediaAnalysisAudit(url, context, site, auditContext = {}) 
       fullAuditRef: url,
     };
   } catch (error) {
-    olog.failure('audit_orchestration_end', 'Audit failed', { ...errorField(error) });
+    olog.failure('audit_orchestration_end', 'Audit failed', { reason: 'unexpected_error', reasonCategory: 'infra', ...errorField(error) });
     return {
       auditResult: {
         success: false,

--- a/src/wikipedia-analysis/handler.js
+++ b/src/wikipedia-analysis/handler.js
@@ -375,7 +375,9 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
       },
     );
   } catch (error) {
-    olog.failure('audit_analysis_start', 'Failed to send Mystique message', { peer: PEER.MYSTIQUE, direction: 'outbound', ...errorField(error) }, error);
+    olog.failure('audit_analysis_start', 'Failed to send Mystique message', {
+      peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'unexpected_error', reasonCategory: 'infra', ...errorField(error),
+    }, error);
     // Re-throw to fail the audit if we can't send to Mystique
     throw error;
   }

--- a/src/youtube-analysis/guidance-handler.js
+++ b/src/youtube-analysis/guidance-handler.js
@@ -44,7 +44,7 @@ const AUDIT_TYPE = Audit.AUDIT_TYPES.YOUTUBE_ANALYSIS;
 const HUMAN_PREFIX = `[offsite:${AUDIT.YOUTUBE}]`;
 
 /**
- * Classifies a presigned-analysis-fetch failure for the `audit_persistence_payload_fetched`
+ * Classifies a presigned-analysis-fetch failure for the `audit_persistence_mystique_payload_read`
  * event's reason token:
  * URL/SSRF/shape and body-shape rejections are `validation`; network / non-2xx / timeout
  * failures are `fetch`. The messages come from analysis-fetch.js / assertPresignedUrl.
@@ -74,13 +74,15 @@ export default async function handler(message, context) {
 
   const olog = createOffsiteLogger(log, { audit: AUDIT.YOUTUBE, siteId, auditId });
 
-  olog.start('audit_analysis_completed', 'Guidance received', {
+  olog.start('audit_analysis_end', 'Guidance received', {
     peer: PEER.MYSTIQUE, direction: 'inbound',
   });
 
+  olog.start('audit_persistence_start', 'Starting audit persistence', {});
+
   if (data?.error) {
-    olog.failure('audit_analysis_completed', 'Mystique returned an error', {
-      peer: PEER.MYSTIQUE, direction: 'inbound', reason: 'mystique_error', mystiqueError: data.errorMessage,
+    olog.failure('audit_analysis_end', 'Mystique returned an error', {
+      peer: PEER.MYSTIQUE, direction: 'inbound', reason: 'mystique_error', reasonCategory: 'infra', mystiqueError: data.errorMessage,
     });
     return noContent();
   }
@@ -94,12 +96,12 @@ export default async function handler(message, context) {
         log,
         prefix: HUMAN_PREFIX,
       });
-      olog.success('audit_persistence_payload_fetched', 'Fetched analysis from presigned URL', {
+      olog.success('audit_persistence_mystique_payload_read', 'Fetched analysis from presigned URL', {
         peer: PEER.S3, direction: 'inbound',
       });
     } catch (error) {
-      olog.failure('audit_persistence_payload_fetched', 'Error fetching from presigned URL', {
-        peer: PEER.S3, direction: 'inbound', reason: classifyFetchFailure(error), ...errorField(error),
+      olog.failure('audit_persistence_mystique_payload_read', 'Error fetching from presigned URL', {
+        peer: PEER.S3, direction: 'inbound', reason: classifyFetchFailure(error), reasonCategory: 'infra', ...errorField(error),
       });
       return badRequest(`Error fetching analysis data: ${error.message}`);
     }
@@ -108,20 +110,20 @@ export default async function handler(message, context) {
   }
 
   if (!analysisData) {
-    olog.failure('audit_persistence_completed', 'No analysis data provided in message', { reason: 'no_analysis_data' });
+    olog.failure('audit_persistence_end', 'No analysis data provided in message', { reason: 'no_analysis_data', reasonCategory: 'infra' });
     return badRequest('Analysis data is required');
   }
 
   const site = await Site.findById(siteId);
   if (!site) {
-    olog.failure('audit_persistence_completed', 'Site not found', { reason: 'site_not_found' });
+    olog.failure('audit_persistence_end', 'Site not found', { reason: 'site_not_found_at_persist', reasonCategory: 'infra' });
     return notFound('Site not found');
   }
 
   if (auditId) {
     const audit = await AuditModel.findById(auditId);
     if (!audit) {
-      olog.failure('audit_persistence_completed', 'Audit not found', { reason: 'audit_not_found' });
+      olog.failure('audit_persistence_end', 'Audit not found', { reason: 'audit_not_found', reasonCategory: 'infra' });
       return notFound('Audit not found');
     }
   }
@@ -133,11 +135,11 @@ export default async function handler(message, context) {
     const opportunityData = analysisData.opportunity || {};
 
     if (suggestions.length === 0) {
-      olog.skip('audit_persistence_completed', 'No suggestions found in analysis', { reason: 'no_suggestions' });
+      olog.skip('audit_persistence_end', 'No suggestions found in analysis', { reason: 'no_suggestions', reasonCategory: 'expected' });
       return noContent();
     }
 
-    olog.debug('audit_analysis_completed', 'Processing suggestions', {
+    olog.debug('audit_analysis_end', 'Processing suggestions', {
       count: suggestions.length, companyName,
     });
 
@@ -147,7 +149,7 @@ export default async function handler(message, context) {
 
     // Validate before mutating the evergreen opportunity.
     if (!isValidOffsiteAnalysis(analysisData, auditType)) {
-      olog.failure('audit_persistence_completed', 'Malformed analysis payload; skipping update', { reason: 'malformed_payload' });
+      olog.failure('audit_persistence_end', 'Malformed analysis payload; skipping update', { reason: 'malformed_payload', reasonCategory: 'infra' });
       return badRequest('Malformed analysis payload');
     }
 
@@ -211,20 +213,22 @@ export default async function handler(message, context) {
           data: suggestion.data,
         }),
       });
-      ologOpp.success('audit_persistence_suggestions_synced', `Synced ${suggestions.length} suggestions`, {
+      ologOpp.success('audit_persistence_evergreen_opportunity_write', `Synced ${suggestions.length} suggestions`, {
         peer: PEER.POSTGRES, direction: 'outbound', count: suggestions.length,
       });
     } catch (error) {
-      ologOpp.failure('audit_persistence_suggestions_synced', 'Failed to sync suggestions', {
-        peer: PEER.POSTGRES, direction: 'outbound', ...errorField(error),
+      ologOpp.failure('audit_persistence_evergreen_opportunity_write', 'Failed to sync suggestions', {
+        peer: PEER.POSTGRES, direction: 'outbound', reason: 'suggestions_write_failed', reasonCategory: 'infra', ...errorField(error),
       });
       throw error;
     }
 
-    ologOpp.success('audit_persistence_completed', 'Run processed successfully', {
+    ologOpp.success('audit_persistence_end', 'Run processed successfully', {
       count: suggestions.length, companyName,
     });
     logOffsiteLlmUsage(log, HUMAN_PREFIX, siteId, opportunityData.llmUsage);
+
+    ologOpp.start('audit_housekeeping_start', 'Starting audit housekeeping', {});
 
     // Expired suggestion deletion must not fail an otherwise successful refresh.
     try {
@@ -232,7 +236,7 @@ export default async function handler(message, context) {
         dataAccess, opportunity, siteId, auditType, log,
       });
     } catch (error) {
-      ologOpp.failure('audit_housekeeping_suggestions_removed', 'OUTDATED suggestion deletion failed', {
+      ologOpp.failure('audit_housekeeping_outdated_suggestions_deleted', 'OUTDATED suggestion deletion failed', {
         peer: PEER.POSTGRES, direction: 'outbound', auditType, ...errorField(error),
       }, error);
     }
@@ -243,7 +247,7 @@ export default async function handler(message, context) {
         dataAccess, siteId, auditType, log,
       });
     } catch (error) {
-      ologOpp.failure('audit_housekeeping_opportunities_removed', 'Snapshot retention failed', {
+      ologOpp.failure('audit_housekeeping_outdated_opportunities_deleted', 'Snapshot retention failed', {
         peer: PEER.POSTGRES, direction: 'outbound', auditType, ...errorField(error),
       }, error);
     }
@@ -281,9 +285,9 @@ export default async function handler(message, context) {
     return ok();
   } catch (error) {
     // Intentional drill-down: a failure already logged by an inner event (e.g.
-    // audit_persistence_suggestions_synced) will also surface here as
-    // audit_persistence_completed outcome=failure — the terminal, per-run marker.
-    olog.failure('audit_persistence_completed', 'Error processing analysis', { ...errorField(error) }, error);
+    // audit_persistence_evergreen_opportunity_write) will also surface here as
+    // audit_persistence_end outcome=failure — the terminal, per-run marker.
+    olog.failure('audit_persistence_end', 'Error processing analysis', { ...errorField(error) }, error);
     return badRequest(`Error processing analysis: ${error.message}`);
   }
 }

--- a/src/youtube-analysis/guidance-handler.js
+++ b/src/youtube-analysis/guidance-handler.js
@@ -287,7 +287,7 @@ export default async function handler(message, context) {
     // Intentional drill-down: a failure already logged by an inner event (e.g.
     // audit_persistence_evergreen_opportunity_write) will also surface here as
     // audit_persistence_end outcome=failure — the terminal, per-run marker.
-    olog.failure('audit_persistence_end', 'Error processing analysis', { ...errorField(error) }, error);
+    olog.failure('audit_persistence_end', 'Error processing analysis', { reason: 'unexpected_error', reasonCategory: 'infra', ...errorField(error) }, error);
     return badRequest(`Error processing analysis: ${error.message}`);
   }
 }

--- a/src/youtube-analysis/handler.js
+++ b/src/youtube-analysis/handler.js
@@ -91,12 +91,12 @@ async function fetchStoreData(siteId, context, site) {
   const olog = createOffsiteLogger(log, { audit: AUDIT.YOUTUBE, siteId });
   const storeClient = StoreClient.createFrom(context);
 
-  olog.start('data_acquisition_store_urls_read', 'Fetching data from stores', {
+  olog.start('data_acquisition_url_store_read', 'Fetching data from stores', {
     peer: PEER.URL_STORE, direction: 'inbound',
   });
 
   const rawUrls = await storeClient.getUrls(siteId, URL_TYPES.YOUTUBE, { sortBy: 'createdAt', sortOrder: 'desc' });
-  olog.success('data_acquisition_store_urls_read', 'Retrieved URLs from URL Store', {
+  olog.success('data_acquisition_url_store_read', 'Retrieved URLs from URL Store', {
     peer: PEER.URL_STORE, direction: 'inbound', count: rawUrls.length,
   });
 
@@ -109,7 +109,7 @@ async function fetchStoreData(siteId, context, site) {
     drsClient,
     olog,
   );
-  olog.success('data_acquisition_scrape_job_status_polled', `${urls.length} YouTube URLs available in DRS${formatDrsExtras(counts)}`, {
+  olog.success('data_acquisition_scrape_content_checked', `${urls.length} YouTube URLs available in DRS${formatDrsExtras(counts)}`, {
     peer: PEER.DRS, direction: 'outbound', available: urls.length,
   });
 
@@ -128,7 +128,7 @@ async function fetchStoreData(siteId, context, site) {
   } catch (error) {
     if (error instanceof StoreEmptyError) {
       olog.skip('audit_orchestration_brand_guidelines_resolved', 'No guidelines configured for youtube-analysis, proceeding without', {
-        peer: PEER.URL_STORE, direction: 'inbound', reason: 'no_guidelines',
+        peer: PEER.URL_STORE, direction: 'inbound', reason: 'no_guidelines', reasonCategory: 'expected',
       });
     } else {
       throw error;
@@ -164,7 +164,7 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
   // handler to report DRS / Mystique / total durations.
   const analysisStartedAt = Date.now();
 
-  olog.start('audit_orchestration_started', 'Audit started');
+  olog.start('audit_orchestration_start', 'Audit started');
 
   const enableBrandProfile = resolveEnableBrandProfile(auditContext, log, HUMAN_PREFIX);
   const forwardedUrlLimit = resolveForwardedUrlLimit(auditContext, log, HUMAN_PREFIX);
@@ -175,7 +175,7 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
 
     if (!youtubeConfig.companyName) {
       olog.warn('audit_orchestration_brand_profile_resolved', 'No company name configured for site, skipping audit', {
-        outcome: OUTCOME.SKIP, reason: 'no_company_name',
+        outcome: OUTCOME.SKIP, reason: 'no_company_name', reasonCategory: 'config',
       });
       return {
         auditResult: {
@@ -191,13 +191,15 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
       website: youtubeConfig.companyWebsite,
     });
 
+    olog.start('data_acquisition_start', 'Starting data acquisition', {});
+
     const storeData = await fetchStoreData(siteId, context, site);
     // Whether this run's DRS scrape produced the content (poll-dispatched) or we are reusing
     // a prior scrape (direct/scheduled run) changes the log and Slack wording so the thread
     // reads as a coherent sequence rather than a contradictory "no scrape needed".
     const scrapedNow = scrapedThisCycle(auditContext);
     olog.success(
-      'data_acquisition_completed',
+      'data_acquisition_end',
       scrapedNow
         ? 'DRS scrape finished this cycle; proceeding to Mystique'
         : 'Reusing previously scraped DRS content; no new scrape needed, proceeding to Mystique',
@@ -225,6 +227,8 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
       { threadTs: slackContext?.threadTs },
     );
 
+    olog.success('audit_orchestration_end', 'Audit complete', { status: 'pending_analysis' });
+
     return {
       auditResult: {
         success: true,
@@ -247,8 +251,8 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
       // A scoped scrape already ran and the store is STILL empty → the brand has no
       // YouTube URLs to analyze. Report a terminal message instead of looping.
       if (auditContext.drsScrapeRequested) {
-        olog.failure('data_acquisition_store_urls_read', 'URL store still empty after scrape', {
-          peer: PEER.URL_STORE, direction: 'inbound', reason: 'empty_after_scrape', ...errorField(error),
+        olog.failure('data_acquisition_url_store_read', 'URL store still empty after scrape', {
+          peer: PEER.URL_STORE, direction: 'inbound', reason: 'store_empty_after_scrape', reasonCategory: 'infra', ...errorField(error),
         });
         await postMessageOptional(
           context,
@@ -264,8 +268,8 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
       // First individual run with an empty store: collect + scrape just this bucket via a
       // domain-scoped offsite-brand-presence run, which re-triggers this analysis when DRS
       // completes — no need to run offsite-brand-presence for all buckets manually.
-      olog.skip('data_acquisition_completed', 'URL store empty, requesting a scoped scrape for youtube.com', {
-        status: 'pending_scrape', peer: PEER.URL_STORE, direction: 'inbound', reason: 'empty_store',
+      olog.skip('data_acquisition_end', 'URL store empty, requesting a scoped scrape for youtube.com', {
+        status: 'pending_scrape', peer: PEER.URL_STORE, direction: 'inbound', reason: 'store_empty_first_attempt', reasonCategory: 'expected',
       });
       await postMessageOptional(
         context,
@@ -295,8 +299,8 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
       const { channelId, threadTs } = slackContext || {};
       if (auditContext.drsScrapeRequested) {
         // A scrape already ran this cycle and DRS still reports no scraped content → terminal.
-        olog.failure('data_acquisition_scrape_job_status_polled', 'No DRS content available after scraping', {
-          peer: PEER.DRS, direction: 'outbound', reason: 'no_content_after_scrape', ...errorField(error),
+        olog.failure('data_acquisition_scrape_content_checked', 'No DRS content available after scraping', {
+          peer: PEER.DRS, direction: 'outbound', reason: 'content_not_scraped_after_retry', reasonCategory: 'infra', ...errorField(error),
         });
         await postMessageOptional(
           context,
@@ -309,8 +313,8 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
           fullAuditRef: url,
         };
       }
-      olog.skip('data_acquisition_completed', 'URLs stored but not scraped in DRS yet, requesting a scrape for youtube.com', {
-        status: 'pending_scrape', peer: PEER.DRS, direction: 'outbound', reason: 'no_drs_content',
+      olog.skip('data_acquisition_end', 'URLs stored but not scraped in DRS yet, requesting a scrape for youtube.com', {
+        status: 'pending_scrape', peer: PEER.DRS, direction: 'outbound', reason: 'content_not_scraped_first_attempt', reasonCategory: 'expected',
       });
       await postMessageOptional(
         context,
@@ -335,7 +339,7 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
       };
     }
 
-    olog.failure('audit_orchestration_started', 'Audit failed', { ...errorField(error) });
+    olog.failure('audit_orchestration_end', 'Audit failed', { ...errorField(error) });
     return {
       auditResult: {
         success: false,
@@ -361,15 +365,15 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
   const olog = createOffsiteLogger(log, { audit: AUDIT.YOUTUBE, siteId, auditId: audit?.getId() });
 
   if (!auditResult.success) {
-    olog.skip('audit_analysis_mystique_request_handoff', 'Audit failed, skipping Mystique message', {
-      peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'audit_failed',
+    olog.skip('audit_analysis_start', 'Audit failed, skipping Mystique message', {
+      peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'audit_failed', reasonCategory: 'expected',
     });
     return auditData;
   }
 
   if (!sqs || !env?.QUEUE_SPACECAT_TO_MYSTIQUE) {
-    olog.warn('audit_analysis_mystique_request_handoff', 'SQS or Mystique queue not configured, skipping message', {
-      outcome: OUTCOME.SKIP, peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'not_configured',
+    olog.warn('audit_analysis_start', 'SQS or Mystique queue not configured, skipping message', {
+      outcome: OUTCOME.SKIP, peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'mystique_not_configured', reasonCategory: 'infra',
     });
     return auditData;
   }
@@ -378,15 +382,15 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     const { Site } = dataAccess;
     const site = await Site.findById(siteId);
     if (!site) {
-      olog.warn('audit_analysis_mystique_request_handoff', 'Site not found, skipping Mystique message', {
-        outcome: OUTCOME.SKIP, peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'site_not_found',
+      olog.warn('audit_analysis_start', 'Site not found, skipping Mystique message', {
+        outcome: OUTCOME.SKIP, peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'site_not_found_at_dispatch', reasonCategory: 'infra',
       });
       return auditData;
     }
 
     const { config, storeData } = auditResult;
     const urlLimit = config?.urlLimit ?? MYSTIQUE_URLS_LIMIT;
-    olog.success('audit_analysis_url_limit_resolved', 'URL limit resolved', { urlLimit });
+    olog.success('audit_orchestration_analysis_url_limit_resolved', 'URL limit resolved', { urlLimit });
 
     const { urls, sentimentConfig } = storeData;
     const enrichedUrls = enrichUrlsWithTopicData(urls, sentimentConfig.topics)
@@ -416,30 +420,28 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     try {
       brand = await resolveBrandForSite(context, site);
     } catch (brandError) {
-      olog.warn('audit_analysis_scope_resolved', 'Brand resolution failed unexpectedly; proceeding without scope', {
-        peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'brand_resolution', ...errorField(brandError),
+      olog.warn('audit_orchestration_brand_scope_resolved', 'Brand resolution failed unexpectedly; proceeding without scope', {
+        peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'brand_resolution', reasonCategory: 'infra', ...errorField(brandError),
       });
     }
     const message = applyBrandScope(baseMessage, brand);
 
-    olog.debug('audit_analysis_mystique_request_built', `Built Mystique message type ${message.type}`, {
-      peer: PEER.MYSTIQUE, direction: 'outbound',
-    });
     await sqs.sendMessage(env.QUEUE_SPACECAT_TO_MYSTIQUE, message);
     olog.success(
-      'audit_analysis_mystique_request_handoff',
+      'audit_analysis_start',
       'Queued analysis request to Mystique',
       {
         peer: PEER.MYSTIQUE,
         direction: 'outbound',
         companyName: config.companyName,
         urls: enrichedUrls.length,
+        messageType: message.type,
         ...(brand && { brandId: brand.brandId }),
       },
     );
     return auditData;
   } catch (error) {
-    olog.failure('audit_analysis_mystique_request_handoff', 'Failed to send Mystique message', {
+    olog.failure('audit_analysis_start', 'Failed to send Mystique message', {
       peer: PEER.MYSTIQUE, direction: 'outbound', ...errorField(error),
     });
     throw error;

--- a/src/youtube-analysis/handler.js
+++ b/src/youtube-analysis/handler.js
@@ -339,7 +339,7 @@ async function runYouTubeAnalysisAudit(url, context, site, auditContext = {}) {
       };
     }
 
-    olog.failure('audit_orchestration_end', 'Audit failed', { ...errorField(error) });
+    olog.failure('audit_orchestration_end', 'Audit failed', { reason: 'unexpected_error', reasonCategory: 'infra', ...errorField(error) });
     return {
       auditResult: {
         success: false,

--- a/src/youtube-analysis/handler.js
+++ b/src/youtube-analysis/handler.js
@@ -442,7 +442,7 @@ async function sendMystiqueMessagePostProcessor(auditUrl, auditData, context) {
     return auditData;
   } catch (error) {
     olog.failure('audit_analysis_start', 'Failed to send Mystique message', {
-      peer: PEER.MYSTIQUE, direction: 'outbound', ...errorField(error),
+      peer: PEER.MYSTIQUE, direction: 'outbound', reason: 'unexpected_error', reasonCategory: 'infra', ...errorField(error),
     });
     throw error;
   }

--- a/test/audits/cited-analysis/guidance-handler.test.js
+++ b/test/audits/cited-analysis/guidance-handler.test.js
@@ -966,6 +966,8 @@ describe('Cited Analysis Guidance Handler', () => {
         sinon.match(/Error processing analysis/)
           .and(sinon.match(/event=audit_persistence_end/))
           .and(sinon.match(/outcome=failure/))
+          .and(sinon.match(/reason=unexpected_error/))
+          .and(sinon.match(/reasonCategory=infra/))
           .and(sinon.match(/errorName=Error/)),
       );
       const outerCatchCall = context.log.error.getCalls().find(

--- a/test/audits/cited-analysis/guidance-handler.test.js
+++ b/test/audits/cited-analysis/guidance-handler.test.js
@@ -233,7 +233,7 @@ describe('Cited Analysis Guidance Handler', () => {
       expect(mockOpportunity.save).to.have.been.calledBefore(syncSuggestionsStub);
       expect(context.log.info).to.have.been.calledWith(
         sinon.match(/Run processed successfully/)
-          .and(sinon.match(/event=audit_persistence_completed/))
+          .and(sinon.match(/event=audit_persistence_end/))
           .and(sinon.match(/outcome=success/)),
       );
     });
@@ -399,7 +399,7 @@ describe('Cited Analysis Guidance Handler', () => {
       expect(result.status).to.equal(204);
       expect(convertToOpportunityStub).to.not.have.been.called;
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/No suggestions found in analysis/).and(sinon.match(/event=audit_persistence_completed/)).and(sinon.match(/outcome=skip/)),
+        sinon.match(/No suggestions found in analysis/).and(sinon.match(/event=audit_persistence_end/)).and(sinon.match(/outcome=skip/)),
       );
     });
 
@@ -438,7 +438,7 @@ describe('Cited Analysis Guidance Handler', () => {
       expect(context.log.error).to.have.been.calledWith(
         sinon.match(/Mystique returned an error/)
           .and(sinon.match(/mystiqueError="HTTP error.*400 Bad Request"/))
-          .and(sinon.match(/event=audit_analysis_completed/))
+          .and(sinon.match(/event=audit_analysis_end/))
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/peer=mystique/)),
       );
@@ -456,7 +456,7 @@ describe('Cited Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(400);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/No analysis data provided in message/).and(sinon.match(/event=audit_persistence_completed/)),
+        sinon.match(/No analysis data provided in message/).and(sinon.match(/event=audit_persistence_end/)),
       );
     });
 
@@ -522,7 +522,7 @@ describe('Cited Analysis Guidance Handler', () => {
       expect(convertToOpportunityStub).to.have.been.calledOnce;
       // P4-4: successful S3 fetch is now logged (peer=s3, inbound).
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=audit_persistence_payload_fetched/).and(sinon.match(/outcome=success/)).and(sinon.match(/peer=s3/)),
+        sinon.match(/event=audit_persistence_mystique_payload_read/).and(sinon.match(/outcome=success/)).and(sinon.match(/peer=s3/)),
       );
 
       const propsArg = convertToOpportunityStub.firstCall.args[5];
@@ -567,7 +567,7 @@ describe('Cited Analysis Guidance Handler', () => {
       // An SSRF/URL-shape rejection is classified reason=validation.
       expect(context.log.error).to.have.been.calledWith(
         sinon.match(/hostname is not an allowlisted/)
-          .and(sinon.match(/event=audit_persistence_payload_fetched/))
+          .and(sinon.match(/event=audit_persistence_mystique_payload_read/))
           .and(sinon.match(/reason=validation/)),
       );
     });
@@ -590,7 +590,7 @@ describe('Cited Analysis Guidance Handler', () => {
       // A transport error is classified reason=fetch.
       expect(context.log.error).to.have.been.calledWith(
         sinon.match(/Error fetching from presigned URL/)
-          .and(sinon.match(/event=audit_persistence_payload_fetched/))
+          .and(sinon.match(/event=audit_persistence_mystique_payload_read/))
           .and(sinon.match(/reason=fetch/)),
       );
     });
@@ -959,17 +959,17 @@ describe('Cited Analysis Guidance Handler', () => {
       const result = await handler.default(message, context);
 
       expect(result.status).to.equal(400);
-      // The outer catch folds the error into a structured audit_persistence_completed failure line
+      // The outer catch folds the error into a structured audit_persistence_end failure line
       // (errorName/errorMessage tokens) and passes the raw error as a genuine second arg
       // purely for stack capture (Fix B).
       expect(context.log.error).to.have.been.calledWith(
         sinon.match(/Error processing analysis/)
-          .and(sinon.match(/event=audit_persistence_completed/))
+          .and(sinon.match(/event=audit_persistence_end/))
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/errorName=Error/)),
       );
       const outerCatchCall = context.log.error.getCalls().find(
-        (c) => /event=audit_persistence_completed/.test(String(c.args[0])),
+        (c) => /event=audit_persistence_end/.test(String(c.args[0])),
       );
       expect(outerCatchCall.args).to.have.lengthOf(2);
       expect(outerCatchCall.args[1]).to.be.an('error');
@@ -996,14 +996,14 @@ describe('Cited Analysis Guidance Handler', () => {
       // Behavior is unchanged: the outer catch still acks with badRequest.
       expect(result.status).to.equal(400);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/event=audit_persistence_suggestions_synced/)
+        sinon.match(/event=audit_persistence_evergreen_opportunity_write/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/peer=postgres/))
           .and(sinon.match(/errorName=Error/)),
       );
-      // ...and the outer catch converts it into a terminal audit_persistence_completed failure.
+      // ...and the outer catch converts it into a terminal audit_persistence_end failure.
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/Error processing analysis/).and(sinon.match(/event=audit_persistence_completed/)),
+        sinon.match(/Error processing analysis/).and(sinon.match(/event=audit_persistence_end/)),
       );
     });
 
@@ -1024,7 +1024,7 @@ describe('Cited Analysis Guidance Handler', () => {
       await handler.default(message, context);
 
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=audit_persistence_suggestions_synced/)
+        sinon.match(/event=audit_persistence_evergreen_opportunity_write/)
           .and(sinon.match(/outcome=success/))
           .and(sinon.match(/peer=postgres/))
           .and(sinon.match(/opportunityId=opp-123/)),
@@ -1078,7 +1078,7 @@ describe('Cited Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(400);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/No analysis data provided in message/).and(sinon.match(/event=audit_persistence_completed/)),
+        sinon.match(/No analysis data provided in message/).and(sinon.match(/event=audit_persistence_end/)),
       );
     });
 
@@ -1149,7 +1149,7 @@ describe('Cited Analysis Guidance Handler', () => {
 
       expect(context.log.info).to.have.been.calledWith(
         sinon.match(/Guidance received/)
-          .and(sinon.match(/event=audit_analysis_completed/))
+          .and(sinon.match(/event=audit_analysis_end/))
           .and(sinon.match(/outcome=start/)),
       );
     });
@@ -1790,7 +1790,7 @@ describe('Cited Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(200);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/event=audit_housekeeping_opportunities_removed/)
+        sinon.match(/event=audit_housekeeping_outdated_opportunities_deleted/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/errorMessage="retention blew up"/)),
       );
@@ -1879,7 +1879,7 @@ describe('Cited Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(200);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/event=audit_housekeeping_suggestions_removed/)
+        sinon.match(/event=audit_housekeeping_outdated_suggestions_deleted/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/errorMessage="retention blew up"/)),
       );

--- a/test/audits/cited-analysis/handler.test.js
+++ b/test/audits/cited-analysis/handler.test.js
@@ -798,7 +798,7 @@ describe('Cited Analysis Handler', function () {
         sinon.match(`urlLimit=${MYSTIQUE_URLS_LIMIT}`),
       );
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=audit_analysis_mystique_request_handoff/)
+        sinon.match(/event=audit_analysis_start/)
           .and(sinon.match('companyName="Example Corp"'))
           .and(sinon.match('urls=2')),
       );
@@ -895,7 +895,7 @@ describe('Cited Analysis Handler', function () {
       const sentMessage = context.sqs.sendMessage.firstCall.args[1];
       expect(sentMessage.data.urls).to.have.lengthOf(MYSTIQUE_URLS_LIMIT);
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=audit_analysis_mystique_request_handoff/)
+        sinon.match(/event=audit_analysis_start/)
           .and(sinon.match('companyName=Test'))
           .and(sinon.match(`urls=${MYSTIQUE_URLS_LIMIT}`)),
       );
@@ -1268,7 +1268,7 @@ describe('Cited Analysis Handler', function () {
       expect(sentMessage.siteId).to.equal(siteId);
       // brandId is now a structured field on the mystique_dispatch success line.
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=audit_analysis_mystique_request_handoff/).and(sinon.match(/brandId=brand-4/)),
+        sinon.match(/event=audit_analysis_start/).and(sinon.match(/brandId=brand-4/)),
       );
     });
 

--- a/test/audits/cited-analysis/handler.test.js
+++ b/test/audits/cited-analysis/handler.test.js
@@ -1037,6 +1037,7 @@ describe('Cited Analysis Handler', function () {
       expect(sentMessage.data.urls.length).to.be.lessThan(MYSTIQUE_URLS_LIMIT);
       expect(Buffer.byteLength(JSON.stringify(sentMessage), 'utf8')).to.be.at.most(200 * 1024);
       expect(context.log.warn).to.have.been.calledWithMatch(/Message size \d+ bytes exceeds budget/);
+      expect(context.log.warn).to.have.been.calledWithMatch(/outcome=success/);
     });
 
     it('should strip prompts from single URL when payload still exceeds budget', async () => {
@@ -1074,6 +1075,7 @@ describe('Cited Analysis Handler', function () {
       expect(sentMessage.data.urls[0].timesCited).to.equal(7);
       expect(Buffer.byteLength(JSON.stringify(sentMessage), 'utf8')).to.be.at.most(200 * 1024);
       expect(context.log.warn).to.have.been.calledWithMatch(/Single-URL payload.*still exceeds budget; stripping prompts/);
+      expect(context.log.warn).to.have.been.calledWithMatch(/outcome=success/);
     });
 
     it('should skip sending message when audit failed', async () => {
@@ -1165,7 +1167,10 @@ describe('Cited Analysis Handler', function () {
       const postProcessor = citedAnalysisHandler.default.postProcessors[0];
       await expect(postProcessor(baseURL, auditData, context)).to.be.rejectedWith('SQS Error');
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/Failed to send Mystique message/).and(sinon.match(/errorMessage="SQS Error"/)),
+        sinon.match(/Failed to send Mystique message/)
+          .and(sinon.match(/reason=unexpected_error/))
+          .and(sinon.match(/reasonCategory=infra/))
+          .and(sinon.match(/errorMessage="SQS Error"/)),
       );
     });
 

--- a/test/audits/offsite-brand-presence-drs-status.test.js
+++ b/test/audits/offsite-brand-presence-drs-status.test.js
@@ -201,7 +201,8 @@ describe('offsite-brand-presence DRS status handler', function () {
     expect(thrown.message).to.equal('SQS reschedule down');
     expect(log.error).to.have.been.calledWith(
       sinon.match(/Failed to re-enqueue DRS status poll/)
-        .and(sinon.match(/event=data_acquisition_scrape_job_poll_rescheduled/))
+        .and(sinon.match(/event=data_acquisition_scrape_job_poll_request_dispatched/))
+        .and(sinon.match(/firstSchedule=false/))
         .and(sinon.match(/outcome=failure/)),
     );
   });
@@ -235,7 +236,7 @@ describe('offsite-brand-presence DRS status handler', function () {
     // P1-6: the youtube bucket (still running at the deadline) is dropped with a
     // structured, alertable failure instead of only appearing in the Slack prose.
     expect(log.error).to.have.been.calledWith(
-      sinon.match(/event=data_acquisition_scrape_job_status_polled/)
+      sinon.match(/event=data_acquisition_scrape_job_poll_checked/)
         .and(sinon.match(/outcome=failure/))
         .and(sinon.match(/reason=budget_exceeded/))
         .and(sinon.match(/auditType=youtube-analysis/)),
@@ -485,7 +486,7 @@ describe('offsite-brand-presence DRS status handler', function () {
       // P1-6: both buckets failed their scrape (all terminal, no success) → dropped with
       // reason=scrape_failed rather than budget_exceeded.
       expect(log.error).to.have.been.calledWith(
-        sinon.match(/event=data_acquisition_scrape_job_status_polled/)
+        sinon.match(/event=data_acquisition_scrape_job_poll_checked/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/reason=scrape_failed/))
           .and(sinon.match(/auditType=reddit-analysis/)),

--- a/test/audits/offsite-brand-presence-drs-status.test.js
+++ b/test/audits/offsite-brand-presence-drs-status.test.js
@@ -494,6 +494,14 @@ describe('offsite-brand-presence DRS status handler', function () {
       expect(log.error).to.have.been.calledWith(
         sinon.match(/reason=scrape_failed/).and(sinon.match(/auditType=youtube-analysis/)),
       );
+      // The aggregate summary line uses a neutral reason regardless of the per-drop
+      // reasons above, since drops in the same run can be a mix of scrape_failed and
+      // budget_exceeded.
+      expect(log.info).to.have.been.calledWith(
+        sinon.match(/event=data_acquisition_scrape_job_poll_end/)
+          .and(sinon.match(/reason=partial_drop/))
+          .and(sinon.match(/reasonCategory=infra/)),
+      );
     });
 
     it('skips domains that do not map to an analysis audit', async () => {

--- a/test/audits/offsite-brand-presence.test.js
+++ b/test/audits/offsite-brand-presence.test.js
@@ -326,7 +326,7 @@ describe('Offsite Brand Presence Handler', function () {
 
       expect(result.auditResult.success).to.be.false;
       expect(result.auditResult.dataSource).to.equal('semrush');
-      expect(result.auditResult.fallbackReason).to.equal('semrush-failed');
+      expect(result.auditResult.fallbackReason).to.equal('semrush_failed');
       expect(result.auditResult.error).to.match(/hard stop/);
       expect(mockLoadCitedUrlsFromSemrush).to.have.been.calledOnce;
       expect(mockLoadBrandPresenceData).to.not.have.been.called; // no legacy fallback
@@ -335,7 +335,7 @@ describe('Offsite Brand Presence Handler', function () {
           .and(sinon.match(/event=data_acquisition_bp_data_semrush_read/))
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/peer=semrush/))
-          .and(sinon.match(/reason=semrush-failed/)),
+          .and(sinon.match(/reason=semrush_failed/)),
       );
     });
 
@@ -348,7 +348,7 @@ describe('Offsite Brand Presence Handler', function () {
 
       expect(result.auditResult.success).to.be.true;
       expect(result.auditResult.dataSource).to.equal('legacy');
-      expect(result.auditResult.fallbackReason).to.equal('semrush-failed');
+      expect(result.auditResult.fallbackReason).to.equal('semrush_failed');
       expect(mockLoadBrandPresenceData).to.have.been.calledOnce;
       expect(result.auditResult.urlCounts['youtube.com']).to.equal(1);
       expect(log.warn).to.have.been.calledWith(
@@ -356,7 +356,7 @@ describe('Offsite Brand Presence Handler', function () {
           .and(sinon.match(/event=data_acquisition_bp_data_semrush_read/))
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/peer=semrush/))
-          .and(sinon.match(/reason=semrush-failed/)),
+          .and(sinon.match(/reason=semrush_failed/)),
       );
     });
 
@@ -435,7 +435,7 @@ describe('Offsite Brand Presence Handler', function () {
 
       expect(result.auditResult.success).to.be.true;
       expect(result.auditResult.dataSource).to.equal('legacy');
-      expect(result.auditResult.fallbackReason).to.equal('semrush-failed');
+      expect(result.auditResult.fallbackReason).to.equal('semrush_failed');
       expect(result.auditResult.urlCounts['youtube.com']).to.equal(0);
     });
 
@@ -462,7 +462,7 @@ describe('Offsite Brand Presence Handler', function () {
     it('surfaces the loader diagnostics fallbackReason code on hard stop', async () => {
       mockLoadCitedUrlsFromSemrush.callsFake(async ({ diagnostics }) => {
         if (diagnostics) {
-          diagnostics.fallbackReason = 'ims-token-failed';
+          diagnostics.fallbackReason = 'ims_token_failed';
         }
         return null;
       });
@@ -473,7 +473,7 @@ describe('Offsite Brand Presence Handler', function () {
 
       expect(result.auditResult.success).to.be.false;
       expect(result.auditResult.dataSource).to.equal('semrush');
-      expect(result.auditResult.fallbackReason).to.equal('ims-token-failed');
+      expect(result.auditResult.fallbackReason).to.equal('ims_token_failed');
       expect(mockLoadBrandPresenceData).to.not.have.been.called;
     });
 
@@ -500,7 +500,7 @@ describe('Offsite Brand Presence Handler', function () {
       expect(log.error).to.not.have.been.called;
       // A deliberate entitlement skip must log at info, never warn — a regression
       // that swaps these branches (or always warns) must fail this test.
-      expect(log.info).to.have.been.calledWithMatch(/Semrush skipped \(not-entitled\); falling back to PostgREST\/SharePoint/);
+      expect(log.info).to.have.been.calledWithMatch(/Semrush skipped \(not_entitled\); falling back to PostgREST\/SharePoint/);
       expect(log.warn).to.not.have.been.calledWithMatch(/Semrush source failed/);
     });
 
@@ -524,20 +524,20 @@ describe('Offsite Brand Presence Handler', function () {
       expect(result.auditResult.entitlementReason).to.equal(SEMRUSH_ENTITLEMENT_REASONS.NO_CLIENT);
       expect(mockLoadBrandPresenceData).to.have.been.calledOnce;
       expect(log.error).to.not.have.been.called;
-      expect(log.info).to.have.been.calledWithMatch(/Semrush skipped \(entitlement-check-failed\); falling back to PostgREST\/SharePoint/);
+      expect(log.info).to.have.been.calledWithMatch(/Semrush skipped \(entitlement_check_failed\); falling back to PostgREST\/SharePoint/);
       expect(log.warn).to.not.have.been.calledWithMatch(/Semrush source failed/);
     });
 
     it('does not surface entitlementReason on a non-entitlement Semrush failure', async () => {
       context.env.OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED = 'true';
-      mockLoadCitedUrlsFromSemrush.resolves(null); // fallbackReason defaults to 'semrush-failed'
+      mockLoadCitedUrlsFromSemrush.resolves(null); // fallbackReason defaults to 'semrush_failed'
       stubBrandPresenceData(['https://www.youtube.com/watch?v=legacy']);
 
       const result = await offsiteBrandPresenceRunner(FINAL_URL, context, site);
 
-      expect(result.auditResult.fallbackReason).to.equal('semrush-failed');
+      expect(result.auditResult.fallbackReason).to.equal('semrush_failed');
       expect(result.auditResult).to.not.have.property('entitlementReason');
-      expect(log.warn).to.have.been.calledWithMatch(/Semrush source failed \(semrush-failed\); falling back to PostgREST\/SharePoint/);
+      expect(log.warn).to.have.been.calledWithMatch(/Semrush source failed \(semrush_failed\); falling back to PostgREST\/SharePoint/);
     });
   });
 
@@ -1656,9 +1656,9 @@ describe('Offsite Brand Presence Handler', function () {
       // level (outcome=failure) rather than a warn/skip — see Fix C.
       expect(log.error).to.have.been.calledWith(
         sinon.match(/DRS_API_URL or DRS_API_KEY not configured/)
-          .and(sinon.match(/event=data_acquisition_scrape_job_submitted/))
+          .and(sinon.match(/event=data_acquisition_scrape_job_request_dispatched/))
           .and(sinon.match(/outcome=failure/))
-          .and(sinon.match(/reason=not_configured/)),
+          .and(sinon.match(/reason=drs_not_configured/)),
       );
     });
 
@@ -1945,9 +1945,10 @@ describe('Offsite Brand Presence Handler', function () {
       expect(context.sqs.sendMessage).to.not.have.been.called;
       // P1-4: the previously-silent empty-jobs early return now logs a structured skip.
       expect(log.info).to.have.been.calledWith(
-        sinon.match(/event=data_acquisition_scrape_job_poll_scheduled/)
+        sinon.match(/event=data_acquisition_scrape_job_poll_request_dispatched/)
           .and(sinon.match(/outcome=skip/))
-          .and(sinon.match(/reason=no_jobs/)),
+          .and(sinon.match(/reason=no_jobs/))
+          .and(sinon.match(/firstSchedule=true/)),
       );
     });
 
@@ -1964,8 +1965,9 @@ describe('Offsite Brand Presence Handler', function () {
       // transient SQS hiccup here must not page.
       expect(log.warn).to.have.been.calledWith(
         sinon.match(/Failed to schedule DRS status poll/)
-          .and(sinon.match(/event=data_acquisition_scrape_job_poll_scheduled/))
-          .and(sinon.match(/outcome=failure/)),
+          .and(sinon.match(/event=data_acquisition_scrape_job_poll_request_dispatched/))
+          .and(sinon.match(/outcome=failure/))
+          .and(sinon.match(/firstSchedule=true/)),
       );
     });
 

--- a/test/audits/reddit-analysis/guidance-handler.test.js
+++ b/test/audits/reddit-analysis/guidance-handler.test.js
@@ -832,6 +832,8 @@ describe('Reddit Analysis Guidance Handler', () => {
         sinon.match(/Error processing analysis/)
           .and(sinon.match(/event=audit_persistence_end/))
           .and(sinon.match(/outcome=failure/))
+          .and(sinon.match(/reason=unexpected_error/))
+          .and(sinon.match(/reasonCategory=infra/))
           .and(sinon.match(/errorName=Error/)),
       );
       const outerCatchCall = context.log.error.getCalls().find(

--- a/test/audits/reddit-analysis/guidance-handler.test.js
+++ b/test/audits/reddit-analysis/guidance-handler.test.js
@@ -316,7 +316,7 @@ describe('Reddit Analysis Guidance Handler', () => {
       expect(result.status).to.equal(204);
       expect(convertToOpportunityStub).to.not.have.been.called;
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/No suggestions found in analysis/).and(sinon.match(/event=audit_persistence_completed/)).and(sinon.match(/outcome=skip/)),
+        sinon.match(/No suggestions found in analysis/).and(sinon.match(/event=audit_persistence_end/)).and(sinon.match(/outcome=skip/)),
       );
     });
 
@@ -370,7 +370,7 @@ describe('Reddit Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(400);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/No analysis data provided in message/).and(sinon.match(/event=audit_persistence_completed/)),
+        sinon.match(/No analysis data provided in message/).and(sinon.match(/event=audit_persistence_end/)),
       );
     });
 
@@ -825,17 +825,17 @@ describe('Reddit Analysis Guidance Handler', () => {
       const result = await handler.default(message, context);
 
       expect(result.status).to.equal(400);
-      // The outer catch folds the error into a structured audit_persistence_completed failure line
+      // The outer catch folds the error into a structured audit_persistence_end failure line
       // (errorName/errorMessage tokens) and passes the raw error as a genuine second arg
       // purely for stack capture (Fix B).
       expect(context.log.error).to.have.been.calledWith(
         sinon.match(/Error processing analysis/)
-          .and(sinon.match(/event=audit_persistence_completed/))
+          .and(sinon.match(/event=audit_persistence_end/))
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/errorName=Error/)),
       );
       const outerCatchCall = context.log.error.getCalls().find(
-        (c) => /event=audit_persistence_completed/.test(String(c.args[0])),
+        (c) => /event=audit_persistence_end/.test(String(c.args[0])),
       );
       expect(outerCatchCall.args).to.have.lengthOf(2);
       expect(outerCatchCall.args[1]).to.be.an('error');
@@ -861,7 +861,7 @@ describe('Reddit Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(400);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/event=audit_persistence_suggestions_synced/)
+        sinon.match(/event=audit_persistence_evergreen_opportunity_write/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/peer=postgres/))
           .and(sinon.match(/errorName=Error/)),
@@ -885,7 +885,7 @@ describe('Reddit Analysis Guidance Handler', () => {
       await handler.default(message, context);
 
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=audit_persistence_suggestions_synced/)
+        sinon.match(/event=audit_persistence_evergreen_opportunity_write/)
           .and(sinon.match(/outcome=success/))
           .and(sinon.match(/peer=postgres/))
           .and(sinon.match(/opportunityId=opp-123/)),
@@ -918,7 +918,7 @@ describe('Reddit Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(400);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/No analysis data provided in message/).and(sinon.match(/event=audit_persistence_completed/)),
+        sinon.match(/No analysis data provided in message/).and(sinon.match(/event=audit_persistence_end/)),
       );
     });
 
@@ -1598,7 +1598,7 @@ describe('Reddit Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(200);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/event=audit_housekeeping_opportunities_removed/)
+        sinon.match(/event=audit_housekeeping_outdated_opportunities_deleted/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/errorMessage="retention blew up"/)),
       );
@@ -1687,7 +1687,7 @@ describe('Reddit Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(200);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/event=audit_housekeeping_suggestions_removed/)
+        sinon.match(/event=audit_housekeeping_outdated_suggestions_deleted/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/errorMessage="retention blew up"/)),
       );

--- a/test/audits/reddit-analysis/handler.test.js
+++ b/test/audits/reddit-analysis/handler.test.js
@@ -848,7 +848,10 @@ describe('Reddit Analysis Handler', function () {
       const postProcessor = redditAnalysisHandler.default.postProcessors[0];
       await expect(postProcessor(baseURL, auditData, context)).to.be.rejectedWith('SQS Error');
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/Failed to send Mystique message/).and(sinon.match(/errorMessage="SQS Error"/)),
+        sinon.match(/Failed to send Mystique message/)
+          .and(sinon.match(/reason=unexpected_error/))
+          .and(sinon.match(/reasonCategory=infra/))
+          .and(sinon.match(/errorMessage="SQS Error"/)),
       );
     });
 

--- a/test/audits/reddit-analysis/handler.test.js
+++ b/test/audits/reddit-analysis/handler.test.js
@@ -617,7 +617,7 @@ describe('Reddit Analysis Handler', function () {
         sinon.match(`urlLimit=${MYSTIQUE_URLS_LIMIT}`),
       );
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=audit_analysis_mystique_request_handoff/)
+        sinon.match(/event=audit_analysis_start/)
           .and(sinon.match('companyName="Example Corp"'))
           .and(sinon.match('urls=2')),
       );
@@ -667,7 +667,7 @@ describe('Reddit Analysis Handler', function () {
       const sentMessage = context.sqs.sendMessage.firstCall.args[1];
       expect(sentMessage.data.urls).to.have.lengthOf(1);
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=audit_analysis_mystique_request_handoff/)
+        sinon.match(/event=audit_analysis_start/)
           .and(sinon.match('companyName=Test'))
           .and(sinon.match('urls=1')),
       );
@@ -696,7 +696,7 @@ describe('Reddit Analysis Handler', function () {
       const sentMessage = context.sqs.sendMessage.firstCall.args[1];
       expect(sentMessage.data.urls).to.have.lengthOf(MYSTIQUE_URLS_LIMIT);
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=audit_analysis_mystique_request_handoff/)
+        sinon.match(/event=audit_analysis_start/)
           .and(sinon.match('companyName=Test'))
           .and(sinon.match(`urls=${MYSTIQUE_URLS_LIMIT}`)),
       );
@@ -726,7 +726,7 @@ describe('Reddit Analysis Handler', function () {
       const sentMessage = context.sqs.sendMessage.firstCall.args[1];
       expect(sentMessage.data.urls).to.have.lengthOf(4);
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=audit_analysis_mystique_request_handoff/)
+        sinon.match(/event=audit_analysis_start/)
           .and(sinon.match('companyName=Test'))
           .and(sinon.match('urls=4')),
       );
@@ -890,7 +890,7 @@ describe('Reddit Analysis Handler', function () {
       expect(sentMessage.siteId).to.equal(siteId);
       // brandId is now a structured field on the mystique_dispatch success line.
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=audit_analysis_mystique_request_handoff/).and(sinon.match(/brandId=brand-3/)),
+        sinon.match(/event=audit_analysis_start/).and(sinon.match(/brandId=brand-3/)),
       );
     });
 

--- a/test/audits/wikipedia-analysis/guidance-handler.test.js
+++ b/test/audits/wikipedia-analysis/guidance-handler.test.js
@@ -466,6 +466,8 @@ describe('Wikipedia Analysis Guidance Handler', function () {
         sinon.match(/Error processing analysis/)
           .and(sinon.match(/event=audit_persistence_end/))
           .and(sinon.match(/outcome=failure/))
+          .and(sinon.match(/reason=unexpected_error/))
+          .and(sinon.match(/reasonCategory=infra/))
           .and(sinon.match(/errorName=Error/)),
       );
       const outerCatchCall = context.log.error.getCalls().find(

--- a/test/audits/wikipedia-analysis/guidance-handler.test.js
+++ b/test/audits/wikipedia-analysis/guidance-handler.test.js
@@ -459,17 +459,17 @@ describe('Wikipedia Analysis Guidance Handler', function () {
       const result = await handler.default(message, context);
 
       expect(result.status).to.equal(400);
-      // The outer catch folds the error into a structured audit_persistence_completed failure line
+      // The outer catch folds the error into a structured audit_persistence_end failure line
       // (errorName/errorMessage tokens) and passes the raw error as a genuine second arg
       // purely for stack capture.
       expect(context.log.error).to.have.been.calledWith(
         sinon.match(/Error processing analysis/)
-          .and(sinon.match(/event=audit_persistence_completed/))
+          .and(sinon.match(/event=audit_persistence_end/))
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/errorName=Error/)),
       );
       const outerCatchCall = context.log.error.getCalls().find(
-        (c) => /event=audit_persistence_completed/.test(String(c.args[0])),
+        (c) => /event=audit_persistence_end/.test(String(c.args[0])),
       );
       expect(outerCatchCall.args).to.have.lengthOf(2);
       expect(outerCatchCall.args[1]).to.be.an('error');
@@ -496,7 +496,7 @@ describe('Wikipedia Analysis Guidance Handler', function () {
       // Inner catch logs the failed sync event, then rethrows into the outer catch (badRequest).
       expect(result.status).to.equal(400);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/event=audit_persistence_suggestions_synced outcome=failure/),
+        sinon.match(/event=audit_persistence_evergreen_opportunity_write outcome=failure/),
       );
     });
 
@@ -777,7 +777,7 @@ describe('Wikipedia Analysis Guidance Handler', function () {
       expect(context.log.error).to.have.been.calledWith(
         sinon.match(/Mystique returned an error/)
           .and(sinon.match(/mystiqueError="Wikipedia analysis failed"/))
-          .and(sinon.match(/event=audit_analysis_completed/))
+          .and(sinon.match(/event=audit_analysis_end/))
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/peer=mystique/)),
       );

--- a/test/audits/wikipedia-analysis/handler.test.js
+++ b/test/audits/wikipedia-analysis/handler.test.js
@@ -593,7 +593,8 @@ describe('Wikipedia Analysis Handler', () => {
       expect(context.log.error).to.have.been.calledWith(
         sinon.match('Failed to send Mystique message')
           .and(sinon.match(/reason=unexpected_error/))
-          .and(sinon.match(/reasonCategory=infra/)),
+          .and(sinon.match(/reasonCategory=infra/))
+          .and(sinon.match(/errorMessage="SQS Error"/)),
       );
     });
 

--- a/test/audits/wikipedia-analysis/handler.test.js
+++ b/test/audits/wikipedia-analysis/handler.test.js
@@ -475,7 +475,7 @@ describe('Wikipedia Analysis Handler', () => {
         }),
       );
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=audit_analysis_mystique_request_handoff/)
+        sinon.match(/event=audit_analysis_start/)
           .and(sinon.match('companyName="Example Corp"'))
           .and(sinon.match('wikipediaUrl=https://en.wikipedia.org/wiki/Example_Corp')),
       );
@@ -501,7 +501,7 @@ describe('Wikipedia Analysis Handler', () => {
       await postProcessor(baseURL, auditData, context);
 
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=audit_analysis_mystique_request_handoff/)
+        sinon.match(/event=audit_analysis_start/)
           .and(sinon.match('wikipediaUrl="(empty → auto-detect)"')),
       );
     });
@@ -634,7 +634,7 @@ describe('Wikipedia Analysis Handler', () => {
       expect(sentMessage.brandId).to.equal('brand-1');
       expect(sentMessage.siteId).to.equal(siteId);
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/brandId=brand-1/).and(sinon.match(/event=audit_analysis_mystique_request_handoff/)),
+        sinon.match(/brandId=brand-1/).and(sinon.match(/event=audit_analysis_start/)),
       );
     });
 

--- a/test/audits/wikipedia-analysis/handler.test.js
+++ b/test/audits/wikipedia-analysis/handler.test.js
@@ -590,7 +590,11 @@ describe('Wikipedia Analysis Handler', () => {
 
       const postProcessor = wikipediaAnalysisHandler.postProcessors[0];
       await expect(postProcessor(baseURL, auditData, context)).to.be.rejectedWith('SQS Error');
-      expect(context.log.error).to.have.been.calledWith(sinon.match('Failed to send Mystique message'));
+      expect(context.log.error).to.have.been.calledWith(
+        sinon.match('Failed to send Mystique message')
+          .and(sinon.match(/reason=unexpected_error/))
+          .and(sinon.match(/reasonCategory=infra/)),
+      );
     });
 
     // Helper: fresh PostgREST chain mock — limit() is the terminal call (org, status, site_id, order, limit)

--- a/test/audits/youtube-analysis/guidance-handler.test.js
+++ b/test/audits/youtube-analysis/guidance-handler.test.js
@@ -682,17 +682,17 @@ describe('YouTube Analysis Guidance Handler', () => {
       const response = await guidanceHandler.default(message, context);
 
       expect(response.status).to.equal(400);
-      // The outer catch folds the error into a structured audit_persistence_completed failure line
+      // The outer catch folds the error into a structured audit_persistence_end failure line
       // (errorName/errorMessage tokens) and passes the raw error as a genuine second arg
       // purely for stack capture (Fix B).
       expect(context.log.error).to.have.been.calledWith(
         sinon.match(/Error processing analysis/)
-          .and(sinon.match(/event=audit_persistence_completed/))
+          .and(sinon.match(/event=audit_persistence_end/))
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/errorName=Error/)),
       );
       const outerCatchCall = context.log.error.getCalls().find(
-        (c) => /event=audit_persistence_completed/.test(String(c.args[0])),
+        (c) => /event=audit_persistence_end/.test(String(c.args[0])),
       );
       expect(outerCatchCall.args).to.have.lengthOf(2);
       expect(outerCatchCall.args[1]).to.be.an('error');
@@ -714,9 +714,11 @@ describe('YouTube Analysis Guidance Handler', () => {
 
       expect(response.status).to.equal(400);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/event=audit_persistence_suggestions_synced/)
+        sinon.match(/event=audit_persistence_evergreen_opportunity_write/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/peer=postgres/))
+          .and(sinon.match(/reason=suggestions_write_failed/))
+          .and(sinon.match(/reasonCategory=infra/))
           .and(sinon.match(/errorName=Error/)),
       );
     });
@@ -734,7 +736,7 @@ describe('YouTube Analysis Guidance Handler', () => {
       await guidanceHandler.default(message, context);
 
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=audit_persistence_suggestions_synced/)
+        sinon.match(/event=audit_persistence_evergreen_opportunity_write/)
           .and(sinon.match(/outcome=success/))
           .and(sinon.match(/peer=postgres/))
           .and(sinon.match(/opportunityId=opportunity-123/)),
@@ -1589,7 +1591,7 @@ describe('YouTube Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(200);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/event=audit_housekeeping_opportunities_removed/)
+        sinon.match(/event=audit_housekeeping_outdated_opportunities_deleted/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/errorMessage="retention blew up"/)),
       );
@@ -1678,7 +1680,7 @@ describe('YouTube Analysis Guidance Handler', () => {
 
       expect(result.status).to.equal(200);
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/event=audit_housekeeping_suggestions_removed/)
+        sinon.match(/event=audit_housekeeping_outdated_suggestions_deleted/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/errorMessage="retention blew up"/)),
       );

--- a/test/audits/youtube-analysis/guidance-handler.test.js
+++ b/test/audits/youtube-analysis/guidance-handler.test.js
@@ -689,6 +689,8 @@ describe('YouTube Analysis Guidance Handler', () => {
         sinon.match(/Error processing analysis/)
           .and(sinon.match(/event=audit_persistence_end/))
           .and(sinon.match(/outcome=failure/))
+          .and(sinon.match(/reason=unexpected_error/))
+          .and(sinon.match(/reasonCategory=infra/))
           .and(sinon.match(/errorName=Error/)),
       );
       const outerCatchCall = context.log.error.getCalls().find(

--- a/test/audits/youtube-analysis/handler.test.js
+++ b/test/audits/youtube-analysis/handler.test.js
@@ -795,7 +795,10 @@ describe('YouTube Analysis Handler', function () {
       const postProcessor = youtubeAnalysisHandler.default.postProcessors[0];
       await expect(postProcessor(baseURL, auditData, context)).to.be.rejectedWith('SQS Error');
       expect(context.log.error).to.have.been.calledWith(
-        sinon.match(/Failed to send Mystique message/).and(sinon.match(/errorMessage="SQS Error"/)),
+        sinon.match(/Failed to send Mystique message/)
+          .and(sinon.match(/reason=unexpected_error/))
+          .and(sinon.match(/reasonCategory=infra/))
+          .and(sinon.match(/errorMessage="SQS Error"/)),
       );
     });
 

--- a/test/audits/youtube-analysis/handler.test.js
+++ b/test/audits/youtube-analysis/handler.test.js
@@ -599,7 +599,7 @@ describe('YouTube Analysis Handler', function () {
         sinon.match(`urlLimit=${MYSTIQUE_URLS_LIMIT}`),
       );
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=audit_analysis_mystique_request_handoff/)
+        sinon.match(/event=audit_analysis_start/)
           .and(sinon.match('companyName="Example Corp"'))
           .and(sinon.match('urls=2')),
       );
@@ -673,7 +673,7 @@ describe('YouTube Analysis Handler', function () {
       const sentMessage = context.sqs.sendMessage.firstCall.args[1];
       expect(sentMessage.data.urls).to.have.lengthOf(MYSTIQUE_URLS_LIMIT);
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=audit_analysis_mystique_request_handoff/)
+        sinon.match(/event=audit_analysis_start/)
           .and(sinon.match('companyName=Test'))
           .and(sinon.match(`urls=${MYSTIQUE_URLS_LIMIT}`)),
       );
@@ -835,7 +835,7 @@ describe('YouTube Analysis Handler', function () {
       expect(sentMessage.brandId).to.equal('brand-2');
       expect(sentMessage.siteId).to.equal(siteId);
       expect(context.log.info).to.have.been.calledWith(
-        sinon.match(/event=audit_analysis_mystique_request_handoff/).and(sinon.match(/brandId=brand-2/)),
+        sinon.match(/event=audit_analysis_start/).and(sinon.match(/brandId=brand-2/)),
       );
     });
 

--- a/test/common/offsite-refresh.test.js
+++ b/test/common/offsite-refresh.test.js
@@ -132,7 +132,7 @@ describe('offsite-refresh', () => {
 
       expect(log.error).to.have.been.calledWith(
         sinon.match(/DB down/)
-          .and(sinon.match(/event=audit_persistence_opportunity_resolved/))
+          .and(sinon.match(/event=audit_persistence_evergreen_opportunity_read/))
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/audit=cited/)),
       );
@@ -148,7 +148,7 @@ describe('offsite-refresh', () => {
       })).to.be.rejectedWith('DB down');
 
       expect(log.error).to.have.been.calledWith(
-        sinon.match(/event=audit_persistence_opportunity_resolved/).and(sinon.match(/audit=unknown/)),
+        sinon.match(/event=audit_persistence_evergreen_opportunity_read/).and(sinon.match(/audit=unknown/)),
       );
     });
 
@@ -307,7 +307,7 @@ describe('offsite-refresh', () => {
       );
 
       expect(log.info).to.have.been.calledWith(
-        sinon.match(/event=audit_persistence_opportunity_persisted/)
+        sinon.match(/event=audit_persistence_evergreen_opportunity_write/)
           .and(sinon.match(/outcome=success/))
           .and(sinon.match(/peer=postgres/))
           .and(sinon.match(/audit=reddit/))
@@ -341,7 +341,7 @@ describe('offsite-refresh', () => {
       );
 
       expect(log.info).to.have.been.calledWith(
-        sinon.match(/event=audit_persistence_opportunity_persisted/)
+        sinon.match(/event=audit_persistence_evergreen_opportunity_write/)
           .and(sinon.match(/outcome=success/))
           .and(sinon.match(/opportunityId=evergreen-1/)),
       );
@@ -363,9 +363,9 @@ describe('offsite-refresh', () => {
       )).to.be.rejectedWith('db exploded');
 
       expect(log.error).to.have.been.calledWith(
-        sinon.match(/event=audit_persistence_opportunity_persisted/)
+        sinon.match(/event=audit_persistence_evergreen_opportunity_write/)
           .and(sinon.match(/outcome=failure/))
-          .and(sinon.match(/reason=db_write/))
+          .and(sinon.match(/reason=opportunity_write_failed/))
           .and(sinon.match(/errorName=Error/))
           .and(sinon.match(/audit=youtube/)),
       );

--- a/test/common/offsite-retention.test.js
+++ b/test/common/offsite-retention.test.js
@@ -346,7 +346,7 @@ describe('offsite-retention', () => {
       expect(retentionSummary.deleted).to.equal(0);
       expect(retentionSummary.scanned).to.equal(0);
       expect(log.info).to.have.been.calledWith(
-        sinon.match(/event=audit_housekeeping_suggestions_removal_summary/)
+        sinon.match(/event=audit_housekeeping_end/)
           .and(sinon.match(/outcome=success/))
           .and(sinon.match(/scanned=0/))
           .and(sinon.match(/eligible=0/))
@@ -380,7 +380,7 @@ describe('offsite-retention', () => {
         scanned: 0, eligible: 0, deleted: 0, failed: 0,
       });
       expect(log.error).to.have.been.calledWith(
-        sinon.match(/event=audit_housekeeping_suggestions_found/)
+        sinon.match(/event=audit_housekeeping_outdated_suggestions_read/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/opportunityId=evergreen-1/))
           .and(sinon.match(/siteId=site-1/))
@@ -407,7 +407,7 @@ describe('offsite-retention', () => {
         scanned: 1, eligible: 1, deleted: 0, failed: 1,
       });
       expect(log.error).to.have.been.calledWith(
-        sinon.match(/event=audit_housekeeping_suggestions_removed/)
+        sinon.match(/event=audit_housekeeping_outdated_suggestions_deleted/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/opportunityId=evergreen-1/))
           .and(sinon.match(/siteId=site-1/))
@@ -534,7 +534,7 @@ describe('offsite-retention', () => {
       // A partial failure must surface at outcome=failure on the summary, not success — an
       // alerting query keyed on outcome=failure must not miss a partial-batch failure.
       expect(log.error).to.have.been.calledWith(
-        sinon.match(/event=audit_housekeeping_suggestions_removal_summary/)
+        sinon.match(/event=audit_housekeeping_end/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(`failed=${suggestionCount - OUTDATED_SUGGESTION_DELETE_BATCH_SIZE}`)),
       );
@@ -561,7 +561,7 @@ describe('offsite-retention', () => {
       expect(removeByIds).to.have.been.calledBefore(log.info);
       expect(log.info).to.have.been.calledWith(
         sinon.match(/Deleted expired OUTDATED suggestions/)
-          .and(sinon.match(/event=audit_housekeeping_suggestions_removed/))
+          .and(sinon.match(/event=audit_housekeeping_outdated_suggestions_deleted/))
           .and(sinon.match(/outcome=success/))
           .and(sinon.match(/opportunityId=evergreen-1/))
           .and(sinon.match(/siteId=site-1/))
@@ -569,7 +569,7 @@ describe('offsite-retention', () => {
       );
       expect(log.info).to.have.been.calledWith(
         sinon.match(/Expired OUTDATED suggestion deletion summary/)
-          .and(sinon.match(/event=audit_housekeeping_suggestions_removal_summary/))
+          .and(sinon.match(/event=audit_housekeeping_end/))
           .and(sinon.match(/outcome=success/))
           .and(sinon.match(/opportunityId=evergreen-1/))
           .and(sinon.match(/siteId=site-1/))
@@ -636,7 +636,7 @@ describe('offsite-retention', () => {
 
       expect(expiredSnapshots).to.deep.equal([]);
       expect(log.error).to.have.been.calledWith(
-        sinon.match(/event=audit_housekeeping_opportunities_found/)
+        sinon.match(/event=audit_housekeeping_outdated_opportunities_read/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/audit=cited/))
           .and(sinon.match(/errorMessage="DB down"/)),
@@ -784,7 +784,7 @@ describe('offsite-retention', () => {
       expect(removeByIdsSuggestion).to.have.been.calledOnceWith(['sugg-2', 'sugg-1']);
       expect(removeByIdsOpportunity).to.have.been.calledOnceWith(['second-expired', 'first-expired']);
       expect(log.info).to.have.been.calledWith(
-        sinon.match(/event=audit_housekeeping_opportunities_removed/)
+        sinon.match(/event=audit_housekeeping_outdated_opportunities_deleted/)
           .and(sinon.match(/outcome=success/))
           .and(sinon.match(/eligible=2/))
           .and(sinon.match(/deleted=2/)),

--- a/test/common/offsite-snapshot.test.js
+++ b/test/common/offsite-snapshot.test.js
@@ -650,7 +650,12 @@ describe('offsite-snapshot', () => {
         log,
       });
 
-      expect(log.error).to.have.been.calledWith(sinon.match(/Suggestions failed to copy onto snapshot/).and(sinon.match(/failed=1/)));
+      expect(log.error).to.have.been.calledWith(
+        sinon.match(/Suggestions failed to copy onto snapshot/)
+          .and(sinon.match(/failed=1/))
+          .and(sinon.match(/reason=suggestions_copy_failed/))
+          .and(sinon.match(/reasonCategory=infra/)),
+      );
     });
 
     it('deletes the orphan snapshot and rethrows when addSuggestions fully rejects', async () => {
@@ -685,7 +690,11 @@ describe('offsite-snapshot', () => {
       })).to.be.rejectedWith('DB write failed');
 
       expect(remove).to.have.been.calledOnce;
-      expect(log.error).to.have.been.calledWith(sinon.match(/addSuggestions threw.*deleting orphan/i));
+      expect(log.error).to.have.been.calledWith(
+        sinon.match(/addSuggestions threw.*deleting orphan/i)
+          .and(sinon.match(/reason=suggestions_copy_failed/))
+          .and(sinon.match(/reasonCategory=infra/)),
+      );
     });
 
     it('still rethrows the original addSuggestions error when orphan removal also fails', async () => {
@@ -720,7 +729,11 @@ describe('offsite-snapshot', () => {
       })).to.be.rejectedWith('DB write failed');
 
       expect(remove).to.have.been.calledOnce;
-      expect(log.error).to.have.been.calledWith(sinon.match(/Failed to delete orphan snapshot/i));
+      expect(log.error).to.have.been.calledWith(
+        sinon.match(/Failed to delete orphan snapshot/i)
+          .and(sinon.match(/reason=orphan_cleanup_failed/))
+          .and(sinon.match(/reasonCategory=infra/)),
+      );
     });
 
     it('creates a managed snapshot without trigger metadata when auditId is missing', async () => {

--- a/test/utils/offsite-audit-utils.test.js
+++ b/test/utils/offsite-audit-utils.test.js
@@ -716,7 +716,7 @@ describe('offsite-audit-utils', () => {
       expect(olog.warn).to.have.been.calledWith(
         'data_acquisition_scrape_job_request_dispatched',
         sinon.match(/Failed to request DRS scrape/),
-        sinon.match({ reason: 'self_heal' }),
+        sinon.match({ reason: 'self_heal_failed', reasonCategory: 'infra' }),
       );
     });
   });

--- a/test/utils/offsite-audit-utils.test.js
+++ b/test/utils/offsite-audit-utils.test.js
@@ -140,9 +140,9 @@ describe('offsite-audit-utils', () => {
       expect(result.urls).to.deep.equal(urls);
       expect(result.counts.determined).to.equal(false);
       expect(olog.skip).to.have.been.calledWith(
-        'data_acquisition_scrape_job_status_polled',
+        'data_acquisition_scrape_content_checked',
         'DRS client not configured, skipping availability filter',
-        sinon.match({ reason: 'not_configured' }),
+        sinon.match({ reason: 'drs_not_configured' }),
       );
     });
 
@@ -186,7 +186,7 @@ describe('offsite-audit-utils', () => {
         total: 3, available: 2, scraping: 0, notFound: 1, determined: true,
       });
       expect(olog.debug).to.have.been.calledWith(
-        'data_acquisition_scrape_job_status_polled',
+        'data_acquisition_scrape_content_checked',
         'DRS availability filter removed URLs not yet scraped',
         sinon.match({ peer: PEER.DRS, removed: 1, remaining: 2 }),
       );
@@ -207,7 +207,7 @@ describe('offsite-audit-utils', () => {
       await filterUrlsByDrsStatus(urls, ['ds1'], siteId, drsClient, olog);
 
       expect(olog.debug).to.have.been.calledWith(
-        'data_acquisition_scrape_job_status_polled',
+        'data_acquisition_scrape_content_checked',
         'DRS lookup dataset summary',
         sinon.match({
           peer: PEER.DRS, datasetId: 'ds1', available: 1, total: 3,
@@ -238,7 +238,7 @@ describe('offsite-audit-utils', () => {
         total: 3, available: 1, scraping: 1, notFound: 1, determined: true,
       });
       expect(olog.debug).to.have.been.calledWith(
-        'data_acquisition_scrape_job_status_polled',
+        'data_acquisition_scrape_content_checked',
         'DRS availability filter removed URLs not yet scraped',
         sinon.match({ peer: PEER.DRS, removed: 2, remaining: 1 }),
       );
@@ -280,8 +280,8 @@ describe('offsite-audit-utils', () => {
 
       expect(result.urls).to.deep.equal(urls);
       expect(result.counts.determined).to.equal(false);
-      expect(olog.warn).to.have.been.calledWith('data_acquisition_scrape_job_status_polled', sinon.match(/DRS lookup returned null/), sinon.match({ peer: PEER.DRS, datasetId: 'ds1', reason: 'null_response' }));
-      expect(olog.warn).to.have.been.calledWith('data_acquisition_scrape_job_status_polled', sinon.match(/All DRS lookups failed or returned null/), sinon.match({ peer: PEER.DRS, reason: 'all_failed' }));
+      expect(olog.warn).to.have.been.calledWith('data_acquisition_scrape_content_checked', sinon.match(/DRS lookup returned null/), sinon.match({ peer: PEER.DRS, datasetId: 'ds1', reason: 'null_response' }));
+      expect(olog.warn).to.have.been.calledWith('data_acquisition_scrape_content_checked', sinon.match(/All DRS lookups failed or returned null/), sinon.match({ peer: PEER.DRS, reason: 'all_failed' }));
     });
 
     it('falls back to full list when all lookups throw', async () => {
@@ -295,10 +295,10 @@ describe('offsite-audit-utils', () => {
 
       expect(result.urls).to.deep.equal(urls);
       expect(result.counts.determined).to.equal(false);
-      expect(olog.warn).to.have.been.calledWith('data_acquisition_scrape_job_status_polled', sinon.match(/DRS lookup failed; skipping dataset/), sinon.match({
+      expect(olog.warn).to.have.been.calledWith('data_acquisition_scrape_content_checked', sinon.match(/DRS lookup failed; skipping dataset/), sinon.match({
         peer: PEER.DRS, datasetId: 'ds1', errorName: 'Error', errorMessage: 'network error',
       }));
-      expect(olog.warn).to.have.been.calledWith('data_acquisition_scrape_job_status_polled', sinon.match(/All DRS lookups failed or returned null/), sinon.match({ peer: PEER.DRS, reason: 'all_failed' }));
+      expect(olog.warn).to.have.been.calledWith('data_acquisition_scrape_content_checked', sinon.match(/All DRS lookups failed or returned null/), sinon.match({ peer: PEER.DRS, reason: 'all_failed' }));
     });
 
     it('does not log removed count when all URLs pass the filter', async () => {
@@ -319,7 +319,7 @@ describe('offsite-audit-utils', () => {
       expect(result.counts).to.deep.equal({
         total: 3, available: 3, scraping: 0, notFound: 0, determined: true,
       });
-      expect(olog.debug).to.not.have.been.calledWith('data_acquisition_scrape_job_status_polled', sinon.match(/DRS availability filter: removed/));
+      expect(olog.debug).to.not.have.been.calledWith('data_acquisition_scrape_content_checked', sinon.match(/DRS availability filter: removed/));
     });
 
     it('works without log or logPrefix', async () => {
@@ -351,7 +351,7 @@ describe('offsite-audit-utils', () => {
       await filterUrlsByDrsStatus(urls, ['ds1'], siteId, drsClient, olog);
 
       expect(olog.debug).to.have.been.calledWith(
-        'data_acquisition_scrape_job_status_polled',
+        'data_acquisition_scrape_content_checked',
         'DRS lookup dataset summary',
         sinon.match({
           peer: PEER.DRS, datasetId: 'ds1', available: 0, total: urls.length,
@@ -495,7 +495,7 @@ describe('offsite-audit-utils', () => {
         { messageData: { urlLimit: MYSTIQUE_URLS_LIMIT + 10 } },
         olog,
       )).to.equal(MYSTIQUE_URLS_LIMIT);
-      expect(olog.debug).to.have.been.calledOnceWith('audit_analysis_url_limit_resolved', sinon.match(/exceeds cap/), sinon.match({ requested: MYSTIQUE_URLS_LIMIT + 10, cap: MYSTIQUE_URLS_LIMIT, urlLimit: MYSTIQUE_URLS_LIMIT }));
+      expect(olog.debug).to.have.been.calledOnceWith('audit_orchestration_analysis_url_limit_resolved', sinon.match(/exceeds cap/), sinon.match({ requested: MYSTIQUE_URLS_LIMIT + 10, cap: MYSTIQUE_URLS_LIMIT, urlLimit: MYSTIQUE_URLS_LIMIT }));
     });
 
     it('returns default and warns when urlLimit is invalid', () => {
@@ -506,7 +506,7 @@ describe('offsite-audit-utils', () => {
       expect(fractional).to.equal(MYSTIQUE_URLS_LIMIT);
       expect(olog.warn).to.have.been.calledTwice;
       expect(olog.warn).to.have.been.calledWith(
-        'audit_analysis_url_limit_resolved',
+        'audit_orchestration_analysis_url_limit_resolved',
         sinon.match(/Invalid urlLimit/),
         sinon.match({ reason: 'invalid' }),
       );
@@ -650,7 +650,7 @@ describe('offsite-audit-utils', () => {
         },
       });
       expect(olog.success).to.have.been.calledWith(
-        'data_acquisition_scrape_job_submitted',
+        'data_acquisition_scrape_job_request_dispatched',
         sinon.match(/Requested DRS scrape/),
         sinon.match({ reason: 'self_heal', domainScope: 'top-cited' }),
       );
@@ -714,7 +714,7 @@ describe('offsite-audit-utils', () => {
       await requestOffsiteScrape(context, 'site-1', 'top-cited', undefined, true, undefined, undefined, olog);
 
       expect(olog.warn).to.have.been.calledWith(
-        'data_acquisition_scrape_job_submitted',
+        'data_acquisition_scrape_job_request_dispatched',
         sinon.match(/Failed to request DRS scrape/),
         sinon.match({ reason: 'self_heal' }),
       );

--- a/test/utils/offsite-brand-presence-semrush.test.js
+++ b/test/utils/offsite-brand-presence-semrush.test.js
@@ -367,14 +367,14 @@ describe('offsite-brand-presence-semrush', function () {
     const diagnostics = {};
     const result = await run({}, {}, undefined, diagnostics);
     expect(result).to.equal(null);
-    expect(diagnostics.fallbackReason).to.equal('domain-urls-failed');
+    expect(diagnostics.fallbackReason).to.equal('domain_urls_failed');
   });
 
   it('falls back (null) on a non-2xx response', async () => {
     fetchStub.resolves({ ok: false, status: 500 });
     const diagnostics = {};
     expect(await run({}, {}, undefined, diagnostics)).to.equal(null);
-    expect(diagnostics.fallbackReason).to.equal('domain-urls-failed');
+    expect(diagnostics.fallbackReason).to.equal('domain_urls_failed');
   });
 
   it('logs a distinct rejection and falls back with domain-urls-auth-failed on a 401', async () => {
@@ -383,7 +383,7 @@ describe('offsite-brand-presence-semrush', function () {
     const result = await run({}, {}, undefined, diagnostics);
     expect(result).to.equal(null);
     expect(erroredWith(/Service token rejected/)).to.equal(true);
-    expect(diagnostics.fallbackReason).to.equal('domain-urls-auth-failed');
+    expect(diagnostics.fallbackReason).to.equal('domain_urls_auth_failed');
   });
 
   it('logs the response body on a 401 so the rejecter (api-service vs Semrush) is identifiable', async () => {
@@ -411,7 +411,7 @@ describe('offsite-brand-presence-semrush', function () {
     const result = await run({}, {}, undefined, diagnostics);
     expect(result).to.equal(null);
     expect(erroredWith(/Service token rejected/)).to.equal(true);
-    expect(diagnostics.fallbackReason).to.equal('domain-urls-auth-failed');
+    expect(diagnostics.fallbackReason).to.equal('domain_urls_auth_failed');
   });
 
   it('falls back (null) when the response body fails to parse', async () => {
@@ -435,7 +435,7 @@ describe('offsite-brand-presence-semrush', function () {
     });
     expect(result).to.equal(null);
     expect(fetchStub).to.not.have.been.called;
-    expect(diagnostics.fallbackReason).to.equal('no-organization-id');
+    expect(diagnostics.fallbackReason).to.equal('no_organization_id');
   });
 
   it('returns null and logs info when the brand is confirmed absent (resolved=true)', async () => {
@@ -466,7 +466,7 @@ describe('offsite-brand-presence-semrush', function () {
     expect(diagnostics.entitlementReason).to.equal(SEMRUSH_ENTITLEMENT_REASONS.NO_WORKSPACE);
     expect(fetchStub).to.not.have.been.called;
     expect(getServiceAccessToken).to.not.have.been.called;
-    expect(log.info).to.have.been.calledWithMatch(/Brand not entitled for Semrush.*entitlementReason=no-workspace/);
+    expect(log.info).to.have.been.calledWithMatch(/Brand not entitled for Semrush.*entitlementReason=no_workspace/);
     expect(onProgress).to.have.been.calledWith(
       ':information_source: Brand is not entitled for Semrush — falling back to the legacy source.',
     );

--- a/test/utils/offsite-logging.test.js
+++ b/test/utils/offsite-logging.test.js
@@ -242,7 +242,7 @@ describe('offsite-logging helper', () => {
   });
 
   describe('withAuditPersistLog', () => {
-    it('is a post-processor that logs audit_persistence_run_recorded success from the persisted audit data', async () => {
+    it('is a post-processor that logs audit_persistence_run_write success from the persisted audit data', async () => {
       const pp = withAuditPersistLog(AUDIT.CITED);
       const auditData = { siteId: 's1', id: 'a1', auditType: 'cited-analysis' };
 
@@ -251,7 +251,7 @@ describe('offsite-logging helper', () => {
       // returns the accumulator unchanged so the post-processor chain is transparent
       expect(result).to.equal(auditData);
       expect(log.info).to.have.been.calledOnceWithExactly(
-        '[offsite:cited] Audit persisted domain=offsite audit=cited event=audit_persistence_run_recorded '
+        '[offsite:cited] Audit persisted domain=offsite audit=cited event=audit_persistence_run_write '
         + 'outcome=success peer=postgres direction=outbound siteId=s1 auditId=a1 auditType=cited-analysis',
       );
     });
@@ -264,7 +264,7 @@ describe('offsite-logging helper', () => {
       await pp('https://example.com', auditData, context, {}, {});
 
       expect(log.info).to.have.been.calledOnceWithExactly(
-        '[offsite:brand-presence] Audit persisted domain=offsite audit=brand-presence event=audit_persistence_run_recorded '
+        '[offsite:brand-presence] Audit persisted domain=offsite audit=brand-presence event=audit_persistence_run_write '
         + 'outcome=success peer=postgres direction=outbound siteId=s2 auditId=a2 auditType=offsite-brand-presence',
       );
     });

--- a/test/utils/semrush-entitlement.test.js
+++ b/test/utils/semrush-entitlement.test.js
@@ -161,7 +161,7 @@ describe('semrush-entitlement', () => {
       dataAccessOverrides: makeDataAccess({ orgWorkspaceId: null, brandSubWorkspaceId: null }),
     });
 
-    expect(result).to.deep.equal({ entitled: false, resolved: true, reason: 'no-workspace' });
+    expect(result).to.deep.equal({ entitled: false, resolved: true, reason: 'no_workspace' });
   });
 
   it('is not entitled (no-workspace) when Organization/Brand rows do not exist at all', async () => {
@@ -170,7 +170,7 @@ describe('semrush-entitlement', () => {
       dataAccessOverrides: makeDataAccess(),
     });
 
-    expect(result).to.deep.equal({ entitled: false, resolved: true, reason: 'no-workspace' });
+    expect(result).to.deep.equal({ entitled: false, resolved: true, reason: 'no_workspace' });
   });
 
   it('is not entitled (flag-disabled) even when a workspace exists — flag wins', async () => {
@@ -181,7 +181,7 @@ describe('semrush-entitlement', () => {
       }),
     });
 
-    expect(result).to.deep.equal({ entitled: false, resolved: true, reason: 'flag-disabled' });
+    expect(result).to.deep.equal({ entitled: false, resolved: true, reason: 'flag_disabled' });
   });
 
   it('is not entitled (flag-disabled) when no flag row exists at all', async () => {
@@ -190,7 +190,7 @@ describe('semrush-entitlement', () => {
       dataAccessOverrides: makeDataAccess({ brandSubWorkspaceId: 'sub-ws-1' }),
     });
 
-    expect(result).to.deep.equal({ entitled: false, resolved: true, reason: 'flag-disabled' });
+    expect(result).to.deep.equal({ entitled: false, resolved: true, reason: 'flag_disabled' });
   });
 
   // --- missing input / missing client ----------------------------------------
@@ -204,7 +204,7 @@ describe('semrush-entitlement', () => {
       { orgId: null, brandId: BRAND_ID },
     );
 
-    expect(result).to.deep.equal({ entitled: false, resolved: false, reason: 'missing-input' });
+    expect(result).to.deep.equal({ entitled: false, resolved: false, reason: 'missing_input' });
     expect(from).to.not.have.been.called;
     expect(dataAccessOverrides.Organization.findById).to.not.have.been.called;
   });
@@ -217,14 +217,14 @@ describe('semrush-entitlement', () => {
       { orgId: ORG_ID, brandId: null },
     );
 
-    expect(result).to.deep.equal({ entitled: false, resolved: false, reason: 'missing-input' });
+    expect(result).to.deep.equal({ entitled: false, resolved: false, reason: 'missing_input' });
     expect(from).to.not.have.been.called;
   });
 
   it('returns missing-input when called without a context or params', async () => {
     const result = await resolveSemrushEntitlement();
 
-    expect(result).to.deep.equal({ entitled: false, resolved: false, reason: 'missing-input' });
+    expect(result).to.deep.equal({ entitled: false, resolved: false, reason: 'missing_input' });
   });
 
   it('returns no-client and warns when the PostgREST client is missing', async () => {
@@ -233,7 +233,7 @@ describe('semrush-entitlement', () => {
       { orgId: ORG_ID, brandId: BRAND_ID },
     );
 
-    expect(result).to.deep.equal({ entitled: false, resolved: false, reason: 'no-client' });
+    expect(result).to.deep.equal({ entitled: false, resolved: false, reason: 'no_client' });
     expect(log.warn).to.have.been.calledWithMatch(/PostgREST client or Organization\/Brand data-access not available/);
   });
 
@@ -243,7 +243,7 @@ describe('semrush-entitlement', () => {
       { orgId: ORG_ID, brandId: BRAND_ID },
     );
 
-    expect(result).to.deep.equal({ entitled: false, resolved: false, reason: 'no-client' });
+    expect(result).to.deep.equal({ entitled: false, resolved: false, reason: 'no_client' });
   });
 
   it('returns no-client when the Organization/Brand collections are unavailable', async () => {
@@ -254,7 +254,7 @@ describe('semrush-entitlement', () => {
       { orgId: ORG_ID, brandId: BRAND_ID },
     );
 
-    expect(result).to.deep.equal({ entitled: false, resolved: false, reason: 'no-client' });
+    expect(result).to.deep.equal({ entitled: false, resolved: false, reason: 'no_client' });
   });
 
   // --- transient failures (resolved:false, fail closed) -----------------------
@@ -265,7 +265,7 @@ describe('semrush-entitlement', () => {
       dataAccessOverrides: makeDataAccess({ brandSubWorkspaceId: 'sub-ws-1' }),
     });
 
-    expect(result).to.deep.equal({ entitled: false, resolved: false, reason: 'check-failed' });
+    expect(result).to.deep.equal({ entitled: false, resolved: false, reason: 'check_failed' });
   });
 
   it('fails closed (check-failed) and warns when the flag query throws', async () => {
@@ -276,7 +276,7 @@ describe('semrush-entitlement', () => {
       { orgId: ORG_ID, brandId: BRAND_ID },
     );
 
-    expect(result).to.deep.equal({ entitled: false, resolved: false, reason: 'check-failed' });
+    expect(result).to.deep.equal({ entitled: false, resolved: false, reason: 'check_failed' });
     expect(log.warn).to.have.been.calledWithMatch(/Error checking serenity flag/);
   });
 
@@ -302,7 +302,7 @@ describe('semrush-entitlement', () => {
       dataAccessOverrides: makeDataAccess({ brandSubWorkspaceId: 'sub-ws-1' }),
     });
 
-    expect(result).to.deep.equal({ entitled: false, resolved: true, reason: 'flag-disabled' });
+    expect(result).to.deep.equal({ entitled: false, resolved: true, reason: 'flag_disabled' });
   });
 
   it("is not entitled (flag-disabled) when the org row is off, even with a different brand's true override", async () => {
@@ -316,7 +316,7 @@ describe('semrush-entitlement', () => {
       dataAccessOverrides: makeDataAccess({ brandSubWorkspaceId: 'sub-ws-1' }),
     });
 
-    expect(result).to.deep.equal({ entitled: false, resolved: true, reason: 'flag-disabled' });
+    expect(result).to.deep.equal({ entitled: false, resolved: true, reason: 'flag_disabled' });
   });
 
   it("is entitled when THIS brand's own override is true, even though the org row is false", async () => {
@@ -346,7 +346,7 @@ describe('semrush-entitlement', () => {
       dataAccessOverrides: makeDataAccess({ brandSubWorkspaceId: 'sub-ws-1' }),
     });
 
-    expect(result).to.deep.equal({ entitled: false, resolved: true, reason: 'flag-disabled' });
+    expect(result).to.deep.equal({ entitled: false, resolved: true, reason: 'flag_disabled' });
   });
 
   it('fails closed (check-failed) and warns when Brand.findById throws', async () => {
@@ -358,7 +358,7 @@ describe('semrush-entitlement', () => {
       }),
     });
 
-    expect(result).to.deep.equal({ entitled: false, resolved: false, reason: 'check-failed' });
+    expect(result).to.deep.equal({ entitled: false, resolved: false, reason: 'check_failed' });
     expect(log.warn).to.have.been.calledWithMatch(/Semrush entitlement check failed/);
   });
 
@@ -371,7 +371,7 @@ describe('semrush-entitlement', () => {
       }),
     });
 
-    expect(result).to.deep.equal({ entitled: false, resolved: false, reason: 'check-failed' });
+    expect(result).to.deep.equal({ entitled: false, resolved: false, reason: 'check_failed' });
   });
 
   it('fails closed (check-failed) and warns on a timeout', async () => {
@@ -389,7 +389,7 @@ describe('semrush-entitlement', () => {
     await clock.tickAsync(SEMRUSH_ENTITLEMENT_TIMEOUT_MS + 1);
     const result = await resultP;
 
-    expect(result).to.deep.equal({ entitled: false, resolved: false, reason: 'check-failed' });
+    expect(result).to.deep.equal({ entitled: false, resolved: false, reason: 'check_failed' });
     expect(log.warn).to.have.been.calledWithMatch(/Semrush entitlement check failed.*timed out/);
   });
 
@@ -398,8 +398,8 @@ describe('semrush-entitlement', () => {
 
   describe('exported reason-string constants', () => {
     it('exposes the two skip-reason literals the loader sets on diagnostics.fallbackReason', () => {
-      expect(SEMRUSH_NOT_ENTITLED_REASON).to.equal('not-entitled');
-      expect(SEMRUSH_ENTITLEMENT_CHECK_FAILED_REASON).to.equal('entitlement-check-failed');
+      expect(SEMRUSH_NOT_ENTITLED_REASON).to.equal('not_entitled');
+      expect(SEMRUSH_ENTITLEMENT_CHECK_FAILED_REASON).to.equal('entitlement_check_failed');
     });
 
     it('bundles both reasons into SEMRUSH_ENTITLEMENT_SKIP_REASONS, and nothing else', () => {
@@ -408,8 +408,8 @@ describe('semrush-entitlement', () => {
       expect(SEMRUSH_ENTITLEMENT_SKIP_REASONS.has(SEMRUSH_ENTITLEMENT_CHECK_FAILED_REASON))
         .to.equal(true);
       expect(SEMRUSH_ENTITLEMENT_SKIP_REASONS.size).to.equal(2);
-      expect(SEMRUSH_ENTITLEMENT_SKIP_REASONS.has('semrush-failed')).to.equal(false);
-      expect(SEMRUSH_ENTITLEMENT_SKIP_REASONS.has('ims-token-failed')).to.equal(false);
+      expect(SEMRUSH_ENTITLEMENT_SKIP_REASONS.has('semrush_failed')).to.equal(false);
+      expect(SEMRUSH_ENTITLEMENT_SKIP_REASONS.has('ims_token_failed')).to.equal(false);
     });
 
     it('is frozen (cannot be mutated by a caller)', () => {
@@ -419,11 +419,11 @@ describe('semrush-entitlement', () => {
     it('exposes the granular reason values resolveSemrushEntitlement returns', () => {
       expect(SEMRUSH_ENTITLEMENT_REASONS).to.deep.equal({
         ENTITLED: 'entitled',
-        FLAG_DISABLED: 'flag-disabled',
-        NO_WORKSPACE: 'no-workspace',
-        MISSING_INPUT: 'missing-input',
-        NO_CLIENT: 'no-client',
-        CHECK_FAILED: 'check-failed',
+        FLAG_DISABLED: 'flag_disabled',
+        NO_WORKSPACE: 'no_workspace',
+        MISSING_INPUT: 'missing_input',
+        NO_CLIENT: 'no_client',
+        CHECK_FAILED: 'check_failed',
       });
       expect(Object.isFrozen(SEMRUSH_ENTITLEMENT_REASONS)).to.equal(true);
     });

--- a/test/utils/store-client.test.js
+++ b/test/utils/store-client.test.js
@@ -286,10 +286,10 @@ describe('StoreClient', () => {
         .to.be.rejectedWith('dynamo exploded');
       expect(dataAccess.AuditUrl.allBySiteIdAndAuditType).to.have.been.calledTwice;
       // A genuine read error is logged as a distinct, alertable
-      // data_acquisition_store_urls_read failure before it is re-thrown (rather than
+      // data_acquisition_url_store_read failure before it is re-thrown (rather than
       // surfacing only as the generic "Audit failed").
       expect(mockLog.error).to.have.been.calledWith(
-        sinon.match(/event=data_acquisition_store_urls_read/)
+        sinon.match(/event=data_acquisition_url_store_read/)
           .and(sinon.match(/outcome=failure/))
           .and(sinon.match(/dynamo exploded/)),
       );


### PR DESCRIPTION
Implements the event/reason taxonomy review for the offsite audit pipeline (brand-presence, cited/reddit/youtube/wikipedia analysis):

Events
- New audit_orchestration_failed: the outer-catch failure in each content-type analysis no longer reuses audit_orchestration_started with outcome=failure (misleading — it fires for any unhandled exception, not a failure to start).
- audit_orchestration_completed now also fires for each content-type analysis's happy-path dispatch, not just the weekly brand-presence collection — closes a gap where analyses had no terminal orchestration marker.
- Split the overloaded data_acquisition_scrape_job_status_polled into data_acquisition_scrape_job_poll_checked (background poll loop) and data_acquisition_scrape_content_checked (per-analysis availability check) — two different questions that were sharing one event name.
- Standardized the "write succeeded" event family to one _persisted suffix: audit_persistence_run_persisted, data_acquisition_urls_persisted, audit_persistence_suggestions_persisted (previously _recorded/_written/ _synced, with no consistent rule).
- Renamed data_acquisition_completed -> audit_analysis_readiness_resolved (it's a routing decision, not a phase completion) and audit_analysis_completed -> audit_analysis_result_received (it marks arrival of a result, not completion of analysis work).
- data_acquisition_analysis_request_handoff -> ...dispatched, and audit_analysis_mystique_request_built -> ...payload_built, removing a naming collision between two different "handoff"/"built" events in adjacent phases.
- Folded the Brandalf-unknown skip from data_acquisition_bp_data_source_selected into data_acquisition_bp_data_postgres_read, where it actually belongs.

Reasons
- Normalized every kebab-case Semrush/entitlement reason to snake_case (no_organization_id, not_entitled, flag_disabled, etc.) — the only reasons in the whole taxonomy that weren't already snake_case.
- Split the overloaded not_configured reason into drs_not_configured / mystique_not_configured, and site_not_found into site_not_found_at_dispatch / site_not_found_at_persist — same underlying fact, different failure points with different remediation.
- Renamed the empty-store/no-content reason pairs to name the first-attempt/after-retry relationship directly: store_empty_first_attempt/store_empty_after_scrape, content_not_scraped_first_attempt/content_not_scraped_after_retry.
- Added a new reasonCategory field (config/infra/expected) alongside every existing reason field, so a dashboard can separate "customer needs to fix a config" from "page on-call" from "working as intended" without hardcoding the whole reason table.
- Added missing reason=lookup to three P5 housekeeping failure events that previously carried only errorName/errorMessage.
- Added a snapshotAction field (reused/creating/created/skipped) to audit_persistence_snapshot_prepared, and dropped/reason=budget_exceeded to the renamed data_acquisition_scrape_poll_completed.
- Added a debug success line to data_acquisition_cooldown_checked, which previously only had a failure line.