### PR TITLE
feat(brand-claims): delay the on-demand claims ready-signal by 850s (LLMO-7263)

### DIFF
--- a/src/brand-claims/handler.js
+++ b/src/brand-claims/handler.js
@@ -19,6 +19,12 @@ const BP_PLATFORM = 'chatgpt_free';
 const SHEET_FILENAME_RE = /-w(\d{1,2})-(\d{4})(?:-(\d{6}))?\.xlsx$/i;
 const KEY_DATE_RE = /\/(\d{4})\/(\d{2})\/(\d{2})\//;
 const MAX_LISTING_PAGES = 10;
+// On-demand claims runs (LLMO-7263) are fired by api-service alongside their
+// prerequisite audits (offsite-brand-presence, wikipedia-analysis). Delay the claims
+// ready-signal so those inputs land in mystique before it runs claims. The
+// mysticat-bp-sheet-ready queue is a standard (non-FIFO) queue, so per-message
+// DelaySeconds applies; 850s stays under the SQS 900s hard cap.
+const ON_DEMAND_READY_DELAY_SECONDS = 850;
 
 // Must match DRS's sanitize_path_component byte-for-byte (BP consumer re-lists on this value).
 export function sanitizePathComponent(component) {
@@ -249,7 +255,11 @@ export default async function brandClaimsHandler(message, context) {
     batch_id: null,
   };
 
-  await sqs.sendMessage(queueUrl, event);
+  // Delay only the on-demand ready-signal so the prerequisite audits complete first;
+  // weekly/enrich runs publish immediately. (sendMessage args: queue, body, msgGroupId,
+  // delaySeconds.)
+  const readyDelaySeconds = onDemand === true ? ON_DEMAND_READY_DELAY_SECONDS : 0;
+  await sqs.sendMessage(queueUrl, event, null, readyDelaySeconds);
   log.info(`brand-claims: published ready-signal for site ${resolvedSiteId} (brand "${brand.name}"), s3_key=${sheet.key}`);
 
   // Record the run as a `brand-claims` audit (LLMO-7263). This handler is a bare

--- a/test/audits/brand-claims.test.js
+++ b/test/audits/brand-claims.test.js
@@ -218,9 +218,25 @@ describe('Brand Claims audit handler', function () {
       expect(res.status).to.equal(200);
       expect(log.info).to.not.have.been.calledWithMatch('not enabled for claims');
       expect(sqs.sendMessage).to.have.been.calledOnce;
-      const [, event] = sqs.sendMessage.firstCall.args;
+      const [, event, , delaySeconds] = sqs.sendMessage.firstCall.args;
       expect(event.on_demand).to.equal(true);
       expect(event.event_type).to.equal('BRAND_PRESENCE_SHEET_WRITTEN');
+      // On-demand ready-signal is delayed 850s so the prerequisite audits land first (LLMO-7263).
+      expect(delaySeconds).to.equal(850);
+    });
+
+    it('publishes the ready-signal with no delay for a weekly (non-on-demand) run', async () => {
+      selectResult = { data: [{ id: BRAND_ID, name: 'Acme Corp', brand_claims_enabled: true }], error: null };
+      const prefix = `${SITE_ID}/acmecorp/analytics/chatgpt_free`;
+      s3Client.send.resolves({
+        Contents: [{ Key: `${prefix}/2026/01/05/bp-w2-2026.xlsx`, LastModified: new Date('2026-01-05T00:00:00Z') }],
+        IsTruncated: false,
+      });
+
+      await brandClaimsHandler({ type: 'brand-claims', siteId: SITE_ID }, buildContext());
+
+      expect(sqs.sendMessage).to.have.been.calledOnce;
+      expect(sqs.sendMessage.firstCall.args[3]).to.equal(0);
     });
   });
 


### PR DESCRIPTION
## What

On-demand Brand Claims runs (LLMO-7263) are fired by api-service alongside their prerequisite audits (`offsite-brand-presence`, `wikipedia-analysis` — see adobe/spacecat-api-service#3208). Delay **only** the on-demand ready-signal published to the BP-sheet-ready queue so those inputs land in mystique before it runs claims.

- `mysticat-bp-sheet-ready` is a standard (non-FIFO) queue, so per-message `DelaySeconds` applies; 850s stays under the SQS 900s hard cap.
- Weekly and enrich runs publish immediately (delay 0).

## Coordination

No deploy-order dependency with the api-service change (if this ships first, a claims run with no prerequisites is just delayed 850s for nothing; if api-service ships first, claims runs without the delay).

## Testing

- `test/audits/brand-claims.test.js` — asserts `DelaySeconds=850` on the on-demand ready-signal and `0` on a weekly run. **33 passing**, handler eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
