### PR TITLE
fix(toc): exclude time-sensitive promotional headings from TOC extraction

### DIFF
--- a/src/headings/utils.js
+++ b/src/headings/utils.js
@@ -88,8 +88,12 @@ export const TOC_EXCLUDED_HEADING_PHRASES = [
  * those are legitimate evergreen headings (SaaS pricing pages, real-estate "Homes for Sale",
  * a services page's "Our Offers"). Only matches when paired with a quantity/urgency signal
  * (a %, a $ amount, a named sale event, or "ends/expires/today only/while supplies last").
+ *
+ * The "save" alternative requires a literal $ unless preceded by "up to" — "Save $50" and
+ * "Save up to 200" both match, but "Save 5 Minutes a Day" / "Save 3 Steps in Your Workflow"
+ * do not, since a bare number after "save" is not itself a quantity/urgency signal.
  */
-const TIME_SENSITIVE_PROMO_RE = /\d+%\s*off\b|\$\d+(?:\.\d{2})?\s*(?:off|savings?)\b|\bsave\s+(?:up\s+to\s+)?\$?\d+\b|\b(?:flash|clearance|blowout|closeout)\s+sale\b|\b(?:black\s*friday|cyber\s*monday)\s+(?:sale|deal)s?\b|\blimited[\s-]time\s+(?:offer|deal)\b|\b(?:offer|sale|deal|discount|promo)\s+(?:ends?|expires?)\b|\bwhile\s+supplies\s+last\b|\btoday\s+only\b|\b(?:promo|coupon|discount)\s+code\b/i;
+const TIME_SENSITIVE_PROMO_RE = /\d+%\s*off\b|\$\d+(?:\.\d{2})?\s*(?:off|savings?)\b|\bsave\s+up\s+to\s+\$?\d+\b|\bsave\s+\$\d+\b|\b(?:flash|clearance|blowout|closeout)\s+sale\b|\b(?:black\s*friday|cyber\s*monday)\s+(?:sale|deal)s?\b|\blimited[\s-]time\s+(?:offer|deal)\b|\b(?:offer|sale|deal|discount|promo)\s+(?:ends?|expires?)\b|\bwhile\s+supplies\s+last\b|\btoday\s+only\b|\b(?:promo|coupon|discount)\s+code\b/i;
 
 /**
  * Normalize heading text for phrase matching: trim, lowercase, collapse whitespace

--- a/src/headings/utils.js
+++ b/src/headings/utils.js
@@ -77,6 +77,21 @@ export const TOC_EXCLUDED_HEADING_PHRASES = [
 ];
 
 /**
+ * Time-sensitive promotional headings (price drops, % off, flash sales, limited-time
+ * offers) go stale within days or hours and describe a merchandising banner, not a stable
+ * content section — a TOC (or an LLM citing it) pointing at "20% Off Everything" next month
+ * links to a dead promo. Unlike consent-widget copy above (a fixed, known set of vendor
+ * phrases), promo copy is open-ended — any percentage, dollar amount, or campaign name — so
+ * this is regex-driven instead of a literal phrase list.
+ *
+ * Deliberately does NOT match bare "Price", "Pricing", "Sale", "Offer", or "Deals" alone —
+ * those are legitimate evergreen headings (SaaS pricing pages, real-estate "Homes for Sale",
+ * a services page's "Our Offers"). Only matches when paired with a quantity/urgency signal
+ * (a %, a $ amount, a named sale event, or "ends/expires/today only/while supplies last").
+ */
+const TIME_SENSITIVE_PROMO_RE = /\d+%\s*off\b|\$\d+(?:\.\d{2})?\s*(?:off|savings?)\b|\bsave\s+(?:up\s+to\s+)?\$?\d+\b|\b(?:flash|clearance|blowout|closeout)\s+sale\b|\b(?:black\s*friday|cyber\s*monday)\s+(?:sale|deal)s?\b|\blimited[\s-]time\s+(?:offer|deal)\b|\b(?:offer|sale|deal|discount|promo)\s+(?:ends?|expires?)\b|\bwhile\s+supplies\s+last\b|\btoday\s+only\b|\b(?:promo|coupon|discount)\s+code\b/i;
+
+/**
  * Normalize heading text for phrase matching: trim, lowercase, collapse whitespace
  * @param {string} text - Raw heading text
  * @returns {string} Normalized text
@@ -101,6 +116,20 @@ export function isExcludedConsentHeadingText(text) {
   return TOC_EXCLUDED_HEADING_PHRASES.some(
     (phrase) => normalized.includes(phrase) || phrase.includes(normalized),
   );
+}
+
+/**
+ * Check if heading text reads as a time-sensitive promotional banner (price drop, % off,
+ * flash sale, limited-time offer) rather than stable page content.
+ * @param {string} text - Heading text
+ * @returns {boolean} True if text matches a time-sensitive promo pattern
+ */
+export function isTimeSensitivePromoHeadingText(text) {
+  const normalized = normalizeHeadingTextForMatch(text);
+  if (!normalized) {
+    return false;
+  }
+  return TIME_SENSITIVE_PROMO_RE.test(normalized);
 }
 
 /**
@@ -300,8 +329,9 @@ export function getScrapeJsonPath(url, siteId) {
 
 /**
  * Extract TOC data from document headings.
- * Excludes headings inside cookie/consent/privacy containers and headings whose
- * text matches consent phrases. When <main> exists, only headings inside
+ * Excludes headings inside cookie/consent/privacy containers, headings whose text matches
+ * consent phrases, and headings that read as time-sensitive promotional banners (price
+ * drops, % off, flash sales, limited-time offers). When <main> exists, only headings inside
  * body > main are considered.
  * @param {CheerioAPI} $ - The Cheerio instance
  * @param {Function} getHeadingSelectorFn - Function to get heading selector
@@ -327,6 +357,9 @@ export function extractTocData($, getHeadingSelectorFn) {
         return false;
       }
       if (isExcludedConsentHeadingText(text)) {
+        return false;
+      }
+      if (isTimeSensitivePromoHeadingText(text)) {
         return false;
       }
       const normalized = normalizeHeadingTextForMatch(text);

--- a/test/audits/toc.test.js
+++ b/test/audits/toc.test.js
@@ -3653,7 +3653,13 @@ describe('TOC (Table of Contents) Audit', () => {
       it('returns true for dollar-off / savings headings', () => {
         expect(isTimeSensitivePromoHeadingText('$50 Off Your First Order')).to.equal(true);
         expect(isTimeSensitivePromoHeadingText('Save up to $200')).to.equal(true);
+        expect(isTimeSensitivePromoHeadingText('Save up to 200')).to.equal(true);
         expect(isTimeSensitivePromoHeadingText('Save $12.99 today')).to.equal(true);
+      });
+      it('does NOT match "save" followed by a bare number with no $ or "up to" prefix', () => {
+        expect(isTimeSensitivePromoHeadingText('Save 5 Minutes a Day')).to.equal(false);
+        expect(isTimeSensitivePromoHeadingText('Save 3 Steps in Your Workflow')).to.equal(false);
+        expect(isTimeSensitivePromoHeadingText('Save 100 Trees This Year')).to.equal(false);
       });
       it('returns true for named sale events', () => {
         expect(isTimeSensitivePromoHeadingText('Flash Sale Starts Now')).to.equal(true);

--- a/test/audits/toc.test.js
+++ b/test/audits/toc.test.js
@@ -26,6 +26,7 @@ import {
   TOC_EXCLUDED_HEADING_PHRASES,
   normalizeHeadingTextForMatch,
   isExcludedConsentHeadingText,
+  isTimeSensitivePromoHeadingText,
   isHeadingInExcludedContainer,
   getSurroundingText,
   getFollowingStructure,
@@ -3644,6 +3645,53 @@ describe('TOC (Table of Contents) Audit', () => {
       });
     });
 
+    describe('isTimeSensitivePromoHeadingText', () => {
+      it('returns true for percentage-off headings', () => {
+        expect(isTimeSensitivePromoHeadingText('25% Off Everything')).to.equal(true);
+        expect(isTimeSensitivePromoHeadingText('Save 30% off sitewide')).to.equal(true);
+      });
+      it('returns true for dollar-off / savings headings', () => {
+        expect(isTimeSensitivePromoHeadingText('$50 Off Your First Order')).to.equal(true);
+        expect(isTimeSensitivePromoHeadingText('Save up to $200')).to.equal(true);
+        expect(isTimeSensitivePromoHeadingText('Save $12.99 today')).to.equal(true);
+      });
+      it('returns true for named sale events', () => {
+        expect(isTimeSensitivePromoHeadingText('Flash Sale Starts Now')).to.equal(true);
+        expect(isTimeSensitivePromoHeadingText('Clearance Sale')).to.equal(true);
+        expect(isTimeSensitivePromoHeadingText('Black Friday Deals')).to.equal(true);
+        expect(isTimeSensitivePromoHeadingText('Cyber Monday Sale')).to.equal(true);
+      });
+      it('returns true for urgency/expiry phrasing', () => {
+        expect(isTimeSensitivePromoHeadingText('Limited Time Offer')).to.equal(true);
+        expect(isTimeSensitivePromoHeadingText('Sale Ends Sunday')).to.equal(true);
+        expect(isTimeSensitivePromoHeadingText('Offer Expires Soon')).to.equal(true);
+        expect(isTimeSensitivePromoHeadingText('While Supplies Last')).to.equal(true);
+        expect(isTimeSensitivePromoHeadingText('Today Only')).to.equal(true);
+      });
+      it('returns true for promo/coupon code headings', () => {
+        expect(isTimeSensitivePromoHeadingText('Use Promo Code SAVE20')).to.equal(true);
+        expect(isTimeSensitivePromoHeadingText('Enter Discount Code')).to.equal(true);
+      });
+      it('is case-insensitive', () => {
+        expect(isTimeSensitivePromoHeadingText('LIMITED TIME OFFER')).to.equal(true);
+      });
+      it('does NOT exclude bare evergreen pricing/sale headings', () => {
+        expect(isTimeSensitivePromoHeadingText('Pricing')).to.equal(false);
+        expect(isTimeSensitivePromoHeadingText('Our Pricing Plans')).to.equal(false);
+        expect(isTimeSensitivePromoHeadingText('Homes for Sale')).to.equal(false);
+        expect(isTimeSensitivePromoHeadingText('Our Offers')).to.equal(false);
+        expect(isTimeSensitivePromoHeadingText('Special Offers')).to.equal(false);
+      });
+      it('returns false for non-promotional content', () => {
+        expect(isTimeSensitivePromoHeadingText('Product details')).to.equal(false);
+        expect(isTimeSensitivePromoHeadingText('Section 1')).to.equal(false);
+      });
+      it('returns false for empty or whitespace', () => {
+        expect(isTimeSensitivePromoHeadingText('')).to.equal(false);
+        expect(isTimeSensitivePromoHeadingText('   ')).to.equal(false);
+      });
+    });
+
     describe('isHeadingInExcludedContainer', () => {
       it('returns false when heading or $ is missing', () => {
         const $ = cheerioLoad('<h1>Title</h1>');
@@ -3917,6 +3965,31 @@ describe('TOC (Table of Contents) Audit', () => {
         const result = extractTocData($, stubGetHeadingSelector);
         expect(result).to.have.lengthOf(2);
         expect(result.map((r) => r.text)).to.deep.equal(['Welcome to {Brand}', '{TITLE} and more']);
+      });
+      it('excludes time-sensitive promotional headings (price drops, flash sales, limited-time offers)', () => {
+        const $ = cheerioLoad(
+          '<body><main>'
+          + '<h1 id="title">Fall Collection</h1>'
+          + '<h2 id="promo1">25% Off Everything</h2>'
+          + '<h2 id="promo2">Flash Sale Ends Tonight</h2>'
+          + '<h2 id="sec">Shipping &amp; Returns</h2>'
+          + '</main></body>',
+        );
+        const result = extractTocData($, stubGetHeadingSelector);
+        expect(result).to.have.lengthOf(2);
+        expect(result.map((r) => r.text)).to.deep.equal(['Fall Collection', 'Shipping & Returns']);
+      });
+      it('keeps evergreen pricing/offer headings that are not time-sensitive', () => {
+        const $ = cheerioLoad(
+          '<body><main>'
+          + '<h1 id="title">Enterprise Plan</h1>'
+          + '<h2 id="pricing">Pricing</h2>'
+          + '<h2 id="offers">Our Offers</h2>'
+          + '</main></body>',
+        );
+        const result = extractTocData($, stubGetHeadingSelector);
+        expect(result).to.have.lengthOf(3);
+        expect(result.map((r) => r.text)).to.deep.equal(['Enterprise Plan', 'Pricing', 'Our Offers']);
       });
     });
 


### PR DESCRIPTION
## Problem
Headings that read as merchandising banners — price drops (`25% Off`), flash sales, limited-time offers, "Save \$50 today" — go stale within days or hours and describe a promo, not a stable content section. A TOC (or an LLM citing it) pointing at "20% Off Everything" next month links to a dead promo.

## Fix
Adds `isTimeSensitivePromoHeadingText()` to `src/headings/utils.js`, wired into `extractTocData()` alongside the existing consent-phrase exclusion (`isExcludedConsentHeadingText`).

Unlike consent-widget copy (a fixed, known set of vendor phrases handled by `TOC_EXCLUDED_HEADING_PHRASES`), promo copy is open-ended — any percentage, dollar amount, or campaign name — so this is a **regex-driven** check rather than a literal phrase list.

Matches:
- `%`-off / `$`-off / "save \$X" phrasing
- Named sale events (flash/clearance/blowout/closeout sale, Black Friday, Cyber Monday)
- Urgency/expiry phrasing ("limited-time offer", "sale ends", "offer expires", "while supplies last", "today only")
- Promo/coupon/discount code call-outs

Deliberately does **not** match bare `"Price"`, `"Pricing"`, `"Sale"`, `"Offer"`, or `"Deals"` alone — those are legitimate evergreen headings (SaaS pricing pages, real-estate "Homes for Sale", a services page's "Our Offers"). Only matches when paired with a quantity/urgency signal.

## Testing
- Added unit tests for `isTimeSensitivePromoHeadingText` (positive cases per pattern category, case-insensitivity, and negative cases for evergreen pricing/offer headings).
- Added `extractTocData()` integration tests: one excludes promo headings, one confirms evergreen pricing/offer headings are kept.
- `npm run test:spec -- test/audits/toc.test.js` → 210 passing, `src/headings/utils.js` at 100% lines/branches/functions/statements.
- `npx eslint src/headings/utils.js` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Dominique Jäggi", "Yaashi Madan"]
rationale: "Regex-based heading filter added to TOC extraction; worst case is a heading wrongly included/excluded, self-corrects on next audit run."
```