### PR TITLE
feat(offsite-brand-presence): richer diagnostics for Semrush S2S auth (LLMO-6709)

### DIFF
--- a/src/utils/offsite-brand-presence-semrush.js
+++ b/src/utils/offsite-brand-presence-semrush.js
@@ -353,7 +353,7 @@ async function fetchDomainUrls(url, headers, olog, pageSize) {
     response = await fetch(url, { headers, timeout: FETCH_TIMEOUT_MS });
   } catch (error) {
     olog.warn('data_acquisition_bp_data_semrush_read', 'Fetch failed for domain-urls', {
-      peer: PEER.SEMRUSH, direction: 'inbound', durationMs: Date.now() - startedAt, reason: 'fetch_failed', outcome: OUTCOME.DEGRADED, ...errorField(error),
+      peer: PEER.SEMRUSH, direction: 'inbound', requestUrl: url, durationMs: Date.now() - startedAt, reason: 'fetch_failed', outcome: OUTCOME.DEGRADED, ...errorField(error),
     }, error);
     return {
       rows: [], ok: false, authFailure: false, truncated: false,
@@ -367,7 +367,7 @@ async function fetchDomainUrls(url, headers, olog, pageSize) {
     // vs Semrush upstream) — the key signal for the LLMO-6709 auth gate.
     const responseBody = await readErrorBodySnippet(response);
     const logFields = {
-      peer: PEER.SEMRUSH, direction: 'inbound', status: response.status, responseBody, durationMs,
+      peer: PEER.SEMRUSH, direction: 'inbound', requestUrl: url, status: response.status, responseBody, durationMs,
     };
     if (authFailure) {
       // Distinct branch so a rejected session token is visible instead of being

--- a/src/utils/offsite-brand-presence-semrush.js
+++ b/src/utils/offsite-brand-presence-semrush.js
@@ -207,6 +207,66 @@ async function getImsAuthorizationHeader(context) {
 }
 
 /**
+ * Non-secret IMS config fields for the `ims_token_failed` diagnostic log, so a misconfig is
+ * obvious from the log line alone rather than needing a repro. Every field below is safe to
+ * log: `imsHost`/`imsClientId`/`imsScope` are identifiers/config (not credentials), and the
+ * client secret is reported only as a presence boolean (`hasClientSecret`), never its value.
+ * The two derived flags target the exact mistakes seen in practice — a scheme in the host
+ * (`https://ims...` → `getaddrinfo ENOTFOUND https`) and whitespace in the scope
+ * (`invalid_scope`) — and are emitted only when true, so they stand out.
+ *
+ * @param {object} [env]
+ * @returns {object} log fields
+ */
+function imsConfigDiagnostics(env) {
+  const imsHost = env?.SEMRUSH_S2S_IMS_HOST;
+  const imsScope = env?.SEMRUSH_S2S_CLIENT_SCOPE;
+  return {
+    imsHost,
+    imsClientId: env?.SEMRUSH_S2S_CLIENT_ID,
+    imsScope,
+    hasClientSecret: Boolean(env?.SEMRUSH_S2S_CLIENT_SECRET),
+    ...(/^https?:\/\//i.test(imsHost || '') && { imsHostHasScheme: true }),
+    ...(/\s/.test(imsScope || '') && { imsScopeHasSpaces: true }),
+  };
+}
+
+/**
+ * Decodes the non-sensitive identity claims from an S2S session-token JWT for logging, so a
+ * run's logs show WHICH consumer identity (and tenant scope) api-service actually granted —
+ * the client-side counterpart to api-service's own `[s2s] granted clientId=... consumerId=...`
+ * line. Reads the JWT payload only (never the signature) and never logs the token itself.
+ * Never throws — returns `{}` for a malformed/opaque token, so nothing is logged then.
+ *
+ * The token carries `client_id`/`is_s2s_consumer`/`tenants`; `consumerId`/`consumer_id` are
+ * logged defensively only if the real token includes them (it's primarily a server-side id).
+ *
+ * @param {string} sessionToken - raw JWT (`header.payload.signature`).
+ * @returns {object} selected claim fields (empty when undecodable).
+ */
+function decodeS2sConsumerClaims(sessionToken) {
+  try {
+    const payload = String(sessionToken).split('.')[1];
+    if (!payload) {
+      return {};
+    }
+    const json = Buffer.from(payload.replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8');
+    const claims = JSON.parse(json);
+    const tenants = Array.isArray(claims.tenants) ? claims.tenants : undefined;
+    return {
+      consumerClientId: claims.client_id,
+      consumerSub: claims.sub,
+      isS2sConsumer: claims.is_s2s_consumer,
+      ...(claims.consumerId !== undefined && { consumerId: claims.consumerId }),
+      ...(claims.consumer_id !== undefined && { consumerId: claims.consumer_id }),
+      ...(tenants && { tenantCount: tenants.length }),
+    };
+  } catch {
+    return {};
+  }
+}
+
+/**
  * Exchanges the consumer's IMS access token for a short-lived (15-min), customer-scoped
  * SpaceCat session token via the S2S login endpoint. The returned session token is a JWT
  * whose `tenants` claim names `imsOrgId` — this is what api-service's
@@ -605,7 +665,7 @@ export async function loadCitedUrlsFromSemrush({
       imsAuthorization = await getImsAuthorizationHeader(context);
     } catch (error) {
       olog.warn('data_acquisition_bp_data_semrush_read', 'Failed to obtain IMS service token', {
-        peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, brandId: brand.brandId, durationMs: elapsed(), reason: 'ims_token_failed', outcome: OUTCOME.DEGRADED, ...errorField(error),
+        peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, brandId: brand.brandId, durationMs: elapsed(), reason: 'ims_token_failed', outcome: OUTCOME.DEGRADED, ...imsConfigDiagnostics(env), ...errorField(error),
       }, error);
       await notify(`:x: Failed to obtain an IMS service token (\`${error.message}\`) — falling back to the legacy source.`);
       setDiagnostics({ fallbackReason: 'ims_token_failed' });
@@ -649,6 +709,11 @@ export async function loadCitedUrlsFromSemrush({
       return null;
     }
     cacheSessionToken(imsOrgId, sessionToken, nowMs, resolveSessionTtlMs(env));
+    // Log the consumer identity we were granted (decoded from the token's claims, never the
+    // token itself) — the client-side match to api-service's `[s2s] granted ...` audit line.
+    olog.success('data_acquisition_bp_data_semrush_read', 'Obtained S2S session token', {
+      peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, brandId: brand.brandId, ...decodeS2sConsumerClaims(sessionToken),
+    });
   }
 
   const headers = {

--- a/src/utils/offsite-brand-presence-semrush.js
+++ b/src/utils/offsite-brand-presence-semrush.js
@@ -729,7 +729,7 @@ export async function loadCitedUrlsFromSemrush({
     baseUrl, spaceCatId, brandId: brand.brandId, startDate, endDate, pageSize: PAGE_SIZE,
   });
   olog.start('data_acquisition_bp_data_semrush_read', 'Querying domain-urls (all hosts, all platforms)', {
-    peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, brandId: brand.brandId, pageSize: PAGE_SIZE,
+    peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, brandId: brand.brandId, requestUrl: url, pageSize: PAGE_SIZE,
   });
   await notify(':satellite: Querying `domain-urls` (all hosts, all platforms) in a single request...');
 
@@ -791,6 +791,7 @@ export async function loadCitedUrlsFromSemrush({
     direction: 'inbound',
     orgId: spaceCatId,
     brandId: brand.brandId,
+    requestUrl: url,
     receivedCount: result.rows.length,
     uniqueUrlCount: allUrls.size,
     droppedCount: result.rows.length - allUrls.size,

--- a/test/utils/offsite-brand-presence-semrush.test.js
+++ b/test/utils/offsite-brand-presence-semrush.test.js
@@ -36,6 +36,8 @@ const CITED_URL = 'https://example.org/page';
 
 const okJson = (body) => ({ ok: true, status: 200, json: async () => body });
 const isLogin = (u) => String(u).includes('/auth/s2s/login');
+// Builds a JWT-shaped token (`header.payload.signature`) whose payload encodes `claims`.
+const makeJwt = (claims) => `h.${Buffer.from(JSON.stringify(claims)).toString('base64url')}.s`;
 
 describe('offsite-brand-presence-semrush', function () {
   this.timeout(10000);
@@ -704,6 +706,40 @@ describe('offsite-brand-presence-semrush', function () {
     expect(warnedWith(/Failed to obtain IMS service token/)).to.equal(true);
   });
 
+  it('logs non-secret IMS config on ims_token_failed (host, clientId, scope, secret presence)', async () => {
+    getServiceAccessTokenV3.rejects(new Error('ims down'));
+    await run({
+      SEMRUSH_S2S_IMS_HOST: 'ims-na1.adobelogin.com',
+      SEMRUSH_S2S_CLIENT_ID: 'cid',
+      SEMRUSH_S2S_CLIENT_SECRET: 'sec',
+      SEMRUSH_S2S_CLIENT_SCOPE: 'openid,AdobeID',
+    });
+    expect(warnedWith(/imsHost=ims-na1\.adobelogin\.com/)).to.equal(true);
+    expect(warnedWith(/imsClientId=cid/)).to.equal(true);
+    expect(warnedWith(/imsScope=openid,AdobeID/)).to.equal(true);
+    expect(warnedWith(/hasClientSecret=true/)).to.equal(true);
+  });
+
+  it('flags a scheme in SEMRUSH_S2S_IMS_HOST on ims_token_failed (the ENOTFOUND https bug)', async () => {
+    getServiceAccessTokenV3.rejects(new Error('getaddrinfo ENOTFOUND https'));
+    await run({ SEMRUSH_S2S_IMS_HOST: 'https://ims-na1.adobelogin.com' });
+    expect(warnedWith(/imsHostHasScheme=true/)).to.equal(true);
+  });
+
+  it('flags whitespace in SEMRUSH_S2S_CLIENT_SCOPE on ims_token_failed', async () => {
+    getServiceAccessTokenV3.rejects(new Error('invalid_scope'));
+    await run({ SEMRUSH_S2S_CLIENT_SCOPE: 'openid, AdobeID' });
+    expect(warnedWith(/imsScopeHasSpaces=true/)).to.equal(true);
+  });
+
+  it('reports hasClientSecret=false and no gotcha flags when config is absent', async () => {
+    getServiceAccessTokenV3.rejects(new Error('ims down'));
+    await run();
+    expect(warnedWith(/hasClientSecret=false/)).to.equal(true);
+    expect(warnedWith(/imsHostHasScheme=/)).to.equal(false);
+    expect(warnedWith(/imsScopeHasSpaces=/)).to.equal(false);
+  });
+
   // --- session token exchange (leg 3) ---------------------------------------
 
   it('splits a 403 login denial into session_token_auth_failed, logs the body, but keeps it out of Slack', async () => {
@@ -765,6 +801,47 @@ describe('offsite-brand-presence-semrush', function () {
     const diagnostics = {};
     expect(await run({}, {}, undefined, diagnostics)).to.equal(null);
     expect(diagnostics.fallbackReason).to.equal('session_token_failed');
+  });
+
+  // --- granted consumer identity (decoded from the session token) ------------
+
+  const grantLine = () => log.info.getCalls()
+    .map((c) => c.args[0])
+    .find((m) => /Obtained S2S session token/.test(m));
+
+  it('logs the granted consumer identity decoded from the session token', async () => {
+    fetchStub.withArgs(sinon.match(isLogin)).resolves(okJson({
+      sessionToken: makeJwt({
+        client_id: 'consumer-cid', is_s2s_consumer: true, sub: 's2s:consumer-cid', tenants: [{ id: 'o1' }, { id: 'o2' }], consumerId: 'cons-123',
+      }),
+    }));
+    await run();
+    expect(grantLine()).to.match(/consumerClientId=consumer-cid/);
+    expect(grantLine()).to.match(/isS2sConsumer=true/);
+    expect(grantLine()).to.match(/consumerId=cons-123/);
+    expect(grantLine()).to.match(/tenantCount=2/);
+  });
+
+  it('reads a snake_case consumer_id claim and omits tenantCount when tenants are absent', async () => {
+    fetchStub.withArgs(sinon.match(isLogin)).resolves(okJson({
+      sessionToken: makeJwt({ client_id: 'cid', consumer_id: 'snake-1' }),
+    }));
+    await run();
+    expect(grantLine()).to.match(/consumerId=snake-1/);
+    expect(grantLine()).to.not.match(/tenantCount=/);
+  });
+
+  it('logs the grant line but no consumer fields for an opaque (non-JWT) token', async () => {
+    await run(); // default SESSION_TOKEN has no payload segment
+    expect(grantLine()).to.be.a('string');
+    expect(grantLine()).to.not.match(/consumerClientId=/);
+  });
+
+  it('tolerates a token whose payload is not valid JSON (decode swallowed)', async () => {
+    fetchStub.withArgs(sinon.match(isLogin)).resolves(okJson({ sessionToken: 'h.@@@notjson@@@.s' }));
+    const result = await run();
+    expect(result).to.not.equal(null); // still proceeds to the data call
+    expect(grantLine()).to.not.match(/consumerClientId=/);
   });
 
   // --- progress notifications (onProgress) -----------------------------------

--- a/test/utils/offsite-brand-presence-semrush.test.js
+++ b/test/utils/offsite-brand-presence-semrush.test.js
@@ -449,6 +449,8 @@ describe('offsite-brand-presence-semrush', function () {
     expect(result).to.equal(null);
     expect(warnedWith(/session token rejected/i)).to.equal(true);
     expect(log.warn.getCalls().some((c) => c.args[0].includes(`responseBody="${proxyMsg}"`))).to.equal(true);
+    // The exact request URL is logged (org/brand/dates/params) to diagnose a malformed request.
+    expect(warnedWith(/requestUrl="[^"]*\/domain-urls\?[^"]*"/)).to.equal(true);
   });
 
   it('handles an empty/unreadable error body on a non-2xx response', async () => {

--- a/test/utils/offsite-brand-presence-semrush.test.js
+++ b/test/utils/offsite-brand-presence-semrush.test.js
@@ -130,6 +130,10 @@ describe('offsite-brand-presence-semrush', function () {
     const [url] = dataCall().args;
     expect(new URL(url).searchParams.has('hostname')).to.equal(false);
     expect(new URL(url).searchParams.get('platform')).to.equal('all');
+    // requestUrl is logged on both the start and the success (Bucketed) lines.
+    const infoLines = log.info.getCalls().map((c) => c.args[0]);
+    expect(infoLines.some((m) => /Querying domain-urls.*requestUrl="[^"]*\/domain-urls\?/.test(m))).to.equal(true);
+    expect(infoLines.some((m) => /Bucketed domain-urls response.*requestUrl="[^"]*\/domain-urls\?/.test(m))).to.equal(true);
   });
 
   it('splits the single response into youtube / reddit / cited buckets', async () => {


### PR DESCRIPTION
## What changed

Makes Semrush S2S wiring failures diagnosable **from the logs alone**, without a repro. Two additions to [`offsite-brand-presence-semrush.js`](src/utils/offsite-brand-presence-semrush.js) — no behavior change to the auth flow itself, logging only.

### 1. `ims_token_failed` now logs the non-secret IMS config that caused it

| Field | Purpose |
|---|---|
| `imsHost` | Raw `SEMRUSH_S2S_IMS_HOST` (shows a malformed scheme, or is absent if unset) |
| `imsClientId` | Which client id we authenticated as |
| `imsScope` | Raw scope (shows wrong/mistyped scopes) |
| `hasClientSecret` | Presence boolean — **never the secret value** |
| `imsHostHasScheme` | Emitted **only when true** — flags a scheme in the host (`https://ims...` → `getaddrinfo ENOTFOUND https`) |
| `imsScopeHasSpaces` | Emitted **only when true** — flags whitespace in the scope (→ `invalid_scope`) |

The two derived flags target the exact misconfigurations hit while wiring this up.

### 2. Successful login now logs the granted consumer identity

Decoded from the session-token JWT's claims — the client-side counterpart to api-service's `[s2s] granted clientId=... consumerId=...` audit line:

`consumerClientId` (`client_id`), `consumerSub` (`sub`), `isS2sConsumer`, `consumerId`/`consumer_id` (only if the token carries one), and `tenantCount`.

Verified against api-service: the login body is just `{ sessionToken }`, and the S2S token's claims are `client_id` / `is_s2s_consumer` / `tenants` / `sub` — there's no `consumerId` field in what the consumer receives (that's api-service's internal DB id), so `client_id` is logged as `consumerClientId`, with `consumerId` surfaced defensively if present.

## Why

Wiring the S2S flow surfaced a chain of config-only failures (missing `SEMRUSH_S2S_IMS_HOST`, a scheme in the host, whitespace in the scope) that all landed as a generic `ims_token_failed` with no indication of the cause. These fields turn each into a one-glance diagnosis, and the consumer-identity line confirms *which* consumer/tenant api-service actually granted once login succeeds.

## Reviewer notes

- **No secrets or token values are ever logged** — the client secret is a presence boolean only; the JWT decode reads the payload (never the signature) and never logs the raw token; it never throws (returns `{}` for an opaque/malformed token).
- **Logging-only** — the auth flow, fallback behavior, and diagnostics contract are unchanged.
- **Coverage:** loader module at 100%; 77 loader + 108 handler tests passing; lint clean.

## Related Issues

LLMO-6709

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["@amitruluimadalina"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```