### PR TITLE
feat(offsite-brand-presence): retrieve Semrush URLs via S2S session-token flow (LLMO-6709)

### DIFF
--- a/docs/decisions/002-offsite-cited-urls-semrush-source.md
+++ b/docs/decisions/002-offsite-cited-urls-semrush-source.md
@@ -50,15 +50,19 @@ involves several non-obvious trade-offs, so it warrants an ADR alongside the spe
    host — the legacy top-cited gate, now applied per URL rather than per domain rollup.
    Citations are clamped (`Math.max(0, …)`) and zero-citation URLs are dropped.
 5. **Auth = IMS service bearer via v2 `getServiceAccessToken()` (`authorization_code`
-   grant), default IMS client.** This is the same S2S path `commerce-product-enrichments`,
-   `vulnerabilities` and `permissions` use. v3 `getServiceAccessTokenV3()`
-   (`client_credentials`) was tried first but returns IMS **`400 unauthorized_client`** —
-   the worker's default IMS client is only provisioned for `authorization_code`; only a
-   dedicated integration (content-ai's `CONTENTAI_*`) is registered for `client_credentials`.
-   The token is forwarded unchanged to Semrush; no `x-promise-token` for a service caller.
-   **Open risk (LLMO-6709):** the proxy is designed around a real *user* IMS token, so whether
-   Semrush accepts the worker's *service* token is unverified — the flag stays off until
-   confirmed end-to-end (use `enableSemrush:true` on one canary run, per Decision 7, to test).
+   grant), default IMS client.** ⚠️ **Superseded by Decision 9 (LLMO-6709 resolved).** This
+   originally minted a raw IMS *service* token and forwarded it unchanged to Semrush. That
+   token carries no `tenants`/org membership, so api-service's IMS path rejects it (401/403) —
+   the `domain-urls-auth-failed` fallbacks. The auth mechanism is now the S2S consumer
+   session-token flow; see Decision 9. Retained for history:
+   > This is the same S2S path `commerce-product-enrichments`, `vulnerabilities` and
+   > `permissions` use. v3 `getServiceAccessTokenV3()` (`client_credentials`) was tried first
+   > but returns IMS **`400 unauthorized_client`** — the worker's default IMS client is only
+   > provisioned for `authorization_code`; only a dedicated integration (content-ai's
+   > `CONTENTAI_*`) is registered for `client_credentials`. The token is forwarded unchanged
+   > to Semrush; no `x-promise-token` for a service caller.
+   > **Open risk (LLMO-6709):** the proxy is designed around a real *user* IMS token, so
+   > whether Semrush accepts the worker's *service* token is unverified.
 6. **`PAGE_SIZE` is a fixed constant (1000).** The response is sorted by
    citations globally across every host, so a low-citation bucket can be starved by too
    small a page — a generous page is cheap since it's one request either way. 1000 is the
@@ -236,6 +240,37 @@ involves several non-obvious trade-offs, so it warrants an ADR alongside the spe
    checked against, since the sibling repo can ship the exact mechanism being ruled out
    before the review round closes.
 
