### PR TITLE
fix(llm-error-pages): drop scanner/probe URLs from error-page opportunities (LLMO-5282)

### DIFF
--- a/src/llm-error-pages/handler.js
+++ b/src/llm-error-pages/handler.js
@@ -454,6 +454,15 @@ export async function runAuditAndSendToMystique(context) {
           log.info(`[LLM-ERROR-PAGES] Filtered ${processedResults.droppedUrls.length} malformed URL(s); sample: ${JSON.stringify(sample)}`);
         }
 
+        // Scanner / vulnerability-probe paths (e.g. '/.github/.env',
+        // '/@fs/app/terraform.tfvars') are well-formed but never legitimate
+        // content; they are dropped in processErrorPagesResults. Log a sample so
+        // the suppressed volume stays diagnosable from Coralogix.
+        if (processedResults.scannerUrls?.length > 0) {
+          const sample = processedResults.scannerUrls.slice(0, 5);
+          log.info(`[LLM-ERROR-PAGES] Filtered ${processedResults.scannerUrls.length} scanner/probe URL(s); sample: ${JSON.stringify(sample)}`);
+        }
+
         log.info(`[LLM-ERROR-PAGES] Found ${processedResults.totalErrors} total errors across ${processedResults.summary.uniqueUrls} unique URLs`);
 
         const opportunityMap = {};

--- a/src/llm-error-pages/utils.js
+++ b/src/llm-error-pages/utils.js
@@ -386,12 +386,102 @@ export function isValidUrlPath(url) {
   return true;
 }
 
