### PR TITLE
feat: add ASO link and IMS org name to low-suggestion-count slack alert

### DIFF
--- a/src/support/plg-suggestion-alert.js
+++ b/src/support/plg-suggestion-alert.js
@@ -57,6 +57,34 @@ async function isSitePlgTier(site, log) {
 }
 
 /**
+ * Resolves the site's organization, IMS org id, and org name for use in an
+ * alert message. Fails soft — returns nulls on lookup failure.
+ *
+ * @param {object} site    - The Site model instance.
+ * @param {object} context - Lambda context ({ dataAccess }).
+ * @param {object} log     - Logger with a warn method.
+ * @returns {Promise<{organizationId: string|null, imsOrgId: string|null, orgName: string|null}>}
+ */
+async function getOrganizationDetails(site, context, log) {
+  const organizationId = site.getOrganizationId?.() ?? null;
+  if (!organizationId) {
+    return { organizationId: null, imsOrgId: null, orgName: null };
+  }
+
+  try {
+    const organization = await context.dataAccess.Organization.findById(organizationId);
+    return {
+      organizationId,
+      imsOrgId: organization?.getImsOrgId?.() ?? null,
+      orgName: organization?.getName?.() ?? null,
+    };
+  } catch (err) {
+    log.warn(`Failed to look up organization for low suggestion count alert (site ${site.getId()}): ${err.message}`);
+    return { organizationId, imsOrgId: null, orgName: null };
+  }
+}
+
+/**
  * Posts a JSON body message to a Slack channel via the Web API.
  *
  * @param {string} channelId
@@ -142,6 +170,18 @@ export async function sendLowSuggestionCountAlert(site, auditType, suggestionCou
 
     if (errorMessage) {
       message += `\n• *Error:* ${sanitizeForSlack(errorMessage)}`;
+    }
+
+    const { organizationId, imsOrgId, orgName } = await getOrganizationDetails(site, context, log);
+    if (orgName) {
+      message += `\n• *IMS Org Name:* ${sanitizeForSlack(orgName)}`;
+    }
+    if (imsOrgId) {
+      message += `\n• *IMS Org ID:* \`${sanitizeForSlack(imsOrgId)}\``;
+    }
+    if (organizationId) {
+      const experienceUrl = env?.EXPERIENCE_URL || 'https://experience.adobe.com';
+      message += `\n• *ASO Link:* ${experienceUrl}/?organizationId=${organizationId}#/sites-optimizer/sites/${site.getId()}`;
     }
 
     await postSlackMessage(channelId, message, token);

--- a/src/support/plg-suggestion-alert.js
+++ b/src/support/plg-suggestion-alert.js
@@ -181,7 +181,7 @@ export async function sendLowSuggestionCountAlert(site, auditType, suggestionCou
     }
     if (organizationId) {
       const experienceUrl = env?.EXPERIENCE_URL || 'https://experience.adobe.com';
-      message += `\n• *ASO Link:* ${experienceUrl}/?organizationId=${organizationId}#/sites-optimizer/sites/${site.getId()}`;
+      message += `\n• *ASO Link:* ${experienceUrl}/?organizationId=${encodeURIComponent(organizationId)}#/sites-optimizer/sites/${encodeURIComponent(site.getId())}`;
     }
 
     await postSlackMessage(channelId, message, token);

--- a/test/support/plg-suggestion-alert.test.js
+++ b/test/support/plg-suggestion-alert.test.js
@@ -291,6 +291,19 @@ describe('sendLowSuggestionCountAlert', () => {
     expect(text).to.include('/sites-optimizer/sites/site-uuid-123');
   });
 
+  it('URL-encodes organizationId and siteId in the ASO link', async () => {
+    const site = makeSite([makeEnrollment('ASO', 'PLG')], 'org&id=weird#value');
+    const weirdSite = { ...site, getId: () => 'site&id=weird#value' };
+
+    await sendLowSuggestionCountAlert(weirdSite, 'cwv', 0, makeContext());
+
+    expect(fetchStub).to.have.been.calledOnce;
+    const text = JSON.stringify(getPostedBody().blocks);
+    expect(text).to.include('organizationId=org%26id%3Dweird%23value');
+    expect(text).to.include('/sites-optimizer/sites/site%26id%3Dweird%23value');
+    expect(text).to.not.include('org&id=weird#value');
+  });
+
   it('omits org/ASO lines when the site has no organizationId', async () => {
     const site = makeSite([makeEnrollment('ASO', 'PLG')], null);
     await sendLowSuggestionCountAlert(site, 'cwv', 0, makeContext());

--- a/test/support/plg-suggestion-alert.test.js
+++ b/test/support/plg-suggestion-alert.test.js
@@ -301,6 +301,21 @@ describe('sendLowSuggestionCountAlert', () => {
     expect(text).to.not.include('ASO Link');
   });
 
+  it('omits IMS org name/id but still shows ASO link when organization lookup resolves null', async () => {
+    const site = makeSite([makeEnrollment('ASO', 'PLG')]);
+    const context = makeContext({
+      dataAccess: { Organization: { findById: sandbox.stub().resolves(null) } },
+    });
+
+    await sendLowSuggestionCountAlert(site, 'cwv', 0, context);
+
+    expect(fetchStub).to.have.been.calledOnce;
+    const text = JSON.stringify(getPostedBody().blocks);
+    expect(text).to.not.include('IMS Org Name');
+    expect(text).to.not.include('IMS Org ID');
+    expect(text).to.include('ASO Link');
+  });
+
   it('logs a warning and omits org lines when organization lookup throws', async () => {
     const site = makeSite([makeEnrollment('ASO', 'PLG')]);
     const context = makeContext({

--- a/test/support/plg-suggestion-alert.test.js
+++ b/test/support/plg-suggestion-alert.test.js
@@ -37,10 +37,16 @@ describe('sendLowSuggestionCountAlert', () => {
     }),
   });
 
-  const makeSite = (enrollments) => ({
+  const makeSite = (enrollments, organizationId = 'org-uuid-789') => ({
     getId: () => 'site-uuid-123',
     getBaseURL: () => 'https://example.com',
     getSiteEnrollments: sinon.stub().resolves(enrollments),
+    getOrganizationId: () => organizationId,
+  });
+
+  const makeOrganization = (imsOrgId = 'ims-org-abc', name = 'Acme Corp') => ({
+    getImsOrgId: () => imsOrgId,
+    getName: () => name,
   });
 
   const makeContext = (overrides = {}) => ({
@@ -52,6 +58,12 @@ describe('sendLowSuggestionCountAlert', () => {
     log: {
       warn: sandbox.stub(),
       error: sandbox.stub(),
+    },
+    dataAccess: {
+      Organization: {
+        findById: sandbox.stub().resolves(makeOrganization()),
+      },
+      ...overrides.dataAccess,
     },
   });
 
@@ -260,5 +272,46 @@ describe('sendLowSuggestionCountAlert', () => {
     const text = JSON.stringify(getPostedBody().blocks);
     expect(text).to.include('&lt;script&gt;bad&lt;/script&gt;');
     expect(text).to.not.include('<script>');
+  });
+
+  it('includes IMS org name and ASO link when organization is resolved', async () => {
+    const site = makeSite([makeEnrollment('ASO', 'PLG')]);
+    const context = makeContext();
+
+    await sendLowSuggestionCountAlert(site, 'cwv', 0, context);
+
+    expect(fetchStub).to.have.been.calledOnce;
+    expect(context.dataAccess.Organization.findById).to.have.been.calledWith('org-uuid-789');
+    const text = JSON.stringify(getPostedBody().blocks);
+    expect(text).to.include('IMS Org Name');
+    expect(text).to.include('Acme Corp');
+    expect(text).to.include('ims-org-abc');
+    expect(text).to.include('ASO Link');
+    expect(text).to.include('organizationId=org-uuid-789');
+    expect(text).to.include('/sites-optimizer/sites/site-uuid-123');
+  });
+
+  it('omits org/ASO lines when the site has no organizationId', async () => {
+    const site = makeSite([makeEnrollment('ASO', 'PLG')], null);
+    await sendLowSuggestionCountAlert(site, 'cwv', 0, makeContext());
+
+    expect(fetchStub).to.have.been.calledOnce;
+    const text = JSON.stringify(getPostedBody().blocks);
+    expect(text).to.not.include('IMS Org Name');
+    expect(text).to.not.include('ASO Link');
+  });
+
+  it('logs a warning and omits org lines when organization lookup throws', async () => {
+    const site = makeSite([makeEnrollment('ASO', 'PLG')]);
+    const context = makeContext({
+      dataAccess: { Organization: { findById: sandbox.stub().rejects(new Error('db down')) } },
+    });
+
+    await sendLowSuggestionCountAlert(site, 'cwv', 0, context);
+
+    expect(fetchStub).to.have.been.calledOnce;
+    const text = JSON.stringify(getPostedBody().blocks);
+    expect(text).to.not.include('IMS Org Name');
+    expect(context.log.warn).to.have.been.calledWithMatch('Failed to look up organization for low suggestion count alert');
   });
 });


### PR DESCRIPTION
## Summary
- Add the site's IMS org name and a direct ASO link to the PLG low-suggestion-count Slack alert (`sendLowSuggestionCountAlert`), matching the context already surfaced in the suggestion-skip alert in spacecat-api-service.

## Details
- New `getOrganizationDetails(site, context, log)` helper resolves `Organization` via `site.getOrganizationId()` → `dataAccess.Organization.findById()`, returning `{ organizationId, imsOrgId, orgName }`. Fails soft (logs a warning, omits the org lines) if the lookup throws.
- Message now includes `IMS Org Name`, `IMS Org ID`, and `ASO Link` lines (only when resolvable), in addition to the existing site/audit-type/suggestion-count/error fields.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```