### PR TITLE
feat: add new agentic bots and merge Research into Chatbots (LLMO-7325)

### DIFF
--- a/src/cdn-analysis/sql/akamai/insert-aggregated.sql
+++ b/src/cdn-analysis/sql/akamai/insert-aggregated.sql
@@ -24,7 +24,7 @@ WHERE year  = '{{year}}'
   {{hourFilter}}
 
   -- match known LLM-related user-agents
-  AND REGEXP_LIKE(ua, '(?i)(ChatGPT|GPTBot|OAI-SearchBot|OAI-AdsBot|Perplexity|Claude|Anthropic|Gemini|Copilot|MistralAI-User|Google-NotebookLM|Google-?Agent|Google-Extended|Googlebot|bingbot|Amzn-User|^Google$)')
+  AND REGEXP_LIKE(ua, '(?i)(ChatGPT|GPTBot|OAI-SearchBot|OAI-AdsBot|Perplexity|Claude|Anthropic|Gemini|Copilot|MistralAI-User|Google-NotebookLM|Google-?Agent|Google-Extended|Googlebot|bingbot|Amzn-User|Shap(Bot|-User)|Manus-User|Keenable-User|^Google$)')
 
   -- exclude Adobe internal/proxied user agents (O@E appends AdobeEdgeOptimize/*, internal crawler uses Spacecat/1.0, Tokowaka)
   AND NOT REGEXP_LIKE(ua, '(?i)(Tokowaka|Spacecat|AdobeEdgeOptimize)')

--- a/src/cdn-analysis/sql/cloudflare/insert-aggregated.sql
+++ b/src/cdn-analysis/sql/cloudflare/insert-aggregated.sql
@@ -25,7 +25,7 @@ WHERE date = '{{year}}{{month}}{{day}}'
   -- The 'hour' column in output provides hourly breakdown within the daily aggregation
 
   -- match known LLM-related user-agents
-  AND REGEXP_LIKE(ClientRequestUserAgent, '(?i)(ChatGPT|GPTBot|OAI-SearchBot|OAI-AdsBot|Perplexity|Claude|Anthropic|Gemini|Copilot|MistralAI-User|Google-NotebookLM|Google-?Agent|Google-Extended|Googlebot|bingbot|Amzn-User|^Google$)')
+  AND REGEXP_LIKE(ClientRequestUserAgent, '(?i)(ChatGPT|GPTBot|OAI-SearchBot|OAI-AdsBot|Perplexity|Claude|Anthropic|Gemini|Copilot|MistralAI-User|Google-NotebookLM|Google-?Agent|Google-Extended|Googlebot|bingbot|Amzn-User|Shap(Bot|-User)|Manus-User|Keenable-User|^Google$)')
 
   -- exclude Adobe internal/proxied user agents (O@E appends AdobeEdgeOptimize/*, internal crawler uses Spacecat/1.0, Tokowaka)
   AND NOT REGEXP_LIKE(ClientRequestUserAgent, '(?i)(Tokowaka|Spacecat|AdobeEdgeOptimize)')

--- a/src/cdn-analysis/sql/cloudfront/insert-aggregated.sql
+++ b/src/cdn-analysis/sql/cloudfront/insert-aggregated.sql
@@ -22,7 +22,7 @@ WHERE year  = '{{year}}'
   {{hourFilter}}
 
    -- match known LLM-related user-agents
-  AND REGEXP_LIKE("cs(user-agent)", '(?i)(ChatGPT|GPTBot|OAI-SearchBot|OAI-AdsBot|Perplexity|Claude|Anthropic|Gemini|Copilot|MistralAI-User|Google-NotebookLM|Google-?Agent|Google-Extended|Googlebot|bingbot|Amzn-User|^Google$)')
+  AND REGEXP_LIKE("cs(user-agent)", '(?i)(ChatGPT|GPTBot|OAI-SearchBot|OAI-AdsBot|Perplexity|Claude|Anthropic|Gemini|Copilot|MistralAI-User|Google-NotebookLM|Google-?Agent|Google-Extended|Googlebot|bingbot|Amzn-User|Shap(Bot|-User)|Manus-User|Keenable-User|^Google$)')
 
   -- exclude Adobe internal/proxied user agents (O@E appends AdobeEdgeOptimize/*, internal crawler uses Spacecat/1.0, Tokowaka)
   AND NOT REGEXP_LIKE("cs(user-agent)", '(?i)(Tokowaka|Spacecat|AdobeEdgeOptimize)')

--- a/src/cdn-analysis/sql/fastly/insert-aggregated.sql
+++ b/src/cdn-analysis/sql/fastly/insert-aggregated.sql
@@ -22,7 +22,7 @@ WHERE year  = '{{year}}'
   {{hourFilter}}
   
    -- match known LLM-related user-agents
-  AND REGEXP_LIKE(request_user_agent, '(?i)(ChatGPT|GPTBot|OAI-SearchBot|OAI-AdsBot|Perplexity|Claude|Anthropic|Gemini|Copilot|MistralAI-User|Google-NotebookLM|Google-?Agent|Google-Extended|Googlebot|bingbot|Amzn-User|^Google$)')
+  AND REGEXP_LIKE(request_user_agent, '(?i)(ChatGPT|GPTBot|OAI-SearchBot|OAI-AdsBot|Perplexity|Claude|Anthropic|Gemini|Copilot|MistralAI-User|Google-NotebookLM|Google-?Agent|Google-Extended|Googlebot|bingbot|Amzn-User|Shap(Bot|-User)|Manus-User|Keenable-User|^Google$)')
 
   -- exclude Adobe internal/proxied user agents (O@E appends AdobeEdgeOptimize/*, internal crawler uses Spacecat/1.0, Tokowaka)
   AND NOT REGEXP_LIKE(request_user_agent, '(?i)(Tokowaka|Spacecat|AdobeEdgeOptimize)')

--- a/src/cdn-analysis/sql/frontdoor/insert-aggregated.sql
+++ b/src/cdn-analysis/sql/frontdoor/insert-aggregated.sql
@@ -22,7 +22,7 @@ WHERE year  = '{{year}}'
   {{hourFilter}}
   
    -- match known LLM-related user-agents
-  AND REGEXP_LIKE(properties.userAgent, '(?i)(ChatGPT|GPTBot|OAI-SearchBot|OAI-AdsBot|Perplexity|Claude|Anthropic|Gemini|Copilot|MistralAI-User|Google-NotebookLM|Google-?Agent|Google-Extended|Googlebot|bingbot|Amzn-User|^Google$)')
+  AND REGEXP_LIKE(properties.userAgent, '(?i)(ChatGPT|GPTBot|OAI-SearchBot|OAI-AdsBot|Perplexity|Claude|Anthropic|Gemini|Copilot|MistralAI-User|Google-NotebookLM|Google-?Agent|Google-Extended|Googlebot|bingbot|Amzn-User|Shap(Bot|-User)|Manus-User|Keenable-User|^Google$)')
 
   -- exclude Adobe internal/proxied user agents (O@E appends AdobeEdgeOptimize/*, internal crawler uses Spacecat/1.0, Tokowaka)
   AND NOT REGEXP_LIKE(properties.userAgent, '(?i)(Tokowaka|Spacecat|AdobeEdgeOptimize)')

--- a/src/cdn-analysis/sql/imperva/insert-aggregated.sql
+++ b/src/cdn-analysis/sql/imperva/insert-aggregated.sql
@@ -21,7 +21,7 @@ WHERE
   date = '{{year}}-{{month}}-{{day}}'
 
   -- match known LLM-related user-agents
-  AND REGEXP_LIKE(cs_user_agent, '(?i)(ChatGPT|GPTBot|OAI-SearchBot|OAI-AdsBot|Perplexity|Claude|Anthropic|Gemini|Copilot|MistralAI-User|Google-NotebookLM|Google-?Agent|Google-Extended|Googlebot|bingbot|Amzn-User|^Google$)')
+  AND REGEXP_LIKE(cs_user_agent, '(?i)(ChatGPT|GPTBot|OAI-SearchBot|OAI-AdsBot|Perplexity|Claude|Anthropic|Gemini|Copilot|MistralAI-User|Google-NotebookLM|Google-?Agent|Google-Extended|Googlebot|bingbot|Amzn-User|Shap(Bot|-User)|Manus-User|Keenable-User|^Google$)')
 
   -- exclude Adobe internal/proxied user agents (O@E appends AdobeEdgeOptimize/*, internal crawler uses Spacecat/1.0, Tokowaka)
   AND NOT REGEXP_LIKE(cs_user_agent, '(?i)(Tokowaka|Spacecat|AdobeEdgeOptimize)')

--- a/src/cdn-analysis/sql/other/insert-aggregated.sql
+++ b/src/cdn-analysis/sql/other/insert-aggregated.sql
@@ -21,7 +21,7 @@ WHERE year  = '{{year}}'
   AND day   = '{{day}}'
   
    -- match known LLM-related user-agents
-  AND REGEXP_LIKE(request_user_agent, '(?i)(ChatGPT|GPTBot|OAI-SearchBot|OAI-AdsBot|Perplexity|Claude|Anthropic|Gemini|Copilot|MistralAI-User|Google-NotebookLM|Google-?Agent|Google-Extended|Googlebot|bingbot|Amzn-User|^Google$)')
+  AND REGEXP_LIKE(request_user_agent, '(?i)(ChatGPT|GPTBot|OAI-SearchBot|OAI-AdsBot|Perplexity|Claude|Anthropic|Gemini|Copilot|MistralAI-User|Google-NotebookLM|Google-?Agent|Google-Extended|Googlebot|bingbot|Amzn-User|Shap(Bot|-User)|Manus-User|Keenable-User|^Google$)')
 
   -- exclude Adobe internal/proxied user agents (O@E appends AdobeEdgeOptimize/*, internal crawler uses Spacecat/1.0, Tokowaka)
   AND NOT REGEXP_LIKE(request_user_agent, '(?i)(Tokowaka|Spacecat|AdobeEdgeOptimize)')

--- a/src/common/user-agent-classification.js
+++ b/src/common/user-agent-classification.js
@@ -188,13 +188,13 @@ export function inferProviderFromUserAgent(userAgent = '') {
   if (/(amzn|amazon)/.test(ua)) {
     return 'Amazon';
   }
-  if (/shap/.test(ua)) {
+  if (/shap(bot|-user)/.test(ua)) {
     return 'Parallel.ai';
   }
-  if (/manus/.test(ua)) {
+  if (/manus-user/.test(ua)) {
     return 'Manus';
   }
-  if (/keenable/.test(ua)) {
+  if (/keenable-user/.test(ua)) {
     return 'Keenable.ai';
   }
 

--- a/src/common/user-agent-classification.js
+++ b/src/common/user-agent-classification.js
@@ -37,7 +37,7 @@ export const PROVIDER_USER_AGENT_PATTERNS = {
   copilot: '(?i)Copilot',
   bing: '(?i)Bingbot',
   amazon: '(?i)Amzn-User',
-  parallel: '(?i)Shap-User',
+  parallel: '(?i)Shap(Bot|-User)',
   manus: '(?i)Manus-User',
   keenable: '(?i)Keenable-User',
 };
@@ -81,6 +81,7 @@ export const USER_AGENT_DISPLAY_PATTERNS = [
   // Amazon
   { pattern: '%amzn-user%', displayName: 'Amzn-User' },
   // Parallel.ai
+  { pattern: '%shapbot%', displayName: 'ShapBot' },
   { pattern: '%shap-user%', displayName: 'Shap-User' },
   // Manus
   { pattern: '%manus-user%', displayName: 'Manus-User' },
@@ -136,8 +137,10 @@ export function buildAgentTypeClassificationSQL() {
     { pattern: '%mistralai-user%', result: 'Chatbots' },
     // Amazon
     { pattern: '%amzn-user%', result: 'Chatbots' },
-    // Parallel.ai
-    { pattern: '%shap-user%', result: 'Web search crawlers' },
+    // Parallel.ai - ShapBot is the automated crawler; Shap-User is user-initiated only
+    // (Parallel does not use it for automatic crawling), so it's a Chatbots-style bot.
+    { pattern: '%shapbot%', result: 'Web search crawlers' },
+    { pattern: '%shap-user%', result: 'Chatbots' },
     // Manus
     { pattern: '%manus-user%', result: 'Chatbots' },
     // Keenable.ai
@@ -185,7 +188,7 @@ export function inferProviderFromUserAgent(userAgent = '') {
   if (/(amzn|amazon)/.test(ua)) {
     return 'Amazon';
   }
-  if (/shap-user/.test(ua)) {
+  if (/shap/.test(ua)) {
     return 'Parallel.ai';
   }
   if (/manus/.test(ua)) {

--- a/src/common/user-agent-classification.js
+++ b/src/common/user-agent-classification.js
@@ -31,12 +31,15 @@ export const PROVIDER_USER_AGENT_PATTERNS = {
   chatgpt: '(?i)(ChatGPT|GPTBot|OAI-SearchBot|OAI-AdsBot)',
   perplexity: '(?i)Perplexity',
   claude: '(?i)Claude(?!-web)',
-  googleai: '(?i)(^Google$|Gemini-Deep-Research|Google-NotebookLM|Google-?Agent)',
+  googleai: '(?i)(^Google$|Google-NotebookLM|Google-?Agent)',
   google: '(?i)(Google-Extended|Googlebot)',
   mistralai: '(?i)MistralAI-User',
   copilot: '(?i)Copilot',
   bing: '(?i)Bingbot',
   amazon: '(?i)Amzn-User',
+  parallel: '(?i)Shap-User',
+  manus: '(?i)Manus-User',
+  keenable: '(?i)Keenable-User',
 };
 
 /**
@@ -58,12 +61,10 @@ export const USER_AGENT_DISPLAY_PATTERNS = [
   { pattern: '%perplexity/%', displayName: 'Perplexity Clients' },
 
   // Google
-  { pattern: '%gemini-deep-research%', displayName: 'Gemini-Deep-Research' },
   { pattern: 'google', displayName: 'Google-ai-mode' },
   { pattern: '%googleagent-urlcontext%', displayName: 'GoogleAgent-URLContext' },
   { pattern: '%googleagent-chrome%', displayName: 'GoogleAgent-Chrome' },
   { pattern: '%googleagent-shopping%', displayName: 'GoogleAgent-Shopping' },
-  { pattern: '%googleagent-mariner%', displayName: 'GoogleAgent-Mariner' },
   { pattern: '%google-agent%', displayName: 'Google-Agent' },
   { pattern: '%google-notebooklm%', displayName: 'Google-NotebookLM' },
   { pattern: '%googlebot%', displayName: 'GoogleBot' },
@@ -79,6 +80,12 @@ export const USER_AGENT_DISPLAY_PATTERNS = [
   { pattern: '%mistralai-user%', displayName: 'MistralAI-User' },
   // Amazon
   { pattern: '%amzn-user%', displayName: 'Amzn-User' },
+  // Parallel.ai
+  { pattern: '%shap-user%', displayName: 'Shap-User' },
+  // Manus
+  { pattern: '%manus-user%', displayName: 'Manus-User' },
+  // Keenable.ai
+  { pattern: '%keenable-user%', displayName: 'Keenable-User' },
 ];
 
 /**
@@ -111,14 +118,12 @@ export function buildAgentTypeClassificationSQL() {
     // Google
     { pattern: '%googlebot%', result: 'Search Bots' },
     { pattern: '%google-extended%', result: 'Search Bots' },
-    { pattern: '%gemini-deep-research%', result: 'Research' },
     { pattern: 'google', result: 'Chatbots' },
     { pattern: '%googleagent-urlcontext%', result: 'Chatbots' },
     { pattern: '%googleagent-chrome%', result: 'Action agents' },
     { pattern: '%googleagent-shopping%', result: 'Shopping agents' },
-    { pattern: '%googleagent-mariner%', result: 'Action agents' },
     { pattern: '%google-agent%', result: 'Action agents' },
-    { pattern: '%google-notebooklm%', result: 'Research' },
+    { pattern: '%google-notebooklm%', result: 'Chatbots' },
     // Bing
     { pattern: '%bingbot%', result: 'Search Bots' },
     // Claude
@@ -131,6 +136,12 @@ export function buildAgentTypeClassificationSQL() {
     { pattern: '%mistralai-user%', result: 'Chatbots' },
     // Amazon
     { pattern: '%amzn-user%', result: 'Chatbots' },
+    // Parallel.ai
+    { pattern: '%shap-user%', result: 'Web search crawlers' },
+    // Manus
+    { pattern: '%manus-user%', result: 'Chatbots' },
+    // Keenable.ai
+    { pattern: '%keenable-user%', result: 'Web search crawlers' },
   ];
 
   const cases = patterns.map((p) => `WHEN LOWER(user_agent) LIKE '${p.pattern}' THEN '${p.result}'`).join('\n          ');
@@ -153,7 +164,7 @@ export function inferProviderFromUserAgent(userAgent = '') {
   if (/(anthropic|claude)/.test(ua)) {
     return 'Anthropic';
   }
-  if (/(gemini-deep-research|google-?agent)/.test(ua)) {
+  if (/google-?agent/.test(ua)) {
     return 'Gemini';
   }
   if (/google-ai-mode/.test(ua)) {
@@ -173,6 +184,15 @@ export function inferProviderFromUserAgent(userAgent = '') {
   }
   if (/(amzn|amazon)/.test(ua)) {
     return 'Amazon';
+  }
+  if (/shap-user/.test(ua)) {
+    return 'Parallel.ai';
+  }
+  if (/manus/.test(ua)) {
+    return 'Manus';
+  }
+  if (/keenable/.test(ua)) {
+    return 'Keenable.ai';
   }
 
   return 'Other';

--- a/src/utils/cdn-utils.js
+++ b/src/utils/cdn-utils.js
@@ -618,6 +618,9 @@ export function buildUserAgentFilter() {
     claude,
     mistralai,
     amazon,
+    parallel,
+    manus,
+    keenable,
   } = PROVIDER_USER_AGENT_PATTERNS;
 
   return `(
@@ -626,7 +629,10 @@ export function buildUserAgentFilter() {
     REGEXP_LIKE(user_agent, '${googleai}') OR
     REGEXP_LIKE(user_agent, '${claude}') OR
     REGEXP_LIKE(user_agent, '${mistralai}') OR
-    REGEXP_LIKE(user_agent, '${amazon}')
+    REGEXP_LIKE(user_agent, '${amazon}') OR
+    REGEXP_LIKE(user_agent, '${parallel}') OR
+    REGEXP_LIKE(user_agent, '${manus}') OR
+    REGEXP_LIKE(user_agent, '${keenable}')
   ) AND ${buildAdobeInternalUaExclusion()}`;
 }
 /* c8 ignore end */

--- a/test/audits/cdn-logs-report/user-agent-patterns.test.js
+++ b/test/audits/cdn-logs-report/user-agent-patterns.test.js
@@ -41,7 +41,6 @@ describe('User Agent Patterns', () => {
       // Google AI agents
       expect(PROVIDER_USER_AGENT_PATTERNS).to.have.property('googleai');
       expect(PROVIDER_USER_AGENT_PATTERNS.googleai).to.include('Google$');
-      expect(PROVIDER_USER_AGENT_PATTERNS.googleai).to.include('Gemini-Deep-Research');
       expect(PROVIDER_USER_AGENT_PATTERNS.googleai).to.include('Google-NotebookLM');
       expect(PROVIDER_USER_AGENT_PATTERNS.googleai).to.include('Google-?Agent');
 
@@ -115,9 +114,11 @@ describe('User Agent Patterns', () => {
       expect(filter).to.include('ChatGPT');
       expect(filter).to.include('Perplexity');
       expect(filter).to.include('Google-?Agent');
-      expect(filter).to.include('Gemini-Deep-Research');
       expect(filter).to.include('Google-NotebookLM');
       expect(filter).to.include('Claude');
+      expect(filter).to.include('Shap-User');
+      expect(filter).to.include('Manus-User');
+      expect(filter).to.include('Keenable-User');
     });
   });
 
@@ -147,6 +148,25 @@ describe('User Agent Patterns', () => {
 
       expect(sql).to.include("LIKE '%com.anthropic.claude%' THEN 'Media fetchers'");
       expect(sql).to.include("LIKE '%claude/%' THEN 'Media fetchers'");
+    });
+
+    it('classifies Google-NotebookLM as Chatbots (Research merged into Chatbots)', () => {
+      const { buildAgentTypeClassificationSQL } = userAgentPatterns;
+      const sql = buildAgentTypeClassificationSQL();
+
+      expect(sql).to.include("LIKE '%google-notebooklm%' THEN 'Chatbots'");
+      expect(sql).to.not.include('Research');
+      expect(sql).to.not.include('gemini-deep-research');
+      expect(sql).to.not.include('googleagent-mariner');
+    });
+
+    it('classifies new agentic search/user bots', () => {
+      const { buildAgentTypeClassificationSQL } = userAgentPatterns;
+      const sql = buildAgentTypeClassificationSQL();
+
+      expect(sql).to.include("LIKE '%shap-user%' THEN 'Web search crawlers'");
+      expect(sql).to.include("LIKE '%manus-user%' THEN 'Chatbots'");
+      expect(sql).to.include("LIKE '%keenable-user%' THEN 'Web search crawlers'");
     });
   });
 
