### PR TITLE
feat(brand-claims): llmo-7177 semrush-aware trigger + ingest_source/domain on event

### DIFF
--- a/docs/decisions/006-brand-claims-drs-vs-semrush-source.md
+++ b/docs/decisions/006-brand-claims-drs-vs-semrush-source.md
@@ -1,0 +1,119 @@
+# 006 — Brand-Claims Trigger: Per-Site DRS-Sheet vs Semrush-Feed Source Decision
+
+- **Status:** Accepted
+- **Date:** 2026-08-28
+- **Related:** spec `docs/specs/2026-08-11-brand-claims-scheduled-trigger.md` · ADR
+  `docs/decisions/002-offsite-cited-urls-semrush-source.md` (the offsite Semrush source swap
+  whose entitlement + override machinery this reuses) · [LLMO-7177](https://jira.corp.adobe.com/browse/LLMO-7177)
+
+## Context
+
+The `brand-claims` audit (spec `2026-08-11-brand-claims-scheduled-trigger.md`) is a per-site
+weekly trigger that publishes the DRS `BRAND_PRESENCE_SHEET_WRITTEN` ready-signal so the
+mystique Brand Claims consumer runs. It was written entirely around the DRS Brand-Presence
+`.xlsx`: it lists S3 for the brand's latest sheet and points the event at that `s3_key`.
+
+For **Semrush-backed** brands there is no BP sheet — the citation data lives in the
+Semrush URL-Inspector feed (the same source the `offsite-brand-presence` audit migrated to;
+see ADR 002). The mystique consumer already needs to pick an ingest source per brand, and it
+was doing so from a **process-wide env var**, which cannot express a per-site decision. The
+agreed design is that the **audit-worker trigger** — which already resolves the site, org, and
+brand — makes the per-site DRS-vs-Semrush call and **stamps it on the existing event**, so the
+consumer sources the right feed without a second source-selection mechanism. Same queue, same
+event type, backward-compatible.
+
+## Decision
+
+1. **The trigger decides the source per site and carries it on the event.** The decision is
+   made in `src/brand-claims/handler.js`, not in the consumer. The existing
+   `BRAND_PRESENCE_SHEET_WRITTEN` event is extended additively (Decision 4) rather than adding
+   a new event type or a second queue — Mystique reads one field to route.
+
+2. **Semrush is chosen only when ENABLED **and** ENTITLED; everything else falls back to DRS.**
+   - *Enabled:* env `BRAND_CLAIMS_SEMRUSH_ENABLED=true`, or the per-run Slack override
+     `enableSemrush` (`auditContext.messageData.enableSemrush`, resolved by the shared
+     `resolveEnableSemrush`). Tri-state: an explicit override wins over the env var; absent/
+     invalid falls through to the env var. This mirrors ADR 002 Decision 7 exactly — the same
+     mechanism, reused, so behavior is identical to the offsite audit an operator already knows.
+     (Unlike ADR 002 Decision 1 there is **no hard-stop** variant here: a `brand-claims` run
+     that can't use Semrush must still publish *something* for the enabled site, and the DRS
+     sheet is a safe, already-written fallback — so every non-Semrush outcome, including an
+     explicitly-forced-on run that then fails entitlement, degrades to DRS.)
+   - *Entitled:* `resolveSemrushEntitlement` (`src/utils/semrush-entitlement.js`) — the shared
+     "serenity feature flag AND resolvable Semrush workspace" gate from ADR 002 Decision 8,
+     reused verbatim. Fail-closed: a confirmed non-entitlement (`flag_disabled` / `no_workspace`)
+     **and** an inconclusive check (`no_client` / `check_failed`) both fall back to DRS.
+   - The gate runs **before** any Semrush-specific work; on the DRS path the entitlement check
+     is never called (no wasted PostgREST round trip on the common case).
+
+3. **The Semrush branch skips the S3 sheet lookup entirely.** There is no sheet for a
+   Semrush-backed brand, so the branch does not build the `{siteId}/{brandSlug}/analytics/…`
+   prefix or list S3. It derives two things instead:
+   - **`domain`** — the registrable domain the feed is keyed by, via the shared `toApexHost`
+     (`offsite-audit-utils.js`), reused rather than re-inlined so the eventual PSL/eTLD+1
+     upgrade is a one-site change. Today this is the www-stripped hostname of `site.getBaseURL()`
+     (no public-suffix list yet); a subdomain like `blog.acme.com` is preserved. If no base
+     URL is configured or it won't parse, the event would have no routable key, so the run
+     falls back to DRS rather than emit an unroutable `semrush_feed` event.
+   - **`(week, year)`** — see Decision 5.
+
+4. **Additive event contract: `ingest_source` on both branches, `domain` iff `semrush_feed`.**
+   `ingest_source` is **optional with default `brand_presence_s3`** (an absent value means DRS,
+   so a pre-7177 consumer is unaffected), but the trigger now stamps it **explicitly on both
+   branches** (`brand_presence_s3` / `semrush_feed`) so the consumer never has to infer it.
+   `domain` is present (and required) only on the `semrush_feed` branch. Sheet-scoped fields
+   diverge by branch: the DRS branch sets `sheet_date`/`s3_bucket`/`s3_key` from the resolved
+   sheet; the Semrush branch sets all three to `null` (no sheet). All other fields
+   (`organization_id`, `brand_id`, `brand`, `site_id`, `platform`, `parent_job_id`, `batch_id`)
+   are identical across branches. The DRS branch's pre-existing fields are otherwise unchanged
+   — no regression to the sheet-selection path.
+
+5. **The Semrush `(week, year)` is a replay-stable run window, not the wall clock.** The DRS
+   branch reads immutable sheet metadata (`week`/`year` parsed from the sheet filename); the
+   Semrush branch has no such artifact. Deriving it from `isoCalendarWeek(new Date())` at emit
+   time would mean a retry / DLQ redrive that crosses the UTC ISO-week boundary re-emits a
+   **different** `(week, year)` for the same logical run (a duplicate bucket downstream). So the
+   branch accepts an explicit `week`+`year` from `auditContext.messageData` (tri-state, both
+   must be present and in range to win — bounded to week 1–53, year 2000–9999), defaulting to
+   the current ISO week only when no valid explicit window is supplied. A scheduler/redrive can
+   pin the window; an ad-hoc run gets today's week.
+
+6. **The source decision runs before the `brandSlug` guard.** The empty-`brandSlug` guard
+   (brand name sanitizes to nothing) is a DRS-only precondition — it can't address an S3 sheet
+   prefix. The Semrush feed is keyed by `domain`, not the slug, so the guard is now scoped to
+   the DRS branch: a Semrush-entitled brand with an empty slug still runs on the feed path (the
+   event's `brand` field is the empty slug, which the domain-keyed consumer ignores). The DRS
+   path behavior is unchanged.
+
+## Consequences
+
+- One event type, one queue, one consumer-side router (`ingest_source`). Adding a third source
+  later is another `ingest_source` value + branch, not new infrastructure.
+- `BRAND_CLAIMS_SEMRUSH_ENABLED` is **environment-global** (like `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED`
+  in ADR 002); true per-site cutover is a follow-up. The per-run `enableSemrush` override is
+  the tool for testing one run against the real entitlement/feed path before flipping the env
+  var. The entitlement gate already narrows the env-global flag to only provisioned brands, so
+  turning it on fleet-wide degrades gracefully to DRS for every non-entitled site.
+- `domain` is the www-stripped hostname, **not** a true public-suffix eTLD+1 — a multi-level
+  TLD (e.g. `example.co.uk`) or an intentional subdomain is passed through as-is. Reusing
+  `toApexHost` keeps the PSL upgrade a single-function change shared with the offsite audit.
+- The fallback-to-DRS-on-any-doubt policy means a Semrush misconfiguration is **silent** in the
+  event stream (it just looks like a DRS run). The granular reason is logged
+  (`not Semrush-entitled (reason=…, resolved=…)` / `no parseable base URL`) for whoever watches
+  logs; there is no dedicated alert (consistent with ADR 002 Decision 8c).
+
+## Alternatives Considered
+
+- **Consumer-side env source selection (status quo).** Rejected: a process-wide env var can't
+  make a per-site call, which is the whole requirement — the trigger already has the site/org/
+  brand context to decide.
+- **A new event type or a second queue for Semrush.** Rejected as disproportionate: the
+  consumer already keys off one event; an additive `ingest_source` field routes it with no new
+  infrastructure and keeps the DRS path backward-compatible.
+- **A hard-stop (no DRS fallback) when `enableSemrush:true`, mirroring ADR 002 Decision 1.**
+  Rejected for `brand-claims`: the offsite audit hard-stops so a canary Semrush failure is
+  *visible* rather than masked by legacy data, but this trigger's job is to publish a
+  ready-signal for an enabled site — failing closed with no event is worse than falling back to
+  the (already-written, correct) DRS sheet. Visibility is via logs, not a withheld event.
+- **Deriving the Semrush `(week, year)` from the wall clock.** Rejected: not replay-stable
+  across the ISO-week boundary (Decision 5).

--- a/docs/decisions/006-brand-claims-drs-vs-semrush-source.md
+++ b/docs/decisions/006-brand-claims-drs-vs-semrush-source.md
@@ -48,25 +48,29 @@ event type, backward-compatible.
 
 3. **The Semrush branch skips the S3 sheet lookup entirely.** There is no sheet for a
    Semrush-backed brand, so the branch does not build the `{siteId}/{brandSlug}/analytics/…`
-   prefix or list S3. It derives two things instead:
-   - **`domain`** — the registrable domain the feed is keyed by, via the shared `toApexHost`
-     (`offsite-audit-utils.js`), reused rather than re-inlined so the eventual PSL/eTLD+1
-     upgrade is a one-site change. Today this is the www-stripped hostname of `site.getBaseURL()`
-     (no public-suffix list yet); a subdomain like `blog.acme.com` is preserved. If no base
-     URL is configured or it won't parse, the event would have no routable key, so the run
-     falls back to DRS rather than emit an unroutable `semrush_feed` event.
-   - **`(week, year)`** — see Decision 5.
+   prefix or list S3. It derives only the `(week, year)` run window (see Decision 5); no other
+   per-branch input is needed, because the feed is routed downstream from identity already on
+   the event (Decision 4a).
 
-4. **Additive event contract: `ingest_source` on both branches, `domain` iff `semrush_feed`.**
+4. **Additive event contract: `ingest_source` on both branches, no `domain`.**
    `ingest_source` is **optional with default `brand_presence_s3`** (an absent value means DRS,
    so a pre-7177 consumer is unaffected), but the trigger now stamps it **explicitly on both
    branches** (`brand_presence_s3` / `semrush_feed`) so the consumer never has to infer it.
-   `domain` is present (and required) only on the `semrush_feed` branch. Sheet-scoped fields
-   diverge by branch: the DRS branch sets `sheet_date`/`s3_bucket`/`s3_key` from the resolved
-   sheet; the Semrush branch sets all three to `null` (no sheet). All other fields
-   (`organization_id`, `brand_id`, `brand`, `site_id`, `platform`, `parent_job_id`, `batch_id`)
-   are identical across branches. The DRS branch's pre-existing fields are otherwise unchanged
-   — no regression to the sheet-selection path.
+   Sheet-scoped fields diverge by branch: the DRS branch sets `sheet_date`/`s3_bucket`/`s3_key`
+   from the resolved sheet; the Semrush branch sets all three to `null` (no sheet). All other
+   fields (`organization_id`, `brand_id`, `brand`, `site_id`, `platform`, `parent_job_id`,
+   `batch_id`) are identical across branches. The DRS branch's pre-existing fields are otherwise
+   unchanged — no regression to the sheet-selection path.
+
+4a. **No `domain` on the event (mysticat-architecture#248 correction).** An earlier revision
+   stamped a registrable `domain` (the brand primary site's apex host) on the Semrush branch.
+   This was dropped: `domain` is a per-**market** concept — each market of a brand has its own
+   domain, and the brand itself has none — so a single brand-primary-site domain mis-binds a
+   multi-market brand. It is also unnecessary: the downstream Serenity proxy resolves the
+   workspace / project / market from `organization_id` + `brand_id`, both already stamped on the
+   event. The domain-derivation helper and its "no parseable base URL → fall back to DRS" branch
+   were removed with it; an entitled brand now always emits the `semrush_feed` event regardless
+   of its base URL.
 
 5. **The Semrush `(week, year)` is a replay-stable run window, not the wall clock.** The DRS
    branch reads immutable sheet metadata (`week`/`year` parsed from the sheet filename); the
@@ -80,10 +84,10 @@ event type, backward-compatible.
 
 6. **The source decision runs before the `brandSlug` guard.** The empty-`brandSlug` guard
    (brand name sanitizes to nothing) is a DRS-only precondition — it can't address an S3 sheet
-   prefix. The Semrush feed is keyed by `domain`, not the slug, so the guard is now scoped to
-   the DRS branch: a Semrush-entitled brand with an empty slug still runs on the feed path (the
-   event's `brand` field is the empty slug, which the domain-keyed consumer ignores). The DRS
-   path behavior is unchanged.
+   prefix. The Semrush feed carries no brand-slug path component (org+brand identity routes it
+   downstream), so the guard is now scoped to the DRS branch: a Semrush-entitled brand with an
+   empty slug still runs on the feed path (the event's `brand` field is the empty slug, which
+   the identity-routed consumer ignores). The DRS path behavior is unchanged.
 
 ## Consequences
 
@@ -94,13 +98,13 @@ event type, backward-compatible.
   the tool for testing one run against the real entitlement/feed path before flipping the env
   var. The entitlement gate already narrows the env-global flag to only provisioned brands, so
   turning it on fleet-wide degrades gracefully to DRS for every non-entitled site.
-- `domain` is the www-stripped hostname, **not** a true public-suffix eTLD+1 — a multi-level
-  TLD (e.g. `example.co.uk`) or an intentional subdomain is passed through as-is. Reusing
-  `toApexHost` keeps the PSL upgrade a single-function change shared with the offsite audit.
+- The consumer routes the Semrush feed from `organization_id` + `brand_id` alone; the event
+  carries no market/domain, so a multi-market brand is not pinned to a single primary-site
+  domain by this trigger.
 - The fallback-to-DRS-on-any-doubt policy means a Semrush misconfiguration is **silent** in the
   event stream (it just looks like a DRS run). The granular reason is logged
-  (`not Semrush-entitled (reason=…, resolved=…)` / `no parseable base URL`) for whoever watches
-  logs; there is no dedicated alert (consistent with ADR 002 Decision 8c).
+  (`not Semrush-entitled (reason=…, resolved=…)`) for whoever watches logs; there is no
+  dedicated alert (consistent with ADR 002 Decision 8c).
 
 ## Alternatives Considered
 

--- a/docs/specs/2026-08-11-brand-claims-scheduled-trigger.md
+++ b/docs/specs/2026-08-11-brand-claims-scheduled-trigger.md
@@ -61,29 +61,31 @@ Flow (`src/brand-claims/handler.js`), for a message `{ type: 'brand-claims', sit
    tri-state, override wins over env, mirroring `offsite-brand-presence`'s `resolveEnableSemrush`)
    **AND** the brand is entitled to it (`resolveSemrushEntitlement` — the shared "serenity flag
    AND resolvable Semrush workspace" gate, fail-closed with reason codes). Anything else —
-   disabled, non-entitled, an inconclusive entitlement check, or no parseable base URL for the
-   feed's `domain` — falls back to the unchanged DRS path, so a Semrush hiccup can never zero
-   out a site that has a DRS sheet. The decision runs **before** the `brandSlug` guard: the
-   Semrush feed is keyed by `domain`, not the S3 brand-slug path component, so a brand whose
-   name sanitizes to an empty slug can still run on the feed path.
+   disabled, non-entitled, or an inconclusive entitlement check — falls back to the unchanged
+   DRS path, so a Semrush hiccup can never zero out a site that has a DRS sheet. The decision
+   runs **before** the `brandSlug` guard: the Semrush feed carries no S3 brand-slug path
+   component (org+brand identity routes it downstream), so a brand whose name sanitizes to an
+   empty slug can still run on the feed path.
 4. **Run** —
    - *DRS branch:* build the S3 prefix `{siteId}/{brandSlug}/analytics/chatgpt_free/` (brand
      slug via `sanitizePathComponent`, byte-for-byte with DRS) and select the latest sheet
      (max by S3 date partition, then `LastModified`).
    - *Semrush branch:* **skip the S3 prefix build and sheet lookup entirely** — there is no
-     sheet. Derive the registrable `domain` from the site's base URL (shared `toApexHost`) and
-     the `(week, year)` run window (explicit `week`+`year` from the message if supplied and
-     valid — replay-stable across a DLQ redrive — else the current ISO week).
+     sheet. Derive only the `(week, year)` run window (explicit `week`+`year` from the message
+     if supplied and valid — replay-stable across a DLQ redrive — else the current ISO week).
 5. **Emit** — publish `BRAND_PRESENCE_SHEET_WRITTEN` to `SQS_BP_SHEET_READY_QUEUE_URL`.
    `organization_id` = SpaceCat org UUID (the BP consumer feeds it into
    `/v2/orgs/{spaceCatId}/…`, which 400s on an IMS org id), plus `brand_id`, `brand` slug,
    `site_id`, `week`, `year`, `cadence: "weekly"`, `platform`. **New in LLMO-7177:** the event
    carries an additive `ingest_source` on **both** branches (default `brand_presence_s3` when
    absent, so a pre-7177 consumer is unaffected) — `brand_presence_s3` on the DRS branch,
-   `semrush_feed` on the Semrush branch — and `domain` (the registrable domain) on the Semrush
-   branch. Sheet-scoped fields differ by branch: the DRS branch sets `sheet_date`, `s3_bucket`,
-   `s3_key` from the resolved sheet; the Semrush branch sets all three to `null`. Same queue,
-   backward-compatible.
+   `semrush_feed` on the Semrush branch. Sheet-scoped fields differ by branch: the DRS branch
+   sets `sheet_date`, `s3_bucket`, `s3_key` from the resolved sheet; the Semrush branch sets all
+   three to `null`. **No `domain` is emitted:** it is a per-market concept (each market has its
+   own domain; the brand has none), and the downstream Serenity proxy resolves
+   workspace/project/market from the `organization_id` + `brand_id` already on the event — a
+   brand-primary-site domain would mis-bind multi-market brands (mysticat-architecture#248
+   correction). Same queue, backward-compatible.
 
 Env (from Vault): `SQS_BP_SHEET_READY_QUEUE_URL`, `DRS_BP_BUCKET`. Feature gate (env, optional,
 default off): `BRAND_CLAIMS_SEMRUSH_ENABLED` — see ADR 006.

--- a/docs/specs/2026-08-11-brand-claims-scheduled-trigger.md
+++ b/docs/specs/2026-08-11-brand-claims-scheduled-trigger.md
@@ -2,6 +2,9 @@
 
 - Status: Implemented
 - Epic: LLMO-5741 (Brand Claims: GA Readiness)
+- Related: [LLMO-7177](https://jira.corp.adobe.com/browse/LLMO-7177) (per-site DRS-vs-Semrush
+  source decision on the trigger) · ADR
+  [`docs/decisions/006-brand-claims-drs-vs-semrush-source.md`](../decisions/006-brand-claims-drs-vs-semrush-source.md)
 
 ## Problem Statement
 
@@ -52,15 +55,38 @@ Flow (`src/brand-claims/handler.js`), for a message `{ type: 'brand-claims', sit
    out of scope; see Problem Statement).
 3. **Gate** — if `brand_claims_enabled` is off, log and ack with no further work (no S3
    listing, no ready-signal). Only enabled brands proceed.
-4. **Run** — build the S3 prefix `{siteId}/{brandSlug}/analytics/chatgpt_free/` (brand slug
-   via `sanitizePathComponent`, byte-for-byte with DRS) and select the latest sheet (max by
-   S3 date partition, then `LastModified`).
-5. **Emit** — publish `BRAND_PRESENCE_SHEET_WRITTEN` to `SQS_BP_SHEET_READY_QUEUE_URL` with
-   the DRS-shaped event (`organization_id` = SpaceCat org UUID — the BP consumer feeds it
-   into `/v2/orgs/{spaceCatId}/…`, which 400s on an IMS org id — `brand_id`, `brand` slug, `site_id`,
-   `week`, `year`, `cadence: "weekly"`, `sheet_date`, `platform`, `s3_bucket`, `s3_key`).
+3b. **Source decision (per site, LLMO-7177)** — decide DRS-sheet vs Semrush-feed for THIS
+   site before running. Semrush is chosen only when it is enabled for the run (env
+   `BRAND_CLAIMS_SEMRUSH_ENABLED=true`, or the per-run Slack override `enableSemrush` —
+   tri-state, override wins over env, mirroring `offsite-brand-presence`'s `resolveEnableSemrush`)
+   **AND** the brand is entitled to it (`resolveSemrushEntitlement` — the shared "serenity flag
+   AND resolvable Semrush workspace" gate, fail-closed with reason codes). Anything else —
+   disabled, non-entitled, an inconclusive entitlement check, or no parseable base URL for the
+   feed's `domain` — falls back to the unchanged DRS path, so a Semrush hiccup can never zero
+   out a site that has a DRS sheet. The decision runs **before** the `brandSlug` guard: the
+   Semrush feed is keyed by `domain`, not the S3 brand-slug path component, so a brand whose
+   name sanitizes to an empty slug can still run on the feed path.
+4. **Run** —
+   - *DRS branch:* build the S3 prefix `{siteId}/{brandSlug}/analytics/chatgpt_free/` (brand
+     slug via `sanitizePathComponent`, byte-for-byte with DRS) and select the latest sheet
+     (max by S3 date partition, then `LastModified`).
+   - *Semrush branch:* **skip the S3 prefix build and sheet lookup entirely** — there is no
+     sheet. Derive the registrable `domain` from the site's base URL (shared `toApexHost`) and
+     the `(week, year)` run window (explicit `week`+`year` from the message if supplied and
+     valid — replay-stable across a DLQ redrive — else the current ISO week).
+5. **Emit** — publish `BRAND_PRESENCE_SHEET_WRITTEN` to `SQS_BP_SHEET_READY_QUEUE_URL`.
+   `organization_id` = SpaceCat org UUID (the BP consumer feeds it into
+   `/v2/orgs/{spaceCatId}/…`, which 400s on an IMS org id), plus `brand_id`, `brand` slug,
+   `site_id`, `week`, `year`, `cadence: "weekly"`, `platform`. **New in LLMO-7177:** the event
+   carries an additive `ingest_source` on **both** branches (default `brand_presence_s3` when
+   absent, so a pre-7177 consumer is unaffected) — `brand_presence_s3` on the DRS branch,
+   `semrush_feed` on the Semrush branch — and `domain` (the registrable domain) on the Semrush
+   branch. Sheet-scoped fields differ by branch: the DRS branch sets `sheet_date`, `s3_bucket`,
+   `s3_key` from the resolved sheet; the Semrush branch sets all three to `null`. Same queue,
+   backward-compatible.
 
-Env (from Vault): `SQS_BP_SHEET_READY_QUEUE_URL`, `DRS_BP_BUCKET`.
+Env (from Vault): `SQS_BP_SHEET_READY_QUEUE_URL`, `DRS_BP_BUCKET`. Feature gate (env, optional,
+default off): `BRAND_CLAIMS_SEMRUSH_ENABLED` — see ADR 006.
 
 **Failure policy.** Infra/config faults throw so SQS retries and the message hits the DLQ:
 missing `SQS_BP_SHEET_READY_QUEUE_URL` / `DRS_BP_BUCKET` / PostgREST client, PostgREST

--- a/src/brand-claims/handler.js
+++ b/src/brand-claims/handler.js
@@ -15,48 +15,84 @@ import { ListObjectsV2Command } from '@aws-sdk/client-s3';
 import { ok } from '@adobe/spacecat-shared-http-utils';
 import { hasText, isoCalendarWeek } from '@adobe/spacecat-shared-utils';
 import { resolveSemrushEntitlement } from '../utils/semrush-entitlement.js';
-import { resolveEnableSemrush } from '../utils/offsite-audit-utils.js';
+import { resolveEnableSemrush, toApexHost } from '../utils/offsite-audit-utils.js';
 import { createOffsiteLogger, AUDIT } from '../utils/offsite-logging.js';
 
 const BP_PLATFORM = 'chatgpt_free';
 
 /**
  * `ingest_source` values on the `BRAND_PRESENCE_SHEET_WRITTEN` event. Additive contract
- * (LLMO-7177): the field is OPTIONAL and defaults to `brand_presence_s3` when absent, so
- * the DRS branch stays byte-identical to the pre-7177 event and only the Semrush branch
- * stamps a value. Mystique reads this to source the right feed (the DRS BP `.xlsx` in S3
- * vs the Semrush URL-Inspector feed keyed by `domain`).
+ * (LLMO-7177): the field is OPTIONAL and defaults to `brand_presence_s3` when absent (so a
+ * pre-7177 consumer is unaffected). BOTH branches now stamp it explicitly — the DRS branch
+ * with `brand_presence_s3`, the Semrush branch with `semrush_feed` — so Mystique can read
+ * it to source the right feed (the DRS BP `.xlsx` in S3 vs the Semrush URL-Inspector feed
+ * keyed by `domain`) without relying on the absent-means-DRS default.
  */
 const INGEST_SOURCE_DRS = 'brand_presence_s3';
 const INGEST_SOURCE_SEMRUSH = 'semrush_feed';
 
 /**
- * Cadence stamped on a Semrush-branch event when the brand config carries none. Claims runs
- * on a weekly cadence (see `isMondayPartition`), so `weekly` is the safe default; a future
- * per-brand cadence column on `brands` is honored automatically via `brand.cadence`.
+ * Cadence stamped on the Semrush-branch event. Claims runs on a weekly cadence (see
+ * `isMondayPartition`), and the `brands` projection (`getBrandForSite`) selects no cadence
+ * column — there is none today — so the value is a fixed default. When a per-brand `cadence`
+ * column is added to `brands`, extend that projection AND read it here (do not read
+ * `brand.cadence` today: it is always `undefined`).
  */
 const BRAND_CLAIMS_DEFAULT_CADENCE = 'weekly';
 
 /**
- * Derives the registrable domain for the Semrush feed from the site's base URL — the
- * www-stripped hostname, matching the `siteHostname` convention the offsite Semrush loader
- * (`offsite-brand-presence-semrush.js`) already uses for the same brand. Returns `null` when
- * no base URL is configured or it cannot be parsed (the caller then falls back to the DRS
- * path, since a `semrush_feed` event requires a `domain`).
+ * Coerces a Slack-delivered `week`/`year` override to a bounded positive integer, or
+ * `undefined` when absent/invalid. Slack custom args arrive as strings, so numeric strings
+ * are accepted alongside real numbers; anything outside the sane bound is rejected (treated
+ * as "not supplied") rather than trusted.
+ *
+ * @param {number|string} raw
+ * @param {number} min
+ * @param {number} max
+ * @returns {number|undefined}
+ */
+function toBoundedInt(raw, min, max) {
+  if (raw === undefined || raw === null || raw === '') {
+    return undefined;
+  }
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < min || n > max) {
+    return undefined;
+  }
+  return n;
+}
+
+/**
+ * Resolves the `(week, year)` the Semrush run is FOR. Prefers an explicit run window from
+ * `auditContext.messageData` (`week`+`year`, tri-state like `enableSemrush`: both must be
+ * present and valid to override), so a retry / DLQ redrive that crosses the UTC ISO-week
+ * boundary re-emits the SAME bucket for the same run rather than drifting to a new week.
+ * Falls back to the current ISO week when no valid explicit window is supplied.
+ *
+ * @param {object} [auditContext] - `message.auditContext`
+ * @returns {{week: number, year: number}}
+ */
+function resolveRunWeekYear(auditContext) {
+  const md = auditContext?.messageData ?? {};
+  const week = toBoundedInt(md.week, 1, 53);
+  const year = toBoundedInt(md.year, 2000, 9999);
+  if (week !== undefined && year !== undefined) {
+    return { week, year };
+  }
+  return isoCalendarWeek(new Date());
+}
+
+/**
+ * Derives the registrable domain for the Semrush feed from the site's base URL, reusing the
+ * shared `toApexHost` (`offsite-audit-utils.js`) so the eventual PSL upgrade stays a
+ * one-site change. Returns `''` when no base URL is configured or it cannot be parsed (the
+ * caller then falls back to the DRS path, since a `semrush_feed` event requires a `domain`).
  *
  * @param {object} site - Site model (`getBaseURL()`).
- * @returns {string|null}
+ * @returns {string}
  */
 function registrableDomainFromSite(site) {
-  const baseURL = site?.getBaseURL?.();
-  if (!hasText(baseURL)) {
-    return null;
-  }
-  try {
-    return new URL(baseURL).hostname.replace(/^www\./, '');
-  } catch {
-    return null;
-  }
+  return toApexHost(site?.getBaseURL?.());
 }
 const SHEET_FILENAME_RE = /-w(\d{1,2})-(\d{4})(?:-(\d{6}))?\.xlsx$/i;
 const KEY_DATE_RE = /\/(\d{4})\/(\d{2})\/(\d{2})\//;
@@ -247,18 +283,16 @@ export default async function brandClaimsHandler(message, context) {
   }
 
   const brandSlug = sanitizePathComponent(brand.name);
-  if (!brandSlug) {
-    log.warn(`brand-claims: brand name "${brand.name}" (${brand.id}) sanitizes to an empty S3 path component — cannot look up its sheet`);
-    return ok();
-  }
 
   // Per-site DRS-vs-Semrush decision (LLMO-7177). Default is the DRS Brand Presence sheet;
   // Semrush is chosen only when it is enabled for this run AND the brand is entitled to it.
   // The per-run Slack override (`enableSemrush`) takes precedence over the env flag, mirroring
   // offsite-brand-presence's `resolveEnableSemrush` pattern. Anything else — disabled,
   // non-entitled, or an inconclusive entitlement check — falls back to the unchanged DRS path,
-  // so a Semrush hiccup can never zero out a site that has a DRS sheet.
-  const olog = createOffsiteLogger(log, { audit: AUDIT.BRAND_PRESENCE, siteId: resolvedSiteId });
+  // so a Semrush hiccup can never zero out a site that has a DRS sheet. This runs BEFORE the
+  // `brandSlug` guard: the Semrush feed is keyed by `domain`, not the S3 brand-slug path
+  // component, so a brand whose name sanitizes to empty can still run on the feed path.
+  const olog = createOffsiteLogger(log, { audit: AUDIT.BRAND_CLAIMS, siteId: resolvedSiteId });
   const enableSemrushOverride = resolveEnableSemrush(message?.auditContext ?? {}, olog);
   const semrushEnabled = enableSemrushOverride
     ?? (env?.BRAND_CLAIMS_SEMRUSH_ENABLED === 'true');
@@ -274,8 +308,10 @@ export default async function brandClaimsHandler(message, context) {
         // key the feed, so fall back to the DRS sheet rather than emit an unroutable event.
         log.warn(`brand-claims: brand ${brand.id} is Semrush-entitled but site ${resolvedSiteId} has no parseable base URL for a registrable domain — falling back to the DRS sheet`);
       } else {
-        const { week, year } = isoCalendarWeek(new Date());
-        const cadence = brand.cadence || BRAND_CLAIMS_DEFAULT_CADENCE;
+        // Replay-stable window: an explicit `week`/`year` (Slack override / redrive) is used
+        // verbatim, else the current ISO week — so a DLQ redrive across the week boundary does
+        // not re-bucket the same run.
+        const { week, year } = resolveRunWeekYear(message?.auditContext);
         const event = {
           event_type: 'BRAND_PRESENCE_SHEET_WRITTEN',
           schema_version: 1,
@@ -285,7 +321,7 @@ export default async function brandClaimsHandler(message, context) {
           site_id: resolvedSiteId,
           week,
           year,
-          cadence,
+          cadence: BRAND_CLAIMS_DEFAULT_CADENCE,
           sheet_date: null,
           platform: BP_PLATFORM,
           s3_bucket: null,
@@ -306,6 +342,12 @@ export default async function brandClaimsHandler(message, context) {
       // helper already logs the granular reason.
       log.info(`brand-claims: brand ${brand.id} ("${brand.name}") on site ${resolvedSiteId} is not Semrush-entitled (reason=${entitlement.reason}, resolved=${entitlement.resolved}) — falling back to the DRS sheet`);
     }
+  }
+
+  // DRS branch requires the S3 brand-slug path component; an empty slug cannot address a sheet.
+  if (!brandSlug) {
+    log.warn(`brand-claims: brand name "${brand.name}" (${brand.id}) sanitizes to an empty S3 path component — cannot look up its sheet`);
+    return ok();
   }
 
   const prefix = `${resolvedSiteId}/${brandSlug}/analytics/${BP_PLATFORM}/`;

--- a/src/brand-claims/handler.js
+++ b/src/brand-claims/handler.js
@@ -25,8 +25,9 @@ const BP_PLATFORM = 'chatgpt_free';
  * (LLMO-7177): the field is OPTIONAL and defaults to `brand_presence_s3` when absent (so a
  * pre-7177 consumer is unaffected). BOTH branches now stamp it explicitly — the DRS branch
  * with `brand_presence_s3`, the Semrush branch with `semrush_feed` — so Mystique can read
- * it to source the right feed (the DRS BP `.xlsx` in S3 vs the Semrush URL-Inspector feed
- * keyed by `domain`) without relying on the absent-means-DRS default.
+ * it to source the right feed (the DRS BP `.xlsx` in S3 vs the Semrush feed, scoped
+ * downstream from `organization_id` + `brand_id` via the Serenity proxy) without relying
+ * on the absent-means-DRS default.
  */
 const INGEST_SOURCE_DRS = 'brand_presence_s3';
 const INGEST_SOURCE_SEMRUSH = 'semrush_feed';

--- a/src/brand-claims/handler.js
+++ b/src/brand-claims/handler.js
@@ -13,9 +13,51 @@
 import crypto from 'crypto';
 import { ListObjectsV2Command } from '@aws-sdk/client-s3';
 import { ok } from '@adobe/spacecat-shared-http-utils';
-import { hasText } from '@adobe/spacecat-shared-utils';
+import { hasText, isoCalendarWeek } from '@adobe/spacecat-shared-utils';
+import { resolveSemrushEntitlement } from '../utils/semrush-entitlement.js';
+import { resolveEnableSemrush } from '../utils/offsite-audit-utils.js';
+import { createOffsiteLogger, AUDIT } from '../utils/offsite-logging.js';
 
 const BP_PLATFORM = 'chatgpt_free';
+
+/**
+ * `ingest_source` values on the `BRAND_PRESENCE_SHEET_WRITTEN` event. Additive contract
+ * (LLMO-7177): the field is OPTIONAL and defaults to `brand_presence_s3` when absent, so
+ * the DRS branch stays byte-identical to the pre-7177 event and only the Semrush branch
+ * stamps a value. Mystique reads this to source the right feed (the DRS BP `.xlsx` in S3
+ * vs the Semrush URL-Inspector feed keyed by `domain`).
+ */
+const INGEST_SOURCE_DRS = 'brand_presence_s3';
+const INGEST_SOURCE_SEMRUSH = 'semrush_feed';
+
+/**
+ * Cadence stamped on a Semrush-branch event when the brand config carries none. Claims runs
+ * on a weekly cadence (see `isMondayPartition`), so `weekly` is the safe default; a future
+ * per-brand cadence column on `brands` is honored automatically via `brand.cadence`.
+ */
+const BRAND_CLAIMS_DEFAULT_CADENCE = 'weekly';
+
+/**
+ * Derives the registrable domain for the Semrush feed from the site's base URL — the
+ * www-stripped hostname, matching the `siteHostname` convention the offsite Semrush loader
+ * (`offsite-brand-presence-semrush.js`) already uses for the same brand. Returns `null` when
+ * no base URL is configured or it cannot be parsed (the caller then falls back to the DRS
+ * path, since a `semrush_feed` event requires a `domain`).
+ *
+ * @param {object} site - Site model (`getBaseURL()`).
+ * @returns {string|null}
+ */
+function registrableDomainFromSite(site) {
+  const baseURL = site?.getBaseURL?.();
+  if (!hasText(baseURL)) {
+    return null;
+  }
+  try {
+    return new URL(baseURL).hostname.replace(/^www\./, '');
+  } catch {
+    return null;
+  }
+}
 const SHEET_FILENAME_RE = /-w(\d{1,2})-(\d{4})(?:-(\d{6}))?\.xlsx$/i;
 const KEY_DATE_RE = /\/(\d{4})\/(\d{2})\/(\d{2})\//;
 const MAX_LISTING_PAGES = 10;
@@ -210,6 +252,62 @@ export default async function brandClaimsHandler(message, context) {
     return ok();
   }
 
+  // Per-site DRS-vs-Semrush decision (LLMO-7177). Default is the DRS Brand Presence sheet;
+  // Semrush is chosen only when it is enabled for this run AND the brand is entitled to it.
+  // The per-run Slack override (`enableSemrush`) takes precedence over the env flag, mirroring
+  // offsite-brand-presence's `resolveEnableSemrush` pattern. Anything else — disabled,
+  // non-entitled, or an inconclusive entitlement check — falls back to the unchanged DRS path,
+  // so a Semrush hiccup can never zero out a site that has a DRS sheet.
+  const olog = createOffsiteLogger(log, { audit: AUDIT.BRAND_PRESENCE, siteId: resolvedSiteId });
+  const enableSemrushOverride = resolveEnableSemrush(message?.auditContext ?? {}, olog);
+  const semrushEnabled = enableSemrushOverride
+    ?? (env?.BRAND_CLAIMS_SEMRUSH_ENABLED === 'true');
+
+  if (semrushEnabled) {
+    const entitlement = await resolveSemrushEntitlement(context, {
+      orgId: organizationId, brandId: brand.id,
+    });
+    if (entitlement.entitled) {
+      const domain = registrableDomainFromSite(site);
+      if (!hasText(domain)) {
+        // A semrush_feed event REQUIRES a domain; without a parseable base URL we cannot
+        // key the feed, so fall back to the DRS sheet rather than emit an unroutable event.
+        log.warn(`brand-claims: brand ${brand.id} is Semrush-entitled but site ${resolvedSiteId} has no parseable base URL for a registrable domain — falling back to the DRS sheet`);
+      } else {
+        const { week, year } = isoCalendarWeek(new Date());
+        const cadence = brand.cadence || BRAND_CLAIMS_DEFAULT_CADENCE;
+        const event = {
+          event_type: 'BRAND_PRESENCE_SHEET_WRITTEN',
+          schema_version: 1,
+          organization_id: organizationId,
+          brand_id: brand.id,
+          brand: brandSlug,
+          site_id: resolvedSiteId,
+          week,
+          year,
+          cadence,
+          sheet_date: null,
+          platform: BP_PLATFORM,
+          s3_bucket: null,
+          s3_key: null,
+          ingest_source: INGEST_SOURCE_SEMRUSH,
+          domain,
+          parent_job_id: null,
+          batch_id: null,
+        };
+
+        await sqs.sendMessage(queueUrl, event);
+        log.info(`brand-claims: published Semrush-feed ready-signal for site ${resolvedSiteId} (brand "${brand.name}"), domain=${domain}, week=${week}, year=${year}`);
+        return ok();
+      }
+    } else {
+      // resolved:true = confirmed non-entitlement (flag off / no workspace); resolved:false =
+      // inconclusive (no client / transient error). Both fall back to DRS — the entitlement
+      // helper already logs the granular reason.
+      log.info(`brand-claims: brand ${brand.id} ("${brand.name}") on site ${resolvedSiteId} is not Semrush-entitled (reason=${entitlement.reason}, resolved=${entitlement.resolved}) — falling back to the DRS sheet`);
+    }
+  }
+
   const prefix = `${resolvedSiteId}/${brandSlug}/analytics/${BP_PLATFORM}/`;
   const sheet = await findLatestSheet(s3Client, drsBpBucket, prefix, log);
   if (!sheet) {
@@ -231,6 +329,7 @@ export default async function brandClaimsHandler(message, context) {
     platform: BP_PLATFORM,
     s3_bucket: drsBpBucket,
     s3_key: sheet.key,
+    ingest_source: INGEST_SOURCE_DRS,
     parent_job_id: null,
     batch_id: null,
   };

--- a/src/brand-claims/handler.js
+++ b/src/brand-claims/handler.js
@@ -15,7 +15,7 @@ import { ListObjectsV2Command } from '@aws-sdk/client-s3';
 import { ok } from '@adobe/spacecat-shared-http-utils';
 import { hasText, isoCalendarWeek } from '@adobe/spacecat-shared-utils';
 import { resolveSemrushEntitlement } from '../utils/semrush-entitlement.js';
-import { resolveEnableSemrush, toApexHost } from '../utils/offsite-audit-utils.js';
+import { resolveEnableSemrush } from '../utils/offsite-audit-utils.js';
 import { createOffsiteLogger, AUDIT } from '../utils/offsite-logging.js';
 
 const BP_PLATFORM = 'chatgpt_free';
@@ -82,18 +82,6 @@ function resolveRunWeekYear(auditContext) {
   return isoCalendarWeek(new Date());
 }
 
-/**
- * Derives the registrable domain for the Semrush feed from the site's base URL, reusing the
- * shared `toApexHost` (`offsite-audit-utils.js`) so the eventual PSL upgrade stays a
- * one-site change. Returns `''` when no base URL is configured or it cannot be parsed (the
- * caller then falls back to the DRS path, since a `semrush_feed` event requires a `domain`).
- *
- * @param {object} site - Site model (`getBaseURL()`).
- * @returns {string}
- */
-function registrableDomainFromSite(site) {
-  return toApexHost(site?.getBaseURL?.());
-}
 const SHEET_FILENAME_RE = /-w(\d{1,2})-(\d{4})(?:-(\d{6}))?\.xlsx$/i;
 const KEY_DATE_RE = /\/(\d{4})\/(\d{2})\/(\d{2})\//;
 const MAX_LISTING_PAGES = 10;
@@ -290,8 +278,9 @@ export default async function brandClaimsHandler(message, context) {
   // offsite-brand-presence's `resolveEnableSemrush` pattern. Anything else — disabled,
   // non-entitled, or an inconclusive entitlement check — falls back to the unchanged DRS path,
   // so a Semrush hiccup can never zero out a site that has a DRS sheet. This runs BEFORE the
-  // `brandSlug` guard: the Semrush feed is keyed by `domain`, not the S3 brand-slug path
-  // component, so a brand whose name sanitizes to empty can still run on the feed path.
+  // `brandSlug` guard: the Semrush feed carries no S3 brand-slug path component (the downstream
+  // Serenity proxy resolves workspace/project/market from `organization_id` + `brand_id`, both
+  // already on the event), so a brand whose name sanitizes to empty can still run on the feed path.
   const olog = createOffsiteLogger(log, { audit: AUDIT.BRAND_CLAIMS, siteId: resolvedSiteId });
   const enableSemrushOverride = resolveEnableSemrush(message?.auditContext ?? {}, olog);
   const semrushEnabled = enableSemrushOverride
@@ -302,46 +291,41 @@ export default async function brandClaimsHandler(message, context) {
       orgId: organizationId, brandId: brand.id,
     });
     if (entitlement.entitled) {
-      const domain = registrableDomainFromSite(site);
-      if (!hasText(domain)) {
-        // A semrush_feed event REQUIRES a domain; without a parseable base URL we cannot
-        // key the feed, so fall back to the DRS sheet rather than emit an unroutable event.
-        log.warn(`brand-claims: brand ${brand.id} is Semrush-entitled but site ${resolvedSiteId} has no parseable base URL for a registrable domain — falling back to the DRS sheet`);
-      } else {
-        // Replay-stable window: an explicit `week`/`year` (Slack override / redrive) is used
-        // verbatim, else the current ISO week — so a DLQ redrive across the week boundary does
-        // not re-bucket the same run.
-        const { week, year } = resolveRunWeekYear(message?.auditContext);
-        const event = {
-          event_type: 'BRAND_PRESENCE_SHEET_WRITTEN',
-          schema_version: 1,
-          organization_id: organizationId,
-          brand_id: brand.id,
-          brand: brandSlug,
-          site_id: resolvedSiteId,
-          week,
-          year,
-          cadence: BRAND_CLAIMS_DEFAULT_CADENCE,
-          sheet_date: null,
-          platform: BP_PLATFORM,
-          s3_bucket: null,
-          s3_key: null,
-          ingest_source: INGEST_SOURCE_SEMRUSH,
-          domain,
-          parent_job_id: null,
-          batch_id: null,
-        };
+      // Replay-stable window: an explicit `week`/`year` (Slack override / redrive) is used
+      // verbatim, else the current ISO week — so a DLQ redrive across the week boundary does
+      // not re-bucket the same run.
+      const { week, year } = resolveRunWeekYear(message?.auditContext);
+      // No `domain`: it is a per-market concept (each market has its own domain, the brand has
+      // none), and the Serenity proxy resolves workspace/project/market from `organization_id`
+      // + `brand_id` downstream — a brand-primary-site domain would mis-bind multi-market brands
+      // (mysticat-architecture#248 correction).
+      const event = {
+        event_type: 'BRAND_PRESENCE_SHEET_WRITTEN',
+        schema_version: 1,
+        organization_id: organizationId,
+        brand_id: brand.id,
+        brand: brandSlug,
+        site_id: resolvedSiteId,
+        week,
+        year,
+        cadence: BRAND_CLAIMS_DEFAULT_CADENCE,
+        sheet_date: null,
+        platform: BP_PLATFORM,
+        s3_bucket: null,
+        s3_key: null,
+        ingest_source: INGEST_SOURCE_SEMRUSH,
+        parent_job_id: null,
+        batch_id: null,
+      };
 
-        await sqs.sendMessage(queueUrl, event);
-        log.info(`brand-claims: published Semrush-feed ready-signal for site ${resolvedSiteId} (brand "${brand.name}"), domain=${domain}, week=${week}, year=${year}`);
-        return ok();
-      }
-    } else {
-      // resolved:true = confirmed non-entitlement (flag off / no workspace); resolved:false =
-      // inconclusive (no client / transient error). Both fall back to DRS — the entitlement
-      // helper already logs the granular reason.
-      log.info(`brand-claims: brand ${brand.id} ("${brand.name}") on site ${resolvedSiteId} is not Semrush-entitled (reason=${entitlement.reason}, resolved=${entitlement.resolved}) — falling back to the DRS sheet`);
+      await sqs.sendMessage(queueUrl, event);
+      log.info(`brand-claims: published Semrush-feed ready-signal for site ${resolvedSiteId} (brand "${brand.name}"), week=${week}, year=${year}`);
+      return ok();
     }
+    // resolved:true = confirmed non-entitlement (flag off / no workspace); resolved:false =
+    // inconclusive (no client / transient error). Both fall back to DRS — the entitlement
+    // helper already logs the granular reason.
+    log.info(`brand-claims: brand ${brand.id} ("${brand.name}") on site ${resolvedSiteId} is not Semrush-entitled (reason=${entitlement.reason}, resolved=${entitlement.resolved}) — falling back to the DRS sheet`);
   }
 
   // DRS branch requires the S3 brand-slug path component; an empty slug cannot address a sheet.

--- a/src/utils/offsite-logging.js
+++ b/src/utils/offsite-logging.js
@@ -37,6 +37,7 @@ export const AUDIT = {
   YOUTUBE: 'youtube',
   WIKIPEDIA: 'wikipedia',
   BRAND_PRESENCE: 'brand-presence',
+  BRAND_CLAIMS: 'brand-claims',
 };
 
 // `DEGRADED` covers a condition that did not go perfectly but that the system handled and moved

--- a/test/audits/brand-claims.test.js
+++ b/test/audits/brand-claims.test.js
@@ -573,6 +573,34 @@ describe('Brand Claims audit handler', function () {
       expect(log.warn).to.have.been.calledWithMatch('no parseable base URL');
     });
 
+    it('falls back to the DRS sheet when entitled but the base URL is malformed (URL parse throws)', async () => {
+      const { handler } = await loadHandler({
+        entitled: true, resolved: true, reason: 'entitled', mode: 'flat',
+      });
+      s3Client.send.resolves({
+        Contents: [{ Key: DRS_SHEET_KEY, LastModified: new Date('2026-01-01T00:00:00Z') }],
+        IsTruncated: false,
+      });
+      // Non-empty text that `new URL()` rejects — exercises the parse-failure catch,
+      // distinct from the empty/absent base URL handled above.
+      const ctx = semrushContext({
+        site: {
+          getId: () => SITE_ID,
+          getOrganizationId: () => ORG_ID,
+          getBaseURL: () => 'not a valid url',
+        },
+      });
+
+      const res = await handler(message, ctx);
+
+      expect(res.status).to.equal(200);
+      expect(s3Client.send).to.have.been.called;
+      const [, event] = sqs.sendMessage.firstCall.args;
+      expect(event.ingest_source).to.equal('brand_presence_s3');
+      expect(event.domain).to.be.undefined;
+      expect(log.warn).to.have.been.calledWithMatch('no parseable base URL');
+    });
+
     it('never consults entitlement or emits a semrush event when Semrush is disabled', async () => {
       const { handler, entitlementStub } = await loadHandler({
         entitled: true, resolved: true, reason: 'entitled', mode: 'flat',

--- a/test/audits/brand-claims.test.js
+++ b/test/audits/brand-claims.test.js
@@ -15,6 +15,8 @@ import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import chaiAsPromised from 'chai-as-promised';
+import esmock from 'esmock';
+import { isoCalendarWeek } from '@adobe/spacecat-shared-utils';
 import brandClaimsHandler, { sanitizePathComponent } from '../../src/brand-claims/handler.js';
 
 use(sinonChai);
@@ -289,6 +291,8 @@ describe('Brand Claims audit handler', function () {
         platform: 'chatgpt_free',
         s3_bucket: 'drs-bp-bucket',
         s3_key: `${prefix}/2026/01/05/bp-w2-2026-030405.xlsx`,
+        // Additive ingest_source (LLMO-7177): the DRS branch stamps the explicit default.
+        ingest_source: 'brand_presence_s3',
         parent_job_id: null,
         batch_id: null,
       });
@@ -378,6 +382,218 @@ describe('Brand Claims audit handler', function () {
       expect(res.status).to.equal(200);
       expect(s3Client.send).to.have.callCount(10);
       expect(sqs.sendMessage).to.not.have.been.called;
+    });
+  });
+
+  describe('Semrush ingest-source decision (LLMO-7177)', () => {
+    const BASE_URL = 'https://www.acme.com';
+    const DRS_SHEET_KEY = `${SITE_ID}/acmecorp/analytics/chatgpt_free/2026/01/01/bp-w1-2026.xlsx`;
+
+    // Loads the handler with resolveSemrushEntitlement stubbed to a canned verdict, so the
+    // test drives the handler's per-site decision without a live PostgREST/Semrush round trip.
+    const loadHandler = async (entitlement) => {
+      const entitlementStub = sandbox.stub().resolves(entitlement);
+      const mod = await esmock('../../src/brand-claims/handler.js', {
+        '../../src/utils/semrush-entitlement.js': { resolveSemrushEntitlement: entitlementStub },
+      });
+      return { handler: mod.default, entitlementStub };
+    };
+
+    // Context with Semrush enabled via the env flag and a parseable base URL for the domain.
+    const semrushContext = (overrides = {}) => {
+      const ctx = buildContext({
+        env: {
+          SQS_BP_SHEET_READY_QUEUE_URL: 'https://sqs.test/bp-sheet-ready',
+          DRS_BP_BUCKET: 'drs-bp-bucket',
+          BRAND_CLAIMS_SEMRUSH_ENABLED: 'true',
+        },
+        site: {
+          getId: () => SITE_ID,
+          getOrganizationId: () => ORG_ID,
+          getBaseURL: () => BASE_URL,
+        },
+        ...overrides,
+      });
+      return ctx;
+    };
+
+    it('emits a semrush_feed event (no sheet lookup, domain set) when entitled', async () => {
+      const { handler, entitlementStub } = await loadHandler({
+        entitled: true, resolved: true, reason: 'entitled', mode: 'flat',
+      });
+
+      const res = await handler(message, semrushContext());
+
+      expect(res.status).to.equal(200);
+      // Semrush branch must skip the DRS-sheet S3 lookup entirely.
+      expect(s3Client.send).to.not.have.been.called;
+      expect(entitlementStub).to.have.been.calledOnceWithExactly(
+        sinon.match.object,
+        { orgId: ORG_ID, brandId: BRAND_ID },
+      );
+      expect(sqs.sendMessage).to.have.been.calledOnce;
+
+      const { week, year } = isoCalendarWeek(new Date());
+      const [queueUrl, event] = sqs.sendMessage.firstCall.args;
+      expect(queueUrl).to.equal('https://sqs.test/bp-sheet-ready');
+      expect(event).to.deep.equal({
+        event_type: 'BRAND_PRESENCE_SHEET_WRITTEN',
+        schema_version: 1,
+        organization_id: ORG_ID,
+        brand_id: BRAND_ID,
+        brand: 'acmecorp',
+        site_id: SITE_ID,
+        week,
+        year,
+        cadence: 'weekly',
+        sheet_date: null,
+        platform: 'chatgpt_free',
+        s3_bucket: null,
+        s3_key: null,
+        ingest_source: 'semrush_feed',
+        domain: 'acme.com',
+        parent_job_id: null,
+        batch_id: null,
+      });
+    });
+
+    it('honors a per-brand cadence from the brand config on the semrush event', async () => {
+      selectResult = {
+        data: [{
+          id: BRAND_ID, name: 'Acme Corp', brand_claims_enabled: true, cadence: 'daily',
+        }],
+        error: null,
+      };
+      const { handler } = await loadHandler({
+        entitled: true, resolved: true, reason: 'entitled', mode: 'subworkspace',
+      });
+
+      await handler(message, semrushContext());
+
+      const [, event] = sqs.sendMessage.firstCall.args;
+      expect(event.cadence).to.equal('daily');
+    });
+
+    it('honors a per-run Slack override (enableSemrush) over the env flag', async () => {
+      const { handler, entitlementStub } = await loadHandler({
+        entitled: true, resolved: true, reason: 'entitled', mode: 'flat',
+      });
+      // Env flag OFF; the Slack override turns Semrush on for this run only.
+      const ctx = semrushContext({
+        env: {
+          SQS_BP_SHEET_READY_QUEUE_URL: 'https://sqs.test/bp-sheet-ready',
+          DRS_BP_BUCKET: 'drs-bp-bucket',
+        },
+      });
+      const overrideMessage = {
+        ...message,
+        auditContext: { messageData: { enableSemrush: true } },
+      };
+
+      await handler(overrideMessage, ctx);
+
+      expect(entitlementStub).to.have.been.calledOnce;
+      const [, event] = sqs.sendMessage.firstCall.args;
+      expect(event.ingest_source).to.equal('semrush_feed');
+    });
+
+    it('lets a Slack override (enableSemrush:false) force the DRS path even when the env flag is on', async () => {
+      const { handler, entitlementStub } = await loadHandler({
+        entitled: true, resolved: true, reason: 'entitled', mode: 'flat',
+      });
+      s3Client.send.resolves({
+        Contents: [{ Key: DRS_SHEET_KEY, LastModified: new Date('2026-01-01T00:00:00Z') }],
+        IsTruncated: false,
+      });
+      const overrideMessage = {
+        ...message,
+        auditContext: { messageData: { enableSemrush: false } },
+      };
+
+      await handler(overrideMessage, semrushContext());
+
+      // Semrush disabled for this run: entitlement is never consulted and DRS serves.
+      expect(entitlementStub).to.not.have.been.called;
+      expect(s3Client.send).to.have.been.called;
+      const [, event] = sqs.sendMessage.firstCall.args;
+      expect(event.ingest_source).to.equal('brand_presence_s3');
+      expect(event.s3_key).to.equal(DRS_SHEET_KEY);
+    });
+
+    const fallbackCases = [
+      ['flag-disabled', { entitled: false, resolved: true, reason: 'flag_disabled' }],
+      ['no-workspace', { entitled: false, resolved: true, reason: 'no_workspace' }],
+      ['transient check failure', { entitled: false, resolved: false, reason: 'check_failed' }],
+      ['no client', { entitled: false, resolved: false, reason: 'no_client' }],
+    ];
+    fallbackCases.forEach(([label, entitlement]) => {
+      it(`falls back to the DRS sheet when the brand is not entitled (${label})`, async () => {
+        const { handler } = await loadHandler(entitlement);
+        s3Client.send.resolves({
+          Contents: [{ Key: DRS_SHEET_KEY, LastModified: new Date('2026-01-01T00:00:00Z') }],
+          IsTruncated: false,
+        });
+
+        const res = await handler(message, semrushContext());
+
+        expect(res.status).to.equal(200);
+        // No regression: the DRS lookup runs and a brand_presence_s3 event is published.
+        expect(s3Client.send).to.have.been.called;
+        expect(sqs.sendMessage).to.have.been.calledOnce;
+        const [, event] = sqs.sendMessage.firstCall.args;
+        expect(event.ingest_source).to.equal('brand_presence_s3');
+        expect(event.s3_key).to.equal(DRS_SHEET_KEY);
+        expect(event.domain).to.be.undefined;
+        expect(log.info).to.have.been.calledWithMatch('not Semrush-entitled');
+      });
+    });
+
+    it('falls back to the DRS sheet when entitled but the base URL is unparseable', async () => {
+      const { handler } = await loadHandler({
+        entitled: true, resolved: true, reason: 'entitled', mode: 'flat',
+      });
+      s3Client.send.resolves({
+        Contents: [{ Key: DRS_SHEET_KEY, LastModified: new Date('2026-01-01T00:00:00Z') }],
+        IsTruncated: false,
+      });
+      const ctx = semrushContext({
+        site: {
+          getId: () => SITE_ID,
+          getOrganizationId: () => ORG_ID,
+          getBaseURL: () => undefined,
+        },
+      });
+
+      const res = await handler(message, ctx);
+
+      expect(res.status).to.equal(200);
+      expect(s3Client.send).to.have.been.called;
+      const [, event] = sqs.sendMessage.firstCall.args;
+      expect(event.ingest_source).to.equal('brand_presence_s3');
+      expect(log.warn).to.have.been.calledWithMatch('no parseable base URL');
+    });
+
+    it('never consults entitlement or emits a semrush event when Semrush is disabled', async () => {
+      const { handler, entitlementStub } = await loadHandler({
+        entitled: true, resolved: true, reason: 'entitled', mode: 'flat',
+      });
+      s3Client.send.resolves({
+        Contents: [{ Key: DRS_SHEET_KEY, LastModified: new Date('2026-01-01T00:00:00Z') }],
+        IsTruncated: false,
+      });
+      // Default buildContext env has no BRAND_CLAIMS_SEMRUSH_ENABLED flag.
+      const res = await handler(message, buildContext({
+        site: {
+          getId: () => SITE_ID,
+          getOrganizationId: () => ORG_ID,
+          getBaseURL: () => BASE_URL,
+        },
+      }));
+
+      expect(res.status).to.equal(200);
+      expect(entitlementStub).to.not.have.been.called;
+      const [, event] = sqs.sendMessage.firstCall.args;
+      expect(event.ingest_source).to.equal('brand_presence_s3');
     });
   });
 });

--- a/test/audits/brand-claims.test.js
+++ b/test/audits/brand-claims.test.js
@@ -416,7 +416,7 @@ describe('Brand Claims audit handler', function () {
       return ctx;
     };
 
-    it('emits a semrush_feed event (no sheet lookup, domain set) when entitled', async () => {
+    it('emits a semrush_feed event (no sheet lookup, no domain) when entitled', async () => {
       // Freeze the clock so week/year are asserted as literals, not recomputed (MF2).
       // 2026-08-24T12:00:00Z is ISO week 35 of 2026.
       sandbox.useFakeTimers(new Date('2026-08-24T12:00:00Z'));
@@ -452,10 +452,12 @@ describe('Brand Claims audit handler', function () {
         s3_bucket: null,
         s3_key: null,
         ingest_source: 'semrush_feed',
-        domain: 'acme.com',
         parent_job_id: null,
         batch_id: null,
       });
+      // domain is a per-market concept and is resolved downstream from org+brand — it must
+      // NOT be on the event (mysticat-architecture#248 correction).
+      expect(event).to.not.have.property('domain');
     });
 
     it('uses an explicit run window (week/year) from the message over the wall clock (replay-stable)', async () => {
@@ -514,27 +516,10 @@ describe('Brand Claims audit handler', function () {
       expect(event.cadence).to.equal('weekly');
     });
 
-    it('preserves a non-www subdomain in the semrush domain', async () => {
-      const { handler } = await loadHandler({
-        entitled: true, resolved: true, reason: 'entitled', mode: 'flat',
-      });
-      const ctx = semrushContext({
-        site: {
-          getId: () => SITE_ID,
-          getOrganizationId: () => ORG_ID,
-          getBaseURL: () => 'https://blog.acme.com',
-        },
-      });
-
-      await handler(message, ctx);
-
-      const [, event] = sqs.sendMessage.firstCall.args;
-      expect(event.domain).to.equal('blog.acme.com');
-    });
-
     it('runs the Semrush feed path even when the brand name sanitizes to an empty slug', async () => {
-      // The feed is keyed by domain, not the S3 brand-slug path component, so an empty slug
-      // must NOT block the Semrush branch (NB2 — decision runs before the brandSlug guard).
+      // The feed carries no S3 brand-slug path component (org+brand identity routes it
+      // downstream), so an empty slug must NOT block the Semrush branch (decision runs before
+      // the brandSlug guard).
       selectResult = {
         data: [{ id: BRAND_ID, name: '   ', brand_claims_enabled: true }],
         error: null,
@@ -550,7 +535,6 @@ describe('Brand Claims audit handler', function () {
       const [, event] = sqs.sendMessage.firstCall.args;
       expect(event.ingest_source).to.equal('semrush_feed');
       expect(event.brand).to.equal('');
-      expect(event.domain).to.equal('acme.com');
     });
 
     it('falls through to the env flag (DRS path) on an invalid enableSemrush override', async () => {
@@ -653,62 +637,8 @@ describe('Brand Claims audit handler', function () {
         const [, event] = sqs.sendMessage.firstCall.args;
         expect(event.ingest_source).to.equal('brand_presence_s3');
         expect(event.s3_key).to.equal(DRS_SHEET_KEY);
-        expect(event.domain).to.be.undefined;
         expect(log.info).to.have.been.calledWithMatch('not Semrush-entitled');
       });
-    });
-
-    it('falls back to the DRS sheet when entitled but the base URL is unparseable', async () => {
-      const { handler } = await loadHandler({
-        entitled: true, resolved: true, reason: 'entitled', mode: 'flat',
-      });
-      s3Client.send.resolves({
-        Contents: [{ Key: DRS_SHEET_KEY, LastModified: new Date('2026-01-01T00:00:00Z') }],
-        IsTruncated: false,
-      });
-      const ctx = semrushContext({
-        site: {
-          getId: () => SITE_ID,
-          getOrganizationId: () => ORG_ID,
-          getBaseURL: () => undefined,
-        },
-      });
-
-      const res = await handler(message, ctx);
-
-      expect(res.status).to.equal(200);
-      expect(s3Client.send).to.have.been.called;
-      const [, event] = sqs.sendMessage.firstCall.args;
-      expect(event.ingest_source).to.equal('brand_presence_s3');
-      expect(log.warn).to.have.been.calledWithMatch('no parseable base URL');
-    });
-
-    it('falls back to the DRS sheet when entitled but the base URL is malformed (URL parse throws)', async () => {
-      const { handler } = await loadHandler({
-        entitled: true, resolved: true, reason: 'entitled', mode: 'flat',
-      });
-      s3Client.send.resolves({
-        Contents: [{ Key: DRS_SHEET_KEY, LastModified: new Date('2026-01-01T00:00:00Z') }],
-        IsTruncated: false,
-      });
-      // Non-empty text that `new URL()` rejects — exercises the parse-failure catch,
-      // distinct from the empty/absent base URL handled above.
-      const ctx = semrushContext({
-        site: {
-          getId: () => SITE_ID,
-          getOrganizationId: () => ORG_ID,
-          getBaseURL: () => 'not a valid url',
-        },
-      });
-
-      const res = await handler(message, ctx);
-
-      expect(res.status).to.equal(200);
-      expect(s3Client.send).to.have.been.called;
-      const [, event] = sqs.sendMessage.firstCall.args;
-      expect(event.ingest_source).to.equal('brand_presence_s3');
-      expect(event.domain).to.be.undefined;
-      expect(log.warn).to.have.been.calledWithMatch('no parseable base URL');
     });
 
     it('never consults entitlement or emits a semrush event when Semrush is disabled', async () => {

--- a/test/audits/brand-claims.test.js
+++ b/test/audits/brand-claims.test.js
@@ -16,7 +16,6 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import chaiAsPromised from 'chai-as-promised';
 import esmock from 'esmock';
-import { isoCalendarWeek } from '@adobe/spacecat-shared-utils';
 import brandClaimsHandler, { sanitizePathComponent } from '../../src/brand-claims/handler.js';
 
 use(sinonChai);
@@ -418,6 +417,9 @@ describe('Brand Claims audit handler', function () {
     };
 
     it('emits a semrush_feed event (no sheet lookup, domain set) when entitled', async () => {
+      // Freeze the clock so week/year are asserted as literals, not recomputed (MF2).
+      // 2026-08-24T12:00:00Z is ISO week 35 of 2026.
+      sandbox.useFakeTimers(new Date('2026-08-24T12:00:00Z'));
       const { handler, entitlementStub } = await loadHandler({
         entitled: true, resolved: true, reason: 'entitled', mode: 'flat',
       });
@@ -433,7 +435,6 @@ describe('Brand Claims audit handler', function () {
       );
       expect(sqs.sendMessage).to.have.been.calledOnce;
 
-      const { week, year } = isoCalendarWeek(new Date());
       const [queueUrl, event] = sqs.sendMessage.firstCall.args;
       expect(queueUrl).to.equal('https://sqs.test/bp-sheet-ready');
       expect(event).to.deep.equal({
@@ -443,8 +444,8 @@ describe('Brand Claims audit handler', function () {
         brand_id: BRAND_ID,
         brand: 'acmecorp',
         site_id: SITE_ID,
-        week,
-        year,
+        week: 35,
+        year: 2026,
         cadence: 'weekly',
         sheet_date: null,
         platform: 'chatgpt_free',
@@ -457,7 +458,46 @@ describe('Brand Claims audit handler', function () {
       });
     });
 
-    it('honors a per-brand cadence from the brand config on the semrush event', async () => {
+    it('uses an explicit run window (week/year) from the message over the wall clock (replay-stable)', async () => {
+      // Clock says week 35/2026; the explicit override must win so a DLQ redrive re-emits
+      // the same bucket regardless of when it runs.
+      sandbox.useFakeTimers(new Date('2026-08-24T12:00:00Z'));
+      const { handler } = await loadHandler({
+        entitled: true, resolved: true, reason: 'entitled', mode: 'flat',
+      });
+      const overrideMessage = {
+        ...message,
+        auditContext: { messageData: { week: '31', year: '2026' } },
+      };
+
+      await handler(overrideMessage, semrushContext());
+
+      const [, event] = sqs.sendMessage.firstCall.args;
+      expect(event.week).to.equal(31);
+      expect(event.year).to.equal(2026);
+    });
+
+    it('ignores a partial/invalid run window and defaults to the current ISO week', async () => {
+      sandbox.useFakeTimers(new Date('2026-08-24T12:00:00Z'));
+      const { handler } = await loadHandler({
+        entitled: true, resolved: true, reason: 'entitled', mode: 'flat',
+      });
+      // week present but year missing, and an out-of-range week — both rejected → default.
+      const overrideMessage = {
+        ...message,
+        auditContext: { messageData: { week: 99 } },
+      };
+
+      await handler(overrideMessage, semrushContext());
+
+      const [, event] = sqs.sendMessage.firstCall.args;
+      expect(event.week).to.equal(35);
+      expect(event.year).to.equal(2026);
+    });
+
+    it('stamps the default weekly cadence (brands has no cadence column) even if a stray cadence field is present', async () => {
+      // Guards MF1: the brands projection selects no cadence column, so any cadence value on
+      // the row is not real and must never leak into the event.
       selectResult = {
         data: [{
           id: BRAND_ID, name: 'Acme Corp', brand_claims_enabled: true, cadence: 'daily',
@@ -471,7 +511,77 @@ describe('Brand Claims audit handler', function () {
       await handler(message, semrushContext());
 
       const [, event] = sqs.sendMessage.firstCall.args;
-      expect(event.cadence).to.equal('daily');
+      expect(event.cadence).to.equal('weekly');
+    });
+
+    it('preserves a non-www subdomain in the semrush domain', async () => {
+      const { handler } = await loadHandler({
+        entitled: true, resolved: true, reason: 'entitled', mode: 'flat',
+      });
+      const ctx = semrushContext({
+        site: {
+          getId: () => SITE_ID,
+          getOrganizationId: () => ORG_ID,
+          getBaseURL: () => 'https://blog.acme.com',
+        },
+      });
+
+      await handler(message, ctx);
+
+      const [, event] = sqs.sendMessage.firstCall.args;
+      expect(event.domain).to.equal('blog.acme.com');
+    });
+
+    it('runs the Semrush feed path even when the brand name sanitizes to an empty slug', async () => {
+      // The feed is keyed by domain, not the S3 brand-slug path component, so an empty slug
+      // must NOT block the Semrush branch (NB2 — decision runs before the brandSlug guard).
+      selectResult = {
+        data: [{ id: BRAND_ID, name: '   ', brand_claims_enabled: true }],
+        error: null,
+      };
+      const { handler } = await loadHandler({
+        entitled: true, resolved: true, reason: 'entitled', mode: 'flat',
+      });
+
+      const res = await handler(message, semrushContext());
+
+      expect(res.status).to.equal(200);
+      expect(s3Client.send).to.not.have.been.called;
+      const [, event] = sqs.sendMessage.firstCall.args;
+      expect(event.ingest_source).to.equal('semrush_feed');
+      expect(event.brand).to.equal('');
+      expect(event.domain).to.equal('acme.com');
+    });
+
+    it('falls through to the env flag (DRS path) on an invalid enableSemrush override', async () => {
+      const { handler, entitlementStub } = await loadHandler({
+        entitled: true, resolved: true, reason: 'entitled', mode: 'flat',
+      });
+      s3Client.send.resolves({
+        Contents: [{ Key: DRS_SHEET_KEY, LastModified: new Date('2026-01-01T00:00:00Z') }],
+        IsTruncated: false,
+      });
+      // env flag absent + an invalid (non-boolean) override → tri-state resolves undefined,
+      // so semrush stays off and DRS serves. Also exercises the invalid-override warning.
+      const ctx = semrushContext({
+        env: {
+          SQS_BP_SHEET_READY_QUEUE_URL: 'https://sqs.test/bp-sheet-ready',
+          DRS_BP_BUCKET: 'drs-bp-bucket',
+        },
+      });
+      const overrideMessage = {
+        ...message,
+        auditContext: { messageData: { enableSemrush: 'maybe' } },
+      };
+
+      const res = await handler(overrideMessage, ctx);
+
+      expect(res.status).to.equal(200);
+      expect(entitlementStub).to.not.have.been.called;
+      expect(s3Client.send).to.have.been.called;
+      const [, event] = sqs.sendMessage.firstCall.args;
+      expect(event.ingest_source).to.equal('brand_presence_s3');
+      expect(log.warn).to.have.been.calledWithMatch('Invalid override value');
     });
 
     it('honors a per-run Slack override (enableSemrush) over the env flag', async () => {

--- a/test/utils/offsite-logging.test.js
+++ b/test/utils/offsite-logging.test.js
@@ -52,6 +52,7 @@ describe('offsite-logging helper', () => {
         YOUTUBE: 'youtube',
         WIKIPEDIA: 'wikipedia',
         BRAND_PRESENCE: 'brand-presence',
+        BRAND_CLAIMS: 'brand-claims',
       });
       expect(OUTCOME).to.deep.equal({
         START: 'start', SUCCESS: 'success', FAILURE: 'failure', SKIP: 'skip', DEGRADED: 'degraded',


### PR DESCRIPTION
## Summary
Makes the `brand-claims` audit decide **DRS-sheet vs Semrush per site** and stamps `ingest_source` on the existing `BRAND_PRESENCE_SHEET_WRITTEN` event, so Mystique can source the right feed. Same queue, additive/backward-compatible. Implements LLMO-7177.

Consumer side of this contract: **experience-platform/mystique#4642** (LLMO-7178).

## What it does
- **Per-site decision** in `src/brand-claims/handler.js`, reusing the offsite helpers: `resolveSemrushEntitlement` (fail-closed, reason codes) + `resolveEnableSemrush` (`BRAND_CLAIMS_SEMRUSH_ENABLED` env + per-run Slack `enableSemrush` override, override wins).
- **Semrush branch** (enabled **and** entitled): skips the DRS S3-sheet lookup; emits `ingest_source: "semrush_feed"`, replay-stable `week`/`year` (an explicit window from `auditContext.messageData` wins, else the current ISO week — so a retry/DLQ redrive across the UTC week boundary re-emits the same bucket), `cadence` (`weekly` default), and `null` `sheet_date`/`s3_bucket`/`s3_key`. Runs **before** the `brandSlug` guard, so a brand whose name sanitizes to empty can still take the feed path.
- **DRS branch** (default / disabled / non-entitled / inconclusive check): unchanged behavior, now stamped with explicit `ingest_source: "brand_presence_s3"`. A Semrush hiccup can never zero out a site that has a DRS sheet.

## No `domain` on the event (spec #248 correction)
An earlier revision stamped a registrable `domain`. That's been **removed**: `domain` is a per-*market* concept (each market has its own domain; the brand has none), and the downstream Serenity proxy resolves workspace/project/market from `organization_id` + `brand_id` — both already on the event. A brand-primary-site domain would mis-bind multi-market brands (mysticat-architecture#248). So the Semrush payload carries **no `domain`**; identity is `org_id` + `brand_id`.

## Event contract
Additive `ingest_source` (optional, defaults to `brand_presence_s3` when absent, so a pre-7177 consumer is unaffected); both branches now stamp it explicitly.

## Tests
Entitlement-gate matrix (entitled / flag-disabled / no-workspace / transient / no-client → DRS fallback), Semrush payload shape (no sheet, no `domain`, `ingest_source: semrush_feed`), per-run cadence, Slack-override precedence, replay-stable `week`/`year` (frozen clock, explicit-window override), and the DRS deep-equal (with the additive `ingest_source`). 100% coverage gate green.

## Notes
- **Dormant until migration:** the Semrush branch only fires with `BRAND_CLAIMS_SEMRUSH_ENABLED` on (default off) or a Slack override, **and** an entitled brand. Flag off → every brand takes the unchanged DRS path.
- Docs: `docs/specs/2026-08-11-brand-claims-scheduled-trigger.md` + `docs/decisions/006-brand-claims-drs-vs-semrush-source.md` updated.
- Live Semrush runs remain gated on the Semrush-side deliverables (LLMO-6836 auth + serenity endpoints); this ticket is buildable/testable now.