+9. **Auth = S2S consumer session-token flow (LLMO-6709, supersedes Decision 5).**
+   api-service ([adobe/spacecat-api-service#3217](https://github.com/adobe/spacecat-api-service/pull/3217))
+   exposes the Semrush-backed brand-presence routes (`domain-urls` included) to **S2S
+   consumers** — authorized by the existing `hasAccess(organization)` check against the
+   caller's session-token `tenants` claim — rather than to raw IMS service tokens. The loader
+   now does a 3-leg exchange:
+   1. resolve the **customer IMS org id** (threaded in from the handler, which already
+      resolves it for DRS scraping — falling back to `getImsOrgId(site, …)` only when a
+      caller omits it, so the session token is never scoped to a different org than the run);
+   2. mint the **consumer's own** IMS token via `getServiceAccessTokenV3()`
+      (`client_credentials`) using dedicated `SEMRUSH_S2S_*` credentials (the same shape
+      content-ai's `CONTENTAI_*` uses; `IMS_CLIENT_CODE` is set to a placeholder because
+      `createFrom` validates it as required but the `client_credentials` grant never sends it);
+   3. exchange it at `POST /api/v1/auth/s2s/login` (`{ imsOrgId }`) for a 15-min,
+      customer-scoped session token, then present that as `Bearer` on the `domain-urls` call.
+   Both the login and data calls must hit the **LLMO host** (`LLMO_API_BASE_URL`, default
+   `llmo.experiencecloud.live`; `LLMO_S2S_LOGIN_URL` overrides the login URL for non-prod
+   path prefixes) because the Fastly edge sets `x-product` from the host. `x-promise-token`
+   forwarding is dropped (the session token is self-contained). The session token is cached
+   module-level keyed by `imsOrgId` (TTL under 15 min), so a warm container reuses it across
+   invocations for the same customer org, collapsing the mint+login to zero network calls.
+   New fallback reasons: `no_ims_org_id`, `ims_token_failed`, `session_token_auth_failed`
+   (401/403 — a static config problem: missing `brand:read` or wrong tenant), and
+   `session_token_failed` (transient/other). The login endpoint's error body is captured in
+   the structured log (`responseBody`) but never forwarded to Slack. **Infra required:**
+   register the worker as an S2S consumer with `brand:read` (multi-org scope), set
+   `SEMRUSH_S2S_*` + `LLMO_API_BASE_URL`, and — producer-side — `SEMRUSH_ADMIN_ELEMENT_API_KEY`
+   / `SEO_API_BASE_URL` in Vault per PR #3217. Until an org has a resolvable `imsOrgId`,
+   Semrush is skipped (`no_ims_org_id`) and the run uses the legacy source — consistent with
+   DRS scraping, which already requires `imsOrgId`.
+
 ## Consequences
 
 - Enabling the flag can never silently zero out offsite (fallback), but the fallback
@@ -267,23 +302,28 @@ override (`enableSemrush`, Decision 7) is the intended tool for step 1: run a si
 request against the real Semrush proxy on one site and confirm the auth path works
 end-to-end before flipping the env var fleet-wide.
 
-1. **Auth/authz verified (LLMO-6709).** Confirm the worker's **service** IMS token is
-   accepted by the Semrush proxy end-to-end. Confirm `tracingFetch` does not emit the
-   `Authorization` header into traces/spans (service-bearer leak).
+1. **Auth/authz verified (LLMO-6709) — now the S2S consumer session-token flow (Decision 9).**
+   Confirm the worker is registered as an S2S consumer with `brand:read`, `SEMRUSH_S2S_*` +
+   `LLMO_API_BASE_URL` are set, and the producer-side Vault keys are provisioned; then confirm
+   the login exchange + `domain-urls` read succeed end-to-end on one canary org. Confirm
+   `tracingFetch` does not emit the `Authorization` header (IMS token or session token) into
+   traces/spans.
 2. **`dataSource` shipped** (this PR) — so parity can be measured.
 3. **Shadow-run parity on a canary site (LLMO-6711)** — top-70 overlap per bucket vs legacy.
 4. **Fleet enable** per environment — **US markets only** until region scoping (LLMO-6710) closes.
 
 ## Configuration / client-convention debt (to resolve before the 3rd caller)
 
-This loader reads `SPACECAT_API_URI` and mints an **IMS service bearer**; `brand-resolver.js`
-reads `SPACECAT_API_BASE_URL` and uses **`x-api-key`** — for the *same* spacecat-api-service.
-The IMS scheme is justified here (the Elements proxy must forward a bearer to Semrush), but
-**two base-URL env vars + two auth schemes** can drift (one caller repointed to stage/prod, the
-other not → IMS traffic to an untrusted issuer → 401 → silent legacy fallback). Documented as
-debt: pick one base-URL env var and one api-service client convention (a shared helper) **before
-the `cited-domains` follow-up adds a third caller** that copies whichever it finds first. A
-tracking ticket will be filed before this debt is resolved; not required to close this PR.
+This loader reads `LLMO_API_BASE_URL` and uses the **S2S consumer session-token** flow
+(Decision 9); `brand-resolver.js` reads `SPACECAT_API_BASE_URL` and uses **`x-api-key`** — for
+the *same* spacecat-api-service. The session-token scheme is required here (only S2S consumers
+may read the Semrush-backed routes), but **two base-URL env vars + two auth schemes** can drift
+(one caller repointed to stage/prod, the other not → traffic to the wrong host/issuer → 401 →
+silent legacy fallback). Documented as debt: pick one base-URL env var and one api-service
+client convention (a shared helper) **before the next S2S-backed source adds a third caller**
+that copies whichever it finds first — the org-id → IMS-token → session-token sequence in
+particular is a good extraction candidate the moment a second consumer needs it. A tracking
+ticket will be filed before this debt is resolved; not required to close this PR.
 
 ## Alternatives Considered
 

--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -874,6 +874,10 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
       site,
       previousWeeks,
       context,
+      // Already resolved above (and reused for DRS scraping) — thread it through so the
+      // loader doesn't independently re-fetch it and risk scoping the session token to a
+      // different org than the rest of this run.
+      imsOrgId,
       siteHostname,
       diagnostics: semrushDiagnostics,
       onProgress: (text) => postMessageOptional(

--- a/src/utils/offsite-brand-presence-semrush.js
+++ b/src/utils/offsite-brand-presence-semrush.js
@@ -75,6 +75,41 @@ const FETCH_TIMEOUT_MS = 10_000;
 const ERROR_BODY_SNIPPET_MAX = 500;
 
 /**
+ * S2S session-token cache TTL. The api-service session token lives 15 min; we cache for a
+ * shorter window so a cached token is never handed to a data call at (or near) expiry. The
+ * cache is module-level, so a warm Lambda container reuses it across audit invocations —
+ * collapsing the IMS mint + login exchange to zero network calls for a brand whose customer
+ * org was minted recently.
+ */
+const SESSION_TOKEN_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * Module-level session-token cache, keyed by customer `imsOrgId` (the scope the token is
+ * minted for). Value: `{ token, expiresAt }`. Not keyed by brand/site — one customer-scoped
+ * session token authorizes every brand under that org.
+ */
+const sessionTokenCache = new Map();
+
+/**
+ * @param {string} imsOrgId
+ * @param {number} nowMs
+ * @returns {string|null} the cached, still-valid session token for this org, or null.
+ */
+function getCachedSessionToken(imsOrgId, nowMs) {
+  const entry = sessionTokenCache.get(imsOrgId);
+  return entry && entry.expiresAt > nowMs ? entry.token : null;
+}
+
+/**
+ * @param {string} imsOrgId
+ * @param {string} token
+ * @param {number} nowMs
+ */
+function cacheSessionToken(imsOrgId, token, nowMs) {
+  sessionTokenCache.set(imsOrgId, { token, expiresAt: nowMs + SESSION_TOKEN_TTL_MS });
+}
+
+/**
  * Reads a non-2xx response body as a short diagnostic snippet. Never throws.
  *
  * @param {Response} response
@@ -104,11 +139,13 @@ async function readErrorBodySnippet(response) {
  * The scheme is normalised to `Bearer` (IMS may return `token_type: "bearer"` lowercase,
  * which a strict `startsWith('Bearer ')` parser upstream would reject).
  *
+ * Returns the full `Bearer <token>` header string (not a bare token) — named accordingly.
+ *
  * @param {object} context - Lambda context (env + log).
  * @returns {Promise<string>} e.g. "Bearer eyJ...".
  * @throws {Error} when the token response has no access_token.
  */
-async function getImsAccessToken(context) {
+async function getImsAuthorizationHeader(context) {
   const { env } = context;
   const imsClient = ImsClient.createFrom({
     ...context,
@@ -118,6 +155,11 @@ async function getImsAccessToken(context) {
       IMS_CLIENT_ID: env?.SEMRUSH_S2S_CLIENT_ID,
       IMS_CLIENT_SECRET: env?.SEMRUSH_S2S_CLIENT_SECRET,
       IMS_SCOPE: env?.SEMRUSH_S2S_CLIENT_SCOPE,
+      // `ImsClient.createFrom` validates clientCode as required, but the client_credentials
+      // grant (`getServiceAccessTokenV3`) never sends it. Set it explicitly so a stripped
+      // env (or the default authorization_code client being retired) can't surface as a
+      // confusing `createFrom` throw masquerading as a token-mint failure.
+      IMS_CLIENT_CODE: env?.SEMRUSH_S2S_CLIENT_CODE || 'unused-for-client-credentials',
     },
   });
   const token = await imsClient.getServiceAccessTokenV3();
@@ -135,12 +177,20 @@ async function getImsAccessToken(context) {
  * consumer. Both this call and the subsequent data call must hit the LLMO host (see
  * `LLMO_API_DEFAULT_BASE_URL`).
  *
+ * On a non-2xx response the thrown error carries `.status` and `.responseBody` so the
+ * caller can (a) split an authz denial (401/403 — a static config problem retries won't
+ * fix) from a transient/other failure, and (b) log the full body while keeping it OUT of
+ * any user-facing (Slack) message — the login endpoint's error body is untrusted upstream
+ * content. The error `.message` deliberately holds only the status, never the body.
+ *
  * @param {object} params
  * @param {string} params.loginUrl - Fully-qualified S2S login URL.
- * @param {string} params.imsAuthorization - `Bearer <ims-token>` from `getImsAccessToken`.
+ * @param {string} params.imsAuthorization - `Bearer <ims-token>` from
+ *   `getImsAuthorizationHeader`.
  * @param {string} params.imsOrgId - Target customer IMS org id (e.g. `...@AdobeOrg`).
  * @returns {Promise<string>} the session token (raw JWT, no scheme prefix).
- * @throws {Error} on network error, non-2xx, unparseable body, or a missing sessionToken.
+ * @throws {Error} on network error, non-2xx (with `.status`/`.responseBody`), unparseable
+ *   body, or a missing sessionToken.
  */
 async function exchangeForSessionToken({ loginUrl, imsAuthorization, imsOrgId }) {
   const response = await fetch(loginUrl, {
@@ -154,8 +204,10 @@ async function exchangeForSessionToken({ loginUrl, imsAuthorization, imsOrgId })
     timeout: FETCH_TIMEOUT_MS,
   });
   if (!response.ok) {
-    const responseBody = await readErrorBodySnippet(response);
-    throw new Error(`s2s login returned ${response.status}${responseBody ? `: ${responseBody}` : ''}`);
+    const error = new Error(`s2s login returned ${response.status}`);
+    error.status = response.status;
+    error.responseBody = await readErrorBodySnippet(response);
+    throw error;
   }
   let body;
   try {
@@ -336,6 +388,11 @@ function classifyRow(row, siteHostname, brandTokens) {
  * @param {object} params.site - Site model (`getOrganizationId()`).
  * @param {Array<{week:number, year:number}>} params.previousWeeks
  * @param {object} params.context - Lambda context (env, log, dataAccess).
+ * @param {string} [params.imsOrgId] - Customer IMS org id (`...@AdobeOrg`) the session token
+ *   is scoped to. The handler already resolves this (for DRS scraping too), so it threads it
+ *   in to avoid a second, independently-fetched lookup that could scope the session token to
+ *   a different org than the rest of the run. Falls back to `getImsOrgId(site, ...)` only when
+ *   the caller omits it.
  * @param {string} [params.siteHostname] - www-stripped site hostname for owned-URL filtering.
  * @param {function(string): Promise<*>} [params.onProgress] - Optional best-effort progress
  *   callback (e.g. a Slack thread reply), invoked with a short human-readable status string at
@@ -345,8 +402,8 @@ function classifyRow(row, siteHostname, brandTokens) {
  * @param {object} [params.diagnostics] - Optional out-param, mutated in place. On a null
  *   return, set to `{ fallbackReason }` with a specific code (`no_organization_id`,
  *   `no_active_brand`, `brand_resolution_failed`, `not_entitled`, `entitlement_check_failed`,
- *   `no_date_window`, `no_ims_org_id`, `ims_token_failed`, `session_token_failed`,
- *   `domain_urls_auth_failed`, or `domain_urls_failed`).
+ *   `no_date_window`, `no_ims_org_id`, `ims_token_failed`, `session_token_auth_failed`,
+ *   `session_token_failed`, `domain_urls_auth_failed`, or `domain_urls_failed`).
  *   The two entitlement reasons additionally set `entitlementReason` to the granular cause
  *   from `resolveSemrushEntitlement` (`flag_disabled` | `no_workspace` | `no_client` |
  *   `check_failed`) — `fallbackReason` alone cannot distinguish a confirmed non-entitlement
@@ -356,7 +413,7 @@ function classifyRow(row, siteHostname, brandTokens) {
  * @returns {Promise<Map<string, {count:number, domain:string|null}> | null>}
  */
 export async function loadCitedUrlsFromSemrush({
-  site, previousWeeks, context, siteHostname, onProgress, diagnostics,
+  site, previousWeeks, context, imsOrgId: providedImsOrgId, siteHostname, onProgress, diagnostics,
 }) {
   const { log, env } = context;
   const startedAt = Date.now();
@@ -481,8 +538,10 @@ export async function loadCitedUrlsFromSemrush({
 
   // Leg 1: the customer IMS org id (…@AdobeOrg) — distinct from spaceCatId (the SpaceCat
   // org UUID used in the route path). This is what the session token's `tenants` claim,
-  // and thus api-service's hasAccess(organization), is keyed on.
-  const imsOrgId = await getImsOrgId(site, context.dataAccess || {}, log);
+  // and thus api-service's hasAccess(organization), is keyed on. The handler already
+  // resolves this (and reuses it for DRS scraping), so prefer the threaded value; the
+  // lookup is only a fallback for callers that don't provide it.
+  const imsOrgId = providedImsOrgId || await getImsOrgId(site, context.dataAccess || {}, log);
   if (!imsOrgId) {
     olog.warn('data_acquisition_bp_data_semrush_read', 'Could not resolve customer IMS org id; skipping Semrush source', {
       peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, brandId: brand.brandId, durationMs: elapsed(), reason: 'no_ims_org_id', outcome: OUTCOME.DEGRADED,
@@ -492,31 +551,63 @@ export async function loadCitedUrlsFromSemrush({
     return null;
   }
 
-  // Leg 2: the consumer's IMS access token (dedicated client_credentials integration).
-  let imsAuthorization;
-  try {
-    imsAuthorization = await getImsAccessToken(context);
-  } catch (error) {
-    olog.warn('data_acquisition_bp_data_semrush_read', 'Failed to obtain IMS service token', {
-      peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, brandId: brand.brandId, durationMs: elapsed(), reason: 'ims_token_failed', outcome: OUTCOME.DEGRADED, ...errorField(error),
-    }, error);
-    await notify(`:x: Failed to obtain an IMS service token (\`${error.message}\`) — falling back to the legacy source.`);
-    setDiagnostics({ fallbackReason: 'ims_token_failed' });
-    return null;
-  }
+  // Legs 2 + 3 — mint the consumer IMS token (client_credentials), then exchange it for a
+  // customer-scoped session token. Both are skipped on a warm-container cache hit: one
+  // customer-scoped token authorizes every brand under the org, so it is cached by imsOrgId
+  // with a TTL under the 15-min server expiry.
+  const nowMs = Date.now();
+  let sessionToken = getCachedSessionToken(imsOrgId, nowMs);
+  if (!sessionToken) {
+    // Leg 2: the consumer's IMS access token (dedicated client_credentials integration).
+    let imsAuthorization;
+    try {
+      imsAuthorization = await getImsAuthorizationHeader(context);
+    } catch (error) {
+      olog.warn('data_acquisition_bp_data_semrush_read', 'Failed to obtain IMS service token', {
+        peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, brandId: brand.brandId, durationMs: elapsed(), reason: 'ims_token_failed', outcome: OUTCOME.DEGRADED, ...errorField(error),
+      }, error);
+      await notify(`:x: Failed to obtain an IMS service token (\`${error.message}\`) — falling back to the legacy source.`);
+      setDiagnostics({ fallbackReason: 'ims_token_failed' });
+      return null;
+    }
 
-  // Leg 3: exchange it for a customer-scoped SpaceCat session token via the LLMO host.
-  const loginUrl = env?.LLMO_S2S_LOGIN_URL || `${baseUrl}${S2S_LOGIN_DEFAULT_PATH}`;
-  let sessionToken;
-  try {
-    sessionToken = await exchangeForSessionToken({ loginUrl, imsAuthorization, imsOrgId });
-  } catch (error) {
-    olog.warn('data_acquisition_bp_data_semrush_read', 'Failed to exchange for an S2S session token', {
-      peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, brandId: brand.brandId, durationMs: elapsed(), reason: 'session_token_failed', outcome: OUTCOME.DEGRADED, ...errorField(error),
-    }, error);
-    await notify(`:x: Failed to obtain an S2S session token (\`${error.message}\`) — falling back to the legacy source.`);
-    setDiagnostics({ fallbackReason: 'session_token_failed' });
-    return null;
+    // Leg 3: exchange it for a customer-scoped SpaceCat session token via the LLMO host.
+    const loginUrl = env?.LLMO_S2S_LOGIN_URL || `${baseUrl}${S2S_LOGIN_DEFAULT_PATH}`;
+    try {
+      sessionToken = await exchangeForSessionToken({ loginUrl, imsAuthorization, imsOrgId });
+    } catch (error) {
+      // Split an authz denial (401/403 — a static config problem retries won't fix: missing
+      // brand:read, or the token's tenants claim doesn't name this org) from a transient/
+      // other failure, mirroring fetchDomainUrls' authFailure branch.
+      const authFailure = error.status === 401 || error.status === 403;
+      const reason = authFailure ? 'session_token_auth_failed' : 'session_token_failed';
+      olog.warn(
+        'data_acquisition_bp_data_semrush_read',
+        authFailure
+          ? 'S2S session-token exchange denied (401/403); verify the consumer has brand:read and the token names this org'
+          : 'Failed to exchange for an S2S session token',
+        {
+          peer: PEER.SEMRUSH,
+          direction: 'inbound',
+          orgId: spaceCatId,
+          brandId: brand.brandId,
+          status: error.status,
+          responseBody: error.responseBody,
+          durationMs: elapsed(),
+          reason,
+          outcome: OUTCOME.DEGRADED,
+          ...errorField(error),
+        },
+        error,
+      );
+      // Forward only the status to Slack — the login endpoint's error body is untrusted
+      // upstream content and must never be echoed into a user-facing channel (it stays in
+      // the structured `responseBody` log field above).
+      await notify(`:x: Failed to obtain an S2S session token${error.status ? ` (HTTP ${error.status})` : ''} — falling back to the legacy source.`);
+      setDiagnostics({ fallbackReason: reason });
+      return null;
+    }
+    cacheSessionToken(imsOrgId, sessionToken, nowMs);
   }
 
   const headers = {

--- a/src/utils/offsite-brand-presence-semrush.js
+++ b/src/utils/offsite-brand-presence-semrush.js
@@ -75,18 +75,34 @@ const FETCH_TIMEOUT_MS = 10_000;
 const ERROR_BODY_SNIPPET_MAX = 500;
 
 /**
- * S2S session-token cache TTL. The api-service session token lives 15 min; we cache for a
- * shorter window so a cached token is never handed to a data call at (or near) expiry. The
- * cache is module-level, so a warm Lambda container reuses it across audit invocations —
+ * Default S2S session-token cache TTL. The api-service session token lives 15 min; we cache
+ * for a shorter window so a cached token is never handed to a data call at (or near) expiry.
+ * The cache is module-level, so a warm Lambda container reuses it across audit invocations —
  * collapsing the IMS mint + login exchange to zero network calls for a brand whose customer
- * org was minted recently.
+ * org was minted recently. Overridable with `SEMRUSH_S2S_SESSION_TTL_MS` so the window can be
+ * retuned (e.g. if the login endpoint's token lifetime changes) without a code deploy.
  */
 const SESSION_TOKEN_TTL_MS = 10 * 60 * 1000;
 
 /**
+ * Resolves the session-token cache TTL from env, falling back to the default. A non-positive
+ * or non-numeric override is ignored (fail-safe to the default rather than a 0/NaN TTL that
+ * would disable or corrupt caching).
+ *
+ * @param {object} env
+ * @returns {number} TTL in ms.
+ */
+function resolveSessionTtlMs(env) {
+  const override = Number(env?.SEMRUSH_S2S_SESSION_TTL_MS);
+  return Number.isFinite(override) && override > 0 ? override : SESSION_TOKEN_TTL_MS;
+}
+
+/**
  * Module-level session-token cache, keyed by customer `imsOrgId` (the scope the token is
  * minted for). Value: `{ token, expiresAt }`. Not keyed by brand/site — one customer-scoped
- * session token authorizes every brand under that org.
+ * session token authorizes every brand under that org. Only ever accessed with a truthy
+ * `imsOrgId` (the `no_ims_org_id` guard above the caching logic returns first), so the key
+ * space can't be polluted by a falsy key.
  */
 const sessionTokenCache = new Map();
 
@@ -101,12 +117,33 @@ function getCachedSessionToken(imsOrgId, nowMs) {
 }
 
 /**
+ * Caches a freshly-minted session token. Opportunistically sweeps expired entries on each
+ * write so the map stays bounded by the number of distinct orgs seen within one TTL window
+ * (not the life of the warm container) — a slow leak this shape would otherwise cause.
+ *
  * @param {string} imsOrgId
  * @param {string} token
  * @param {number} nowMs
+ * @param {number} ttlMs
  */
-function cacheSessionToken(imsOrgId, token, nowMs) {
-  sessionTokenCache.set(imsOrgId, { token, expiresAt: nowMs + SESSION_TOKEN_TTL_MS });
+function cacheSessionToken(imsOrgId, token, nowMs, ttlMs) {
+  for (const [key, entry] of sessionTokenCache) {
+    if (entry.expiresAt <= nowMs) {
+      sessionTokenCache.delete(key);
+    }
+  }
+  sessionTokenCache.set(imsOrgId, { token, expiresAt: nowMs + ttlMs });
+}
+
+/**
+ * Drops the cached token for an org — called when a cached token is rejected downstream by
+ * the data call (401/403), so a revoked/rotated token can't be replayed for the rest of its
+ * TTL and the next run re-mints (restoring the pre-caching self-heal-on-next-invocation).
+ *
+ * @param {string} imsOrgId
+ */
+function evictSessionToken(imsOrgId) {
+  sessionTokenCache.delete(imsOrgId);
 }
 
 /**
@@ -557,6 +594,10 @@ export async function loadCitedUrlsFromSemrush({
   // with a TTL under the 15-min server expiry.
   const nowMs = Date.now();
   let sessionToken = getCachedSessionToken(imsOrgId, nowMs);
+  // Tracked so that a downstream 401/403 on the data call can distinguish "our cached token
+  // went stale mid-window" (evict + self-heal next run) from "a freshly-minted token was
+  // rejected" (the consumer registration / grant is actually broken).
+  const sessionTokenFromCache = sessionToken !== null;
   if (!sessionToken) {
     // Leg 2: the consumer's IMS access token (dedicated client_credentials integration).
     let imsAuthorization;
@@ -607,7 +648,7 @@ export async function loadCitedUrlsFromSemrush({
       setDiagnostics({ fallbackReason: reason });
       return null;
     }
-    cacheSessionToken(imsOrgId, sessionToken, nowMs);
+    cacheSessionToken(imsOrgId, sessionToken, nowMs, resolveSessionTtlMs(env));
   }
 
   const headers = {
@@ -629,8 +670,21 @@ export async function loadCitedUrlsFromSemrush({
 
   const result = await fetchDomainUrls(url, headers, olog, PAGE_SIZE);
   if (!result.ok) {
+    if (result.authFailure) {
+      // The session token was rejected by the data call — evict it so a revoked/rotated
+      // token can't be replayed from the cache for the rest of its TTL; the next run
+      // re-mints. `wasCachedToken` lets ops tell a mid-window staleness (self-heals next
+      // run) from a genuinely broken registration (a freshly-minted token rejected).
+      evictSessionToken(imsOrgId);
+    }
     olog.warn('data_acquisition_bp_data_semrush_read', 'domain-urls request failed; using legacy fallback', {
-      peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, durationMs: elapsed(), reason: 'domain_urls_failed', outcome: OUTCOME.DEGRADED,
+      peer: PEER.SEMRUSH,
+      direction: 'inbound',
+      orgId: spaceCatId,
+      durationMs: elapsed(),
+      reason: 'domain_urls_failed',
+      outcome: OUTCOME.DEGRADED,
+      ...(result.authFailure && { wasCachedToken: sessionTokenFromCache }),
     });
     await notify(':x: `domain-urls` request failed — falling back to the legacy source.');
     setDiagnostics({

--- a/src/utils/offsite-brand-presence-semrush.js
+++ b/src/utils/offsite-brand-presence-semrush.js
@@ -19,6 +19,7 @@ import {
   SEMRUSH_ENTITLEMENT_CHECK_FAILED_REASON,
 } from './semrush-entitlement.js';
 import { getDateWindowForPreviousWeeks } from './offsite-brand-presence-postgrest.js';
+import { getImsOrgId } from './data-access.js';
 import { classifyAndNormalize } from './offsite-brand-presence-enrichment.js';
 import { computeBrandTokens, isExcludedCitedHost } from './offsite-audit-utils.js';
 import {
@@ -31,13 +32,26 @@ import {
 } from '../offsite-brand-presence/constants.js';
 
 /**
- * Default spacecat-api-service base URL. Its Elements proxy
- * (`src/controllers/elements.js`) serves the Semrush-backed Serenity
- * URL-Inspector endpoints at
- * `/v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/*`.
- * Overridable per-environment with `SPACECAT_API_URI`.
+ * Default spacecat-api-service base URL (host root, no path prefix). Its Elements proxy
+ * (`src/controllers/elements.js`) serves the Semrush-backed Serenity URL-Inspector
+ * endpoints at `/v2/orgs/:spaceCatId/brands/:brandId/serenity/brand-presence/url-inspector/*`.
+ *
+ * This MUST be the **LLMO** host, not the ASO host: the Fastly edge sets the `x-product`
+ * header from the request `Host`, and these are LLMO routes. Minting the S2S session token
+ * (and calling the data route) on the ASO host yields an ASO-context token that fails the
+ * per-product entitlement check even with a valid `brand:read` grant. Prod is
+ * `llmo.experiencecloud.live`; dev/CI is `llmo.experiencecloud.page` — override with
+ * `LLMO_API_BASE_URL`.
  */
-export const SPACECAT_API_DEFAULT_BASE_URL = 'https://spacecat.experiencecloud.live/api/v1';
+export const LLMO_API_DEFAULT_BASE_URL = 'https://llmo.experiencecloud.live';
+
+/**
+ * Path (relative to the LLMO host root) of the S2S login endpoint that exchanges the
+ * consumer's IMS access token for a short-lived, customer-scoped SpaceCat session token.
+ * The prod prefix is `/api/v1`; non-prod uses `/api/ci`, so the whole URL is overridable
+ * with `LLMO_S2S_LOGIN_URL` when the environment's prefix differs.
+ */
+export const S2S_LOGIN_DEFAULT_PATH = '/api/v1/auth/s2s/login';
 
 /**
  * `domain-urls` page size. One request (no `hostname`, `platform=all`) covers all three
@@ -54,10 +68,9 @@ export const PAGE_SIZE = 1000;
 const FETCH_TIMEOUT_MS = 10_000;
 
 /**
- * Max chars of a non-2xx response body to log. The body of a rejected
- * serenity/Semrush call identifies the rejecter — api-service `requireImsBearer`
- * ("...send the x-promise-token header instead") vs a Semrush upstream error —
- * which decides who owns the LLMO-6709 auth fix. Capped defensively.
+ * Max chars of a non-2xx response body to log. The body of a rejected serenity/Semrush
+ * call identifies the rejecter — an api-service auth/ACL denial vs a Semrush upstream
+ * error — which decides where an auth failure needs fixing. Capped defensively.
  */
 const ERROR_BODY_SNIPPET_MAX = 500;
 
@@ -77,29 +90,83 @@ async function readErrorBodySnippet(response) {
 }
 
 /**
- * Mints an IMS service access token as an Authorization header value.
+ * Mints an IMS access token for the audit-worker's dedicated Semrush S2S consumer, as an
+ * Authorization header value.
  *
- * Uses the v2 `getServiceAccessToken()` (`authorization_code` grant) with the
- * worker's default IMS client — the same S2S path `commerce-product-enrichments`,
- * `vulnerabilities` and `permissions` use. The default client is provisioned for
- * `authorization_code`, NOT the `client_credentials` grant that
- * `getServiceAccessTokenV3()` requests (which returns IMS `400 unauthorized_client`
- * unless a dedicated client_credentials integration is configured, e.g. content-ai's
- * `CONTENTAI_*`). The scheme is normalised to `Bearer` (the endpoint may return
- * `token_type: "bearer"` lowercase, which a strict `startsWith('Bearer ')` parser
- * upstream would reject).
+ * Unlike the worker's default IMS client (provisioned for `authorization_code`), the S2S
+ * consumer is a dedicated `client_credentials` OAuth Server-to-Server integration — the
+ * same shape content-ai uses (`CONTENTAI_*`). Its credentials come from `SEMRUSH_S2S_*`
+ * env vars and are minted with `getServiceAccessTokenV3()` (the `client_credentials`
+ * grant). This IMS token is only the FIRST leg — it is not sent to the data route
+ * directly; it is exchanged for a customer-scoped session token (see
+ * `exchangeForSessionToken`).
+ *
+ * The scheme is normalised to `Bearer` (IMS may return `token_type: "bearer"` lowercase,
+ * which a strict `startsWith('Bearer ')` parser upstream would reject).
  *
  * @param {object} context - Lambda context (env + log).
  * @returns {Promise<string>} e.g. "Bearer eyJ...".
  * @throws {Error} when the token response has no access_token.
  */
-async function getAuthorizationHeader(context) {
-  const imsClient = ImsClient.createFrom(context);
-  const token = await imsClient.getServiceAccessToken();
+async function getImsAccessToken(context) {
+  const { env } = context;
+  const imsClient = ImsClient.createFrom({
+    ...context,
+    env: {
+      ...env,
+      IMS_HOST: env?.SEMRUSH_S2S_IMS_HOST,
+      IMS_CLIENT_ID: env?.SEMRUSH_S2S_CLIENT_ID,
+      IMS_CLIENT_SECRET: env?.SEMRUSH_S2S_CLIENT_SECRET,
+      IMS_SCOPE: env?.SEMRUSH_S2S_CLIENT_SCOPE,
+    },
+  });
+  const token = await imsClient.getServiceAccessTokenV3();
   if (!token?.access_token) {
-    throw new Error('IMS service token response missing access_token');
+    throw new Error('IMS S2S token response missing access_token');
   }
   return `Bearer ${token.access_token}`;
+}
+
+/**
+ * Exchanges the consumer's IMS access token for a short-lived (15-min), customer-scoped
+ * SpaceCat session token via the S2S login endpoint. The returned session token is a JWT
+ * whose `tenants` claim names `imsOrgId` — this is what api-service's
+ * `hasAccess(organization)` actually checks to authorize the domain-urls read as an S2S
+ * consumer. Both this call and the subsequent data call must hit the LLMO host (see
+ * `LLMO_API_DEFAULT_BASE_URL`).
+ *
+ * @param {object} params
+ * @param {string} params.loginUrl - Fully-qualified S2S login URL.
+ * @param {string} params.imsAuthorization - `Bearer <ims-token>` from `getImsAccessToken`.
+ * @param {string} params.imsOrgId - Target customer IMS org id (e.g. `...@AdobeOrg`).
+ * @returns {Promise<string>} the session token (raw JWT, no scheme prefix).
+ * @throws {Error} on network error, non-2xx, unparseable body, or a missing sessionToken.
+ */
+async function exchangeForSessionToken({ loginUrl, imsAuthorization, imsOrgId }) {
+  const response = await fetch(loginUrl, {
+    method: 'POST',
+    headers: {
+      Authorization: imsAuthorization,
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({ imsOrgId }),
+    timeout: FETCH_TIMEOUT_MS,
+  });
+  if (!response.ok) {
+    const responseBody = await readErrorBodySnippet(response);
+    throw new Error(`s2s login returned ${response.status}${responseBody ? `: ${responseBody}` : ''}`);
+  }
+  let body;
+  try {
+    body = await response.json();
+  } catch {
+    throw new Error('s2s login response was not parseable JSON');
+  }
+  if (!body?.sessionToken) {
+    throw new Error('s2s login response missing sessionToken');
+  }
+  return body.sessionToken;
 }
 
 /**
@@ -154,9 +221,11 @@ async function fetchDomainUrls(url, headers, olog, pageSize) {
       peer: PEER.SEMRUSH, direction: 'inbound', status: response.status, responseBody, durationMs,
     };
     if (authFailure) {
-      // Distinct branch so a rejected service token is visible instead of being
-      // masked as "Semrush returned nothing" (LLMO-6709 verification).
-      olog.warn('data_acquisition_bp_data_semrush_read', 'Service token rejected for domain-urls; verify the IMS service token is authorized by the Semrush proxy (LLMO-6709)', {
+      // Distinct branch so a rejected session token is visible instead of being
+      // masked as "Semrush returned nothing". On the S2S path a 401/403 here means the
+      // session token expired/was invalid, or the consumer lacks `brand:read` / its
+      // token's `tenants` claim doesn't name this org.
+      olog.warn('data_acquisition_bp_data_semrush_read', 'S2S session token rejected for domain-urls; verify the consumer has brand:read and the session token names this org', {
         ...logFields, reason: 'auth_rejected', outcome: OUTCOME.DEGRADED,
       });
     } else {
@@ -276,7 +345,8 @@ function classifyRow(row, siteHostname, brandTokens) {
  * @param {object} [params.diagnostics] - Optional out-param, mutated in place. On a null
  *   return, set to `{ fallbackReason }` with a specific code (`no_organization_id`,
  *   `no_active_brand`, `brand_resolution_failed`, `not_entitled`, `entitlement_check_failed`,
- *   `no_date_window`, `ims_token_failed`, `domain_urls_auth_failed`, or `domain_urls_failed`).
+ *   `no_date_window`, `no_ims_org_id`, `ims_token_failed`, `session_token_failed`,
+ *   `domain_urls_auth_failed`, or `domain_urls_failed`).
  *   The two entitlement reasons additionally set `entitlementReason` to the granular cause
  *   from `resolveSemrushEntitlement` (`flag_disabled` | `no_workspace` | `no_client` |
  *   `check_failed`) — `fallbackReason` alone cannot distinguish a confirmed non-entitlement
@@ -293,7 +363,7 @@ export async function loadCitedUrlsFromSemrush({
   const siteId = site?.getId?.();
   const olog = createOffsiteLogger(log, { audit: AUDIT.BRAND_PRESENCE, siteId });
   const elapsed = () => Date.now() - startedAt;
-  const baseUrl = env?.SPACECAT_API_URI || SPACECAT_API_DEFAULT_BASE_URL;
+  const baseUrl = env?.LLMO_API_BASE_URL || LLMO_API_DEFAULT_BASE_URL;
 
   const notify = async (text) => {
     if (typeof onProgress !== 'function') {
@@ -401,9 +471,31 @@ export async function loadCitedUrlsFromSemrush({
   }
   const { startDate, endDate } = dateWindow;
 
-  let authorization;
+  // S2S auth (3 legs). api-service serves the Semrush-backed domain-urls route to S2S
+  // consumers, not to raw IMS service tokens (which carry no `tenants`/org membership and
+  // are rejected by the IMS path). So we:
+  //   1. resolve the customer's IMS org id (the session token must be scoped to it),
+  //   2. mint the consumer's own IMS token (client_credentials),
+  //   3. exchange it for a 15-min session token whose `tenants` claim names that org.
+  // The domain-urls call then presents that session token.
+
+  // Leg 1: the customer IMS org id (…@AdobeOrg) — distinct from spaceCatId (the SpaceCat
+  // org UUID used in the route path). This is what the session token's `tenants` claim,
+  // and thus api-service's hasAccess(organization), is keyed on.
+  const imsOrgId = await getImsOrgId(site, context.dataAccess || {}, log);
+  if (!imsOrgId) {
+    olog.warn('data_acquisition_bp_data_semrush_read', 'Could not resolve customer IMS org id; skipping Semrush source', {
+      peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, brandId: brand.brandId, durationMs: elapsed(), reason: 'no_ims_org_id', outcome: OUTCOME.DEGRADED,
+    });
+    await notify(':x: Could not resolve the customer IMS org id — falling back to the legacy source.');
+    setDiagnostics({ fallbackReason: 'no_ims_org_id' });
+    return null;
+  }
+
+  // Leg 2: the consumer's IMS access token (dedicated client_credentials integration).
+  let imsAuthorization;
   try {
-    authorization = await getAuthorizationHeader(context);
+    imsAuthorization = await getImsAccessToken(context);
   } catch (error) {
     olog.warn('data_acquisition_bp_data_semrush_read', 'Failed to obtain IMS service token', {
       peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, brandId: brand.brandId, durationMs: elapsed(), reason: 'ims_token_failed', outcome: OUTCOME.DEGRADED, ...errorField(error),
@@ -413,16 +505,27 @@ export async function loadCitedUrlsFromSemrush({
     return null;
   }
 
+  // Leg 3: exchange it for a customer-scoped SpaceCat session token via the LLMO host.
+  const loginUrl = env?.LLMO_S2S_LOGIN_URL || `${baseUrl}${S2S_LOGIN_DEFAULT_PATH}`;
+  let sessionToken;
+  try {
+    sessionToken = await exchangeForSessionToken({ loginUrl, imsAuthorization, imsOrgId });
+  } catch (error) {
+    olog.warn('data_acquisition_bp_data_semrush_read', 'Failed to exchange for an S2S session token', {
+      peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, brandId: brand.brandId, durationMs: elapsed(), reason: 'session_token_failed', outcome: OUTCOME.DEGRADED, ...errorField(error),
+    }, error);
+    await notify(`:x: Failed to obtain an S2S session token (\`${error.message}\`) — falling back to the legacy source.`);
+    setDiagnostics({ fallbackReason: 'session_token_failed' });
+    return null;
+  }
+
   const headers = {
-    Authorization: authorization,
+    // The customer-scoped S2S session token authorizes the read as an S2S consumer; it is
+    // self-contained (no x-promise-token / IMS-forwarding needed on this path).
+    Authorization: `Bearer ${sessionToken}`,
     // GET has no body — advertise the desired representation with Accept rather
     // than Content-Type (some proxies buffer/reject a Content-Type on a bodyless GET).
     Accept: 'application/json',
-    // The api-service Elements proxy authenticates IMS callers directly and
-    // forwards this Bearer to Semrush (resolveElementsImsToken fallback), so a
-    // promise token is not required for a service caller. Forward one only if
-    // the platform later threads it onto the context (non-IMS callers).
-    ...(context.promiseToken ? { 'x-promise-token': context.promiseToken } : {}),
   };
 
   const url = buildDomainUrlsUrl({

--- a/test/utils/offsite-brand-presence-semrush.test.js
+++ b/test/utils/offsite-brand-presence-semrush.test.js
@@ -622,6 +622,72 @@ describe('offsite-brand-presence-semrush', function () {
     expect(getServiceAccessTokenV3.callCount).to.equal(2);
   });
 
+  it('evicts a cached session token when the data call rejects it (401), so the next run re-mints', async () => {
+    let dataResponse = okJson({ urls: [] });
+    fetchStub.withArgs(sinon.match((u) => !isLogin(u))).callsFake(async () => dataResponse);
+
+    await run(); // call 1: mint + login + data(200) -> caches the token
+    dataResponse = { ok: false, status: 401 };
+    await run(); // call 2: cache HIT, data(401) -> evict + fallback (no new login)
+    dataResponse = okJson({ urls: [] });
+    const third = await run(); // call 3: cache empty (evicted) -> re-mint + login
+
+    expect(loginCallCount()).to.equal(2); // call 1 and call 3; call 2 reused then evicted
+    expect(getServiceAccessTokenV3.callCount).to.equal(2);
+    expect(third).to.not.equal(null);
+    // The stale-cache signal is logged so ops can tell it apart from a broken registration.
+    expect(log.warn.getCalls().some((c) => c.args[0].includes('wasCachedToken=true'))).to.equal(true);
+  });
+
+  it('does not evict on a non-auth data failure (500) — only auth rejections poison the token', async () => {
+    let dataResponse = okJson({ urls: [] });
+    fetchStub.withArgs(sinon.match((u) => !isLogin(u))).callsFake(async () => dataResponse);
+
+    await run(); // caches
+    dataResponse = { ok: false, status: 500 };
+    await run(); // cache hit, data(500) -> NOT evicted
+    dataResponse = okJson({ urls: [] });
+    await run(); // still cached -> hit, no re-mint
+
+    expect(loginCallCount()).to.equal(1);
+  });
+
+  it('keeps unexpired entries for other orgs when caching a new one (bounded sweep)', async () => {
+    const call = (imsOrgId) => mod.loadCitedUrlsFromSemrush({
+      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(), imsOrgId,
+    });
+    await call('orgA@AdobeOrg'); // mint + cache A
+    await call('orgB@AdobeOrg'); // mint + cache B (sweep sees A unexpired -> keeps it)
+    await call('orgA@AdobeOrg'); // A still cached -> hit, no re-mint
+
+    expect(loginCallCount()).to.equal(2); // A and B; the 3rd (A) reused the cache
+  });
+
+  it('honours SEMRUSH_S2S_SESSION_TTL_MS as the cache window', async () => {
+    const clock = sandbox.useFakeTimers({ now: 1_000_000, toFake: ['Date'] });
+    await run({ SEMRUSH_S2S_SESSION_TTL_MS: '60000' }); // 60s TTL (well under the 10-min default)
+    clock.tick(30 * 1000);
+    await run({ SEMRUSH_S2S_SESSION_TTL_MS: '60000' });
+    expect(loginCallCount()).to.equal(1); // 30s < 60s -> still cached
+    clock.tick(40 * 1000);
+    await run({ SEMRUSH_S2S_SESSION_TTL_MS: '60000' });
+    // 70s > 60s -> expired, re-mint (the default 10min TTL would still have it cached).
+    expect(loginCallCount()).to.equal(2);
+  });
+
+  it('ignores an invalid SEMRUSH_S2S_SESSION_TTL_MS (non-numeric or non-positive) and uses the default', async () => {
+    const callWith = (ttl, imsOrgId) => mod.loadCitedUrlsFromSemrush({
+      site,
+      previousWeeks: PREVIOUS_WEEKS,
+      context: makeContext({ SEMRUSH_S2S_SESSION_TTL_MS: ttl }),
+      imsOrgId,
+    });
+    await callWith('nonsense', 'orgN@AdobeOrg'); // NaN -> default
+    await callWith('0', 'orgZ@AdobeOrg'); // finite but <= 0 -> default
+    // Distinct orgs => both are cache misses => both exercise resolveSessionTtlMs's fallback.
+    expect(loginCallCount()).to.equal(2);
+  });
+
   // --- IMS token minting (leg 2) --------------------------------------------
 
   it('returns null (ims_token_failed) when the IMS service token cannot be minted', async () => {

--- a/test/utils/offsite-brand-presence-semrush.test.js
+++ b/test/utils/offsite-brand-presence-semrush.test.js
@@ -67,6 +67,7 @@ describe('offsite-brand-presence-semrush', function () {
   const dataCall = () => fetchStub.getCalls().find((c) => !isLogin(c.args[0]));
   const loginCall = () => fetchStub.getCalls().find((c) => isLogin(c.args[0]));
   const dataCallCount = () => fetchStub.getCalls().filter((c) => !isLogin(c.args[0])).length;
+  const loginCallCount = () => fetchStub.getCalls().filter((c) => isLogin(c.args[0])).length;
 
   async function loadModule(overrides = {}) {
     return esmock('../../src/utils/offsite-brand-presence-semrush.js', {
@@ -172,6 +173,16 @@ describe('offsite-brand-presence-semrush', function () {
     expect(passedEnv.IMS_CLIENT_SECRET).to.equal('secret');
     expect(passedEnv.IMS_SCOPE).to.equal('scope');
     expect(passedEnv.IMS_HOST).to.equal('https://ims.example');
+  });
+
+  it('sets a placeholder IMS_CLIENT_CODE (createFrom requires it; client_credentials ignores it)', async () => {
+    await run(); // no SEMRUSH_S2S_CLIENT_CODE set
+    expect(imsCreateFrom.firstCall.args[0].env.IMS_CLIENT_CODE).to.equal('unused-for-client-credentials');
+  });
+
+  it('uses SEMRUSH_S2S_CLIENT_CODE for IMS_CLIENT_CODE when provided', async () => {
+    await run({ SEMRUSH_S2S_CLIENT_CODE: 'the-code' });
+    expect(imsCreateFrom.firstCall.args[0].env.IMS_CLIENT_CODE).to.equal('the-code');
   });
 
   it('exchanges the IMS token for a customer-scoped session token: POST login, Bearer IMS token, { imsOrgId } body', async () => {
@@ -584,6 +595,33 @@ describe('offsite-brand-presence-semrush', function () {
     expect(getImsOrgIdStub.firstCall.args[1]).to.deep.equal({});
   });
 
+  it('prefers a threaded imsOrgId and skips the getImsOrgId lookup', async () => {
+    await mod.loadCitedUrlsFromSemrush({
+      site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(), imsOrgId: 'threaded@AdobeOrg',
+    });
+    expect(getImsOrgIdStub).to.not.have.been.called;
+    expect(JSON.parse(loginCall().args[1].body)).to.deep.equal({ imsOrgId: 'threaded@AdobeOrg' });
+  });
+
+  // --- session token caching (keyed by imsOrgId) ----------------------------
+
+  it('reuses a cached session token on a second call for the same imsOrgId (skips IMS mint + login)', async () => {
+    await run();
+    await run();
+    expect(getServiceAccessTokenV3.callCount).to.equal(1);
+    expect(loginCallCount()).to.equal(1);
+    expect(dataCallCount()).to.equal(2); // the data call still fires each time
+  });
+
+  it('re-mints the session token after the cached one expires (TTL)', async () => {
+    const clock = sandbox.useFakeTimers({ now: 1_000_000, toFake: ['Date'] });
+    await run();
+    clock.tick(11 * 60 * 1000); // past the 10-minute TTL
+    await run();
+    expect(loginCallCount()).to.equal(2);
+    expect(getServiceAccessTokenV3.callCount).to.equal(2);
+  });
+
   // --- IMS token minting (leg 2) --------------------------------------------
 
   it('returns null (ims_token_failed) when the IMS service token cannot be minted', async () => {
@@ -602,28 +640,49 @@ describe('offsite-brand-presence-semrush', function () {
 
   // --- session token exchange (leg 3) ---------------------------------------
 
-  it('returns null (session_token_failed) on a non-2xx login response (with a body)', async () => {
-    fetchStub.withArgs(sinon.match(isLogin)).resolves({ ok: false, status: 403, text: async () => 'nope' });
+  it('splits a 403 login denial into session_token_auth_failed, logs the body, but keeps it out of Slack', async () => {
+    const denyBody = 'Denied - reason=no-org-access secret=abc123';
+    fetchStub.withArgs(sinon.match(isLogin))
+      .resolves({ ok: false, status: 403, text: async () => denyBody });
     const diagnostics = {};
-    const result = await run({}, {}, undefined, diagnostics);
+    const onProgress = sandbox.stub().resolves();
+    const result = await run({}, {}, onProgress, diagnostics);
+
     expect(result).to.equal(null);
-    expect(diagnostics.fallbackReason).to.equal('session_token_failed');
+    expect(diagnostics.fallbackReason).to.equal('session_token_auth_failed');
     expect(dataCall()).to.equal(undefined); // never reaches the data call
-    expect(warnedWith(/Failed to exchange for an S2S session token/)).to.equal(true);
+    expect(warnedWith(/session-token exchange denied/)).to.equal(true);
+    // The untrusted upstream body is captured in the structured log...
+    expect(log.warn.getCalls().some((c) => c.args[0].includes(`responseBody="${denyBody}"`))).to.equal(true);
+    // ...but only the status (never the body) is forwarded to the user-facing Slack notify.
+    const slack = onProgress.getCalls().map((c) => c.args[0]);
+    expect(slack.some((m) => /S2S session token.*HTTP 403/.test(m))).to.equal(true);
+    expect(slack.some((m) => m.includes(denyBody))).to.equal(false);
   });
 
-  it('returns null (session_token_failed) on a non-2xx login response (no readable body)', async () => {
+  it('treats a 401 login denial as session_token_auth_failed too', async () => {
+    fetchStub.withArgs(sinon.match(isLogin)).resolves({ ok: false, status: 401 });
+    const diagnostics = {};
+    expect(await run({}, {}, undefined, diagnostics)).to.equal(null);
+    expect(diagnostics.fallbackReason).to.equal('session_token_auth_failed');
+  });
+
+  it('returns null (session_token_failed) on a non-auth non-2xx login response (no readable body)', async () => {
     fetchStub.withArgs(sinon.match(isLogin)).resolves({ ok: false, status: 500 });
     const diagnostics = {};
     expect(await run({}, {}, undefined, diagnostics)).to.equal(null);
     expect(diagnostics.fallbackReason).to.equal('session_token_failed');
+    expect(warnedWith(/Failed to exchange for an S2S session token/)).to.equal(true);
   });
 
-  it('returns null (session_token_failed) on a network error during login', async () => {
+  it('returns null (session_token_failed) on a network error during login (no status -> no HTTP suffix in Slack)', async () => {
     fetchStub.withArgs(sinon.match(isLogin)).rejects(new Error('login down'));
     const diagnostics = {};
-    expect(await run({}, {}, undefined, diagnostics)).to.equal(null);
+    const onProgress = sandbox.stub().resolves();
+    expect(await run({}, {}, onProgress, diagnostics)).to.equal(null);
     expect(diagnostics.fallbackReason).to.equal('session_token_failed');
+    const slack = onProgress.getCalls().map((c) => c.args[0]);
+    expect(slack.some((m) => /Failed to obtain an S2S session token — falling back/.test(m))).to.equal(true);
   });
 
   it('returns null (session_token_failed) when the login body is not parseable JSON', async () => {

--- a/test/utils/offsite-brand-presence-semrush.test.js
+++ b/test/utils/offsite-brand-presence-semrush.test.js
@@ -25,6 +25,8 @@ use(sinonChai);
 
 const ORG_ID = 'e07a0aae-b794-41f6-9622-a602203c5a3e';
 const BRAND_ID = 'cb84e91a-f7e9-488b-8220-e0d031941cd7';
+const IMS_ORG_ID = '899D173E60B73D8B0A495C0A@AdobeOrg';
+const SESSION_TOKEN = 'sess-jwt-token';
 const PREVIOUS_WEEKS = [{ week: 29, year: 2026 }, { week: 28, year: 2026 }];
 
 const YT_URL = 'https://www.youtube.com/watch?v=abc';
@@ -33,6 +35,7 @@ const RD_URL = 'https://www.reddit.com/r/Lovesac/comments/1/pros_cons';
 const CITED_URL = 'https://example.org/page';
 
 const okJson = (body) => ({ ok: true, status: 200, json: async () => body });
+const isLogin = (u) => String(u).includes('/auth/s2s/login');
 
 describe('offsite-brand-presence-semrush', function () {
   this.timeout(10000);
@@ -42,8 +45,9 @@ describe('offsite-brand-presence-semrush', function () {
   let fetchStub;
   let resolveBrandResultForSite;
   let resolveSemrushEntitlement;
-  let getServiceAccessToken;
+  let getServiceAccessTokenV3;
   let imsCreateFrom;
+  let getImsOrgIdStub;
   let mod;
 
   const SITE_ID = '5b0d4d6e-3d2e-4a5b-8e2a-9b6f7c9c1e2a';
@@ -52,14 +56,24 @@ describe('offsite-brand-presence-semrush', function () {
     getId: () => SITE_ID,
     getConfig: () => ({ getBrandKeywords: () => [] }),
   };
-  const makeContext = (env = {}, extra = {}) => ({ log, env, ...extra });
+  const makeContext = (env = {}, extra = {}) => ({
+    log, env, dataAccess: {}, ...extra,
+  });
   const warnedWith = (re) => log.warn.getCalls().some((c) => re.test(c.args[0]));
+
+  // Both the S2S login POST and the domain-urls GET go through the same `fetch`. The login
+  // call is matched by URL (withArgs) and resolves a session token by default; each test's
+  // `fetchStub.resolves(...)` sets the DATA-call response only.
+  const dataCall = () => fetchStub.getCalls().find((c) => !isLogin(c.args[0]));
+  const loginCall = () => fetchStub.getCalls().find((c) => isLogin(c.args[0]));
+  const dataCallCount = () => fetchStub.getCalls().filter((c) => !isLogin(c.args[0])).length;
 
   async function loadModule(overrides = {}) {
     return esmock('../../src/utils/offsite-brand-presence-semrush.js', {
       '@adobe/spacecat-shared-ims-client': { ImsClient: { createFrom: imsCreateFrom } },
       '../../src/utils/brand-resolver.js': { resolveBrandResultForSite },
       '../../src/utils/semrush-entitlement.js': { resolveSemrushEntitlement },
+      '../../src/utils/data-access.js': { getImsOrgId: getImsOrgIdStub },
       '@adobe/spacecat-shared-utils': { ...spacecatSharedUtils, tracingFetch: fetchStub },
       ...overrides,
     });
@@ -80,6 +94,10 @@ describe('offsite-brand-presence-semrush', function () {
       info: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub(), debug: sandbox.stub(),
     };
     fetchStub = sandbox.stub();
+    // The login leg always succeeds by default; tests override it explicitly when they
+    // exercise a login failure. The default (non-login) behavior is the data response.
+    fetchStub.withArgs(sinon.match(isLogin)).resolves(okJson({ sessionToken: SESSION_TOKEN }));
+    fetchStub.resolves(okJson({ urls: [] }));
     resolveBrandResultForSite = sandbox.stub()
       .resolves({ brand: { brandId: BRAND_ID }, resolved: true });
     resolveSemrushEntitlement = sandbox.stub()
@@ -89,8 +107,9 @@ describe('offsite-brand-presence-semrush', function () {
         reason: SEMRUSH_ENTITLEMENT_REASONS.ENTITLED,
         mode: 'subworkspace',
       });
-    getServiceAccessToken = sandbox.stub().resolves({ token_type: 'Bearer', access_token: 'tok' });
-    imsCreateFrom = sandbox.stub().returns({ getServiceAccessToken });
+    getServiceAccessTokenV3 = sandbox.stub().resolves({ token_type: 'Bearer', access_token: 'tok' });
+    imsCreateFrom = sandbox.stub().returns({ getServiceAccessTokenV3 });
+    getImsOrgIdStub = sandbox.stub().resolves(IMS_ORG_ID);
     mod = await loadModule();
   });
 
@@ -100,12 +119,12 @@ describe('offsite-brand-presence-semrush', function () {
 
   // --- happy path -----------------------------------------------------------
 
-  it('makes exactly ONE domain-urls request (no hostname, platform=all)', async () => {
-    fetchStub.resolves(okJson({ urls: [] }));
+  it('makes exactly ONE domain-urls request (no hostname, platform=all) after an S2S login', async () => {
     await run();
 
-    expect(fetchStub.callCount).to.equal(1);
-    const [url] = fetchStub.firstCall.args;
+    expect(dataCallCount()).to.equal(1);
+    expect(loginCall()).to.not.equal(undefined);
+    const [url] = dataCall().args;
     expect(new URL(url).searchParams.has('hostname')).to.equal(false);
     expect(new URL(url).searchParams.get('platform')).to.equal('all');
   });
@@ -126,42 +145,66 @@ describe('offsite-brand-presence-semrush', function () {
     expect(allUrls.get(CITED_URL)).to.deep.equal({ count: 5, domain: null });
   });
 
-  it('sends Authorization+Accept+timeout, no Content-Type, no x-promise-token by default', async () => {
-    fetchStub.resolves(okJson({ urls: [] }));
+  // --- S2S auth (IMS token -> session token) --------------------------------
+
+  it('sends the session token (not the IMS token) as Bearer, with Accept and a timeout, and no Content-Type on the data call', async () => {
     await run();
 
-    const [url, opts] = fetchStub.firstCall.args;
-    expect(url).to.contain(`${mod.SPACECAT_API_DEFAULT_BASE_URL}/v2/orgs/${ORG_ID}/brands/${BRAND_ID}`);
-    expect(opts.headers.Authorization).to.equal('Bearer tok');
+    const [url, opts] = dataCall().args;
+    expect(url).to.contain(`${mod.LLMO_API_DEFAULT_BASE_URL}/v2/orgs/${ORG_ID}/brands/${BRAND_ID}`);
+    expect(opts.headers.Authorization).to.equal(`Bearer ${SESSION_TOKEN}`);
     expect(opts.headers.Accept).to.equal('application/json');
     expect(opts.headers).to.not.have.property('Content-Type');
-    expect(opts.headers).to.not.have.property('x-promise-token');
     expect(opts.timeout).to.equal(10000);
   });
 
-  it('normalizes a lowercase token_type to Bearer', async () => {
-    getServiceAccessToken.resolves({ token_type: 'bearer', access_token: 'tok' });
-    fetchStub.resolves(okJson({ urls: [] }));
+  it('mints the consumer IMS token via getServiceAccessTokenV3 (client_credentials) with SEMRUSH_S2S_* creds', async () => {
+    await run({
+      SEMRUSH_S2S_IMS_HOST: 'https://ims.example',
+      SEMRUSH_S2S_CLIENT_ID: 'cid',
+      SEMRUSH_S2S_CLIENT_SECRET: 'secret',
+      SEMRUSH_S2S_CLIENT_SCOPE: 'scope',
+    });
+
+    expect(getServiceAccessTokenV3).to.have.been.calledOnce;
+    const passedEnv = imsCreateFrom.firstCall.args[0].env;
+    expect(passedEnv.IMS_CLIENT_ID).to.equal('cid');
+    expect(passedEnv.IMS_CLIENT_SECRET).to.equal('secret');
+    expect(passedEnv.IMS_SCOPE).to.equal('scope');
+    expect(passedEnv.IMS_HOST).to.equal('https://ims.example');
+  });
+
+  it('exchanges the IMS token for a customer-scoped session token: POST login, Bearer IMS token, { imsOrgId } body', async () => {
     await run();
-    expect(fetchStub.firstCall.args[1].headers.Authorization).to.equal('Bearer tok');
+
+    const [url, opts] = loginCall().args;
+    expect(url).to.equal(`${mod.LLMO_API_DEFAULT_BASE_URL}${mod.S2S_LOGIN_DEFAULT_PATH}`);
+    expect(opts.method).to.equal('POST');
+    expect(opts.headers.Authorization).to.equal('Bearer tok');
+    expect(opts.headers['Content-Type']).to.equal('application/json');
+    expect(JSON.parse(opts.body)).to.deep.equal({ imsOrgId: IMS_ORG_ID });
   });
 
-  it('forwards x-promise-token when present on the context', async () => {
-    fetchStub.resolves(okJson({ urls: [] }));
-    await run({}, { promiseToken: 'ptok' });
-    expect(fetchStub.firstCall.args[1].headers['x-promise-token']).to.equal('ptok');
+  it('always normalizes the consumer IMS token to a Bearer scheme (even when IMS returns lowercase)', async () => {
+    getServiceAccessTokenV3.resolves({ token_type: 'bearer', access_token: 'tok' });
+    await run();
+    expect(loginCall().args[1].headers.Authorization).to.equal('Bearer tok');
   });
 
-  it('honours the SPACECAT_API_URI override', async () => {
-    fetchStub.resolves(okJson({ urls: [] }));
-    await run({ SPACECAT_API_URI: 'https://stage.example/api' });
-    expect(fetchStub.firstCall.args[0]).to.contain('https://stage.example/api/v2/orgs/');
+  it('honours the LLMO_API_BASE_URL override for both the login and the data call', async () => {
+    await run({ LLMO_API_BASE_URL: 'https://stage.example' });
+    expect(dataCall().args[0]).to.contain('https://stage.example/v2/orgs/');
+    expect(loginCall().args[0]).to.equal(`https://stage.example${mod.S2S_LOGIN_DEFAULT_PATH}`);
+  });
+
+  it('honours the LLMO_S2S_LOGIN_URL override for the login call', async () => {
+    await run({ LLMO_S2S_LOGIN_URL: 'https://llmo.experiencecloud.page/api/ci/auth/s2s/login' });
+    expect(loginCall().args[0]).to.equal('https://llmo.experiencecloud.page/api/ci/auth/s2s/login');
   });
 
   it('always requests PAGE_SIZE', async () => {
-    fetchStub.resolves(okJson({ urls: [] }));
     await run();
-    expect(new URL(fetchStub.firstCall.args[0]).searchParams.get('pageSize')).to.equal(String(mod.PAGE_SIZE));
+    expect(new URL(dataCall().args[0]).searchParams.get('pageSize')).to.equal(String(mod.PAGE_SIZE));
   });
 
   // --- filtering / scope ----------------------------------------------------
@@ -362,7 +405,8 @@ describe('offsite-brand-presence-semrush', function () {
   // --- request-level fallback (returns null) --------------------------------
 
   it('falls back (null) on a network error', async () => {
-    fetchStub.rejects(new Error('network down'));
+    // Login (withArgs from beforeEach) still resolves; only the data call rejects.
+    fetchStub.withArgs(sinon.match((u) => !isLogin(u))).rejects(new Error('network down'));
     const diagnostics = {};
     const result = await run({}, {}, undefined, diagnostics);
     expect(result).to.equal(null);
@@ -381,17 +425,16 @@ describe('offsite-brand-presence-semrush', function () {
     const diagnostics = {};
     const result = await run({}, {}, undefined, diagnostics);
     expect(result).to.equal(null);
-    expect(warnedWith(/Service token rejected/)).to.equal(true);
+    expect(warnedWith(/session token rejected/i)).to.equal(true);
     expect(diagnostics.fallbackReason).to.equal('domain_urls_auth_failed');
   });
 
   it('logs the response body on a 401 so the rejecter (api-service vs Semrush) is identifiable', async () => {
-    const proxyMsg = 'Elements proxy requires IMS authentication; send the x-promise-token header instead';
+    const proxyMsg = 'Denied - reason=no-org-access';
     fetchStub.resolves({ ok: false, status: 401, text: async () => proxyMsg });
     const result = await run();
     expect(result).to.equal(null);
-    expect(warnedWith(/Service token rejected/)).to.equal(true);
-    // The captured body identifies the rejecter (api-service vs Semrush) — LLMO-6709.
+    expect(warnedWith(/session token rejected/i)).to.equal(true);
     expect(log.warn.getCalls().some((c) => c.args[0].includes(`responseBody="${proxyMsg}"`))).to.equal(true);
   });
 
@@ -399,8 +442,6 @@ describe('offsite-brand-presence-semrush', function () {
     fetchStub.resolves({ ok: false, status: 500, text: async () => '' });
     const result = await run();
     expect(result).to.equal(null);
-    // Empty values are dropped by the offsite-logging taxonomy, so no responseBody token
-    // is emitted at all — the status is still captured.
     expect(log.warn.getCalls().some((c) => c.args[0].includes('status=500') && !c.args[0].includes('responseBody='))).to.equal(true);
   });
 
@@ -409,7 +450,7 @@ describe('offsite-brand-presence-semrush', function () {
     const diagnostics = {};
     const result = await run({}, {}, undefined, diagnostics);
     expect(result).to.equal(null);
-    expect(warnedWith(/Service token rejected/)).to.equal(true);
+    expect(warnedWith(/session token rejected/i)).to.equal(true);
     expect(diagnostics.fallbackReason).to.equal('domain_urls_auth_failed');
   });
 
@@ -464,7 +505,8 @@ describe('offsite-brand-presence-semrush', function () {
     expect(diagnostics.fallbackReason).to.equal(SEMRUSH_NOT_ENTITLED_REASON);
     expect(diagnostics.entitlementReason).to.equal(SEMRUSH_ENTITLEMENT_REASONS.NO_WORKSPACE);
     expect(fetchStub).to.not.have.been.called;
-    expect(getServiceAccessToken).to.not.have.been.called;
+    expect(getServiceAccessTokenV3).to.not.have.been.called;
+    expect(getImsOrgIdStub).to.not.have.been.called;
     expect(log.warn).to.have.been.calledWithMatch(/Brand not entitled for Semrush.*entitlementReason=no_workspace/);
     expect(onProgress).to.have.been.calledWith(
       ':information_source: Brand is not entitled for Semrush — falling back to the legacy source.',
@@ -491,8 +533,6 @@ describe('offsite-brand-presence-semrush', function () {
   });
 
   it('passes the resolved orgId/brandId to the entitlement check and proceeds when entitled', async () => {
-    fetchStub.resolves(okJson({ urls: [] }));
-
     await run();
 
     expect(resolveSemrushEntitlement).to.have.been.calledOnce;
@@ -508,16 +548,98 @@ describe('offsite-brand-presence-semrush', function () {
     expect(result).to.equal(null);
   });
 
-  it('returns null when the IMS service token cannot be minted', async () => {
-    getServiceAccessToken.rejects(new Error('ims down'));
-    expect(await run()).to.equal(null);
+  // --- IMS org id resolution (leg 1) ----------------------------------------
+
+  it('returns null (no_ims_org_id) and never mints a token when the customer IMS org id cannot be resolved', async () => {
+    getImsOrgIdStub.resolves(null);
+    const diagnostics = {};
+    const onProgress = sandbox.stub().resolves();
+
+    const result = await run({}, {}, onProgress, diagnostics);
+
+    expect(result).to.equal(null);
+    expect(diagnostics.fallbackReason).to.equal('no_ims_org_id');
+    expect(getServiceAccessTokenV3).to.not.have.been.called;
+    expect(fetchStub).to.not.have.been.called;
+    expect(warnedWith(/Could not resolve customer IMS org id/)).to.equal(true);
+    expect(onProgress).to.have.been.calledWith(
+      ':x: Could not resolve the customer IMS org id — falling back to the legacy source.',
+    );
+  });
+
+  it('passes the site and dataAccess through to getImsOrgId', async () => {
+    const dataAccess = { Organization: {} };
+    await mod.loadCitedUrlsFromSemrush({
+      site, previousWeeks: PREVIOUS_WEEKS, context: { log, env: {}, dataAccess },
+    });
+    expect(getImsOrgIdStub).to.have.been.calledOnce;
+    expect(getImsOrgIdStub.firstCall.args[0]).to.equal(site);
+    expect(getImsOrgIdStub.firstCall.args[1]).to.equal(dataAccess);
+  });
+
+  it('defaults dataAccess to an empty object when the context omits it', async () => {
+    await mod.loadCitedUrlsFromSemrush({
+      site, previousWeeks: PREVIOUS_WEEKS, context: { log, env: {} },
+    });
+    expect(getImsOrgIdStub.firstCall.args[1]).to.deep.equal({});
+  });
+
+  // --- IMS token minting (leg 2) --------------------------------------------
+
+  it('returns null (ims_token_failed) when the IMS service token cannot be minted', async () => {
+    getServiceAccessTokenV3.rejects(new Error('ims down'));
+    const diagnostics = {};
+    expect(await run({}, {}, undefined, diagnostics)).to.equal(null);
+    expect(diagnostics.fallbackReason).to.equal('ims_token_failed');
     expect(warnedWith(/Failed to obtain IMS service token/)).to.equal(true);
   });
 
   it('returns null when the IMS token response has no access_token', async () => {
-    getServiceAccessToken.resolves({ token_type: 'Bearer' });
+    getServiceAccessTokenV3.resolves({ token_type: 'Bearer' });
     expect(await run()).to.equal(null);
-    expect(warnedWith(/access_token/)).to.equal(true);
+    expect(warnedWith(/Failed to obtain IMS service token/)).to.equal(true);
+  });
+
+  // --- session token exchange (leg 3) ---------------------------------------
+
+  it('returns null (session_token_failed) on a non-2xx login response (with a body)', async () => {
+    fetchStub.withArgs(sinon.match(isLogin)).resolves({ ok: false, status: 403, text: async () => 'nope' });
+    const diagnostics = {};
+    const result = await run({}, {}, undefined, diagnostics);
+    expect(result).to.equal(null);
+    expect(diagnostics.fallbackReason).to.equal('session_token_failed');
+    expect(dataCall()).to.equal(undefined); // never reaches the data call
+    expect(warnedWith(/Failed to exchange for an S2S session token/)).to.equal(true);
+  });
+
+  it('returns null (session_token_failed) on a non-2xx login response (no readable body)', async () => {
+    fetchStub.withArgs(sinon.match(isLogin)).resolves({ ok: false, status: 500 });
+    const diagnostics = {};
+    expect(await run({}, {}, undefined, diagnostics)).to.equal(null);
+    expect(diagnostics.fallbackReason).to.equal('session_token_failed');
+  });
+
+  it('returns null (session_token_failed) on a network error during login', async () => {
+    fetchStub.withArgs(sinon.match(isLogin)).rejects(new Error('login down'));
+    const diagnostics = {};
+    expect(await run({}, {}, undefined, diagnostics)).to.equal(null);
+    expect(diagnostics.fallbackReason).to.equal('session_token_failed');
+  });
+
+  it('returns null (session_token_failed) when the login body is not parseable JSON', async () => {
+    fetchStub.withArgs(sinon.match(isLogin)).resolves({
+      ok: true, status: 200, json: async () => { throw new Error('bad json'); },
+    });
+    const diagnostics = {};
+    expect(await run({}, {}, undefined, diagnostics)).to.equal(null);
+    expect(diagnostics.fallbackReason).to.equal('session_token_failed');
+  });
+
+  it('returns null (session_token_failed) when the login response has no sessionToken', async () => {
+    fetchStub.withArgs(sinon.match(isLogin)).resolves(okJson({ notAToken: true }));
+    const diagnostics = {};
+    expect(await run({}, {}, undefined, diagnostics)).to.equal(null);
+    expect(diagnostics.fallbackReason).to.equal('session_token_failed');
   });
 
   // --- progress notifications (onProgress) -----------------------------------
@@ -550,7 +672,6 @@ describe('offsite-brand-presence-semrush', function () {
   });
 
   it('logs a warning and does not throw when onProgress rejects', async () => {
-    fetchStub.resolves(okJson({ urls: [] }));
     const onProgress = sandbox.stub().rejects(new Error('slack down'));
 
     const allUrls = await run({}, {}, onProgress);


### PR DESCRIPTION
## What changed

Switches the offsite-brand-presence Semrush **URL retrieval** from a raw IMS-service-token call to the **S2S consumer session-token** flow now supported by api-service ([adobe/spacecat-api-service#3217](https://github.com/adobe/spacecat-api-service/pull/3217)).

All changes are isolated to [`src/utils/offsite-brand-presence-semrush.js`](https://github.com/adobe/spacecat-audit-worker/blob/claude/audit-worker-semrush-s2s-38be8e/src/utils/offsite-brand-presence-semrush.js) and its test. Bucketing, the entitlement gate, the `OFFSITE_BRAND_PRESENCE_SEMRUSH_ENABLED` gate, and the fallback contract are unchanged.

### Before → after (auth)

| | Before | After |
|---|---|---|
| Token | raw IMS **service** token (`getServiceAccessToken`, authorization_code, default client) | **S2S consumer** IMS token (`getServiceAccessTokenV3`, client_credentials, `SEMRUSH_S2S_*`) → exchanged for a customer-scoped **session token** |
| Exchange | none — sent straight to the data route | `POST /api/v1/auth/s2s/login` with `{ imsOrgId }` → 15-min session token whose `tenants` claim authorizes the read |
| Host | ASO (`spacecat.experiencecloud.live`) | **LLMO** (`llmo.experiencecloud.live`) — `x-product` is host-driven at the edge |
| `x-promise-token` | forwarded | dropped (session token is self-contained) |

New graceful-fallback diagnostics reasons: `no_ims_org_id`, `session_token_failed`. Reuses the existing `getImsOrgId` helper for the customer IMS org id.

## Why

The old path minted a raw IMS **service** token, which carries no `tenants`/org membership, so api-service's IMS path rejects it (401/403) — the source of the `LLMO-6709` "service token rejected" fallbacks. PR #3217 authorizes S2S consumers for the brand-presence routes via the existing `hasAccess(organization)` check; this change adopts that flow and should close LLMO-6709.

## Reviewer notes

- **Fail-safe:** a missing/misconfigured S2S setup (`SEMRUSH_S2S_*`, unresolved IMS org id, login failure) falls back to the legacy source rather than failing the audit.
- **Route already S2S-enabled:** `.../url-inspector/domain-urls` requires `brand:read` in api-service's `required-capabilities.js` — no producer change needed.
- **Scope:** URL retrieval only. Fetching prompts *from Semrush* (for the cited/youtube/reddit audits) is deliberately out of scope and tracked as follow-up work.
- **Coverage:** loader module remains at 100% lines/branches/statements; 58 loader tests + full handler suite pass; lint clean.

### Infra required before this is live (ops)

- Register audit-worker as an **S2S consumer** with `brand:read` (multi-org scope), producing client_credentials creds.
- Env vars: `SEMRUSH_S2S_IMS_HOST/CLIENT_ID/CLIENT_SECRET/CLIENT_SCOPE`, `LLMO_API_BASE_URL` (default `https://llmo.experiencecloud.live`), optional `LLMO_S2S_LOGIN_URL` for non-prod path prefixes.
- Producer-side Vault (from #3217): `SEMRUSH_ADMIN_ELEMENT_API_KEY` + `SEO_API_BASE_URL` per env.

## Related Issues

LLMO-6709

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Andrei Paraschiv", "@amitruluimadalina"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```