@@ -184,9 +204,7 @@ describe('User Agent Patterns', () => {
       expect(inferProviderFromUserAgent('PerplexityBot')).to.equal('Perplexity');
       expect(inferProviderFromUserAgent('ClaudeBot')).to.equal('Anthropic');
       expect(inferProviderFromUserAgent('Anthropic-SearchBot')).to.equal('Anthropic');
-      expect(inferProviderFromUserAgent('Gemini-Deep-Research')).to.equal('Gemini');
       expect(inferProviderFromUserAgent('GoogleAgent-Chrome')).to.equal('Gemini');
-      expect(inferProviderFromUserAgent('GoogleAgent-Mariner')).to.equal('Gemini');
       expect(inferProviderFromUserAgent('GoogleAgent-URLContext')).to.equal('Gemini');
       expect(inferProviderFromUserAgent('GoogleAgent-Shopping')).to.equal('Gemini');
       expect(inferProviderFromUserAgent('Google-Agent')).to.equal('Gemini');
@@ -196,6 +214,9 @@ describe('User Agent Patterns', () => {
       expect(inferProviderFromUserAgent('BingBot')).to.equal('Bing');
       expect(inferProviderFromUserAgent('MistralAI-Search')).to.equal('MistralAI');
       expect(inferProviderFromUserAgent('Amazonbot/0.1')).to.equal('Amazon');
+      expect(inferProviderFromUserAgent('Shap-User/0.1.0')).to.equal('Parallel.ai');
+      expect(inferProviderFromUserAgent('Manus-User/1.0')).to.equal('Manus');
+      expect(inferProviderFromUserAgent('Keenable-User/1.0')).to.equal('Keenable.ai');
       expect(inferProviderFromUserAgent('something-unknown')).to.equal('Other');
     });
   });

