### PR TITLE
fix(broken-internal-links): flag uncorroborated boilerplate crawl links (SITES-50131)

### DIFF
--- a/src/internal-links/config.js
+++ b/src/internal-links/config.js
@@ -267,6 +267,29 @@ export class InternalLinksConfigResolver {
     return getBooleanConfig(this.handlerConfig.excludeCrossLocalePDP, false);
   }
 
+  /**
+   * When true, DROP uncorroborated site-wide boilerplate broken internal links: a target
+   * flagged ONLY by the crawl detector across many pages, that RUM never observed a
+   * navigation to. Catches JS-intercepted nav/footer widgets whose static fallback href
+   * 404s (SITES-50131). See {@link identifyUncorroboratedBoilerplateLinks}.
+   *
+   * Defaults to FALSE (shadow mode): the audit still records what it WOULD suppress
+   * (`suppressedBoilerplateLinks` in the audit result) without removing anything, so the
+   * false-negative rate can be measured fleet-wide before enabling per-site.
+   */
+  getSuppressUncorroboratedBoilerplate() {
+    return getBooleanConfig(this.handlerConfig.suppressUncorroboratedBoilerplate, false);
+  }
+
+  /**
+   * Minimum distinct source pages a crawl-only target must appear on to be treated as
+   * site-wide boilerplate. Default 10; floored at 5 so an over-aggressive override cannot
+   * suppress targets that repeat on only a handful of pages.
+   */
+  getBoilerplateMinSourcePages() {
+    return Math.max(5, getPositiveIntConfig(this.handlerConfig.boilerplateMinSourcePages, 10));
+  }
+
   getBrightDataConfig() {
     return {
       validateUrls: this.handlerConfig.validateBrightDataUrls

--- a/src/internal-links/finalization.js
+++ b/src/internal-links/finalization.js
@@ -12,7 +12,12 @@
 
 import { prependSchema, stripWWW } from '@adobe/spacecat-shared-utils';
 import { createInternalLinksStepLogger } from './logging.js';
-import { classifyStatusBucket, isLinkInaccessible } from './helpers.js';
+import {
+  classifyStatusBucket,
+  isLinkInaccessible,
+  identifyUncorroboratedBoilerplateLinks,
+} from './helpers.js';
+import { normalizeComparableUrl } from './link-key.js';
 import { isWithinAuditScope } from './subpath-filter.js';
 import { isSharedInternalResource } from './scope-utils.js';
 
@@ -181,6 +186,7 @@ export function createFinalizeCrawlDetection({
 
     let finalLinks = rumLinks;
     let opportunityResult;
+    let suppressedBoilerplateLinks = null;
 
     try {
       if (!skipCrawlDetection) {
@@ -271,6 +277,34 @@ export function createFinalizeCrawlDetection({
         log.info('No crawl results to merge, using RUM-only results');
       }
 
+      // Always classify uncorroborated site-wide boilerplate broken links so we can record
+      // what would be suppressed (observability). Only actually remove them when the
+      // suppression flag is enabled for the site; otherwise this is shadow mode.
+      const { kept, suppressed } = identifyUncorroboratedBoilerplateLinks(finalLinks, {
+        rumProducedBrokenLinks: rumLinks.length > 0,
+        minSourcePages: config.getBoilerplateMinSourcePages(),
+      });
+      const suppressionApplied = config.getSuppressUncorroboratedBoilerplate();
+      if (suppressed.length > 0) {
+        const distinctTargets = [
+          ...new Set(suppressed.map((l) => normalizeComparableUrl(l.urlTo))),
+        ];
+        suppressedBoilerplateLinks = {
+          count: suppressed.length,
+          distinctTargets: distinctTargets.length,
+          targets: distinctTargets,
+          applied: suppressionApplied,
+        };
+        log.info(
+          `Uncorroborated boilerplate: ${suppressed.length} crawl-only suggestion(s) across `
+          + `${distinctTargets.length} site-wide target(s) (>= ${config.getBoilerplateMinSourcePages()} pages, `
+          + `no RUM/LinkChecker corroboration); applied=${suppressionApplied}`,
+        );
+        if (suppressionApplied) {
+          finalLinks = kept;
+        }
+      }
+
       const beforeStatusFilter = finalLinks.length;
       finalLinks = filterByStatusIfNeeded(finalLinks, config.getIncludedStatusBuckets());
       if (finalLinks.length < beforeStatusFilter) {
@@ -292,6 +326,7 @@ export function createFinalizeCrawlDetection({
       const updatedAuditResult = {
         ...auditResult,
         brokenInternalLinks: prioritizedLinks,
+        ...(suppressedBoilerplateLinks ? { suppressedBoilerplateLinks } : {}),
       };
 
       log.info('=====================================================');

--- a/src/internal-links/finalization.js
+++ b/src/internal-links/finalization.js
@@ -17,9 +17,12 @@ import {
   isLinkInaccessible,
   identifyUncorroboratedBoilerplateLinks,
 } from './helpers.js';
-import { normalizeComparableUrl } from './link-key.js';
 import { isWithinAuditScope } from './subpath-filter.js';
 import { isSharedInternalResource } from './scope-utils.js';
+
+// Cap the number of distinct target URLs recorded in the audit result's
+// suppressedBoilerplateLinks observability field to keep the payload bounded.
+const MAX_SUPPRESSED_TARGETS_RECORDED = 50;
 
 function isOnAuditHost(url, baseURL) {
   try {
@@ -273,36 +276,37 @@ export function createFinalizeCrawlDetection({
 
         finalLinks = mergeAndDeduplicate(crawlAndLinkCheckerMerged, rumLinks, log);
         log.info(`After 3-way merge (crawl+linkchecker+RUM): ${finalLinks.length} unique broken links`);
+
+        // Classify uncorroborated site-wide boilerplate broken links so we can record what
+        // would be suppressed (observability). Only actually remove them when the suppression
+        // flag is enabled for the site; otherwise this is shadow mode. Lives inside the crawl
+        // branch because it is a no-op on the RUM-only path (there are no crawl-only links).
+        const { kept, suppressed, suppressedTargets } = identifyUncorroboratedBoilerplateLinks(
+          finalLinks,
+          {
+            rumProducedBrokenLinks: rumLinks.length > 0,
+            minSourcePages: config.getBoilerplateMinSourcePages(),
+          },
+        );
+        if (suppressed.length > 0) {
+          const suppressionApplied = config.getSuppressUncorroboratedBoilerplate();
+          suppressedBoilerplateLinks = {
+            count: suppressed.length,
+            distinctTargets: suppressedTargets.length,
+            targets: suppressedTargets.slice(0, MAX_SUPPRESSED_TARGETS_RECORDED),
+            applied: suppressionApplied,
+          };
+          log.info(
+            `Uncorroborated boilerplate: ${suppressed.length} crawl-only suggestion(s) across `
+            + `${suppressedTargets.length} site-wide target(s) (>= ${config.getBoilerplateMinSourcePages()} pages, `
+            + `no RUM/LinkChecker corroboration); applied=${suppressionApplied}`,
+          );
+          if (suppressionApplied) {
+            finalLinks = kept;
+          }
+        }
       } else {
         log.info('No crawl results to merge, using RUM-only results');
-      }
-
-      // Always classify uncorroborated site-wide boilerplate broken links so we can record
-      // what would be suppressed (observability). Only actually remove them when the
-      // suppression flag is enabled for the site; otherwise this is shadow mode.
-      const { kept, suppressed } = identifyUncorroboratedBoilerplateLinks(finalLinks, {
-        rumProducedBrokenLinks: rumLinks.length > 0,
-        minSourcePages: config.getBoilerplateMinSourcePages(),
-      });
-      const suppressionApplied = config.getSuppressUncorroboratedBoilerplate();
-      if (suppressed.length > 0) {
-        const distinctTargets = [
-          ...new Set(suppressed.map((l) => normalizeComparableUrl(l.urlTo))),
-        ];
-        suppressedBoilerplateLinks = {
-          count: suppressed.length,
-          distinctTargets: distinctTargets.length,
-          targets: distinctTargets,
-          applied: suppressionApplied,
-        };
-        log.info(
-          `Uncorroborated boilerplate: ${suppressed.length} crawl-only suggestion(s) across `
-          + `${distinctTargets.length} site-wide target(s) (>= ${config.getBoilerplateMinSourcePages()} pages, `
-          + `no RUM/LinkChecker corroboration); applied=${suppressionApplied}`,
-        );
-        if (suppressionApplied) {
-          finalLinks = kept;
-        }
       }
 
       const beforeStatusFilter = finalLinks.length;

--- a/src/internal-links/helpers.js
+++ b/src/internal-links/helpers.js
@@ -15,6 +15,7 @@ import {
   isInternalLinksContextLogger,
 } from './logging.js';
 import { isHtmlContentType, isSoft404Body } from '../utils/url-utils.js';
+import { normalizeComparableUrl, DEFAULT_ITEM_TYPE } from './link-key.js';
 
 const AUDIT_TYPE = 'broken-internal-links';
 
@@ -366,4 +367,93 @@ export function calculatePriority(links) {
       priority,
     };
   });
+}
+
+/**
+ * Identifies uncorroborated site-wide boilerplate broken *internal links*.
+ *
+ * Background: the crawl detector reads a link's `href` from the (JS-hydrated) DOM and
+ * validates it with a direct HTTP fetch. It cannot execute click handlers, so a
+ * template widget (nav/footer) whose anchor carries a same-domain fallback `href` but
+ * whose click is intercepted by client-side JS (e.g. it actually navigates cross-domain)
+ * is flagged as broken on every page the widget renders on. See SITES-50131: one shared
+ * footer "Privacy Notice" button produced 60 of a domain's 184 broken-internal-link
+ * suggestions, all pointing at the same fabricated same-domain 404.
+ *
+ * Heuristic: if the identical `urlTo` is flagged **only** by the crawl detector
+ * (`detectionSource === 'crawl'`, i.e. never corroborated by RUM or LinkChecker) across
+ * at least `minSourcePages` distinct source pages, it is site-wide boilerplate. When RUM
+ * detection produced broken-link signal for this site yet never observed a real
+ * navigation to that target, the target is almost certainly never navigated to by users
+ * (JS-intercepted or decorative), so the crawl finding is very likely a false positive.
+ *
+ * This function only CLASSIFIES — it never mutates. The caller decides whether to drop
+ * the `suppressed` links or merely record them (shadow mode). Conservative by design
+ * (avoids over-flagging genuinely broken template links):
+ *  - only runs when `rumProducedBrokenLinks` is true (RUM produced a validated broken
+ *    link for this site, so absence of RUM corroboration for this target is meaningful);
+ *  - only ever flags `detectionSource === 'crawl'` links — anything RUM/LinkChecker also
+ *    saw (`crawl+rum`, `crawl+linkchecker`, ...) is always kept;
+ *  - requires the target to repeat across `minSourcePages` distinct pages (true
+ *    boilerplate), so a one-off broken link is never affected.
+ *
+ * NOTE: RUM's broken-link signal is traffic-gated, so a genuinely dead but rarely-clicked
+ * footer link (Privacy/Terms/Sitemap) can share this exact signature. Callers should treat
+ * suppression as advisory (shadow/observability first) rather than a guaranteed-safe drop.
+ *
+ * @param {Array} links - merged broken links (each with urlFrom, urlTo, itemType,
+ *   detectionSource)
+ * @param {object} opts
+ * @param {boolean} opts.rumProducedBrokenLinks - whether RUM detection produced at least
+ *   one validated broken link for this site
+ * @param {number} opts.minSourcePages - min distinct source pages for a target to count as
+ *   boilerplate
+ * @returns {{kept: Array, suppressed: Array}} partition of the input links
+ */
+export function identifyUncorroboratedBoilerplateLinks(
+  links,
+  { rumProducedBrokenLinks, minSourcePages } = {},
+) {
+  if (!Array.isArray(links) || links.length === 0 || !rumProducedBrokenLinks) {
+    return { kept: links, suppressed: [] };
+  }
+
+  const targetKey = (link) => `${normalizeComparableUrl(link.urlTo)}|${link.itemType || DEFAULT_ITEM_TYPE}`;
+
+  // Count distinct source pages per target among crawl-only links.
+  const sourcePagesByTarget = new Map();
+  for (const link of links) {
+    if (link.detectionSource !== 'crawl') {
+      continue; // eslint-disable-line no-continue
+    }
+    const key = targetKey(link);
+    let pages = sourcePagesByTarget.get(key);
+    if (!pages) {
+      pages = new Set();
+      sourcePagesByTarget.set(key, pages);
+    }
+    pages.add(normalizeComparableUrl(link.urlFrom));
+  }
+
+  const boilerplateTargets = new Set(
+    [...sourcePagesByTarget.entries()]
+      .filter(([, pages]) => pages.size >= minSourcePages)
+      .map(([key]) => key),
+  );
+
+  if (boilerplateTargets.size === 0) {
+    return { kept: links, suppressed: [] };
+  }
+
+  const kept = [];
+  const suppressed = [];
+  for (const link of links) {
+    if (link.detectionSource === 'crawl' && boilerplateTargets.has(targetKey(link))) {
+      suppressed.push(link);
+    } else {
+      kept.push(link);
+    }
+  }
+
+  return { kept, suppressed };
 }

--- a/src/internal-links/helpers.js
+++ b/src/internal-links/helpers.js
@@ -408,22 +408,24 @@ export function calculatePriority(links) {
  *   one validated broken link for this site
  * @param {number} opts.minSourcePages - min distinct source pages for a target to count as
  *   boilerplate
- * @returns {{kept: Array, suppressed: Array}} partition of the input links
+ * @returns {{kept: Array, suppressed: Array, suppressedTargets: string[]}} partition of the
+ *   input links plus the distinct normalized target URLs that were flagged
  */
 export function identifyUncorroboratedBoilerplateLinks(
   links,
   { rumProducedBrokenLinks, minSourcePages } = {},
 ) {
   if (!Array.isArray(links) || links.length === 0 || !rumProducedBrokenLinks) {
-    return { kept: links, suppressed: [] };
+    return { kept: links, suppressed: [], suppressedTargets: [] };
   }
 
   const targetKey = (link) => `${normalizeComparableUrl(link.urlTo)}|${link.itemType || DEFAULT_ITEM_TYPE}`;
 
-  // Count distinct source pages per target among crawl-only links.
+  // Count distinct source pages per target among crawl-only links. Links without a real
+  // urlTo are skipped so malformed rows can never collapse into a single "undefined" key.
   const sourcePagesByTarget = new Map();
   for (const link of links) {
-    if (link.detectionSource !== 'crawl') {
+    if (link.detectionSource !== 'crawl' || !link.urlTo) {
       continue; // eslint-disable-line no-continue
     }
     const key = targetKey(link);
@@ -442,18 +444,20 @@ export function identifyUncorroboratedBoilerplateLinks(
   );
 
   if (boilerplateTargets.size === 0) {
-    return { kept: links, suppressed: [] };
+    return { kept: links, suppressed: [], suppressedTargets: [] };
   }
 
   const kept = [];
   const suppressed = [];
+  const suppressedTargets = new Set();
   for (const link of links) {
-    if (link.detectionSource === 'crawl' && boilerplateTargets.has(targetKey(link))) {
+    if (link.detectionSource === 'crawl' && link.urlTo && boilerplateTargets.has(targetKey(link))) {
       suppressed.push(link);
+      suppressedTargets.add(normalizeComparableUrl(link.urlTo));
     } else {
       kept.push(link);
     }
   }
 
-  return { kept, suppressed };
+  return { kept, suppressed, suppressedTargets: [...suppressedTargets] };
 }

--- a/src/internal-links/link-key.js
+++ b/src/internal-links/link-key.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-const DEFAULT_ITEM_TYPE = 'link';
+export const DEFAULT_ITEM_TYPE = 'link';
 
 export function normalizeComparableUrl(url) {
   if (!url) {

--- a/test/audits/internal-links/config.test.js
+++ b/test/audits/internal-links/config.test.js
@@ -147,6 +147,8 @@ describe('internal-links config resolver', () => {
       'media',
     ]);
     expect(resolver.getExcludeCrossLocalePDP()).to.equal(false);
+    expect(resolver.getSuppressUncorroboratedBoilerplate()).to.equal(false);
+    expect(resolver.getBoilerplateMinSourcePages()).to.equal(10);
     expect(resolver.getMystiqueItemTypes()).to.deep.equal([
       'link',
       'form',
@@ -171,6 +173,22 @@ describe('internal-links config resolver', () => {
     }), {});
 
     expect(resolver.getExcludedElementClasses()).to.deep.equal(['no-audit', 'editorial']);
+  });
+
+  it('reads suppressUncorroboratedBoilerplate and boilerplateMinSourcePages overrides', () => {
+    const resolver = new InternalLinksConfigResolver(createSite({
+      suppressUncorroboratedBoilerplate: true,
+      boilerplateMinSourcePages: 25,
+    }), {});
+    expect(resolver.getSuppressUncorroboratedBoilerplate()).to.equal(true);
+    expect(resolver.getBoilerplateMinSourcePages()).to.equal(25);
+  });
+
+  it('floors boilerplateMinSourcePages at 5 for over-aggressive overrides', () => {
+    const resolver = new InternalLinksConfigResolver(createSite({
+      boilerplateMinSourcePages: 1,
+    }), {});
+    expect(resolver.getBoilerplateMinSourcePages()).to.equal(5);
   });
 
   it('returns excludeCrossLocalePDP from handler config when the value is set to true', () => {

--- a/test/audits/internal-links/finalization.test.js
+++ b/test/audits/internal-links/finalization.test.js
@@ -29,6 +29,8 @@ describe('internal-links finalization', () => {
       createConfigResolver: () => ({
         getIncludedStatusBuckets: () => ['not_found_404'],
         getIncludedItemTypes: () => ['link'],
+        getSuppressUncorroboratedBoilerplate: () => true,
+        getBoilerplateMinSourcePages: () => 10,
       }),
       calculatePriority: (links) => links,
       mergeAndDeduplicate: (firstLinks, secondLinks) => [...secondLinks, ...firstLinks],
@@ -82,6 +84,8 @@ describe('internal-links finalization', () => {
       createConfigResolver: () => ({
         getIncludedStatusBuckets: () => ['not_found_404'],
         getIncludedItemTypes: () => ['link'],
+        getSuppressUncorroboratedBoilerplate: () => true,
+        getBoilerplateMinSourcePages: () => 10,
       }),
       calculatePriority: (links) => links,
       mergeAndDeduplicate: (firstLinks, secondLinks) => [...secondLinks, ...firstLinks],
@@ -119,6 +123,144 @@ describe('internal-links finalization', () => {
     expect(updateAuditResult.firstCall.args[2]).to.deep.equal([]);
   });
 
+  it('drops uncorroborated boilerplate crawl links when suppression is enabled', async () => {
+    const calculatePriority = sinon.spy((links) => links);
+    const updateAuditResult = sinon.stub().resolves({});
+    const base = 'https://example.com';
+    const boilerplate = Array.from({ length: 11 }, (_, i) => ({
+      urlFrom: `${base}/page-${i}`,
+      urlTo: `${base}/support/privacy-notice/`,
+      itemType: 'link',
+      detectionSource: 'crawl',
+      statusBucket: 'not_found_404',
+      httpStatus: 404,
+    }));
+    const genuine = {
+      urlFrom: `${base}/blog`,
+      urlTo: `${base}/genuinely-missing/`,
+      itemType: 'link',
+      detectionSource: 'crawl',
+      statusBucket: 'not_found_404',
+      httpStatus: 404,
+    };
+    const rumLink = {
+      urlFrom: `${base}/home`,
+      urlTo: `${base}/rum-broken/`,
+      itemType: 'link',
+      detectionSource: 'rum',
+      statusBucket: 'not_found_404',
+      httpStatus: 404,
+    };
+
+    const finalize = createFinalizeCrawlDetection({
+      auditType: 'broken-internal-links',
+      createContextLogger: (log) => log,
+      createConfigResolver: () => ({
+        getIncludedStatusBuckets: () => ['not_found_404'],
+        getIncludedItemTypes: () => ['link'],
+        getSuppressUncorroboratedBoilerplate: () => true,
+        getBoilerplateMinSourcePages: () => 10,
+      }),
+      calculatePriority,
+      mergeAndDeduplicate: (firstLinks, secondLinks) => [...secondLinks, ...firstLinks],
+      loadFinalResults: sinon.stub().resolves([...boilerplate, genuine]),
+      cleanupBatchState: sinon.stub().resolves(),
+      getTimeoutStatus: sinon.stub().returns({
+        percentUsed: 1,
+        safeTimeRemaining: 100000,
+        isApproachingTimeout: false,
+      }),
+      updateAuditResult,
+      opportunityAndSuggestionsStep: sinon.stub().resolves({ status: 'complete' }),
+      filterByStatusIfNeeded,
+      filterByItemTypes,
+    });
+
+    await finalize({
+      log: {
+        info: sinon.stub(), warn: sinon.stub(), error: sinon.stub(), debug: sinon.stub(),
+      },
+      site: { getId: () => 'site-1', getBaseURL: () => 'https://example.com' },
+      env: {},
+      audit: {
+        getId: () => 'audit-1',
+        getAuditResult: () => ({ brokenInternalLinks: [rumLink] }),
+      },
+      dataAccess: {},
+      linkCheckerResults: [],
+    }, { skipCrawlDetection: false });
+
+    const prioritized = calculatePriority.firstCall.args[0];
+    const targets = prioritized.map((l) => l.urlTo);
+    expect(targets).to.not.include(`${base}/support/privacy-notice/`);
+    expect(targets).to.include(`${base}/genuinely-missing/`);
+    expect(targets).to.include(`${base}/rum-broken/`);
+
+    const savedResult = updateAuditResult.firstCall.args[1];
+    expect(savedResult.suppressedBoilerplateLinks).to.include({ count: 11, applied: true });
+    expect(savedResult.suppressedBoilerplateLinks.targets)
+      .to.deep.equal([`${base}/support/privacy-notice`]);
+  });
+
+  it('shadow mode (default): records suppressedBoilerplateLinks but keeps the links', async () => {
+    const calculatePriority = sinon.spy((links) => links);
+    const updateAuditResult = sinon.stub().resolves({});
+    const base = 'https://example.com';
+    const boilerplate = Array.from({ length: 11 }, (_, i) => ({
+      urlFrom: `${base}/page-${i}`,
+      urlTo: `${base}/support/privacy-notice/`,
+      itemType: 'link',
+      detectionSource: 'crawl',
+      statusBucket: 'not_found_404',
+      httpStatus: 404,
+    }));
+
+    const finalize = createFinalizeCrawlDetection({
+      auditType: 'broken-internal-links',
+      createContextLogger: (log) => log,
+      createConfigResolver: () => ({
+        getIncludedStatusBuckets: () => ['not_found_404'],
+        getIncludedItemTypes: () => ['link'],
+        getSuppressUncorroboratedBoilerplate: () => false,
+        getBoilerplateMinSourcePages: () => 10,
+      }),
+      calculatePriority,
+      mergeAndDeduplicate: (firstLinks, secondLinks) => [...secondLinks, ...firstLinks],
+      loadFinalResults: sinon.stub().resolves([...boilerplate]),
+      cleanupBatchState: sinon.stub().resolves(),
+      getTimeoutStatus: sinon.stub().returns({
+        percentUsed: 1,
+        safeTimeRemaining: 100000,
+        isApproachingTimeout: false,
+      }),
+      updateAuditResult,
+      opportunityAndSuggestionsStep: sinon.stub().resolves({ status: 'complete' }),
+      filterByStatusIfNeeded,
+      filterByItemTypes,
+    });
+
+    await finalize({
+      log: {
+        info: sinon.stub(), warn: sinon.stub(), error: sinon.stub(), debug: sinon.stub(),
+      },
+      site: { getId: () => 'site-1', getBaseURL: () => 'https://example.com' },
+      env: {},
+      audit: {
+        getId: () => 'audit-1',
+        getAuditResult: () => ({ brokenInternalLinks: [{ urlFrom: `${base}/x`, urlTo: `${base}/y`, detectionSource: 'rum' }] }),
+      },
+      dataAccess: {},
+      linkCheckerResults: [],
+    }, { skipCrawlDetection: false });
+
+    const prioritized = calculatePriority.firstCall.args[0];
+    // Links are NOT removed in shadow mode...
+    expect(prioritized.filter((l) => l.urlTo === `${base}/support/privacy-notice/`)).to.have.lengthOf(11);
+    // ...but the audit result records what WOULD have been suppressed.
+    const savedResult = updateAuditResult.firstCall.args[1];
+    expect(savedResult.suppressedBoilerplateLinks).to.include({ count: 11, applied: false });
+  });
+
   it('filters final links by configured status buckets and item types', async () => {
     const updateAuditResult = sinon.stub();
     updateAuditResult.resolves({});
@@ -129,6 +271,8 @@ describe('internal-links finalization', () => {
       createConfigResolver: () => ({
         getIncludedStatusBuckets: () => ['not_found_404', 'masked_by_linkchecker'],
         getIncludedItemTypes: () => ['link'],
+        getSuppressUncorroboratedBoilerplate: () => true,
+        getBoilerplateMinSourcePages: () => 10,
       }),
       calculatePriority: (links) => links.map((link) => ({ ...link, priority: 'high' })),
       mergeAndDeduplicate: (firstLinks, secondLinks) => [...secondLinks, ...firstLinks],
@@ -204,6 +348,8 @@ describe('internal-links finalization', () => {
       createConfigResolver: () => ({
         getIncludedStatusBuckets: () => ['not_found_404'],
         getIncludedItemTypes: () => ['link'],
+        getSuppressUncorroboratedBoilerplate: () => true,
+        getBoilerplateMinSourcePages: () => 10,
       }),
       calculatePriority: (links) => links.map((link) => ({ ...link, priority: 'high' })),
       mergeAndDeduplicate: (firstLinks, secondLinks) => [...secondLinks, ...firstLinks],
@@ -262,6 +408,8 @@ describe('internal-links finalization', () => {
       createConfigResolver: () => ({
         getIncludedStatusBuckets: () => ['not_found_404'],
         getIncludedItemTypes: () => ['link'],
+        getSuppressUncorroboratedBoilerplate: () => true,
+        getBoilerplateMinSourcePages: () => 10,
       }),
       calculatePriority: (links) => links.map((link) => ({ ...link, priority: 'high' })),
       mergeAndDeduplicate: (firstLinks, secondLinks) => [...secondLinks, ...firstLinks],
@@ -317,6 +465,8 @@ describe('internal-links finalization', () => {
       createConfigResolver: () => ({
         getIncludedStatusBuckets: () => ['not_found_404'],
         getIncludedItemTypes: () => ['link'],
+        getSuppressUncorroboratedBoilerplate: () => true,
+        getBoilerplateMinSourcePages: () => 10,
       }),
       calculatePriority: (links) => links.map((link) => ({ ...link, priority: 'high' })),
       mergeAndDeduplicate: (firstLinks, secondLinks) => [...secondLinks, ...firstLinks],
@@ -382,6 +532,8 @@ describe('internal-links finalization', () => {
       createConfigResolver: () => ({
         getIncludedStatusBuckets: () => ['not_found_404'],
         getIncludedItemTypes: () => ['js'],
+        getSuppressUncorroboratedBoilerplate: () => true,
+        getBoilerplateMinSourcePages: () => 10,
       }),
       calculatePriority: (links) => links.map((link) => ({ ...link, priority: 'high' })),
       mergeAndDeduplicate: (firstLinks, secondLinks) => [...secondLinks, ...firstLinks],
@@ -451,6 +603,8 @@ describe('internal-links finalization', () => {
       createConfigResolver: () => ({
         getIncludedStatusBuckets: () => ['masked_by_linkchecker', 'not_found_404'],
         getIncludedItemTypes: () => ['link'],
+        getSuppressUncorroboratedBoilerplate: () => true,
+        getBoilerplateMinSourcePages: () => 10,
       }),
       calculatePriority: (links) => links.map((link) => ({ ...link, priority: 'high' })),
       mergeAndDeduplicate: (firstLinks, secondLinks) => [...secondLinks, ...firstLinks],
@@ -536,6 +690,8 @@ describe('internal-links finalization', () => {
       createConfigResolver: () => ({
         getIncludedStatusBuckets: () => ['not_found_404'],
         getIncludedItemTypes: () => ['link'],
+        getSuppressUncorroboratedBoilerplate: () => true,
+        getBoilerplateMinSourcePages: () => 10,
       }),
       calculatePriority: (links) => links.map((link) => ({ ...link, priority: 'high' })),
       mergeAndDeduplicate: (firstLinks, secondLinks) => [...secondLinks, ...firstLinks],
@@ -597,6 +753,8 @@ describe('internal-links finalization', () => {
       createConfigResolver: () => ({
         getIncludedStatusBuckets: () => ['not_found_404'],
         getIncludedItemTypes: () => ['link'],
+        getSuppressUncorroboratedBoilerplate: () => true,
+        getBoilerplateMinSourcePages: () => 10,
       }),
       calculatePriority: (links) => links.map((link) => ({ ...link, priority: 'high' })),
       mergeAndDeduplicate: (firstLinks, secondLinks) => [...secondLinks, ...firstLinks],
@@ -647,6 +805,8 @@ describe('internal-links finalization', () => {
       createConfigResolver: () => ({
         getIncludedStatusBuckets: () => ['not_found_404'],
         getIncludedItemTypes: () => ['link'],
+        getSuppressUncorroboratedBoilerplate: () => true,
+        getBoilerplateMinSourcePages: () => 10,
       }),
       calculatePriority: (links) => links.map((link) => ({ ...link, priority: 'high' })),
       mergeAndDeduplicate: (firstLinks, secondLinks) => [...secondLinks, ...firstLinks],
@@ -716,6 +876,8 @@ describe('internal-links finalization', () => {
         createConfigResolver: () => ({
           getIncludedStatusBuckets: () => ['not_found_404', 'masked_by_linkchecker'],
           getIncludedItemTypes: () => ['link'],
+          getSuppressUncorroboratedBoilerplate: () => true,
+          getBoilerplateMinSourcePages: () => 10,
         }),
         calculatePriority: (links) => links.map((link) => ({ ...link, priority: 'high' })),
         mergeAndDeduplicate: (first, second) => [...second, ...first],

--- a/test/audits/internal-links/helpers.test.js
+++ b/test/audits/internal-links/helpers.test.js
@@ -21,6 +21,7 @@ import {
   CPC_DEFAULT_VALUE,
   isLinkInaccessible,
   calculatePriority,
+  identifyUncorroboratedBoilerplateLinks,
   classifyStatusBucket,
   STATUS_BUCKETS,
 } from '../../../src/internal-links/helpers.js';
@@ -603,6 +604,133 @@ describe('calculatePriority', () => {
     expect(result[0].trafficDomain).to.equal(1000);
     expect(result[1].trafficDomain).to.equal(500);
     expect(result[2].trafficDomain).to.equal(10);
+  });
+});
+
+describe('identifyUncorroboratedBoilerplateLinks', () => {
+  const base = 'https://www.example.com';
+  // N crawl-only links pointing at the same broken target from N distinct pages
+  const boilerplate = (target, pages, extra = {}) => Array.from({ length: pages }, (_, i) => ({
+    urlFrom: `${base}/page-${i}`,
+    urlTo: `${base}${target}`,
+    itemType: 'link',
+    detectionSource: 'crawl',
+    ...extra,
+  }));
+
+  it('flags a crawl-only target that repeats across > minSourcePages distinct pages', () => {
+    const links = boilerplate('/support/privacy-notice/', 12);
+    const { kept, suppressed } = identifyUncorroboratedBoilerplateLinks(links, {
+      rumProducedBrokenLinks: true,
+      minSourcePages: 10,
+    });
+    expect(kept).to.be.an('array').that.is.empty;
+    expect(suppressed).to.have.lengthOf(12);
+  });
+
+  it('flags at exactly minSourcePages (>= is inclusive)', () => {
+    const links = boilerplate('/support/privacy-notice/', 10);
+    const { kept, suppressed } = identifyUncorroboratedBoilerplateLinks(links, {
+      rumProducedBrokenLinks: true,
+      minSourcePages: 10,
+    });
+    expect(kept).to.be.empty;
+    expect(suppressed).to.have.lengthOf(10);
+  });
+
+  it('keeps a target that appears on fewer than minSourcePages pages', () => {
+    const links = boilerplate('/rare-404/', 9);
+    const { kept, suppressed } = identifyUncorroboratedBoilerplateLinks(links, {
+      rumProducedBrokenLinks: true,
+      minSourcePages: 10,
+    });
+    expect(kept).to.have.lengthOf(9);
+    expect(suppressed).to.be.empty;
+  });
+
+  it('never flags links corroborated by RUM/LinkChecker', () => {
+    const links = boilerplate('/real-broken/', 20, { detectionSource: 'crawl+rum' });
+    const { kept, suppressed } = identifyUncorroboratedBoilerplateLinks(links, {
+      rumProducedBrokenLinks: true,
+      minSourcePages: 10,
+    });
+    expect(kept).to.have.lengthOf(20);
+    expect(suppressed).to.be.empty;
+  });
+
+  it('preserves the per-page decision when the same target is mixed crawl-only and corroborated', () => {
+    // 10 crawl-only pages for the target + 1 page where it was also seen by RUM.
+    const links = [
+      ...boilerplate('/support/privacy-notice/', 10),
+      {
+        urlFrom: `${base}/page-hot`,
+        urlTo: `${base}/support/privacy-notice/`,
+        itemType: 'link',
+        detectionSource: 'crawl+rum',
+      },
+    ];
+    const { kept, suppressed } = identifyUncorroboratedBoilerplateLinks(links, {
+      rumProducedBrokenLinks: true,
+      minSourcePages: 10,
+    });
+    // The corroborated instance survives; only the 10 crawl-only instances are flagged.
+    expect(suppressed).to.have.lengthOf(10);
+    expect(suppressed.every((l) => l.detectionSource === 'crawl')).to.be.true;
+    expect(kept).to.have.lengthOf(1);
+    expect(kept[0].detectionSource).to.equal('crawl+rum');
+  });
+
+  it('is a no-op when RUM produced no broken-link signal for the site', () => {
+    const links = boilerplate('/support/privacy-notice/', 20);
+    const { kept, suppressed } = identifyUncorroboratedBoilerplateLinks(links, {
+      rumProducedBrokenLinks: false,
+      minSourcePages: 10,
+    });
+    expect(kept).to.have.lengthOf(20);
+    expect(suppressed).to.be.empty;
+  });
+
+  it('flags only the boilerplate target, keeping unrelated crawl links', () => {
+    const links = [
+      ...boilerplate('/support/privacy-notice/', 15),
+      {
+        urlFrom: `${base}/blog/a`,
+        urlTo: `${base}/genuinely-missing/`,
+        itemType: 'link',
+        detectionSource: 'crawl',
+      },
+    ];
+    const { kept, suppressed } = identifyUncorroboratedBoilerplateLinks(links, {
+      rumProducedBrokenLinks: true,
+      minSourcePages: 10,
+    });
+    expect(kept).to.have.lengthOf(1);
+    expect(kept[0].urlTo).to.equal(`${base}/genuinely-missing/`);
+    expect(suppressed).to.have.lengthOf(15);
+  });
+
+  it('counts distinct pages only (duplicate source pages do not inflate the count)', () => {
+    const links = Array.from({ length: 12 }, () => ({
+      urlFrom: `${base}/same-page`,
+      urlTo: `${base}/support/privacy-notice/`,
+      itemType: 'link',
+      detectionSource: 'crawl',
+    }));
+    const { kept, suppressed } = identifyUncorroboratedBoilerplateLinks(links, {
+      rumProducedBrokenLinks: true,
+      minSourcePages: 10,
+    });
+    // Only 1 distinct source page -> not boilerplate -> kept
+    expect(kept).to.have.lengthOf(12);
+    expect(suppressed).to.be.empty;
+  });
+
+  it('handles empty / non-array input', () => {
+    expect(identifyUncorroboratedBoilerplateLinks([], {
+      rumProducedBrokenLinks: true, minSourcePages: 10,
+    })).to.deep.equal({ kept: [], suppressed: [] });
+    expect(identifyUncorroboratedBoilerplateLinks(undefined, {}))
+      .to.deep.equal({ kept: undefined, suppressed: [] });
   });
 });
 

--- a/test/audits/internal-links/helpers.test.js
+++ b/test/audits/internal-links/helpers.test.js
@@ -725,6 +725,63 @@ describe('identifyUncorroboratedBoilerplateLinks', () => {
     expect(suppressed).to.be.empty;
   });
 
+  it('flags multiple distinct boilerplate targets simultaneously', () => {
+    const links = [
+      ...boilerplate('/support/privacy-notice/', 12),
+      ...boilerplate('/support/terms/', 11),
+      {
+        urlFrom: `${base}/blog/a`,
+        urlTo: `${base}/one-off-404/`,
+        itemType: 'link',
+        detectionSource: 'crawl',
+      },
+    ];
+    const { kept, suppressed, suppressedTargets } = identifyUncorroboratedBoilerplateLinks(links, {
+      rumProducedBrokenLinks: true,
+      minSourcePages: 10,
+    });
+    expect(suppressed).to.have.lengthOf(23);
+    expect(kept).to.have.lengthOf(1);
+    expect(kept[0].urlTo).to.equal(`${base}/one-off-404/`);
+    expect(suppressedTargets).to.have.members([
+      `${base}/support/privacy-notice`,
+      `${base}/support/terms`,
+    ]);
+    expect(suppressedTargets).to.have.lengthOf(2);
+  });
+
+  it('never flags links corroborated by LinkChecker (crawl+linkchecker)', () => {
+    const links = boilerplate('/real-broken/', 20, { detectionSource: 'crawl+linkchecker' });
+    const { kept, suppressed, suppressedTargets } = identifyUncorroboratedBoilerplateLinks(links, {
+      rumProducedBrokenLinks: true,
+      minSourcePages: 10,
+    });
+    expect(kept).to.have.lengthOf(20);
+    expect(suppressed).to.be.empty;
+    expect(suppressedTargets).to.be.empty;
+  });
+
+  it('skips links with a falsy urlTo (never groups them into an "undefined" target)', () => {
+    const links = [
+      ...boilerplate('/support/privacy-notice/', 11), // real boilerplate -> flagged
+      ...Array.from({ length: 3 }, (_, i) => ({
+        urlFrom: `${base}/malformed-${i}`,
+        urlTo: undefined, // malformed row -> must be ignored, not grouped
+        itemType: 'link',
+        detectionSource: 'crawl',
+      })),
+    ];
+    const { kept, suppressed, suppressedTargets } = identifyUncorroboratedBoilerplateLinks(links, {
+      rumProducedBrokenLinks: true,
+      minSourcePages: 10,
+    });
+    expect(suppressed).to.have.lengthOf(11);
+    expect(suppressedTargets).to.deep.equal([`${base}/support/privacy-notice`]);
+    // the 3 malformed links are kept, not collapsed into a spurious boilerplate target
+    expect(kept).to.have.lengthOf(3);
+    expect(kept.every((l) => l.urlTo === undefined)).to.be.true;
+  });
+
   it('falls back to the default item type when itemType is missing', () => {
     const links = Array.from({ length: 11 }, (_, i) => ({
       urlFrom: `${base}/page-${i}`,
@@ -743,9 +800,9 @@ describe('identifyUncorroboratedBoilerplateLinks', () => {
   it('handles empty / non-array input', () => {
     expect(identifyUncorroboratedBoilerplateLinks([], {
       rumProducedBrokenLinks: true, minSourcePages: 10,
-    })).to.deep.equal({ kept: [], suppressed: [] });
+    })).to.deep.equal({ kept: [], suppressed: [], suppressedTargets: [] });
     expect(identifyUncorroboratedBoilerplateLinks(undefined, {}))
-      .to.deep.equal({ kept: undefined, suppressed: [] });
+      .to.deep.equal({ kept: undefined, suppressed: [], suppressedTargets: [] });
   });
 });
 

--- a/test/audits/internal-links/helpers.test.js
+++ b/test/audits/internal-links/helpers.test.js
@@ -725,6 +725,21 @@ describe('identifyUncorroboratedBoilerplateLinks', () => {
     expect(suppressed).to.be.empty;
   });
 
+  it('falls back to the default item type when itemType is missing', () => {
+    const links = Array.from({ length: 11 }, (_, i) => ({
+      urlFrom: `${base}/page-${i}`,
+      urlTo: `${base}/support/privacy-notice/`,
+      detectionSource: 'crawl',
+      // itemType intentionally omitted -> exercises the DEFAULT_ITEM_TYPE fallback
+    }));
+    const { kept, suppressed } = identifyUncorroboratedBoilerplateLinks(links, {
+      rumProducedBrokenLinks: true,
+      minSourcePages: 10,
+    });
+    expect(kept).to.be.empty;
+    expect(suppressed).to.have.lengthOf(11);
+  });
+
   it('handles empty / non-array input', () => {
     expect(identifyUncorroboratedBoilerplateLinks([], {
       rumProducedBrokenLinks: true, minSourcePages: 10,


### PR DESCRIPTION
## Problem (SITES-50131)

The broken-internal-links (BIL) crawl detector reads a link's `href` from the **JS-hydrated DOM** and validates it with a direct HTTP fetch. It cannot execute click handlers, so a template **nav/footer widget** whose anchor carries a same-domain fallback `href` that 404s — but whose click is intercepted by client-side JS (e.g. it actually navigates cross-domain) — gets flagged as broken **on every page the widget renders on**.

On `www.toyotacertified.com`, one shared footer **"Privacy Notice"** button (a SPA-rendered JS control) produced **60 of the domain's 184** BIL suggestions, all pointing at the same fabricated same-domain 404 (`/support/privacy-notice/`). The real link navigates to `toyota.com`, which the crawl never sees. This false-positive class is undetectable from static markup (the click handler is framework-bound; there is no `onclick`/`role` marker), so the only reliable signal is behavioral.

## Approach

Add a conservative, **generic** heuristic (`identifyUncorroboratedBoilerplateLinks`) that classifies a target as *uncorroborated site-wide boilerplate* when **all** hold:

- flagged **only** by the crawl detector (`detectionSource === 'crawl'` — never corroborated by RUM or LinkChecker; corroborated combos like `crawl+rum` are always kept);
- the identical `urlTo` repeats across **≥ `minSourcePages`** (default 10, floored at 5) distinct source pages — true boilerplate, never a one-off;
- **RUM produced validated broken links for this site**, so the absence of RUM corroboration for this target is meaningful (a site-wide link that real users never navigate to).

### Ships in shadow mode (default off)

`suppressUncorroboratedBoilerplate` defaults to **`false`** — nothing is removed yet. The audit still records what it *would* suppress in `auditResult.suppressedBoilerplateLinks` (`count`, `distinctTargets`, `targets`, `applied`) so we can measure the false-negative rate fleet-wide before enabling per-site. Flip to `true` per site (handler config) to actually drop.

**Why shadow-first:** RUM's broken-link signal is traffic-gated, so a genuinely dead but rarely-clicked footer link (Privacy/Terms/Sitemap) can share this exact signature. Shadow mode lets us validate against real opportunity data before hard-dropping anything customer-facing.

## Config knobs (per-site handler config)

| key | default | meaning |
|---|---|---|
| `suppressUncorroboratedBoilerplate` | `false` | actually drop matching links (vs shadow-record only) |
| `boilerplateMinSourcePages` | `10` (min 5) | distinct pages a crawl-only target must span to count as boilerplate |

## Testing

- 13 new helper unit tests (boundary at exactly `minSourcePages`, mixed corroboration on the same target, distinct-page counting, no-op guards, empty input).
- Config default + override + floor tests.
- 2 finalization integration tests: enabled → drops + records `applied: true`; shadow default → keeps links + records `applied: false`.
- Full `test/audits/internal-links` suite: no new failures (30 pre-existing failures are unrelated and also fail on `origin/main`).

## Notes / follow-ups

- Mystique's **V2/SEMRUSH** BIL path has the same static-crawl blind spot (SEMRUSH is also a static crawler) — an analogous filter belongs at DRS ingestion. Out of scope here; worth a follow-up.
- Alternative considered: priority-demotion instead of drop (never lose data). Left as a future option; shadow mode gives us the data to decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: []
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```