### PR TITLE
feat(gsc-search-analytics): self-serve self-sourcing + out_of_scope status

### DIFF
--- a/docs/specs/gsc-search-analytics.md
+++ b/docs/specs/gsc-search-analytics.md
@@ -10,27 +10,61 @@ The customer's GSC OAuth token lives only in the SpaceCat prod account's Secrets
 
 ## Input contract
 
-The runner reads `auditContext.fixedUrls` (fallback `auditContext.messageData?.fixedUrls`): an array of `{ url, fixType, fixDate }`, `fixDate` as `YYYY-MM-DD`. Supplied manually for the pilot; may later be sourced from ASO's own FIXED-suggestion records.
+The runner has two modes.
+
+**Self-sourced (default).** With no explicit URL list, the runner sources the site's own DEPLOYED/PUBLISHED fixes from the data-service (`fix_entities` via `spacecat-shared-data-access`, read off `context.dataAccess`) and builds the `{ url, fixType, fixDate }` list itself (`deriveFixedUrls` in `derive.js`). Inputs arrive as Slack/API keyword args on `auditContext.messageData` (or `auditContext` directly):
+- `since` — a single `YYYY-MM-DD` watermark. Present → **incremental** mode: only fixes that matured since then. Absent → **backfill** of the full measurable band (`now-396d` → `now-87d`).
+- `fixStatuses` — optional, default `[DEPLOYED, PUBLISHED]`.
+- `fixTypes` — optional; an explicit list overrides the default SEO allow-list (see below).
+- `from` / `to` — undocumented low-level date overrides that exist for deterministic tests; they win over `since`/backfill. Not for normal use.
+
+**Explicit override.** `auditContext.fixedUrls` (fallback `auditContext.messageData?.fixedUrls`) — an array of `{ url, fixType, fixDate }` (`fixDate` as `YYYY-MM-DD`). When supplied and non-empty it wins and self-sourcing is skipped; used for tests and reruns.
+
+**SEO allow-list.** Self-sourcing sources only SEO opportunity types by default (`SEO_FIX_TYPES` in `derive.js`): `meta-tags`, `broken-internal-links`, `broken-backlinks`, `sitemap`, `canonical`, `structured-data`, `hreflang`, `cwv`, `readability`, `redirect-chains`. **`alt-text` is excluded by default** — its signal is image-search, not the web-search clicks/impressions/position this audit records, and it is the largest volume driver (caps pressure). It is still reachable with `fixTypes:['alt-text']` (an explicit `fixTypes` overrides the default set).
+
+**Backfill is bounded.** A wide backfill is capped to the **newest `MAX_DATE_GROUPS` (30)** distinct deploy-dates and `MAX_FIXED_URLS` (500) URLs, so it can never trip the run's hard abort-caps (below); it measures the most-recent batch instead of returning zero. Older history is reached with an explicit narrower window (`since:` or `from`/`to`). Self-sourced runs carry a top-level `sourcing` object — `{ mode, sourcedDateGroups, keptDateGroups, truncated }` — where `truncated: true` means older fixes were left out of this run.
 
 Guards (fail closed, recorded as a status, never a crash):
-- `missing_fixed_urls` — empty/absent list.
+- `missing_fixed_urls` — empty/absent list (nothing supplied and nothing sourced).
 - `too_many_fixed_urls` — more than 500 URLs.
 - `too_many_date_groups` — more than 30 distinct fix dates (each date = one sequential pair of window pulls; bounded to stay within the Lambda timeout).
+- `sourcing_failed` — the self-source data lookup threw (e.g. a data-service error); recorded instead of crashing the run.
+
+## Running the audit (Slack)
+
+Self-serve via `@spacecat`; the site is the only required input.
+
+```
+# backfill — everything currently measurable (run once)
+@spacecat run audit https://krisshop.com audit:gsc-search-analytics
+# incremental — only fixes matured since your last run (monthly)
+@spacecat run audit https://krisshop.com audit:gsc-search-analytics since:2026-05-01
+# optional type filter (single type)
+@spacecat run audit https://krisshop.com audit:gsc-search-analytics since:2026-05-01 fixTypes:meta-tags
+```
+
+`fixTypes` from Slack is a single type value; the worker also accepts an array via `messageData` when multiple types are needed.
 
 ## Processing
 
 1. `GoogleClient.createFrom(context, finalUrl)`. Any failure is recorded as `status:'not_connected'` with a bounded `reason` (repo convention; never throws).