--- a/test/audits/cdn-logs-report/user-agent-patterns.test.js
+++ b/test/audits/cdn-logs-report/user-agent-patterns.test.js
@@ -10,10 +10,17 @@
  * governing permissions and limitations under the License.
  */
 
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import { expect, use } from 'chai';
 import sinonChai from 'sinon-chai';
 
 use(sinonChai);
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const SQL_PROVIDERS_DIR = path.join(__dirname, '../../../src/cdn-analysis/sql');
 
 describe('User Agent Patterns', () => {
   let userAgentPatterns;
@@ -220,6 +227,50 @@ describe('User Agent Patterns', () => {
       expect(inferProviderFromUserAgent('Manus-User/1.0')).to.equal('Manus');
       expect(inferProviderFromUserAgent('Keenable-User/1.0')).to.equal('Keenable.ai');
       expect(inferProviderFromUserAgent('something-unknown')).to.equal('Other');
+    });
+  });
+
+  describe('CDN ingestion SQL (src/cdn-analysis/sql/*/insert-aggregated.sql)', () => {
+    // Each provider's insert-aggregated.sql independently duplicates the "match known
+    // LLM-related user-agents" REGEXP_LIKE inclusion list (different column name per
+    // CDN, same regex literal) -- a UA that isn't in *this* list never reaches the
+    // aggregated table, so Gate 1 (buildUserAgentFilter) never even sees it. This
+    // guards that every provider stays in sync and that new bots are present here too.
+    const providerDirs = fs.readdirSync(SQL_PROVIDERS_DIR)
+      .filter((name) => fs.statSync(path.join(SQL_PROVIDERS_DIR, name)).isDirectory());
+
+    function extractUaInclusionPattern(sql) {
+      const match = sql.match(/match known LLM-related user-agents\s*\n\s*AND REGEXP_LIKE\([^,]+,\s*'([^']+)'\)/);
+      return match?.[1] ?? null;
+    }
+
+    const patternsByProvider = Object.fromEntries(
+      providerDirs.map((provider) => {
+        const sql = fs.readFileSync(path.join(SQL_PROVIDERS_DIR, provider, 'insert-aggregated.sql'), 'utf8');
+        return [provider, extractUaInclusionPattern(sql)];
+      }),
+    );
+
+    it('has the UA inclusion regex in every provider file', () => {
+      providerDirs.forEach((provider) => {
+        expect(patternsByProvider[provider], `missing UA inclusion pattern in ${provider}`).to.not.be.null;
+      });
+    });
+
+    it('keeps the UA inclusion regex identical across every CDN provider', () => {
+      const [first, ...rest] = providerDirs;
+      rest.forEach((provider) => {
+        expect(patternsByProvider[provider], `${provider} drifted from ${first}`).to.equal(patternsByProvider[first]);
+      });
+    });
+
+    it('includes every new agentic bot added in LLMO-7325', () => {
+      const pattern = patternsByProvider[providerDirs[0]];
+
+      expect(pattern).to.include('Shap(Bot|-User)');
+      expect(pattern).to.include('Manus-User');
+      expect(pattern).to.include('Keenable-User');
+      expect(pattern).to.include('Google-NotebookLM');
     });
   });
 });

