### PR TITLE
fix(prerender): outdate suggestions for URLs that start redirecting

### DIFF
--- a/src/prerender/handler.js
+++ b/src/prerender/handler.js
@@ -1244,6 +1244,9 @@ export async function uploadStatusSummaryToS3(auditUrl, auditData, context) {
     const scrapeForbiddenCount = mergedPages.filter(
       (p) => p.scrapeError?.statusCode === 403,
     ).length;
+    const urlsRedirected = mergedPages.filter(
+      (p) => p.scrapingStatus === 'redirect',
+    ).length;
 
     const statusSummary = {
       baseUrl: auditUrl,
@@ -1258,6 +1261,7 @@ export async function uploadStatusSummaryToS3(auditUrl, auditData, context) {
       scrapeForbidden: auditResult.scrapeForbidden ?? false,
       scrapeForbiddenCount,
       scrapeForbiddenSince: auditResult.scrapeForbiddenSince ?? existingStatus.scrapeForbiddenSince,
+      urlsRedirected,
       lastAuditSuccess: auditResult.lastAuditSuccess !== false,
       pages: mergedPages,
     };
@@ -1289,7 +1293,7 @@ export async function uploadStatusSummaryToS3(auditUrl, auditData, context) {
  * @param {number} urlsToCheckLength - Fallback count when ScrapeUrl is unavailable
  * @param {Object} context - Audit context with dataAccess, s3Client, env, log
  * @returns {Promise<{urlsSubmittedForScraping: number, scrapeForbiddenCount: number,
- *   scrapeForbidden: boolean, missingPages: Object[]}>}
+ *   scrapeForbidden: boolean, missingPages: Object[], redirectedUrls: string[]}>}
  */
 export async function getScrapeJobStats(
   scrapeJobId,
@@ -1308,6 +1312,7 @@ export async function getScrapeJobStats(
       scrapeForbiddenCount: 0,
       missingPages: [],
       submittedUrlSet: null,
+      redirectedUrls: [],
     };
   }
 
@@ -1321,6 +1326,7 @@ export async function getScrapeJobStats(
       scrapeForbiddenCount: completeForbiddenCount,
       missingPages: [],
       submittedUrlSet: null,
+      redirectedUrls: [],
     };
   }
 
@@ -1341,13 +1347,13 @@ export async function getScrapeJobStats(
         const scrapeJsonKey = getS3Path(url, scrapeJobId, 'scrape.json');
         const metadata = await getObjectFromKey(s3Client, bucketName, scrapeJsonKey, log)
           .catch(() => null);
-        return { url, metadata };
+        return { url, metadata, status: su.getStatus?.() };
       }),
     );
 
