### PR TITLE
fix(cdn-analysis): exclude favicon requests from CDN referral traffic (LLMO-7412)

### DIFF
--- a/src/cdn-analysis/sql/akamai/insert-aggregated-referral.sql
+++ b/src/cdn-analysis/sql/akamai/insert-aggregated-referral.sql
@@ -105,6 +105,10 @@ referrals_raw AS (
          java|go-http-client|php|ruby|perl|axios|node|synthetics|probe|ahc
       )'
     )
+
+    -- exclude favicon requests: never a real content page view, but they return an
+    -- HTML error page so they pass the text/html gate and get counted as referral traffic
+    AND NOT REGEXP_LIKE(url_extract_path(url), '(?i)^/favicon\.ico(\.html)?$')
 )
 
 SELECT 

--- a/src/cdn-analysis/sql/cloudflare/insert-aggregated-referral.sql
+++ b/src/cdn-analysis/sql/cloudflare/insert-aggregated-referral.sql
@@ -94,6 +94,10 @@ referrals_raw AS (
          java|go-http-client|php|ruby|perl|axios|node|synthetics|probe|ahc
       )'
     )
+
+    -- exclude favicon requests: never a real content page view, but they return an
+    -- HTML error page so they pass the text/html gate and get counted as referral traffic
+    AND NOT REGEXP_LIKE(url_extract_path(url), '(?i)^/favicon\.ico(\.html)?$')
 )
 
 SELECT 

--- a/src/cdn-analysis/sql/cloudfront/insert-aggregated-referral.sql
+++ b/src/cdn-analysis/sql/cloudfront/insert-aggregated-referral.sql
@@ -100,6 +100,10 @@ referrals_raw AS (
          java|go-http-client|php|ruby|perl|axios|node|synthetics|probe|ahc
       )'
     )
+
+    -- exclude favicon requests: never a real content page view, but they return an
+    -- HTML error page so they pass the text/html gate and get counted as referral traffic
+    AND NOT REGEXP_LIKE(url_extract_path(url), '(?i)^/favicon\.ico(\.html)?$')
 )
 
 SELECT 

--- a/src/cdn-analysis/sql/fastly/insert-aggregated-referral.sql
+++ b/src/cdn-analysis/sql/fastly/insert-aggregated-referral.sql
@@ -88,6 +88,10 @@ referrals_raw AS (
          java|go-http-client|php|ruby|perl|axios|node|synthetics|probe|ahc
       )'
     )
+
+    -- exclude favicon requests: never a real content page view, but they return an
+    -- HTML error page so they pass the text/html gate and get counted as referral traffic
+    AND NOT REGEXP_LIKE(url_extract_path(url), '(?i)^/favicon\.ico(\.html)?$')
 )
 
 SELECT 

--- a/src/cdn-analysis/sql/frontdoor/insert-aggregated-referral.sql
+++ b/src/cdn-analysis/sql/frontdoor/insert-aggregated-referral.sql
@@ -90,6 +90,10 @@ referrals_raw AS (
          java|go-http-client|php|ruby|perl|axios|node|synthetics|probe|ahc
       )'
     )
+
+    -- exclude favicon requests: never a real content page view, but they return an
+    -- HTML error page so they pass the text/html gate and get counted as referral traffic
+    AND NOT REGEXP_LIKE(url_extract_path(properties.requestUri), '(?i)^/favicon\.ico(\.html)?$')
 )
 
 SELECT 

--- a/src/cdn-analysis/sql/imperva/insert-aggregated-referral.sql
+++ b/src/cdn-analysis/sql/imperva/insert-aggregated-referral.sql
@@ -101,6 +101,10 @@ referrals_raw AS (
          java|go-http-client|php|ruby|perl|axios|node|synthetics|probe|ahc
       )'
     )
+
+    -- exclude favicon requests: never a real content page view, but they return an
+    -- HTML error page so they pass the text/html gate and get counted as referral traffic
+    AND NOT REGEXP_LIKE(url_extract_path(url), '(?i)^/favicon\.ico(\.html)?$')
 )
 
 SELECT 