--- a/test/audits/cdn-logs-report/user-agent-patterns.test.js
+++ b/test/audits/cdn-logs-report/user-agent-patterns.test.js
@@ -116,7 +116,7 @@ describe('User Agent Patterns', () => {
       expect(filter).to.include('Google-?Agent');
       expect(filter).to.include('Google-NotebookLM');
       expect(filter).to.include('Claude');
-      expect(filter).to.include('Shap-User');
+      expect(filter).to.include('Shap(Bot|-User)');
       expect(filter).to.include('Manus-User');
       expect(filter).to.include('Keenable-User');
     });
@@ -164,7 +164,8 @@ describe('User Agent Patterns', () => {
       const { buildAgentTypeClassificationSQL } = userAgentPatterns;
       const sql = buildAgentTypeClassificationSQL();
 
-      expect(sql).to.include("LIKE '%shap-user%' THEN 'Web search crawlers'");
+      expect(sql).to.include("LIKE '%shapbot%' THEN 'Web search crawlers'");
+      expect(sql).to.include("LIKE '%shap-user%' THEN 'Chatbots'");
       expect(sql).to.include("LIKE '%manus-user%' THEN 'Chatbots'");
       expect(sql).to.include("LIKE '%keenable-user%' THEN 'Web search crawlers'");
     });
