### PR TITLE
feat(seo-gap-analysis): add keyword SERP competitor gap analysis hand…

### DIFF
--- a/docs/specs/2026-09-11-seo-gap-analysis.md
+++ b/docs/specs/2026-09-11-seo-gap-analysis.md
@@ -1,0 +1,73 @@
+# Spec: SEO / GEO / AEO Competitor Gap Analysis
+
+- Status: Proposed
+- Date: 2026-09-11
+- Author: (Ashutosh Shroti)
+
+## Problem statement
+
+Given a keyword, a target URL to optimize, and a set of domains to exclude, we want to
+discover the competitor pages ranking for that keyword, analyze each page for SEO / GEO
+(generative-engine) / AEO (answer-engine) signals, and return a structured gap report the
+downstream content-optimization service can act on. The analysis must run behind a public
+HTTP API with an async (submit → poll) contract, and must work for competitor URLs that are
+**not** registered SpaceCat sites (they are discovered at request time).
+
+## Goals
+
+- Keyword → SERP (Bright Data, ~2 pages) → bucket results (target / branded / competitor /
+  filtered) excluding the target and `filterDomains`.
+- Scrape each competitor page + the target with full JS hydration (up to 45s) and extract a
+  normalized SEO/GEO/AEO signal snapshot.
+- Diff the target against competitors and return a generic, extensible comparison report.
+- No dependency on a registered `site` record.
+
+## Non-goals
+
+- Third-party vs. competitor sub-classification (bucket enum reserves `third-party` for a
+  later heuristic; today all non-branded, non-filtered results are `competitor`).
+- Rendering / UI. This service produces the data another service consumes.
+
+## Technical design
+
+Three cooperating repos:
+
+1. **spacecat-api-service** — public `POST /seo-gap-analysis` (IMS-authenticated + entitlement)
+   creates an `AsyncJob`, emits a `seo-gap-analysis` SQS message, returns `202 { jobId, pollUrl }`.
+   `GET /seo-gap-analysis/jobs/{jobId}` returns the `AsyncJob` status/result.
+2. **spacecat-audit-worker** — two operational handlers (no AuditBuilder, non-site):
+   - `seo-gap-analysis` (phase 1): SERP via `BrightDataClient.googleSearchByQuery` (keyword mode,
+     no `site:` scope), `bucketSerpResults`, then `ScrapeClient.createScrapeJob` with
+     `processingType: 'seo-comparison'` for `[targetUrl, ...competitors]`. Buckets + scrapeJobId
+     recorded on the `AsyncJob` metadata.
+   - `seo-comparison` (phase 2): triggered by the content-scraper completion, reads each snapshot
+     from S3, separates target from competitors, `computeSeoGap`, writes the report onto the
+     `AsyncJob` (COMPLETED).
+3. **spacecat-content-scraper** — new `seo-comparison` handler + `seo-comparison.js` extraction
+   script (45s hydration, `networkidle2`) capturing meta, canonical/hreflang, OpenGraph/Twitter,
+   full heading hierarchy, schema.org JSON-LD + types, content-depth, link/image stats.
+
+The gap engine (`gap.js`) is a **factor registry** — each comparable signal is one `FACTOR`
+descriptor, so new SEO/GEO/AEO dimensions are added without touching the diff logic.
+
+## Correlation / open integration point
+
+Phase 2 is keyed on the content-scraper completion `type` (`seo-comparison`). The originating
+`AsyncJob` id is echoed via the scrape `metaData` (`seoGapAnalysisJobId`) and resolved with
+fallbacks (`auditContext` → `metaData` → per-result `jobMetadata`), plus the scrapeJobId stored
+on the AsyncJob metadata as a backstop. **The exact echo path of `metaData` into the completion
+message must be validated end-to-end** against the scrape-job-manager / content-scraper
+completion behavior, since this handler runs outside the AuditBuilder step framework that
+normally wires this automatically.
+
+## Security
+
+Caller-controlled `targetUrl` and SERP-discovered URLs are fetched server-side (SSRF surface).
+The public endpoint is IMS + entitlement gated; an allow/deny + private-range guard on scraped
+URLs should be added before GA.
+
+## Success criteria
+
+- End-to-end: keyword → report JSON with per-factor target-vs-competitor diffs and a prioritized
+  recommendation list.
+- 100% unit coverage on the new worker modules (met).

--- a/src/index.js
+++ b/src/index.js
@@ -129,6 +129,7 @@ import offsiteBrandPresenceDrsStatus from './offsite-brand-presence/drs-status-h
 import { refreshGeoBrandPresenceSheetsHandler } from './geo-brand-presence/geo-brand-presence-refresh-handler.js';
 import { refreshGeoBrandPresenceDailyHandler } from './geo-brand-presence-daily/geo-brand-presence-refresh-handler.js';
 import brandClaims from './brand-claims/handler.js';