--- a/src/cdn-analysis/sql/other/insert-aggregated-referral.sql
+++ b/src/cdn-analysis/sql/other/insert-aggregated-referral.sql
@@ -98,6 +98,10 @@ referrals_raw AS (
          java|go-http-client|php|ruby|perl|axios|node|synthetics|probe|ahc
       )'
     )
+
+    -- exclude favicon requests: never a real content page view, but they return an
+    -- HTML error page so they pass the text/html gate and get counted as referral traffic
+    AND NOT REGEXP_LIKE(url_extract_path(url), '(?i)^/favicon\.ico(\.html)?$')
 )
 
 SELECT 

--- a/test/audits/cdn-analysis/handler.test.js
+++ b/test/audits/cdn-analysis/handler.test.js
@@ -763,6 +763,9 @@ describe('CDN Analysis Handler', () => {
       expect(referralCall.args[0]).to.include("lower(response_content_type) LIKE 'text/html%'");
       expect(referralCall.args[0]).to.include("NULLIF(trim(response_content_type), '') IS NULL");
       expect(referralCall.args[0]).to.include("NOT REGEXP_LIKE(url_extract_path(COALESCE(url, ''))");
+      // LLMO-7412: favicon requests return an HTML error page and would otherwise be
+      // counted as referral pageviews; they must be excluded from referral aggregation.
+      expect(referralCall.args[0]).to.include("AND NOT REGEXP_LIKE(url_extract_path(url), '(?i)^/favicon\\.ico(\\.html)?$')");
     });
 
     it('dispatcher-scheduled byocdn-other run with no recent files returns early', async () => {

--- a/test/audits/cdn-analysis/insert-aggregated-referral-favicon.test.js
+++ b/test/audits/cdn-analysis/insert-aggregated-referral-favicon.test.js
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import { expect } from 'chai';
+import { getStaticContent } from '@adobe/spacecat-shared-utils';
+
+// LLMO-7412: favicon requests (/favicon.ico and the /favicon.ico.html variant)
+// return an HTML error page, so they pass the text/html content-type gate in the
+// referral aggregation and get counted as ChatGPT referral pageviews. Each vendor's
+// insert-aggregated-referral.sql must exclude them from the referrals_raw CTE.
+//
+// Most vendors expose the request path as the `url` column inside referrals_raw;
+// frontdoor has no such column there and references `properties.requestUri` directly.
+const FAVICON_REGEX = "'(?i)^/favicon\\.ico(\\.html)?$'";
+
+const VENDOR_URL_EXPR = {
+  fastly: 'url_extract_path(url)',
+  cloudfront: 'url_extract_path(url)',
+  cloudflare: 'url_extract_path(url)',
+  akamai: 'url_extract_path(url)',
+  imperva: 'url_extract_path(url)',
+  other: 'url_extract_path(url)',
+  frontdoor: 'url_extract_path(properties.requestUri)',
+};
+
+const TEMPLATE_VARIABLES = {
+  database: 'cdn_logs_db',
+  rawTable: 'raw_logs',
+  aggregatedTable: 'aggregated_referral_logs',
+  year: '2026',
+  month: '06',
+  day: '25',
+  hour: '10',
+  hourFilter: '',
+  bucket: 'cdn-logs-bucket',
+  serviceProvider: 'byocdn-other',
+};
+
+async function renderReferralSql(provider) {
+  return getStaticContent(
+    TEMPLATE_VARIABLES,
+    `./src/cdn-analysis/sql/${provider}/insert-aggregated-referral.sql`,
+  );
+}
+
+describe('CDN referral aggregation - favicon exclusion (LLMO-7412)', () => {
+  Object.entries(VENDOR_URL_EXPR).forEach(([provider, urlExpr]) => {
+    it(`${provider}: excludes favicon requests from the referrals_raw CTE`, async () => {
+      const sql = await renderReferralSql(provider);
+
+      const faviconPredicate = `AND NOT REGEXP_LIKE(${urlExpr}, ${FAVICON_REGEX})`;
+      expect(sql).to.include(faviconPredicate);
+
+      // The exclusion must sit inside the referrals_raw CTE (before its closing
+      // paren and the final SELECT), not somewhere in the outer query.
+      const cteEnd = sql.indexOf('FROM referrals_raw');
+      expect(cteEnd).to.be.greaterThan(-1);
+      expect(sql.indexOf(faviconPredicate)).to.be.lessThan(cteEnd);
+
+      // It must come after the bot user-agent filter, so it does not disturb that block.
+      const botFilterIndex = sql.indexOf('synthetics|probe|ahc');
+      expect(botFilterIndex).to.be.greaterThan(-1);
+      expect(sql.indexOf(faviconPredicate)).to.be.greaterThan(botFilterIndex);
+    });
+  });
+});


### PR DESCRIPTION
<!-- mysticat-pr-skill -->

## 1. Abstract
Excludes favicon requests from the CDN referral-traffic aggregation across all seven CDN vendor SQL templates, so they are no longer counted as referral pageviews.

## 2. Reasoning
The CDN referral aggregation was counting favicon requests as referral pageviews, predominantly attributed to ChatGPT/`openai`. `/favicon.ico` (and the `/favicon.ico.html` variant that appears in the pipeline) is not a real content page view, but the origin serves it an HTML error page. That response carries a `text/html` content type, so the request passes the `text/html` gate in the `referrals_raw` CTE and is emitted as a referral row. On `lumen.com`, favicon requests accounted for roughly 95% of the `openai` CDN referral volume — a plateau from 2026-06-25 to 2026-07-30 plus a chronic tail through 2026-09-05. Tracked in LLMO-7412.

## 3. High-level overview of the changes
Adds a favicon exclusion to the `referrals_raw` CTE `WHERE` clause, placed immediately after the existing bot user-agent filter, in every CDN vendor template (fastly, cloudfront, cloudflare, akamai, imperva, frontdoor, other).

Behaviour delta:
- Before: a request whose path is `/favicon.ico` (or `/favicon.ico.html`) that returns an HTML error page satisfies the `text/html` gate and is aggregated as a referral pageview — inflating earned/LLM referral counts (most visibly `openai`).
- After: such requests are dropped from the referral aggregation. The exclusion is path-anchored and case-insensitive, and it operates on the extracted URL path so query strings do not defeat it. Real content pages are unaffected.

The predicate matches each file's existing structure: six templates reference the request path as the `url` column inside `referrals_raw`; `frontdoor` has no such column there and references `properties.requestUri` directly, so its predicate uses that expression instead. This is orthogonal to LLMO-7216 and deliberately does not add a `chatgpt-user` (or any) user-agent-string carve-out to the bot regex — a UA-string carve-out is unreliable and re-admits spoofed traffic platform-wide, whereas excluding the favicon path targets the actual source of the inflation.

## 4. Required information
- Jira / issue: [LLMO-7412](https://jira.corp.adobe.com/browse/LLMO-7412)

## 7. Test plan
(a) Local verification (beyond unit tests): rendered each of the seven vendor `insert-aggregated-referral.sql` templates through the real `getStaticContent` load path and confirmed the favicon exclusion is present, sits inside the `referrals_raw` CTE (before the final `FROM referrals_raw`), and is positioned after the bot user-agent filter — with the correct URL expression per vendor. The change is SQL-template-only; no full Athena aggregation was run locally.

(b) Per-environment verification (dev / prod): after deploy, re-run `cdn-logs-analysis` for an affected site (e.g. `lumen.com`) over the plateau window (2026-06-25..07-30) with `forceReprocess` so the aggregated-referral partitions are rebuilt. Then confirm in the `aggregated-referral` output that no rows have a `url` of `/favicon.ico` or `/favicon.ico.html`, and that the daily `openai` referral pageview counts drop to the expected non-favicon baseline. Spot-check one non-favicon referral URL to confirm legitimate referral traffic is retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
