### PR TITLE
fix(referral-traffic): validate market/region against ISO allow-list (agentic parity) | LLMO-7346

### DIFF
--- a/src/cdn-logs-report/referral-daily-export.js
+++ b/src/cdn-logs-report/referral-daily-export.js
@@ -16,6 +16,7 @@ import { DeleteObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
 import { classifyTrafficSource } from '@adobe/spacecat-shared-rum-api-client/src/common/traffic.js';
 import { joinBaseAndPath } from '../utils/url-utils.js';
 import { loadSql, getImporterS3Client } from './utils/report-utils.js';
+import { validateCountryCode } from '../common/country-codes.js';
 import { weeklyBreakdownQueries } from './utils/query-builder.js';
 import { buildClassificationRows, serializeClassificationCsv, canonicalizeUrlPath } from '../llmo-referral-traffic-daily/classify.js';
 import { fetchAgenticUrlClassificationRules } from '../common/agentic-url-classification-rules.js';
@@ -70,6 +71,10 @@ async function ensureAthenaDatabase(athenaClient, databaseName) {
 export function mapToReferralCsvRows(rawRows, site, trafficDate) {
   const baseURL = site.getBaseURL();
   const siteHost = new URL(baseURL).hostname;
+  // Mirror the agentic path (agentic-traffic-mapper): validate the URL-path-derived
+  // region against the ISO allow-list + the site's ignore list so non-country path
+  // segments (EN/CS/UQ/…) collapse to GLOBAL instead of showing as fake markets.
+  const siteIgnoreList = site.getConfig?.()?.getLlmoCountryCodeIgnoreList?.() || [];
   const grouped = new Map();
 
   for (const row of rawRows) {
@@ -80,7 +85,7 @@ export function mapToReferralCsvRows(rawRows, site, trafficDate) {
     } = row;
     const device = row.device || '';
     const normalizedDate = (row.date || '') || trafficDate;
-    const region = row.region || 'GLOBAL';
+    const region = validateCountryCode(row.region, siteIgnoreList);
     const rowPageviews = row.pageviews;
 
     // Canonical url_path (chunk 7) — one form shared with the optel producer so the

--- a/src/llmo-referral-traffic-daily/handler.js
+++ b/src/llmo-referral-traffic-daily/handler.js
@@ -18,6 +18,7 @@ import { AuditBuilder } from '../common/audit-builder.js';
 import { wwwUrlResolver } from '../common/index.js';
 import { DEFAULT_COUNTRY_PATTERNS } from '../common/country-patterns.js';
 import { generateReferralCategoryRules } from '../cdn-logs-report/patterns/patterns-uploader.js';
+import { validateCountryCode } from '../common/country-codes.js';
 import { fetchAgenticUrlClassificationRules } from '../common/agentic-url-classification-rules.js';
 import { buildClassificationRows, serializeClassificationCsv, canonicalizeUrlPath } from './classify.js';
 
@@ -75,7 +76,7 @@ export function serializeCsv(rows) {
   return [header, ...body].join('\r\n');
 }
 
-function buildCsvRows(records, host) {
+function buildCsvRows(records, host, siteIgnoreList) {
   const grouped = new Map();
 
   for (const row of records) {
@@ -87,7 +88,7 @@ function buildCsvRows(records, host) {
       const urlPath = canonicalizeUrlPath(row.path);
       const trfPlatform = row.trf_platform || '';
       const device = row.device || '';
-      const region = extractCountryCode(urlPath);
+      const region = validateCountryCode(extractCountryCode(urlPath), siteIgnoreList);
       const consentBool = consentToBool(row.consent);
       const bounced = row.engaged > 0 ? 0 : 1;
       const pageviews = Number(row.pageviews || 0);
@@ -326,7 +327,10 @@ export async function referralTrafficDailyRunner(context) {
     throw err;
   }
 
-  const rows = buildCsvRows(records, host);
+  // Mirror the agentic path: validate URL-path-derived regions against the ISO
+  // allow-list + the site's ignore list so non-country segments collapse to GLOBAL.
+  const siteIgnoreList = site.getConfig?.()?.getLlmoCountryCodeIgnoreList?.() || [];
+  const rows = buildCsvRows(records, host, siteIgnoreList);
 
   if (rows.length === 0) {
     log.info(`[llmo-referral-traffic-daily] No LLM referral rows after filter for site ${siteId} on ${date}`);

--- a/test/audits/cdn-logs-report/referral-daily-export.test.js
+++ b/test/audits/cdn-logs-report/referral-daily-export.test.js
@@ -180,6 +180,35 @@ describe('referral daily export', function referralDailyExportTests() {
     );
   });
 
+  it('validates region against ISO + site ignore list (agentic parity)', async () => {
+    const classifyStub = sandbox.stub().returns({ type: 'earned', category: 'llm', vendor: 'chatgpt' });
+    const module = await loadModule(classifyStub);
+    const site = makeSite({
+      getConfig: () => ({
+        getLlmoCdnlogsFilter: () => [],
+        getLlmoCountryCodeIgnoreList: () => ['US'],
+      }),
+    });
+
+    const rows = module.mapToReferralCsvRows(
+      [
+        {
+          path: '/a', referrer: 'chatgpt.com', device: 'desktop', date: '2026-03-31', region: 'US', pageviews: 3,
+        },
+        {
+          path: '/b', referrer: 'chatgpt.com', device: 'desktop', date: '2026-03-31', region: 'EN', pageviews: 2,
+        },
+      ],
+      site,
+      '2026-03-31',
+    );
+
+    // US is a valid ISO code but ignored for this site; EN is a language, not a
+    // country. Both collapse to GLOBAL instead of showing as fake markets.
+    expect(rows).to.have.length(2);
+    expect(rows.every((r) => r.region === 'GLOBAL')).to.equal(true);
+  });
+
   it('omits org_id when site has no organization', async () => {
     const classifyStub = sandbox.stub().returns({ type: 'earned', category: 'llm', vendor: 'perplexity' });
     const module = await loadModule(classifyStub);
@@ -573,7 +602,7 @@ describe('referral daily export', function referralDailyExportTests() {
           tracking_param: null,
           device: null,     // triggers row.device || ''
           date: '2026-03-31',
-          region: null,     // triggers row.region || 'GLOBAL'
+          region: null,     // validateCountryCode(null) -> GLOBAL
           pageviews: null,  // triggers Number(null) || 0
         }]),
       },

--- a/test/audits/llmo-referral-traffic-daily/handler.test.js
+++ b/test/audits/llmo-referral-traffic-daily/handler.test.js
@@ -462,6 +462,39 @@ describe('LLMO Referral Traffic Daily Handler', function () {
       expect(putCall.Body).to.include('GLOBAL');
     });
 
+    it('collapses non-ISO path segments to GLOBAL (validateCountryCode)', async () => {
+      // /en/ derives EN, which is a language code, not a country -> GLOBAL
+      parquetReadObjectsStub.resolves([{ ...PARQUET_ROW, path: '/en/page1' }]);
+      s3ClientStub.send
+        .onFirstCall().resolves({
+          Body: { transformToByteArray: sandbox.stub().resolves(new Uint8Array([0])) },
+        })
+        .onSecondCall().resolves({});
+
+      await handlerModule.referralTrafficDailyRunner(context);
+
+      const putCall = s3ClientStub.send.secondCall.args[0];
+      expect(putCall.Body).to.include('GLOBAL');
+      expect(putCall.Body).to.not.match(/,EN,/);
+    });
+
+    it('applies the site country-code ignore list (agentic parity)', async () => {
+      site.getConfig = sandbox.stub().returns({ getLlmoCountryCodeIgnoreList: () => ['DE'] });
+      // /de/page1 derives DE (valid ISO), but DE is ignored for this site -> GLOBAL
+      parquetReadObjectsStub.resolves([{ ...PARQUET_ROW, path: '/de/page1' }]);
+      s3ClientStub.send
+        .onFirstCall().resolves({
+          Body: { transformToByteArray: sandbox.stub().resolves(new Uint8Array([0])) },
+        })
+        .onSecondCall().resolves({});
+
+      await handlerModule.referralTrafficDailyRunner(context);
+
+      const putCall = s3ClientStub.send.secondCall.args[0];
+      expect(putCall.Body).to.include('GLOBAL');
+      expect(putCall.Body).to.not.match(/,DE,/);
+    });
+
     it('should map consent=null to true (consent=true in CSV)', async () => {
       parquetReadObjectsStub.resolves([{ ...PARQUET_ROW, consent: null }]);
       s3ClientStub.send


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Validates the referral-traffic "Market"/region value against the ISO-3166 allow-list + the site's country-code ignore list at both referral write paths (optel and cdn), mirroring the agentic-traffic path.

## 2. Reasoning
Referral traffic derives market/region from the first URL path segment and wrote it raw, so non-country segments (`EN`, `CS`, `LP`, `UQ`, …) surface as fake "markets" in the Market dropdown across hundreds of sites (reported for KDDI, but systemic). Agentic traffic already guards this via `validateCountryCode` (shipped in LLMO-7230); referral was the one write path that skipped it. LLMO-7346.

## 3. High-level overview of the changes
Wraps the derived region in `validateCountryCode(code, siteIgnoreList)` at the two referral choke points — `mapToReferralCsvRows` (cdn: `cdn-logs-report/referral-daily-export`) and `buildCsvRows` (optel: `llmo-referral-traffic-daily`) — reading the per-site ignore list from `site.getConfig().getLlmoCountryCodeIgnoreList()`, exactly as `agentic-traffic-mapper` already does.

- Before: any 2-letter first path segment became a market — `EN` (a language) appeared on ~238 sites; `CS`, `LP`, `UQ`, `TV`, etc. showed as countries.
- After: non-ISO codes (and codes on the site's ignore list, and the built-in `TV`/`ST`) collapse to `GLOBAL`. Genuine ISO country codes are unchanged.
- Scope: this is the junk-markets fix only. It deliberately does **not** surface a site's home market (e.g. KDDI's Japanese pages served at root with no `/jp/` segment still fall into `GLOBAL`) — home-market attribution via `site.region` is a separate follow-up that needs a product decision. KDDI's `/my-au/`→`AU` false positive (`AU` is a valid ISO code) is handled per-site via `getLlmoCountryCodeIgnoreList` config, not code.

## 4. Required information
- Jira / issue: LLMO-7346 — https://jira.corp.adobe.com/browse/LLMO-7346
- Other: precedent LLMO-7230 (agentic `validateCountryCode`, closed) — https://jira.corp.adobe.com/browse/LLMO-7230 ; related LLMO-7213 (agentic 5xx country filter, open) — https://jira.corp.adobe.com/browse/LLMO-7213

## 5. Affected / used mysticat-workspace projects
- spacecat-audit-worker (this repo) — changed.
- Consumes the per-site `getLlmoCountryCodeIgnoreList` site-config contract (already used by the agentic path); no schema change.

## 6. Additional information outside the code
Root cause confirmed against prod this session (SpaceCat prod DB, read-only):
- KDDI `au.com` (`referral_traffic_cdn`/`_optel`): most pageviews in `GLOBAL` (365K cdn / 495K optel) which are the real Japanese pages served at root; plus `AU` (from `/my-au/`), `PR`, `ID`, `CS`, `LP`, `UQ`, `CM`, `TV`, `EN`. No `JP` value exists (no `/jp/`, `/ja/` paths).
- Systemic across `referral_traffic_cdn`: `GLOBAL` on 578 sites, `EN` on 238, plus `CS`/`LP`/`GO`/`TV`/`VA`/`UQ` on dozens — confirming this is fleet-wide, not KDDI-specific.

## 7. Test plan
(a) Added unit tests on both changed choke points: a non-ISO path segment (e.g. `/en/`) and a per-site ignore-listed ISO code both resolve to `GLOBAL`, while valid ISO codes pass through.
(b) Per-env (post-deploy): for an affected site (e.g. KDDI `au.com`), verify the referral Market dropdown no longer lists `EN`/`CS`/`LP`/`UQ`. Note `JP` will still not appear — that is the separate home-market follow-up, not this change. No eph/stage-specific steps beyond the normal referral daily export running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["@IrisAlexandrescu", "Dominique Jäggi"]
rationale: "Data-quality validation added to referral market/region derivation; bad values are cosmetic and recoverable on next export."
```