+/**
+ * Denylist of well-formed paths that are never legitimate site content.
+ * Automated vulnerability scanners and secret-harvesting bots spoof an LLM
+ * user-agent while probing these paths, slip past the user-agent filter, and
+ * land a (correct) 4xx — most often 403. They are real security value on the
+ * customer's edge but pure noise in the LLM error-pages opportunity, so we drop
+ * them before building suggestions. Companion to the UA / IP-fingerprint
+ * hardening tracked in LLMO-5282; `isValidUrlPath` only rejects *malformed*
+ * URLs, whereas these are syntactically valid and need a content denylist.
+ *
+ * Each pattern is anchored to a path *segment* or filename (not a bare
+ * substring) so legitimate pages survive: `/environment` !~ `.env`,
+ * `/gitane-bikes` !~ `.git`, `/inventory` !~ `.env`, `/manager-specials`
+ * !~ `manager/html`. Patterns run against the decoded pathname (see
+ * `isLikelyScannerPath`), so encoded-separator traversal (`..%2f`) is caught.
+ * (A fully-encoded double-dot segment such as `%2e%2e` is resolved away by the
+ * URL parser before we ever see it, so it needs no pattern.) All patterns are
+ * case-insensitive; none carry the `g` flag (which would make `.test()`
+ * stateful across calls).
+ *
+ * Trade-off: on CMS-backed sites `wp-content` / `wp-includes` can host real
+ * media, but (a) only error rows reach this boundary — a 200 asset never
+ * appears — and (b) a spoofed-UA 403 to those paths is not an actionable LLM
+ * finding. Named groups exist so Coralogix telemetry can report *what class* of
+ * probe was suppressed.
+ */
+export const SCANNER_PROBE_PATTERNS = [
+  // Version-control metadata (source tree & history exfiltration).
+  { name: 'vcs-metadata', regex: /(^|\/)\.(git|svn|hg|bzr)(ignore|config|attributes|modules)?($|\/)/i },
+
+  // Environment / secret / credential files.
+  { name: 'secret-file', regex: /(^|\/)\.env(\.[a-z0-9]+)?($|\/)|(^|\/)(id_rsa|id_dsa|id_ecdsa|id_ed25519|\.htpasswd|\.htaccess|\.netrc|\.npmrc|\.pgpass|\.dockercfg)($|\/)/i },
+
+  // Cloud / IaC state & config (AWS, SSH, Terraform, Kubernetes, Docker, CI, IDE).
+  { name: 'cloud-iac', regex: /(^|\/)\.(aws|ssh|kube|docker|terraform|circleci|github|gitlab|vscode|idea)($|\/)|\.tf(vars|state)(\.[a-z0-9]+)?($|\/)/i },
+
+  // Front-end dev-server / bundler internals — never served in production.
+  { name: 'dev-server-internal', regex: /(^|\/)@(fs|vite|id|react-refresh)($|\/)|(^|\/)(\.vite|node_modules|__webpack_hmr|webpack-dev-server)($|\/)/i },
+
+  // CMS / admin-panel probes (WordPress, Joomla, phpMyAdmin, Adminer, Typo3).
+  { name: 'cms-admin-probe', regex: /(^|\/)(wp-admin|wp-includes|wp-content|wp-json|xmlrpc\.php|phpmyadmin|adminer|administrator|typo3)($|\/)|wp-(login|config)\.php/i },
+
+  // Server / framework introspection & webshell probes.
+  { name: 'server-probe', regex: /(^|\/)(cgi-bin|actuator|jmx-console|server-status|server-info|_profiler)($|\/)|(^|\/)(phpinfo|info|test|shell|cmd|eval-stdin)\.php($|\/)|(^|\/)manager\/(html|status|text)($|\/)/i },
+
+  // Path traversal / local-file-inclusion (decoded, so %2e%2e is covered).
+  { name: 'path-traversal', regex: /\.\.[/\\]|(^|\/)(etc\/passwd|etc\/shadow|proc\/self|windows\/win\.ini|boot\.ini)($|\/)/i },
+
+  // Cloud instance-metadata SSRF targets.
+  { name: 'metadata-ssrf', regex: /(^|\/)(latest\/meta-data|computeMetadata)($|\/)|169\.254\.169\.254/i },
+
+  // Database dumps / backup archives at common probe names, plus editor swap files.
+  { name: 'backup-dump', regex: /(^|\/)(backup|backups|dump|database|db|www|web|site|public_html|htdocs)\.(sql|zip|tar\.gz|tgz|gz|rar|7z|bak)($|\/)|\.(swp|swo|swn)($|\/)/i },
+];
+
+/**
+ * Returns true when a URL's path matches a known scanner / vulnerability-probe
+ * signature (see `SCANNER_PROBE_PATTERNS`). Assumes the input already passed
+ * `isValidUrlPath`; unparseable input returns false so the malformed-URL filter
+ * remains the single owner of that rejection.
+ *
+ * @param {string} url - Absolute URL or path from a CDN log row.
+ * @returns {boolean} True if the path looks like an automated probe.
+ */
+export function isLikelyScannerPath(url) {
+  if (typeof url !== 'string' || !url.trim()) {
+    return false;
+  }
+
+  let pathname;
+  try {
+    pathname = new URL(url.trim(), 'https://example.com').pathname;
+  } catch {
+    return false;
+  }
+
+  // Decode so percent-encoded traversal / separators (`%2e%2e`, `%2f`) match the
+  // same patterns as their literal forms. Malformed escapes (`%ZZ`) throw — fall
+  // back to the raw pathname rather than crash the whole audit row.
+  let decoded = pathname;
+  try {
+    decoded = decodeURIComponent(pathname);
+  } catch {
+    decoded = pathname;
+  }
+
+  return SCANNER_PROBE_PATTERNS.some(({ regex }) => regex.test(decoded));
+}
+
 export function processErrorPagesResults(results) {
   if (!results || results.length === 0) {
     return {
       totalErrors: 0,
       errorPages: [],
       droppedUrls: [],
+      scannerUrls: [],
       summary: {
         uniqueUrls: 0,
         uniqueUserAgents: 0,
@@ -400,16 +490,21 @@ export function processErrorPagesResults(results) {
     };
   }
 
-  // Filter malformed URLs at the data boundary so `errorPages`, the per-status
-  // categorization, the Excel export, the opportunity sync, and the Mystique
-  // payload all share one consistent view.
+  // Filter malformed URLs and scanner/probe noise at the data boundary so
+  // `errorPages`, the per-status categorization, the Excel export, the
+  // opportunity sync, and the Mystique payload all share one consistent view.
+  // `droppedUrls` (malformed) and `scannerUrls` (well-formed probes) are tracked
+  // separately so telemetry can attribute each class of exclusion.
   const errorPages = [];
   const droppedUrls = [];
+  const scannerUrls = [];
   results.forEach((row) => {
-    if (isValidUrlPath(row.url)) {
-      errorPages.push(row);
-    } else {
+    if (!isValidUrlPath(row.url)) {
       droppedUrls.push(row.url);
+    } else if (isLikelyScannerPath(row.url)) {
+      scannerUrls.push(row.url);
+    } else {
+      errorPages.push(row);
     }
   });
 
@@ -433,6 +528,7 @@ export function processErrorPagesResults(results) {
     totalErrors,
     errorPages,
     droppedUrls,
+    scannerUrls,
     summary: {
       uniqueUrls: uniqueUrls.size,
       uniqueUserAgents: uniqueUserAgents.size,

--- a/test/audits/llm-error-pages/handler.test.js
+++ b/test/audits/llm-error-pages/handler.test.js
@@ -421,6 +421,28 @@ describe('LLM Error Pages Handler', function () {
       );
     });
 
+    it('logs a sample of scanner/probe URLs filtered upstream in processErrorPagesResults', async () => {
+      mockProcessResults.returns({
+        totalErrors: 1,
+        errorPages: [
+          { user_agent: 'ChatGPT', url: '/legit-page', status: 404, total_requests: 10 },
+        ],
+        droppedUrls: [],
+        scannerUrls: [
+          '/.github/.env',
+          '/@fs/app/terraform.tfvars',
+        ],
+        summary: { uniqueUrls: 1, uniqueUserAgents: 1, statusCodes: { 404: 10 } },
+      });
+
+      const result = await runAuditAndSendToMystique(context);
+
+      expect(result.auditResult[0].success).to.be.true;
+      expect(context.log.info).to.have.been.calledWith(
+        sinon.match(/Filtered 2 scanner\/probe URL\(s\); sample: \[.*terraform\.tfvars.*\]/),
+      );
+    });
+
     it('should target the last completed week when run on a Monday without weekOffset', async () => {
       const monday = new Date('2025-08-18T12:00:00Z'); // Monday
       const clock = sinon.useFakeTimers(monday.getTime());

--- a/test/audits/llm-error-pages/utils.test.js
+++ b/test/audits/llm-error-pages/utils.test.js
@@ -29,6 +29,8 @@ import {
   sortErrorsByTrafficVolume,
   toPathOnly,
   isValidUrlPath,
+  isLikelyScannerPath,
+  SCANNER_PROBE_PATTERNS,
   downloadExistingCdnSheet,
   groupErrorsByUrl,
   parsePeriodIdentifier,
@@ -1122,6 +1124,121 @@ describe('LLM Error Pages Utils', () => {
     });
   });
 
+  describe('isLikelyScannerPath', () => {
+    it('flags version-control metadata probes', () => {
+      expect(isLikelyScannerPath('/.git/config')).to.equal(true);
+      expect(isLikelyScannerPath('/.git')).to.equal(true);
+      expect(isLikelyScannerPath('/.gitignore')).to.equal(true);
+      expect(isLikelyScannerPath('/.svn/entries')).to.equal(true);
+      expect(isLikelyScannerPath('/.hg/store')).to.equal(true);
+    });
+
+    it('flags environment / secret / credential files', () => {
+      expect(isLikelyScannerPath('/.env')).to.equal(true);
+      expect(isLikelyScannerPath('/.env.production')).to.equal(true);
+      expect(isLikelyScannerPath('/config/.env.local')).to.equal(true);
+      expect(isLikelyScannerPath('/.github/.env')).to.equal(true);
+      expect(isLikelyScannerPath('/id_rsa')).to.equal(true);
+      expect(isLikelyScannerPath('/.htpasswd')).to.equal(true);
+      expect(isLikelyScannerPath('/.npmrc')).to.equal(true);
+    });
+
+    it('flags cloud / IaC state & config probes', () => {
+      expect(isLikelyScannerPath('/.aws/credentials')).to.equal(true);
+      expect(isLikelyScannerPath('/.ssh/id_rsa')).to.equal(true);
+      expect(isLikelyScannerPath('/@fs/app/terraform.tfvars')).to.equal(true);
+      expect(isLikelyScannerPath('/infra/main.tfstate')).to.equal(true);
+      expect(isLikelyScannerPath('/.kube/config')).to.equal(true);
+      expect(isLikelyScannerPath('/.circleci/config.yml')).to.equal(true);
+    });
+
+    it('flags front-end dev-server / bundler internals', () => {
+      expect(isLikelyScannerPath('/@vite/client')).to.equal(true);
+      expect(isLikelyScannerPath('/@id/vite')).to.equal(true);
+      expect(isLikelyScannerPath('/node_modules/.bin/x')).to.equal(true);
+      expect(isLikelyScannerPath('/webpack-dev-server')).to.equal(true);
+    });
+
+    it('flags CMS / admin-panel probes', () => {
+      expect(isLikelyScannerPath('/wp-admin/')).to.equal(true);
+      expect(isLikelyScannerPath('/wp-login.php')).to.equal(true);
+      expect(isLikelyScannerPath('/wp-config.php')).to.equal(true);
+      expect(isLikelyScannerPath('/xmlrpc.php')).to.equal(true);
+      expect(isLikelyScannerPath('/phpmyadmin/index.php')).to.equal(true);
+      expect(isLikelyScannerPath('/administrator/')).to.equal(true);
+    });
+
+    it('flags server introspection & webshell probes', () => {
+      expect(isLikelyScannerPath('/cgi-bin/test.cgi')).to.equal(true);
+      expect(isLikelyScannerPath('/actuator/env')).to.equal(true);
+      expect(isLikelyScannerPath('/phpinfo.php')).to.equal(true);
+      expect(isLikelyScannerPath('/manager/html')).to.equal(true);
+    });
+
+    it('flags path traversal / LFI, including encoded-separator forms', () => {
+      expect(isLikelyScannerPath('/foo/..%2f..%2fetc/passwd')).to.equal(true);
+      expect(isLikelyScannerPath('/etc/passwd')).to.equal(true);
+      expect(isLikelyScannerPath('/windows/win.ini')).to.equal(true);
+    });
+
+    it('flags cloud instance-metadata SSRF targets', () => {
+      expect(isLikelyScannerPath('/latest/meta-data/iam')).to.equal(true);
+      expect(isLikelyScannerPath('/computeMetadata/v1')).to.equal(true);
+    });
+
+    it('flags database dumps / backups & editor swap files', () => {
+      expect(isLikelyScannerPath('/backup.sql')).to.equal(true);
+      expect(isLikelyScannerPath('/database.tar.gz')).to.equal(true);
+      expect(isLikelyScannerPath('/index.php.swp')).to.equal(true);
+    });
+
+    it('does not flag legitimate e-commerce / content paths', () => {
+      expect(isLikelyScannerPath('/roc-boots')).to.equal(false);
+      expect(isLikelyScannerPath('/bobux')).to.equal(false);
+      expect(isLikelyScannerPath('/colorado')).to.equal(false);
+      expect(isLikelyScannerPath('/environment')).to.equal(false);
+      expect(isLikelyScannerPath('/inventory')).to.equal(false);
+      expect(isLikelyScannerPath('/gitane-bikes')).to.equal(false);
+      expect(isLikelyScannerPath('/manager-specials')).to.equal(false);
+      expect(isLikelyScannerPath('/administrator-tools')).to.equal(false);
+      expect(isLikelyScannerPath('/products/o\'reilly')).to.equal(false);
+      expect(isLikelyScannerPath('/collections/test-drive')).to.equal(false);
+    });
+
+    it('normalizes literal dot-segments away before matching (no false positive)', () => {
+      // The URL parser collapses `/foo/../bar` to `/bar`, so a literal relative
+      // path is not mistaken for traversal — only encoded `..` survives.
+      expect(isLikelyScannerPath('/foo/../bar')).to.equal(false);
+    });
+
+    it('returns false for non-strings, empty, and unparseable input', () => {
+      expect(isLikelyScannerPath(null)).to.equal(false);
+      expect(isLikelyScannerPath(undefined)).to.equal(false);
+      expect(isLikelyScannerPath(42)).to.equal(false);
+      expect(isLikelyScannerPath('')).to.equal(false);
+      expect(isLikelyScannerPath('   ')).to.equal(false);
+      expect(isLikelyScannerPath('http://[invalid')).to.equal(false);
+    });
+
+    it('falls back to the raw pathname when percent-decoding throws', () => {
+      // `%E0%A4%A` is an incomplete escape → decodeURIComponent throws; the
+      // function must not crash and should still evaluate the raw pathname. The
+      // trailing bad escape sits past the matched segment, so a real probe is
+      // still flagged while a benign path is not.
+      expect(isLikelyScannerPath('/latest/meta-data/%E0%A4%A')).to.equal(true);
+      expect(isLikelyScannerPath('/safe/%E0%A4%A')).to.equal(false);
+    });
+
+    it('exposes a named, non-empty, non-global pattern list', () => {
+      expect(SCANNER_PROBE_PATTERNS).to.be.an('array').with.length.greaterThan(0);
+      SCANNER_PROBE_PATTERNS.forEach(({ name, regex }) => {
+        expect(name).to.be.a('string').and.not.empty;
+        expect(regex).to.be.instanceOf(RegExp);
+        expect(regex.global, `${name} must not use the g flag`).to.equal(false);
+      });
+    });
+  });
+
   // ============================================================================
   // Additional coverage tests for missing functions
   // ============================================================================
@@ -1273,12 +1390,32 @@ describe('LLM Error Pages Utils', () => {
         totalErrors: 0,
         errorPages: [],
         droppedUrls: [],
+        scannerUrls: [],
         summary: {
           uniqueUrls: 0,
           uniqueUserAgents: 0,
           statusCodes: {},
         },
       });
+    });
+
+    it('drops scanner/probe URLs into scannerUrls, keeps them out of errorPages and totals', () => {
+      const results = [
+        { url: '/roc-boots', total_requests: '9', status: '403', user_agent: 'ChatGPT' },
+        { url: '/.github/.env', total_requests: '4', status: '403', user_agent: 'GPTBot' },
+        { url: '/@fs/app/terraform.tfvars', total_requests: '6', status: '403', user_agent: 'GPTBot' },
+        { url: '/brandshttps://evil.com/x', total_requests: '2', status: '404', user_agent: 'GPTBot' },
+      ];
+      const processed = processErrorPagesResults(results);
+      expect(processed.errorPages).to.have.lengthOf(1);
+      expect(processed.errorPages[0].url).to.equal('/roc-boots');
+      expect(processed.scannerUrls).to.deep.equal([
+        '/.github/.env',
+        '/@fs/app/terraform.tfvars',
+      ]);
+      expect(processed.droppedUrls).to.deep.equal(['/brandshttps://evil.com/x']);
+      expect(processed.totalErrors).to.equal(9);
+      expect(processed.summary.statusCodes).to.deep.equal({ 403: 9 });
     });
 
     it('should coerce non-numeric total_requests to 0 and compute counts', () => {


### PR DESCRIPTION
Scanner probes (e.g. /.github/.env, /@fs/app/terraform.tfvars) spoof an LLM user-agent, land a correct 403, and pollute the llm-error-pages opportunity. Adds a segment-anchored scanner denylist (SCANNER_PROBE_PATTERNS + isLikelyScannerPath); probes now divert to a scannerUrls bucket, kept out of errorPages/totals/export/suggestions/Mystique payload. Anchored so legit pages survive. Companion to the UA/IP hardening tracked in LLMO-5282.