### PR TITLE
fix(offsite-brand-presence): declare missing SEMRUSH_S2S_* template params

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -48,6 +48,11 @@ Resources:
           CONTENTAI_CLIENT_SECRET: !Ref CONTENTAI_CLIENT_SECRET
           CONTENTAI_CLIENT_SCOPE: !Ref CONTENTAI_CLIENT_SCOPE
           CONTENTAI_ENDPOINT: !Ref CONTENTAI_ENDPOINT
+          SEMRUSH_S2S_IMS_HOST: !Ref SEMRUSH_S2S_IMS_HOST
+          SEMRUSH_S2S_CLIENT_ID: !Ref SEMRUSH_S2S_CLIENT_ID
+          SEMRUSH_S2S_CLIENT_SECRET: !Ref SEMRUSH_S2S_CLIENT_SECRET
+          SEMRUSH_S2S_CLIENT_SCOPE: !Ref SEMRUSH_S2S_CLIENT_SCOPE
+          SEMRUSH_S2S_CLIENT_CODE: !Ref SEMRUSH_S2S_CLIENT_CODE
           S3_CONFIG_BUCKET: !Ref S3_CONFIG_BUCKET
           AZURE_OPENAI_ENDPOINT: !Ref AZURE_OPENAI_ENDPOINT
           AZURE_OPENAI_KEY: !Ref AZURE_OPENAI_KEY
@@ -154,6 +159,22 @@ Parameters:
   CONTENTAI_ENDPOINT:
     Type: String
     Description: ContentAI Endpoint
+  SEMRUSH_S2S_IMS_HOST:
+    Type: String
+    Description: Semrush S2S IMS Host
+  SEMRUSH_S2S_CLIENT_ID:
+    Type: String
+    Description: Semrush S2S Client ID
+  SEMRUSH_S2S_CLIENT_SECRET:
+    Type: String
+    Description: Semrush S2S Client Secret
+  SEMRUSH_S2S_CLIENT_SCOPE:
+    Type: String
+    Description: Semrush S2S Client Scope
+  SEMRUSH_S2S_CLIENT_CODE:
+    Type: String
+    Description: Semrush S2S Client Code (unused for client_credentials grant; defaults in code if unset)
+    Default: unused-for-client-credentials
   S3_CONFIG_BUCKET:
     Type: String
     Description: S3 Config Bucket Name


### PR DESCRIPTION
## Problem

`offsite:brand-presence` audit is failing to acquire Semrush data with `ims_token_failed` in production, hard-stopping (no legacy fallback) since `enableSemrush:true` is set:

```
errorMessage="Context param must include properties: imsHost, clientId, clientCode, and clientSecret."
```

## Root cause

#2958 (LLMO-6709) switched Semrush's IMS auth in `src/utils/offsite-brand-presence-semrush.js` from the worker's default IMS client to a dedicated S2S `client_credentials` consumer keyed on new `SEMRUSH_S2S_IMS_HOST` / `SEMRUSH_S2S_CLIENT_ID` / `SEMRUSH_S2S_CLIENT_SECRET` / `SEMRUSH_S2S_CLIENT_SCOPE` / `SEMRUSH_S2S_CLIENT_CODE` env vars, but that PR never added the corresponding params to `template.yml`. In every deployed environment these env vars are therefore `undefined`, and `@adobe/spacecat-shared-ims-client`'s `ImsClient.createFrom` throws the error above.

## Fix

Add the five `SEMRUSH_S2S_*` CloudFormation parameters and Lambda `Environment.Variables` mappings, mirroring the existing `CONTENTAI_*` S2S wiring pattern already in this template. `SEMRUSH_S2S_CLIENT_CODE` keeps a default (`unused-for-client-credentials`) matching the code's own fallback, since it's not needed for the `client_credentials` grant.

## Deployment

/ephemeral

Deployed secret injection (the actual S2S client id/secret/host/scope values) is required for this to take effect — this PR only wires the template parameters, it does not provision the secret values.

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["TB ADBE"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```