### PR TITLE
fix(loffsite): audit_housekeeping_end fires after both cleanups (LLMO-6973)

### DIFF
--- a/src/cited-analysis/guidance-handler.js
+++ b/src/cited-analysis/guidance-handler.js
@@ -37,6 +37,7 @@ import {
 import {
   deleteExpiredSnapshots,
   deleteExpiredOutdatedSuggestions,
+  logHousekeepingSummary,
 } from '../common/offsite-retention.js';
 
 const AUDIT_TYPE = Audit.AUDIT_TYPES.CITED_ANALYSIS;
@@ -261,26 +262,9 @@ export default async function handler(message, context) {
       });
     }
 
-    const housekeepingHadFailure = suggestionsErrored || snapshotsErrored
-      || suggestionsSummary.failed > 0;
-    const housekeepingSummaryFields = {
-      peer: PEER.POSTGRES,
-      direction: 'outbound',
-      auditType,
-      suggestionsScanned: suggestionsSummary.scanned,
-      suggestionsEligible: suggestionsSummary.eligible,
-      suggestionsDeleted: suggestionsSummary.deleted,
-      suggestionsFailed: suggestionsSummary.failed,
-      snapshotsEligible: snapshotsSummary.eligible,
-      snapshotsDeleted: snapshotsSummary.deleted,
-    };
-    if (housekeepingHadFailure) {
-      ologOpp.warn('audit_housekeeping_end', 'Housekeeping cleanup summary', {
-        ...housekeepingSummaryFields, reason: 'partial_cleanup_failure', outcome: OUTCOME.DEGRADED,
-      });
-    } else {
-      ologOpp.success('audit_housekeeping_end', 'Housekeeping cleanup summary', housekeepingSummaryFields);
-    }
+    logHousekeepingSummary(ologOpp, {
+      auditType, suggestionsSummary, snapshotsSummary, suggestionsErrored, snapshotsErrored,
+    });
 
     if (auditId) {
       const auditRecord = await AuditModel.findById(auditId);

--- a/src/cited-analysis/guidance-handler.js
+++ b/src/cited-analysis/guidance-handler.js
@@ -232,25 +232,54 @@ export default async function handler(message, context) {
     ologOpp.start('audit_housekeeping_start', 'Housekeeping started');
 
     // Expired suggestion deletion must not fail an otherwise successful refresh.
+    let suggestionsSummary = {
+      scanned: 0, eligible: 0, deleted: 0, failed: 0,
+    };
+    let suggestionsErrored = false;
     try {
-      await deleteExpiredOutdatedSuggestions({
+      suggestionsSummary = await deleteExpiredOutdatedSuggestions({
         dataAccess, opportunity, siteId, auditType, log,
       });
     } catch (error) {
+      suggestionsErrored = true;
       ologOpp.warn('audit_housekeeping_outdated_suggestions_deleted', 'OUTDATED suggestion deletion failed', {
         peer: PEER.POSTGRES, direction: 'outbound', auditType, outcome: OUTCOME.DEGRADED, ...errorField(error),
       });
     }
 
     // Expired snapshot deletion must not fail an otherwise successful refresh.
+    let snapshotsSummary = { eligible: 0, deleted: 0 };
+    let snapshotsErrored = false;
     try {
-      await deleteExpiredSnapshots({
+      snapshotsSummary = await deleteExpiredSnapshots({
         dataAccess, siteId, auditType, log,
       });
     } catch (error) {
+      snapshotsErrored = true;
       ologOpp.warn('audit_housekeeping_outdated_opportunities_deleted', 'Snapshot retention failed', {
         peer: PEER.POSTGRES, direction: 'outbound', auditType, outcome: OUTCOME.DEGRADED, ...errorField(error),
       });
+    }
+
+    const housekeepingHadFailure = suggestionsErrored || snapshotsErrored
+      || suggestionsSummary.failed > 0;
+    const housekeepingSummaryFields = {
+      peer: PEER.POSTGRES,
+      direction: 'outbound',
+      auditType,
+      suggestionsScanned: suggestionsSummary.scanned,
+      suggestionsEligible: suggestionsSummary.eligible,
+      suggestionsDeleted: suggestionsSummary.deleted,
+      suggestionsFailed: suggestionsSummary.failed,
+      snapshotsEligible: snapshotsSummary.eligible,
+      snapshotsDeleted: snapshotsSummary.deleted,
+    };
+    if (housekeepingHadFailure) {
+      ologOpp.warn('audit_housekeeping_end', 'Housekeeping cleanup summary', {
+        ...housekeepingSummaryFields, reason: 'partial_cleanup_failure', outcome: OUTCOME.DEGRADED,
+      });
+    } else {
+      ologOpp.success('audit_housekeeping_end', 'Housekeeping cleanup summary', housekeepingSummaryFields);
     }
 
     if (auditId) {

--- a/src/common/offsite-retention.js
+++ b/src/common/offsite-retention.js
@@ -92,7 +92,7 @@ export async function deleteExpiredSnapshots({
     olog.warn('audit_housekeeping_outdated_opportunities_deleted', 'No expired snapshots eligible for deletion', {
       auditType, eligible: 0, outcome: OUTCOME.SKIP,
     });
-    return 0;
+    return { eligible: 0, deleted: 0 };
   }
 
   const suggestionIds = [];
@@ -114,7 +114,7 @@ export async function deleteExpiredSnapshots({
     peer: PEER.POSTGRES, direction: 'outbound', auditType, eligible: allExpiredSnapshots.length, deleted: snapshotIds.length,
   });
 
-  return snapshotIds.length;
+  return { eligible: allExpiredSnapshots.length, deleted: snapshotIds.length };
 }
 
 export const OUTDATED_SUGGESTION_RETENTION_DAYS = 30;
@@ -212,23 +212,6 @@ export async function deleteExpiredOutdatedSuggestions({
     eligible: expiredOutdatedSuggestions.length,
     ...deletionTotals,
   };
-
-  const summaryFields = {
-    peer: PEER.POSTGRES,
-    direction: 'outbound',
-    auditType,
-    scanned: retentionSummary.scanned,
-    eligible: retentionSummary.eligible,
-    deleted: retentionSummary.deleted,
-    failed: retentionSummary.failed,
-  };
-  if (retentionSummary.failed > 0) {
-    olog.warn('audit_housekeeping_end', 'Expired OUTDATED suggestion deletion summary', {
-      ...summaryFields, reason: 'partial_delete_failure', outcome: OUTCOME.DEGRADED,
-    });
-  } else {
-    olog.success('audit_housekeeping_end', 'Expired OUTDATED suggestion deletion summary', summaryFields);
-  }
 
   return retentionSummary;
 }

--- a/src/common/offsite-retention.js
+++ b/src/common/offsite-retention.js
@@ -215,3 +215,37 @@ export async function deleteExpiredOutdatedSuggestions({
 
   return retentionSummary;
 }
+
+/**
+ * Emits the combined `audit_housekeeping_end` summary for the two retention cleanups
+ * (expired OUTDATED suggestions + expired snapshots) run by each offsite guidance handler.
+ * Escalates to warn/degraded when either cleanup threw (suggestionsErrored/snapshotsErrored)
+ * or when suggestion deletion resolved normally but reported a per-batch failure
+ * (suggestionsSummary.failed > 0).
+ */
+export function logHousekeepingSummary(olog, {
+  auditType, suggestionsSummary, snapshotsSummary, suggestionsErrored, snapshotsErrored,
+}) {
+  const housekeepingHadFailure = suggestionsErrored || snapshotsErrored
+    || suggestionsSummary.failed > 0;
+  const summaryFields = {
+    peer: PEER.POSTGRES,
+    direction: 'outbound',
+    auditType,
+    suggestionsScanned: suggestionsSummary.scanned,
+    suggestionsEligible: suggestionsSummary.eligible,
+    suggestionsDeleted: suggestionsSummary.deleted,
+    suggestionsFailed: suggestionsSummary.failed,
+    snapshotsEligible: snapshotsSummary.eligible,
+    snapshotsDeleted: snapshotsSummary.deleted,
+  };
+  if (housekeepingHadFailure) {
+    olog.warn('audit_housekeeping_end', 'Housekeeping cleanup summary', {
+      ...summaryFields, reason: 'partial_cleanup_failure', outcome: OUTCOME.DEGRADED,
+    });
+  } else {
+    olog.success('audit_housekeeping_end', 'Housekeeping cleanup summary', {
+      ...summaryFields, outcome: OUTCOME.SUCCESS,
+    });
+  }
+}

--- a/src/reddit-analysis/guidance-handler.js
+++ b/src/reddit-analysis/guidance-handler.js
@@ -37,6 +37,7 @@ import {
 import {
   deleteExpiredSnapshots,
   deleteExpiredOutdatedSuggestions,
+  logHousekeepingSummary,
 } from '../common/offsite-retention.js';
 
 const AUDIT_TYPE = Audit.AUDIT_TYPES.REDDIT_ANALYSIS;
@@ -262,26 +263,9 @@ export default async function handler(message, context) {
       });
     }
 
-    const housekeepingHadFailure = suggestionsErrored || snapshotsErrored
-      || suggestionsSummary.failed > 0;
-    const housekeepingSummaryFields = {
-      peer: PEER.POSTGRES,
-      direction: 'outbound',
-      auditType,
-      suggestionsScanned: suggestionsSummary.scanned,
-      suggestionsEligible: suggestionsSummary.eligible,
-      suggestionsDeleted: suggestionsSummary.deleted,
-      suggestionsFailed: suggestionsSummary.failed,
-      snapshotsEligible: snapshotsSummary.eligible,
-      snapshotsDeleted: snapshotsSummary.deleted,
-    };
-    if (housekeepingHadFailure) {
-      ologOpp.warn('audit_housekeeping_end', 'Housekeeping cleanup summary', {
-        ...housekeepingSummaryFields, reason: 'partial_cleanup_failure', outcome: OUTCOME.DEGRADED,
-      });
-    } else {
-      ologOpp.success('audit_housekeeping_end', 'Housekeeping cleanup summary', housekeepingSummaryFields);
-    }
+    logHousekeepingSummary(ologOpp, {
+      auditType, suggestionsSummary, snapshotsSummary, suggestionsErrored, snapshotsErrored,
+    });
 
     if (auditId) {
       const auditRecord = await AuditModel.findById(auditId);

--- a/src/reddit-analysis/guidance-handler.js
+++ b/src/reddit-analysis/guidance-handler.js
@@ -233,25 +233,54 @@ export default async function handler(message, context) {
     ologOpp.start('audit_housekeeping_start', 'Housekeeping started');
 
     // Expired suggestion deletion must not fail an otherwise successful refresh.
+    let suggestionsSummary = {
+      scanned: 0, eligible: 0, deleted: 0, failed: 0,
+    };
+    let suggestionsErrored = false;
     try {
-      await deleteExpiredOutdatedSuggestions({
+      suggestionsSummary = await deleteExpiredOutdatedSuggestions({
         dataAccess, opportunity, siteId, auditType, log,
       });
     } catch (error) {
+      suggestionsErrored = true;
       ologOpp.warn('audit_housekeeping_outdated_suggestions_deleted', 'OUTDATED suggestion deletion failed', {
         peer: PEER.POSTGRES, direction: 'outbound', auditType, outcome: OUTCOME.DEGRADED, ...errorField(error),
       });
     }
 
     // Expired snapshot deletion must not fail an otherwise successful refresh.
+    let snapshotsSummary = { eligible: 0, deleted: 0 };
+    let snapshotsErrored = false;
     try {
-      await deleteExpiredSnapshots({
+      snapshotsSummary = await deleteExpiredSnapshots({
         dataAccess, siteId, auditType, log,
       });
     } catch (error) {
+      snapshotsErrored = true;
       ologOpp.warn('audit_housekeeping_outdated_opportunities_deleted', 'Snapshot retention failed', {
         peer: PEER.POSTGRES, direction: 'outbound', auditType, outcome: OUTCOME.DEGRADED, ...errorField(error),
       });
+    }
+
+    const housekeepingHadFailure = suggestionsErrored || snapshotsErrored
+      || suggestionsSummary.failed > 0;
+    const housekeepingSummaryFields = {
+      peer: PEER.POSTGRES,
+      direction: 'outbound',
+      auditType,
+      suggestionsScanned: suggestionsSummary.scanned,
+      suggestionsEligible: suggestionsSummary.eligible,
+      suggestionsDeleted: suggestionsSummary.deleted,
+      suggestionsFailed: suggestionsSummary.failed,
+      snapshotsEligible: snapshotsSummary.eligible,
+      snapshotsDeleted: snapshotsSummary.deleted,
+    };
+    if (housekeepingHadFailure) {
+      ologOpp.warn('audit_housekeeping_end', 'Housekeeping cleanup summary', {
+        ...housekeepingSummaryFields, reason: 'partial_cleanup_failure', outcome: OUTCOME.DEGRADED,
+      });
+    } else {
+      ologOpp.success('audit_housekeeping_end', 'Housekeeping cleanup summary', housekeepingSummaryFields);
     }
 
     if (auditId) {

--- a/src/youtube-analysis/guidance-handler.js
+++ b/src/youtube-analysis/guidance-handler.js
@@ -231,25 +231,54 @@ export default async function handler(message, context) {
     ologOpp.start('audit_housekeeping_start', 'Housekeeping started', {});
 
     // Expired suggestion deletion must not fail an otherwise successful refresh.
+    let suggestionsSummary = {
+      scanned: 0, eligible: 0, deleted: 0, failed: 0,
+    };
+    let suggestionsErrored = false;
     try {
-      await deleteExpiredOutdatedSuggestions({
+      suggestionsSummary = await deleteExpiredOutdatedSuggestions({
         dataAccess, opportunity, siteId, auditType, log,
       });
     } catch (error) {
+      suggestionsErrored = true;
       ologOpp.warn('audit_housekeeping_outdated_suggestions_deleted', 'OUTDATED suggestion deletion failed', {
         peer: PEER.POSTGRES, direction: 'outbound', auditType, outcome: OUTCOME.DEGRADED, ...errorField(error),
       });
     }
 
     // Expired snapshot deletion must not fail an otherwise successful refresh.
+    let snapshotsSummary = { eligible: 0, deleted: 0 };
+    let snapshotsErrored = false;
     try {
-      await deleteExpiredSnapshots({
+      snapshotsSummary = await deleteExpiredSnapshots({
         dataAccess, siteId, auditType, log,
       });
     } catch (error) {
+      snapshotsErrored = true;
       ologOpp.warn('audit_housekeeping_outdated_opportunities_deleted', 'Snapshot retention failed', {
         peer: PEER.POSTGRES, direction: 'outbound', auditType, outcome: OUTCOME.DEGRADED, ...errorField(error),
       });
+    }
+
+    const housekeepingHadFailure = suggestionsErrored || snapshotsErrored
+      || suggestionsSummary.failed > 0;
+    const housekeepingSummaryFields = {
+      peer: PEER.POSTGRES,
+      direction: 'outbound',
+      auditType,
+      suggestionsScanned: suggestionsSummary.scanned,
+      suggestionsEligible: suggestionsSummary.eligible,
+      suggestionsDeleted: suggestionsSummary.deleted,
+      suggestionsFailed: suggestionsSummary.failed,
+      snapshotsEligible: snapshotsSummary.eligible,
+      snapshotsDeleted: snapshotsSummary.deleted,
+    };
+    if (housekeepingHadFailure) {
+      ologOpp.warn('audit_housekeeping_end', 'Housekeeping cleanup summary', {
+        ...housekeepingSummaryFields, reason: 'partial_cleanup_failure', outcome: OUTCOME.DEGRADED,
+      });
+    } else {
+      ologOpp.success('audit_housekeeping_end', 'Housekeeping cleanup summary', housekeepingSummaryFields);
     }
 
     if (auditId) {

--- a/src/youtube-analysis/guidance-handler.js
+++ b/src/youtube-analysis/guidance-handler.js
@@ -35,6 +35,7 @@ import {
 import {
   deleteExpiredSnapshots,
   deleteExpiredOutdatedSuggestions,
+  logHousekeepingSummary,
 } from '../common/offsite-retention.js';
 
 const AUDIT_TYPE = Audit.AUDIT_TYPES.YOUTUBE_ANALYSIS;
@@ -260,26 +261,9 @@ export default async function handler(message, context) {
       });
     }
 
-    const housekeepingHadFailure = suggestionsErrored || snapshotsErrored
-      || suggestionsSummary.failed > 0;
-    const housekeepingSummaryFields = {
-      peer: PEER.POSTGRES,
-      direction: 'outbound',
-      auditType,
-      suggestionsScanned: suggestionsSummary.scanned,
-      suggestionsEligible: suggestionsSummary.eligible,
-      suggestionsDeleted: suggestionsSummary.deleted,
-      suggestionsFailed: suggestionsSummary.failed,
-      snapshotsEligible: snapshotsSummary.eligible,
-      snapshotsDeleted: snapshotsSummary.deleted,
-    };
-    if (housekeepingHadFailure) {
-      ologOpp.warn('audit_housekeeping_end', 'Housekeeping cleanup summary', {
-        ...housekeepingSummaryFields, reason: 'partial_cleanup_failure', outcome: OUTCOME.DEGRADED,
-      });
-    } else {
-      ologOpp.success('audit_housekeeping_end', 'Housekeeping cleanup summary', housekeepingSummaryFields);
-    }
+    logHousekeepingSummary(ologOpp, {
+      auditType, suggestionsSummary, snapshotsSummary, suggestionsErrored, snapshotsErrored,
+    });
 
     if (auditId) {
       const audit = await AuditModel.findById(auditId);

--- a/test/audits/cited-analysis/guidance-handler.test.js
+++ b/test/audits/cited-analysis/guidance-handler.test.js
@@ -1886,10 +1886,72 @@ describe('Cited Analysis Guidance Handler', () => {
       const result = await handler.default(validMessage(), context);
 
       expect(result.status).to.equal(200);
+      // suggestionsErrored is true because the cleanup threw, so the summary fields for
+      // suggestions fall back to the zero-defaults set before the try/catch, not any partial
+      // values from the (rejected) promise; snapshots resolved normally with its own zeros.
       expect(context.log.warn).to.have.been.calledWith(
         sinon.match(/event=audit_housekeeping_end/)
           .and(sinon.match(/outcome=degraded/))
-          .and(sinon.match(/reason=partial_cleanup_failure/)),
+          .and(sinon.match(/reason=partial_cleanup_failure/))
+          .and(sinon.match(/suggestionsScanned=0/))
+          .and(sinon.match(/suggestionsEligible=0/))
+          .and(sinon.match(/suggestionsDeleted=0/))
+          .and(sinon.match(/suggestionsFailed=0/))
+          .and(sinon.match(/snapshotsEligible=0/))
+          .and(sinon.match(/snapshotsDeleted=0/)),
+      );
+    });
+
+    it('escalates to degraded independently via snapshotsErrored when snapshot cleanup throws (suggestions succeed normally)', async () => {
+      deleteExpiredOutdatedSuggestionsStub.resolves({
+        scanned: 4, eligible: 1, deleted: 1, failed: 0,
+      });
+      deleteExpiredSnapshotsStub.rejects(new Error('snapshot cleanup blew up'));
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus: sandbox.stub().resolves([]) };
+
+      const result = await handler.default(validMessage(), context);
+
+      expect(result.status).to.equal(200);
+      // snapshotsErrored is true because the cleanup threw, so the summary fields for
+      // snapshots fall back to the zero-defaults; suggestions resolved normally with no
+      // failures, distinct from the already-tested "suggestions throws" path above.
+      expect(context.log.warn).to.have.been.calledWith(
+        sinon.match(/event=audit_housekeeping_end/)
+          .and(sinon.match(/outcome=degraded/))
+          .and(sinon.match(/reason=partial_cleanup_failure/))
+          .and(sinon.match(/suggestionsScanned=4/))
+          .and(sinon.match(/suggestionsEligible=1/))
+          .and(sinon.match(/suggestionsDeleted=1/))
+          .and(sinon.match(/suggestionsFailed=0/))
+          .and(sinon.match(/snapshotsEligible=0/))
+          .and(sinon.match(/snapshotsDeleted=0/)),
+      );
+    });
+
+    it('escalates to degraded when suggestion cleanup resolves normally but reports a per-batch failure (failed > 0)', async () => {
+      // This exercises the suggestionsSummary.failed > 0 branch of housekeepingHadFailure,
+      // independent of the suggestionsErrored/exception path above: deleteExpiredOutdatedSuggestions
+      // resolves normally (no throw) but its own returned summary reports a nonzero failed count
+      // (a per-batch delete failure caught inside that function).
+      deleteExpiredOutdatedSuggestionsStub.resolves({
+        scanned: 10, eligible: 4, deleted: 2, failed: 2,
+      });
+      deleteExpiredSnapshotsStub.resolves({ eligible: 0, deleted: 0 });
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus: sandbox.stub().resolves([]) };
+
+      const result = await handler.default(validMessage(), context);
+
+      expect(result.status).to.equal(200);
+      expect(context.log.warn).to.have.been.calledWith(
+        sinon.match(/event=audit_housekeeping_end/)
+          .and(sinon.match(/outcome=degraded/))
+          .and(sinon.match(/reason=partial_cleanup_failure/))
+          .and(sinon.match(/suggestionsScanned=10/))
+          .and(sinon.match(/suggestionsEligible=4/))
+          .and(sinon.match(/suggestionsDeleted=2/))
+          .and(sinon.match(/suggestionsFailed=2/))
+          .and(sinon.match(/snapshotsEligible=0/))
+          .and(sinon.match(/snapshotsDeleted=0/)),
       );
     });
 

--- a/test/audits/cited-analysis/guidance-handler.test.js
+++ b/test/audits/cited-analysis/guidance-handler.test.js
@@ -140,7 +140,7 @@ describe('Cited Analysis Guidance Handler', () => {
       }
       return { opportunityData, opportunityToUpdate: evergreenOpportunity };
     });
-    deleteExpiredSnapshotsStub = sandbox.stub().resolves(0);
+    deleteExpiredSnapshotsStub = sandbox.stub().resolves({ eligible: 0, deleted: 0 });
     deleteExpiredOutdatedSuggestionsStub = sandbox.stub().resolves({
       scanned: 0, eligible: 0, deleted: 0, failed: 0,
     });
@@ -1851,6 +1851,46 @@ describe('Cited Analysis Guidance Handler', () => {
       expect(deleteExpiredOutdatedSuggestionsStub).to.have.been.calledAfter(syncSuggestionsStub);
       expect(deleteExpiredOutdatedSuggestionsStub)
         .to.have.been.calledBefore(deleteExpiredSnapshotsStub);
+    });
+
+    it('emits a single combined audit_housekeeping_end summary after both cleanups resolve', async () => {
+      deleteExpiredOutdatedSuggestionsStub.resolves({
+        scanned: 5, eligible: 3, deleted: 3, failed: 0,
+      });
+      deleteExpiredSnapshotsStub.resolves({ eligible: 2, deleted: 2 });
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus: sandbox.stub().resolves([]) };
+
+      const result = await handler.default(validMessage(), context);
+
+      expect(result.status).to.equal(200);
+      expect(context.log.info).to.have.been.calledWith(
+        sinon.match(/event=audit_housekeeping_end/)
+          .and(sinon.match(/outcome=success/))
+          .and(sinon.match(/suggestionsScanned=5/))
+          .and(sinon.match(/suggestionsEligible=3/))
+          .and(sinon.match(/suggestionsDeleted=3/))
+          .and(sinon.match(/suggestionsFailed=0/))
+          .and(sinon.match(/snapshotsEligible=2/))
+          .and(sinon.match(/snapshotsDeleted=2/)),
+      );
+      // The combined summary is logged only after both cleanups have resolved.
+      expect(deleteExpiredSnapshotsStub).to.have.been.calledOnce;
+      expect(deleteExpiredOutdatedSuggestionsStub).to.have.been.calledOnce;
+    });
+
+    it('emits a degraded audit_housekeeping_end summary when suggestion cleanup fails', async () => {
+      deleteExpiredOutdatedSuggestionsStub.rejects(new Error('sugg cleanup blew up'));
+      deleteExpiredSnapshotsStub.resolves({ eligible: 0, deleted: 0 });
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus: sandbox.stub().resolves([]) };
+
+      const result = await handler.default(validMessage(), context);
+
+      expect(result.status).to.equal(200);
+      expect(context.log.warn).to.have.been.calledWith(
+        sinon.match(/event=audit_housekeeping_end/)
+          .and(sinon.match(/outcome=degraded/))
+          .and(sinon.match(/reason=partial_cleanup_failure/)),
+      );
     });
 
     it('does NOT run retention when the handler returns before a successful sync', async () => {

--- a/test/audits/reddit-analysis/guidance-handler.test.js
+++ b/test/audits/reddit-analysis/guidance-handler.test.js
@@ -136,7 +136,7 @@ describe('Reddit Analysis Guidance Handler', () => {
       }
       return { opportunityData, opportunityToUpdate: evergreenOpportunity };
     });
-    deleteExpiredSnapshotsStub = sandbox.stub().resolves(0);
+    deleteExpiredSnapshotsStub = sandbox.stub().resolves({ eligible: 0, deleted: 0 });
     deleteExpiredOutdatedSuggestionsStub = sandbox.stub().resolves({
       scanned: 0, eligible: 0, deleted: 0, failed: 0,
     });
@@ -1659,6 +1659,45 @@ describe('Reddit Analysis Guidance Handler', () => {
       expect(deleteExpiredOutdatedSuggestionsStub).to.have.been.calledAfter(syncSuggestionsStub);
       expect(deleteExpiredOutdatedSuggestionsStub)
         .to.have.been.calledBefore(deleteExpiredSnapshotsStub);
+    });
+
+    it('emits a single combined audit_housekeeping_end summary after both cleanups resolve', async () => {
+      deleteExpiredOutdatedSuggestionsStub.resolves({
+        scanned: 5, eligible: 3, deleted: 3, failed: 0,
+      });
+      deleteExpiredSnapshotsStub.resolves({ eligible: 2, deleted: 2 });
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus: sandbox.stub().resolves([]) };
+
+      const result = await handler.default(validMessage(), context);
+
+      expect(result.status).to.equal(200);
+      expect(context.log.info).to.have.been.calledWith(
+        sinon.match(/event=audit_housekeeping_end/)
+          .and(sinon.match(/outcome=success/))
+          .and(sinon.match(/suggestionsScanned=5/))
+          .and(sinon.match(/suggestionsEligible=3/))
+          .and(sinon.match(/suggestionsDeleted=3/))
+          .and(sinon.match(/suggestionsFailed=0/))
+          .and(sinon.match(/snapshotsEligible=2/))
+          .and(sinon.match(/snapshotsDeleted=2/)),
+      );
+      expect(deleteExpiredSnapshotsStub).to.have.been.calledOnce;
+      expect(deleteExpiredOutdatedSuggestionsStub).to.have.been.calledOnce;
+    });
+
+    it('emits a degraded audit_housekeeping_end summary when suggestion cleanup fails', async () => {
+      deleteExpiredOutdatedSuggestionsStub.rejects(new Error('sugg cleanup blew up'));
+      deleteExpiredSnapshotsStub.resolves({ eligible: 0, deleted: 0 });
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus: sandbox.stub().resolves([]) };
+
+      const result = await handler.default(validMessage(), context);
+
+      expect(result.status).to.equal(200);
+      expect(context.log.warn).to.have.been.calledWith(
+        sinon.match(/event=audit_housekeeping_end/)
+          .and(sinon.match(/outcome=degraded/))
+          .and(sinon.match(/reason=partial_cleanup_failure/)),
+      );
     });
 
     it('does NOT run retention when the handler returns before a successful sync', async () => {

--- a/test/audits/reddit-analysis/guidance-handler.test.js
+++ b/test/audits/reddit-analysis/guidance-handler.test.js
@@ -1693,10 +1693,72 @@ describe('Reddit Analysis Guidance Handler', () => {
       const result = await handler.default(validMessage(), context);
 
       expect(result.status).to.equal(200);
+      // suggestionsErrored is true because the cleanup threw, so the summary fields for
+      // suggestions fall back to the zero-defaults set before the try/catch, not any partial
+      // values from the (rejected) promise; snapshots resolved normally with its own zeros.
       expect(context.log.warn).to.have.been.calledWith(
         sinon.match(/event=audit_housekeeping_end/)
           .and(sinon.match(/outcome=degraded/))
-          .and(sinon.match(/reason=partial_cleanup_failure/)),
+          .and(sinon.match(/reason=partial_cleanup_failure/))
+          .and(sinon.match(/suggestionsScanned=0/))
+          .and(sinon.match(/suggestionsEligible=0/))
+          .and(sinon.match(/suggestionsDeleted=0/))
+          .and(sinon.match(/suggestionsFailed=0/))
+          .and(sinon.match(/snapshotsEligible=0/))
+          .and(sinon.match(/snapshotsDeleted=0/)),
+      );
+    });
+
+    it('escalates to degraded independently via snapshotsErrored when snapshot cleanup throws (suggestions succeed normally)', async () => {
+      deleteExpiredOutdatedSuggestionsStub.resolves({
+        scanned: 4, eligible: 1, deleted: 1, failed: 0,
+      });
+      deleteExpiredSnapshotsStub.rejects(new Error('snapshot cleanup blew up'));
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus: sandbox.stub().resolves([]) };
+
+      const result = await handler.default(validMessage(), context);
+
+      expect(result.status).to.equal(200);
+      // snapshotsErrored is true because the cleanup threw, so the summary fields for
+      // snapshots fall back to the zero-defaults; suggestions resolved normally with no
+      // failures, distinct from the already-tested "suggestions throws" path above.
+      expect(context.log.warn).to.have.been.calledWith(
+        sinon.match(/event=audit_housekeeping_end/)
+          .and(sinon.match(/outcome=degraded/))
+          .and(sinon.match(/reason=partial_cleanup_failure/))
+          .and(sinon.match(/suggestionsScanned=4/))
+          .and(sinon.match(/suggestionsEligible=1/))
+          .and(sinon.match(/suggestionsDeleted=1/))
+          .and(sinon.match(/suggestionsFailed=0/))
+          .and(sinon.match(/snapshotsEligible=0/))
+          .and(sinon.match(/snapshotsDeleted=0/)),
+      );
+    });
+
+    it('escalates to degraded when suggestion cleanup resolves normally but reports a per-batch failure (failed > 0)', async () => {
+      // This exercises the suggestionsSummary.failed > 0 branch of housekeepingHadFailure,
+      // independent of the suggestionsErrored/exception path above: deleteExpiredOutdatedSuggestions
+      // resolves normally (no throw) but its own returned summary reports a nonzero failed count
+      // (a per-batch delete failure caught inside that function).
+      deleteExpiredOutdatedSuggestionsStub.resolves({
+        scanned: 10, eligible: 4, deleted: 2, failed: 2,
+      });
+      deleteExpiredSnapshotsStub.resolves({ eligible: 0, deleted: 0 });
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus: sandbox.stub().resolves([]) };
+
+      const result = await handler.default(validMessage(), context);
+
+      expect(result.status).to.equal(200);
+      expect(context.log.warn).to.have.been.calledWith(
+        sinon.match(/event=audit_housekeeping_end/)
+          .and(sinon.match(/outcome=degraded/))
+          .and(sinon.match(/reason=partial_cleanup_failure/))
+          .and(sinon.match(/suggestionsScanned=10/))
+          .and(sinon.match(/suggestionsEligible=4/))
+          .and(sinon.match(/suggestionsDeleted=2/))
+          .and(sinon.match(/suggestionsFailed=2/))
+          .and(sinon.match(/snapshotsEligible=0/))
+          .and(sinon.match(/snapshotsDeleted=0/)),
       );
     });
 

--- a/test/audits/youtube-analysis/guidance-handler.test.js
+++ b/test/audits/youtube-analysis/guidance-handler.test.js
@@ -159,7 +159,7 @@ describe('YouTube Analysis Guidance Handler', () => {
       }
       return { opportunityData, opportunityToUpdate: evergreenOpportunity };
     });
-    deleteExpiredSnapshotsStub = sandbox.stub().resolves(0);
+    deleteExpiredSnapshotsStub = sandbox.stub().resolves({ eligible: 0, deleted: 0 });
     deleteExpiredOutdatedSuggestionsStub = sandbox.stub().resolves({
       scanned: 0, eligible: 0, deleted: 0, failed: 0,
     });
@@ -1679,6 +1679,45 @@ describe('YouTube Analysis Guidance Handler', () => {
       expect(deleteExpiredOutdatedSuggestionsStub).to.have.been.calledAfter(mockSyncSuggestions);
       expect(deleteExpiredOutdatedSuggestionsStub)
         .to.have.been.calledBefore(deleteExpiredSnapshotsStub);
+    });
+
+    it('emits a single combined audit_housekeeping_end summary after both cleanups resolve', async () => {
+      deleteExpiredOutdatedSuggestionsStub.resolves({
+        scanned: 5, eligible: 3, deleted: 3, failed: 0,
+      });
+      deleteExpiredSnapshotsStub.resolves({ eligible: 2, deleted: 2 });
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus: sandbox.stub().resolves([]) };
+
+      const result = await guidanceHandler.default(validMessage(), context);
+
+      expect(result.status).to.equal(200);
+      expect(context.log.info).to.have.been.calledWith(
+        sinon.match(/event=audit_housekeeping_end/)
+          .and(sinon.match(/outcome=success/))
+          .and(sinon.match(/suggestionsScanned=5/))
+          .and(sinon.match(/suggestionsEligible=3/))
+          .and(sinon.match(/suggestionsDeleted=3/))
+          .and(sinon.match(/suggestionsFailed=0/))
+          .and(sinon.match(/snapshotsEligible=2/))
+          .and(sinon.match(/snapshotsDeleted=2/)),
+      );
+      expect(deleteExpiredSnapshotsStub).to.have.been.calledOnce;
+      expect(deleteExpiredOutdatedSuggestionsStub).to.have.been.calledOnce;
+    });
+
+    it('emits a degraded audit_housekeeping_end summary when suggestion cleanup fails', async () => {
+      deleteExpiredOutdatedSuggestionsStub.rejects(new Error('sugg cleanup blew up'));
+      deleteExpiredSnapshotsStub.resolves({ eligible: 0, deleted: 0 });
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus: sandbox.stub().resolves([]) };
+
+      const result = await guidanceHandler.default(validMessage(), context);
+
+      expect(result.status).to.equal(200);
+      expect(context.log.warn).to.have.been.calledWith(
+        sinon.match(/event=audit_housekeeping_end/)
+          .and(sinon.match(/outcome=degraded/))
+          .and(sinon.match(/reason=partial_cleanup_failure/)),
+      );
     });
 
     it('does NOT run retention when the handler returns before a successful sync', async () => {

--- a/test/audits/youtube-analysis/guidance-handler.test.js
+++ b/test/audits/youtube-analysis/guidance-handler.test.js
@@ -1713,10 +1713,72 @@ describe('YouTube Analysis Guidance Handler', () => {
       const result = await guidanceHandler.default(validMessage(), context);
 
       expect(result.status).to.equal(200);
+      // suggestionsErrored is true because the cleanup threw, so the summary fields for
+      // suggestions fall back to the zero-defaults set before the try/catch, not any partial
+      // values from the (rejected) promise; snapshots resolved normally with its own zeros.
       expect(context.log.warn).to.have.been.calledWith(
         sinon.match(/event=audit_housekeeping_end/)
           .and(sinon.match(/outcome=degraded/))
-          .and(sinon.match(/reason=partial_cleanup_failure/)),
+          .and(sinon.match(/reason=partial_cleanup_failure/))
+          .and(sinon.match(/suggestionsScanned=0/))
+          .and(sinon.match(/suggestionsEligible=0/))
+          .and(sinon.match(/suggestionsDeleted=0/))
+          .and(sinon.match(/suggestionsFailed=0/))
+          .and(sinon.match(/snapshotsEligible=0/))
+          .and(sinon.match(/snapshotsDeleted=0/)),
+      );
+    });
+
+    it('escalates to degraded independently via snapshotsErrored when snapshot cleanup throws (suggestions succeed normally)', async () => {
+      deleteExpiredOutdatedSuggestionsStub.resolves({
+        scanned: 4, eligible: 1, deleted: 1, failed: 0,
+      });
+      deleteExpiredSnapshotsStub.rejects(new Error('snapshot cleanup blew up'));
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus: sandbox.stub().resolves([]) };
+
+      const result = await guidanceHandler.default(validMessage(), context);
+
+      expect(result.status).to.equal(200);
+      // snapshotsErrored is true because the cleanup threw, so the summary fields for
+      // snapshots fall back to the zero-defaults; suggestions resolved normally with no
+      // failures, distinct from the already-tested "suggestions throws" path above.
+      expect(context.log.warn).to.have.been.calledWith(
+        sinon.match(/event=audit_housekeeping_end/)
+          .and(sinon.match(/outcome=degraded/))
+          .and(sinon.match(/reason=partial_cleanup_failure/))
+          .and(sinon.match(/suggestionsScanned=4/))
+          .and(sinon.match(/suggestionsEligible=1/))
+          .and(sinon.match(/suggestionsDeleted=1/))
+          .and(sinon.match(/suggestionsFailed=0/))
+          .and(sinon.match(/snapshotsEligible=0/))
+          .and(sinon.match(/snapshotsDeleted=0/)),
+      );
+    });
+
+    it('escalates to degraded when suggestion cleanup resolves normally but reports a per-batch failure (failed > 0)', async () => {
+      // This exercises the suggestionsSummary.failed > 0 branch of housekeepingHadFailure,
+      // independent of the suggestionsErrored/exception path above: deleteExpiredOutdatedSuggestions
+      // resolves normally (no throw) but its own returned summary reports a nonzero failed count
+      // (a per-batch delete failure caught inside that function).
+      deleteExpiredOutdatedSuggestionsStub.resolves({
+        scanned: 10, eligible: 4, deleted: 2, failed: 2,
+      });
+      deleteExpiredSnapshotsStub.resolves({ eligible: 0, deleted: 0 });
+      context.dataAccess.Opportunity = { allBySiteIdAndStatus: sandbox.stub().resolves([]) };
+
+      const result = await guidanceHandler.default(validMessage(), context);
+
+      expect(result.status).to.equal(200);
+      expect(context.log.warn).to.have.been.calledWith(
+        sinon.match(/event=audit_housekeeping_end/)
+          .and(sinon.match(/outcome=degraded/))
+          .and(sinon.match(/reason=partial_cleanup_failure/))
+          .and(sinon.match(/suggestionsScanned=10/))
+          .and(sinon.match(/suggestionsEligible=4/))
+          .and(sinon.match(/suggestionsDeleted=2/))
+          .and(sinon.match(/suggestionsFailed=2/))
+          .and(sinon.match(/snapshotsEligible=0/))
+          .and(sinon.match(/snapshotsDeleted=0/)),
       );
     });
 

--- a/test/common/offsite-retention.test.js
+++ b/test/common/offsite-retention.test.js
@@ -26,6 +26,7 @@ import {
   OUTDATED_SUGGESTION_DELETE_BATCH_SIZE,
   isOutdatedSuggestionExpired,
   deleteExpiredOutdatedSuggestions,
+  logHousekeepingSummary,
 } from '../../src/common/offsite-retention.js';
 
 use(sinonChai);
@@ -926,6 +927,131 @@ describe('offsite-retention', () => {
       expect(deletedIds).to.not.include('snap-1');
       expect(log.info).to.have.been.calledWith(
         sinon.match(`eligible=${totalExpired}`).and(sinon.match(`deleted=${MAX_DELETIONS_PER_RUN}`)),
+      );
+    });
+  });
+
+  describe('logHousekeepingSummary', () => {
+    let olog;
+
+    beforeEach(() => {
+      olog = { warn: sandbox.stub(), success: sandbox.stub() };
+    });
+
+    const expectedFields = ({
+      suggestionsSummary, snapshotsSummary,
+    }) => ({
+      peer: 'postgres',
+      direction: 'outbound',
+      auditType,
+      suggestionsScanned: suggestionsSummary.scanned,
+      suggestionsEligible: suggestionsSummary.eligible,
+      suggestionsDeleted: suggestionsSummary.deleted,
+      suggestionsFailed: suggestionsSummary.failed,
+      snapshotsEligible: snapshotsSummary.eligible,
+      snapshotsDeleted: snapshotsSummary.deleted,
+    });
+
+    it('emits success with outcome=success when neither cleanup failed', () => {
+      const suggestionsSummary = {
+        scanned: 5, eligible: 3, deleted: 3, failed: 0,
+      };
+      const snapshotsSummary = { eligible: 2, deleted: 2 };
+
+      logHousekeepingSummary(olog, {
+        auditType,
+        suggestionsSummary,
+        snapshotsSummary,
+        suggestionsErrored: false,
+        snapshotsErrored: false,
+      });
+
+      expect(olog.warn).to.not.have.been.called;
+      expect(olog.success).to.have.been.calledOnceWith(
+        'audit_housekeeping_end',
+        'Housekeeping cleanup summary',
+        {
+          ...expectedFields({ suggestionsSummary, snapshotsSummary }),
+          outcome: 'success',
+        },
+      );
+    });
+
+    it('escalates to warn/degraded when suggestionsErrored is true', () => {
+      const suggestionsSummary = {
+        scanned: 0, eligible: 0, deleted: 0, failed: 0,
+      };
+      const snapshotsSummary = { eligible: 0, deleted: 0 };
+
+      logHousekeepingSummary(olog, {
+        auditType,
+        suggestionsSummary,
+        snapshotsSummary,
+        suggestionsErrored: true,
+        snapshotsErrored: false,
+      });
+
+      expect(olog.success).to.not.have.been.called;
+      expect(olog.warn).to.have.been.calledOnceWith(
+        'audit_housekeeping_end',
+        'Housekeeping cleanup summary',
+        {
+          ...expectedFields({ suggestionsSummary, snapshotsSummary }),
+          reason: 'partial_cleanup_failure',
+          outcome: 'degraded',
+        },
+      );
+    });
+
+    it('escalates to warn/degraded when snapshotsErrored is true', () => {
+      const suggestionsSummary = {
+        scanned: 4, eligible: 1, deleted: 1, failed: 0,
+      };
+      const snapshotsSummary = { eligible: 0, deleted: 0 };
+
+      logHousekeepingSummary(olog, {
+        auditType,
+        suggestionsSummary,
+        snapshotsSummary,
+        suggestionsErrored: false,
+        snapshotsErrored: true,
+      });
+
+      expect(olog.success).to.not.have.been.called;
+      expect(olog.warn).to.have.been.calledOnceWith(
+        'audit_housekeeping_end',
+        'Housekeeping cleanup summary',
+        {
+          ...expectedFields({ suggestionsSummary, snapshotsSummary }),
+          reason: 'partial_cleanup_failure',
+          outcome: 'degraded',
+        },
+      );
+    });
+
+    it('escalates to warn/degraded when suggestionsSummary.failed > 0 (no exception)', () => {
+      const suggestionsSummary = {
+        scanned: 10, eligible: 4, deleted: 2, failed: 2,
+      };
+      const snapshotsSummary = { eligible: 0, deleted: 0 };
+
+      logHousekeepingSummary(olog, {
+        auditType,
+        suggestionsSummary,
+        snapshotsSummary,
+        suggestionsErrored: false,
+        snapshotsErrored: false,
+      });
+
+      expect(olog.success).to.not.have.been.called;
+      expect(olog.warn).to.have.been.calledOnceWith(
+        'audit_housekeeping_end',
+        'Housekeeping cleanup summary',
+        {
+          ...expectedFields({ suggestionsSummary, snapshotsSummary }),
+          reason: 'partial_cleanup_failure',
+          outcome: 'degraded',
+        },
       );
     });
   });

--- a/test/common/offsite-retention.test.js
+++ b/test/common/offsite-retention.test.js
@@ -343,16 +343,9 @@ describe('offsite-retention', () => {
         log,
       });
       expect(removeByIds).to.not.have.been.called;
-      expect(retentionSummary.deleted).to.equal(0);
-      expect(retentionSummary.scanned).to.equal(0);
-      expect(log.info).to.have.been.calledWith(
-        sinon.match(/event=audit_housekeeping_end/)
-          .and(sinon.match(/outcome=success/))
-          .and(sinon.match(/scanned=0/))
-          .and(sinon.match(/eligible=0/))
-          .and(sinon.match(/deleted=0/))
-          .and(sinon.match(/failed=0/)),
-      );
+      expect(retentionSummary).to.deep.equal({
+        scanned: 0, eligible: 0, deleted: 0, failed: 0,
+      });
     });
 
     it('treats a falsy getSuggestions result as an empty set', async () => {
@@ -533,17 +526,9 @@ describe('offsite-retention', () => {
       expect(log.info).to.not.have.been.calledWith(
         sinon.match(new RegExp(`suggestionIds=.*\\b${failedSuggestionId}\\b`)),
       );
-      // A partial failure must surface at outcome=degraded on the summary, not success — the
-      // per-batch failures it rolls up are self-healed, non-fatal deletion failures.
-      expect(log.warn).to.have.been.calledWith(
-        sinon.match(/event=audit_housekeeping_end/)
-          .and(sinon.match(/outcome=degraded/))
-          .and(sinon.match(`failed=${suggestionCount - OUTDATED_SUGGESTION_DELETE_BATCH_SIZE}`))
-          .and(sinon.match(/reason=partial_delete_failure/)),
-      );
     });
 
-    it('logs each deletion only after its batch succeeds and emits a summary', async () => {
+    it('logs each deletion only after its batch succeeds and returns the summary', async () => {
       const expiredOutdatedSuggestion = buildSuggestion({
         id: 'old',
         updatedAt: daysAgo(40),
@@ -570,16 +555,13 @@ describe('offsite-retention', () => {
           .and(sinon.match(/siteId=site-1/))
           .and(sinon.match(/suggestionIds=old/)),
       );
-      expect(log.info).to.have.been.calledWith(
-        sinon.match(/Expired OUTDATED suggestion deletion summary/)
-          .and(sinon.match(/event=audit_housekeeping_end/))
-          .and(sinon.match(/outcome=success/))
-          .and(sinon.match(/opportunityId=evergreen-1/))
-          .and(sinon.match(/siteId=site-1/))
-          .and(sinon.match(/scanned=1/))
-          .and(sinon.match(/eligible=1/))
-          .and(sinon.match(/deleted=1/))
-          .and(sinon.match(/failed=0/)),
+      // The combined audit_housekeeping_end summary is now emitted by the guidance-handlers,
+      // not this function — see guidance-handler.test.js for that assertion.
+      expect(log.info).to.not.have.been.calledWith(
+        sinon.match(/event=audit_housekeeping_end/),
+      );
+      expect(log.warn).to.not.have.been.calledWith(
+        sinon.match(/event=audit_housekeeping_end/),
       );
     });
   });
@@ -778,11 +760,11 @@ describe('offsite-retention', () => {
         Suggestion: { removeByIds: removeByIdsSuggestion },
       };
 
-      const deletedSnapshotCount = await deleteExpiredSnapshots({
+      const result = await deleteExpiredSnapshots({
         dataAccess, siteId, auditType, log,
       });
 
-      expect(deletedSnapshotCount).to.equal(2);
+      expect(result).to.deep.equal({ eligible: 2, deleted: 2 });
       // Oldest-first ordering from findExpiredSnapshots is preserved into the bulk call.
       expect(removeByIdsSuggestion).to.have.been.calledOnceWith(['sugg-2', 'sugg-1']);
       expect(removeByIdsOpportunity).to.have.been.calledOnceWith(['second-expired', 'first-expired']);
@@ -806,16 +788,16 @@ describe('offsite-retention', () => {
         Suggestion: { removeByIds: removeByIdsSuggestion },
       };
 
-      const deletedSnapshotCount = await deleteExpiredSnapshots({
+      const result = await deleteExpiredSnapshots({
         dataAccess, siteId, auditType, log,
       });
 
-      expect(deletedSnapshotCount).to.equal(1);
+      expect(result).to.deep.equal({ eligible: 1, deleted: 1 });
       expect(removeByIdsSuggestion).to.not.have.been.called;
       expect(removeByIdsOpportunity).to.have.been.calledOnceWith(['no-suggestions']);
     });
 
-    it('returns 0, calls no removeByIds, and does not log when nothing is expired', async () => {
+    it('returns { eligible: 0, deleted: 0 }, calls no removeByIds, and does not log when nothing is expired', async () => {
       const youngSnapshot = buildSnapshotOpportunity({ id: 'young', createdAt: daysAgo(5) });
       const removeByIdsSuggestion = sandbox.stub().resolves();
       const removeByIdsOpportunity = sandbox.stub().resolves();
@@ -827,11 +809,11 @@ describe('offsite-retention', () => {
         Suggestion: { removeByIds: removeByIdsSuggestion },
       };
 
-      const deletedSnapshotCount = await deleteExpiredSnapshots({
+      const result = await deleteExpiredSnapshots({
         dataAccess, siteId, auditType, log,
       });
 
-      expect(deletedSnapshotCount).to.equal(0);
+      expect(result).to.deep.equal({ eligible: 0, deleted: 0 });
       expect(removeByIdsSuggestion).to.not.have.been.called;
       expect(removeByIdsOpportunity).to.not.have.been.called;
       // "Ran, nothing eligible" must be distinguishable from "never invoked" — a warn-level
@@ -845,7 +827,7 @@ describe('offsite-retention', () => {
       );
     });
 
-    it('returns 0 without calling removeByIds when the lookup fails', async () => {
+    it('returns { eligible: 0, deleted: 0 } without calling removeByIds when the lookup fails', async () => {
       const removeByIdsOpportunity = sandbox.stub().resolves();
       const dataAccess = {
         Opportunity: {
@@ -854,11 +836,11 @@ describe('offsite-retention', () => {
         },
       };
 
-      const deletedSnapshotCount = await deleteExpiredSnapshots({
+      const result = await deleteExpiredSnapshots({
         dataAccess, siteId, auditType, log,
       });
 
-      expect(deletedSnapshotCount).to.equal(0);
+      expect(result).to.deep.equal({ eligible: 0, deleted: 0 });
       expect(removeByIdsOpportunity).to.not.have.been.called;
     });
 
@@ -931,11 +913,11 @@ describe('offsite-retention', () => {
         Suggestion: { removeByIds: sandbox.stub().resolves() },
       };
 
-      const deletedSnapshotCount = await deleteExpiredSnapshots({
+      const result = await deleteExpiredSnapshots({
         dataAccess, siteId, auditType, log,
       });
 
-      expect(deletedSnapshotCount).to.equal(MAX_DELETIONS_PER_RUN);
+      expect(result).to.deep.equal({ eligible: totalExpired, deleted: MAX_DELETIONS_PER_RUN });
       const deletedIds = removeByIdsOpportunity.firstCall.args[0];
       expect(deletedIds).to.have.lengthOf(MAX_DELETIONS_PER_RUN);
       // The oldest snapshot (snap-<totalExpired>, daysAgo(45 + totalExpired)) must be included.


### PR DESCRIPTION
##Summary

audit_housekeeping_end was logged from inside deleteExpiredOutdatedSuggestions, which runs before deleteExpiredSnapshots — so the phase's own "_end" marker fired before snapshot cleanup even started, breaking the invariant that every phase gets a genuine, unconditional final boundary line.

Moves the combined summary to each guidance-handler, emitted once both cleanups have resolved, carrying suggestionsScanned/Eligible/Deleted/Failed and snapshotsEligible/Deleted together, escalating to warn/degraded if either cleanup failed. deleteExpiredSnapshots now returns {eligible, deleted} instead of a bare count so the caller has both sides' stats to merge.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```