-    const missingPages = missingPagesRaw.map(({ url, metadata }) => ({
+    const missingPages = missingPagesRaw.map(({ url, metadata, status }) => ({
       url,
-      scrapingStatus: 'failed',
+      scrapingStatus: status === 'REDIRECT' ? 'redirect' : 'failed',
       needsPrerender: false,
       ...(metadata?.error && { scrapeError: metadata.error }),
     }));
@@ -1356,12 +1362,16 @@ export async function getScrapeJobStats(
     const missingForbiddenCount = missingPages
       .filter((p) => p.scrapeError?.statusCode === 403).length;
     const scrapeForbiddenCount = completeForbiddenCount + missingForbiddenCount;
+    const redirectedUrls = missingPages
+      .filter((p) => p.scrapingStatus === 'redirect')
+      .map((p) => p.url);
 
     return {
       urlsSubmittedForScraping: allScrapeUrls.length,
       scrapeForbiddenCount,
       missingPages,
       submittedUrlSet: new Set(allScrapeUrls.map((su) => su.getUrl())),
+      redirectedUrls,
     };
   } catch (e) {
     log.warn(`${LOG_PREFIX} Failed to fetch ScrapeUrl stats for scrapeJobId=${scrapeJobId}, using fallback: ${e.message}`);
@@ -1370,6 +1380,7 @@ export async function getScrapeJobStats(
       scrapeForbiddenCount: completeForbiddenCount,
       missingPages: [],
       submittedUrlSet: null,
+      redirectedUrls: [],
     };
   }
 }
@@ -1452,6 +1463,7 @@ export async function processContentAndGenerateOpportunities(context) {
       scrapeForbiddenCount,
       missingPages,
       submittedUrlSet,
+      redirectedUrls,
     } = await getScrapeJobStats(scrapeJobId, comparisonResults, urlCount, context);
 
     log.info(`${LOG_PREFIX} Scrape analysis for baseUrl=${site.getBaseURL()}, siteId=${siteId}, scrapeForbiddenCount=${scrapeForbiddenCount}, totalUrlsChecked=${comparisonResults.length}, isPaidLLMOCustomer=${isPaid}`);
@@ -1488,11 +1500,16 @@ export async function processContentAndGenerateOpportunities(context) {
     // Exclude deployed URLs — don't mark their suggestions outdated regardless of needsPrerender.
     // isDeployedAtEdge=true means prerender is already active at CDN level (via RCV, LLMO
     // side-effect, or domain-wide deployment); no authoritative "resolved" judgment applies.
-    const scrapedUrlsSet = new Set(
-      successfulComparisons
+    // Redirected URLs are unioned in too: they're absent from successfulComparisons (never part
+    // of comparisonResults at all), but they represent a definitive, non-retryable outcome for
+    // this run's scope, so they should count as "examined" for the outdating coverage guard
+    // in handleOutdatedSuggestions (LLMO-6423) even though they never generate a suggestion.
+    const scrapedUrlsSet = new Set([
+      ...successfulComparisons
         .filter((r) => !r.isDeployedAtEdge)
         .map((r) => r.url),
-    );
+      ...redirectedUrls,
+    ]);
 
     const auditResult = {
       totalUrlsChecked: comparisonResults.length,
@@ -1506,10 +1523,11 @@ export async function processContentAndGenerateOpportunities(context) {
       scrapeForbidden,
       scrapeForbiddenSince,
       scrapeForbiddenCount,
+      urlsRedirected: redirectedUrls.length,
       lastAuditSuccess: true,
     };
 
-    log.info(`${LOG_PREFIX} Scraping metrics for baseUrl=${site.getBaseURL()}, siteId=${siteId}. urlsSubmittedForScraping=${urlsSubmittedForScraping}, urlsScrapedSuccessfully=${successfulComparisons.length}, scrapeForbiddenCount=${scrapeForbiddenCount}, scrapingErrorRate=${scrapingErrorRate}%`);
+    log.info(`${LOG_PREFIX} Scraping metrics for baseUrl=${site.getBaseURL()}, siteId=${siteId}. urlsSubmittedForScraping=${urlsSubmittedForScraping}, urlsScrapedSuccessfully=${successfulComparisons.length}, scrapeForbiddenCount=${scrapeForbiddenCount}, urlsRedirected=${redirectedUrls.length}, scrapingErrorRate=${scrapingErrorRate}%`);
 
     let opportunityWithSuggestions = null;
 

--- a/test/audits/prerender/behaviour/redirect-outdating.test.js
+++ b/test/audits/prerender/behaviour/redirect-outdating.test.js
@@ -1,0 +1,261 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * Behavior tests for LLMO-6423: URLs that redirect should have their existing
+ * prerender suggestion marked OUTDATED, since the audit can no longer verify the
+ * content diff against a URL that no longer resolves with a 200.
+ *
+ * handleOutdatedSuggestions (src/utils/data-access.js) only outdates a suggestion
+ * if its URL is present in scrapedUrlsSet (the "was this URL actually examined this
+ * run" coverage guard). These tests confirm: (a) a redirected URL absent from
+ * scrapedUrlsSet is NOT outdated (the pre-fix gap), (b) once unioned into
+ * scrapedUrlsSet it IS outdated, and (c) processContentAndGenerateOpportunities
+ * performs that union end-to-end via getScrapeJobStats' redirectedUrls.
+ */
+
+import esmock from 'esmock';
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { Suggestion } from '@adobe/spacecat-shared-data-access';
+
+use(sinonChai);
+
+const BASE_URL = 'https://example.com';
+
+function makeUrlSuggestion(id, url, initialStatus, extraData = {}) {
+  let currentStatus = initialStatus;
+  return {
+    getId: () => id,
+    getStatus: () => currentStatus,
+    setStatus: sinon.stub().callsFake((s) => { currentStatus = s; }),
+    setUpdatedBy: sinon.stub(),
+    getData: sinon.stub().returns({ url, isDomainWide: false, ...extraData }),
+    setData: sinon.stub(),
+  };
+}
+
+/**
+ * Runs processOpportunityAndSuggestions directly. auditResult hits /page1 only;
+ * scrapedUrlsSet is caller-controlled so each test can isolate the coverage guard.
+ */
+async function runAudit(sandbox, existingSuggestions, scrapedUrlsSet) {
+  const bulkUpdateStatusStub = sandbox.stub().resolves();
+
+  const mockOpportunity = {
+    getId: () => 'test-opp-id',
+    getSiteId: () => 'test-site-id',
+    getType: () => 'prerender',
+    getSuggestions: sandbox.stub().resolves(existingSuggestions),
+    addSuggestions: sandbox.stub().resolves({ errorItems: [], createdItems: [] }),
+  };
+
+  const handler = await esmock('../../../../src/prerender/handler.js', {
+    '../../../../src/common/opportunity.js': {
+      convertToOpportunity: sandbox.stub().resolves(mockOpportunity),
+    },
+  });
+
+  const auditData = {
+    siteId: 'test-site',
+    auditId: 'audit-123',
+    scrapeJobId: 'job-123',
+    auditResult: {
+      urlsNeedingPrerender: 1,
+      results: [{
+        url: `${BASE_URL}/page1`,
+        needsPrerender: true,
+        contentGainRatio: 2.0,
+        wordCountBefore: 100,
+        wordCountAfter: 200,
+      }],
+    },
+    scrapedUrlsSet,
+  };
+
+  const context = {
+    log: {
+      info: sandbox.stub(),
+      debug: sandbox.stub(),
+      warn: sandbox.stub(),
+      error: sandbox.stub(),
+    },
+    dataAccess: {
+      Suggestion: {
+        saveMany: sandbox.stub().resolves(),
+        bulkUpdateStatus: bulkUpdateStatusStub,
+        STATUSES: Suggestion.STATUSES,
+      },
+      SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([]) },
+    },
+    site: {
+      getId: () => 'test-site-id',
+      getBaseURL: () => BASE_URL,
+      requiresValidation: false,
+    },
+  };
+
+  await handler.processOpportunityAndSuggestions(BASE_URL, auditData, context, true);
+
+  return { bulkUpdateStatusStub };
+}
+
+describe('Prerender redirect-outdating behaviour (LLMO-6423)', () => {
+  const sandbox = sinon.createSandbox();
+
+  afterEach(() => sandbox.restore());
+
+  it('redirected URL absent from scrapedUrlsSet is NOT outdated (pre-fix gap, coverage guard blocks it)', async function test() {
+    this.timeout(10000);
+    const redirected = makeUrlSuggestion(
+      'sug-redirected',
+      `${BASE_URL}/redirected-page`,
+      Suggestion.STATUSES.NEW,
+    );
+
+    // scrapedUrlsSet only contains page1 — redirected-page was never unioned in.
+    const { bulkUpdateStatusStub } = await runAudit(
+      sandbox,
+      [redirected],
+      new Set([`${BASE_URL}/page1`]),
+    );
+
+    if (bulkUpdateStatusStub.called) {
+      const outdatedCandidates = bulkUpdateStatusStub.args.flat(2);
+      expect(outdatedCandidates).not.to.include(redirected);
+    }
+  });
+
+  it('redirected URL unioned into scrapedUrlsSet IS marked OUTDATED', async function test() {
+    this.timeout(10000);
+    const redirected = makeUrlSuggestion(
+      'sug-redirected',
+      `${BASE_URL}/redirected-page`,
+      Suggestion.STATUSES.NEW,
+    );
+
+    // scrapedUrlsSet includes redirected-page, simulating the getScrapeJobStats union (§3).
+    const { bulkUpdateStatusStub } = await runAudit(
+      sandbox,
+      [redirected],
+      new Set([`${BASE_URL}/page1`, `${BASE_URL}/redirected-page`]),
+    );
+
+    expect(bulkUpdateStatusStub).to.have.been.called;
+    const outdatedCandidates = bulkUpdateStatusStub.firstCall.args[0];
+    expect(outdatedCandidates).to.include(redirected);
+    expect(bulkUpdateStatusStub.firstCall.args[1]).to.equal(Suggestion.STATUSES.OUTDATED);
+  });
+
+  it('edgeDeployed suggestion for a redirected URL is still protected even when unioned into scrapedUrlsSet', async function test() {
+    this.timeout(10000);
+    const deployedRedirected = makeUrlSuggestion(
+      'sug-deployed-redirected',
+      `${BASE_URL}/redirected-page`,
+      Suggestion.STATUSES.NEW,
+      { edgeDeployed: Date.now() },
+    );
+
+    const { bulkUpdateStatusStub } = await runAudit(
+      sandbox,
+      [deployedRedirected],
+      new Set([`${BASE_URL}/page1`, `${BASE_URL}/redirected-page`]),
+    );
+
+    const outdatedCandidates = bulkUpdateStatusStub.args.flat(2);
+    expect(outdatedCandidates).not.to.include(deployedRedirected);
+  });
+
+  describe('processContentAndGenerateOpportunities integration', () => {
+    // HTML pair that produces contentGainRatio > threshold so page1 registers needsPrerender.
+    const serverHtml = '<html><body><p>Short</p></body></html>';
+    const clientHtml = '<html><body><p>Short</p><p>Much more dynamic content loaded by JavaScript making the page significantly longer than the server-side render and pushing the content gain ratio well above the threshold</p></body></html>';
+
+    it('outdates the existing suggestion for a URL whose ScrapeUrl status is REDIRECT', async function test() {
+      this.timeout(10000);
+      const knownUrl = `${BASE_URL}/page1`;
+      const redirectedUrl = `${BASE_URL}/redirected-page`;
+
+      const allScrapeUrls = [
+        { getUrl: () => knownUrl, getStatus: () => 'COMPLETE' },
+        { getUrl: () => redirectedUrl, getStatus: () => 'REDIRECT' },
+      ];
+
+      const redirectedSuggestion = makeUrlSuggestion(
+        'sug-redirected',
+        redirectedUrl,
+        Suggestion.STATUSES.NEW,
+      );
+
+      const bulkUpdateStatusStub = sandbox.stub().resolves();
+      const mockOpportunity = {
+        getId: () => 'opp-1',
+        getSiteId: () => 'test-site-id',
+        getType: () => 'prerender',
+        getSuggestions: sandbox.stub().resolves([redirectedSuggestion]),
+        addSuggestions: sandbox.stub().resolves({ errorItems: [], createdItems: [] }),
+      };
+
+      const mockHandler = await esmock('../../../../src/prerender/handler.js', {
+        '../../../../src/common/opportunity.js': {
+          convertToOpportunity: sandbox.stub().resolves(mockOpportunity),
+        },
+      });
+
+      const context = {
+        site: { getId: () => 'test-site-id', getBaseURL: () => BASE_URL },
+        audit: {
+          getId: () => 'audit-1',
+          getFullAuditRef: () => 'ref',
+          getAuditedAt: () => '2026-01-01T00:00:00Z',
+          getInvocationId: () => 'inv-1',
+        },
+        log: {
+          info: sandbox.stub(), debug: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub(),
+        },
+        env: { S3_SCRAPER_BUCKET_NAME: 'test-bucket' },
+        auditContext: { scrapeJobId: 'job-1' },
+        scrapeResultPaths: new Map([[knownUrl, '/tmp/p1']]),
+        s3Client: {
+          send: sandbox.stub().callsFake((command) => {
+            if (command.constructor.name === 'PutObjectCommand') return Promise.resolve({});
+            const key = command.input?.Key || '';
+            if (key.endsWith('server-side.html')) return Promise.resolve({ ContentType: 'text/html', Body: { transformToString: () => Promise.resolve(serverHtml) } });
+            if (key.endsWith('client-side.html')) return Promise.resolve({ ContentType: 'text/html', Body: { transformToString: () => Promise.resolve(clientHtml) } });
+            // No scrape.json for the redirected URL — RedirectError never uploads one.
+            return Promise.reject(new Error('Not found'));
+          }),
+        },
+        dataAccess: {
+          ScrapeUrl: { allByScrapeJobId: sandbox.stub().resolves(allScrapeUrls) },
+          Suggestion: {
+            saveMany: sandbox.stub().resolves(),
+            bulkUpdateStatus: bulkUpdateStatusStub,
+            STATUSES: Suggestion.STATUSES,
+          },
+          SiteTopPage: { allBySiteIdAndSourceAndGeo: sandbox.stub().resolves([]) },
+          LatestAudit: { updateByKeys: sandbox.stub().resolves() },
+        },
+      };
+
+      const result = await mockHandler.processContentAndGenerateOpportunities(context);
+
+      expect(result.status).to.equal('complete');
+      expect(result.auditResult.urlsRedirected).to.equal(1);
+      expect(bulkUpdateStatusStub).to.have.been.called;
+      const outdatedCandidates = bulkUpdateStatusStub.firstCall.args[0];
+      expect(outdatedCandidates).to.include(redirectedSuggestion);
+      expect(bulkUpdateStatusStub.firstCall.args[1]).to.equal(Suggestion.STATUSES.OUTDATED);
+    });
+  });
+});

--- a/test/audits/prerender/handler.test.js
+++ b/test/audits/prerender/handler.test.js
@@ -8879,7 +8879,7 @@ describe('Prerender Audit', () => {
       };
       const result = await getScrapeJobStats(null, [], 5, context);
       expect(result).to.deep.equal({
-        urlsSubmittedForScraping: 5, scrapeForbiddenCount: 0, missingPages: [], submittedUrlSet: null,
+        urlsSubmittedForScraping: 5, scrapeForbiddenCount: 0, missingPages: [], submittedUrlSet: null, redirectedUrls: [],
       });
       expect(context.dataAccess.ScrapeUrl.allByScrapeJobId).to.not.have.been.called;
     });
@@ -8893,7 +8893,7 @@ describe('Prerender Audit', () => {
       };
       const result = await getScrapeJobStats('job-1', [], 5, context);
       expect(result).to.deep.equal({
-        urlsSubmittedForScraping: 5, scrapeForbiddenCount: 0, missingPages: [], submittedUrlSet: null,
+        urlsSubmittedForScraping: 5, scrapeForbiddenCount: 0, missingPages: [], submittedUrlSet: null, redirectedUrls: [],
       });
     });
 
@@ -9051,7 +9051,7 @@ describe('Prerender Audit', () => {
       };
       const result = await getScrapeJobStats('job-1', [], 3, context);
       expect(result).to.deep.equal({
-        urlsSubmittedForScraping: 3, scrapeForbiddenCount: 0, missingPages: [], submittedUrlSet: null,
+        urlsSubmittedForScraping: 3, scrapeForbiddenCount: 0, missingPages: [], submittedUrlSet: null, redirectedUrls: [],
       });
       expect(context.log.warn).to.have.been.calledWith(sinon.match('Failed to fetch ScrapeUrl stats'));
     });
@@ -9070,7 +9070,7 @@ describe('Prerender Audit', () => {
       ];
       const result = await getScrapeJobStats('job-1', comparisonResults, 2, context);
       expect(result).to.deep.equal({
-        urlsSubmittedForScraping: 2, scrapeForbiddenCount: 2, missingPages: [], submittedUrlSet: null,
+        urlsSubmittedForScraping: 2, scrapeForbiddenCount: 2, missingPages: [], submittedUrlSet: null, redirectedUrls: [],
       });
       expect(context.log.warn).to.have.been.calledWith(sinon.match('Failed to fetch ScrapeUrl stats'));
     });