@@ -215,6 +216,7 @@ describe('User Agent Patterns', () => {
       expect(inferProviderFromUserAgent('MistralAI-Search')).to.equal('MistralAI');
       expect(inferProviderFromUserAgent('Amazonbot/0.1')).to.equal('Amazon');
       expect(inferProviderFromUserAgent('Shap-User/0.1.0')).to.equal('Parallel.ai');
+      expect(inferProviderFromUserAgent('ShapBot/0.1.0')).to.equal('Parallel.ai');
       expect(inferProviderFromUserAgent('Manus-User/1.0')).to.equal('Manus');
       expect(inferProviderFromUserAgent('Keenable-User/1.0')).to.equal('Keenable.ai');
       expect(inferProviderFromUserAgent('something-unknown')).to.equal('Other');

--- a/test/audits/cdn-logs-report/user-agent-patterns.test.js
+++ b/test/audits/cdn-logs-report/user-agent-patterns.test.js
@@ -226,6 +226,11 @@ describe('User Agent Patterns', () => {
       expect(inferProviderFromUserAgent('ShapBot/0.1.0')).to.equal('Parallel.ai');
       expect(inferProviderFromUserAgent('Manus-User/1.0')).to.equal('Manus');
       expect(inferProviderFromUserAgent('Keenable-User/1.0')).to.equal('Keenable.ai');
+      // regexes must stay as specific as PROVIDER_USER_AGENT_PATTERNS -- not broad
+      // substring matches that would misattribute an unrelated bot's provider
+      expect(inferProviderFromUserAgent('reshape-bot/1.0')).to.equal('Other');
+      expect(inferProviderFromUserAgent('manuscript-crawler/1.0')).to.equal('Other');
+      expect(inferProviderFromUserAgent('unkeenable-thing/1.0')).to.equal('Other');
       expect(inferProviderFromUserAgent('something-unknown')).to.equal('Other');
     });
   });


