### PR TITLE
fix(agentic-traffic): ignore-list language codes that collide with real countries

### DIFF
--- a/src/cdn-logs-report/utils/report-utils.js
+++ b/src/cdn-logs-report/utils/report-utils.js
@@ -55,7 +55,12 @@ export async function loadSql(filename, variables) {
 export function validateCountryCode(code, siteIgnoreList = []) {
   const DEFAULT_COUNTRY_CODE = 'GLOBAL';
   // these are codes that are not valid to be regions as these are small islands
-  const globalIgnoreCodes = ['TV', 'ST'];
+  // VI/ML/NE/MR/KN/BN/GU/MS/SR/SL/SV/ET/GA collide with language path segments
+  // (e.g. /vi/, /ml/, /sv/) and are dominated by that language traffic fleet-wide
+  // (LLMO-7230) rather than genuine traffic from the country they also name
+  const globalIgnoreCodes = [
+    'TV', 'ST', 'VI', 'ML', 'NE', 'MR', 'KN', 'BN', 'GU', 'MS', 'SR', 'SL', 'SV', 'ET', 'GA',
+  ];
   const countryAliases = {
     UK: 'UK',
   };

--- a/src/cdn-logs-report/utils/report-utils.js
+++ b/src/cdn-logs-report/utils/report-utils.js
@@ -57,9 +57,12 @@ export function validateCountryCode(code, siteIgnoreList = []) {
   // these are codes that are not valid to be regions as these are small islands
   // VI/ML/NE/MR/KN/BN/GU/MS/SR/SL/SV/ET/GA collide with language path segments
   // (e.g. /vi/, /ml/, /sv/) and are dominated by that language traffic fleet-wide
-  // (LLMO-7230) rather than genuine traffic from the country they also name
+  // (LLMO-7230) rather than genuine traffic from the country they also name.
+  // GL collides with "Global" locale notation (e.g. /en_gl/) rather than Greenland.
+  // CY is intentionally NOT here: /cy/el/... is a genuine country-then-language path
+  // (Cyprus, Greek), verified against live traffic - not a language-path collision.
   const globalIgnoreCodes = [
-    'TV', 'ST', 'VI', 'ML', 'NE', 'MR', 'KN', 'BN', 'GU', 'MS', 'SR', 'SL', 'SV', 'ET', 'GA',
+    'TV', 'ST', 'VI', 'ML', 'NE', 'MR', 'KN', 'BN', 'GU', 'MS', 'SR', 'SL', 'SV', 'ET', 'GA', 'GL',
   ];
   const countryAliases = {
     UK: 'UK',

--- a/src/cdn-logs-report/utils/report-utils.js
+++ b/src/cdn-logs-report/utils/report-utils.js
@@ -52,18 +52,43 @@ export async function loadSql(filename, variables) {
   return getStaticContent(variables, `./src/cdn-logs-report/sql/${filename}.sql`);
 }
 
+// Codes that are valid ISO-3166 countries but are not real regions - small
+// islands whose code is dominated by an unrelated URL path token.
+const NON_REGION_CODES = ['TV', 'ST'];
+
+// Codes that are valid ISO-3166 countries but collide with an ISO-639 language
+// code, and are dominated fleet-wide by that language's URL path segment
+// (e.g. /vi/, /ml/, /sv/, /en_gl/) rather than genuine traffic from the named
+// country (LLMO-7230). Each value documents the collision so the reasoning
+// survives independently of the PR/test history. CY and AF are deliberately
+// NOT here - both were checked against live traffic and are genuine
+// country-then-language paths (/cy/el/..., /af/en/...), not language leaks.
+// PA is also deliberately not here - Panama is genuine traffic fleet-wide;
+// sites needing to exclude it (e.g. Zee5's Punjabi /pa/) use siteIgnoreList.
+const LANGUAGE_COLLISION_CODES = {
+  VI: 'Vietnamese vs Virgin Islands',
+  ML: 'Malayalam vs Mali',
+  NE: 'Nepali vs Niger',
+  MR: 'Marathi vs Mauritania',
+  KN: 'Kannada vs St Kitts',
+  BN: 'Bengali vs Brunei',
+  GU: 'Gujarati vs Guam',
+  MS: 'Malay(sian) vs Montserrat',
+  SR: 'Serbian vs Suriname',
+  SL: 'Slovenian vs Sierra Leone',
+  SV: 'Swedish vs El Salvador',
+  ET: 'Estonian vs Ethiopia',
+  GA: 'Irish/Georgian vs Gabon',
+  GL: '"Global" locale (/en_gl/) vs Greenland',
+};
+
+const GLOBAL_IGNORE_CODES = new Set([
+  ...NON_REGION_CODES,
+  ...Object.keys(LANGUAGE_COLLISION_CODES),
+]);
+
 export function validateCountryCode(code, siteIgnoreList = []) {
   const DEFAULT_COUNTRY_CODE = 'GLOBAL';
-  // these are codes that are not valid to be regions as these are small islands
-  // VI/ML/NE/MR/KN/BN/GU/MS/SR/SL/SV/ET/GA collide with language path segments
-  // (e.g. /vi/, /ml/, /sv/) and are dominated by that language traffic fleet-wide
-  // (LLMO-7230) rather than genuine traffic from the country they also name.
-  // GL collides with "Global" locale notation (e.g. /en_gl/) rather than Greenland.
-  // CY is intentionally NOT here: /cy/el/... is a genuine country-then-language path
-  // (Cyprus, Greek), verified against live traffic - not a language-path collision.
-  const globalIgnoreCodes = [
-    'TV', 'ST', 'VI', 'ML', 'NE', 'MR', 'KN', 'BN', 'GU', 'MS', 'SR', 'SL', 'SV', 'ET', 'GA', 'GL',
-  ];
   const countryAliases = {
     UK: 'UK',
   };
@@ -73,7 +98,7 @@ export function validateCountryCode(code, siteIgnoreList = []) {
 
   const upperCode = code.toUpperCase();
   const upperSiteIgnoreList = siteIgnoreList.map((c) => c.toUpperCase());
-  const ignoreCountryCodes = [...globalIgnoreCodes, ...upperSiteIgnoreList];
+  const ignoreCountryCodes = [...GLOBAL_IGNORE_CODES, ...upperSiteIgnoreList];
 
   if (upperCode === DEFAULT_COUNTRY_CODE || ignoreCountryCodes.includes(upperCode)) {
     return DEFAULT_COUNTRY_CODE;

--- a/test/audits/cdn-logs-report/report-utils.test.js
+++ b/test/audits/cdn-logs-report/report-utils.test.js
@@ -14,9 +14,11 @@ import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import chaiAsPromised from 'chai-as-promised';
+import esmock from 'esmock';
 import { getS3Config } from '../../../src/utils/cdn-utils.js';
 import { fetchAgenticUrlClassificationRules } from '../../../src/common/agentic-url-classification-rules.js';
 import * as reportUtils from '../../../src/cdn-logs-report/utils/report-utils.js';
+import { getConfigs } from '../../../src/cdn-logs-report/constants/report-configs.js';
 
 use(sinonChai);
 use(chaiAsPromised);
@@ -24,6 +26,8 @@ use(chaiAsPromised);
 describe('CDN Logs Report Utils', () => {
   let sandbox;
   let mockContext;
+  const referralConfig = getConfigs('test-bucket', 'test-site-id')
+    .find((c) => c.name === 'referral');
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();

--- a/test/audits/cdn-logs-report/report-utils.test.js
+++ b/test/audits/cdn-logs-report/report-utils.test.js
@@ -14,11 +14,9 @@ import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import chaiAsPromised from 'chai-as-promised';
-import esmock from 'esmock';
 import { getS3Config } from '../../../src/utils/cdn-utils.js';
 import { fetchAgenticUrlClassificationRules } from '../../../src/common/agentic-url-classification-rules.js';
 import * as reportUtils from '../../../src/cdn-logs-report/utils/report-utils.js';
-import { getConfigs } from '../../../src/cdn-logs-report/constants/report-configs.js';
 
 use(sinonChai);
 use(chaiAsPromised);
@@ -26,8 +24,6 @@ use(chaiAsPromised);
 describe('CDN Logs Report Utils', () => {
   let sandbox;
   let mockContext;
-  const referralConfig = getConfigs('test-bucket', 'test-site-id')
-    .find((c) => c.name === 'referral');
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
@@ -158,6 +154,38 @@ describe('CDN Logs Report Utils', () => {
     it('handles GLOBAL country code correctly', () => {
       expect(reportUtils.validateCountryCode('GLOBAL')).to.equal('GLOBAL');
       expect(reportUtils.validateCountryCode('global')).to.equal('GLOBAL');
+    });
+
+    it('returns GLOBAL for language codes that collide with a real country (LLMO-7230)', () => {
+      expect(reportUtils.validateCountryCode('VI')).to.equal('GLOBAL'); // Vietnamese vs Virgin Islands
+      expect(reportUtils.validateCountryCode('vi')).to.equal('GLOBAL');
+      expect(reportUtils.validateCountryCode('ML')).to.equal('GLOBAL'); // Malayalam vs Mali
+      expect(reportUtils.validateCountryCode('NE')).to.equal('GLOBAL'); // Nepali vs Niger
+      expect(reportUtils.validateCountryCode('MR')).to.equal('GLOBAL'); // Marathi vs Mauritania
+      expect(reportUtils.validateCountryCode('KN')).to.equal('GLOBAL'); // Kannada vs St Kitts
+      expect(reportUtils.validateCountryCode('BN')).to.equal('GLOBAL'); // Bengali vs Brunei
+      expect(reportUtils.validateCountryCode('GU')).to.equal('GLOBAL'); // Gujarati vs Guam
+      expect(reportUtils.validateCountryCode('MS')).to.equal('GLOBAL'); // Malay(sian) vs Montserrat
+      expect(reportUtils.validateCountryCode('SR')).to.equal('GLOBAL'); // Serbian vs Suriname
+      expect(reportUtils.validateCountryCode('SL')).to.equal('GLOBAL'); // Slovenian/Slovak vs Sierra Leone
+      expect(reportUtils.validateCountryCode('SV')).to.equal('GLOBAL'); // Swedish vs El Salvador
+      expect(reportUtils.validateCountryCode('ET')).to.equal('GLOBAL'); // Estonian vs Ethiopia
+      expect(reportUtils.validateCountryCode('GA')).to.equal('GLOBAL'); // Irish/Georgian vs Gabon
+    });
+
+    it('does not ignore-list countries with genuine fleet-wide traffic (LLMO-7230)', () => {
+      expect(reportUtils.validateCountryCode('CA')).to.equal('CA');
+      expect(reportUtils.validateCountryCode('MY')).to.equal('MY');
+      expect(reportUtils.validateCountryCode('ID')).to.equal('ID');
+      expect(reportUtils.validateCountryCode('TH')).to.equal('TH');
+      expect(reportUtils.validateCountryCode('BE')).to.equal('BE');
+      expect(reportUtils.validateCountryCode('DE')).to.equal('DE');
+      expect(reportUtils.validateCountryCode('FR')).to.equal('FR');
+    });
+
+    it('allows PA to be ignored per-site (e.g. Zee5 Punjabi /pa/) without a global ignore', () => {
+      expect(reportUtils.validateCountryCode('PA')).to.equal('PA');
+      expect(reportUtils.validateCountryCode('PA', ['PA'])).to.equal('GLOBAL');
     });
 
     it('returns GLOBAL for codes in per-site ignore list', () => {

--- a/test/audits/cdn-logs-report/report-utils.test.js
+++ b/test/audits/cdn-logs-report/report-utils.test.js
@@ -171,7 +171,7 @@ describe('CDN Logs Report Utils', () => {
       expect(reportUtils.validateCountryCode('GU')).to.equal('GLOBAL'); // Gujarati vs Guam
       expect(reportUtils.validateCountryCode('MS')).to.equal('GLOBAL'); // Malay(sian) vs Montserrat
       expect(reportUtils.validateCountryCode('SR')).to.equal('GLOBAL'); // Serbian vs Suriname
-      expect(reportUtils.validateCountryCode('SL')).to.equal('GLOBAL'); // Slovenian/Slovak vs Sierra Leone
+      expect(reportUtils.validateCountryCode('SL')).to.equal('GLOBAL'); // Slovenian vs Sierra Leone (Slovak is 'sk', not 'sl')
       expect(reportUtils.validateCountryCode('SV')).to.equal('GLOBAL'); // Swedish vs El Salvador
       expect(reportUtils.validateCountryCode('ET')).to.equal('GLOBAL'); // Estonian vs Ethiopia
       expect(reportUtils.validateCountryCode('GA')).to.equal('GLOBAL'); // Irish/Georgian vs Gabon

--- a/test/audits/cdn-logs-report/report-utils.test.js
+++ b/test/audits/cdn-logs-report/report-utils.test.js
@@ -171,6 +171,7 @@ describe('CDN Logs Report Utils', () => {
       expect(reportUtils.validateCountryCode('SV')).to.equal('GLOBAL'); // Swedish vs El Salvador
       expect(reportUtils.validateCountryCode('ET')).to.equal('GLOBAL'); // Estonian vs Ethiopia
       expect(reportUtils.validateCountryCode('GA')).to.equal('GLOBAL'); // Irish/Georgian vs Gabon
+      expect(reportUtils.validateCountryCode('GL')).to.equal('GLOBAL'); // "Global" locale (/en_gl/) vs Greenland
     });
 
     it('does not ignore-list countries with genuine fleet-wide traffic (LLMO-7230)', () => {
@@ -181,6 +182,9 @@ describe('CDN Logs Report Utils', () => {
       expect(reportUtils.validateCountryCode('BE')).to.equal('BE');
       expect(reportUtils.validateCountryCode('DE')).to.equal('DE');
       expect(reportUtils.validateCountryCode('FR')).to.equal('FR');
+      // CY verified against live traffic: /cy/el/... is a genuine Cyprus (country) +
+      // Greek (language) path, not a Welsh-language leak, so CY stays a real code
+      expect(reportUtils.validateCountryCode('CY')).to.equal('CY');
     });
 
     it('allows PA to be ignored per-site (e.g. Zee5 Punjabi /pa/) without a global ignore', () => {


### PR DESCRIPTION
## Summary
- `validateCountryCode`'s `globalIgnoreCodes` (same mechanism already used for `TV`/`ST`) now also drops language-path segments that happen to be valid ISO country codes: `VI, ML, NE, MR, KN, BN, GU, MS, SR, SL, SV, ET, GA, GL`. These were being fleet-wide mislabeled as real countries (e.g. `/vi/` Vietnamese shown as "Virgin Islands", `/ml/` Malayalam as "Mali", `/sv/` Swedish as "El Salvador", `/en_gl/` "Global" locale as "Greenland") — ~150 sites affected, including helpx.adobe.com (VI = 1.28M hits) and one AEM Cloud host (GL = 10.5M hits).
- Country-dominant collisions (`CA, MY, ID, TH, BE, DE, FR`) are intentionally left untouched — real traffic for those sites.
- `CY` and `AF` were considered (same collision class — Welsh/Cyprus, Afrikaans/Afghanistan) but verified against live traffic as genuine country-then-language paths (`/cy/el/...`, `/af/en/...`) rather than language leaks, so they're intentionally **not** added.
- `PA` is intentionally **not** added to the global list either — Panama is genuine traffic for other sites (WestJet, BHHS); per-site exclusion (e.g. Zee5's Punjabi `/pa/`) should go through the existing `siteIgnoreList` mechanism instead.

Scope note: this fixes the "hits by market" chart surface, which already calls `validateCountryCode`. The 5xx/4xx opportunity "Country" filter (`llm-error-pages`) does not call this function today and needs separate follow-up work to wire it in — tracked as a second part of LLMO-7230, not included in this PR.

Jira: LLMO-7230 (relates to LLMO-7213)
Introduced by: N/A

## Test plan
- [x] Added unit tests covering all 14 collision codes → `GLOBAL`
- [x] Added unit tests confirming country-dominant codes (`CA, MY, ID, TH, BE, DE, FR, CY`) are unaffected
- [x] Added unit test confirming `PA` stays a real code globally but resolves to `GLOBAL` via per-site `siteIgnoreList`
- [x] `npx eslint` clean (0 errors/warnings) on changed files
- [x] `report-utils.js` at 100% line/statement/function/branch coverage
- [x] Full repo suite: 9,889 passing, 0 failing (pre-existing 99.98% global coverage gap confirmed unrelated to this change)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Data-mapping fix to a reporting classification list, fully covered by unit tests and easily revertible."
```