### PR DESCRIPTION
## Summary
- RCV/prerender audits couldn't outdate a stale suggestion once its URL starts redirecting: the generic outdating mechanism (`handleOutdatedSuggestions` in `src/utils/data-access.js`) requires a URL to be present in `scrapedUrlsSet` to be reconsidered, but redirected URLs never entered that set (they never enter `comparisonResults`, since `getScrapeResultPaths` only returns `COMPLETE`-status URLs).
- `getScrapeJobStats` now tags `ScrapeUrl` `REDIRECT`-status entries distinctly (`scrapingStatus: 'redirect'` instead of the generic `'failed'`) and returns their URLs (`redirectedUrls`), which get unioned into `scrapedUrlsSet` so the existing outdating guard picks them up — no changes needed to the shared `syncSuggestions`/`handleOutdatedSuggestions` helper itself.
- Adds `urlsRedirected` to the per-run metrics log line and to `status.json`, mirroring the existing `scrapeForbiddenCount` pattern — previously there was zero redirect-specific observability anywhere in this audit.
- Scope: only `REDIRECT`-status URLs are unioned in (not other `FAILED` reasons like 403/404/5xx) — 403s already have separate handling (`createScrapeForbiddenOpportunity`), and other failure reasons can be transient, so they're intentionally left out of auto-outdating for now.

## Context
Follow-up to the content-scraper fix for [LLMO-6423](https://jira.corp.adobe.com/browse/LLMO-6423) ([spacecat-content-scraper#937](https://github.com/adobe/spacecat-content-scraper/pull/937)), which broadened redirect detection so that any non-canonical redirect (path or host change — only bare-domain↔www and http→https are still allowed through) is treated as a scrape failure, not just cross-domain redirects. This surfaced a gap where previously-suggested pages that now redirect would keep a stale, no-longer-verifiable suggestion around indefinitely.

## Jira
https://jira.corp.adobe.com/browse/LLMO-6423

## Test plan
- [x] `npm run test:spec -- test/audits/prerender/**` — 574 passing
- [x] `npm test` (full suite) — 9945 passing; 1 unrelated pre-existing flaky timeout in `test/audits/llmo-referral-traffic-daily/handler.test.js` (no code overlap with this change, reproduces in isolation too)
- [x] `npm run lint` — clean
- [x] 100% line/branch/statement coverage on `src/prerender` maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Nitin Gupta", "Dominique Jäggi"]
rationale: "Extends suggestion-outdating logic to redirected URLs; a stale or wrongly-outdated suggestion is recoverable on the next audit run."
```