-2. Split invalid dates out as `status:'invalid_date'`. Group the rest by `fixDate` so URLs sharing a date share one pull pair.
-3. Per date-group: compute the two 84-day windows (`computeWindows`), assess completeness (`assessCompleteness` vs GSC's ~3-day freshness lag and ~16-month retention), fetch each window's page rows (`fetchWindow`, paginated, 50-page cap → `truncated` flag), and match each fixed URL client-side (`match.js`, normalized: lowercased host, no fragment, sorted query, trailing slash stripped).
+2. Resolve the GSC query scope once via `composeAuditURL(finalUrl)` — the host+path the client's page-filter is scoped to (e.g. `www.krisshop.com/en`). A fixed URL outside that resolved host+path is never queried and is classified `out_of_scope`. `composeAuditURL` does a live HTTP GET; if it fails, the run degrades to treating all fixed URLs as in-scope (logs a warning) rather than failing, since GSC is already connected.
+3. Split invalid dates out as `status:'invalid_date'`. Group the rest by `fixDate` so URLs sharing a date share one pull pair.
+4. Per date-group: compute the two 84-day windows (`computeWindows`), assess completeness (`assessCompleteness` vs GSC's ~3-day freshness lag and ~16-month retention), fetch each window's page rows (`fetchWindow`, paginated, 50-page cap → `truncated` flag), and match each fixed URL client-side (`match.js`, normalized: lowercased host, no fragment, sorted query, trailing slash stripped).
 
 ## Output (`audit_result`)
 
-`{ schemaVersion, interpretation, connected, status, fixCount, measuredCount, fixes[] }`. Each fix: `{ url, fixType, fixDate, status, windows, before, after, delta, found, dataQuality }`.
+`{ schemaVersion, interpretation, connected, status, fixCount, measuredCount, fixes[] }`, plus an optional top-level `sourcing` object on self-sourced runs (see below). Each fix: `{ url, fixType, fixDate, status, windows, before, after, delta, found, dataQuality }`.
 
-Per-fix `status`:
+Envelope-level `status` is one of: `ok | not_connected | missing_fixed_urls | too_many_fixed_urls | too_many_date_groups | sourcing_failed`. `sourcing_failed` = the self-source data lookup threw (e.g. a data-service error); recorded instead of crashing the run.
+
+The top-level `sourcing` object (`{ mode, sourcedDateGroups, keptDateGroups, truncated }`) is present on self-sourced runs — on **both** the `ok` and the `missing_fixed_urls` results, so a "found 0 deployed fixes in band" run is still diagnosable. It is absent on explicit-`fixedUrls` runs.
+
+Per-fix `status` is one of `measured | not_found | incomplete | invalid_date | failed | out_of_scope`:
 - `measured` — both windows found and fully elapsed/in-retention; `delta` = after minus before (for `position`, negative = moved up = better).
-- `not_found` — a window returned no row for the URL.
+- `not_found` — a window was queried and returned no row for the URL.
 - `incomplete` — a window is not fully elapsed or predates retention (`delta:null`; completeness is checked before presence).
+- `out_of_scope` — the URL is outside the GSC page-filter's resolved host+path scope, so it was never queried — distinct from `not_found` (queried, no data).
 - `invalid_date` / `failed` — recorded with an error, never fetched / fetch failed.
 
 `delta` is populated **only** for `measured`, so a partial window can never masquerade as a complete change.
@@ -49,7 +83,9 @@ URL matching assumes `www.` and apex are equivalent (see `match.js`). If a windo
 
 ## Non-goals
 
-Causal attribution, touched-vs-untouched comparison, dollarization, cross-URL aggregation, automated apply, and sourcing the fixed-URL list from SpaceCat (pilot supplies it manually).
+Causal attribution, touched-vs-untouched comparison, dollarization, cross-URL aggregation, and automated apply.
+
+Self-sourcing the fixed-URL list from SpaceCat — formerly a non-goal — is now **implemented**: the source of truth is `fix_entities` via `spacecat-shared-data-access` (see Input contract). A manually-supplied `fixedUrls` list still works as an explicit override.
 
 ## Related
 

--- a/src/gsc-search-analytics/constants.js
+++ b/src/gsc-search-analytics/constants.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// Shared caps for the gsc-search-analytics audit. `derive.js` uses these to BOUND its
+// self-sourced output; `lib.js` uses the same values as the runtime ABORT cap. Keeping
+// them in one place stops the derive bound and the runtime cap from drifting apart.
+export const MAX_FIXED_URLS = 500;
+export const MAX_DATE_GROUPS = 30;

--- a/src/gsc-search-analytics/derive.js
+++ b/src/gsc-search-analytics/derive.js
@@ -14,14 +14,23 @@ import { limitConcurrencyAllSettled } from '../support/utils.js';
 // Caps shared with lib.js (which imports the same constants) so the derive OUTPUT bound
 // here and lib.js's runtime ABORT cap stay in lock-step.
 import { MAX_FIXED_URLS, MAX_DATE_GROUPS } from './constants.js';
+// Timing constants are owned by windows.js (the before/after window math). Derive the
+// derive-side lags from them instead of re-hardcoding 84/87/396 here, so the two files
+// cannot silently drift apart.
+import { DAYS, GSC_LAG_DAYS, RETENTION_DAYS } from './windows.js';
 
-const MAX_CONCURRENT = 10; // bound the per-opportunity FixEntity fan-out (no N+1)
+// One FixEntity batch-load per relevant opportunity, bounded by this concurrency limit.
+// getAllFixesWithSuggestionsByOpportunityId batches the suggestion lookup inside the
+// data-access layer, so DB work is ~constant per opportunity — there is no per-fix
+// getSuggestions() N+1 fanning out over the site's whole fix history.
+const MAX_CONCURRENT = 10;
 
 const iso = (d) => d.toISOString().slice(0, 10);
 const addDays = (d, n) => new Date(d.getTime() + n * 86400000);
 const toUtc = (s) => new Date(`${s}T00:00:00Z`);
-const READY_LAG = 84 + 3; // a fix matures (after-window complete) ~87 days after deploy
-const RETENTION_FLOOR = 396; // older fixes lose their before-window to GSC's ~16mo retention
+const READY_LAG = DAYS + GSC_LAG_DAYS; // 87: after-window completes ~87 days after deploy
+// 396: before-window still inside GSC's ~16mo retention
+const RETENTION_FLOOR = RETENTION_DAYS - DAYS;
 
 /**
  * Resolve the deploy-date band to source fixes from, from a single optional `since`.
@@ -55,9 +64,10 @@ export function resolveBand(opts = {}, now = new Date()) {
 // silently drops whole types (broken-internal-links, broken-backlinks, sitemap, alt-text,
 // redirect-chains). Map the SEO types we measure to their key; fall through the common
 // spellings for anything unlisted.
-const PAGE_URL_KEYS = {
+export const PAGE_URL_KEYS = {
   'meta-tags': ['url', 'pageUrl'],
-  'broken-internal-links': ['urlFrom'],
+  // suggestion schema allows either spelling; snake_case (url_from) was silently yielding 0 URLs
+  'broken-internal-links': ['urlFrom', 'url_from'],
   'broken-backlinks': ['url_to', 'urlTo'],
   sitemap: ['pageUrl'],
   canonical: ['url'],
@@ -65,7 +75,10 @@ const PAGE_URL_KEYS = {
   hreflang: ['url'],
   cwv: ['url'],
   readability: ['pageUrl', 'url'],
-  'redirect-chains': ['finalUrlFull', 'finalUrl'],
+  // TODO(validate): redirect-chains key semantics — whether the measured page is the SOURCE
+  // (sourceUrl) or the DESTINATION (finalUrl*) — need validation against real suggestion
+  // data. sourceUrl is a last-resort fallback only until that is confirmed.
+  'redirect-chains': ['finalUrlFull', 'finalUrl', 'sourceUrl'],
 };
 const FALLBACK_URL_KEYS = ['url', 'pageUrl', 'urlFrom', 'url_to', 'urlTo'];
 const isHttp = (v) => typeof v === 'string' && v.startsWith('http');
@@ -121,15 +134,19 @@ export function pageUrlsFromSuggestion(oppType, data) {
  * @param {{since?:string,from?:string,to?:string,fixStatuses?:string[],fixTypes?:string[]}} opts
  * @param {object} context - { dataAccess: { Opportunity, FixEntity }, log }
  * @returns {Promise<{fixedUrls: Array<{url:string,fixType:string,fixDate:string}>,
- *   sourcing: {mode:string, sourcedDateGroups:number, keptDateGroups:number, truncated:boolean}}>}
+ *   sourcing: {mode:string, sourcedDateGroups:number, keptDateGroups:number, truncated:boolean,
+ *   opportunitiesErrored:number, partial:boolean, fixesSkippedNoDate:number}}>}
  */
 export async function deriveFixedUrls(siteId, opts, context) {
   const { dataAccess, log } = context;
   const { Opportunity, FixEntity } = dataAccess;
   const { from, to } = resolveBand(opts);
-  const statuses = opts.fixStatuses ?? [FixEntity.STATUSES.DEPLOYED, FixEntity.STATUSES.PUBLISHED];
+  const statuses = new Set(
+    opts.fixStatuses ?? [FixEntity.STATUSES.DEPLOYED, FixEntity.STATUSES.PUBLISHED],
+  );
   const typeFilter = Array.isArray(opts.fixTypes) ? new Set(opts.fixTypes) : null;
-  const inRange = (d) => !!d && d >= from && d <= to;
+  // d is a real YYYY-MM-DD here — the null case is already filtered out below.
+  const inRange = (d) => d >= from && d <= to;
 
   // Explicit fixTypes OVERRIDE the default set (so `fixTypes:['alt-text']` works); with no
   // fixTypes we fall back to the SEO_FIX_TYPES default (which excludes alt-text). Either
@@ -140,35 +157,54 @@ export async function deriveFixedUrls(siteId, opts, context) {
     return typeFilter ? typeFilter.has(t) : SEO_FIX_TYPES.has(t);
   });
 
+  // Partial-sourcing telemetry (surfaced on the audit row): a run that silently lost some
+  // opportunities to fetch errors, or dropped fixes with no usable date, must be
+  // distinguishable from a genuine clean zero.
+  let opportunitiesErrored = 0;
+  let fixesSkippedNoDate = 0;
+
   const tasks = relevant.map((opp) => async () => {
+    const oppType = opp.getType();
     try {
       const rows = [];
-      for (const status of statuses) {
-        // eslint-disable-next-line no-await-in-loop
-        const fes = await FixEntity.allByOpportunityIdAndStatus(opp.getId(), status);
-        for (const fe of fes) {
-          const raw = fe.getPublishedAt?.() ?? fe.getExecutedAt?.();
-          const fixDate = raw ? String(raw).slice(0, 10) : null;
-          if (!inRange(fixDate)) {
-            // eslint-disable-next-line no-continue
-            continue;
-          }
-          const cd = fe.getChangeDetails?.() ?? {};
-          let urls = isHttp(cd.url) ? [cd.url] : [];
-          if (urls.length === 0) {
-            // eslint-disable-next-line no-await-in-loop
-            const sugs = (await fe.getSuggestions?.()) ?? [];
-            // Type-aware: the fixed-page URL key varies by opportunity type (see PAGE_URL_KEYS).
-            urls = sugs.flatMap((s) => pageUrlsFromSuggestion(opp.getType(), s.getData?.()));
-          }
-          for (const url of urls) {
-            rows.push({ url, fixType: opp.getType(), fixDate });
-          }
+      // Batch-load every fix for this opportunity WITH its suggestions attached in ~constant
+      // queries, then filter status + date in memory. DB suggestion-resolution is bounded by
+      // the opportunity count, not by total site fix history — no per-fix getSuggestions() N+1.
+      const fixesWithSuggestions = await FixEntity
+        .getAllFixesWithSuggestionsByOpportunityId(opp.getId());
+      for (const { fixEntity: fe, suggestions } of fixesWithSuggestions) {
+        // getAllFixesWithSuggestionsByOpportunityId returns every status; keep only ours.
+        if (!statuses.has(fe.getStatus?.())) {
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+        const raw = fe.getPublishedAt?.() ?? fe.getExecutedAt?.();
+        const fixDate = raw ? String(raw).slice(0, 10) : null;
+        if (!fixDate) {
+          fixesSkippedNoDate += 1;
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+        if (!inRange(fixDate)) {
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+        // v1-only fast-path: v1 changeDetails carried a top-level `url`; v2 changeDetails has
+        // no top-level url, so this rarely hits and the suggestion fallback is the common path.
+        const cd = fe.getChangeDetails?.() ?? {};
+        let urls = isHttp(cd.url) ? [cd.url] : [];
+        if (urls.length === 0) {
+          // Type-aware: the fixed-page URL key varies by opportunity type (see PAGE_URL_KEYS).
+          urls = suggestions.flatMap((s) => pageUrlsFromSuggestion(oppType, s.getData?.()));
+        }
+        for (const url of urls) {
+          rows.push({ url, fixType: oppType, fixDate });
         }
       }
       return rows;
     } catch (e) {
-      log.warn(`gsc-search-analytics: fix-entity fetch failed for opp ${opp.getId()} (${opp.getType()}): ${e.message}`);
+      opportunitiesErrored += 1;
+      log.warn(`gsc-search-analytics: fix-entity fetch failed for opp ${opp.getId()} (${oppType}): ${e.message}`);
       return [];
     }
   });
@@ -202,13 +238,27 @@ export async function deriveFixedUrls(siteId, opts, context) {
   if (urlTruncated) {
     fixedUrls = fixedUrls.slice(0, MAX_FIXED_URLS);
   }
+  // BACKFILL = full measurable band (no bounds given). INCREMENTAL = since a date.
+  // EXPLICIT = a from/to window was pinned; that is a bounded, deterministic pull, NOT a
+  // backfill, so don't mislabel it.
+  let mode;
+  if (opts.since) {
+    mode = 'incremental';
+  } else if (opts.from || opts.to) {
+    mode = 'explicit';
+  } else {
+    mode = 'backfill';
+  }
   const sourcing = {
-    mode: opts.since ? 'incremental' : 'backfill',
+    mode,
     sourcedDateGroups: allDates.length,
     // distinct dates ACTUALLY in the output — recomputed AFTER the URL cap, which can trim
     // the tail of a kept date-group, so this can be < min(allDates, MAX_DATE_GROUPS).
     keptDateGroups: new Set(fixedUrls.map((f) => f.fixDate)).size,
     truncated: allDates.length > MAX_DATE_GROUPS || urlTruncated,
+    opportunitiesErrored,
+    partial: opportunitiesErrored > 0,
+    fixesSkippedNoDate,
   };
   if (sourcing.truncated) {
     log.warn(`gsc-search-analytics: sourcing truncated for site ${siteId} — kept newest ${sourcing.keptDateGroups}/${sourcing.sourcedDateGroups} date-groups (${fixedUrls.length} URLs). Narrow with an explicit window to reach older fixes.`);

--- a/src/gsc-search-analytics/derive.js
+++ b/src/gsc-search-analytics/derive.js
@@ -11,9 +11,8 @@
  */
 
 import { limitConcurrencyAllSettled } from '../support/utils.js';
-// Shared with lib.js so the derive OUTPUT bound and the runtime ABORT cap can never drift.
-// (Extract lib.js's existing MAX_FIXED_URLS/MAX_DATE_GROUPS into this new constants.js and
-// import them in both files — see Task 2, Step 3.)
+// Caps shared with lib.js (which imports the same constants) so the derive OUTPUT bound
+// here and lib.js's runtime ABORT cap stay in lock-step.
 import { MAX_FIXED_URLS, MAX_DATE_GROUPS } from './constants.js';
 
 const MAX_CONCURRENT = 10; // bound the per-opportunity FixEntity fan-out (no N+1)
@@ -142,31 +141,36 @@ export async function deriveFixedUrls(siteId, opts, context) {
   });
 
   const tasks = relevant.map((opp) => async () => {
-    const rows = [];
-    for (const status of statuses) {
-      // eslint-disable-next-line no-await-in-loop
-      const fes = await FixEntity.allByOpportunityIdAndStatus(opp.getId(), status);
-      for (const fe of fes) {
-        const raw = fe.getPublishedAt?.() ?? fe.getExecutedAt?.();
-        const fixDate = raw ? String(raw).slice(0, 10) : null;
-        if (!inRange(fixDate)) {
-          // eslint-disable-next-line no-continue
-          continue;
-        }
-        const cd = fe.getChangeDetails?.() ?? {};
-        let urls = isHttp(cd.url) ? [cd.url] : [];
-        if (urls.length === 0) {
-          // eslint-disable-next-line no-await-in-loop
-          const sugs = (await fe.getSuggestions?.()) ?? [];
-          // Type-aware: the fixed-page URL key varies by opportunity type (see PAGE_URL_KEYS).
-          urls = sugs.flatMap((s) => pageUrlsFromSuggestion(opp.getType(), s.getData?.()));
-        }
-        for (const url of urls) {
-          rows.push({ url, fixType: opp.getType(), fixDate });
+    try {
+      const rows = [];
+      for (const status of statuses) {
+        // eslint-disable-next-line no-await-in-loop
+        const fes = await FixEntity.allByOpportunityIdAndStatus(opp.getId(), status);
+        for (const fe of fes) {
+          const raw = fe.getPublishedAt?.() ?? fe.getExecutedAt?.();
+          const fixDate = raw ? String(raw).slice(0, 10) : null;
+          if (!inRange(fixDate)) {
+            // eslint-disable-next-line no-continue
+            continue;
+          }
+          const cd = fe.getChangeDetails?.() ?? {};
+          let urls = isHttp(cd.url) ? [cd.url] : [];
+          if (urls.length === 0) {
+            // eslint-disable-next-line no-await-in-loop
+            const sugs = (await fe.getSuggestions?.()) ?? [];
+            // Type-aware: the fixed-page URL key varies by opportunity type (see PAGE_URL_KEYS).
+            urls = sugs.flatMap((s) => pageUrlsFromSuggestion(opp.getType(), s.getData?.()));
+          }
+          for (const url of urls) {
+            rows.push({ url, fixType: opp.getType(), fixDate });
+          }
         }
       }
+      return rows;
+    } catch (e) {
+      log.warn(`gsc-search-analytics: fix-entity fetch failed for opp ${opp.getId()} (${opp.getType()}): ${e.message}`);
+      return [];
     }
-    return rows;
   });
 
   // limitConcurrencyAllSettled returns only the fulfilled task values (rejected ones

--- a/src/gsc-search-analytics/derive.js
+++ b/src/gsc-search-analytics/derive.js
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { limitConcurrencyAllSettled } from '../support/utils.js';
+// Shared with lib.js so the derive OUTPUT bound and the runtime ABORT cap can never drift.
+// (Extract lib.js's existing MAX_FIXED_URLS/MAX_DATE_GROUPS into this new constants.js and
+// import them in both files — see Task 2, Step 3.)
+import { MAX_FIXED_URLS, MAX_DATE_GROUPS } from './constants.js';
+
+const MAX_CONCURRENT = 10; // bound the per-opportunity FixEntity fan-out (no N+1)
+
+const iso = (d) => d.toISOString().slice(0, 10);
+const addDays = (d, n) => new Date(d.getTime() + n * 86400000);
+const toUtc = (s) => new Date(`${s}T00:00:00Z`);
+const READY_LAG = 84 + 3; // a fix matures (after-window complete) ~87 days after deploy
+const RETENTION_FLOOR = 396; // older fixes lose their before-window to GSC's ~16mo retention
+
+/**
+ * Resolve the deploy-date band to source fixes from, from a single optional `since`.
+ *   - no input  -> BACKFILL: full measurable band (~13 months ago .. ~3 months ago)
+ *   - since:D    -> INCREMENTAL: only fixes that matured (crossed the ~87-day line) since D
+ * Explicit from/to still win as low-level overrides (deterministic tests, power users).
+ * The `now` arg is injectable so the since/backfill branches are unit-testable.
+ * @param {{since?:string, from?:string, to?:string}} opts
+ * @param {Date} [now]
+ * @returns {{from: string, to: string}}
+ */
+export function resolveBand(opts = {}, now = new Date()) {
+  const { since, from, to } = opts;
+  const readyEdge = iso(addDays(now, -READY_LAG)); // ~3 months ago
+  const floor = iso(addDays(now, -RETENTION_FLOOR)); // ~13 months ago
+  const resolvedTo = to ?? readyEdge;
+  let resolvedFrom;
+  if (from) {
+    resolvedFrom = from;
+  } else if (since) {
+    const inc = iso(addDays(toUtc(since), -READY_LAG)); // fixes matured since `since`
+    resolvedFrom = inc > floor ? inc : floor; // never dip below the retention floor
+  } else {
+    resolvedFrom = floor;
+  }
+  return { from: resolvedFrom, to: resolvedTo };
+}
+
+// Where the *fixed page's* public URL lives in suggestion.data differs by opportunity
+// type (verified across all customers' spacecat.json, 2026-09-01). Reading only `data.url`
+// silently drops whole types (broken-internal-links, broken-backlinks, sitemap, alt-text,
+// redirect-chains). Map the SEO types we measure to their key; fall through the common
+// spellings for anything unlisted.
+const PAGE_URL_KEYS = {
+  'meta-tags': ['url', 'pageUrl'],
+  'broken-internal-links': ['urlFrom'],
+  'broken-backlinks': ['url_to', 'urlTo'],
+  sitemap: ['pageUrl'],
+  canonical: ['url'],
+  'structured-data': ['url'],
+  hreflang: ['url'],
+  cwv: ['url'],
+  readability: ['pageUrl', 'url'],
+  'redirect-chains': ['finalUrlFull', 'finalUrl'],
+};
+const FALLBACK_URL_KEYS = ['url', 'pageUrl', 'urlFrom', 'url_to', 'urlTo'];
+const isHttp = (v) => typeof v === 'string' && v.startsWith('http');
+
+// SEO allow-list: the DEFAULT set of opportunity types whose page-level fix has a
+// meaningful GSC web-search before/after. Everything else (a11y, forms, security,
+// paid-traffic, LLMO summarization/toc, offsite analyses, prerender, llm-error-pages) is
+// excluded up front — keeps meaningless measurements out AND bounds the fan-out.
+// alt-text is EXCLUDED by default (decision 2026-09-07): its signal is image-search, not
+// the web-search clicks/impressions/position this audit records, and it is the largest
+// volume driver (caps pressure). It is still reachable by passing fixTypes:['alt-text']
+// explicitly, which overrides this default set (see the filter in deriveFixedUrls).
+export const SEO_FIX_TYPES = new Set([
+  'meta-tags', 'broken-internal-links', 'broken-backlinks', 'sitemap', 'canonical',
+  'structured-data', 'hreflang', 'cwv', 'readability', 'redirect-chains',
+]);
+
+/**
+ * Extract the fixed-page public URL(s) from one suggestion's data, keyed by opportunity
+ * type. alt-text has no top-level URL — its per-image entries live under recommendations[].
+ * Returns [] when no public URL is present (e.g. author-only fixes carrying only a documentPath).
+ * @param {string} oppType
+ * @param {object} data - suggestion.getData()
+ * @returns {string[]}
+ */
+export function pageUrlsFromSuggestion(oppType, data) {
+  if (!data || typeof data !== 'object') {
+    return [];
+  }
+  // alt-text is the only type whose URL is nested under recommendations[]. Gate on the
+  // type: other types (e.g. paid-traffic) ALSO carry a `recommendations` array with a
+  // different shape, so this branch must not run for them.
+  if (oppType === 'alt-text' && Array.isArray(data.recommendations)) {
+    const recs = data.recommendations
+      .map((r) => r?.pageUrl ?? r?.url)
+      .filter(isHttp);
+    if (recs.length) {
+      return [...new Set(recs)];
+    }
+  }
+  const keys = PAGE_URL_KEYS[oppType] ?? FALLBACK_URL_KEYS;
+  for (const k of keys) {
+    if (isHttp(data[k])) {
+      return [data[k]];
+    }
+  }
+  return [];
+}
+
+/**
+ * Source the site's DEPLOYED/PUBLISHED fixed URLs from the data-service.
+ * @param {string} siteId
+ * @param {{since?:string,from?:string,to?:string,fixStatuses?:string[],fixTypes?:string[]}} opts
+ * @param {object} context - { dataAccess: { Opportunity, FixEntity }, log }
+ * @returns {Promise<{fixedUrls: Array<{url:string,fixType:string,fixDate:string}>,
+ *   sourcing: {mode:string, sourcedDateGroups:number, keptDateGroups:number, truncated:boolean}}>}
+ */
+export async function deriveFixedUrls(siteId, opts, context) {
+  const { dataAccess, log } = context;
+  const { Opportunity, FixEntity } = dataAccess;
+  const { from, to } = resolveBand(opts);
+  const statuses = opts.fixStatuses ?? [FixEntity.STATUSES.DEPLOYED, FixEntity.STATUSES.PUBLISHED];
+  const typeFilter = Array.isArray(opts.fixTypes) ? new Set(opts.fixTypes) : null;
+  const inRange = (d) => !!d && d >= from && d <= to;
+
+  // Explicit fixTypes OVERRIDE the default set (so `fixTypes:['alt-text']` works); with no
+  // fixTypes we fall back to the SEO_FIX_TYPES default (which excludes alt-text). Either
+  // way this bounds the FixEntity fan-out to just the relevant opportunities.
+  const opps = await Opportunity.allBySiteId(siteId);
+  const relevant = opps.filter((o) => {
+    const t = o.getType();
+    return typeFilter ? typeFilter.has(t) : SEO_FIX_TYPES.has(t);
+  });
+
+  const tasks = relevant.map((opp) => async () => {
+    const rows = [];
+    for (const status of statuses) {
+      // eslint-disable-next-line no-await-in-loop
+      const fes = await FixEntity.allByOpportunityIdAndStatus(opp.getId(), status);
+      for (const fe of fes) {
+        const raw = fe.getPublishedAt?.() ?? fe.getExecutedAt?.();
+        const fixDate = raw ? String(raw).slice(0, 10) : null;
+        if (!inRange(fixDate)) {
+          // eslint-disable-next-line no-continue
+          continue;
+        }
+        const cd = fe.getChangeDetails?.() ?? {};
+        let urls = isHttp(cd.url) ? [cd.url] : [];
+        if (urls.length === 0) {
+          // eslint-disable-next-line no-await-in-loop
+          const sugs = (await fe.getSuggestions?.()) ?? [];
+          // Type-aware: the fixed-page URL key varies by opportunity type (see PAGE_URL_KEYS).
+          urls = sugs.flatMap((s) => pageUrlsFromSuggestion(opp.getType(), s.getData?.()));
+        }
+        for (const url of urls) {
+          rows.push({ url, fixType: opp.getType(), fixDate });
+        }
+      }
+    }
+    return rows;
+  });
+
+  // limitConcurrencyAllSettled returns only the fulfilled task values (rejected ones
+  // are dropped — one opportunity's fetch failing must not sink the whole derive).
+  const settled = await limitConcurrencyAllSettled(tasks, MAX_CONCURRENT);
+  const flat = settled.flat();
+
+  // Dedupe on (url, fixDate). NOTE: if two opportunity types fixed the SAME url on the SAME
+  // day, only the first fixType survives — acceptable for a tracking record (lossy
+  // attribution), not a measurement error.
+  const seen = new Set();
+  const deduped = [];
+  for (const f of flat) {
+    const key = `${f.url} ${f.fixDate}`;
+    if (!seen.has(key)) {
+      seen.add(key);
+      deduped.push(f);
+    }
+  }
+  // Bound the output so a wide backfill can't trip lib.js's hard caps (which ABORT the
+  // whole run). Keep the MOST-RECENT MAX_DATE_GROUPS distinct fix-dates, then cap total
+  // URLs at MAX_FIXED_URLS. Report truncation honestly (it surfaces in the audit row);
+  // older history stays reachable with an explicit from/to (or an earlier `since`) window.
+  deduped.sort((a, b) => b.fixDate.localeCompare(a.fixDate)); // newest fix-date first
+  const allDates = [...new Set(deduped.map((f) => f.fixDate))];
+  const keptDates = new Set(allDates.slice(0, MAX_DATE_GROUPS));
+  let fixedUrls = deduped.filter((f) => keptDates.has(f.fixDate));
+  const urlTruncated = fixedUrls.length > MAX_FIXED_URLS;
+  if (urlTruncated) {
+    fixedUrls = fixedUrls.slice(0, MAX_FIXED_URLS);
+  }
+  const sourcing = {
+    mode: opts.since ? 'incremental' : 'backfill',
+    sourcedDateGroups: allDates.length,
+    // distinct dates ACTUALLY in the output — recomputed AFTER the URL cap, which can trim
+    // the tail of a kept date-group, so this can be < min(allDates, MAX_DATE_GROUPS).
+    keptDateGroups: new Set(fixedUrls.map((f) => f.fixDate)).size,
+    truncated: allDates.length > MAX_DATE_GROUPS || urlTruncated,
+  };
+  if (sourcing.truncated) {
+    log.warn(`gsc-search-analytics: sourcing truncated for site ${siteId} — kept newest ${sourcing.keptDateGroups}/${sourcing.sourcedDateGroups} date-groups (${fixedUrls.length} URLs). Narrow with an explicit window to reach older fixes.`);
+  }
+  log.info(`gsc-search-analytics: derived ${fixedUrls.length} fixed URLs for site ${siteId} in ${from}..${to} (${sourcing.mode})`);
+  return { fixedUrls, sourcing };
+}

--- a/src/gsc-search-analytics/lib.js
+++ b/src/gsc-search-analytics/lib.js
@@ -11,9 +11,10 @@
  */
 
 import GoogleClient from '@adobe/spacecat-shared-google-client';
+import { composeAuditURL, stripWWW } from '@adobe/spacecat-shared-utils';
 import { computeWindows, assessCompleteness, isValidFixDate } from './windows.js';
 import { fetchWindow } from './fetch.js';
-import { indexRows, lookup } from './match.js';
+import { indexRows, lookup, normalizeUrl } from './match.js';
 import { buildDelta } from './summarize.js';
 import { deriveFixedUrls } from './derive.js';
 // Shared caps (single source of truth): derive.js bounds its output to the same
@@ -146,6 +147,27 @@ export async function runGscSearchAnalytics(finalUrl, context, site, auditContex
     }, finalUrl);
   }
 
+  // The GSC client scopes every query to `page contains composeAuditURL(finalUrl)` — for
+  // krisshop that resolves (following redirects) to www.krisshop.com/en. A fixed URL
+  // outside that host+path is never queried, so it must be distinguished from "queried,
+  // no data" (not_found).
+  const scope = await composeAuditURL(finalUrl); // e.g. "www.krisshop.com/en"
+  const slash = scope.indexOf('/');
+  const scopeHost = stripWWW((slash >= 0 ? scope.slice(0, slash) : scope).toLowerCase());
+  const scopePath = slash >= 0 ? scope.slice(slash) : '/';
+  const inScope = (url) => {
+    try {
+      const u = new URL(normalizeUrl(url));
+      // path-boundary safe: `/en` must not match `/enterprise`; a bare-root base
+      // (scopePath === '/') treats every same-host URL as in scope.
+      const p = u.pathname;
+      const pathOk = p === scopePath || p.startsWith(`${scopePath}/`) || scopePath === '/';
+      return stripWWW(u.host) === scopeHost && pathOk;
+    } catch {
+      return false;
+    }
+  };
+
   const now = new Date();
   const fixes = [];
   const byDate = new Map();
@@ -188,9 +210,13 @@ export async function runGscSearchAnalytics(finalUrl, context, site, auditContex
           matchedAny = true;
         }
         let status;
-        // Completeness is checked FIRST: a not-yet-elapsed after-window legitimately
-        // returns no rows, which must read as 'incomplete', not 'not_found'.
-        if (!completeness.afterComplete || !completeness.beforeComplete) {
+        // out_of_scope is checked FIRST: a URL outside the GSC page-filter's host+path
+        // scope was never queried, so it must not masquerade as 'not_found'. Completeness
+        // is next: a not-yet-elapsed after-window legitimately returns no rows, which must
+        // read as 'incomplete', not 'not_found'.
+        if (!inScope(f.url)) {
+          status = 'out_of_scope';
+        } else if (!completeness.afterComplete || !completeness.beforeComplete) {
           status = 'incomplete';
         } else if (!found.before || !found.after) {
           status = 'not_found';
@@ -210,12 +236,16 @@ export async function runGscSearchAnalytics(finalUrl, context, site, auditContex
           dataQuality,
         });
       }
-      // Rows came back but none of this group's fixed URLs matched -> almost always a
-      // host mismatch (www/apex, or fixedUrls built from a different host than the GSC
-      // property). Surface it instead of silently reporting not_found.
+      // Prefer the real cause when any URL in this group is structurally out of scope
+      // (locale/path filtering); otherwise fall back to the host-mismatch signal — rows
+      // came back but no in-scope fixed URL matched (www/apex, or fixedUrls built from a
+      // different host than the GSC property).
       const rowsSeen = beforeMap.size + afterMap.size > 0;
-      if (!matchedAny && rowsSeen) {
-        log.warn(`gsc-search-analytics: ${fixDate} returned rows but no fixed URL matched for ${finalUrl} - likely host mismatch (www/apex or GSC property host)`);
+      const anyOutOfScope = group.some((f) => !inScope(f.url));
+      if (anyOutOfScope) {
+        log.warn(`gsc-search-analytics: ${fixDate} — one or more fixed URLs are outside the GSC fetch scope (${scope}); locale/path scoping, reported as out_of_scope for ${finalUrl}`);
+      } else if (!matchedAny && rowsSeen) {
+        log.warn(`gsc-search-analytics: ${fixDate} returned rows but no in-scope fixed URL matched for ${finalUrl}`);
       }
     } catch (e) {
       // A failure on one date-group must not wipe the others; leave a diagnostic entry.

--- a/src/gsc-search-analytics/lib.js
+++ b/src/gsc-search-analytics/lib.js
@@ -22,6 +22,10 @@ import { deriveFixedUrls } from './derive.js';
 import { MAX_FIXED_URLS, MAX_DATE_GROUPS } from './constants.js';
 
 const SCHEMA_VERSION = 1;
+// Bound the scope-resolution HTTP GET: composeAuditURL follows redirects against a live
+// origin, and a hung origin would otherwise stall the whole Lambda. On timeout we degrade
+// to all-in-scope (same as any other scope-resolution failure).
+const SCOPE_TIMEOUT_MS = 8000;
 const toDate = (s) => new Date(`${s}T00:00:00Z`);
 const clip = (s) => String(s).slice(0, 300); // bound stored error text
 
@@ -58,21 +62,35 @@ function envelope(fields, finalUrl) {
 /**
  * Tracking-only audit: for each URL ASO fixed, record its GSC clicks/impressions/
  * ctr/position for the 84 days before and after the URL's own fix date. No causal
- * claim — this is the "Measured" layer. Input is a manually-supplied list of
- * { url, fixType, fixDate } in auditContext.fixedUrls.
+ * claim — this is the "Measured" layer.
+ *
+ * Input: by DEFAULT the runner SELF-SOURCES the site's DEPLOYED/PUBLISHED fixed URLs from
+ * the data-service (deriveFixedUrls). An explicit `{ url, fixType, fixDate }[]` list in
+ * auditContext.fixedUrls (or auditContext.messageData.fixedUrls) overrides that path. On the
+ * self-source path these keyword args (from messageData, else auditContext) tune the pull:
+ *   - since        — single watermark; incremental when set, full backfill when absent.
+ *   - from / to    — low-level explicit band overrides (deterministic tests / power users).
+ *   - fixStatuses  — FixEntity statuses to source (default DEPLOYED + PUBLISHED).
+ *   - fixTypes     — opportunity types to source (default SEO set; alt-text is opt-in only).
+ * A lone scalar arg (e.g. fixTypes:'meta-tags') is coerced to a one-element array; a
+ * malformed since/from/to short-circuits to status 'invalid_input'.
  *
  * Result envelope (audit_result JSON): { schemaVersion, connected, status, fixCount,
- * measuredCount, fixes[] }. Each fix carries a `status` of one of:
+ * measuredCount, fixes[], scopeResolved?, sourcing? }. `sourcing` is present only on a
+ * self-sourced run ({ mode, sourcedDateGroups, keptDateGroups, truncated, ... }).
+ * `scopeResolved` is false when the page-scope lookup failed or timed out and every URL was
+ * therefore treated as in scope. Each fix carries a `status` of one of:
  *   measured | not_found | incomplete | invalid_date | out_of_scope | failed
  * plus before/after/delta/found and a dataQuality marker so a later reader can tell a
  * real signal from a data gap. Envelope-level `status` may also be one of:
  *   ok | not_connected | missing_fixed_urls | too_many_fixed_urls |
- *   too_many_date_groups | sourcing_failed
+ *   too_many_date_groups | sourcing_failed | invalid_input
  *
  * @param {string} finalUrl - resolved site base URL.
- * @param {object} context - audit context ({ log, ... }).
+ * @param {object} context - audit context ({ log, dataAccess, ... }).
  * @param {object} site - the site under audit.
- * @param {object} auditContext - carries fixedUrls (or messageData.fixedUrls).
+ * @param {object} auditContext - explicit fixedUrls, or messageData keyword args (since,
+ *   from, to, fixStatuses, fixTypes) driving the self-sourcing default.
  * @returns {Promise<{auditResult: object, fullAuditRef: string}>}
  */
 export async function runGscSearchAnalytics(finalUrl, context, site, auditContext = {}) {
@@ -86,6 +104,31 @@ export async function runGscSearchAnalytics(finalUrl, context, site, auditContex
   // Trigger: an absent OR empty fixedUrls both self-source (empty list == not supplied).
   if (!Array.isArray(fixedUrls) || fixedUrls.length === 0) {
     const kwargs = auditContext.messageData ?? auditContext;
+
+    // Fix 2: a malformed since/from/to (e.g. '2026-5-1') would otherwise throw a RangeError
+    // out of resolveBand and surface as an opaque 'sourcing_failed'. Reject any supplied-but-
+    // invalid date up front with a distinct, self-describing status. Reached only on the
+    // self-source path, so an explicit fixedUrls override with its own dates is never gated.
+    const badDateField = ['since', 'from', 'to']
+      .find((k) => kwargs[k] != null && !isValidFixDate(kwargs[k]));
+    if (badDateField) {
+      log.warn(`gsc-search-analytics: invalid ${badDateField} '${kwargs[badDateField]}' for ${finalUrl}`);
+      return envelope({
+        connected: null,
+        status: 'invalid_input',
+        reason: `invalid ${badDateField}: ${clip(String(kwargs[badDateField]))}`,
+        fixCount: 0,
+        measuredCount: 0,
+        fixes: [],
+      }, finalUrl);
+    }
+
+    // Fix 1: a single Slack/API value arrives scalar (fixTypes:'meta-tags'), but derive.js
+    // gates on Array.isArray — a bare string silently falls back to the default set
+    // (fixTypes) or iterates the string's characters (fixStatuses). Coerce a lone value to a
+    // one-element array; leave an absent arg undefined so derive keeps its own defaults.
+    const toList = (v) => (v == null ? undefined : [].concat(v));
+
     let derived;
     try {
       derived = await deriveFixedUrls(
@@ -94,8 +137,8 @@ export async function runGscSearchAnalytics(finalUrl, context, site, auditContex
           since: kwargs.since, // single watermark: incremental when set, backfill when absent
           from: kwargs.from, // low-level overrides (tests / power users)
           to: kwargs.to,
-          fixStatuses: kwargs.fixStatuses,
-          fixTypes: kwargs.fixTypes,
+          fixStatuses: toList(kwargs.fixStatuses),
+          fixTypes: toList(kwargs.fixTypes),
         },
         context,
       );
@@ -144,8 +187,11 @@ export async function runGscSearchAnalytics(finalUrl, context, site, auditContex
     // Repo convention (see structured-data/lib.js, opportunity-utils.checkGoogleConnection):
     // any createFrom failure means the site is not connected to GSC. Record it, don't crash.
     log.info(`gsc-search-analytics: GSC not connected for ${finalUrl}: ${e.message}`);
+    // Fix 4: a self-sourced run that connected fine but then fails createFrom keeps its
+    // sourcing telemetry, so a partial failure stays diagnosable (invalid_input deliberately
+    // does NOT — sourcing hasn't run yet at that point).
     return envelope({
-      connected: false, status: 'not_connected', reason: clip(e.message), fixCount: 0, measuredCount: 0, fixes: [],
+      connected: false, status: 'not_connected', reason: clip(e.message), fixCount: 0, measuredCount: 0, fixes: [], ...(sourcing && { sourcing }),
     }, finalUrl);
   }
 
@@ -156,12 +202,24 @@ export async function runGscSearchAnalytics(finalUrl, context, site, auditContex
   // composeAuditURL does a live HTTP GET; every other external call in this runner records
   // a status instead of throwing. A DNS/transport error here must not reject the whole audit
   // now that GSC is already connected — degrade to prior behavior (all URLs in scope).
+  // Fix 3: the try/catch below already degrades a THROW to all-in-scope, but a hung origin
+  // would never throw — it would just stall the whole Lambda. Race the live GET against a
+  // bounded timeout that rejects, so a slow origin routes into the same degrade path.
   let scope;
+  let scopeTimer;
   try {
-    scope = await composeAuditURL(finalUrl); // e.g. "www.krisshop.com/en"
+    const timeout = new Promise((_, reject) => {
+      scopeTimer = setTimeout(
+        () => reject(new Error(`scope resolution timed out after ${SCOPE_TIMEOUT_MS}ms`)),
+        SCOPE_TIMEOUT_MS,
+      );
+    });
+    scope = await Promise.race([composeAuditURL(finalUrl), timeout]); // e.g. "www.krisshop.com/en"
   } catch (e) {
     log.warn(`gsc-search-analytics: scope resolution failed for ${finalUrl}: ${e.message}; treating all fixed URLs as in scope`);
     scope = null;
+  } finally {
+    clearTimeout(scopeTimer); // cancel the pending timer whichever side of the race won
   }
   let inScope;
   if (!scope) {
@@ -206,6 +264,25 @@ export async function runGscSearchAnalytics(finalUrl, context, site, auditContex
 
   for (const [fixDate, group] of byDate) {
     const windows = computeWindows(fixDate);
+    // Fix 5: compute each fix's in-scope-ness ONCE and reuse it below (classification, the
+    // group-level warning, and the whole-group skip) instead of calling inScope(f.url) twice
+    // per URL.
+    const groupInScope = group.map((f) => inScope(f.url));
+    const anyOutOfScope = groupInScope.some((v) => !v);
+
+    // Fix 5: if EVERY URL in this date-group is out of scope, none of them will ever be
+    // queried — skip BOTH paginated GSC pulls entirely and record them straight as
+    // out_of_scope. (A GSC round-trip for a group with no in-scope URL is pure waste.)
+    if (!groupInScope.some((v) => v)) {
+      log.warn(`gsc-search-analytics: ${fixDate} — all fixed URLs are outside the GSC fetch scope (${scope}); skipping GSC fetch, reported as out_of_scope for ${finalUrl}`);
+      for (const f of group) {
+        // Fix 6: never queried, so windows/before/after/delta stay null (baseFix shape).
+        fixes.push(baseFix(f, 'out_of_scope'));
+      }
+      // eslint-disable-next-line no-continue
+      continue;
+    }
+
     const completeness = assessCompleteness(windows, now);
     try {
       /* eslint-disable no-await-in-loop */
@@ -222,7 +299,16 @@ export async function runGscSearchAnalytics(finalUrl, context, site, auditContex
         truncated: [beforeRes, afterRes].some((r) => r.truncated),
       };
       let matchedAny = false;
-      for (const f of group) {
+      for (let i = 0; i < group.length; i += 1) {
+        const f = group[i];
+        // out_of_scope is checked FIRST: a URL outside the GSC page-filter's host+path scope
+        // was never queried, so it must not masquerade as 'not_found' — and Fix 6 nulls its
+        // windows/before/after/delta (baseFix shape) so the row isn't misleading.
+        if (!groupInScope[i]) {
+          fixes.push(baseFix(f, 'out_of_scope'));
+          // eslint-disable-next-line no-continue
+          continue;
+        }
         const b = lookup(beforeMap, f.url);
         const a = lookup(afterMap, f.url);
         const found = { before: !!b, after: !!a };
@@ -230,13 +316,9 @@ export async function runGscSearchAnalytics(finalUrl, context, site, auditContex
           matchedAny = true;
         }
         let status;
-        // out_of_scope is checked FIRST: a URL outside the GSC page-filter's host+path
-        // scope was never queried, so it must not masquerade as 'not_found'. Completeness
-        // is next: a not-yet-elapsed after-window legitimately returns no rows, which must
-        // read as 'incomplete', not 'not_found'.
-        if (!inScope(f.url)) {
-          status = 'out_of_scope';
-        } else if (!completeness.afterComplete || !completeness.beforeComplete) {
+        // Completeness is next: a not-yet-elapsed after-window legitimately returns no rows,
+        // which must read as 'incomplete', not 'not_found'.
+        if (!completeness.afterComplete || !completeness.beforeComplete) {
           status = 'incomplete';
         } else if (!found.before || !found.after) {
           status = 'not_found';
@@ -256,12 +338,11 @@ export async function runGscSearchAnalytics(finalUrl, context, site, auditContex
           dataQuality,
         });
       }
-      // Prefer the real cause when any URL in this group is structurally out of scope
-      // (locale/path filtering); otherwise fall back to the host-mismatch signal — rows
-      // came back but no in-scope fixed URL matched (www/apex, or fixedUrls built from a
+      // Prefer the real cause when SOME (but not all) URLs in this group are structurally out
+      // of scope (locale/path filtering); otherwise fall back to the host-mismatch signal —
+      // rows came back but no in-scope fixed URL matched (www/apex, or fixedUrls built from a
       // different host than the GSC property).
       const rowsSeen = beforeMap.size + afterMap.size > 0;
-      const anyOutOfScope = group.some((f) => !inScope(f.url));
       if (anyOutOfScope) {
         log.warn(`gsc-search-analytics: ${fixDate} — one or more fixed URLs are outside the GSC fetch scope (${scope}); locale/path scoping, reported as out_of_scope for ${finalUrl}`);
       } else if (!matchedAny && rowsSeen) {
@@ -278,6 +359,9 @@ export async function runGscSearchAnalytics(finalUrl, context, site, auditContex
 
   const measuredCount = fixes.filter((f) => f.status === 'measured').length;
   return envelope({
-    connected: true, status: 'ok', fixCount: fixes.length, measuredCount, fixes, ...(sourcing && { sourcing }),
+    // Fix 4: surface whether page-scope resolution succeeded. false => composeAuditURL failed
+    // or timed out and every URL was treated as in scope (out_of_scope verdicts are then
+    // unreliable), so the degraded run stays queryable.
+    connected: true, status: 'ok', fixCount: fixes.length, measuredCount, fixes, scopeResolved: scope !== null, ...(sourcing && { sourcing }),
   }, finalUrl);
 }

--- a/src/gsc-search-analytics/lib.js
+++ b/src/gsc-search-analytics/lib.js
@@ -80,19 +80,30 @@ export async function runGscSearchAnalytics(finalUrl, context, site, auditContex
   // Self-source when no explicit list is supplied: read the deploy-date range (and
   // optional filters) from the Slack/API keyword args (messageData) or auditContext,
   // and gather the site's DEPLOYED/PUBLISHED fixed URLs from the data-service.
+  // Trigger: an absent OR empty fixedUrls both self-source (empty list == not supplied).
   if (!Array.isArray(fixedUrls) || fixedUrls.length === 0) {
-    const p = auditContext.messageData ?? auditContext;
-    const derived = await deriveFixedUrls(
-      site.getId(),
-      {
-        since: p.since, // single watermark: incremental when set, backfill when absent
-        from: p.from, // low-level overrides (tests / power users)
-        to: p.to,
-        fixStatuses: p.fixStatuses,
-        fixTypes: p.fixTypes,
-      },
-      context,
-    );
+    const kwargs = auditContext.messageData ?? auditContext;
+    let derived;
+    try {
+      derived = await deriveFixedUrls(
+        site.getId(),
+        {
+          since: kwargs.since, // single watermark: incremental when set, backfill when absent
+          from: kwargs.from, // low-level overrides (tests / power users)
+          to: kwargs.to,
+          fixStatuses: kwargs.fixStatuses,
+          fixTypes: kwargs.fixTypes,
+        },
+        context,
+      );
+    } catch (e) {
+      // Mirror the createFrom handling below: a data-layer failure records a status
+      // instead of rejecting out of the whole audit.
+      log.error(`gsc-search-analytics: self-source failed for ${finalUrl}: ${e.message}`);
+      return envelope({
+        connected: null, status: 'sourcing_failed', reason: clip(e.message), fixCount: 0, measuredCount: 0, fixes: [],
+      }, finalUrl);
+    }
     fixedUrls = derived.fixedUrls;
     sourcing = derived.sourcing; // { mode, sourcedDateGroups, keptDateGroups, truncated }
   }
@@ -100,7 +111,7 @@ export async function runGscSearchAnalytics(finalUrl, context, site, auditContex
   if (!Array.isArray(fixedUrls) || fixedUrls.length === 0) {
     log.info(`gsc-search-analytics: no fixedUrls supplied or derived for ${finalUrl}`);
     return envelope({
-      connected: null, status: 'missing_fixed_urls', fixCount: 0, measuredCount: 0, fixes: [],
+      connected: null, status: 'missing_fixed_urls', fixCount: 0, measuredCount: 0, fixes: [], ...(sourcing && { sourcing }),
     }, finalUrl);
   }
 

--- a/src/gsc-search-analytics/lib.js
+++ b/src/gsc-search-analytics/lib.js
@@ -63,9 +63,11 @@ function envelope(fields, finalUrl) {
  *
  * Result envelope (audit_result JSON): { schemaVersion, connected, status, fixCount,
  * measuredCount, fixes[] }. Each fix carries a `status` of one of:
- *   measured | not_found | incomplete | invalid_date | failed
+ *   measured | not_found | incomplete | invalid_date | out_of_scope | failed
  * plus before/after/delta/found and a dataQuality marker so a later reader can tell a
- * real signal from a data gap.
+ * real signal from a data gap. Envelope-level `status` may also be one of:
+ *   ok | not_connected | missing_fixed_urls | too_many_fixed_urls |
+ *   too_many_date_groups | sourcing_failed
  *
  * @param {string} finalUrl - resolved site base URL.
  * @param {object} context - audit context ({ log, ... }).
@@ -151,22 +153,40 @@ export async function runGscSearchAnalytics(finalUrl, context, site, auditContex
   // krisshop that resolves (following redirects) to www.krisshop.com/en. A fixed URL
   // outside that host+path is never queried, so it must be distinguished from "queried,
   // no data" (not_found).
-  const scope = await composeAuditURL(finalUrl); // e.g. "www.krisshop.com/en"
-  const slash = scope.indexOf('/');
-  const scopeHost = stripWWW((slash >= 0 ? scope.slice(0, slash) : scope).toLowerCase());
-  const scopePath = slash >= 0 ? scope.slice(slash) : '/';
-  const inScope = (url) => {
-    try {
-      const u = new URL(normalizeUrl(url));
-      // path-boundary safe: `/en` must not match `/enterprise`; a bare-root base
-      // (scopePath === '/') treats every same-host URL as in scope.
-      const p = u.pathname;
-      const pathOk = p === scopePath || p.startsWith(`${scopePath}/`) || scopePath === '/';
-      return stripWWW(u.host) === scopeHost && pathOk;
-    } catch {
-      return false;
-    }
-  };
+  // composeAuditURL does a live HTTP GET; every other external call in this runner records
+  // a status instead of throwing. A DNS/transport error here must not reject the whole audit
+  // now that GSC is already connected — degrade to prior behavior (all URLs in scope).
+  let scope;
+  try {
+    scope = await composeAuditURL(finalUrl); // e.g. "www.krisshop.com/en"
+  } catch (e) {
+    log.warn(`gsc-search-analytics: scope resolution failed for ${finalUrl}: ${e.message}; treating all fixed URLs as in scope`);
+    scope = null;
+  }
+  let inScope;
+  if (!scope) {
+    inScope = () => true;
+  } else {
+    const slash = scope.indexOf('/');
+    const scopeHost = stripWWW((slash >= 0 ? scope.slice(0, slash) : scope).toLowerCase());
+    // composeAuditURL leaves a trailing slash on multi-segment paths ("/en/") while the
+    // fixed-URL side is normalized (match.js normalizeUrl strips it), so strip it here too
+    // to keep both sides aligned; a bare-root path ("/") is left as-is.
+    const rawPath = slash >= 0 ? scope.slice(slash) : '/';
+    const scopePath = rawPath.length > 1 ? rawPath.replace(/\/+$/, '') : rawPath;
+    inScope = (url) => {
+      try {
+        const u = new URL(normalizeUrl(url));
+        // path-boundary safe: `/en` must not match `/enterprise`; a bare-root base
+        // (scopePath === '/') treats every same-host URL as in scope.
+        const p = u.pathname;
+        const pathOk = p === scopePath || p.startsWith(`${scopePath}/`) || scopePath === '/';
+        return stripWWW(u.host) === scopeHost && pathOk;
+      } catch {
+        return false;
+      }
+    };
+  }
 
   const now = new Date();
   const fixes = [];

--- a/src/gsc-search-analytics/lib.js
+++ b/src/gsc-search-analytics/lib.js
@@ -15,12 +15,12 @@ import { computeWindows, assessCompleteness, isValidFixDate } from './windows.js
 import { fetchWindow } from './fetch.js';
 import { indexRows, lookup } from './match.js';
 import { buildDelta } from './summarize.js';
+import { deriveFixedUrls } from './derive.js';
+// Shared caps (single source of truth): derive.js bounds its output to the same
+// numbers this file uses as the runtime abort cap, so they cannot drift apart.
+import { MAX_FIXED_URLS, MAX_DATE_GROUPS } from './constants.js';
 
 const SCHEMA_VERSION = 1;
-const MAX_FIXED_URLS = 500; // guard against an unbounded, Lambda-timeout-risking run
-// Each distinct fix date is one date-group = up to two paginated window pulls run
-// sequentially, so cap the number of groups to stay well inside the Lambda timeout.
-const MAX_DATE_GROUPS = 30;
 const toDate = (s) => new Date(`${s}T00:00:00Z`);
 const clip = (s) => String(s).slice(0, 300); // bound stored error text
 
@@ -74,10 +74,31 @@ function envelope(fields, finalUrl) {
  */
 export async function runGscSearchAnalytics(finalUrl, context, site, auditContext = {}) {
   const { log } = context;
-  const fixedUrls = auditContext.fixedUrls ?? auditContext.messageData?.fixedUrls;
+  let fixedUrls = auditContext.fixedUrls ?? auditContext.messageData?.fixedUrls;
+  let sourcing; // set only on the self-sourced path; surfaced in the final envelope
+
+  // Self-source when no explicit list is supplied: read the deploy-date range (and
+  // optional filters) from the Slack/API keyword args (messageData) or auditContext,
+  // and gather the site's DEPLOYED/PUBLISHED fixed URLs from the data-service.
+  if (!Array.isArray(fixedUrls) || fixedUrls.length === 0) {
+    const p = auditContext.messageData ?? auditContext;
+    const derived = await deriveFixedUrls(
+      site.getId(),
+      {
+        since: p.since, // single watermark: incremental when set, backfill when absent
+        from: p.from, // low-level overrides (tests / power users)
+        to: p.to,
+        fixStatuses: p.fixStatuses,
+        fixTypes: p.fixTypes,
+      },
+      context,
+    );
+    fixedUrls = derived.fixedUrls;
+    sourcing = derived.sourcing; // { mode, sourcedDateGroups, keptDateGroups, truncated }
+  }
 
   if (!Array.isArray(fixedUrls) || fixedUrls.length === 0) {
-    log.info(`gsc-search-analytics: no fixedUrls supplied for ${finalUrl}`);
+    log.info(`gsc-search-analytics: no fixedUrls supplied or derived for ${finalUrl}`);
     return envelope({
       connected: null, status: 'missing_fixed_urls', fixCount: 0, measuredCount: 0, fixes: [],
     }, finalUrl);
@@ -196,6 +217,6 @@ export async function runGscSearchAnalytics(finalUrl, context, site, auditContex
 
   const measuredCount = fixes.filter((f) => f.status === 'measured').length;
   return envelope({
-    connected: true, status: 'ok', fixCount: fixes.length, measuredCount, fixes,
+    connected: true, status: 'ok', fixCount: fixes.length, measuredCount, fixes, ...(sourcing && { sourcing }),
   }, finalUrl);
 }

--- a/src/gsc-search-analytics/windows.js
+++ b/src/gsc-search-analytics/windows.js
@@ -10,7 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
-const DAYS = 84; // 12 weeks
+export const DAYS = 84; // 12 weeks
 // GSC finalizes data with a ~2-3 day lag; treat the trailing 3 days as not yet available.
 export const GSC_LAG_DAYS = 3;
 // GSC retains ~16 months of history; older data falls off and returns empty.

--- a/test/audits/gsc-search-analytics/derive.test.js
+++ b/test/audits/gsc-search-analytics/derive.test.js
@@ -221,4 +221,20 @@ describe('deriveFixedUrls', () => {
     const out = await deriveFixedUrls('site-1', { since: '2026-08-01' }, context);
     expect(out.sourcing.mode).to.equal('incremental'); // opts.since truthy branch
   });
+
+  it('logs and drops a per-opportunity fetch failure without sinking the rest', async () => {
+    Opportunity.allBySiteId.resolves([
+      { getId: () => 'op1', getType: () => 'meta-tags' },
+      { getId: () => 'op2', getType: () => 'meta-tags' },
+    ]);
+    FixEntity.allByOpportunityIdAndStatus.withArgs('op1', 'DEPLOYED').rejects(new Error('boom'));
+    FixEntity.allByOpportunityIdAndStatus.withArgs('op2', 'DEPLOYED')
+      .resolves([mkFe({ getChangeDetails: () => ({ url: 'https://k/ok' }) })]);
+
+    const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-06-05' }, context);
+
+    // op2's URL survives, op1's rejected fetch is dropped (not sunk) and logged
+    expect(out.fixedUrls.map((f) => f.url)).to.deep.equal(['https://k/ok']);
+    expect(context.log.warn).to.have.been.called;
+  });
 });

--- a/test/audits/gsc-search-analytics/derive.test.js
+++ b/test/audits/gsc-search-analytics/derive.test.js
@@ -2,7 +2,9 @@
 import { expect, use } from 'chai';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
-import { deriveFixedUrls, resolveBand, pageUrlsFromSuggestion } from '../../../src/gsc-search-analytics/derive.js';
+import {
+  deriveFixedUrls, resolveBand, pageUrlsFromSuggestion, SEO_FIX_TYPES, PAGE_URL_KEYS,
+} from '../../../src/gsc-search-analytics/derive.js';
 
 use(sinonChai);
 
@@ -15,6 +17,20 @@ describe('pageUrlsFromSuggestion', () => {
       .to.deep.equal(['https://k/to']);
     expect(pageUrlsFromSuggestion('sitemap', { pageUrl: 'https://k/p', sitemapUrl: 'https://k/sm.xml' }))
       .to.deep.equal(['https://k/p']);
+  });
+
+  it('resolves the broken-internal-links snake_case url_from and the redirect-chains keys (fix 1)', () => {
+    // snake_case spelling must resolve (it was silently yielding 0 URLs before)
+    expect(pageUrlsFromSuggestion('broken-internal-links', { url_from: 'https://k/from' }))
+      .to.deep.equal(['https://k/from']);
+    // camelCase still wins when both are present (first key match)
+    expect(pageUrlsFromSuggestion('broken-internal-links', { urlFrom: 'https://k/camel', url_from: 'https://k/snake' }))
+      .to.deep.equal(['https://k/camel']);
+    // redirect-chains resolves via finalUrlFull, and via the sourceUrl fallback
+    expect(pageUrlsFromSuggestion('redirect-chains', { finalUrlFull: 'https://k/final' }))
+      .to.deep.equal(['https://k/final']);
+    expect(pageUrlsFromSuggestion('redirect-chains', { sourceUrl: 'https://k/src' }))
+      .to.deep.equal(['https://k/src']);
   });
 
   it('reads alt-text from nested recommendations[], deduped, and only for alt-text', () => {
@@ -31,11 +47,24 @@ describe('pageUrlsFromSuggestion', () => {
   });
 });
 
+describe('SEO_FIX_TYPES to PAGE_URL_KEYS contract', () => {
+  it('every SEO fix type has an explicit PAGE_URL_KEYS mapping (no silent FALLBACK)', () => {
+    for (const type of SEO_FIX_TYPES) {
+      expect(PAGE_URL_KEYS, `missing PAGE_URL_KEYS mapping for SEO type ${type}`)
+        .to.have.property(type);
+    }
+    // alt-text is intentionally NOT in PAGE_URL_KEYS (nor in SEO_FIX_TYPES): its URL is nested
+    // under recommendations[] and handled by the dedicated branch in pageUrlsFromSuggestion.
+    expect([...SEO_FIX_TYPES]).to.not.include('alt-text');
+    expect(PAGE_URL_KEYS).to.not.have.property('alt-text');
+  });
+});
+
 describe('resolveBand', () => {
   const now = new Date('2026-09-01T00:00:00Z');
 
   it('backfills the full band when no input is given', () => {
-    // ~13 months ago .. ~3 months ago
+    // ~13 months ago .. ~3 months ago (READY_LAG=87, RETENTION_FLOOR=396, tied to windows.js)
     expect(resolveBand({}, now)).to.deep.equal({ from: '2025-08-01', to: '2026-06-06' });
   });
 
@@ -56,13 +85,17 @@ describe('resolveBand', () => {
   });
 });
 
+// A fix entity as returned inside getAllFixesWithSuggestionsByOpportunityId's rows.
 const mkFe = (over) => ({
+  getStatus: () => 'DEPLOYED',
   getPublishedAt: () => null,
   getExecutedAt: () => '2026-05-04T10:00:00.000Z',
   getChangeDetails: () => ({}),
-  getSuggestions: async () => [],
   ...over,
 });
+// One { fixEntity, suggestions } row — the shape the batch data-access method returns
+// (suggestions are ALREADY attached, so derive never calls fe.getSuggestions()).
+const mkRow = (fixEntity, suggestions = []) => ({ fixEntity, suggestions });
 
 describe('deriveFixedUrls', () => {
   const sandbox = sinon.createSandbox();
@@ -73,7 +106,7 @@ describe('deriveFixedUrls', () => {
   beforeEach(() => {
     FixEntity = {
       STATUSES: { DEPLOYED: 'DEPLOYED', PUBLISHED: 'PUBLISHED' },
-      allByOpportunityIdAndStatus: sandbox.stub().resolves([]),
+      getAllFixesWithSuggestionsByOpportunityId: sandbox.stub().resolves([]),
     };
     Opportunity = { allBySiteId: sandbox.stub().resolves([]) };
     context = { log: { info: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub() }, dataAccess: { Opportunity, FixEntity } };
@@ -83,27 +116,40 @@ describe('deriveFixedUrls', () => {
 
   it('pulls URL from changeDetails.url and type from the opportunity', async () => {
     Opportunity.allBySiteId.resolves([{ getId: () => 'op1', getType: () => 'meta-tags' }]);
-    FixEntity.allByOpportunityIdAndStatus
-      .withArgs('op1', 'DEPLOYED')
-      .resolves([mkFe({ getChangeDetails: () => ({ url: 'https://krisshop.com/en/brands/loccitane.html' }) })]);
+    FixEntity.getAllFixesWithSuggestionsByOpportunityId
+      .withArgs('op1')
+      .resolves([mkRow(mkFe({ getChangeDetails: () => ({ url: 'https://krisshop.com/en/brands/loccitane.html' }) }))]);
 
     const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-06-05' }, context);
 
     expect(out.fixedUrls).to.deep.equal([
       { url: 'https://krisshop.com/en/brands/loccitane.html', fixType: 'meta-tags', fixDate: '2026-05-04' },
     ]);
-    expect(out.sourcing).to.include({ mode: 'backfill', truncated: false });
+    // explicit from/to window => mode 'explicit' (a bounded pull, NOT a backfill); nothing partial
+    expect(out.sourcing).to.include({
+      mode: 'explicit', truncated: false, partial: false, opportunitiesErrored: 0,
+    });
   });
 
-  it('falls back to the linked suggestion, using the type-aware key (bbl uses urlFrom, not url)', async () => {
+  it('falls back to the linked suggestion, using the type-aware key (broken-internal-links uses urlFrom, not url)', async () => {
     Opportunity.allBySiteId.resolves([{ getId: () => 'op1', getType: () => 'broken-internal-links' }]);
-    FixEntity.allByOpportunityIdAndStatus.withArgs('op1', 'DEPLOYED').resolves([mkFe({
+    FixEntity.getAllFixesWithSuggestionsByOpportunityId.withArgs('op1').resolves([mkRow(mkFe(), [
       // broken-internal-links stores the fixed page under data.urlFrom — a plain data.url read would drop it
-      getSuggestions: async () => [{ getData: () => ({ urlFrom: 'https://krisshop.com/en/x.html', urlTo: 'https://krisshop.com/en/target' }) }],
-    })]);
+      { getData: () => ({ urlFrom: 'https://krisshop.com/en/x.html', urlTo: 'https://krisshop.com/en/target' }) },
+    ])]);
 
     const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-06-05' }, context);
     expect(out.fixedUrls.map((f) => f.url)).to.deep.equal(['https://krisshop.com/en/x.html']);
+  });
+
+  it('resolves a redirect-chains fix via the linked suggestion key', async () => {
+    Opportunity.allBySiteId.resolves([{ getId: () => 'op1', getType: () => 'redirect-chains' }]);
+    FixEntity.getAllFixesWithSuggestionsByOpportunityId.withArgs('op1').resolves([mkRow(mkFe(), [
+      { getData: () => ({ finalUrlFull: 'https://krisshop.com/en/final.html' }) },
+    ])]);
+
+    const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-06-05' }, context);
+    expect(out.fixedUrls.map((f) => f.url)).to.deep.equal(['https://krisshop.com/en/final.html']);
   });
 
   it('excludes non-SEO opportunity types (SEO allow-list) without fetching their fix entities', async () => {
@@ -113,16 +159,27 @@ describe('deriveFixedUrls', () => {
     ]);
     const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-06-05' }, context);
     expect(out.fixedUrls).to.deep.equal([]);
-    expect(FixEntity.allByOpportunityIdAndStatus).to.not.have.been.called;
+    expect(FixEntity.getAllFixesWithSuggestionsByOpportunityId).to.not.have.been.called;
   });
 
   it('filters out fixes outside the date range', async () => {
     Opportunity.allBySiteId.resolves([{ getId: () => 'op1', getType: () => 'meta-tags' }]);
-    FixEntity.allByOpportunityIdAndStatus.withArgs('op1', 'DEPLOYED').resolves([
-      mkFe({ getExecutedAt: () => '2020-01-01T00:00:00Z', getChangeDetails: () => ({ url: 'https://k/old' }) }),
+    FixEntity.getAllFixesWithSuggestionsByOpportunityId.withArgs('op1').resolves([
+      mkRow(mkFe({ getExecutedAt: () => '2020-01-01T00:00:00Z', getChangeDetails: () => ({ url: 'https://k/old' }) })),
     ]);
     const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-06-05' }, context);
     expect(out.fixedUrls).to.deep.equal([]);
+  });
+
+  it('skips fixes whose status is not in the requested set (in-memory status filter)', async () => {
+    Opportunity.allBySiteId.resolves([{ getId: () => 'op1', getType: () => 'meta-tags' }]);
+    FixEntity.getAllFixesWithSuggestionsByOpportunityId.withArgs('op1').resolves([
+      // getAllFixesWithSuggestionsByOpportunityId returns EVERY status; PENDING must be dropped
+      mkRow(mkFe({ getStatus: () => 'PENDING', getChangeDetails: () => ({ url: 'https://k/pending' }) })),
+      mkRow(mkFe({ getStatus: () => 'DEPLOYED', getChangeDetails: () => ({ url: 'https://k/deployed' }) })),
+    ]);
+    const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-06-05' }, context);
+    expect(out.fixedUrls.map((f) => f.url)).to.deep.equal(['https://k/deployed']);
   });
 
   it('honours fixTypes filter and dedupes on (url, fixDate)', async () => {
@@ -130,20 +187,20 @@ describe('deriveFixedUrls', () => {
       { getId: () => 'op1', getType: () => 'meta-tags' },
       { getId: () => 'op2', getType: () => 'alt-text' },
     ]);
-    FixEntity.allByOpportunityIdAndStatus.withArgs('op1', 'DEPLOYED').resolves([
-      mkFe({ getChangeDetails: () => ({ url: 'https://k/a' }) }),
-      mkFe({ getChangeDetails: () => ({ url: 'https://k/a' }) }), // dup
+    FixEntity.getAllFixesWithSuggestionsByOpportunityId.withArgs('op1').resolves([
+      mkRow(mkFe({ getChangeDetails: () => ({ url: 'https://k/a' }) })),
+      mkRow(mkFe({ getChangeDetails: () => ({ url: 'https://k/a' }) })), // dup
     ]);
     const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-06-05', fixTypes: ['meta-tags'] }, context);
     expect(out.fixedUrls).to.have.length(1);
-    expect(FixEntity.allByOpportunityIdAndStatus).to.not.have.been.calledWith('op2', 'DEPLOYED');
+    expect(FixEntity.getAllFixesWithSuggestionsByOpportunityId).to.not.have.been.calledWith('op2');
   });
 
   it('explicit fixTypes:[alt-text] overrides the default set (alt-text not in SEO_FIX_TYPES)', async () => {
     Opportunity.allBySiteId.resolves([{ getId: () => 'op1', getType: () => 'alt-text' }]);
-    FixEntity.allByOpportunityIdAndStatus.withArgs('op1', 'DEPLOYED').resolves([mkFe({
-      getSuggestions: async () => [{ getData: () => ({ recommendations: [{ pageUrl: 'https://k/en/img.html' }] }) }],
-    })]);
+    FixEntity.getAllFixesWithSuggestionsByOpportunityId.withArgs('op1').resolves([mkRow(mkFe(), [
+      { getData: () => ({ recommendations: [{ pageUrl: 'https://k/en/img.html' }] }) },
+    ])]);
     const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-06-05', fixTypes: ['alt-text'] }, context);
     expect(out.fixedUrls.map((f) => f.url)).to.deep.equal(['https://k/en/img.html']);
   });
@@ -155,13 +212,13 @@ describe('deriveFixedUrls', () => {
       const id = `op${i}`;
       const date = `2026-06-${String(i + 1).padStart(2, '0')}`; // wide spread within band
       opps.push({ getId: () => id, getType: () => 'meta-tags' });
-      FixEntity.allByOpportunityIdAndStatus.withArgs(id, 'DEPLOYED').resolves([mkFe({
+      FixEntity.getAllFixesWithSuggestionsByOpportunityId.withArgs(id).resolves([mkRow(mkFe({
         getExecutedAt: () => `${date}T00:00:00Z`,
         getChangeDetails: () => ({ url: `https://k/en/p${i}` }),
-      })]);
+      }))]);
     }
     Opportunity.allBySiteId.resolves(opps);
-    const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-07-15' }, context); // backfill (no since)
+    const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-07-15' }, context); // explicit window
     const distinctDates = new Set(out.fixedUrls.map((f) => f.fixDate));
     expect(distinctDates.size).to.equal(30); // capped
     expect(out.sourcing).to.include({ truncated: true, sourcedDateGroups: 31, keptDateGroups: 30 });
@@ -174,10 +231,10 @@ describe('deriveFixedUrls', () => {
       suggestions.push({ getData: () => ({ url: `https://k/en/p${i}` }) });
     }
     Opportunity.allBySiteId.resolves([{ getId: () => 'op1', getType: () => 'meta-tags' }]);
-    FixEntity.allByOpportunityIdAndStatus.withArgs('op1', 'DEPLOYED').resolves([mkFe({
+    FixEntity.getAllFixesWithSuggestionsByOpportunityId.withArgs('op1').resolves([mkRow(mkFe({
       getExecutedAt: () => '2026-05-04T00:00:00Z',
-      getSuggestions: async () => suggestions, // changeDetails.url absent → suggestion path
-    })]);
+      // changeDetails.url absent (mkFe default {}) => suggestion path
+    }), suggestions)]);
     const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-07-15' }, context);
     expect(out.fixedUrls).to.have.length(500); // urlTruncated branch exercised
     expect(out.sourcing).to.include({ truncated: true, keptDateGroups: 1 });
@@ -185,34 +242,35 @@ describe('deriveFixedUrls', () => {
 
   it('prefers getPublishedAt over getExecutedAt when present', async () => {
     Opportunity.allBySiteId.resolves([{ getId: () => 'op1', getType: () => 'meta-tags' }]);
-    FixEntity.allByOpportunityIdAndStatus.withArgs('op1', 'DEPLOYED').resolves([mkFe({
+    FixEntity.getAllFixesWithSuggestionsByOpportunityId.withArgs('op1').resolves([mkRow(mkFe({
       getPublishedAt: () => '2026-05-10T09:00:00Z', // published wins over executed
       getExecutedAt: () => '2026-05-04T10:00:00Z',
       getChangeDetails: () => ({ url: 'https://k/pub' }),
-    })]);
+    }))]);
     const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-06-05' }, context);
     expect(out.fixedUrls).to.deep.equal([{ url: 'https://k/pub', fixType: 'meta-tags', fixDate: '2026-05-10' }]);
   });
 
-  it('skips a fix entity with neither published nor executed date', async () => {
+  it('skips a fix entity with neither published nor executed date and counts it', async () => {
     Opportunity.allBySiteId.resolves([{ getId: () => 'op1', getType: () => 'meta-tags' }]);
-    FixEntity.allByOpportunityIdAndStatus.withArgs('op1', 'DEPLOYED').resolves([mkFe({
+    FixEntity.getAllFixesWithSuggestionsByOpportunityId.withArgs('op1').resolves([mkRow(mkFe({
       getPublishedAt: () => null,
-      getExecutedAt: () => null, // raw null -> fixDate null -> filtered out of range
+      getExecutedAt: () => null, // raw null -> fixDate null -> skipped and counted
       getChangeDetails: () => ({ url: 'https://k/x' }),
-    })]);
+    }))]);
     const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-06-05' }, context);
     expect(out.fixedUrls).to.deep.equal([]);
+    expect(out.sourcing.fixesSkippedNoDate).to.equal(1);
   });
 
-  it('tolerates missing getChangeDetails/getSuggestions accessors', async () => {
+  it('tolerates a missing getChangeDetails accessor and empty suggestions', async () => {
     Opportunity.allBySiteId.resolves([{ getId: () => 'op1', getType: () => 'meta-tags' }]);
-    FixEntity.allByOpportunityIdAndStatus.withArgs('op1', 'DEPLOYED').resolves([{
+    FixEntity.getAllFixesWithSuggestionsByOpportunityId.withArgs('op1').resolves([mkRow({
+      getStatus: () => 'DEPLOYED',
       getPublishedAt: () => null,
       getExecutedAt: () => '2026-05-04T00:00:00Z',
       getChangeDetails: undefined, // exercises `?.` + `?? {}` fallback
-      getSuggestions: undefined, // exercises `?.` + `?? []` fallback
-    }]);
+    }, [])]);
     const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-06-05' }, context);
     expect(out.fixedUrls).to.deep.equal([]);
   });
@@ -222,19 +280,27 @@ describe('deriveFixedUrls', () => {
     expect(out.sourcing.mode).to.equal('incremental'); // opts.since truthy branch
   });
 
-  it('logs and drops a per-opportunity fetch failure without sinking the rest', async () => {
+  it('reports backfill mode (and clean telemetry) when neither since nor from/to is given', async () => {
+    const out = await deriveFixedUrls('site-1', {}, context);
+    expect(out.sourcing.mode).to.equal('backfill'); // no bounds => full backfill
+    expect(out.sourcing).to.include({ partial: false, opportunitiesErrored: 0, fixesSkippedNoDate: 0 });
+  });
+
+  it('logs and drops a per-opportunity fetch failure and marks the sourcing partial', async () => {
     Opportunity.allBySiteId.resolves([
       { getId: () => 'op1', getType: () => 'meta-tags' },
       { getId: () => 'op2', getType: () => 'meta-tags' },
     ]);
-    FixEntity.allByOpportunityIdAndStatus.withArgs('op1', 'DEPLOYED').rejects(new Error('boom'));
-    FixEntity.allByOpportunityIdAndStatus.withArgs('op2', 'DEPLOYED')
-      .resolves([mkFe({ getChangeDetails: () => ({ url: 'https://k/ok' }) })]);
+    FixEntity.getAllFixesWithSuggestionsByOpportunityId.withArgs('op1').rejects(new Error('boom'));
+    FixEntity.getAllFixesWithSuggestionsByOpportunityId.withArgs('op2')
+      .resolves([mkRow(mkFe({ getChangeDetails: () => ({ url: 'https://k/ok' }) }))]);
 
     const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-06-05' }, context);
 
-    // op2's URL survives, op1's rejected fetch is dropped (not sunk) and logged
+    // op2's URL survives, op1's rejected fetch is dropped (not sunk), logged, and counted
     expect(out.fixedUrls.map((f) => f.url)).to.deep.equal(['https://k/ok']);
     expect(context.log.warn).to.have.been.called;
+    expect(out.sourcing.opportunitiesErrored).to.equal(1);
+    expect(out.sourcing.partial).to.equal(true);
   });
 });

--- a/test/audits/gsc-search-analytics/derive.test.js
+++ b/test/audits/gsc-search-analytics/derive.test.js
@@ -1,0 +1,224 @@
+/* eslint-env mocha */
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { deriveFixedUrls, resolveBand, pageUrlsFromSuggestion } from '../../../src/gsc-search-analytics/derive.js';
+
+use(sinonChai);
+
+describe('pageUrlsFromSuggestion', () => {
+  it('reads the type-specific key for each opportunity type', () => {
+    expect(pageUrlsFromSuggestion('meta-tags', { url: 'https://k/a' })).to.deep.equal(['https://k/a']);
+    expect(pageUrlsFromSuggestion('broken-internal-links', { urlFrom: 'https://k/from', urlTo: 'https://k/to' }))
+      .to.deep.equal(['https://k/from']);
+    expect(pageUrlsFromSuggestion('broken-backlinks', { url_to: 'https://k/to', url_from: 'https://ext/x' }))
+      .to.deep.equal(['https://k/to']);
+    expect(pageUrlsFromSuggestion('sitemap', { pageUrl: 'https://k/p', sitemapUrl: 'https://k/sm.xml' }))
+      .to.deep.equal(['https://k/p']);
+  });
+
+  it('reads alt-text from nested recommendations[], deduped, and only for alt-text', () => {
+    const data = { recommendations: [{ pageUrl: 'https://k/img' }, { pageUrl: 'https://k/img' }, { url: 'https://k/img2' }] };
+    expect(pageUrlsFromSuggestion('alt-text', data)).to.deep.equal(['https://k/img', 'https://k/img2']);
+    // a non-alt-text type that also carries a recommendations array must NOT take that branch
+    expect(pageUrlsFromSuggestion('paid-traffic', data)).to.deep.equal([]);
+  });
+
+  it('falls back through common keys for an unmapped type and returns [] when nothing matches', () => {
+    expect(pageUrlsFromSuggestion('some-new-type', { pageUrl: 'https://k/p' })).to.deep.equal(['https://k/p']);
+    expect(pageUrlsFromSuggestion('meta-tags', { documentPath: '/content/site/en/a' })).to.deep.equal([]); // author path, not http
+    expect(pageUrlsFromSuggestion('meta-tags', null)).to.deep.equal([]);
+  });
+});
+
+describe('resolveBand', () => {
+  const now = new Date('2026-09-01T00:00:00Z');
+
+  it('backfills the full band when no input is given', () => {
+    // ~13 months ago .. ~3 months ago
+    expect(resolveBand({}, now)).to.deep.equal({ from: '2025-08-01', to: '2026-06-06' });
+  });
+
+  it('since:D shifts the from-edge to fixes matured since D (minus the ~87-day lag)', () => {
+    const { from, to } = resolveBand({ since: '2026-08-01' }, now);
+    expect(from).to.equal('2026-05-06'); // 2026-08-01 minus 87 days
+    expect(to).to.equal('2026-06-06');
+  });
+
+  it('never lets since dip below the retention floor', () => {
+    const { from } = resolveBand({ since: '2020-01-01' }, now);
+    expect(from).to.equal('2025-08-01'); // clamped to floor, not 2019
+  });
+
+  it('explicit from/to override everything', () => {
+    expect(resolveBand({ since: '2026-08-01', from: '2026-01-01', to: '2026-06-05' }, now))
+      .to.deep.equal({ from: '2026-01-01', to: '2026-06-05' });
+  });
+});
+
+const mkFe = (over) => ({
+  getPublishedAt: () => null,
+  getExecutedAt: () => '2026-05-04T10:00:00.000Z',
+  getChangeDetails: () => ({}),
+  getSuggestions: async () => [],
+  ...over,
+});
+
+describe('deriveFixedUrls', () => {
+  const sandbox = sinon.createSandbox();
+  let context;
+  let Opportunity;
+  let FixEntity;
+
+  beforeEach(() => {
+    FixEntity = {
+      STATUSES: { DEPLOYED: 'DEPLOYED', PUBLISHED: 'PUBLISHED' },
+      allByOpportunityIdAndStatus: sandbox.stub().resolves([]),
+    };
+    Opportunity = { allBySiteId: sandbox.stub().resolves([]) };
+    context = { log: { info: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub() }, dataAccess: { Opportunity, FixEntity } };
+  });
+
+  afterEach(() => sandbox.restore());
+
+  it('pulls URL from changeDetails.url and type from the opportunity', async () => {
+    Opportunity.allBySiteId.resolves([{ getId: () => 'op1', getType: () => 'meta-tags' }]);
+    FixEntity.allByOpportunityIdAndStatus
+      .withArgs('op1', 'DEPLOYED')
+      .resolves([mkFe({ getChangeDetails: () => ({ url: 'https://krisshop.com/en/brands/loccitane.html' }) })]);
+
+    const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-06-05' }, context);
+
+    expect(out.fixedUrls).to.deep.equal([
+      { url: 'https://krisshop.com/en/brands/loccitane.html', fixType: 'meta-tags', fixDate: '2026-05-04' },
+    ]);
+    expect(out.sourcing).to.include({ mode: 'backfill', truncated: false });
+  });
+
+  it('falls back to the linked suggestion, using the type-aware key (bbl uses urlFrom, not url)', async () => {
+    Opportunity.allBySiteId.resolves([{ getId: () => 'op1', getType: () => 'broken-internal-links' }]);
+    FixEntity.allByOpportunityIdAndStatus.withArgs('op1', 'DEPLOYED').resolves([mkFe({
+      // broken-internal-links stores the fixed page under data.urlFrom — a plain data.url read would drop it
+      getSuggestions: async () => [{ getData: () => ({ urlFrom: 'https://krisshop.com/en/x.html', urlTo: 'https://krisshop.com/en/target' }) }],
+    })]);
+
+    const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-06-05' }, context);
+    expect(out.fixedUrls.map((f) => f.url)).to.deep.equal(['https://krisshop.com/en/x.html']);
+  });
+
+  it('excludes non-SEO opportunity types (SEO allow-list) without fetching their fix entities', async () => {
+    Opportunity.allBySiteId.resolves([
+      { getId: () => 'op1', getType: () => 'security-vulnerabilities' },
+      { getId: () => 'op2', getType: () => 'paid-traffic' },
+    ]);
+    const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-06-05' }, context);
+    expect(out.fixedUrls).to.deep.equal([]);
+    expect(FixEntity.allByOpportunityIdAndStatus).to.not.have.been.called;
+  });
+
+  it('filters out fixes outside the date range', async () => {
+    Opportunity.allBySiteId.resolves([{ getId: () => 'op1', getType: () => 'meta-tags' }]);
+    FixEntity.allByOpportunityIdAndStatus.withArgs('op1', 'DEPLOYED').resolves([
+      mkFe({ getExecutedAt: () => '2020-01-01T00:00:00Z', getChangeDetails: () => ({ url: 'https://k/old' }) }),
+    ]);
+    const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-06-05' }, context);
+    expect(out.fixedUrls).to.deep.equal([]);
+  });
+
+  it('honours fixTypes filter and dedupes on (url, fixDate)', async () => {
+    Opportunity.allBySiteId.resolves([
+      { getId: () => 'op1', getType: () => 'meta-tags' },
+      { getId: () => 'op2', getType: () => 'alt-text' },
+    ]);
+    FixEntity.allByOpportunityIdAndStatus.withArgs('op1', 'DEPLOYED').resolves([
+      mkFe({ getChangeDetails: () => ({ url: 'https://k/a' }) }),
+      mkFe({ getChangeDetails: () => ({ url: 'https://k/a' }) }), // dup
+    ]);
+    const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-06-05', fixTypes: ['meta-tags'] }, context);
+    expect(out.fixedUrls).to.have.length(1);
+    expect(FixEntity.allByOpportunityIdAndStatus).to.not.have.been.calledWith('op2', 'DEPLOYED');
+  });
+
+  it('explicit fixTypes:[alt-text] overrides the default set (alt-text not in SEO_FIX_TYPES)', async () => {
+    Opportunity.allBySiteId.resolves([{ getId: () => 'op1', getType: () => 'alt-text' }]);
+    FixEntity.allByOpportunityIdAndStatus.withArgs('op1', 'DEPLOYED').resolves([mkFe({
+      getSuggestions: async () => [{ getData: () => ({ recommendations: [{ pageUrl: 'https://k/en/img.html' }] }) }],
+    })]);
+    const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-06-05', fixTypes: ['alt-text'] }, context);
+    expect(out.fixedUrls.map((f) => f.url)).to.deep.equal(['https://k/en/img.html']);
+  });
+
+  it('bounds a wide backfill to the newest MAX_DATE_GROUPS and flags truncation', async () => {
+    // 31 distinct fix-dates, one URL each — exceeds the 30-group cap by one.
+    const opps = [];
+    for (let i = 0; i < 31; i += 1) {
+      const id = `op${i}`;
+      const date = `2026-06-${String(i + 1).padStart(2, '0')}`; // wide spread within band
+      opps.push({ getId: () => id, getType: () => 'meta-tags' });
+      FixEntity.allByOpportunityIdAndStatus.withArgs(id, 'DEPLOYED').resolves([mkFe({
+        getExecutedAt: () => `${date}T00:00:00Z`,
+        getChangeDetails: () => ({ url: `https://k/en/p${i}` }),
+      })]);
+    }
+    Opportunity.allBySiteId.resolves(opps);
+    const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-07-15' }, context); // backfill (no since)
+    const distinctDates = new Set(out.fixedUrls.map((f) => f.fixDate));
+    expect(distinctDates.size).to.equal(30); // capped
+    expect(out.sourcing).to.include({ truncated: true, sourcedDateGroups: 31, keptDateGroups: 30 });
+  });
+
+  it('caps URLs to MAX_FIXED_URLS within the kept date-groups and flags truncation', async () => {
+    // 1 deploy-date, 600 distinct URLs — under the 30-date cap but over the 500-URL cap.
+    const suggestions = [];
+    for (let i = 0; i < 600; i += 1) {
+      suggestions.push({ getData: () => ({ url: `https://k/en/p${i}` }) });
+    }
+    Opportunity.allBySiteId.resolves([{ getId: () => 'op1', getType: () => 'meta-tags' }]);
+    FixEntity.allByOpportunityIdAndStatus.withArgs('op1', 'DEPLOYED').resolves([mkFe({
+      getExecutedAt: () => '2026-05-04T00:00:00Z',
+      getSuggestions: async () => suggestions, // changeDetails.url absent → suggestion path
+    })]);
+    const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-07-15' }, context);
+    expect(out.fixedUrls).to.have.length(500); // urlTruncated branch exercised
+    expect(out.sourcing).to.include({ truncated: true, keptDateGroups: 1 });
+  });
+
+  it('prefers getPublishedAt over getExecutedAt when present', async () => {
+    Opportunity.allBySiteId.resolves([{ getId: () => 'op1', getType: () => 'meta-tags' }]);
+    FixEntity.allByOpportunityIdAndStatus.withArgs('op1', 'DEPLOYED').resolves([mkFe({
+      getPublishedAt: () => '2026-05-10T09:00:00Z', // published wins over executed
+      getExecutedAt: () => '2026-05-04T10:00:00Z',
+      getChangeDetails: () => ({ url: 'https://k/pub' }),
+    })]);
+    const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-06-05' }, context);
+    expect(out.fixedUrls).to.deep.equal([{ url: 'https://k/pub', fixType: 'meta-tags', fixDate: '2026-05-10' }]);
+  });
+
+  it('skips a fix entity with neither published nor executed date', async () => {
+    Opportunity.allBySiteId.resolves([{ getId: () => 'op1', getType: () => 'meta-tags' }]);
+    FixEntity.allByOpportunityIdAndStatus.withArgs('op1', 'DEPLOYED').resolves([mkFe({
+      getPublishedAt: () => null,
+      getExecutedAt: () => null, // raw null -> fixDate null -> filtered out of range
+      getChangeDetails: () => ({ url: 'https://k/x' }),
+    })]);
+    const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-06-05' }, context);
+    expect(out.fixedUrls).to.deep.equal([]);
+  });
+
+  it('tolerates missing getChangeDetails/getSuggestions accessors', async () => {
+    Opportunity.allBySiteId.resolves([{ getId: () => 'op1', getType: () => 'meta-tags' }]);
+    FixEntity.allByOpportunityIdAndStatus.withArgs('op1', 'DEPLOYED').resolves([{
+      getPublishedAt: () => null,
+      getExecutedAt: () => '2026-05-04T00:00:00Z',
+      getChangeDetails: undefined, // exercises `?.` + `?? {}` fallback
+      getSuggestions: undefined, // exercises `?.` + `?? []` fallback
+    }]);
+    const out = await deriveFixedUrls('site-1', { from: '2026-01-01', to: '2026-06-05' }, context);
+    expect(out.fixedUrls).to.deep.equal([]);
+  });
+
+  it('reports incremental mode when since is supplied', async () => {
+    const out = await deriveFixedUrls('site-1', { since: '2026-08-01' }, context);
+    expect(out.sourcing.mode).to.equal('incremental'); // opts.since truthy branch
+  });
+});

--- a/test/audits/gsc-search-analytics/lib.test.js
+++ b/test/audits/gsc-search-analytics/lib.test.js
@@ -12,6 +12,7 @@
 
 import { expect } from 'chai';
 import sinon from 'sinon';
+import esmock from 'esmock';
 import GoogleClient from '@adobe/spacecat-shared-google-client';
 import { runGscSearchAnalytics } from '../../../src/gsc-search-analytics/lib.js';
 import { computeWindows } from '../../../src/gsc-search-analytics/windows.js';
@@ -36,8 +37,17 @@ const afterStartMs = (fixDate) => new Date(`${computeWindows(fixDate).after.star
 
 describe('runGscSearchAnalytics', () => {
   const finalUrl = 'https://krisshop.com';
-  const site = { getBaseURL: () => finalUrl };
-  const context = { log: { info() {}, warn() {}, error() {} } };
+  // getId feeds the self-source path (deriveFixedUrls(site.getId(), ...)); the explicit
+  // fixedUrls tests never call it. dataAccess lets the real derive.js return an empty list
+  // (no opportunities) when a test exercises the self-source path without stubbing derive.
+  const site = { getBaseURL: () => finalUrl, getId: () => 'site-id-123' };
+  const context = {
+    log: { info() {}, warn() {}, error() {} },
+    dataAccess: {
+      Opportunity: { allBySiteId: async () => [] },
+      FixEntity: { STATUSES: { DEPLOYED: 'DEPLOYED', PUBLISHED: 'PUBLISHED' } },
+    },
+  };
   const url = 'https://krisshop.com/products/x';
 
   afterEach(() => sinon.restore());
@@ -219,6 +229,42 @@ describe('runGscSearchAnalytics', () => {
     const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site);
     expect(auditResult.status).to.equal('missing_fixed_urls');
     expect(auditResult.connected).to.equal(null);
+  });
+
+  it('self-sources fixed URLs from a since watermark, and surfaces sourcing in the result', async () => {
+    const derived = {
+      fixedUrls: [{ url: 'https://krisshop.com/en/x.html', fixType: 'meta-tags', fixDate: '2026-05-04' }],
+      sourcing: {
+        mode: 'incremental', sourcedDateGroups: 1, keptDateGroups: 1, truncated: false,
+      },
+    };
+    const googleStub = { getOrganicSearchData: sinon.stub().resolves(emptyRows()) };
+    const seen = {};
+    const { runGscSearchAnalytics: run } = await esmock('../../../src/gsc-search-analytics/lib.js', {
+      '../../../src/gsc-search-analytics/derive.js': {
+        deriveFixedUrls: async (_siteId, opts) => { seen.opts = opts; return derived; },
+      },
+      '@adobe/spacecat-shared-google-client': { default: { createFrom: async () => googleStub } },
+    });
+    const res = await run(finalUrl, context, site, { messageData: { since: '2026-05-01' } });
+    expect(seen.opts.since).to.equal('2026-05-01'); // watermark forwarded to derive
+    expect(res.auditResult.fixCount).to.be.greaterThan(0);
+    expect(res.auditResult.sourcing).to.include({ mode: 'incremental', truncated: false });
+  });
+
+  it('records missing_fixed_urls when derive yields nothing and no range given', async () => {
+    const { runGscSearchAnalytics: run } = await esmock('../../../src/gsc-search-analytics/lib.js', {
+      '../../../src/gsc-search-analytics/derive.js': {
+        deriveFixedUrls: async () => ({
+          fixedUrls: [],
+          sourcing: {
+            mode: 'backfill', sourcedDateGroups: 0, keptDateGroups: 0, truncated: false,
+          },
+        }),
+      },
+    });
+    const res = await run(finalUrl, context, site, {});
+    expect(res.auditResult.status).to.equal('missing_fixed_urls');
   });
 
   it('returns too_many_fixed_urls above the cap', async () => {

--- a/test/audits/gsc-search-analytics/lib.test.js
+++ b/test/audits/gsc-search-analytics/lib.test.js
@@ -265,6 +265,20 @@ describe('runGscSearchAnalytics', () => {
     });
     const res = await run(finalUrl, context, site, {});
     expect(res.auditResult.status).to.equal('missing_fixed_urls');
+    // Fix 2: a self-sourced "found 0 fixes in band" run stays diagnosable.
+    expect(res.auditResult.sourcing).to.include({ mode: 'backfill', truncated: false });
+  });
+
+  it('records sourcing_failed (and does not throw) when derive rejects', async () => {
+    const { runGscSearchAnalytics: run } = await esmock('../../../src/gsc-search-analytics/lib.js', {
+      '../../../src/gsc-search-analytics/derive.js': {
+        deriveFixedUrls: async () => { throw new Error('db down'); },
+      },
+    });
+    const res = await run(finalUrl, context, site, { messageData: { since: '2026-05-01' } });
+    expect(res.auditResult.status).to.equal('sourcing_failed');
+    expect(res.auditResult.connected).to.equal(null);
+    expect(res.auditResult.reason).to.match(/db down/);
   });
 
   it('returns too_many_fixed_urls above the cap', async () => {

--- a/test/audits/gsc-search-analytics/lib.test.js
+++ b/test/audits/gsc-search-analytics/lib.test.js
@@ -87,6 +87,7 @@ describe('runGscSearchAnalytics', () => {
     const { auditResult, fullAuditRef } = await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
     expect(fullAuditRef).to.equal(finalUrl);
     expect(auditResult).to.include({ schemaVersion: 1, connected: true, status: 'ok' });
+    expect(auditResult.scopeResolved).to.equal(true); // Fix 4: scope resolved normally
     expect(auditResult.interpretation).to.match(/not a causal or attributed/);
     expect(auditResult.fixCount).to.equal(1);
     expect(auditResult.measuredCount).to.equal(1);
@@ -445,6 +446,162 @@ describe('runGscSearchAnalytics', () => {
     const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
     expect(auditResult.connected).to.equal(true);
     expect(auditResult.status).to.equal('ok');
+    expect(auditResult.scopeResolved).to.equal(false); // Fix 4: degraded scope is queryable
     expect(auditResult.fixes[0].status).to.equal('measured');
+  });
+
+  it('degrades to all-in-scope when scope resolution TIMES OUT (bounded race)', async () => {
+    // Fix 3: composeAuditURL hangs (never resolves). The ~8s race timeout must fire and route
+    // into the same degrade-to-all-in-scope path as a throw, so the run still completes.
+    const google = { getOrganicSearchData: sinon.stub().resolves(rowFor(url)) };
+    const { runGscSearchAnalytics: run } = await esmock('../../../src/gsc-search-analytics/lib.js', {
+      '@adobe/spacecat-shared-utils': { composeAuditURL: () => new Promise(() => {}), stripWWW },
+      '@adobe/spacecat-shared-google-client': { default: { createFrom: async () => google } },
+    });
+    // Pin "now" so the 2026-03-01 fix's windows are fully elapsed -> measured under fake time.
+    const clock = sinon.useFakeTimers({ now: new Date('2026-09-09T00:00:00Z').getTime() });
+    try {
+      const fixedUrls = [{ url, fixType: 'meta-tags', fixDate: '2026-03-01' }];
+      const promise = run(finalUrl, context, site, { fixedUrls });
+      await clock.tickAsync(8001); // advance past SCOPE_TIMEOUT_MS to fire the timeout
+      const { auditResult } = await promise;
+      expect(auditResult.status).to.equal('ok');
+      expect(auditResult.connected).to.equal(true);
+      expect(auditResult.scopeResolved).to.equal(false); // timed out -> degraded
+      expect(auditResult.fixes[0].status).to.equal('measured'); // treated as in scope
+    } finally {
+      clock.restore();
+    }
+  });
+
+  it('coerces a scalar fixTypes kwarg to a one-element array for derive', async () => {
+    // Fix 1: a single Slack value arrives as a string; derive.js gates on Array.isArray.
+    const seen = {};
+    const google = { getOrganicSearchData: sinon.stub().resolves(emptyRows()) };
+    const { runGscSearchAnalytics: run } = await esmock('../../../src/gsc-search-analytics/lib.js', {
+      '../../../src/gsc-search-analytics/derive.js': {
+        deriveFixedUrls: async (_siteId, opts) => {
+          seen.opts = opts;
+          return { fixedUrls: [], sourcing: { mode: 'incremental', truncated: false } };
+        },
+      },
+      '@adobe/spacecat-shared-google-client': { default: { createFrom: async () => google } },
+      '@adobe/spacecat-shared-utils': { composeAuditURL: async () => 'krisshop.com', stripWWW },
+    });
+    await run(finalUrl, context, site, { messageData: { fixTypes: 'meta-tags' } });
+    expect(seen.opts.fixTypes).to.deep.equal(['meta-tags']);
+  });
+
+  it('coerces a scalar fixStatuses kwarg to a one-element array for derive', async () => {
+    // Fix 1: a bare 'DEPLOYED' would otherwise iterate the string's characters in derive.
+    const seen = {};
+    const { runGscSearchAnalytics: run } = await esmock('../../../src/gsc-search-analytics/lib.js', {
+      '../../../src/gsc-search-analytics/derive.js': {
+        deriveFixedUrls: async (_siteId, opts) => {
+          seen.opts = opts;
+          return { fixedUrls: [], sourcing: { mode: 'backfill', truncated: false } };
+        },
+      },
+      '@adobe/spacecat-shared-utils': { composeAuditURL: async () => 'krisshop.com', stripWWW },
+    });
+    await run(finalUrl, context, site, { messageData: { fixStatuses: 'DEPLOYED' } });
+    expect(seen.opts.fixStatuses).to.deep.equal(['DEPLOYED']);
+  });
+
+  it('returns invalid_input (not sourcing_failed) for a malformed since', async () => {
+    // Fix 2: '2026-5-1' would throw a RangeError out of resolveBand -> opaque sourcing_failed.
+    // Validation short-circuits BEFORE derive/createFrom/composeAuditURL, so no stubs needed.
+    const res = await runGscSearchAnalytics(finalUrl, context, site, { messageData: { since: '2026-5-1' } });
+    expect(res.auditResult.status).to.equal('invalid_input');
+    expect(res.auditResult.connected).to.equal(null);
+    expect(res.auditResult.reason).to.match(/invalid since/);
+    expect(res.auditResult.sourcing).to.equal(undefined); // Fix 4: invalid_input carries no sourcing
+  });
+
+  it('keeps sourcing on the not_connected envelope when a self-sourced run fails createFrom', async () => {
+    // Fix 4: a self-sourced run that connected fine but then fails createFrom must not lose
+    // its sourcing telemetry.
+    const sourcing = {
+      mode: 'incremental', sourcedDateGroups: 1, keptDateGroups: 1, truncated: false,
+    };
+    const { runGscSearchAnalytics: run } = await esmock('../../../src/gsc-search-analytics/lib.js', {
+      '../../../src/gsc-search-analytics/derive.js': {
+        deriveFixedUrls: async () => ({
+          fixedUrls: [{ url: 'https://krisshop.com/en/x.html', fixType: 'meta-tags', fixDate: '2026-05-04' }],
+          sourcing,
+        }),
+      },
+      '@adobe/spacecat-shared-google-client': {
+        default: { createFrom: async () => { throw new Error('ResourceNotFoundException: no secret'); } },
+      },
+      '@adobe/spacecat-shared-utils': { composeAuditURL: async () => 'krisshop.com', stripWWW },
+    });
+    const res = await run(finalUrl, context, site, { messageData: { since: '2026-05-01' } });
+    expect(res.auditResult.status).to.equal('not_connected');
+    expect(res.auditResult.connected).to.equal(false);
+    expect(res.auditResult.sourcing).to.include({ mode: 'incremental', truncated: false });
+  });
+
+  it('skips both GSC pulls when a date-group is entirely out of scope (no wasted fetch)', async () => {
+    // Fix 5: every URL in the group is out of scope -> neither paginated pull should run.
+    scopeReturn = 'www.krisshop.com/en';
+    const google = { getOrganicSearchData: sinon.stub().resolves(emptyRows()) };
+    sinon.stub(GoogleClient, 'createFrom').resolves(google);
+    const res = await runGscSearchAnalytics(finalUrl, context, site, {
+      fixedUrls: [{ url: 'https://www.krisshop.com/', fixType: 'meta-tags', fixDate: '2026-03-01' }],
+    });
+    const fix = res.auditResult.fixes[0];
+    expect(fix.status).to.equal('out_of_scope');
+    expect(google.getOrganicSearchData.callCount).to.equal(0); // both pulls skipped
+    // Fix 6: never queried -> windows/before/after/delta nulled so the row isn't misleading.
+    expect(fix.windows).to.equal(null);
+    expect(fix.before).to.equal(null);
+    expect(fix.after).to.equal(null);
+    expect(fix.delta).to.equal(null);
+  });
+
+  it('marks a fixed URL under a sibling path prefix (/enterprise vs /en) as out_of_scope', async () => {
+    // Fix 6: proves the startsWith(`${scopePath}/`) boundary — /en must NOT swallow /enterprise.
+    scopeReturn = 'www.krisshop.com/en';
+    const google = { getOrganicSearchData: sinon.stub().resolves(emptyRows()) };
+    sinon.stub(GoogleClient, 'createFrom').resolves(google);
+    const res = await runGscSearchAnalytics(finalUrl, context, site, {
+      fixedUrls: [{ url: 'https://www.krisshop.com/enterprise/landing', fixType: 'meta-tags', fixDate: '2026-03-01' }],
+    });
+    expect(res.auditResult.fixes[0].status).to.equal('out_of_scope');
+  });
+
+  it('reclassifies a supplied non-/en URL as out_of_scope on the explicit fixedUrls path', async () => {
+    // Fix 6: scoping applies to the override path too — an operator-supplied out-of-scope URL
+    // is still out_of_scope, not blindly measured.
+    scopeReturn = 'www.krisshop.com/en';
+    const google = { getOrganicSearchData: sinon.stub().resolves(emptyRows()) };
+    sinon.stub(GoogleClient, 'createFrom').resolves(google);
+    const res = await runGscSearchAnalytics(finalUrl, context, site, {
+      fixedUrls: [{ url: 'https://www.krisshop.com/fr/x', fixType: 'meta-tags', fixDate: '2026-03-01' }],
+    });
+    expect(res.auditResult.fixes[0].status).to.equal('out_of_scope');
+  });
+
+  it('fetches a MIXED date-group but marks only the out-of-scope URL out_of_scope (fields nulled)', async () => {
+    // Fix 5/6: a group with at least one in-scope URL still fetches; the out-of-scope member
+    // is classified out_of_scope with nulled windows/before/after/delta.
+    scopeReturn = 'www.krisshop.com/en';
+    const inUrl = 'https://www.krisshop.com/en/products/x';
+    const outUrl = 'https://www.krisshop.com/enterprise/y';
+    const google = { getOrganicSearchData: sinon.stub().resolves(rowFor(inUrl)) };
+    sinon.stub(GoogleClient, 'createFrom').resolves(google);
+    const res = await runGscSearchAnalytics(finalUrl, context, site, {
+      fixedUrls: [
+        { url: inUrl, fixType: 'meta-tags', fixDate: '2026-03-01' },
+        { url: outUrl, fixType: 'meta-tags', fixDate: '2026-03-01' },
+      ],
+    });
+    const byUrl = Object.fromEntries(res.auditResult.fixes.map((f) => [f.url, f]));
+    expect(byUrl[inUrl].status).to.equal('measured'); // in-scope member still queried + measured
+    expect(byUrl[outUrl].status).to.equal('out_of_scope');
+    expect(byUrl[outUrl].windows).to.equal(null);
+    expect(byUrl[outUrl].delta).to.equal(null);
+    expect(google.getOrganicSearchData.callCount).to.equal(2); // mixed group DID fetch (2 pulls)
   });
 });

--- a/test/audits/gsc-search-analytics/lib.test.js
+++ b/test/audits/gsc-search-analytics/lib.test.js
@@ -57,11 +57,17 @@ describe('runGscSearchAnalytics', () => {
   // and stripWWW is passed through real so the scope math is genuine.
   let runGscSearchAnalytics;
   let scopeReturn = 'krisshop.com';
+  // Opt-in flag: only the scope-resolution-failure test flips this true so the shared
+  // composeAuditURL stub rejects; every other test keeps the default resolve behavior.
+  let scopeThrows = false;
 
   before(async () => {
     ({ runGscSearchAnalytics } = await esmock('../../../src/gsc-search-analytics/lib.js', {
       '@adobe/spacecat-shared-utils': {
-        composeAuditURL: async () => scopeReturn,
+        composeAuditURL: async () => {
+          if (scopeThrows) throw new Error('dns fail');
+          return scopeReturn;
+        },
         stripWWW,
       },
     }));
@@ -69,7 +75,7 @@ describe('runGscSearchAnalytics', () => {
 
   // Default scope = bare host -> scopePath '/', so every same-host fixed URL in the
   // existing tests stays IN scope and keeps its measured/not_found/incomplete verdict.
-  beforeEach(() => { scopeReturn = 'krisshop.com'; });
+  beforeEach(() => { scopeReturn = 'krisshop.com'; scopeThrows = false; });
 
   afterEach(() => sinon.restore());
 
@@ -394,5 +400,51 @@ describe('runGscSearchAnalytics', () => {
       fixedUrls: [{ url: 'not a url', fixType: 'meta-tags', fixDate: '2026-03-01' }],
     });
     expect(res.auditResult.fixes[0].status).to.equal('out_of_scope');
+  });
+
+  it('normalizes a trailing-slash scope so in-scope URLs are measured, not out_of_scope', async () => {
+    // composeAuditURL leaves the trailing slash on a multi-segment path ("/en/"); the fixed
+    // URLs are normalized ("/en", "/en/products/x"), so without the scopePath trim they would
+    // all falsely read out_of_scope.
+    scopeReturn = 'www.krisshop.com/en/';
+    const exactUrl = 'https://www.krisshop.com/en';
+    const subUrl = 'https://www.krisshop.com/en/products/x';
+    const google = {
+      getOrganicSearchData: sinon.stub().resolves({
+        data: {
+          rows: [
+            {
+              keys: [exactUrl], clicks: 5, impressions: 50, ctr: 0.1, position: 4,
+            },
+            {
+              keys: [subUrl], clicks: 5, impressions: 50, ctr: 0.1, position: 4,
+            },
+          ],
+        },
+      }),
+    };
+    sinon.stub(GoogleClient, 'createFrom').resolves(google);
+    const res = await runGscSearchAnalytics(finalUrl, context, site, {
+      fixedUrls: [
+        { url: exactUrl, fixType: 'meta-tags', fixDate: '2026-03-01' },
+        { url: subUrl, fixType: 'meta-tags', fixDate: '2026-03-01' },
+      ],
+    });
+    const byUrl = Object.fromEntries(res.auditResult.fixes.map((f) => [f.url, f.status]));
+    expect(byUrl[exactUrl]).to.equal('measured');
+    expect(byUrl[subUrl]).to.equal('measured');
+  });
+
+  it('degrades to all-in-scope (still measures) when scope resolution throws', async () => {
+    // composeAuditURL does a live HTTP GET; a DNS/transport error must not reject the whole
+    // audit after GSC is connected — the runner treats every fixed URL as in scope.
+    scopeThrows = true;
+    const google = { getOrganicSearchData: sinon.stub().resolves(rowFor(url)) };
+    sinon.stub(GoogleClient, 'createFrom').resolves(google);
+    const fixedUrls = [{ url, fixType: 'meta-tags', fixDate: '2026-03-01' }];
+    const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
+    expect(auditResult.connected).to.equal(true);
+    expect(auditResult.status).to.equal('ok');
+    expect(auditResult.fixes[0].status).to.equal('measured');
   });
 });

--- a/test/audits/gsc-search-analytics/lib.test.js
+++ b/test/audits/gsc-search-analytics/lib.test.js
@@ -14,7 +14,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import esmock from 'esmock';
 import GoogleClient from '@adobe/spacecat-shared-google-client';
-import { runGscSearchAnalytics } from '../../../src/gsc-search-analytics/lib.js';
+import { stripWWW } from '@adobe/spacecat-shared-utils';
 import { computeWindows } from '../../../src/gsc-search-analytics/windows.js';
 
 const iso = (offsetDays) => new Date(Date.now() + offsetDays * 86400000).toISOString().split('T')[0];
@@ -49,6 +49,27 @@ describe('runGscSearchAnalytics', () => {
     },
   };
   const url = 'https://krisshop.com/products/x';
+
+  // Task 3 added `const scope = await composeAuditURL(finalUrl)` to lib.js, which performs
+  // a LIVE HTTP GET. Load lib.js through esmock with composeAuditURL stubbed so no test
+  // ever hits the network. `scopeReturn` is mutable so a test can pick the resolved scope;
+  // GoogleClient stays REAL (each test still uses sinon.stub(GoogleClient, 'createFrom')),
+  // and stripWWW is passed through real so the scope math is genuine.
+  let runGscSearchAnalytics;
+  let scopeReturn = 'krisshop.com';
+
+  before(async () => {
+    ({ runGscSearchAnalytics } = await esmock('../../../src/gsc-search-analytics/lib.js', {
+      '@adobe/spacecat-shared-utils': {
+        composeAuditURL: async () => scopeReturn,
+        stripWWW,
+      },
+    }));
+  });
+
+  // Default scope = bare host -> scopePath '/', so every same-host fixed URL in the
+  // existing tests stays IN scope and keeps its measured/not_found/incomplete verdict.
+  beforeEach(() => { scopeReturn = 'krisshop.com'; });
 
   afterEach(() => sinon.restore());
 
@@ -175,7 +196,7 @@ describe('runGscSearchAnalytics', () => {
     expect(failFix.found).to.deep.equal({ before: false, after: false });
   });
 
-  it('warns on a host mismatch: rows returned but no fixed URL matched', async () => {
+  it('warns when rows returned but no in-scope fixed URL matched (host mismatch)', async () => {
     const warn = sinon.spy();
     const ctx = { log: { info() {}, warn, error() {} } };
     // GSC rows are on a different host than the supplied fixed URL -> nothing matches.
@@ -189,7 +210,7 @@ describe('runGscSearchAnalytics', () => {
     const { auditResult } = await runGscSearchAnalytics(finalUrl, ctx, site, { fixedUrls });
     expect(auditResult.fixes[0].status).to.equal('not_found');
     expect(warn.calledOnce).to.equal(true);
-    expect(warn.firstCall.args[0]).to.match(/host mismatch/);
+    expect(warn.firstCall.args[0]).to.match(/no in-scope fixed URL matched/);
   });
 
   it('flags truncation and reads not_found when the URL is past the page cap', async () => {
@@ -245,6 +266,7 @@ describe('runGscSearchAnalytics', () => {
         deriveFixedUrls: async (_siteId, opts) => { seen.opts = opts; return derived; },
       },
       '@adobe/spacecat-shared-google-client': { default: { createFrom: async () => googleStub } },
+      '@adobe/spacecat-shared-utils': { composeAuditURL: async () => 'krisshop.com', stripWWW },
     });
     const res = await run(finalUrl, context, site, { messageData: { since: '2026-05-01' } });
     expect(seen.opts.since).to.equal('2026-05-01'); // watermark forwarded to derive
@@ -262,6 +284,7 @@ describe('runGscSearchAnalytics', () => {
           },
         }),
       },
+      '@adobe/spacecat-shared-utils': { composeAuditURL: async () => 'krisshop.com', stripWWW },
     });
     const res = await run(finalUrl, context, site, {});
     expect(res.auditResult.status).to.equal('missing_fixed_urls');
@@ -274,6 +297,7 @@ describe('runGscSearchAnalytics', () => {
       '../../../src/gsc-search-analytics/derive.js': {
         deriveFixedUrls: async () => { throw new Error('db down'); },
       },
+      '@adobe/spacecat-shared-utils': { composeAuditURL: async () => 'krisshop.com', stripWWW },
     });
     const res = await run(finalUrl, context, site, { messageData: { since: '2026-05-01' } });
     expect(res.auditResult.status).to.equal('sourcing_failed');
@@ -298,5 +322,77 @@ describe('runGscSearchAnalytics', () => {
     }));
     const { auditResult } = await runGscSearchAnalytics(finalUrl, context, site, { fixedUrls });
     expect(auditResult.status).to.equal('too_many_date_groups');
+  });
+
+  it('marks a URL outside the resolved fetch scope as out_of_scope, not not_found', async () => {
+    // finalUrl resolves (composeAuditURL) to www.krisshop.com/en; the bare root is out of scope.
+    scopeReturn = 'www.krisshop.com/en';
+    const google = { getOrganicSearchData: sinon.stub().resolves(emptyRows()) };
+    sinon.stub(GoogleClient, 'createFrom').resolves(google);
+    const res = await runGscSearchAnalytics(finalUrl, context, site, {
+      fixedUrls: [{ url: 'https://www.krisshop.com/', fixType: 'smoke', fixDate: '2026-01-15' }],
+    });
+    expect(res.auditResult.fixes[0].status).to.equal('out_of_scope');
+  });
+
+  it('measures in-scope URLs at and below the resolved locale path (exact + subpath)', async () => {
+    scopeReturn = 'www.krisshop.com/en';
+    const exactUrl = 'https://www.krisshop.com/en'; // pathname === scopePath
+    const subUrl = 'https://www.krisshop.com/en/products/x'; // pathname startsWith `${scopePath}/`
+    const google = {
+      getOrganicSearchData: sinon.stub().resolves({
+        data: {
+          rows: [
+            {
+              keys: [exactUrl], clicks: 5, impressions: 50, ctr: 0.1, position: 4,
+            },
+            {
+              keys: [subUrl], clicks: 5, impressions: 50, ctr: 0.1, position: 4,
+            },
+          ],
+        },
+      }),
+    };
+    sinon.stub(GoogleClient, 'createFrom').resolves(google);
+    const res = await runGscSearchAnalytics(finalUrl, context, site, {
+      fixedUrls: [
+        { url: exactUrl, fixType: 'meta-tags', fixDate: '2026-03-01' },
+        { url: subUrl, fixType: 'meta-tags', fixDate: '2026-03-01' },
+      ],
+    });
+    const byUrl = Object.fromEntries(res.auditResult.fixes.map((f) => [f.url, f.status]));
+    expect(byUrl[exactUrl]).to.equal('measured');
+    expect(byUrl[subUrl]).to.equal('measured');
+  });
+
+  it('marks a same-path but different-host URL as out_of_scope', async () => {
+    scopeReturn = 'www.krisshop.com/en';
+    const google = { getOrganicSearchData: sinon.stub().resolves(emptyRows()) };
+    sinon.stub(GoogleClient, 'createFrom').resolves(google);
+    const res = await runGscSearchAnalytics(finalUrl, context, site, {
+      fixedUrls: [{ url: 'https://elsewhere.com/en/x', fixType: 'meta-tags', fixDate: '2026-03-01' }],
+    });
+    expect(res.auditResult.fixes[0].status).to.equal('out_of_scope');
+  });
+
+  it('treats every same-host URL as in scope when the base resolves to bare root', async () => {
+    scopeReturn = 'www.krisshop.com'; // no path segment -> scopePath '/'
+    const deepUrl = 'https://krisshop.com/de-de/deep/page';
+    const google = { getOrganicSearchData: sinon.stub().resolves(rowFor(deepUrl)) };
+    sinon.stub(GoogleClient, 'createFrom').resolves(google);
+    const res = await runGscSearchAnalytics(finalUrl, context, site, {
+      fixedUrls: [{ url: deepUrl, fixType: 'meta-tags', fixDate: '2026-03-01' }],
+    });
+    expect(res.auditResult.fixes[0].status).to.equal('measured');
+  });
+
+  it('marks an unparseable URL as out_of_scope via the scope guard (try/catch)', async () => {
+    scopeReturn = 'www.krisshop.com/en';
+    const google = { getOrganicSearchData: sinon.stub().resolves(emptyRows()) };
+    sinon.stub(GoogleClient, 'createFrom').resolves(google);
+    const res = await runGscSearchAnalytics(finalUrl, context, site, {
+      fixedUrls: [{ url: 'not a url', fixType: 'meta-tags', fixDate: '2026-03-01' }],
+    });
+    expect(res.auditResult.fixes[0].status).to.equal('out_of_scope');
   });
 });


### PR DESCRIPTION
## What
Makes the `gsc-search-analytics` audit self-serve. Run it from Slack with just a site (and an optional `since:` watermark); it self-sources the site's DEPLOYED/PUBLISHED fixed-URL list from `fix_entities`, measures each URL's 84-day-before / 84-day-after GSC metrics, and labels URLs the GSC page-filter can't reach as `out_of_scope` (distinct from `not_found`).

Follow-up to #2849 (the supplied-list tracking audit, already merged). This PR adds self-sourcing + honest scoping on top.

## Why
- Self-serve: no hand-built payload needed.
- Honest labelling: fixes the homepage `not_found` case (URLs outside the resolved base-scope were previously indistinguishable from "no GSC data").

## Changes
- `derive.js` (new): self-source with type-aware URL keys, an SEO allow-list (alt-text opt-in only), a bounded backfill (newest 30 deploy-dates / 500 URLs) with a `sourcing` report, and partial-failure telemetry. Sourcing uses the batched `getAllFixesWithSuggestionsByOpportunityId` (no N+1).
- `constants.js` (new): shared caps so the derive output bound and the runtime abort cap can't drift.
- `lib.js`: self-source wiring, `out_of_scope` classification, scalar `fixTypes`/`fixStatuses` coercion, `invalid_input` validation, an 8s timeout on the scope-resolution GET, and `sourcing`/`scopeResolved` telemetry.
- `docs/specs/gsc-search-analytics.md`: updated.

## Scope
Phase 1 only (self-serve + honest labelling). Per-section/multi-locale coverage and a weekly time-series are deferred.

## Testing
Full suite green; 100% line/branch/statement coverage on `src/gsc-search-analytics/*`.

## Reviews
Reviewed by a multi-role panel twice. Non-blocking follow-ups tracked: a whole-run wall-clock deadline, a per-call timeout on `getOrganicSearchData`, server-side status/date pushdown for the per-opportunity fetch, and redirect-chains source-vs-destination validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
