### PR TITLE
fix(commerce-product-enrichments): use domcontentloaded to avoid navigation timeout on heavy pages

### DIFF
--- a/src/commerce-product-enrichments/handler.js
+++ b/src/commerce-product-enrichments/handler.js
@@ -146,6 +146,7 @@ async function buildScrapePayload({
       waitTimeoutForMetaTags: 5000,
       screenshotTypes: [],
       expandShadowDOM: false,
+      waitUntil: 'domcontentloaded',
     },
     customHeaders: {
       'User-Agent': 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; gptbot/1.2; +https://openai.com/gptbot',

--- a/test/audits/commerce-product-enrichments/handler.test.js
+++ b/test/audits/commerce-product-enrichments/handler.test.js
@@ -263,6 +263,7 @@ describe('Commerce Product Enrichments Handler', () => {
         waitTimeoutForMetaTags: 5000,
         screenshotTypes: [],
         expandShadowDOM: false,
+        waitUntil: 'domcontentloaded',
       },
       customHeaders: {
         'User-Agent': 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; gptbot/1.2; +https://openai.com/gptbot',
@@ -516,6 +517,7 @@ describe('Commerce Product Enrichments Handler', () => {
         waitTimeoutForMetaTags: 5000,
         screenshotTypes: [],
         expandShadowDOM: false,
+        waitUntil: 'domcontentloaded',
       },
       customHeaders: {
         'User-Agent': 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko); compatible; gptbot/1.2; +https://openai.com/gptbot',


### PR DESCRIPTION
## What

Sets `waitUntil: 'domcontentloaded'` in the `commerce-product-enrichments` scrape payload options.

## Why

Commerce sites using heavy SPA stacks fail scraping with `Navigation timeout of 30000 ms exceeded` and `errorCategory=BROWSER_CORRUPT` when the scraper uses the default `networkidle2` strategy — waiting for all network activity on a JS-heavy page takes well over 30s.

`domcontentloaded` fires as soon as the initial HTML is parsed. Verified that the critical product metadata (JSON-LD `Product`, `og:*` tags) is server-rendered in the initial HTML for these page types — not JS-injected — so switching strategies does not affect data quality. The existing `waitTimeoutForMetaTags: 5000` provides an additional 5s buffer. A manual scrape job with `waitUntil: domcontentloaded` on the same URLs returned `COMPLETE` where the default returned `FAILED`.

## Tests

Updated 2 existing assertions in `handler.test.js`. All 66 tests passing.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Mihaela Danila", "Dominique Jäggi"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```