### PR TITLE
fix(csp): protect the same suggestion statuses as the shared helper on resolve (SITES-49908)

### DIFF
--- a/src/csp/csp.js
+++ b/src/csp/csp.js
@@ -17,7 +17,7 @@ import {
 } from '@adobe/spacecat-shared-data-access';
 import { isNonEmptyArray } from '@adobe/spacecat-shared-utils';
 import { convertToOpportunity } from '../common/opportunity.js';
-import { syncSuggestions } from '../utils/data-access.js';
+import { RESOLVE_PROTECTED_STATUSES, syncSuggestions } from '../utils/data-access.js';
 import { cspAutoSuggest } from './csp-auto-suggest.js';
 
 const AUDIT_TYPE = Audit.AUDIT_TYPES.SECURITY_CSP;
@@ -121,12 +121,7 @@ export async function resolveOpportunity(auditData, context, auditType) {
 
     const existingSuggestions = await opportunity.getSuggestions();
     const existingOutdatedSuggestions = existingSuggestions
-      .filter((existing) => ![
-        SuggestionDataAccess.STATUSES.OUTDATED,
-        SuggestionDataAccess.STATUSES.FIXED,
-        SuggestionDataAccess.STATUSES.ERROR,
-        SuggestionDataAccess.STATUSES.SKIPPED,
-      ].includes(existing.getStatus()));
+      .filter((existing) => !RESOLVE_PROTECTED_STATUSES.includes(existing.getStatus()));
     if (isNonEmptyArray(existingOutdatedSuggestions)) {
       await Suggestion.bulkUpdateStatus(
         existingOutdatedSuggestions,

--- a/src/utils/data-access.js
+++ b/src/utils/data-access.js
@@ -35,6 +35,22 @@ export const AUTHOR_ONLY_OPPORTUNITY_TYPES = [
 ];
 
 /**
+ * Statuses a reconcile/resolve sweep must NEVER overwrite when aging suggestions to
+ * OUTDATED: terminal (OUTDATED/FIXED/ERROR/SKIPPED), reviewer-acted (REJECTED/APPROVED),
+ * or mid-remediation (IN_PROGRESS). Shared by {@link handleOutdatedSuggestions} and the
+ * CSP resolveOpportunity sweep so both protect the same set (SITES-49908).
+ */
+export const RESOLVE_PROTECTED_STATUSES = [
+  SuggestionDataAccess.STATUSES.OUTDATED,
+  SuggestionDataAccess.STATUSES.FIXED,
+  SuggestionDataAccess.STATUSES.ERROR,
+  SuggestionDataAccess.STATUSES.SKIPPED,
+  SuggestionDataAccess.STATUSES.REJECTED,
+  SuggestionDataAccess.STATUSES.APPROVED,
+  SuggestionDataAccess.STATUSES.IN_PROGRESS,
+];
+
+/**
  * Validates suggestion data against the Joi schema for the given opportunity type.
  * Logs a warning if validation fails but does not block the operation.
  *
@@ -273,15 +289,12 @@ export const handleOutdatedSuggestions = async ({
   const { Suggestion } = context.dataAccess;
   const { log } = context;
 
-  const excludedStatuses = [
-    SuggestionDataAccess.STATUSES.OUTDATED,
-    SuggestionDataAccess.STATUSES.FIXED,
-    SuggestionDataAccess.STATUSES.ERROR,
-    SuggestionDataAccess.STATUSES.SKIPPED,
-    SuggestionDataAccess.STATUSES.REJECTED,
-    SuggestionDataAccess.STATUSES.APPROVED,
-    ...(outdateInProgress ? [] : [SuggestionDataAccess.STATUSES.IN_PROGRESS]),
-  ];
+  // Derive from the shared protected set so CSP + this sweep stay in lockstep
+  // (SITES-49908). Byte-identical to the prior inline list: full 7 normally, and 6
+  // (IN_PROGRESS dropped) when outdateInProgress is true.
+  const excludedStatuses = outdateInProgress
+    ? RESOLVE_PROTECTED_STATUSES.filter((s) => s !== SuggestionDataAccess.STATUSES.IN_PROGRESS)
+    : RESOLVE_PROTECTED_STATUSES;
 
   const existingOutdatedSuggestions = existingSuggestions
     .filter((existing) => !newDataKeys.has(buildKey(existing.getData())))

--- a/test/audits/csp/csp.test.js
+++ b/test/audits/csp/csp.test.js
@@ -310,6 +310,34 @@ describe('CSP Post-processor', () => {
     ], Suggestion.STATUSES.OUTDATED);
   });
 
+  it('should NOT overwrite REJECTED/APPROVED/IN_PROGRESS suggestions when resolving (SITES-49908)', async () => {
+    sinon.replace(configuration, 'isHandlerEnabledForSite', (toggle) => toggle === 'security-csp');
+    auditData.auditResult.csp = [];
+
+    sinon.replace(opportunityStub, 'allBySiteIdAndStatus', sinon.stub().resolves([cspOpportunity]));
+    const newSuggestion = { getStatus: () => Suggestion.STATUSES.NEW };
+    const rejectedSuggestion = { getStatus: () => Suggestion.STATUSES.REJECTED };
+    const approvedSuggestion = { getStatus: () => Suggestion.STATUSES.APPROVED };
+    const inProgressSuggestion = { getStatus: () => Suggestion.STATUSES.IN_PROGRESS };
+    sinon.replace(cspOpportunity, 'getSuggestions', sinon.stub().resolves([
+      newSuggestion,
+      rejectedSuggestion,
+      approvedSuggestion,
+      inProgressSuggestion,
+    ]));
+
+    const cspAuditData = await cspOpportunityAndSuggestions(siteUrl, auditData, context, cspSite);
+    assertAuditData(cspAuditData);
+
+    expect(cspOpportunity.setStatus).to.have.been.calledWith(Opportunity.STATUSES.RESOLVED);
+    // Only the NEW suggestion is aged to OUTDATED; reviewer-acted (REJECTED/APPROVED)
+    // and mid-remediation (IN_PROGRESS) are protected — never overwritten.
+    expect(suggestionStub.bulkUpdateStatus).to.have.been.calledWith(
+      [newSuggestion],
+      Suggestion.STATUSES.OUTDATED,
+    );
+  });
+
   it('should resolve existing opportunity if no CSP findings in lighthouse report - error case 1', async () => {
     sinon.replace(configuration, 'isHandlerEnabledForSite', (toggle) => toggle === 'security-csp');
     auditData.auditResult.csp = [];

--- a/test/utils/data-access.test.js
+++ b/test/utils/data-access.test.js
@@ -33,6 +33,7 @@ import {
   isTBYBSite,
   SUMMIT_PLG_HANDLER,
   resolveOpportunityIfNoIssues,
+  RESOLVE_PROTECTED_STATUSES,
 } from '../../src/utils/data-access.js';
 import { MockContextBuilder } from '../shared.js';
 
@@ -40,6 +41,20 @@ use(sinonChai);
 use(chaiAsPromised);
 
 describe('data-access', () => {
+  describe('RESOLVE_PROTECTED_STATUSES (SITES-49908)', () => {
+    it('protects the 7 terminal / reviewer-acted / mid-remediation statuses', () => {
+      expect([...RESOLVE_PROTECTED_STATUSES].sort()).to.deep.equal([
+        SuggestionDataAccess.STATUSES.OUTDATED,
+        SuggestionDataAccess.STATUSES.FIXED,
+        SuggestionDataAccess.STATUSES.ERROR,
+        SuggestionDataAccess.STATUSES.SKIPPED,
+        SuggestionDataAccess.STATUSES.REJECTED,
+        SuggestionDataAccess.STATUSES.APPROVED,
+        SuggestionDataAccess.STATUSES.IN_PROGRESS,
+      ].sort());
+    });
+  });
+
   describe('retrieveSiteBySiteId', () => {
     let mockDataAccess;
     let mockLog;


### PR DESCRIPTION
## Summary
CSP's `resolveOpportunity` (run when a CSP audit finds zero issues) aged the opportunity's suggestions to `OUTDATED` using an exclusion list of only **4** statuses — `OUTDATED/FIXED/ERROR/SKIPPED` — whereas the shared `handleOutdatedSuggestions` helper protects **7**. So CSP silently overwrote **reviewer-REJECTED / APPROVED** and **mid-remediation IN_PROGRESS** suggestions — a data-integrity gap that can feed downstream fix-entity/deployment tracking incorrectly.

## Fix (DRY)
- Add an exported `RESOLVE_PROTECTED_STATUSES` in `src/utils/data-access.js` — the 7 statuses a resolve/reconcile sweep must never overwrite (terminal + reviewer-acted + in-progress).
- `handleOutdatedSuggestions` now **derives** its `excludedStatuses` from it (byte-identical: full 7 normally, 6 with `outdateInProgress`).
- CSP `resolveOpportunity` uses the shared constant instead of its 4-item list.

Both paths now stay in lockstep — no future drift.

## Tests
- CSP: REJECTED / APPROVED / IN_PROGRESS suggestions are **not** overwritten on a zero-issues resolve; `NEW` is still marked `OUTDATED`.
- data-access: asserts the constant's 7 members; existing `handleOutdatedSuggestions`/`syncSuggestions` tests unchanged (behavior-preserving).
- 187 passing on the focused suites; eslint clean on changed src files.

## AC
CSP suggestions in REJECTED/APPROVED/IN_PROGRESS are not overwritten (to FIXED or OUTDATED) when the audit finds no remaining issues. ✓

## Follow-up (out of scope)
`src/utils/data-access.js` also has `resolveOpportunityIfNoIssues` with its own distinct protection list — worth a separate audit against `RESOLVE_PROTECTED_STATUSES`.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```