### PR TITLE
fix: Sitemap audit uses overrideBaseURL when present

### DIFF
--- a/src/sitemap/handler.js
+++ b/src/sitemap/handler.js
@@ -55,7 +55,7 @@ import { convertToOpportunity } from '../common/opportunity.js';
 import { createOpportunityData } from './opportunity-data-mapper.js';
 
 const auditType = Audit.AUDIT_TYPES.SITEMAP;
-const HANDLER_VERSION = 2; // manually update as needed
+const HANDLER_VERSION = 3; // manually update as needed
 
 // HTTP status codes explicitly handled by this audit for suggestion generation
 const TRACKED_STATUS_CODES = Object.freeze([...REDIRECT_STATUSES, 404]);

--- a/src/sitemap/handler.js
+++ b/src/sitemap/handler.js
@@ -29,6 +29,7 @@
 
 import {
   isArray,
+  isValidUrl,
 } from '@adobe/spacecat-shared-utils';
 import { Audit } from '@adobe/spacecat-shared-data-access';
 import {
@@ -356,13 +357,25 @@ export async function findSitemap(inputUrl, log) {
 /**
  * Main audit runner function
  */
-export async function sitemapAuditRunner(baseURL, context) {
+export async function sitemapAuditRunner(baseURL, context, site) {
   const { log } = context;
   const startTime = process.hrtime();
 
   log.info(`Starting sitemap audit v${HANDLER_VERSION}-${COMMON_VERSION} for ${baseURL}`);
 
-  const auditResult = await findSitemap(baseURL, log);
+  let urlToProbe = baseURL;
+  const overrideBaseURL = site?.getConfig?.()?.getFetchConfig?.()?.overrideBaseURL;
+  if (overrideBaseURL) {
+    if (isValidUrl(overrideBaseURL)) {
+      /* c8 ignore next */
+      log.info(`Sitemap: using overrideBaseURL ${overrideBaseURL} instead of baseURL ${baseURL} for site ${site.getId()}`);
+      urlToProbe = overrideBaseURL;
+    } else {
+      log.warn(`Sitemap: ignoring overrideBaseURL "${overrideBaseURL}" for site ${site.getId()} — missing http/https protocol; using baseURL ${baseURL} instead`);
+    }
+  }
+
+  const auditResult = await findSitemap(urlToProbe, log);
 
   const endTime = process.hrtime(startTime);
   const elapsedSeconds = endTime[0] + endTime[1] / 1e9;

--- a/test/audits/sitemap.test.js
+++ b/test/audits/sitemap.test.js
@@ -279,6 +279,88 @@ describe('Sitemap Audit', () => {
         url,
       });
     });
+
+    it('probes overrideBaseURL instead of baseURL when it is a valid http(s) URL', async () => {
+      const overrideBaseURL = 'https://override-domain.adobe';
+      const site = {
+        getId: sandbox.stub().returns('site-123'),
+        getConfig: sandbox.stub().returns({
+          getFetchConfig: sandbox.stub().returns({ overrideBaseURL }),
+        }),
+      };
+
+      nock(overrideBaseURL).get('/robots.txt').reply(404);
+
+      const result = await sitemapAuditRunner(url, context, site);
+      expect(result).to.eql({
+        auditResult: {
+          reasons: [
+            {
+              error: ERROR_CODES.CANNOT_READ_ROBOTS,
+              value: `Fetch error for ${overrideBaseURL}/robots.txt Status: 404`,
+            },
+          ],
+          url: overrideBaseURL,
+        },
+        fullAuditRef: url,
+        url,
+      });
+    });
+
+    it('falls back to baseURL when overrideBaseURL is missing a http/https protocol', async () => {
+      const site = {
+        getId: sandbox.stub().returns('site-123'),
+        getConfig: sandbox.stub().returns({
+          getFetchConfig: sandbox.stub().returns({ overrideBaseURL: 'override-domain.adobe' }),
+        }),
+      };
+
+      nock(url).get('/robots.txt').reply(404);
+
+      const result = await sitemapAuditRunner(url, context, site);
+      expect(result).to.eql({
+        auditResult: {
+          reasons: [
+            {
+              error: ERROR_CODES.CANNOT_READ_ROBOTS,
+              value: `Fetch error for ${url}/robots.txt Status: 404`,
+            },
+          ],
+          url,
+        },
+        fullAuditRef: url,
+        url,
+      });
+      expect(context.log.warn).to.have.been.calledWith(
+        sinon.match(/ignoring overrideBaseURL "override-domain.adobe"/),
+      );
+    });
+
+    it('uses baseURL as-is when site has no overrideBaseURL configured', async () => {
+      const site = {
+        getId: sandbox.stub().returns('site-123'),
+        getConfig: sandbox.stub().returns({
+          getFetchConfig: sandbox.stub().returns({}),
+        }),
+      };
+
+      nock(url).get('/robots.txt').reply(404);
+
+      const result = await sitemapAuditRunner(url, context, site);
+      expect(result).to.eql({
+        auditResult: {
+          reasons: [
+            {
+              error: ERROR_CODES.CANNOT_READ_ROBOTS,
+              value: `Fetch error for ${url}/robots.txt Status: 404`,
+            },
+          ],
+          url,
+        },
+        fullAuditRef: url,
+        url,
+      });
+    });
   });
 
   describe('fetchWithHeadFallback', () => {


### PR DESCRIPTION
 * If the site config specifies an override URL for the base URL, use the override base URL to find the initial set of critical sitemap files

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues
- [SITES-51218](https://jira.corp.adobe.com/browse/SITES-51218)

Thanks for contributing!

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Jesus Sanchez", "oleksii iatsiuk", "Dominique Jäggi"]
rationale: "Small, scoped fix to sitemap base-URL resolution; recoverable via redeploy and re-run of the audit."
```