### PR TITLE
feat(LLMO-6973): add success logging to four DB read events in offsite pipeline

### DIFF
--- a/docs/specs/2026-07-31-offsite-structured-logging.md
+++ b/docs/specs/2026-07-31-offsite-structured-logging.md
@@ -91,7 +91,10 @@ sink does not surface a second-arg object to Splunk — see ADR 002).
 - P4: `audit_analysis_run_write` (via post-processor);
   `audit_persistence_evergreen_opportunity_write` success **and** the previously-silent
   DB-write failure made loud; `audit_persistence_mystique_payload_s3_read` success/failure;
-  `audit_persistence_evergreen_opportunity_write` (suggestions half); `audit_persistence_opportunity_retired`.
+  `audit_persistence_evergreen_opportunity_write` (suggestions half); `audit_persistence_opportunity_retired`;
+  `audit_persistence_evergreen_opportunity_read` success (count); `audit_persistence_snapshot_opportunity_read` success (count).
+- P5: `audit_housekeeping_outdated_opportunities_read` success (count);
+  `audit_housekeeping_outdated_suggestions_read` success (count).
 
 ### Scope boundaries
 Offsite-only files were converted (collector, poll, analysis + guidance handlers,

--- a/src/common/offsite-refresh.js
+++ b/src/common/offsite-refresh.js
@@ -179,6 +179,10 @@ export async function resolveEvergreenOffsiteOpportunity({
     throw e;
   }
 
+  olog.success('audit_persistence_evergreen_opportunity_read', 'Fetched opportunities', {
+    peer: PEER.POSTGRES, direction: 'inbound', count: (opportunities || []).length,
+  });
+
   const matchingOpportunities = (opportunities || [])
     .filter((opportunity) => opportunity.getType() === auditType);
   if (matchingOpportunities.length === 0) {

--- a/src/common/offsite-retention.js
+++ b/src/common/offsite-retention.js
@@ -53,6 +53,10 @@ export async function findExpiredSnapshots({
     return [];
   }
 
+  olog.success('audit_housekeeping_outdated_opportunities_read', 'Found snapshots', {
+    peer: PEER.POSTGRES, direction: 'inbound', auditType, count: (ignoredOpportunities || []).length,
+  });
+
   const retentionCutoff = subDays(new Date(), SNAPSHOT_RETENTION_DAYS);
 
   return (ignoredOpportunities || [])
@@ -173,6 +177,10 @@ export async function deleteExpiredOutdatedSuggestions({
     });
     return emptyRetentionSummary;
   }
+
+  olog.success('audit_housekeeping_outdated_suggestions_read', 'Read suggestions for OUTDATED suggestion cleanup', {
+    peer: PEER.POSTGRES, direction: 'inbound', auditType, count: opportunitySuggestions.length,
+  });
 
   const retentionCutoff = subDays(new Date(), OUTDATED_SUGGESTION_RETENTION_DAYS);
   const expiredOutdatedSuggestions = opportunitySuggestions

--- a/src/common/offsite-snapshot.js
+++ b/src/common/offsite-snapshot.js
@@ -66,6 +66,10 @@ export async function findSnapshotByTriggerAuditId({
     return null;
   }
 
+  olog.success('audit_persistence_snapshot_opportunity_read', 'Looked up existing snapshots', {
+    peer: PEER.POSTGRES, direction: 'inbound', auditType, count: (opportunities || []).length,
+  });
+
   return (opportunities || []).find((opportunity) => {
     const snapshotMetadata = opportunity.getData()?.snapshot;
 

--- a/test/common/offsite-refresh.test.js
+++ b/test/common/offsite-refresh.test.js
@@ -166,6 +166,11 @@ describe('offsite-refresh', () => {
       });
 
       expect(result).to.equal(only);
+      expect(log.info).to.have.been.calledWith(
+        sinon.match(/event=audit_persistence_evergreen_opportunity_read/)
+          .and(sinon.match(/outcome=success/))
+          .and(sinon.match(/count=1/)),
+      );
     });
 
     it('ignores opportunities of a different type', async () => {

--- a/test/common/offsite-retention.test.js
+++ b/test/common/offsite-retention.test.js
@@ -347,6 +347,11 @@ describe('offsite-retention', () => {
       expect(retentionSummary).to.deep.equal({
         scanned: 0, eligible: 0, deleted: 0, failed: 0,
       });
+      expect(log.info).to.have.been.calledWith(
+        sinon.match(/event=audit_housekeeping_outdated_suggestions_read/)
+          .and(sinon.match(/outcome=success/))
+          .and(sinon.match(/count=0/)),
+      );
     });
 
     it('treats a falsy getSuggestions result as an empty set', async () => {
@@ -609,6 +614,11 @@ describe('offsite-retention', () => {
       });
 
       expect(allBySiteIdAndStatus).to.have.been.calledWith(siteId, 'IGNORED');
+      expect(log.info).to.have.been.calledWith(
+        sinon.match(/event=audit_housekeeping_outdated_opportunities_read/)
+          .and(sinon.match(/outcome=success/))
+          .and(sinon.match(/count=0/)),
+      );
     });
 
     it('returns [] and logs (does not throw) when the lookup rejects', async () => {

--- a/test/common/offsite-snapshot.test.js
+++ b/test/common/offsite-snapshot.test.js
@@ -146,6 +146,11 @@ describe('offsite-snapshot', () => {
       });
 
       expect(result).to.be.null;
+      expect(log.info).to.have.been.calledWith(
+        sinon.match(/event=audit_persistence_snapshot_opportunity_read/)
+          .and(sinon.match(/outcome=success/))
+          .and(sinon.match(/count=0/)),
+      );
     });
 
     it('logs and returns null (treats as no existing snapshot) on lookup failures', async () => {


### PR DESCRIPTION
# Summary

Each of the four DB read steps in P4 and P5 (evergreen opportunity lookup, snapshot lookup, outdated snapshots search, outdated suggestions read) previously emitted structured log lines only on failure. All four now also emit an info/success line on the normal path, carrying a count field that shows how many rows were inspected. This completes the structured logging coverage for the offsite pipeline's read boundary events and allows a healthy run to be distinguished from a silently-failing one without relying on the absence of an error line.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Purely additive success-path logging on existing DB reads; no behavior change."
```