### PR TITLE
fix(llmo-customer-analysis): resolve real LLMO entitlement tier before creating brand-presence schedule (LLMO-7366)

### DIFF
--- a/src/llmo-customer-analysis/handler.js
+++ b/src/llmo-customer-analysis/handler.js
@@ -15,6 +15,8 @@ import {
 } from '@adobe/spacecat-shared-utils';
 import RUMAPIClient from '@adobe/spacecat-shared-rum-api-client';
 import DrsClient from '@adobe/spacecat-shared-drs-client';
+import { TierClient } from '@adobe/spacecat-shared-tier-client';
+import { Entitlement } from '@adobe/spacecat-shared-data-access';
 import { Config } from '@adobe/spacecat-shared-data-access/src/models/site/config.js';
 import { AuditBuilder } from '../common/audit-builder.js';
 import { wwwUrlResolver } from '../common/index.js';
@@ -93,6 +95,36 @@ async function checkOptelData(domain, context) {
 }
 
 /**
+ * Resolves the org's LLMO entitlement tier for a site, so the brand-presence schedule
+ * can be built with the right (tier-appropriate) platform set (LLMO-7366: PLG/free-trial
+ * orgs must not get ChatGPT Paid / Copilot). Fails CLOSED (returns FREE_TRIAL, the most
+ * restrictive tier `createBrandPresenceSchedule` recognizes) on any lookup error — DRS's
+ * own create_schedule.py guard is a backstop either way, but the failure direction here
+ * should never accidentally grant a paid-only surface to an org whose tier is unknown.
+ *
+ * @param {object} context - Universal context with dataAccess and log
+ * @param {object} site - Site model instance
+ * @param {string} siteId - Site id, for the warn log only (avoids depending on
+ *   site.getId() succeeding on the SAME error path that's already handling a failure).
+ * @returns {Promise<string>} One of Entitlement.TIERS
+ */
+async function resolveLlmoEntitlementTier(context, site, siteId) {
+  const { log } = context;
+  try {
+    const tierClient = await TierClient.createForSite(
+      context,
+      site,
+      Entitlement.PRODUCT_CODES.LLMO,
+    );
+    const { entitlement } = await tierClient.checkValidEntitlement();
+    return entitlement?.getTier() ?? Entitlement.TIERS.FREE_TRIAL;
+  } catch (error) {
+    log.warn(`Failed to resolve LLMO entitlement tier for site ${siteId}: ${error.message}`);
+    return Entitlement.TIERS.FREE_TRIAL;
+  }
+}
+
+/**
  * Creates and triggers the recurring brand-presence schedule for a first-time
  * onboarded site, via the shared `createBrandPresenceSchedule` drs-client helper
  * (LLMO-5605). That helper is the single definition of the brand-presence schedule:
@@ -107,10 +139,12 @@ async function checkOptelData(domain, context) {
  * @param {object} [opts]
  * @param {string} [opts.brandId] - Brand UUID for v2 schedules (required for v2 dedup)
  * @param {string} [opts.organizationId] - SpaceCat org UUID for v2 schedules
+ * @param {object} [opts.site] - Site model instance, used to resolve the LLMO entitlement
+ *   tier. Omitted only by tests that stub tier resolution directly.
  * @returns {Promise<string>} The created (or existing) schedule id
  */
 export async function createAndTriggerBrandPresenceSchedule(context, siteId, domain, opts = {}) {
-  const { brandId, organizationId } = opts;
+  const { brandId, organizationId, site } = opts;
   const { log } = context;
 
   const drsClient = DrsClient.createFrom(context);
@@ -118,13 +152,18 @@ export async function createAndTriggerBrandPresenceSchedule(context, siteId, dom
     throw new Error('DRS API URL or key not configured; skipping brand presence schedule creation');
   }
 
-  log.info(`Creating brand presence schedule for site ${siteId}`);
+  const tier = site
+    ? await resolveLlmoEntitlementTier(context, site, siteId)
+    : Entitlement.TIERS.FREE_TRIAL;
+
+  log.info(`Creating brand presence schedule for site ${siteId} (tier=${tier})`);
   const { scheduleId, alreadyExisted } = await drsClient.createBrandPresenceSchedule({
     siteId,
     brandId,
     orgId: organizationId,
     description: `Onboarding brand presence: ${domain} (${siteId})`,
     triggerImmediately: true,
+    tier,
   });
 
   log.info(
@@ -258,7 +297,7 @@ export async function runLlmoCustomerAnalysis(finalUrl, context, site, auditCont
 
     // Create and trigger brand presence schedule via DRS API (non-fatal)
     try {
-      const bpOpts = { brandId, organizationId };
+      const bpOpts = { brandId, organizationId, site };
       bpScheduleId = await createAndTriggerBrandPresenceSchedule(context, siteId, domain, bpOpts);
       triggeredSteps.push('brand-presence-schedule');
     } catch (error) {

--- a/src/llmo-customer-analysis/handler.js
+++ b/src/llmo-customer-analysis/handler.js
@@ -140,7 +140,9 @@ async function resolveLlmoEntitlementTier(context, site, siteId) {
  * @param {string} [opts.brandId] - Brand UUID for v2 schedules (required for v2 dedup)
  * @param {string} [opts.organizationId] - SpaceCat org UUID for v2 schedules
  * @param {object} [opts.site] - Site model instance, used to resolve the LLMO entitlement
- *   tier. Omitted only by tests that stub tier resolution directly.
+ *   tier. The one production caller (runLlmoCustomerAnalysis) always provides it; if
+ *   omitted for any reason this defensively fails to the restrictive FREE_TRIAL tier
+ *   rather than skip tier resolution silently (LLMO-7366).
  * @returns {Promise<string>} The created (or existing) schedule id
  */
 export async function createAndTriggerBrandPresenceSchedule(context, siteId, domain, opts = {}) {

--- a/test/audits/llmo-customer-analysis.test.js
+++ b/test/audits/llmo-customer-analysis.test.js
@@ -112,6 +112,8 @@ describe('LLMO Customer Analysis Handler', () => {
     let triggerBrandDetectionStub;
     let createBrandPresenceScheduleStub;
     let drsCreateFromStub;
+    let checkValidEntitlementStub;
+    let tierClientCreateForSiteStub;
 
     beforeEach(async () => {
       sqs.sendMessage.resetHistory();
@@ -125,6 +127,15 @@ describe('LLMO Customer Analysis Handler', () => {
         isConfigured: sandbox.stub().returns(true),
         triggerBrandDetection: triggerBrandDetectionStub,
         createBrandPresenceSchedule: createBrandPresenceScheduleStub,
+      });
+
+      // Defaults to a FREE_TRIAL entitlement (the common PLG case); individual
+      // tests override checkValidEntitlementStub to exercise PAID and lookup-failure paths.
+      checkValidEntitlementStub = sandbox.stub().resolves({
+        entitlement: { getTier: () => 'FREE_TRIAL' },
+      });
+      tierClientCreateForSiteStub = sandbox.stub().resolves({
+        checkValidEntitlement: checkValidEntitlementStub,
       });
 
       mockLlmoConfig = {
@@ -209,6 +220,9 @@ describe('LLMO Customer Analysis Handler', () => {
         },
         '@adobe/spacecat-shared-drs-client': {
           default: { createFrom: drsCreateFromStub },
+        },
+        '@adobe/spacecat-shared-tier-client': {
+          TierClient: { createForSite: tierClientCreateForSiteStub },
         },
       });
     });
@@ -1146,10 +1160,61 @@ describe('LLMO Customer Analysis Handler', () => {
         siteId: 'site-123',
         description: sinon.match(/Onboarding brand presence:.*site-123/),
         triggerImmediately: true,
+        tier: 'FREE_TRIAL',
       });
+      expect(tierClientCreateForSiteStub).to.have.been.calledOnce;
 
       expect(result.auditResult.triggeredSteps).to.include('brand-presence-schedule');
       expect(result.auditResult.brandPresenceScheduleId).to.equal('sched-001');
+    });
+
+    it('passes tier=PAID through to createBrandPresenceSchedule when the org has a PAID LLMO entitlement', async () => {
+      checkValidEntitlementStub.resolves({ entitlement: { getTier: () => 'PAID' } });
+
+      mockLlmoConfig.readConfig.resolves({
+        config: {
+          entities: {},
+          categories: {},
+          topics: {},
+          brands: { aliases: [] },
+          competitors: { competitors: [] },
+        },
+      });
+
+      await mockHandler.runLlmoCustomerAnalysis(
+        'https://example.com',
+        context,
+        site,
+        { configVersion: 'v1' },
+      );
+
+      expect(createBrandPresenceScheduleStub).to.have.been.calledWithMatch({ tier: 'PAID' });
+    });
+
+    it('fails closed to FREE_TRIAL when the entitlement lookup throws', async () => {
+      tierClientCreateForSiteStub.rejects(new Error('SpaceCat unreachable'));
+
+      mockLlmoConfig.readConfig.resolves({
+        config: {
+          entities: {},
+          categories: {},
+          topics: {},
+          brands: { aliases: [] },
+          competitors: { competitors: [] },
+        },
+      });
+
+      await mockHandler.runLlmoCustomerAnalysis(
+        'https://example.com',
+        context,
+        site,
+        { configVersion: 'v1' },
+      );
+
+      expect(createBrandPresenceScheduleStub).to.have.been.calledWithMatch({ tier: 'FREE_TRIAL' });
+      expect(log.warn).to.have.been.calledWith(
+        sinon.match(/Failed to resolve LLMO entitlement tier for site site-123/),
+      );
     });
 
     it('should log "already existed" when schedule already existed', async () => {

--- a/test/audits/llmo-customer-analysis.test.js
+++ b/test/audits/llmo-customer-analysis.test.js
@@ -1217,6 +1217,22 @@ describe('LLMO Customer Analysis Handler', () => {
       );
     });
 
+    it('defaults to FREE_TRIAL and skips entitlement resolution entirely when opts.site is omitted', async () => {
+      // The one production caller (runLlmoCustomerAnalysis) always supplies opts.site --
+      // this exercises the direct call site's own defensive fallback, which had no test
+      // coverage before (caught in review).
+      const scheduleId = await mockHandler.createAndTriggerBrandPresenceSchedule(
+        context,
+        'site-123',
+        'example.com',
+        {},
+      );
+
+      expect(scheduleId).to.equal('sched-001');
+      expect(createBrandPresenceScheduleStub).to.have.been.calledWithMatch({ tier: 'FREE_TRIAL' });
+      expect(tierClientCreateForSiteStub).to.not.have.been.called;
+    });
+
     it('should log "already existed" when schedule already existed', async () => {
       const auditContext = { configVersion: 'v1' };
 


### PR DESCRIPTION
## Summary
- PLG (free-trial) DRS customers were getting a brand-presence schedule that included two paid-tier-only platforms (ChatGPT Paid, Copilot), because `createAndTriggerBrandPresenceSchedule` called `@adobe/spacecat-shared-drs-client`'s `createBrandPresenceSchedule` with no tier awareness.
- Resolves the org's real LLMO entitlement tier via `TierClient` before calling the shared client, and passes `tier: 'PAID' | 'FREE_TRIAL'` through. Fails closed to `FREE_TRIAL` on any entitlement-lookup error.
- Companion fixes: `spacecat-shared` (shared client now fails safe/restricted on missing tier), `spacecat-api-service` (self-serve activate-brand route passes `tier: 'PAID'` explicitly), and DRS (`llmo-data-retrieval-service` — server-side backstop, already merged/PR #3178).

## Test plan
- [x] `npx mocha test/audits/llmo-customer-analysis.test.js` — 44/44 passing, including new cases for tier resolution and fail-closed behavior
- [x] `npx eslint src/llmo-customer-analysis/handler.js` — clean

Introduced by: N/A

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi"]
rationale: "Corrects tier resolution for a scheduled config (fails closed to FREE_TRIAL on error); a wrong schedule is correctable and re-triggerable, not an access-control breach."
```