### PR DESCRIPTION
## Summary
LLMO-7325: Cedric reviewed CDN logs and identified new agentic bots and Google bot list changes to surface in the Agentic Traffic UI.

- Adds new agentic UAs to the classification pipeline (Gate 1 filter, display names, `agent_type` SQL, provider inference):
  - `Shap-User` (Parallel.ai) → Chatbots (user-initiated only; Parallel does not use it for automatic crawling per their docs)
  - `ShapBot` (Parallel.ai) → Web search crawlers (the actual automated crawler)
  - `Manus-User` (Manus) → Chatbots (acts only on a user request, same pattern as other `-User` bots)
  - `Keenable-User` (Keenable.ai) → Web search crawlers
- Also extends every CDN provider's `insert-aggregated.sql` (akamai, cloudflare, cloudfront, fastly, frontdoor, imperva, other) with the same new bots — this ingestion-time regex runs *before* Gate 1, so without this a matching UA never reaches the aggregated table at all. Added a parity test that fails if a provider's regex drifts from the others or is missing a bot, since nothing enforced this beyond a code comment before.
- Removes `Gemini-Deep-Research` (no longer used per ticket)
- Reclassifies `Google-NotebookLM` from `Research` → `Chatbots` (Research category is being retired, companion UI change in project-elmo-ui)
- Removes the dedicated `GoogleAgent-Mariner` classification (no longer used); the remaining `%google-agent%` LIKE pattern has a literal hyphen that doesn't match `googleagent-mariner`, so it now falls into `Other` and is dropped downstream — which matches the ticket's intent to stop tracking it