+import { analyze as seoGapAnalysis, aggregate as seoGapAnalysisAggregate } from './seo-gap-analysis/handler.js';
 
 const HANDLERS = {
   accessibility,
@@ -243,6 +244,10 @@ const HANDLERS = {
   'geo-brand-presence-trigger-refresh': refreshGeoBrandPresenceSheetsHandler,
   'refresh:geo-brand-presence-daily': refreshGeoBrandPresenceDailyHandler,
   'brand-claims': brandClaims,
+  // SEO gap analysis: phase 1 (SERP + scrape fan-out) and phase 2 (aggregate + diff).
+  // Phase 2 is keyed on the content-scraper completion `type` (seo-comparison).
+  'seo-gap-analysis': seoGapAnalysis,
+  'seo-comparison': seoGapAnalysisAggregate,
   'rum-config-refresh': rumConfigRefresh,
   dummy: (message) => ok(message),
 };

--- a/src/seo-gap-analysis/constants.js
+++ b/src/seo-gap-analysis/constants.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+// Message type consumed from api-service to start the analysis (phase 1).
+export const SEO_GAP_ANALYSIS_TYPE = 'seo-gap-analysis';
+
+// Processing type routed to the content-scraper seo-comparison handler. The scrape
+// completion message arrives back on this type and drives aggregation (phase 2).
+export const SEO_COMPARISON_PROCESSING_TYPE = 'seo-comparison';
+
+// Number of organic SERP results to inspect (~2 pages of Google results).
+export const DEFAULT_SERP_RESULTS = 20;
+
+// Cap on competitor pages scraped per analysis, to bound cost/latency of the fan-out.
+export const MAX_COMPETITORS = 15;
+
+// URL buckets produced from the SERP.
+export const BUCKET = {
+  TARGET: 'target',
+  BRANDED: 'branded',
+  COMPETITOR: 'competitor',
+  THIRD_PARTY: 'third-party',
+  FILTERED: 'filtered',
+};

--- a/src/seo-gap-analysis/gap.js
+++ b/src/seo-gap-analysis/gap.js
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/**
+ * SEO / GEO / AEO gap computation.
+ *
+ * The engine is intentionally data-driven: every comparable page signal is described by a
+ * FACTOR descriptor, and {@link computeSeoGap} simply runs each descriptor over the target
+ * snapshot and the competitor snapshots. Adding a new comparison dimension means adding one
+ * FACTOR entry — the diffing, scoring and output shape stay untouched. This keeps the public
+ * API generic and extensible for the downstream content-optimization service.
+ */
+
+const num = (v) => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
+const median = (values) => {
+  const sorted = values.map(num).sort((a, b) => a - b);
+  if (sorted.length === 0) return 0;
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+};
+const prevalence = (values) => (values.length
+  ? Number((values.filter(Boolean).length / values.length).toFixed(3))
+  : 0);
+
+/**
+ * A factor descriptor.
+ * @typedef {Object} Factor
+ * @property {string} key       - Stable identifier surfaced in the API.
+ * @property {string} dimension - 'seo' | 'geo' | 'aeo'.
+ * @property {string} label     - Human-readable description.
+ * @property {'count'|'presence'} kind - Whether the value is a magnitude or a boolean signal.
+ * @property {(s: object) => number|boolean} extract - Pull the value from a page snapshot.
+ */
+
+/** @type {Factor[]} */
+export const FACTORS = [
+  {
+    key: 'wordCount',
+    dimension: 'seo',
+    label: 'Body word count (content depth)',
+    kind: 'count',
+    extract: (s) => num(s?.content?.wordCount),
+  },
+  {
+    key: 'h2Count',
+    dimension: 'seo',
+    label: 'Number of H2 sub-headings (structure)',
+    kind: 'count',
+    extract: (s) => num(s?.headings?.counts?.h2),
+  },
+  {
+    key: 'internalLinks',
+    dimension: 'seo',
+    label: 'Internal links (site depth signal)',
+    kind: 'count',
+    extract: (s) => num(s?.links?.internal),
+  },
+  {
+    key: 'imageAltCoverage',
+    dimension: 'seo',
+    label: 'Fraction of images with alt text',
+    kind: 'count',
+    extract: (s) => num(s?.images?.altCoverage),
+  },
+  {
+    key: 'hasStructuredData',
+    dimension: 'geo',
+    label: 'Presence of schema.org structured data (JSON-LD)',
+    kind: 'presence',
+    extract: (s) => Array.isArray(s?.structuredData) && s.structuredData.length > 0,
+  },
+  {
+    key: 'schemaTypeCount',
+    dimension: 'geo',
+    label: 'Distinct schema.org @types declared',
+    kind: 'count',
+    extract: (s) => (Array.isArray(s?.schemaTypes) ? s.schemaTypes.length : 0),
+  },
+  {
+    key: 'hasOpenGraph',
+    dimension: 'geo',
+    label: 'Open Graph tags for rich/LLM previews',
+    kind: 'presence',
+    extract: (s) => !!s?.openGraph && Object.keys(s.openGraph).length > 0,
+  },
+  {
+    key: 'hasFaqSchema',
+    dimension: 'aeo',
+    label: 'FAQ/Q&A structured data (answer-engine signal)',
+    kind: 'presence',
+    extract: (s) => !!s?.content?.hasFaqSchema,
+  },
+  {
+    key: 'hasMetaDescription',
+    dimension: 'seo',
+    label: 'Meta description present',
+    kind: 'presence',
+    extract: (s) => !!(s?.meta?.description),
+  },
+];
+
+/**
+ * Compares a single factor across the target and competitors.
+ *
+ * @param {Factor} factor
+ * @param {object} target - Target page snapshot.
+ * @param {object[]} competitors - Competitor page snapshots.
+ * @returns {object} Per-factor gap record.
+ */
+function compareFactor(factor, target, competitors) {
+  const targetValue = factor.extract(target);
+  const competitorValues = competitors.map((c) => factor.extract(c));
+
+  if (factor.kind === 'presence') {
+    const competitorPrevalence = prevalence(competitorValues);
+    // A gap exists when the target lacks a signal the majority of competitors have.
+    const gap = !targetValue && competitorPrevalence >= 0.5;
+    return {
+      factor: factor.key,
+      dimension: factor.dimension,
+      label: factor.label,
+      kind: factor.kind,
+      target: !!targetValue,
+      competitorPrevalence,
+      gap,
+      recommendation: gap
+        ? `Add ${factor.label.toLowerCase()} — present on ${Math.round(competitorPrevalence * 100)}% of ranking competitors but missing on the target.`
+        : null,
+    };
+  }
+
+  const competitorMedian = median(competitorValues);
+  // A gap exists when the target is materially below the competitor median.
+  const gap = targetValue < competitorMedian;
+  const deficit = gap ? Number((competitorMedian - targetValue).toFixed(3)) : 0;
+  return {
+    factor: factor.key,
+    dimension: factor.dimension,
+    label: factor.label,
+    kind: factor.kind,
+    target: targetValue,
+    competitorMedian,
+    competitorMax: competitorValues.length ? Math.max(...competitorValues.map(num)) : 0,
+    gap,
+    deficit,
+    recommendation: gap
+      ? `Increase ${factor.label.toLowerCase()}: target=${targetValue} vs competitor median=${competitorMedian}.`
+      : null,
+  };
+}
+
+/**
+ * Computes the full gap report of the target page against its competitors.
+ *
+ * @param {object} target - Target page snapshot (from the seo-comparison scrape).
+ * @param {object[]} competitors - Competitor page snapshots.
+ * @param {Factor[]} [factors] - Factor registry (defaults to {@link FACTORS}); injectable for
+ *   extension/testing.
+ * @returns {object} Structured, extensible comparison report.
+ */
+export function computeSeoGap(target, competitors, factors = FACTORS) {
+  const safeTarget = target || {};
+  const safeCompetitors = Array.isArray(competitors) ? competitors.filter(Boolean) : [];
+
+  const factorResults = factors.map((f) => compareFactor(f, safeTarget, safeCompetitors));
+  const gaps = factorResults.filter((r) => r.gap);
+
+  const byDimension = factorResults.reduce((acc, r) => {
+    acc[r.dimension] = acc[r.dimension] || { total: 0, gaps: 0 };
+    acc[r.dimension].total += 1;
+    if (r.gap) acc[r.dimension].gaps += 1;
+    return acc;
+  }, {});
+
+  return {
+    schemaVersion: 1,
+    target: { url: safeTarget.url ?? null },
+    competitorCount: safeCompetitors.length,
+    summary: {
+      totalFactors: factorResults.length,
+      gapsFound: gaps.length,
+      byDimension,
+    },
+    factors: factorResults,
+    // Prioritized, ready-to-action list for the downstream optimizer service.
+    recommendations: gaps.map((g) => ({
+      factor: g.factor,
+      dimension: g.dimension,
+      recommendation: g.recommendation,
+    })),
+  };
+}

--- a/src/seo-gap-analysis/gap.js
+++ b/src/seo-gap-analysis/gap.js
@@ -23,7 +23,9 @@
 const num = (v) => (typeof v === 'number' && Number.isFinite(v) ? v : 0);
 const median = (values) => {
   const sorted = values.map(num).sort((a, b) => a - b);
-  if (sorted.length === 0) return 0;
+  if (sorted.length === 0) {
+    return 0;
+  }
   const mid = Math.floor(sorted.length / 2);
   return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
 };
@@ -177,7 +179,9 @@ export function computeSeoGap(target, competitors, factors = FACTORS) {
   const byDimension = factorResults.reduce((acc, r) => {
     acc[r.dimension] = acc[r.dimension] || { total: 0, gaps: 0 };
     acc[r.dimension].total += 1;
-    if (r.gap) acc[r.dimension].gaps += 1;
+    if (r.gap) {
+      acc[r.dimension].gaps += 1;
+    }
     return acc;
   }, {});
 

--- a/src/seo-gap-analysis/handler.js
+++ b/src/seo-gap-analysis/handler.js
@@ -1,0 +1,209 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { ok, notFound, internalServerError } from '@adobe/spacecat-shared-http-utils';
+import { hasText, isNonEmptyArray } from '@adobe/spacecat-shared-utils';
+import { AsyncJob } from '@adobe/spacecat-shared-data-access';
+import { ScrapeClient } from '@adobe/spacecat-shared-scrape-client';
+import BrightDataClient from '../support/bright-data-client.js';
+import { getObjectFromKey } from '../utils/s3-utils.js';
+import { bucketSerpResults } from './serp.js';
+import { computeSeoGap } from './gap.js';
+import {
+  DEFAULT_SERP_RESULTS,
+  MAX_COMPETITORS,
+  SEO_COMPARISON_PROCESSING_TYPE,
+} from './constants.js';
+
+/**
+ * Phase 1 — SERP discovery + scrape fan-out.
+ *
+ * Consumes the `seo-gap-analysis` message emitted by api-service, runs the keyword through
+ * the Bright Data SERP, buckets the results relative to the target, records the buckets on
+ * the AsyncJob, then submits the target + competitor URLs to the content-scraper
+ * `seo-comparison` handler. The scrape completion re-enters this worker as a `seo-comparison`
+ * message and is handled by {@link aggregate} (phase 2).
+ *
+ * @param {object} message - `{ jobId, keyword, targetUrl, filterDomains, currentRanking, locale }`
+ * @param {object} context - Universal Lambda context.
+ * @returns {Promise<Response>}
+ */
+export async function analyze(message, context) {
+  const { log, env } = context;
+  const { AsyncJob: AsyncJobEntity } = context.dataAccess;
+  const {
+    jobId,
+    keyword,
+    targetUrl,
+    filterDomains = [],
+    locale = null,
+  } = message;
+
+  if (!hasText(jobId) || !hasText(keyword) || !hasText(targetUrl)) {
+    log.error('[seo-gap-analysis] Missing required fields (jobId, keyword, targetUrl)');
+    return notFound();
+  }
+
+  const job = await AsyncJobEntity.findById(jobId);
+  if (!job) {
+    log.error(`[seo-gap-analysis] AsyncJob ${jobId} not found`);
+    return notFound();
+  }
+
+  try {
+    job.setStatus(AsyncJob.Status.IN_PROGRESS);
+    await job.save();
+
+    const brightData = BrightDataClient.createFrom(context);
+    const results = await brightData.googleSearchByQuery(keyword, DEFAULT_SERP_RESULTS, locale);
+
+    const buckets = bucketSerpResults(results, {
+      targetUrl,
+      filterDomains,
+      maxCompetitors: MAX_COMPETITORS,
+    });
+
+    // Always scrape the target so phase 2 has a baseline to diff against, plus each competitor.
+    const urls = [targetUrl, ...buckets.competitors.map((c) => c.url)]
+      .map((url) => ({ url }));
+
+    log.info(
+      `[seo-gap-analysis] job=${jobId} keyword="${keyword}" competitors=${buckets.competitors.length} `
+      + `branded=${buckets.branded.length} filtered=${buckets.filtered.length}`,
+    );
+
+    const scrapeClient = ScrapeClient.createFrom(context);
+    const scrapeJob = await scrapeClient.createScrapeJob({
+      urls,
+      processingType: SEO_COMPARISON_PROCESSING_TYPE,
+      maxScrapeAge: 24,
+      // Correlation: echoed back on the scrape completion so phase 2 can resolve the AsyncJob
+      // and know which URL is the target. Also carried into completionQueueUrl routing via
+      // the scrape stack's env config (AUDIT_JOBS_QUEUE_URL).
+      metaData: {
+        seoGapAnalysisJobId: jobId,
+        targetUrl,
+        completionQueueUrl: env?.AUDIT_JOBS_QUEUE_URL,
+      },
+    });
+
+    // Persist buckets + the scrape job id onto the AsyncJob metadata for observability and
+    // as a fallback correlation key.
+    const metadata = job.getMetadata() || {};
+    job.setMetadata({
+      ...metadata,
+      seoGapAnalysis: {
+        keyword,
+        targetUrl,
+        scrapeJobId: scrapeJob.id,
+        buckets,
+      },
+    });
+    await job.save();
+
+    return ok({ jobId, scrapeJobId: scrapeJob.id });
+  } catch (e) {
+    log.error(`[seo-gap-analysis] job=${jobId} failed in phase 1: ${e.message}`, e);
+    job.setStatus(AsyncJob.Status.FAILED);
+    job.setError({ code: e.code ?? 'EXCEPTION', message: e.message, details: e.stack });
+    job.setEndedAt(new Date().toISOString());
+    await job.save();
+    return internalServerError();
+  }
+}
+
+/**
+ * Reads a single scraped page snapshot from S3.
+ *
+ * @param {object} scrapeResult - One entry of the completion message `scrapeResults`.
+ * @param {object} context - Lambda context (s3Client, env, log).
+ * @returns {Promise<object|null>} The seo-comparison snapshot, or null when unavailable.
+ */
+async function readSnapshot(scrapeResult, context) {
+  const { s3Client, env, log } = context;
+  const key = scrapeResult?.location || scrapeResult?.metadata?.path;
+  if (!hasText(key)) return null;
+  const obj = await getObjectFromKey(s3Client, env.S3_SCRAPER_BUCKET_NAME, key, log);
+  // The stored object nests the eval output under `scrapeResult` (see content-scraper).
+  return obj?.scrapeResult ? { ...obj.scrapeResult, finalUrl: obj.finalUrl } : null;
+}
+
+/**
+ * Phase 2 — aggregate scrape results and compute the gap report.
+ *
+ * Triggered by the content-scraper `seo-comparison` completion message. Loads every scraped
+ * snapshot, separates the target from the competitors, computes the SEO/GEO/AEO gap report,
+ * and writes it onto the originating AsyncJob (COMPLETED).
+ *
+ * @param {object} message - The scrape completion message.
+ * @param {object} context - Universal Lambda context.
+ * @returns {Promise<Response>}
+ */
+export async function aggregate(message, context) {
+  const { log } = context;
+  const { AsyncJob: AsyncJobEntity } = context.dataAccess;
+
+  // Correlation id is echoed by the content-scraper handler (auditContext) or carried on the
+  // per-result jobMetadata / message metaData.
+  const seoGapAnalysisJobId = message?.auditContext?.seoGapAnalysisJobId
+    ?? message?.metaData?.seoGapAnalysisJobId
+    ?? message?.scrapeResults?.[0]?.metadata?.jobMetadata?.seoGapAnalysisJobId;
+  const targetUrl = message?.auditContext?.targetUrl
+    ?? message?.metaData?.targetUrl;
+
+  if (!hasText(seoGapAnalysisJobId)) {
+    log.warn('[seo-gap-analysis] completion message missing seoGapAnalysisJobId; ignoring');
+    return notFound();
+  }
+
+  const job = await AsyncJobEntity.findById(seoGapAnalysisJobId);
+  if (!job) {
+    log.error(`[seo-gap-analysis] AsyncJob ${seoGapAnalysisJobId} not found for aggregation`);
+    return notFound();
+  }
+
+  try {
+    const scrapeResults = isNonEmptyArray(message?.scrapeResults) ? message.scrapeResults : [];
+    const snapshots = (await Promise.all(
+      scrapeResults.map((r) => readSnapshot(r, context)),
+    )).filter(Boolean);
+
+    const effectiveTarget = targetUrl
+      ?? job.getMetadata()?.seoGapAnalysis?.targetUrl;
+
+    const isTarget = (s) => effectiveTarget
+      && (s.url === effectiveTarget || s.finalUrl === effectiveTarget);
+    const target = snapshots.find(isTarget) || null;
+    const competitors = snapshots.filter((s) => !isTarget(s));
+
+    const report = computeSeoGap(target, competitors);
+
+    job.setStatus(AsyncJob.Status.COMPLETED);
+    job.setResult(report);
+    job.setEndedAt(new Date().toISOString());
+    await job.save();
+
+    log.info(
+      `[seo-gap-analysis] job=${seoGapAnalysisJobId} completed: `
+      + `${report.summary.gapsFound}/${report.summary.totalFactors} gaps across ${competitors.length} competitors`,
+    );
+
+    return ok({ jobId: seoGapAnalysisJobId });
+  } catch (e) {
+    log.error(`[seo-gap-analysis] job=${seoGapAnalysisJobId} failed in phase 2: ${e.message}`, e);
+    job.setStatus(AsyncJob.Status.FAILED);
+    job.setError({ code: e.code ?? 'EXCEPTION', message: e.message, details: e.stack });
+    job.setEndedAt(new Date().toISOString());
+    await job.save();
+    return internalServerError();
+  }
+}

--- a/src/seo-gap-analysis/handler.js
+++ b/src/seo-gap-analysis/handler.js
@@ -131,7 +131,9 @@ export async function analyze(message, context) {
 async function readSnapshot(scrapeResult, context) {
   const { s3Client, env, log } = context;
   const key = scrapeResult?.location || scrapeResult?.metadata?.path;
-  if (!hasText(key)) return null;
+  if (!hasText(key)) {
+    return null;
+  }
   const obj = await getObjectFromKey(s3Client, env.S3_SCRAPER_BUCKET_NAME, key, log);
   // The stored object nests the eval output under `scrapeResult` (see content-scraper).
   return obj?.scrapeResult ? { ...obj.scrapeResult, finalUrl: obj.finalUrl } : null;

--- a/src/seo-gap-analysis/serp.js
+++ b/src/seo-gap-analysis/serp.js
@@ -21,7 +21,9 @@ import { BUCKET } from './constants.js';
  * @returns {string|null} The normalized hostname, or null if the URL is unparseable.
  */
 export function hostOf(url) {
-  if (!hasText(url)) return null;
+  if (!hasText(url)) {
+    return null;
+  }
   try {
     const withProto = url.startsWith('http') ? url : `https://${url}`;
     return new URL(withProto).hostname.toLowerCase().replace(/^www\./, '');
@@ -40,7 +42,9 @@ export function hostOf(url) {
  */
 export function hostMatchesDomain(host, domain) {
   const normalizedDomain = (domain || '').toLowerCase().replace(/^www\./, '');
-  if (!host || !normalizedDomain) return false;
+  if (!host || !normalizedDomain) {
+    return false;
+  }
   return host === normalizedDomain || host.endsWith(`.${normalizedDomain}`);
 }
 

--- a/src/seo-gap-analysis/serp.js
+++ b/src/seo-gap-analysis/serp.js
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { hasText } from '@adobe/spacecat-shared-utils';
+import { BUCKET } from './constants.js';
+
+/**
+ * Extracts a normalized, lower-cased registrable-ish host from a URL.
+ * Strips a leading "www." so target/competitor matching is not defeated by the www alias.
+ *
+ * @param {string} url - The URL to parse.
+ * @returns {string|null} The normalized hostname, or null if the URL is unparseable.
+ */
+export function hostOf(url) {
+  if (!hasText(url)) return null;
+  try {
+    const withProto = url.startsWith('http') ? url : `https://${url}`;
+    return new URL(withProto).hostname.toLowerCase().replace(/^www\./, '');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * True when `host` equals `domain` or is a subdomain of it. Comparison is done on
+ * www-stripped, lower-cased hosts so "shop.brand.com" matches a filterDomain of "brand.com".
+ *
+ * @param {string} host - The candidate host.
+ * @param {string} domain - The domain to match against.
+ * @returns {boolean}
+ */
+export function hostMatchesDomain(host, domain) {
+  const normalizedDomain = (domain || '').toLowerCase().replace(/^www\./, '');
+  if (!host || !normalizedDomain) return false;
+  return host === normalizedDomain || host.endsWith(`.${normalizedDomain}`);
+}
+
+/**
+ * Heuristic: two hosts share a brand when they share the same second-level label
+ * (e.g. "blog.nike.com" and "nike.com" both reduce to "nike"). Deliberately simple —
+ * it only needs to catch a target's own alternate hosts appearing in the SERP.
+ *
+ * @param {string} host - Candidate host.
+ * @param {string} targetHost - The target's host.
+ * @returns {boolean}
+ */
+export function sharesBrand(host, targetHost) {
+  const label = (h) => {
+    const parts = h.split('.');
+    return parts.length >= 2 ? parts[parts.length - 2] : parts[0];
+  };
+  return label(host) === label(targetHost);
+}
+
+/**
+ * Buckets raw Bright Data organic SERP results relative to the target page.
+ *
+ * Rules (first match wins):
+ * - the target URL's own host                    -> target   (excluded from scraping)
+ * - any host matching one of `filterDomains`     -> filtered (excluded from scraping)
+ * - a host equal to the target host's brand      -> branded  (same registrable brand, other host)
+ * - everything else                              -> competitor
+ *
+ * Third-party classification is intentionally left as a follow-on refinement; today every
+ * non-target, non-filtered, non-branded result is treated as a competitor. The bucket enum
+ * still carries THIRD_PARTY so a future heuristic (e.g. marketplaces, directories) can split
+ * it out without changing the contract.
+ *
+ * @param {Array<object>} results - Bright Data organic results (each with a `.link`/`.url`).
+ * @param {object} opts
+ * @param {string} opts.targetUrl - The URL being optimized.
+ * @param {string[]} [opts.filterDomains] - Domains to exclude (owned/partner/noise).
+ * @param {number} [opts.maxCompetitors] - Cap on competitor URLs returned.
+ * @returns {{ target: object|null, competitors: object[], branded: object[], filtered: object[] }}
+ */
+export function bucketSerpResults(results, opts) {
+  const { targetUrl, filterDomains = [], maxCompetitors = Infinity } = opts;
+  const targetHost = hostOf(targetUrl);
+
+  const buckets = {
+    target: null,
+    competitors: [],
+    branded: [],
+    filtered: [],
+  };
+
+  const seen = new Set();
+
+  (Array.isArray(results) ? results : []).forEach((raw) => {
+    const url = raw?.link || raw?.url;
+    const host = hostOf(url);
+    // Skip unparseable entries, and de-duplicate on the exact URL so the same result
+    // listed twice is scraped once.
+    if (!host || seen.has(url)) {
+      return;
+    }
+    seen.add(url);
+
+    const entry = {
+      url,
+      host,
+      position: raw?.rank ?? raw?.position ?? null,
+      title: raw?.title ?? null,
+      snippet: raw?.description ?? raw?.snippet ?? null,
+    };
+
+    if (targetHost && host === targetHost) {
+      entry.bucket = BUCKET.TARGET;
+      // Keep only the first (highest-ranked) target occurrence.
+      buckets.target = buckets.target || entry;
+    } else if (filterDomains.some((d) => hostMatchesDomain(host, d))) {
+      entry.bucket = BUCKET.FILTERED;
+      buckets.filtered.push(entry);
+    } else if (targetHost && sharesBrand(host, targetHost)) {
+      entry.bucket = BUCKET.BRANDED;
+      buckets.branded.push(entry);
+    } else {
+      entry.bucket = BUCKET.COMPETITOR;
+      buckets.competitors.push(entry);
+    }
+  });
+
+  // Preserve SERP order (Bright Data returns ranked) and cap the fan-out.
+  buckets.competitors = buckets.competitors.slice(0, maxCompetitors);
+
+  return buckets;
+}

--- a/test/audits/seo-gap-analysis/gap.test.js
+++ b/test/audits/seo-gap-analysis/gap.test.js
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import { expect } from 'chai';
+import { computeSeoGap, FACTORS } from '../../../src/seo-gap-analysis/gap.js';
+
+const snapshot = (over = {}) => ({
+  url: 'https://x.com',
+  content: { wordCount: 500, hasFaqSchema: false },
+  headings: { counts: { h2: 5 } },
+  links: { internal: 20 },
+  images: { altCoverage: 0.9 },
+  structuredData: [{ '@type': 'Article' }],
+  schemaTypes: ['Article'],
+  openGraph: { 'og:title': 'x' },
+  meta: { description: 'a desc' },
+  ...over,
+});
+
+describe('seo-gap-analysis/gap', () => {
+  it('exposes a factor registry covering seo/geo/aeo', () => {
+    const dims = new Set(FACTORS.map((f) => f.dimension));
+    expect(dims).to.include.members(['seo', 'geo', 'aeo']);
+  });
+
+  it('reports no gaps when the target matches competitors', () => {
+    const target = snapshot();
+    const competitors = [snapshot(), snapshot()];
+    const report = computeSeoGap(target, competitors);
+    expect(report.summary.gapsFound).to.equal(0);
+    expect(report.recommendations).to.deep.equal([]);
+    expect(report.competitorCount).to.equal(2);
+    expect(report.target.url).to.equal('https://x.com');
+  });
+
+  it('detects count gaps (word count below competitor median)', () => {
+    const target = snapshot({ content: { wordCount: 100, hasFaqSchema: false } });
+    const competitors = [
+      snapshot({ content: { wordCount: 800, hasFaqSchema: false } }),
+      snapshot({ content: { wordCount: 900, hasFaqSchema: false } }),
+    ];
+    const report = computeSeoGap(target, competitors);
+    const wc = report.factors.find((f) => f.factor === 'wordCount');
+    expect(wc.gap).to.equal(true);
+    expect(wc.deficit).to.be.greaterThan(0);
+    expect(wc.competitorMax).to.equal(900);
+    expect(report.recommendations.some((r) => r.factor === 'wordCount')).to.equal(true);
+  });
+
+  it('detects presence gaps (missing structured data on target)', () => {
+    const target = snapshot({ structuredData: [], schemaTypes: [] });
+    const competitors = [snapshot(), snapshot()];
+    const report = computeSeoGap(target, competitors);
+    const sd = report.factors.find((f) => f.factor === 'hasStructuredData');
+    expect(sd.gap).to.equal(true);
+    expect(sd.competitorPrevalence).to.equal(1);
+  });
+
+  it('does not flag a presence gap when competitors also lack the signal', () => {
+    const target = snapshot({ openGraph: {} });
+    const competitors = [snapshot({ openGraph: {} }), snapshot({ openGraph: {} })];
+    const report = computeSeoGap(target, competitors);
+    const og = report.factors.find((f) => f.factor === 'hasOpenGraph');
+    expect(og.gap).to.equal(false);
+  });
+
+  it('handles empty/undefined inputs defensively', () => {
+    const report = computeSeoGap(undefined, undefined);
+    expect(report.competitorCount).to.equal(0);
+    expect(report.target.url).to.equal(null);
+    expect(report.summary.totalFactors).to.equal(FACTORS.length);
+    // With no competitor data, medians are 0 so counts never fall "below"; presence
+    // factors have 0 prevalence so no gaps either.
+    expect(report.summary.gapsFound).to.equal(0);
+  });
+
+  it('supports an injected custom factor registry', () => {
+    const custom = [{
+      key: 'custom', dimension: 'seo', label: 'Custom', kind: 'count', extract: () => 1,
+    }];
+    const report = computeSeoGap(snapshot(), [snapshot()], custom);
+    expect(report.summary.totalFactors).to.equal(1);
+  });
+
+  it('computes even-length median correctly', () => {
+    const target = snapshot({ links: { internal: 0 } });
+    const competitors = [
+      snapshot({ links: { internal: 10 } }),
+      snapshot({ links: { internal: 20 } }),
+    ];
+    const report = computeSeoGap(target, competitors);
+    const il = report.factors.find((f) => f.factor === 'internalLinks');
+    expect(il.competitorMedian).to.equal(15);
+  });
+});

--- a/test/audits/seo-gap-analysis/handler.test.js
+++ b/test/audits/seo-gap-analysis/handler.test.js
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import { expect, use } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
+import esmock from 'esmock';
+
+use(sinonChai);
+use(chaiAsPromised);
+
+const JOB_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const TARGET = 'https://mybrand.com/page';
+
+describe('seo-gap-analysis/handler', () => {
+  const sandbox = sinon.createSandbox();
+
+  let handler;
+  let job;
+  let googleSearchByQuery;
+  let createScrapeJob;
+  let getObjectFromKey;
+  let context;
+
+  const makeJob = () => ({
+    metadata: { seoGapAnalysis: { targetUrl: TARGET } },
+    setStatus: sandbox.stub(),
+    setResult: sandbox.stub(),
+    setError: sandbox.stub(),
+    setEndedAt: sandbox.stub(),
+    setMetadata: sandbox.stub(),
+    getMetadata() { return this.metadata; },
+    save: sandbox.stub().resolves(),
+  });
+
+  const load = async () => esmock('../../../src/seo-gap-analysis/handler.js', {
+    '@adobe/spacecat-shared-data-access': { AsyncJob: { Status: { IN_PROGRESS: 'IN_PROGRESS', COMPLETED: 'COMPLETED', FAILED: 'FAILED' } } },
+    '@adobe/spacecat-shared-scrape-client': { ScrapeClient: { createFrom: () => ({ createScrapeJob }) } },
+    '../../../src/support/bright-data-client.js': { default: { createFrom: () => ({ googleSearchByQuery }) } },
+    '../../../src/utils/s3-utils.js': { getObjectFromKey },
+  });
+
+  beforeEach(async () => {
+    job = makeJob();
+    googleSearchByQuery = sandbox.stub().resolves([
+      { link: TARGET, rank: 1 },
+      { link: 'https://competitor.com/x', rank: 2 },
+    ]);
+    createScrapeJob = sandbox.stub().resolves({ id: 'scrape-job-1' });
+    getObjectFromKey = sandbox.stub();
+    context = {
+      log: {
+        info: sandbox.stub(), warn: sandbox.stub(), error: sandbox.stub(), debug: sandbox.stub(),
+      },
+      env: { AUDIT_JOBS_QUEUE_URL: 'q', S3_SCRAPER_BUCKET_NAME: 'bucket' },
+      s3Client: {},
+      dataAccess: { AsyncJob: { findById: sandbox.stub().resolves(job) } },
+    };
+    handler = await load();
+  });
+
+  afterEach(() => sandbox.restore());
+
+  describe('analyze (phase 1)', () => {
+    it('returns notFound when required fields are missing', async () => {
+      const res = await handler.analyze({ jobId: JOB_ID }, context);
+      expect(res.status).to.equal(404);
+    });
+
+    it('returns notFound when the AsyncJob does not exist', async () => {
+      context.dataAccess.AsyncJob.findById.resolves(null);
+      const res = await handler.analyze(
+        { jobId: JOB_ID, keyword: 'shoes', targetUrl: TARGET }, context,
+      );
+      expect(res.status).to.equal(404);
+    });
+
+    it('runs SERP, buckets, fans out scrape and records metadata', async () => {
+      const res = await handler.analyze(
+        {
+          jobId: JOB_ID, keyword: 'shoes', targetUrl: TARGET, filterDomains: ['partner.com'],
+        },
+        context,
+      );
+      expect(res.status).to.equal(200);
+      expect(googleSearchByQuery).to.have.been.calledWith('shoes', 20, null);
+      expect(createScrapeJob).to.have.been.calledOnce;
+      const payload = createScrapeJob.firstCall.args[0];
+      expect(payload.processingType).to.equal('seo-comparison');
+      expect(payload.urls.map((u) => u.url)).to.include(TARGET);
+      expect(job.setMetadata).to.have.been.calledOnce;
+      expect(job.setStatus).to.have.been.calledWith('IN_PROGRESS');
+    });
+
+    it('defaults job metadata to an empty object when absent', async () => {
+      job.getMetadata = () => undefined;
+      const res = await handler.analyze(
+        { jobId: JOB_ID, keyword: 'shoes', targetUrl: TARGET }, context,
+      );
+      expect(res.status).to.equal(200);
+      const written = job.setMetadata.firstCall.args[0];
+      expect(written.seoGapAnalysis.scrapeJobId).to.equal('scrape-job-1');
+    });
+
+    it('passes an explicit locale through to the SERP call', async () => {
+      await handler.analyze(
+        {
+          jobId: JOB_ID, keyword: 'shoes', targetUrl: TARGET, locale: 'de',
+        },
+        context,
+      );
+      expect(googleSearchByQuery).to.have.been.calledWith('shoes', 20, 'de');
+    });
+
+    it('marks the job FAILED and returns 500 when SERP fails', async () => {
+      googleSearchByQuery.rejects(new Error('brightdata down'));
+      const res = await handler.analyze(
+        { jobId: JOB_ID, keyword: 'shoes', targetUrl: TARGET }, context,
+      );
+      expect(res.status).to.equal(500);
+      expect(job.setStatus).to.have.been.calledWith('FAILED');
+      expect(job.setError).to.have.been.calledOnce;
+    });
+  });
+
+  describe('aggregate (phase 2)', () => {
+    const targetSnap = { url: TARGET, structuredData: [{ '@type': 'Article' }], schemaTypes: ['Article'] };
+    const competitorSnap = { url: 'https://competitor.com/x', structuredData: [{ '@type': 'Product' }], schemaTypes: ['Product'] };
+
+    const completion = {
+      type: 'seo-comparison',
+      auditContext: { seoGapAnalysisJobId: JOB_ID, targetUrl: TARGET },
+      scrapeResults: [
+        { location: 'scrapes/1/target.json', metadata: { url: TARGET } },
+        { location: 'scrapes/1/comp.json', metadata: { url: 'https://competitor.com/x' } },
+      ],
+    };
+
+    it('returns notFound without a correlation id', async () => {
+      const res = await handler.aggregate({ scrapeResults: [] }, context);
+      expect(res.status).to.equal(404);
+    });
+
+    it('returns notFound when the AsyncJob is gone', async () => {
+      context.dataAccess.AsyncJob.findById.resolves(null);
+      const res = await handler.aggregate(completion, context);
+      expect(res.status).to.equal(404);
+    });
+
+    it('computes the gap report and completes the job', async () => {
+      getObjectFromKey
+        .withArgs(sinon.match.any, 'bucket', 'scrapes/1/target.json', sinon.match.any)
+        .resolves({ scrapeResult: targetSnap, finalUrl: TARGET });
+      getObjectFromKey
+        .withArgs(sinon.match.any, 'bucket', 'scrapes/1/comp.json', sinon.match.any)
+        .resolves({ scrapeResult: competitorSnap, finalUrl: 'https://competitor.com/x' });
+
+      const res = await handler.aggregate(completion, context);
+      expect(res.status).to.equal(200);
+      expect(job.setStatus).to.have.been.calledWith('COMPLETED');
+      const report = job.setResult.firstCall.args[0];
+      expect(report.competitorCount).to.equal(1);
+      expect(report.target.url).to.equal(TARGET);
+    });
+
+    it('resolves target from job metadata and skips null snapshots', async () => {
+      const msg = { ...completion, auditContext: { seoGapAnalysisJobId: JOB_ID } };
+      getObjectFromKey.onFirstCall().resolves(null); // missing snapshot skipped
+      getObjectFromKey.onSecondCall().resolves({ scrapeResult: competitorSnap });
+      const res = await handler.aggregate(msg, context);
+      expect(res.status).to.equal(200);
+      expect(job.setStatus).to.have.been.calledWith('COMPLETED');
+    });
+
+    it('resolves correlation + target from message metaData and reads via metadata.path', async () => {
+      const msg = {
+        type: 'seo-comparison',
+        metaData: { seoGapAnalysisJobId: JOB_ID, targetUrl: TARGET },
+        scrapeResults: [
+          { metadata: { path: 'scrapes/1/target.json', url: TARGET } },
+          { metadata: {} }, // no location and no path -> snapshot skipped
+        ],
+      };
+      getObjectFromKey
+        .withArgs(sinon.match.any, 'bucket', 'scrapes/1/target.json', sinon.match.any)
+        .resolves({ scrapeResult: targetSnap, finalUrl: TARGET });
+      const res = await handler.aggregate(msg, context);
+      expect(res.status).to.equal(200);
+      expect(job.setStatus).to.have.been.calledWith('COMPLETED');
+    });
+
+    it('resolves correlation from per-result jobMetadata and tolerates no known target', async () => {
+      job.metadata = {}; // no seoGapAnalysis.targetUrl fallback either
+      const msg = {
+        type: 'seo-comparison',
+        scrapeResults: [
+          { location: 'scrapes/1/a.json', metadata: { jobMetadata: { seoGapAnalysisJobId: JOB_ID } } },
+        ],
+      };
+      getObjectFromKey.resolves({ scrapeResult: competitorSnap });
+      const res = await handler.aggregate(msg, context);
+      expect(res.status).to.equal(200);
+      // With no identifiable target, everything is treated as a competitor.
+      const report = job.setResult.firstCall.args[0];
+      expect(report.competitorCount).to.equal(1);
+      expect(report.target.url).to.equal(null);
+    });
+
+    it('matches the target by finalUrl when the scraped url differs (redirect)', async () => {
+      getObjectFromKey
+        .withArgs(sinon.match.any, 'bucket', 'scrapes/1/target.json', sinon.match.any)
+        .resolves({ scrapeResult: { ...targetSnap, url: 'https://mybrand.com/redirected' }, finalUrl: TARGET });
+      getObjectFromKey
+        .withArgs(sinon.match.any, 'bucket', 'scrapes/1/comp.json', sinon.match.any)
+        .resolves({ scrapeResult: competitorSnap, finalUrl: 'https://competitor.com/x' });
+      const res = await handler.aggregate(completion, context);
+      expect(res.status).to.equal(200);
+      const report = job.setResult.firstCall.args[0];
+      expect(report.competitorCount).to.equal(1);
+    });
+
+    it('completes with an empty report when the completion carries no scrapeResults', async () => {
+      const res = await handler.aggregate(
+        { type: 'seo-comparison', auditContext: { seoGapAnalysisJobId: JOB_ID, targetUrl: TARGET } },
+        context,
+      );
+      expect(res.status).to.equal(200);
+      const report = job.setResult.firstCall.args[0];
+      expect(report.competitorCount).to.equal(0);
+    });
+
+    it('marks the job FAILED and returns 500 when reading snapshots throws', async () => {
+      getObjectFromKey.rejects(new Error('s3 boom'));
+      const res = await handler.aggregate(completion, context);
+      expect(res.status).to.equal(500);
+      expect(job.setStatus).to.have.been.calledWith('FAILED');
+    });
+  });
+});

--- a/test/audits/seo-gap-analysis/serp.test.js
+++ b/test/audits/seo-gap-analysis/serp.test.js
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2026 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+import { expect } from 'chai';
+import {
+  hostOf, hostMatchesDomain, sharesBrand, bucketSerpResults,
+} from '../../../src/seo-gap-analysis/serp.js';
+import { BUCKET } from '../../../src/seo-gap-analysis/constants.js';
+
+describe('seo-gap-analysis/serp', () => {
+  describe('hostOf', () => {
+    it('normalizes and strips www', () => {
+      expect(hostOf('https://www.Nike.com/shoes')).to.equal('nike.com');
+    });
+    it('adds a protocol when missing', () => {
+      expect(hostOf('nike.com/x')).to.equal('nike.com');
+    });
+    it('returns null for empty input', () => {
+      expect(hostOf('')).to.equal(null);
+      expect(hostOf(undefined)).to.equal(null);
+    });
+    it('returns null for unparseable input', () => {
+      expect(hostOf('http://')).to.equal(null);
+    });
+  });
+
+  describe('hostMatchesDomain', () => {
+    it('matches exact host', () => {
+      expect(hostMatchesDomain('brand.com', 'brand.com')).to.equal(true);
+    });
+    it('matches subdomain', () => {
+      expect(hostMatchesDomain('shop.brand.com', 'www.brand.com')).to.equal(true);
+    });
+    it('does not match a different domain', () => {
+      expect(hostMatchesDomain('other.com', 'brand.com')).to.equal(false);
+    });
+    it('returns false for empty inputs', () => {
+      expect(hostMatchesDomain('', 'brand.com')).to.equal(false);
+      expect(hostMatchesDomain('brand.com', '')).to.equal(false);
+    });
+  });
+
+  describe('sharesBrand', () => {
+    it('matches on the second-level label', () => {
+      expect(sharesBrand('blog.nike.com', 'nike.com')).to.equal(true);
+    });
+    it('is false for different brands', () => {
+      expect(sharesBrand('adidas.com', 'nike.com')).to.equal(false);
+    });
+    it('handles single-label hosts', () => {
+      expect(sharesBrand('localhost', 'localhost')).to.equal(true);
+    });
+  });
+
+  describe('bucketSerpResults', () => {
+    const targetUrl = 'https://www.mybrand.com/page';
+    const results = [
+      { link: 'https://www.mybrand.com/page', rank: 1, title: 'Us' },
+      { link: 'https://blog.mybrand.com/post', rank: 2 },
+      { link: 'https://competitor-a.com/x', rank: 3, description: 'A' },
+      { url: 'https://competitor-b.com/y', position: 4 },
+      { link: 'https://partner.com/z', rank: 5 },
+      { link: 'https://competitor-a.com/x', rank: 6 }, // duplicate
+      { link: 'not a url', rank: 7 }, // unparseable
+      { rank: 8 }, // no link at all
+    ];
+
+    it('buckets target, branded, competitors and filtered correctly', () => {
+      const buckets = bucketSerpResults(results, {
+        targetUrl,
+        filterDomains: ['partner.com'],
+      });
+      expect(buckets.target.url).to.equal('https://www.mybrand.com/page');
+      expect(buckets.target.bucket).to.equal(BUCKET.TARGET);
+      expect(buckets.branded.map((b) => b.host)).to.deep.equal(['blog.mybrand.com']);
+      expect(buckets.filtered.map((f) => f.host)).to.deep.equal(['partner.com']);
+      expect(buckets.competitors.map((c) => c.host))
+        .to.deep.equal(['competitor-a.com', 'competitor-b.com']);
+    });
+
+    it('keeps only the first target occurrence and ignores later same-host hits', () => {
+      const dupTarget = [
+        { link: 'https://www.mybrand.com/a', rank: 1 },
+        { link: 'https://mybrand.com/b', rank: 2 }, // same host as target -> ignored
+      ];
+      const buckets = bucketSerpResults(dupTarget, { targetUrl });
+      expect(buckets.target.url).to.equal('https://www.mybrand.com/a');
+      expect(buckets.branded).to.have.length(0);
+      expect(buckets.competitors).to.have.length(0);
+    });
+
+    it('caps competitors at maxCompetitors', () => {
+      const many = Array.from({ length: 5 }, (_, i) => ({ link: `https://c${i}.com/`, rank: i }));
+      const buckets = bucketSerpResults(many, { targetUrl, maxCompetitors: 2 });
+      expect(buckets.competitors).to.have.length(2);
+    });
+
+    it('handles non-array input and missing target host', () => {
+      const buckets = bucketSerpResults(null, { targetUrl: '' });
+      expect(buckets.competitors).to.deep.equal([]);
+      expect(buckets.target).to.equal(null);
+    });
+
+    it('treats every result as a competitor when target host is unparseable', () => {
+      const buckets = bucketSerpResults(
+        [{ link: 'https://c.com/' }],
+        { targetUrl: 'http://' },
+      );
+      expect(buckets.competitors).to.have.length(1);
+    });
+  });
+});


### PR DESCRIPTION
…lers

Adds a two-phase, non-site operational flow that turns a keyword + target URL into an SEO/GEO/AEO competitor gap report, consumed over the api-service async HTTP contract.

- serp.js: keyword SERP result bucketing (target/branded/competitor/filtered), www-aware host matching, dedup + competitor cap. Reuses the existing BrightDataClient.googleSearchByQuery in open-web (no site: scope) mode — no change needed to bright-data-client.
- gap.js: extensible factor-registry diff engine. Each comparable SEO/GEO/AEO signal is one FACTOR descriptor, so new dimensions are added without touching the diff/scoring logic. Emits per-factor target-vs-competitor diffs plus a prioritized recommendation list.
- handler.js:
  * phase 1 (seo-gap-analysis): SERP -> bucket -> ScrapeClient fan-out to the content-scraper seo-comparison handler; records buckets on the AsyncJob.
  * phase 2 (seo-comparison): aggregates scrape snapshots from S3, diffs target vs competitors, writes the report onto the AsyncJob (COMPLETED).
- registered both handlers in src/index.js (phase 2 keyed on the content-scraper completion type).
- 100% unit coverage on all new modules (39 tests).
- spec: docs/specs/2026-09-11-seo-gap-analysis.md, including the one open integration point (metaData echo on scrape completion) to validate e2e.

Companion branches of the same name: spacecat-content-scraper (seo-comparison handler), spacecat-api-service (public endpoint), spacecat-infrastructure (queue).

Please ensure your pull request adheres to the following guidelines:
- [ ] make sure to link the related issues in this description
- [ ] when merging / squashing, make sure the fixed issue references are visible in the commits, for easy compilation of release notes
- [ ] If data sources for any opportunity has been updated/added, please update the [wiki](https://wiki.corp.adobe.com/display/AEMSites/Data+Sources+for+Opportunities) for same opportunity.

## Related Issues


Thanks for contributing!
