### PR TITLE
feat(offsite-brand-presence): temporary S2S auth diagnostic probe (LLMO-6709)

### DIFF
--- a/src/offsite-brand-presence/handler.js
+++ b/src/offsite-brand-presence/handler.js
@@ -18,6 +18,7 @@ import { AuditBuilder } from '../common/audit-builder.js';
 import { noopUrlResolver } from '../common/index.js';
 import { getPreviousWeeks, loadBrandPresenceData } from '../utils/offsite-brand-presence-enrichment.js';
 import { loadCitedUrlsFromSemrush } from '../utils/offsite-brand-presence-semrush.js';
+import { runSemrushAuthProbes } from '../utils/offsite-brand-presence-semrush-auth-probe.js';
 import { SEMRUSH_ENTITLEMENT_SKIP_REASONS } from '../utils/semrush-entitlement.js';
 import { postMessageOptional } from '../utils/slack-utils.js';
 import {
@@ -829,6 +830,19 @@ export async function offsiteBrandPresenceRunner(finalUrl, context, site, auditC
   olog.start('audit_orchestration_spacecat_request_received', 'Audit started', {
     weeks: weekLabels, ...resolveTriggerFields(auditContext),
   });
+
+  // TEMPORARY (LLMO-6709): S2S auth diagnostic. When enabled for this run (per-run Slack
+  // `semrushAuthProbe:true`, or fleet env `OFFSITE_SEMRUSH_AUTH_PROBE=true`), probe whether the
+  // worker's EXISTING IMS client already has api-service access — via the S2S login exchange
+  // and via a direct IMS call — emitting Splunk logs only. Best-effort; never affects the audit.
+  const semrushAuthProbeEnabled = auditContext?.messageData?.semrushAuthProbe === true
+    || auditContext?.messageData?.semrushAuthProbe === 'true'
+    || context.env?.OFFSITE_SEMRUSH_AUTH_PROBE === 'true';
+  if (semrushAuthProbeEnabled) {
+    await runSemrushAuthProbes({
+      site, previousWeeks, context, imsOrgId,
+    });
+  }
 
   let siteHostname;
   try {

--- a/src/utils/offsite-brand-presence-semrush-auth-probe.js
+++ b/src/utils/offsite-brand-presence-semrush-auth-probe.js
@@ -22,13 +22,16 @@
  * using only the worker's EXISTING default IMS client, does api-service already grant this
  * worker access — and via which path?
  *
- * It runs two probes back-to-back and emits one structured Splunk log line per step (event
+ * It runs three probes back-to-back and emits one structured Splunk log line per step (event
  * `data_acquisition_bp_semrush_auth_probe`, distinct `probe`/`step`/`status` fields), so each
  * outcome is independently greppable:
  *   - `login_existing_ims`: mint an IMS token from the worker's existing default client, POST
  *     it to /auth/s2s/login, and (if a session token comes back) call domain-urls with it.
  *   - `direct_ims`: call domain-urls with the raw existing IMS bearer, no login exchange
  *     (this exercises api-service's IMS path, not the S2S path).
+ *   - `apikey_direct`: call domain-urls with the scoped `x-api-key` (`SPACECAT_API_KEY`, the
+ *     credential `brand-resolver.js` already uses against /v2/orgs/...). Independent of IMS —
+ *     if the route accepts it, that's access with zero new registration.
  *
  * It is best-effort and side-effect-free: it NEVER throws to the caller and NEVER influences
  * the audit result — it only writes logs. Remove this file (and its handler call site) once
@@ -70,17 +73,19 @@ async function readBodySnippet(response) {
 }
 
 /**
- * Calls the domain-urls endpoint with the given Authorization header and logs the outcome
- * under a `probe`/`step=domain_urls` line. Returns nothing — this is telemetry only.
+ * Calls the domain-urls endpoint with the given auth headers and logs the outcome under a
+ * `probe`/`step=domain_urls` line. `authHeaders` is the credential to test (e.g.
+ * `{ Authorization: 'Bearer ...' }` or `{ 'x-api-key': '...' }`); `Accept` is added here.
+ * Returns nothing — this is telemetry only.
  */
 async function probeDomainUrls({
-  olog, probe, authorization, url,
+  olog, probe, authHeaders, url,
 }) {
   const startedAt = Date.now();
   let response;
   try {
     response = await fetch(url, {
-      headers: { Authorization: authorization, Accept: 'application/json' },
+      headers: { ...authHeaders, Accept: 'application/json' },
       timeout: FETCH_TIMEOUT_MS,
     });
   } catch (error) {
@@ -154,7 +159,7 @@ async function probeLoginExistingIms({
     peer: PEER.SEMRUSH, direction: 'inbound', probe, step: 'login', status, authorized: true, hasSessionToken: true, durationMs,
   });
   await probeDomainUrls({
-    olog, probe, authorization: `Bearer ${sessionToken}`, url: domainUrlsUrl,
+    olog, probe, authHeaders: { Authorization: `Bearer ${sessionToken}` }, url: domainUrlsUrl,
   });
 }
 
@@ -209,10 +214,10 @@ export async function runSemrushAuthProbes({
       peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, brandId: brand.brandId, imsClientId: env?.IMS_CLIENT_ID, baseUrl,
     });
 
-    // Mint ONE IMS token from the worker's EXISTING default IMS client (v2
-    // authorization_code — the grant the default client is provisioned for), reused by both
-    // probes. `imsClientId` is logged (identifier, not a secret) to answer "which client id
-    // did we actually authenticate as".
+    // Probes A + B use an IMS token minted from the worker's EXISTING default IMS client (v2
+    // authorization_code — the grant the default client is provisioned for). `imsClientId` is
+    // logged (identifier, not a secret) to answer "which client id did we authenticate as".
+    // A mint failure only skips A + B; Probe C (x-api-key) is independent and still runs.
     let imsAuthorization;
     try {
       const imsClient = ImsClient.createFrom(context);
@@ -225,16 +230,31 @@ export async function runSemrushAuthProbes({
       olog.warn(PROBE_EVENT, 'Auth probe could not mint an IMS token from the existing default client', {
         peer: PEER.SEMRUSH, direction: 'inbound', step: 'ims_mint', imsClientId: env?.IMS_CLIENT_ID, reason: 'ims_mint_failed', outcome: OUTCOME.DEGRADED, ...errorField(error),
       });
-      return;
     }
 
     // Probe A, then Probe B — sequentially, so each result is clearly attributable.
-    await probeLoginExistingIms({
-      olog, loginUrl, imsAuthorization, imsOrgId, domainUrlsUrl,
-    });
-    await probeDomainUrls({
-      olog, probe: 'direct_ims', authorization: imsAuthorization, url: domainUrlsUrl,
-    });
+    if (imsAuthorization) {
+      await probeLoginExistingIms({
+        olog, loginUrl, imsAuthorization, imsOrgId, domainUrlsUrl,
+      });
+      await probeDomainUrls({
+        olog, probe: 'direct_ims', authHeaders: { Authorization: imsAuthorization }, url: domainUrlsUrl,
+      });
+    }
+
+    // Probe C — the scoped api key (`SPACECAT_API_KEY`, the credential `brand-resolver.js`
+    // already uses against /v2/orgs/...). Independent of IMS; needs no login. If the route
+    // accepts it, this is access with zero new registration.
+    const apiKey = env?.SPACECAT_API_KEY;
+    if (apiKey) {
+      await probeDomainUrls({
+        olog, probe: 'apikey_direct', authHeaders: { 'x-api-key': apiKey }, url: domainUrlsUrl,
+      });
+    } else {
+      olog.warn(PROBE_EVENT, 'Auth probe [apikey_direct] skipped — SPACECAT_API_KEY not configured', {
+        peer: PEER.SEMRUSH, direction: 'inbound', probe: 'apikey_direct', step: 'domain_urls', reason: 'apikey_not_configured', outcome: OUTCOME.SKIP,
+      });
+    }
   } catch (error) {
     // A diagnostic must never affect the audit — swallow everything.
     olog.warn(PROBE_EVENT, 'Auth probe crashed (swallowed — audit unaffected)', {

--- a/src/utils/offsite-brand-presence-semrush-auth-probe.js
+++ b/src/utils/offsite-brand-presence-semrush-auth-probe.js
@@ -1,0 +1,244 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * TEMPORARY diagnostic (LLMO-6709) — NOT part of the production data path.
+ *
+ * The production loader (`offsite-brand-presence-semrush.js`) authenticates to the
+ * Semrush-backed api-service routes as a registered S2S consumer:
+ *   dedicated SEMRUSH_S2S_* IMS client -> POST /auth/s2s/login -> customer-scoped
+ *   session token -> domain-urls.
+ * That requires the dedicated consumer's client id/secret, which we are still trying to
+ * pin down. This module answers a narrower operational question WITHOUT those credentials:
+ * using only the worker's EXISTING default IMS client, does api-service already grant this
+ * worker access — and via which path?
+ *
+ * It runs two probes back-to-back and emits one structured Splunk log line per step (event
+ * `data_acquisition_bp_semrush_auth_probe`, distinct `probe`/`step`/`status` fields), so each
+ * outcome is independently greppable:
+ *   - `login_existing_ims`: mint an IMS token from the worker's existing default client, POST
+ *     it to /auth/s2s/login, and (if a session token comes back) call domain-urls with it.
+ *   - `direct_ims`: call domain-urls with the raw existing IMS bearer, no login exchange
+ *     (this exercises api-service's IMS path, not the S2S path).
+ *
+ * It is best-effort and side-effect-free: it NEVER throws to the caller and NEVER influences
+ * the audit result — it only writes logs. Remove this file (and its handler call site) once
+ * the S2S credential question is settled.
+ */
+
+import { ImsClient } from '@adobe/spacecat-shared-ims-client';
+import { tracingFetch as fetch } from '@adobe/spacecat-shared-utils';
+import { resolveBrandResultForSite } from './brand-resolver.js';
+import { getDateWindowForPreviousWeeks } from './offsite-brand-presence-postgrest.js';
+import { getImsOrgId } from './data-access.js';
+import {
+  buildDomainUrlsUrl,
+  LLMO_API_DEFAULT_BASE_URL,
+  S2S_LOGIN_DEFAULT_PATH,
+  PAGE_SIZE,
+} from './offsite-brand-presence-semrush.js';
+import {
+  createOffsiteLogger, errorField, AUDIT, OUTCOME, PEER,
+} from './offsite-logging.js';
+
+const PROBE_EVENT = 'data_acquisition_bp_semrush_auth_probe';
+const FETCH_TIMEOUT_MS = 10_000;
+const BODY_SNIPPET_MAX = 500;
+
+/**
+ * Reads a response body as a short diagnostic snippet. Never throws.
+ *
+ * @param {Response} response
+ * @returns {Promise<string>} the body (capped), or '' if empty/unreadable.
+ */
+async function readBodySnippet(response) {
+  try {
+    const text = await response.text();
+    return text ? text.slice(0, BODY_SNIPPET_MAX) : '';
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Calls the domain-urls endpoint with the given Authorization header and logs the outcome
+ * under a `probe`/`step=domain_urls` line. Returns nothing — this is telemetry only.
+ */
+async function probeDomainUrls({
+  olog, probe, authorization, url,
+}) {
+  const startedAt = Date.now();
+  let response;
+  try {
+    response = await fetch(url, {
+      headers: { Authorization: authorization, Accept: 'application/json' },
+      timeout: FETCH_TIMEOUT_MS,
+    });
+  } catch (error) {
+    olog.warn(PROBE_EVENT, `Auth probe [${probe}] domain-urls request failed (network)`, {
+      peer: PEER.SEMRUSH, direction: 'inbound', probe, step: 'domain_urls', reason: 'fetch_failed', durationMs: Date.now() - startedAt, outcome: OUTCOME.DEGRADED, ...errorField(error),
+    });
+    return;
+  }
+  const { status } = response;
+  const durationMs = Date.now() - startedAt;
+  if (response.ok) {
+    olog.success(PROBE_EVENT, `Auth probe [${probe}] domain-urls: HTTP ${status} (authorized)`, {
+      peer: PEER.SEMRUSH, direction: 'inbound', probe, step: 'domain_urls', status, authorized: true, durationMs,
+    });
+    return;
+  }
+  const responseBody = await readBodySnippet(response);
+  olog.warn(PROBE_EVENT, `Auth probe [${probe}] domain-urls: HTTP ${status} (not authorized)`, {
+    peer: PEER.SEMRUSH, direction: 'inbound', probe, step: 'domain_urls', status, authorized: false, responseBody, durationMs, outcome: OUTCOME.DEGRADED,
+  });
+}
+
+/**
+ * Probe A — exchange the worker's existing IMS token for a customer-scoped session token via
+ * /auth/s2s/login, then (if it succeeds) call domain-urls with that session token. Logs the
+ * login status and whether a session token came back; a successful login proves the worker's
+ * existing IMS identity is a registered S2S consumer for this org.
+ */
+async function probeLoginExistingIms({
+  olog, loginUrl, imsAuthorization, imsOrgId, domainUrlsUrl,
+}) {
+  const probe = 'login_existing_ims';
+  const startedAt = Date.now();
+  let response;
+  try {
+    response = await fetch(loginUrl, {
+      method: 'POST',
+      headers: { Authorization: imsAuthorization, 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({ imsOrgId }),
+      timeout: FETCH_TIMEOUT_MS,
+    });
+  } catch (error) {
+    olog.warn(PROBE_EVENT, `Auth probe [${probe}] login request failed (network)`, {
+      peer: PEER.SEMRUSH, direction: 'inbound', probe, step: 'login', reason: 'fetch_failed', durationMs: Date.now() - startedAt, outcome: OUTCOME.DEGRADED, ...errorField(error),
+    });
+    return;
+  }
+  const { status } = response;
+  const durationMs = Date.now() - startedAt;
+  if (!response.ok) {
+    const responseBody = await readBodySnippet(response);
+    olog.warn(PROBE_EVENT, `Auth probe [${probe}] login: HTTP ${status} (rejected — existing IMS identity is likely not a registered S2S consumer)`, {
+      peer: PEER.SEMRUSH, direction: 'inbound', probe, step: 'login', status, authorized: false, responseBody, durationMs, outcome: OUTCOME.DEGRADED,
+    });
+    return;
+  }
+  let body;
+  try {
+    body = await response.json();
+  } catch {
+    body = null;
+  }
+  const sessionToken = body?.sessionToken;
+  if (!sessionToken) {
+    olog.warn(PROBE_EVENT, `Auth probe [${probe}] login: HTTP ${status} but no sessionToken in the response body`, {
+      peer: PEER.SEMRUSH, direction: 'inbound', probe, step: 'login', status, authorized: false, hasSessionToken: false, durationMs, outcome: OUTCOME.DEGRADED,
+    });
+    return;
+  }
+  olog.success(PROBE_EVENT, `Auth probe [${probe}] login: HTTP ${status} — sessionToken received (existing IMS identity IS a registered S2S consumer)`, {
+    peer: PEER.SEMRUSH, direction: 'inbound', probe, step: 'login', status, authorized: true, hasSessionToken: true, durationMs,
+  });
+  await probeDomainUrls({
+    olog, probe, authorization: `Bearer ${sessionToken}`, url: domainUrlsUrl,
+  });
+}
+
+/**
+ * Runs the two S2S auth diagnostics (see the module header) for one site, using ONLY the
+ * worker's existing default IMS client. Best-effort telemetry: never throws, never affects
+ * the audit.
+ *
+ * @param {object} params
+ * @param {object} params.site - Site model.
+ * @param {Array<{week:number, year:number}>} params.previousWeeks
+ * @param {object} params.context - Lambda context (env, log, dataAccess).
+ * @param {string} [params.imsOrgId] - Customer IMS org id, if the caller already resolved it.
+ * @returns {Promise<void>}
+ */
+export async function runSemrushAuthProbes({
+  site, previousWeeks, context, imsOrgId: providedImsOrgId,
+}) {
+  const { log, env } = context;
+  const olog = createOffsiteLogger(log, { audit: AUDIT.BRAND_PRESENCE, siteId: site?.getId?.() });
+  try {
+    const spaceCatId = site?.getOrganizationId?.();
+    const { brand } = await resolveBrandResultForSite(context, site);
+    const imsOrgId = providedImsOrgId || await getImsOrgId(site, context.dataAccess || {}, log);
+    const dateWindow = getDateWindowForPreviousWeeks(previousWeeks);
+    if (!spaceCatId || !brand?.brandId || !imsOrgId || !dateWindow) {
+      olog.warn(PROBE_EVENT, 'Auth probe skipped — missing prerequisites (org id / brand / imsOrgId / date window)', {
+        peer: PEER.SEMRUSH,
+        direction: 'inbound',
+        hasOrgId: Boolean(spaceCatId),
+        hasBrand: Boolean(brand?.brandId),
+        hasImsOrgId: Boolean(imsOrgId),
+        hasDateWindow: Boolean(dateWindow),
+        reason: 'probe_prerequisites_missing',
+        outcome: OUTCOME.SKIP,
+      });
+      return;
+    }
+
+    const baseUrl = env?.LLMO_API_BASE_URL || LLMO_API_DEFAULT_BASE_URL;
+    const loginUrl = env?.LLMO_S2S_LOGIN_URL || `${baseUrl}${S2S_LOGIN_DEFAULT_PATH}`;
+    const domainUrlsUrl = buildDomainUrlsUrl({
+      baseUrl,
+      spaceCatId,
+      brandId: brand.brandId,
+      startDate: dateWindow.startDate,
+      endDate: dateWindow.endDate,
+      pageSize: PAGE_SIZE,
+    });
+
+    olog.start(PROBE_EVENT, 'Starting Semrush S2S auth probes (existing IMS client)', {
+      peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, brandId: brand.brandId, imsClientId: env?.IMS_CLIENT_ID, baseUrl,
+    });
+
+    // Mint ONE IMS token from the worker's EXISTING default IMS client (v2
+    // authorization_code — the grant the default client is provisioned for), reused by both
+    // probes. `imsClientId` is logged (identifier, not a secret) to answer "which client id
+    // did we actually authenticate as".
+    let imsAuthorization;
+    try {
+      const imsClient = ImsClient.createFrom(context);
+      const token = await imsClient.getServiceAccessToken();
+      if (!token?.access_token) {
+        throw new Error('IMS token response missing access_token');
+      }
+      imsAuthorization = `Bearer ${token.access_token}`;
+    } catch (error) {
+      olog.warn(PROBE_EVENT, 'Auth probe could not mint an IMS token from the existing default client', {
+        peer: PEER.SEMRUSH, direction: 'inbound', step: 'ims_mint', imsClientId: env?.IMS_CLIENT_ID, reason: 'ims_mint_failed', outcome: OUTCOME.DEGRADED, ...errorField(error),
+      });
+      return;
+    }
+
+    // Probe A, then Probe B — sequentially, so each result is clearly attributable.
+    await probeLoginExistingIms({
+      olog, loginUrl, imsAuthorization, imsOrgId, domainUrlsUrl,
+    });
+    await probeDomainUrls({
+      olog, probe: 'direct_ims', authorization: imsAuthorization, url: domainUrlsUrl,
+    });
+  } catch (error) {
+    // A diagnostic must never affect the audit — swallow everything.
+    olog.warn(PROBE_EVENT, 'Auth probe crashed (swallowed — audit unaffected)', {
+      peer: PEER.SEMRUSH, direction: 'inbound', reason: 'probe_crashed', outcome: OUTCOME.DEGRADED, ...errorField(error),
+    });
+  }
+}

--- a/test/audits/offsite-brand-presence.test.js
+++ b/test/audits/offsite-brand-presence.test.js
@@ -38,6 +38,7 @@ describe('Offsite Brand Presence Handler', function () {
   let sandbox;
   let mockLoadBrandPresenceData;
   let mockLoadCitedUrlsFromSemrush;
+  let mockRunSemrushAuthProbes;
   let mockGetPreviousWeeks;
   let mockSubmitScrapeJob;
   let mockDrsIsConfigured;
@@ -61,6 +62,7 @@ describe('Offsite Brand Presence Handler', function () {
 
     mockLoadBrandPresenceData = sandbox.stub();
     mockLoadCitedUrlsFromSemrush = sandbox.stub().resolves(null);
+    mockRunSemrushAuthProbes = sandbox.stub().resolves();
     mockGetPreviousWeeks = sandbox.stub().returns([
       { week: DEFAULT_WEEK, year: DEFAULT_YEAR },
       { week: DEFAULT_WEEK_2, year: DEFAULT_YEAR },
@@ -76,6 +78,9 @@ describe('Offsite Brand Presence Handler', function () {
       },
       '../../src/utils/offsite-brand-presence-semrush.js': {
         loadCitedUrlsFromSemrush: mockLoadCitedUrlsFromSemrush,
+      },
+      '../../src/utils/offsite-brand-presence-semrush-auth-probe.js': {
+        runSemrushAuthProbes: mockRunSemrushAuthProbes,
       },
       '@adobe/spacecat-shared-drs-client': {
         default: {
@@ -346,6 +351,28 @@ describe('Offsite Brand Presence Handler', function () {
           .and(sinon.match(/peer=semrush/))
           .and(sinon.match(/reason=semrush_failed/)),
       );
+    });
+
+    it('runs the S2S auth probe when the per-run Slack override semrushAuthProbe:true is set', async () => {
+      await offsiteBrandPresenceRunner(
+        FINAL_URL, context, site, { messageData: { semrushAuthProbe: true } },
+      );
+      expect(mockRunSemrushAuthProbes).to.have.been.calledOnce;
+      const args = mockRunSemrushAuthProbes.firstCall.args[0];
+      expect(args.site).to.equal(site);
+      expect(args).to.have.property('imsOrgId');
+      expect(args).to.have.property('previousWeeks');
+    });
+
+    it('runs the S2S auth probe when the env flag OFFSITE_SEMRUSH_AUTH_PROBE=true is set', async () => {
+      context.env.OFFSITE_SEMRUSH_AUTH_PROBE = 'true';
+      await offsiteBrandPresenceRunner(FINAL_URL, context, site, {});
+      expect(mockRunSemrushAuthProbes).to.have.been.calledOnce;
+    });
+
+    it('does not run the S2S auth probe by default', async () => {
+      await offsiteBrandPresenceRunner(FINAL_URL, context, site, {});
+      expect(mockRunSemrushAuthProbes).to.not.have.been.called;
     });
 
     it('falls back to legacy when an ENV-enabled Semrush run fails (no hard stop)', async () => {

--- a/test/utils/offsite-brand-presence-semrush-auth-probe.test.js
+++ b/test/utils/offsite-brand-presence-semrush-auth-probe.test.js
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import esmock from 'esmock';
+import * as spacecatSharedUtils from '@adobe/spacecat-shared-utils';
+
+use(sinonChai);
+
+const ORG_ID = 'e07a0aae-b794-41f6-9622-a602203c5a3e';
+const BRAND_ID = 'cb84e91a-f7e9-488b-8220-e0d031941cd7';
+const IMS_ORG_ID = '899D173E60B73D8B0A495C0A@AdobeOrg';
+const SITE_ID = '5b0d4d6e-3d2e-4a5b-8e2a-9b6f7c9c1e2a';
+const PREVIOUS_WEEKS = [{ week: 29, year: 2026 }, { week: 28, year: 2026 }];
+const DATE_WINDOW = { startDate: '2026-07-06', endDate: '2026-08-02' };
+
+const okJson = (body) => ({ ok: true, status: 200, json: async () => body });
+const isLogin = (u) => String(u).includes('/auth/s2s/login');
+
+describe('offsite-brand-presence-semrush-auth-probe', function () {
+  this.timeout(10000);
+
+  let sandbox;
+  let log;
+  let fetchStub;
+  let resolveBrandResultForSite;
+  let getImsOrgIdStub;
+  let getDateWindowStub;
+  let getServiceAccessToken;
+  let imsCreateFrom;
+  let mod;
+
+  const site = {
+    getOrganizationId: () => ORG_ID,
+    getId: () => SITE_ID,
+  };
+  const makeContext = (env = {}) => ({ log, env, dataAccess: {} });
+
+  const dataCalls = () => fetchStub.getCalls().filter((c) => !isLogin(c.args[0]));
+  const loginCalls = () => fetchStub.getCalls().filter((c) => isLogin(c.args[0]));
+  const infoWith = (re) => log.info.getCalls().some((c) => re.test(c.args[0]));
+  const warnWith = (re) => log.warn.getCalls().some((c) => re.test(c.args[0]));
+
+  async function loadModule() {
+    return esmock('../../src/utils/offsite-brand-presence-semrush-auth-probe.js', {
+      '@adobe/spacecat-shared-ims-client': { ImsClient: { createFrom: imsCreateFrom } },
+      '@adobe/spacecat-shared-utils': { ...spacecatSharedUtils, tracingFetch: fetchStub },
+      '../../src/utils/brand-resolver.js': { resolveBrandResultForSite },
+      '../../src/utils/data-access.js': { getImsOrgId: getImsOrgIdStub },
+      '../../src/utils/offsite-brand-presence-postgrest.js': {
+        getDateWindowForPreviousWeeks: getDateWindowStub,
+      },
+    });
+  }
+
+  const run = (env = {}, imsOrgId = undefined) => mod.runSemrushAuthProbes({
+    site, previousWeeks: PREVIOUS_WEEKS, context: makeContext(env), imsOrgId,
+  });
+
+  beforeEach(async () => {
+    sandbox = sinon.createSandbox();
+    log = {
+      info: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub(), debug: sandbox.stub(),
+    };
+    fetchStub = sandbox.stub();
+    fetchStub.withArgs(sinon.match(isLogin)).resolves(okJson({ sessionToken: 'sess-jwt' }));
+    fetchStub.resolves(okJson({ urls: [] })); // default = domain-urls
+    resolveBrandResultForSite = sandbox.stub()
+      .resolves({ brand: { brandId: BRAND_ID }, resolved: true });
+    getImsOrgIdStub = sandbox.stub().resolves(IMS_ORG_ID);
+    getDateWindowStub = sandbox.stub().returns(DATE_WINDOW);
+    getServiceAccessToken = sandbox.stub().resolves({ token_type: 'Bearer', access_token: 'ims-tok' });
+    imsCreateFrom = sandbox.stub().returns({ getServiceAccessToken });
+    mod = await loadModule();
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  // --- happy path: both probes run ------------------------------------------
+
+  it('runs probe A (login->data) then probe B (direct) using the existing IMS client', async () => {
+    await run();
+
+    expect(getServiceAccessToken).to.have.been.calledOnce; // one IMS token, reused
+    expect(loginCalls().length).to.equal(1);
+    expect(dataCalls().length).to.equal(2); // probe A (session token) + probe B (direct)
+
+    // Probe A login succeeded and yielded a session token.
+    expect(infoWith(/login_existing_ims\] login.*sessionToken received/)).to.equal(true);
+    // Both probes hit domain-urls; default 200 -> authorized.
+    expect(infoWith(/login_existing_ims\] domain-urls: HTTP 200 \(authorized\)/)).to.equal(true);
+    expect(infoWith(/direct_ims\] domain-urls: HTTP 200 \(authorized\)/)).to.equal(true);
+  });
+
+  it('sends the IMS bearer to the login POST and the session token to probe A domain-urls', async () => {
+    await run();
+    const login = loginCalls()[0];
+    expect(login.args[1].method).to.equal('POST');
+    expect(login.args[1].headers.Authorization).to.equal('Bearer ims-tok');
+    expect(JSON.parse(login.args[1].body)).to.deep.equal({ imsOrgId: IMS_ORG_ID });
+
+    const probeA = dataCalls()[0];
+    expect(probeA.args[1].headers.Authorization).to.equal('Bearer sess-jwt');
+    const probeB = dataCalls()[1];
+    expect(probeB.args[1].headers.Authorization).to.equal('Bearer ims-tok'); // direct: raw IMS
+  });
+
+  it('logs the IMS client id used (identifier, not a secret)', async () => {
+    await run({ IMS_CLIENT_ID: 'the-worker-client-id' });
+    expect(infoWith(/imsClientId=the-worker-client-id/)).to.equal(true);
+  });
+
+  it('prefers a threaded imsOrgId and skips the getImsOrgId lookup', async () => {
+    await run({}, 'threaded@AdobeOrg');
+    expect(getImsOrgIdStub).to.not.have.been.called;
+    expect(JSON.parse(loginCalls()[0].args[1].body)).to.deep.equal({ imsOrgId: 'threaded@AdobeOrg' });
+  });
+
+  it('falls back to getImsOrgId when no imsOrgId is threaded', async () => {
+    await run();
+    expect(getImsOrgIdStub).to.have.been.calledOnceWith(site, sinon.match.object);
+  });
+
+  it('defaults dataAccess to an empty object when the context omits it', async () => {
+    await mod.runSemrushAuthProbes({
+      site, previousWeeks: PREVIOUS_WEEKS, context: { log, env: {} },
+    });
+    expect(getImsOrgIdStub.firstCall.args[1]).to.deep.equal({});
+  });
+
+  // --- prerequisites --------------------------------------------------------
+
+  it('skips when the site has no organization id', async () => {
+    const bare = { getOrganizationId: () => null, getId: () => SITE_ID };
+    await mod.runSemrushAuthProbes({
+      site: bare, previousWeeks: PREVIOUS_WEEKS, context: makeContext(),
+    });
+    expect(warnWith(/skipped — missing prerequisites/)).to.equal(true);
+    expect(fetchStub).to.not.have.been.called;
+  });
+
+  it('skips when no active brand resolves', async () => {
+    resolveBrandResultForSite.resolves({ brand: null, resolved: true });
+    await run();
+    expect(warnWith(/missing prerequisites/)).to.equal(true);
+    expect(fetchStub).to.not.have.been.called;
+  });
+
+  it('skips when the customer IMS org id cannot be resolved', async () => {
+    getImsOrgIdStub.resolves(null);
+    await run();
+    expect(warnWith(/missing prerequisites/)).to.equal(true);
+    expect(fetchStub).to.not.have.been.called;
+  });
+
+  it('skips when no date window can be derived', async () => {
+    getDateWindowStub.returns(null);
+    await run();
+    expect(warnWith(/missing prerequisites/)).to.equal(true);
+    expect(fetchStub).to.not.have.been.called;
+  });
+
+  // --- IMS mint -------------------------------------------------------------
+
+  it('logs ims_mint_failed and runs no probes when the IMS token cannot be minted', async () => {
+    getServiceAccessToken.rejects(new Error('ims down'));
+    await run();
+    expect(warnWith(/could not mint an IMS token/)).to.equal(true);
+    expect(fetchStub).to.not.have.been.called;
+  });
+
+  it('logs ims_mint_failed when the IMS token response has no access_token', async () => {
+    getServiceAccessToken.resolves({ token_type: 'Bearer' });
+    await run();
+    expect(warnWith(/could not mint an IMS token/)).to.equal(true);
+    expect(fetchStub).to.not.have.been.called;
+  });
+
+  // --- probe A (login exchange) --------------------------------------------
+
+  it('logs a login rejection (non-2xx) and does not call domain-urls for probe A', async () => {
+    fetchStub.withArgs(sinon.match(isLogin)).resolves({ ok: false, status: 403, text: async () => 'no-access' });
+    await run();
+    expect(warnWith(/login_existing_ims\] login: HTTP 403 \(rejected/)).to.equal(true);
+    expect(warnWith(/responseBody=no-access/)).to.equal(true);
+    // Probe A skipped its data call; only probe B (direct) hits domain-urls.
+    expect(dataCalls().length).to.equal(1);
+  });
+
+  it('logs a login network error for probe A', async () => {
+    fetchStub.withArgs(sinon.match(isLogin)).rejects(new Error('login net down'));
+    await run();
+    expect(warnWith(/login_existing_ims\] login request failed \(network\)/)).to.equal(true);
+    expect(dataCalls().length).to.equal(1); // only probe B
+  });
+
+  it('logs when login is 200 but the body has no sessionToken', async () => {
+    fetchStub.withArgs(sinon.match(isLogin)).resolves(okJson({ notAToken: true }));
+    await run();
+    expect(warnWith(/login: HTTP 200 but no sessionToken/)).to.equal(true);
+    expect(dataCalls().length).to.equal(1); // only probe B
+  });
+
+  it('treats an unparseable login body as no sessionToken', async () => {
+    fetchStub.withArgs(sinon.match(isLogin)).resolves({
+      ok: true, status: 200, json: async () => { throw new Error('bad json'); },
+    });
+    await run();
+    expect(warnWith(/no sessionToken/)).to.equal(true);
+    expect(dataCalls().length).to.equal(1);
+  });
+
+  // --- domain-urls outcomes (shared by both probes) -------------------------
+
+  it('logs a non-authorized domain-urls result with the response body', async () => {
+    fetchStub.withArgs(sinon.match((u) => !isLogin(u)))
+      .resolves({ ok: false, status: 401, text: async () => 'denied' });
+    await run();
+    expect(warnWith(/domain-urls: HTTP 401 \(not authorized\)/)).to.equal(true);
+    expect(warnWith(/responseBody=denied/)).to.equal(true);
+  });
+
+  it('tolerates an unreadable error body (text() throws) — no responseBody token emitted', async () => {
+    fetchStub.withArgs(sinon.match((u) => !isLogin(u)))
+      .resolves({ ok: false, status: 500, text: async () => { throw new Error('unreadable'); } });
+    await run();
+    expect(warnWith(/domain-urls: HTTP 500 \(not authorized\)/)).to.equal(true);
+    expect(log.warn.getCalls().some((c) => /status=500/.test(c.args[0]) && !/responseBody=/.test(c.args[0]))).to.equal(true);
+  });
+
+  it('handles an empty domain-urls error body (no responseBody token emitted)', async () => {
+    fetchStub.withArgs(sinon.match((u) => !isLogin(u)))
+      .resolves({ ok: false, status: 500, text: async () => '' });
+    await run();
+    expect(log.warn.getCalls().some((c) => /status=500/.test(c.args[0]) && !/responseBody=/.test(c.args[0]))).to.equal(true);
+  });
+
+  it('logs a domain-urls network error', async () => {
+    fetchStub.withArgs(sinon.match((u) => !isLogin(u))).rejects(new Error('data net down'));
+    await run();
+    expect(warnWith(/domain-urls request failed \(network\)/)).to.equal(true);
+  });
+
+  // --- crash safety ---------------------------------------------------------
+
+  it('swallows any unexpected error and never throws (audit unaffected)', async () => {
+    resolveBrandResultForSite.rejects(new Error('unexpected'));
+    await run(); // must not throw
+    expect(warnWith(/Auth probe crashed \(swallowed/)).to.equal(true);
+  });
+
+  it('honours LLMO_API_BASE_URL / LLMO_S2S_LOGIN_URL overrides', async () => {
+    await run({
+      LLMO_API_BASE_URL: 'https://stage.example',
+      LLMO_S2S_LOGIN_URL: 'https://stage.example/api/ci/auth/s2s/login',
+    });
+    expect(loginCalls()[0].args[0]).to.equal('https://stage.example/api/ci/auth/s2s/login');
+    expect(dataCalls()[0].args[0]).to.contain('https://stage.example/v2/orgs/');
+  });
+});

--- a/test/utils/offsite-brand-presence-semrush-auth-probe.test.js
+++ b/test/utils/offsite-brand-presence-semrush-auth-probe.test.js
@@ -254,6 +254,34 @@ describe('offsite-brand-presence-semrush-auth-probe', function () {
     expect(warnWith(/domain-urls request failed \(network\)/)).to.equal(true);
   });
 
+  // --- probe C (x-api-key) --------------------------------------------------
+
+  it('runs probe C (x-api-key) against domain-urls when SPACECAT_API_KEY is set', async () => {
+    await run({ SPACECAT_API_KEY: 'the-key' });
+    // A (session token) + B (direct IMS) + C (api key) = 3 domain-urls calls.
+    expect(dataCalls().length).to.equal(3);
+    const probeC = dataCalls()[2];
+    expect(probeC.args[0]).to.contain('/domain-urls'); // same LLMO-host route as A/B
+    expect(probeC.args[1].headers['x-api-key']).to.equal('the-key');
+    expect(probeC.args[1].headers).to.not.have.property('Authorization');
+    expect(infoWith(/apikey_direct\] domain-urls: HTTP 200 \(authorized\)/)).to.equal(true);
+  });
+
+  it('skips probe C and logs when SPACECAT_API_KEY is not configured', async () => {
+    await run(); // no api key
+    expect(warnWith(/apikey_direct\] skipped — SPACECAT_API_KEY not configured/)).to.equal(true);
+    expect(dataCalls().length).to.equal(2); // only A and B
+  });
+
+  it('runs probe C even when the IMS mint fails (it is independent of IMS)', async () => {
+    getServiceAccessToken.rejects(new Error('ims down'));
+    await run({ SPACECAT_API_KEY: 'the-key' });
+    expect(warnWith(/could not mint an IMS token/)).to.equal(true);
+    expect(loginCalls().length).to.equal(0); // probe A skipped (no IMS token)
+    expect(dataCalls().length).to.equal(1); // only probe C hit domain-urls
+    expect(dataCalls()[0].args[1].headers['x-api-key']).to.equal('the-key');
+  });
+
   // --- crash safety ---------------------------------------------------------
 
   it('swallows any unexpected error and never throws (audit unaffected)', async () => {


### PR DESCRIPTION
## What changed

Adds a **temporary, telemetry-only** diagnostic that answers one operational question — *without* the dedicated `SEMRUSH_S2S_*` consumer credentials we're still pinning down: **which credential does api-service accept for the Semrush routes from the audit-worker?**

The production S2S session-token loader ([`offsite-brand-presence-semrush.js`](https://github.com/adobe/spacecat-audit-worker/blob/main/src/utils/offsite-brand-presence-semrush.js), merged in #2958) is **unchanged and remains the primary data path**. This PR only adds a side probe.

### New module: [`offsite-brand-presence-semrush-auth-probe.js`](src/utils/offsite-brand-presence-semrush-auth-probe.js)

`runSemrushAuthProbes(...)` runs **three** probes back-to-back against the same LLMO-host `domain-urls` route, varying only the credential (the route always requires *some* token — a no-token call is `401` at the edge):

| Probe | Credential sent | What a result means |
|---|---|---|
| `login_existing_ims` | Mint IMS token from the worker's **existing default client** → `POST /auth/s2s/login` → call `domain-urls` with the returned `sessionToken` | Login `200` + sessionToken → the existing IMS identity **is already a registered S2S consumer** for the org. `401/403` → it isn't. |
| `direct_ims` | Raw IMS bearer, no login exchange | Exercises api-service's **IMS path**. `401/403` expected for a service token. |
| `apikey_direct` | Scoped **`x-api-key`** (`SPACECAT_API_KEY`, the credential `brand-resolver.js` already uses against `/v2/orgs/...`) | Independent of IMS — no login, no IMS token. If the route accepts it, that's **access with zero new registration**. |

Each step emits one structured Splunk line (`event=data_acquisition_bp_semrush_auth_probe`, distinct `probe`/`step`/`status`/`authorized`/capped `responseBody` fields, plus **`imsClientId`** — the identity we actually authenticated as). No token/key values are ever logged. Probe C runs even if the IMS mint fails (it doesn't need IMS), and is skipped with a logged reason when `SPACECAT_API_KEY` is absent.

## Why

We can't yet identify the registered S2S consumer's client id/secret. Rather than block, this probe reuses credentials the worker **already holds** (its default IMS client, and the `SPACECAT_API_KEY` used elsewhere) to determine — from Splunk, on one canary run — whether we already have access and via which mechanism, so we know whether a separate registration is actually required.

## How to run

Per-run on one site (Slack `messageData`): `semrushAuthProbe: true`. Or fleet-wide: env `OFFSITE_SEMRUSH_AUTH_PROBE=true`. Then filter Splunk for `event=data_acquisition_bp_semrush_auth_probe`.

## Reviewer notes

- **Side-effect-free:** the probe never throws and **never affects the audit result** — it only writes logs. Gated off by default.
- **Temporary:** intended to be removed (module + the handler call site) once the S2S credential question is settled. Comment at the top of the module says so.
- **Isolation:** the only production-path change is a gated, best-effort call in [`offsite-brand-presence/handler.js`](src/offsite-brand-presence/handler.js) after `imsOrgId`/`previousWeeks` are resolved.
- **Coverage:** new module at 100%; full suite green (100% gate held); lint clean.

## Related Issues

LLMO-6709

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Andrei Paraschiv"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```