### PR TITLE
feat(cutover): bow out of legacy canonical / meta-tags / broken-internal-links audits on deliveryConfig.<opp>Engine=blackboard

### DIFF
--- a/src/canonical/handler.js
+++ b/src/canonical/handler.js
@@ -27,6 +27,7 @@ import {
 } from '../utils/data-access.js';
 import { getMergedAuditInputUrls } from '../utils/audit-input-urls.js';
 import { convertToOpportunity } from '../common/opportunity.js';
+import { isBlackboardEngine } from '../common/delivery-engine.js';
 import { createOpportunityData, createOpportunityDataForElmo } from './opportunity-data-mapper.js';
 import { CANONICAL_CHECKS } from './constants.js';
 import { getObjectFromKey } from '../utils/s3-utils.js';
@@ -773,8 +774,16 @@ export async function processScrapedContent(context) {
 
   log.info(`[canonical] Generated ${sortedSuggestions.length} canonical suggestions for ${baseURL}`);
 
-  // Create opportunities and sync suggestions
-  if (sortedSuggestions.length > 0) {
+  // Per-site V1 -> V2 cutover (Spec 009-04 / ADR-0022): when the CANONICAL opportunity is
+  // owned by Mystique's blackboard producer cascade (deliveryConfig.canonicalEngine=blackboard),
+  // bow out of the legacy CANONICAL sync and resolve any pre-existing legacy CANONICAL
+  // opportunity so the flip strands no active rows. The Elmo generic-opportunity below is a
+  // separate surface and is intentionally left running.
+  if (isBlackboardEngine(site, 'canonicalEngine')) {
+    log.info(`[canonical] siteId: ${site.getId()} | bowing out of legacy CANONICAL sync — deliveryConfig.canonicalEngine=blackboard (Mystique-owned)`);
+    await resolveOpportunityIfNoIssues(site.getId(), auditType, context.dataAccess, log);
+  } else if (sortedSuggestions.length > 0) {
+    // Create opportunities and sync suggestions
     log.info(`[canonical] Creating canonical opportunity and syncing ${sortedSuggestions.length} suggestions`);
 
     const opportunity = await convertToOpportunity(

--- a/src/common/delivery-engine.js
+++ b/src/common/delivery-engine.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Per-site V1 -> V2 cutover: a site's opportunity is owned by the Mystique blackboard
+ * producer cascade — rather than this legacy audit — when its per-audit
+ * `deliveryConfig.<engineField>` is set to `"blackboard"` (Spec 009-04 / ADR-0022).
+ *
+ * Generalizes the CWV-specific `isCwvBlackboardEngine` (see `src/cwv/handler.js`, #2825)
+ * so any audit can gate on its own engine field (`canonicalEngine`, `metaTagsEngine`,
+ * `brokenInternalLinksEngine`, ...). Degrades to legacy on absent / null / any other
+ * value.
+ */
+export const BLACKBOARD_ENGINE = 'blackboard';
+
+/**
+ * @param {Object} site - Site with a `getDeliveryConfig()` accessor.
+ * @param {string} engineField - The per-audit deliveryConfig key, e.g. `"canonicalEngine"`.
+ * @returns {boolean} True when the flag selects the Mystique blackboard engine.
+ */
+export function isBlackboardEngine(site, engineField) {
+  return site?.getDeliveryConfig?.()?.[engineField] === BLACKBOARD_ENGINE;
+}

--- a/src/internal-links/opportunity-suggestions.js
+++ b/src/internal-links/opportunity-suggestions.js
@@ -13,11 +13,12 @@
 import { pickUrlsFromSerpResults } from '../support/bright-data-serp-urls.js';
 import { createInternalLinksConfigResolver } from './config.js';
 import { createInternalLinksStepLogger } from './logging.js';
-import { warnOnInvalidSuggestionData } from '../utils/data-access.js';
+import { warnOnInvalidSuggestionData, resolveOpportunityIfNoIssues } from '../utils/data-access.js';
 import { getMergedAuditInputUrls } from '../utils/audit-input-urls.js';
 import { loadScrapeResultPaths } from './batch-state.js';
 import { normalizeComparableUrl } from './link-key.js';
 import { isWithinAuditScope } from './subpath-filter.js';
+import { isBlackboardEngine } from '../common/delivery-engine.js';
 
 /**
  * Builds the crawl-coverage set for this run: the normalized set of source pages
@@ -107,6 +108,17 @@ export function createOpportunityAndSuggestionsStep({
     const reportedLinks = filteredBrokenInternalLinks.length > maxBrokenLinksReported
       ? filteredBrokenInternalLinks.slice(0, maxBrokenLinksReported)
       : filteredBrokenInternalLinks;
+
+    // Per-site V1 -> V2 cutover (Spec 009-04 / ADR-0022): when the BROKEN_INTERNAL_LINKS
+    // opportunity is owned by Mystique's blackboard producer cascade
+    // (deliveryConfig.brokenInternalLinksEngine=blackboard), bow out before creating the
+    // opportunity or dispatching to Mystique, and resolve any pre-existing legacy opportunity
+    // so the flip strands no active rows.
+    if (isBlackboardEngine(site, 'brokenInternalLinksEngine')) {
+      log.info('Bowing out — deliveryConfig.brokenInternalLinksEngine=blackboard (Mystique-owned); resolving any legacy opportunity, skipping create/dispatch');
+      await resolveOpportunityIfNoIssues(site.getId(), auditType, dataAccess, log);
+      return { status: 'complete', reportedBrokenLinks: reportedLinks };
+    }
 
     if (!success) {
       log.info('Audit failed, skipping suggestions generation');

--- a/src/metatags/handler.js
+++ b/src/metatags/handler.js
@@ -19,6 +19,7 @@ import SeoChecks from './seo-checks.js';
 import { AuditBuilder } from '../common/audit-builder.js';
 import { wwwUrlResolver } from '../common/index.js';
 import { convertToOpportunity } from '../common/opportunity.js';
+import { isBlackboardEngine } from '../common/delivery-engine.js';
 import { getIssueRanking, trimTagValue, normalizeTagValue } from '../utils/seo-utils.js';
 import { getBaseUrl } from '../utils/url-utils.js';
 import {
@@ -292,6 +293,18 @@ export async function runAuditAndGenerateSuggestions(context) {
 
   log.info(`[metatags] scrapeResultPaths for ${site.getId()}: ${JSON.stringify(scrapeResultPaths)}`);
   log.info(`[metatags] Start runAuditAndGenerateSuggestions step for: ${site.getId()}`);
+
+  // Per-site V1 -> V2 cutover (Spec 009-04 / ADR-0022): when the META_TAGS opportunity is
+  // owned by Mystique's blackboard producer cascade (deliveryConfig.metaTagsEngine=blackboard),
+  // bow out before detection / creation / Mystique dispatch and resolve any pre-existing legacy
+  // META_TAGS opportunity so the flip strands no active rows.
+  if (isBlackboardEngine(site, 'metaTagsEngine')) {
+    log.info(`[metatags] siteId: ${site.getId()} | bowing out — deliveryConfig.metaTagsEngine=blackboard (Mystique-owned); resolving any legacy meta-tags opportunity, skipping detection/creation/dispatch`);
+    await resolveOpportunityIfNoIssues(site.getId(), auditType, context.dataAccess, log);
+    return {
+      status: 'complete',
+    };
+  }
 
   const {
     seoChecks,

--- a/test/audits/canonical.test.js
+++ b/test/audits/canonical.test.js
@@ -2638,6 +2638,89 @@ describe('Canonical URL Tests', () => {
         expect(context.log.info).to.have.been.calledWith('[canonical] No scrapeResultPaths found for site test-site-id');
       });
 
+      it('bows out of legacy CANONICAL creation and resolves the legacy canonical opportunity when canonicalEngine=blackboard', async function () {
+        this.timeout(5000);
+        site.getDeliveryConfig = sinon.stub().returns({ canonicalEngine: 'blackboard' });
+
+        const scrapedContent = {
+          url: 'https://example.com/page1',
+          finalUrl: 'https://example.com/page1',
+          isPreview: false,
+          scrapeResult: {
+            canonical: {
+              exists: true, count: 1, href: 'https://example.com/other-page', inHead: true,
+            },
+            rawBody: createValidRawBody('<html><head><link rel="canonical" href="https://example.com/other-page"></head><body><p>Content for testing canonical URL validation.</p></body></html>'),
+          },
+        };
+        const mockGetObjectFromKey = sinon.stub().resolves(scrapedContent);
+
+        const legacyCanonicalOppty = {
+          getType: () => 'canonical',
+          getId: () => 'legacy-canonical-oppty',
+          setStatus: sinon.stub().resolves(),
+          setUpdatedBy: sinon.stub(),
+          save: sinon.stub().resolves(),
+          getSuggestions: sinon.stub().resolves([{ getStatus: () => 'NEW' }]),
+        };
+
+        const testContext = {
+          ...context,
+          site,
+          s3Client: {},
+          scrapeResultPaths: new Map([
+            ['https://example.com/page1', 'scrapes/job-id/page1/scrape.json'],
+          ]),
+          audit: { getId: () => 'test-audit-id' },
+          dataAccess: {
+            Opportunity: {
+              allBySiteId: sinon.stub().resolves([]),
+              allBySiteIdAndStatus: sinon.stub().resolves([legacyCanonicalOppty]),
+              create: sinon.stub().resolves({
+                getId: () => 'test-oppty-id',
+                getType: () => 'generic-opportunity',
+                getSuggestions: sinon.stub().resolves([]),
+                addSuggestions: sinon.stub().resolves({ createdItems: [] }),
+              }),
+            },
+            Suggestion: {
+              allByOpportunityId: sinon.stub().resolves([]),
+              createMany: sinon.stub().resolves([]),
+              removeMany: sinon.stub().resolves([]),
+              bulkUpdateStatus: sinon.stub().resolves(),
+            },
+          },
+        };
+
+        // Stub convertToOpportunity so the separate Elmo generic-opportunity path (which
+        // still runs after the CANONICAL bow-out) is inert here — this test asserts the
+        // bow-out cleanup, not opportunity construction. resolveOpportunityIfNoIssues
+        // (data-access.js) stays real.
+        const { processScrapedContent: processScrapedContentMocked } = await esmock(
+          '../../src/canonical/handler.js',
+          {
+            '../../src/utils/s3-utils.js': { getObjectFromKey: mockGetObjectFromKey },
+            '../../src/common/opportunity-utils.js': { checkGoogleConnection: sinon.stub().resolves(false) },
+            '../../src/common/opportunity.js': {
+              convertToOpportunity: sinon.stub().resolves({
+                getId: () => 'elmo-oppty',
+                getType: () => 'generic-opportunity',
+                getSuggestions: sinon.stub().resolves([]),
+                addSuggestions: sinon.stub().resolves({ createdItems: [] }),
+              }),
+            },
+          },
+        );
+
+        await processScrapedContentMocked(testContext);
+
+        // The bow-out log fires and the legacy CANONICAL opportunity is resolved — neither
+        // happens on the normal issues-present path (which would create the CANONICAL row).
+        expect(testContext.log.info).to.have.been.calledWithMatch('bowing out of legacy CANONICAL sync');
+        expect(legacyCanonicalOppty.setStatus).to.have.been.calledWith('RESOLVED');
+        expect(legacyCanonicalOppty.save).to.have.been.called;
+      });
+
       it('should process scraped content and detect canonical issues', async function () {
         this.timeout(5000);
         const scrapedContent = {

--- a/test/audits/internal-links/opportunity-suggestions-step.test.js
+++ b/test/audits/internal-links/opportunity-suggestions-step.test.js
@@ -127,6 +127,89 @@ describe('internal-links opportunity suggestions step', () => {
     expect(payload.data.brokenLinks[0].urlTo).to.equal('https://example.com/broken-link');
   });
 
+  it('bows out (no convertToOpportunity, no Mystique dispatch) and resolves the legacy opportunity when brokenInternalLinksEngine=blackboard', async () => {
+    const sqs = { sendMessage: sinon.stub().resolves() };
+    const convertToOpportunity = sinon.stub().resolves({
+      getId: () => 'oppty-1', getType: () => 'broken-internal-links',
+    });
+    const legacyOppty = {
+      getType: () => 'broken-internal-links',
+      getId: () => 'legacy-bil-oppty',
+      setStatus: sinon.stub().resolves(),
+      setUpdatedBy: sinon.stub(),
+      save: sinon.stub().resolves(),
+      getSuggestions: sinon.stub().resolves([{ getStatus: () => 'NEW' }]),
+    };
+    const bulkUpdateStatus = sinon.stub().resolves();
+
+    const step = createOpportunityAndSuggestionsStep({
+      auditType: 'broken-internal-links',
+      opptyStatuses: { NEW: 'NEW', RESOLVED: 'RESOLVED' },
+      suggestionStatuses: { NEW: 'NEW', OUTDATED: 'OUTDATED' },
+      isNonEmptyArray: (value) => Array.isArray(value) && value.length > 0,
+      createContextLogger: (log) => log,
+      calculateKpiDeltasForAudit: sinon.stub().returns({}),
+      convertToOpportunity,
+      createOpportunityData: sinon.stub(),
+      syncBrokenInternalLinksSuggestions: sinon.stub().resolves(),
+      filterByAuditScope: (pages) => pages,
+      extractPathPrefix: () => null,
+      isUnscrapeable: () => false,
+      filterBrokenSuggestedUrls: sinon.stub().resolves([]),
+      BrightDataClient: { createFrom: sinon.stub() },
+      buildLocaleSearchUrl: sinon.stub(),
+      sleep: sinon.stub().resolves(),
+      updateAuditResult: sinon.stub().resolves(),
+      isCanonicalOrHreflangLink: () => false,
+    });
+
+    const context = {
+      log: {
+        info: sinon.stub(), warn: sinon.stub(), error: sinon.stub(), debug: sinon.stub(),
+      },
+      site: {
+        getId: () => 'site-1',
+        getBaseURL: () => 'https://example.com',
+        getDeliveryType: () => 'aem_edge',
+        getDeliveryConfig: () => ({ brokenInternalLinksEngine: 'blackboard' }),
+        getConfig: () => ({
+          getHandlers: () => ({ 'broken-internal-links': { config: { mystiqueItemTypes: ['link'] } } }),
+          getIncludedURLs: () => [],
+        }),
+      },
+      finalUrl: 'https://example.com',
+      sqs,
+      env: {},
+      dataAccess: {
+        Opportunity: { allBySiteIdAndStatus: sinon.stub().resolves([legacyOppty]) },
+        Suggestion: { bulkUpdateStatus },
+      },
+      audit: {
+        getId: () => 'audit-1',
+        getAuditResult: () => ({
+          brokenInternalLinks: [
+            { urlFrom: 'https://example.com/source', urlTo: 'https://example.com/broken-link', itemType: 'link' },
+          ],
+          success: true,
+        }),
+      },
+      updatedAuditResult: {
+        brokenInternalLinks: [
+          { urlFrom: 'https://example.com/source', urlTo: 'https://example.com/broken-link', itemType: 'link' },
+        ],
+        success: true,
+      },
+    };
+
+    const result = await step(context);
+
+    expect(result.status).to.equal('complete');
+    expect(convertToOpportunity.called).to.equal(false);
+    expect(sqs.sendMessage.called).to.equal(false);
+    expect(context.dataAccess.Opportunity.allBySiteIdAndStatus.calledWith('site-1', 'NEW')).to.equal(true);
+    expect(bulkUpdateStatus.calledOnce).to.equal(true);
+  });
+
   it('treats missing itemType as link for Mystique filtering', async () => {
     const sqs = { sendMessage: sinon.stub().resolves() };
     const opportunity = {

--- a/test/common/delivery-engine.test.js
+++ b/test/common/delivery-engine.test.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect } from 'chai';
+import { BLACKBOARD_ENGINE, isBlackboardEngine } from '../../src/common/delivery-engine.js';
+
+const siteWith = (deliveryConfig) => ({ getDeliveryConfig: () => deliveryConfig });
+
+describe('delivery-engine — isBlackboardEngine', () => {
+  it('is true only when the requested field equals "blackboard"', () => {
+    expect(isBlackboardEngine(siteWith({ canonicalEngine: 'blackboard' }), 'canonicalEngine')).to.be.true;
+  });
+
+  it('is false for legacy / absent / any other value (degrades to legacy)', () => {
+    expect(isBlackboardEngine(siteWith({ canonicalEngine: 'legacy' }), 'canonicalEngine')).to.be.false;
+    expect(isBlackboardEngine(siteWith({ canonicalEngine: 'v2' }), 'canonicalEngine')).to.be.false;
+    expect(isBlackboardEngine(siteWith({ canonicalEngine: null }), 'canonicalEngine')).to.be.false;
+    expect(isBlackboardEngine(siteWith({}), 'canonicalEngine')).to.be.false;
+  });
+
+  it('checks the requested field independently of sibling engine keys', () => {
+    const site = siteWith({ cwvEngine: 'blackboard', canonicalEngine: 'legacy' });
+    expect(isBlackboardEngine(site, 'cwvEngine')).to.be.true;
+    expect(isBlackboardEngine(site, 'canonicalEngine')).to.be.false;
+    expect(isBlackboardEngine(site, 'metaTagsEngine')).to.be.false;
+  });
+
+  it('degrades safely when the site or its deliveryConfig is missing', () => {
+    expect(isBlackboardEngine(undefined, 'canonicalEngine')).to.be.false;
+    expect(isBlackboardEngine({}, 'canonicalEngine')).to.be.false;
+    expect(isBlackboardEngine({ getDeliveryConfig: () => undefined }, 'canonicalEngine')).to.be.false;
+  });
+
+  it('exposes the shared blackboard constant', () => {
+    expect(BLACKBOARD_ENGINE).to.equal('blackboard');
+  });
+});

--- a/test/metatags/metatags.test.js
+++ b/test/metatags/metatags.test.js
@@ -41,10 +41,72 @@ import {
   fetchAndProcessPageObject,
   opportunityAndSuggestions,
   buildKey,
+  runAuditAndGenerateSuggestions,
 } from '../../src/metatags/handler.js';
 
 use(sinonChai);
 use(chaiAsPromised);
+
+describe('Meta Tags — blackboard bow-out (Spec 009-04 / ADR-0022)', () => {
+  let sandbox;
+  let site;
+  let dataAccess;
+  let context;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    const newSuggestion = { getStatus: () => 'NEW' };
+    const legacyOppty = {
+      getType: () => 'meta-tags',
+      getId: () => 'legacy-meta-oppty',
+      setStatus: sandbox.stub().resolves(),
+      setUpdatedBy: sandbox.stub(),
+      save: sandbox.stub().resolves(),
+      getSuggestions: sandbox.stub().resolves([newSuggestion]),
+    };
+    dataAccess = {
+      Opportunity: {
+        allBySiteIdAndStatus: sandbox.stub().resolves([legacyOppty]),
+        create: sandbox.stub().resolves({}),
+      },
+      Suggestion: { bulkUpdateStatus: sandbox.stub().resolves() },
+    };
+    site = {
+      getId: () => 'site-id',
+      getBaseURL: () => 'https://example.com',
+      getDeliveryConfig: sandbox.stub().returns({ metaTagsEngine: 'blackboard' }),
+    };
+    context = {
+      site,
+      audit: { getId: () => 'audit-id' },
+      finalUrl: 'https://example.com',
+      scrapeResultPaths: new Map(),
+      log: {
+        info: sandbox.stub(), debug: sandbox.stub(), error: sandbox.stub(), warn: sandbox.stub(),
+      },
+      sqs: { sendMessage: sandbox.stub().resolves() },
+      env: { QUEUE_SPACECAT_TO_MYSTIQUE: 'q' },
+      dataAccess,
+    };
+  });
+
+  afterEach(() => sandbox.restore());
+
+  it('creates no opportunity, sends no Mystique message, and returns complete when metaTagsEngine=blackboard', async () => {
+    const result = await runAuditAndGenerateSuggestions(context);
+
+    expect(result).to.deep.equal({ status: 'complete' });
+    expect(dataAccess.Opportunity.create).to.not.have.been.called;
+    expect(context.sqs.sendMessage).to.not.have.been.called;
+  });
+
+  it('resolves the pre-existing legacy meta-tags opportunity and outdates only its live suggestions', async () => {
+    await runAuditAndGenerateSuggestions(context);
+
+    expect(dataAccess.Opportunity.allBySiteIdAndStatus).to.have.been.calledWith('site-id', 'NEW');
+    expect(dataAccess.Suggestion.bulkUpdateStatus).to.have.been.calledOnce;
+  });
+});
 
 describe('Meta Tags', () => {
   describe('SeoChecks', () => {


### PR DESCRIPTION
## What

Generalizes the CWV per-site V1→V2 cutover bow-out (#2825) to three more legacy audits: **canonical**, **meta-tags**, and **broken-internal-links**.

When a site's opportunity is owned by Mystique's blackboard producer cascade — i.e. its per-audit `deliveryConfig.<opp>Engine` is `"blackboard"` — the legacy audit now **bows out**:
- creates no SpaceCat opportunity / suggestion and sends no Mystique message, and
- resolves the pre-existing legacy opportunity and outdates its live (NEW/PENDING) suggestions, via the shared `resolveOpportunityIfNoIssues` helper,

returning the step's normal clean-completion shape. Absent / `"legacy"` / any other value is unchanged (default legacy path).

New shared helper `src/common/delivery-engine.js#isBlackboardEngine(site, engineField)` generalizes `cwv/handler.js#isCwvBlackboardEngine` so any audit can gate on its own engine field. `deliveryConfig` is `type: 'any'`, so **no schema change** is needed.

| Audit | Engine field | Guard location |
|---|---|---|
| canonical | `canonicalEngine` | `processScrapedContent` — gates the CANONICAL opportunity; the separate Elmo `generic-opportunity` is intentionally left running |
| meta-tags (`META_TAGS`) | `metaTagsEngine` | top of `runAuditAndGenerateSuggestions`, before detection / creation / Mystique dispatch. `product-metatags` is **not** gated (no Mystique V2 equivalent) |
| broken-internal-links | `brokenInternalLinksEngine` | top of the opportunity-and-suggestions step, before create + Mystique dispatch |

## Why

Both the legacy audit and Mystique's blackboard cascade write the same SpaceCat `type` opportunity + suggestion rows; if both run for one site they collide (a second null-scoped opportunity, disjoint suggestion keys). A collision-free per-site cutover needs the legacy source to stop writing — the same rationale as #2825 (Spec 009-04 / ADR-0022). Mystique already writes these `<opp>Engine` flags to `deliveryConfig`, but only CWV honored them; this closes the gap for canonical / meta-tags / broken-internal-links.

## Testing

- New `test/common/delivery-engine.test.js` — the helper (true only for `"blackboard"`; degrades to legacy for absent / `"legacy"` / other; per-field independence; null-safe).
- Per-audit bow-out cases in `canonical.test.js`, `metatags.test.js`, and `internal-links/opportunity-suggestions-step.test.js`: assert no opportunity create, no Mystique dispatch, and that the pre-existing legacy opportunity is resolved + its live suggestions outdated.
- All four new test groups pass locally.

> Note: the existing `canonical` / `metatags` suites show some failures on a stale local `node_modules` vs this branch's `main` (`Oppty.SCOPE_TYPES` undefined) — they reproduce on **untouched** tests and are unrelated to this change; `npm ci` in CI resolves them.

## Mystique follow-up (separate repo/PR)

Mystique's cutover panel already writes these flags. Once this deploys, the panel's `audit_honors` for these three opportunities flips `NOT_YET → FULL` (grey → green "stops V1"); until then it honestly reports `inert_pending_spacecat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Lucian Felix Ghita", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```