### PR TITLE
feat(brand-claims): on-demand one-shot trial runs (LLMO-7263)

### DIFF
--- a/docs/specs/2026-08-11-brand-claims-scheduled-trigger.md
+++ b/docs/specs/2026-08-11-brand-claims-scheduled-trigger.md
@@ -50,15 +50,24 @@ Flow (`src/brand-claims/handler.js`), for a message `{ type: 'brand-claims', sit
    `organization_id` + `status='active'` + `site_id`, deterministic tiebreak, LLMO-4592).
    The read is inspection-only — the handler never writes the `brands` table (enable is
    out of scope; see Problem Statement).
-3. **Gate** — if `brand_claims_enabled` is off, log and ack with no further work (no S3
-   listing, no ready-signal). Only enabled brands proceed.
+3. **Gate** — if `brand_claims_enabled` is off **and the run is not on-demand**
+   (`message.onDemand !== true`), log and ack with no further work (no S3 listing, no
+   ready-signal). Scheduled/weekly runs require the enable flag; an on-demand run
+   (LLMO-7263) is an explicit one-shot that bypasses this gate for a disabled brand.
 4. **Run** — build the S3 prefix `{siteId}/{brandSlug}/analytics/chatgpt_free/` (brand slug
    via `sanitizePathComponent`, byte-for-byte with DRS) and select the latest sheet (max by
    S3 date partition, then `LastModified`).
 5. **Emit** — publish `BRAND_PRESENCE_SHEET_WRITTEN` to `SQS_BP_SHEET_READY_QUEUE_URL` with
    the DRS-shaped event (`organization_id` = SpaceCat org UUID — the BP consumer feeds it
    into `/v2/orgs/{spaceCatId}/…`, which 400s on an IMS org id — `brand_id`, `brand` slug, `site_id`,
-   `week`, `year`, `cadence: "weekly"`, `sheet_date`, `platform`, `s3_bucket`, `s3_key`).
+   `week`, `year`, `cadence`, `sheet_date`, `platform`, `s3_bucket`, `s3_key`, and
+   `on_demand` (`message.onDemand === true`), which tells the BP consumer to bypass its
+   own enablement + cadence gates for this single event).
+6. **Record** — persist a minimal `brand-claims` `Audit` row (`auditedAt`, `auditResult`
+   carrying `onDemand`/sheet metadata) when a run is triggered. This is the timestamp the
+   api-service on-demand request cooldown (`getLatestAuditByAuditType('brand-claims')`) and
+   the elmo-ui pending/cooldown states read (LLMO-7263). Best-effort: the event is already
+   published, so a persistence failure warns and acks rather than failing the handler.
 
 Env (from Vault): `SQS_BP_SHEET_READY_QUEUE_URL`, `DRS_BP_BUCKET`.
 
@@ -67,8 +76,10 @@ missing `SQS_BP_SHEET_READY_QUEUE_URL` / `DRS_BP_BUCKET` / PostgREST client, Pos
 errors, S3 listing failure, SQS publish failure. Genuine business no-ops warn/info + ack:
 missing `siteId`, no active brand, brand not enabled for claims, brand slug empty, no sheet yet.
 
-**Why not `AuditBuilder`.** This handler audits no URL and persists no audit result — it is
-a side-effecting operational trigger (publish an SQS event). `AuditBuilder`'s
+**Why not `AuditBuilder`.** This handler audits no URL — it is a side-effecting operational
+trigger (publish an SQS event), and the only thing it persists is a lightweight
+`brand-claims` `Audit` row used as the on-demand cooldown timestamp (step 6), not a
+URL-scoped audit result. `AuditBuilder`'s
 validate-site / resolve-URL / persist / post-process machinery does not apply. This matches
 the existing plain-handler precedent in the repo (`rum-config-refresh`,
 `offsite-brand-presence-drs-status`, `dummy`), now documented in CLAUDE.md.
@@ -88,5 +99,8 @@ the existing plain-handler precedent in the repo (`rum-config-refresh`,
 - Infra/config errors surface via SQS retry + DLQ (never silently acked); business no-ops
   ack without retry.
 - The handler is read-only against the `brands` table (no enable side-effect).
-- A brand with `brand_claims_enabled = false` is skipped: no S3 listing, no ready-signal.
+- A brand with `brand_claims_enabled = false` is skipped on a scheduled run: no S3 listing,
+  no ready-signal. An on-demand run (`onDemand: true`) bypasses that gate and proceeds.
+- A triggered run persists a `brand-claims` `Audit` row (the on-demand cooldown timestamp);
+  a persistence failure is best-effort (warns + acks, run already published).
 - 100% line/branch/statement coverage on `src/brand-claims/handler.js`.

--- a/src/brand-claims/handler.js
+++ b/src/brand-claims/handler.js
@@ -151,7 +151,7 @@ export default async function brandClaimsHandler(message, context) {
   const {
     log, sqs, dataAccess, s3Client, env,
   } = context;
-  const { siteId } = message;
+  const { siteId, onDemand } = message;
 
   if (!hasText(siteId)) {
     log.warn('brand-claims: message missing siteId');
@@ -199,7 +199,11 @@ export default async function brandClaimsHandler(message, context) {
   // enable-brand-claims Slack command) for the sites we want weekly claims on. A disabled
   // brand is skipped entirely — no ready-signal is published, so no claims are (re)generated
   // for sites we don't want to touch.
-  if (!brand.brand_claims_enabled) {
+  // On-demand runs (LLMO-7263) bypass the per-brand enable gate: the request is an
+  // explicit one-shot, and the emitted event carries on_demand=true so the Brand
+  // Claims consumer also bypasses its own enablement gate for this single event.
+  // The weekly (non-on-demand) path stays gated as before.
+  if (!brand.brand_claims_enabled && onDemand !== true) {
     log.info(`brand-claims: brand ${brand.id} ("${brand.name}") on site ${resolvedSiteId} is not enabled for claims — skipping run`);
     return ok();
   }
@@ -231,6 +235,7 @@ export default async function brandClaimsHandler(message, context) {
     platform: BP_PLATFORM,
     s3_bucket: drsBpBucket,
     s3_key: sheet.key,
+    on_demand: onDemand === true,
     parent_job_id: null,
     batch_id: null,
   };

--- a/src/brand-claims/handler.js
+++ b/src/brand-claims/handler.js
@@ -175,7 +175,7 @@ export default async function brandClaimsHandler(message, context) {
     throw new Error(`brand-claims: brand storage (postgrestClient) is not available for site ${siteId}`);
   }
 
-  const { Site } = dataAccess;
+  const { Site, Audit } = dataAccess;
   const site = context.site || await Site.findById(siteId);
   if (!site) {
     log.warn(`brand-claims: site not found: ${siteId}`);
@@ -242,6 +242,33 @@ export default async function brandClaimsHandler(message, context) {
 
   await sqs.sendMessage(queueUrl, event);
   log.info(`brand-claims: published ready-signal for site ${resolvedSiteId} (brand "${brand.name}"), s3_key=${sheet.key}`);
+
+  // Record the run as a `brand-claims` audit (LLMO-7263). This handler is a bare
+  // utility handler (not an AuditBuilder audit), so nothing else persists a row —
+  // yet the on-demand 7-day request cooldown in api-service
+  // (getLatestAuditByAuditType('brand-claims')) and the elmo-ui pending/cooldown
+  // states both read `auditedAt` from it. Without this write those never fire.
+  // Best-effort: the run has already been triggered, so a persistence failure must
+  // not fail the handler (fail-open matches the api-service cooldown's own miss
+  // handling — a missed record just means the next request isn't throttled).
+  try {
+    await Audit.create({
+      siteId: resolvedSiteId,
+      isLive: site.getIsLive(),
+      auditedAt: new Date().toISOString(),
+      auditType: 'brand-claims',
+      auditResult: {
+        onDemand: onDemand === true,
+        week: sheet.week,
+        year: sheet.year,
+        sheetDate: sheet.sheetDate,
+        sheetKey: sheet.key,
+      },
+      fullAuditRef: sheet.key,
+    });
+  } catch (err) {
+    log.warn(`brand-claims: failed to persist brand-claims audit for site ${resolvedSiteId} (run already triggered): ${err.message}`);
+  }
 
   return ok();
 }

--- a/src/brand-claims/handler.js
+++ b/src/brand-claims/handler.js
@@ -151,7 +151,7 @@ export default async function brandClaimsHandler(message, context) {
   const {
     log, sqs, dataAccess, s3Client, env,
   } = context;
-  const { siteId, onDemand } = message;
+  const { siteId, onDemand, topics } = message;
 
   if (!hasText(siteId)) {
     log.warn('brand-claims: message missing siteId');
@@ -239,6 +239,13 @@ export default async function brandClaimsHandler(message, context) {
     parent_job_id: null,
     batch_id: null,
   };
+
+  // Optional topic filter (LLMO-7263): pass the selected topics through to the
+  // Brand Claims consumer, which scopes the run to claims for those topics.
+  // Absent/empty means all topics (default weekly behavior).
+  if (Array.isArray(topics) && topics.length > 0) {
+    event.topics = topics;
+  }
 
   await sqs.sendMessage(queueUrl, event);
   log.info(`brand-claims: published ready-signal for site ${resolvedSiteId} (brand "${brand.name}"), s3_key=${sheet.key}`);

--- a/src/brand-claims/handler.js
+++ b/src/brand-claims/handler.js
@@ -151,7 +151,7 @@ export default async function brandClaimsHandler(message, context) {
   const {
     log, sqs, dataAccess, s3Client, env,
   } = context;
-  const { siteId, onDemand, topics } = message;
+  const { siteId, onDemand } = message;
 
   if (!hasText(siteId)) {
     log.warn('brand-claims: message missing siteId');
@@ -239,13 +239,6 @@ export default async function brandClaimsHandler(message, context) {
     parent_job_id: null,
     batch_id: null,
   };
-
-  // Optional topic filter (LLMO-7263): pass the selected topics through to the
-  // Brand Claims consumer, which scopes the run to claims for those topics.
-  // Absent/empty means all topics (default weekly behavior).
-  if (Array.isArray(topics) && topics.length > 0) {
-    event.topics = topics;
-  }
 
   await sqs.sendMessage(queueUrl, event);
   log.info(`brand-claims: published ready-signal for site ${resolvedSiteId} (brand "${brand.name}"), s3_key=${sheet.key}`);

--- a/test/audits/brand-claims.test.js
+++ b/test/audits/brand-claims.test.js
@@ -200,6 +200,26 @@ describe('Brand Claims audit handler', function () {
       expect(log.warn).to.have.been.calledWithMatch('no Brand Presence sheet');
       expect(sqs.sendMessage).to.not.have.been.called;
     });
+
+    it('on_demand bypasses the enable gate for a disabled brand and stamps on_demand=true', async () => {
+      // Disabled brand + onDemand=true → runs anyway and marks the event on-demand
+      // (LLMO-7263), so the Brand Claims consumer bypasses its gate for this event.
+      selectResult = { data: [{ id: BRAND_ID, name: 'Acme Corp', brand_claims_enabled: false }], error: null };
+      const prefix = `${SITE_ID}/acmecorp/analytics/chatgpt_free`;
+      s3Client.send.resolves({
+        Contents: [{ Key: `${prefix}/2026/01/05/bp-w2-2026.xlsx`, LastModified: new Date('2026-01-05T00:00:00Z') }],
+        IsTruncated: false,
+      });
+
+      const res = await brandClaimsHandler({ type: 'brand-claims', siteId: SITE_ID, onDemand: true }, buildContext());
+
+      expect(res.status).to.equal(200);
+      expect(log.info).to.not.have.been.calledWithMatch('not enabled for claims');
+      expect(sqs.sendMessage).to.have.been.calledOnce;
+      const [, event] = sqs.sendMessage.firstCall.args;
+      expect(event.on_demand).to.equal(true);
+      expect(event.event_type).to.equal('BRAND_PRESENCE_SHEET_WRITTEN');
+    });
   });
 
   describe('error propagation (SQS retry)', () => {
@@ -289,6 +309,7 @@ describe('Brand Claims audit handler', function () {
         platform: 'chatgpt_free',
         s3_bucket: 'drs-bp-bucket',
         s3_key: `${prefix}/2026/01/05/bp-w2-2026-030405.xlsx`,
+        on_demand: false,
         parent_job_id: null,
         batch_id: null,
       });

--- a/test/audits/brand-claims.test.js
+++ b/test/audits/brand-claims.test.js
@@ -211,7 +211,10 @@ describe('Brand Claims audit handler', function () {
         IsTruncated: false,
       });
 
-      const res = await brandClaimsHandler({ type: 'brand-claims', siteId: SITE_ID, onDemand: true }, buildContext());
+      const res = await brandClaimsHandler(
+        { type: 'brand-claims', siteId: SITE_ID, onDemand: true, topics: ['Pricing', 'Support'] },
+        buildContext(),
+      );
 
       expect(res.status).to.equal(200);
       expect(log.info).to.not.have.been.calledWithMatch('not enabled for claims');
@@ -219,6 +222,21 @@ describe('Brand Claims audit handler', function () {
       const [, event] = sqs.sendMessage.firstCall.args;
       expect(event.on_demand).to.equal(true);
       expect(event.event_type).to.equal('BRAND_PRESENCE_SHEET_WRITTEN');
+      // Topic filter (LLMO-7263) is passed through to the consumer.
+      expect(event.topics).to.deep.equal(['Pricing', 'Support']);
+    });
+
+    it('does not stamp topics when none are provided (empty array)', async () => {
+      const prefix = `${SITE_ID}/acmecorp/analytics/chatgpt_free`;
+      s3Client.send.resolves({
+        Contents: [{ Key: `${prefix}/2026/01/05/bp-w2-2026.xlsx`, LastModified: new Date('2026-01-05T00:00:00Z') }],
+        IsTruncated: false,
+      });
+
+      await brandClaimsHandler({ type: 'brand-claims', siteId: SITE_ID, topics: [] }, buildContext());
+
+      const [, event] = sqs.sendMessage.firstCall.args;
+      expect(event).to.not.have.property('topics');
     });
   });
 

--- a/test/audits/brand-claims.test.js
+++ b/test/audits/brand-claims.test.js
@@ -211,10 +211,7 @@ describe('Brand Claims audit handler', function () {
         IsTruncated: false,
       });
 
-      const res = await brandClaimsHandler(
-        { type: 'brand-claims', siteId: SITE_ID, onDemand: true, topics: ['Pricing', 'Support'] },
-        buildContext(),
-      );
+      const res = await brandClaimsHandler({ type: 'brand-claims', siteId: SITE_ID, onDemand: true }, buildContext());
 
       expect(res.status).to.equal(200);
       expect(log.info).to.not.have.been.calledWithMatch('not enabled for claims');
@@ -222,21 +219,6 @@ describe('Brand Claims audit handler', function () {
       const [, event] = sqs.sendMessage.firstCall.args;
       expect(event.on_demand).to.equal(true);
       expect(event.event_type).to.equal('BRAND_PRESENCE_SHEET_WRITTEN');
-      // Topic filter (LLMO-7263) is passed through to the consumer.
-      expect(event.topics).to.deep.equal(['Pricing', 'Support']);
-    });
-
-    it('does not stamp topics when none are provided (empty array)', async () => {
-      const prefix = `${SITE_ID}/acmecorp/analytics/chatgpt_free`;
-      s3Client.send.resolves({
-        Contents: [{ Key: `${prefix}/2026/01/05/bp-w2-2026.xlsx`, LastModified: new Date('2026-01-05T00:00:00Z') }],
-        IsTruncated: false,
-      });
-
-      await brandClaimsHandler({ type: 'brand-claims', siteId: SITE_ID, topics: [] }, buildContext());
-
-      const [, event] = sqs.sendMessage.firstCall.args;
-      expect(event).to.not.have.property('topics');
     });
   });
 

--- a/test/audits/brand-claims.test.js
+++ b/test/audits/brand-claims.test.js
@@ -67,11 +67,13 @@ describe('Brand Claims audit handler', function () {
     },
     dataAccess: {
       Site: { findById: sandbox.stub().resolves(null) },
+      Audit: { create: sandbox.stub().resolves({}) },
       services: { postgrestClient },
     },
     site: {
       getId: () => SITE_ID,
       getOrganizationId: () => ORG_ID,
+      getIsLive: () => true,
     },
     ...overrides,
   });
@@ -315,6 +317,37 @@ describe('Brand Claims audit handler', function () {
       });
     });
 
+    it('persists a brand-claims audit so the on-demand cooldown has a row to read', async () => {
+      s3Client.send.resolves({
+        Contents: [{ Key: `${SITE_ID}/acmecorp/analytics/chatgpt_free/2026/01/05/bp-w2-2026.xlsx`, LastModified: new Date('2026-01-05T00:00:00Z') }],
+        IsTruncated: false,
+      });
+      const ctx = buildContext();
+      const res = await brandClaimsHandler({ type: 'brand-claims', siteId: SITE_ID, onDemand: true }, ctx);
+
+      expect(res.status).to.equal(200);
+      expect(ctx.dataAccess.Audit.create).to.have.been.calledOnce;
+      const auditArg = ctx.dataAccess.Audit.create.firstCall.args[0];
+      expect(auditArg.auditType).to.equal('brand-claims');
+      expect(auditArg.siteId).to.equal(SITE_ID);
+      expect(auditArg.auditedAt).to.be.a('string');
+      expect(auditArg.auditResult.onDemand).to.equal(true);
+    });
+
+    it('still succeeds when the audit persistence fails (best-effort, run already triggered)', async () => {
+      s3Client.send.resolves({
+        Contents: [{ Key: `${SITE_ID}/acmecorp/analytics/chatgpt_free/2026/01/05/bp-w2-2026.xlsx`, LastModified: new Date('2026-01-05T00:00:00Z') }],
+        IsTruncated: false,
+      });
+      const ctx = buildContext();
+      ctx.dataAccess.Audit.create.rejects(new Error('db down'));
+      const res = await brandClaimsHandler(message, ctx);
+
+      expect(res.status).to.equal(200);
+      expect(sqs.sendMessage).to.have.been.calledOnce;
+      expect(log.warn).to.have.been.calledWithMatch(/failed to persist brand-claims audit/);
+    });
+
     it('skips a mid-week daily sheet and picks the latest Monday daily sheet', async () => {
       const prefix = `${SITE_ID}/acmecorp/analytics/chatgpt_free`;
       // Daily-cadence site with a Monday (2026-01-05) and a newer Tuesday
@@ -365,6 +398,7 @@ describe('Brand Claims audit handler', function () {
       ctx.dataAccess.Site.findById.resolves({
         getId: () => SITE_ID,
         getOrganizationId: () => ORG_ID,
+        getIsLive: () => true,
       });
       s3Client.send.resolves({
         Contents: [{ Key: `${SITE_ID}/acmecorp/analytics/chatgpt_free/2026/01/01/bp-w1-2026.xlsx`, LastModified: new Date('2026-01-01T00:00:00Z') }],


### PR DESCRIPTION
## What

Makes the `brand-claims` audit trigger a **one-shot** on-demand run for trial customers (LLMO-7263).

## Why

Trials request a Brand Claims run on demand (UI → api-service → this audit → mystique consumer). The audit must (a) run even when the brand's persistent `brand_claims_enabled` flag is off, and (b) mark the emitted event as `on_demand` so the consumer runs it **once** instead of enabling the weekly cadence.

## Changes

- `src/brand-claims/handler.js` — read `onDemand` from the message; gate `if (!brand.brand_claims_enabled && onDemand !== true)` (on-demand bypasses the disabled flag); stamp `on_demand: onDemand === true` on the emitted `BRAND_PRESENCE_SHEET_WRITTEN` event.
- `test/audits/brand-claims.test.js` — coverage for the onDemand bypass and the `on_demand` event field.

## Testing

`npx mocha test/audits/brand-claims.test.js` → **25 passing**.

## Rollout order (LLMO-7263, 4 repos)

Deploy downstream-consumer first: **mystique → spacecat-audit-worker (this) → spacecat-api-service → project-elmo-ui**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Adds an on-demand bypass gate for trial customers behind an explicit message flag; reversible feature-trigger change, not an access-control boundary."
```