**Out of scope / follow-up:** `GoogleOther` and `Google-Lens` are intentionally *not* added — the ticket flags `GoogleOther` as needing investigation, and `Google-Lens` has no category specified. Both need a follow-up decision from Cedric/Flavio before being added. Generic search crawlers (`Googlebot-Image`, `Googlebot/2.1`, `Googlebot-Video`, `Google-AdWords`) are intentionally excluded per Claudia's follow-up comment on the ticket (already tracked elsewhere, would inflate agentic volume). A third UA list, `LLM_USER_AGENT_PATTERNS` in `src/llm-error-pages/utils.js`, was found during review but intentionally left alone — see PR comments for why.

Companion UI PR: adobe/project-elmo-ui#3095

## Test plan
- [x] Updated `test/audits/cdn-logs-report/user-agent-patterns.test.js` for all pattern/classification/provider changes, plus a new parity guard across the 7 ingestion SQL files
- [x] CI (`ci/build`, codecov) passes
- [x] Ran the full test file locally (`npx mocha test/audits/cdn-logs-report/user-agent-patterns.test.js`, unblocking a missing local `dotenv` install) — 18/18 passing

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Akshay", "Dominique Jäggi"]
rationale: "Bot classification regex/SQL updates for CDN traffic categorization; misclassification is recoverable data, correctable and re-aggregatable."
```