### PR TITLE
fix(offsite-brand-presence): send the /api/v1 gateway prefix on the domain-urls call (LLMO-6709)

### DIFF
--- a/src/utils/offsite-brand-presence-semrush.js
+++ b/src/utils/offsite-brand-presence-semrush.js
@@ -46,12 +46,13 @@ import {
 export const LLMO_API_DEFAULT_BASE_URL = 'https://llmo.experiencecloud.live';
 
 /**
- * Path (relative to the LLMO host root) of the S2S login endpoint that exchanges the
- * consumer's IMS access token for a short-lived, customer-scoped SpaceCat session token.
- * The prod prefix is `/api/v1`; non-prod uses `/api/ci`, so the whole URL is overridable
- * with `LLMO_S2S_LOGIN_URL` when the environment's prefix differs.
+ * API gateway prefix in front of the host root. The LLMO Fastly edge routes api-service
+ * under this prefix — the internal routes are registered bare (`/v2/orgs/...`,
+ * `/auth/s2s/login`), and both the login AND the data call must carry the prefix externally
+ * (confirmed against the UI's own network calls, which use `/api/v1/v2/...`). Prod is
+ * `/api/v1`; non-prod uses `/api/ci` — override with `LLMO_API_PREFIX`.
  */
-export const S2S_LOGIN_DEFAULT_PATH = '/api/v1/auth/s2s/login';
+export const LLMO_API_DEFAULT_PREFIX = '/api/v1';
 
 /**
  * `domain-urls` page size. One request (no `hostname`, `platform=all`) covers all three
@@ -517,7 +518,10 @@ export async function loadCitedUrlsFromSemrush({
   const siteId = site?.getId?.();
   const olog = createOffsiteLogger(log, { audit: AUDIT.BRAND_PRESENCE, siteId });
   const elapsed = () => Date.now() - startedAt;
+  // Host root + gateway prefix. The LLMO edge routes api-service under `/api/v1` (prod) —
+  // both the login and the data call carry it, matching the UI's own `/api/v1/v2/...` calls.
   const baseUrl = env?.LLMO_API_BASE_URL || LLMO_API_DEFAULT_BASE_URL;
+  const apiBaseUrl = `${baseUrl}${env?.LLMO_API_PREFIX || LLMO_API_DEFAULT_PREFIX}`;
 
   const notify = async (text) => {
     if (typeof onProgress !== 'function') {
@@ -673,7 +677,7 @@ export async function loadCitedUrlsFromSemrush({
     }
 
     // Leg 3: exchange it for a customer-scoped SpaceCat session token via the LLMO host.
-    const loginUrl = env?.LLMO_S2S_LOGIN_URL || `${baseUrl}${S2S_LOGIN_DEFAULT_PATH}`;
+    const loginUrl = env?.LLMO_S2S_LOGIN_URL || `${apiBaseUrl}/auth/s2s/login`;
     try {
       sessionToken = await exchangeForSessionToken({ loginUrl, imsAuthorization, imsOrgId });
     } catch (error) {
@@ -726,7 +730,12 @@ export async function loadCitedUrlsFromSemrush({
   };
 
   const url = buildDomainUrlsUrl({
-    baseUrl, spaceCatId, brandId: brand.brandId, startDate, endDate, pageSize: PAGE_SIZE,
+    baseUrl: apiBaseUrl,
+    spaceCatId,
+    brandId: brand.brandId,
+    startDate,
+    endDate,
+    pageSize: PAGE_SIZE,
   });
   olog.start('data_acquisition_bp_data_semrush_read', 'Querying domain-urls (all hosts, all platforms)', {
     peer: PEER.SEMRUSH, direction: 'inbound', orgId: spaceCatId, brandId: brand.brandId, requestUrl: url, pageSize: PAGE_SIZE,

--- a/test/utils/offsite-brand-presence-semrush.test.js
+++ b/test/utils/offsite-brand-presence-semrush.test.js
@@ -158,7 +158,7 @@ describe('offsite-brand-presence-semrush', function () {
     await run();
 
     const [url, opts] = dataCall().args;
-    expect(url).to.contain(`${mod.LLMO_API_DEFAULT_BASE_URL}/v2/orgs/${ORG_ID}/brands/${BRAND_ID}`);
+    expect(url).to.contain(`${mod.LLMO_API_DEFAULT_BASE_URL}${mod.LLMO_API_DEFAULT_PREFIX}/v2/orgs/${ORG_ID}/brands/${BRAND_ID}`);
     expect(opts.headers.Authorization).to.equal(`Bearer ${SESSION_TOKEN}`);
     expect(opts.headers.Accept).to.equal('application/json');
     expect(opts.headers).to.not.have.property('Content-Type');
@@ -195,7 +195,7 @@ describe('offsite-brand-presence-semrush', function () {
     await run();
 
     const [url, opts] = loginCall().args;
-    expect(url).to.equal(`${mod.LLMO_API_DEFAULT_BASE_URL}${mod.S2S_LOGIN_DEFAULT_PATH}`);
+    expect(url).to.equal(`${mod.LLMO_API_DEFAULT_BASE_URL}${mod.LLMO_API_DEFAULT_PREFIX}/auth/s2s/login`);
     expect(opts.method).to.equal('POST');
     expect(opts.headers.Authorization).to.equal('Bearer tok');
     expect(opts.headers['Content-Type']).to.equal('application/json');
@@ -210,8 +210,21 @@ describe('offsite-brand-presence-semrush', function () {
 
   it('honours the LLMO_API_BASE_URL override for both the login and the data call', async () => {
     await run({ LLMO_API_BASE_URL: 'https://stage.example' });
-    expect(dataCall().args[0]).to.contain('https://stage.example/v2/orgs/');
-    expect(loginCall().args[0]).to.equal(`https://stage.example${mod.S2S_LOGIN_DEFAULT_PATH}`);
+    expect(dataCall().args[0]).to.contain('https://stage.example/api/v1/v2/orgs/');
+    expect(loginCall().args[0]).to.equal('https://stage.example/api/v1/auth/s2s/login');
+  });
+
+  it('carries the /api/v1 gateway prefix on both the login and data URLs by default', async () => {
+    await run();
+    expect(loginCall().args[0]).to.contain('/api/v1/auth/s2s/login');
+    expect(dataCall().args[0]).to.contain('/api/v1/v2/orgs/');
+  });
+
+  it('honours the LLMO_API_PREFIX override (e.g. non-prod /api/ci) on both URLs', async () => {
+    await run({ LLMO_API_PREFIX: '/api/ci' });
+    expect(loginCall().args[0]).to.contain('/api/ci/auth/s2s/login');
+    expect(dataCall().args[0]).to.contain('/api/ci/v2/orgs/');
+    expect(dataCall().args[0]).to.not.contain('/api/v1/');
   });
 
   it('honours the LLMO_S2S_LOGIN_URL override for the login call', async () => {


### PR DESCRIPTION
## What changed

Prepends the `/api/v1` gateway prefix to the Semrush `domain-urls` data call, matching the login call and the UI's own network requests.

## Why

The LLMO Fastly edge routes api-service under `/api/v1` (prod). api-service registers the routes bare internally (`/v2/orgs/...`, `/auth/s2s/login`), but the **edge expects the prefix in the external URL**. The login call already carried it and worked; the data call did **not** — so the edge rejected the bare `GET /v2/orgs/.../domain-urls` with a synthetic **Varnish 400 "Invalid request" in ~4ms**, before it ever reached api-service.

Diagnosis from production logs (via the diagnostics merged in #2965):
- `Obtained S2S session token` ✅ — IMS mint + S2S login both succeed (`isS2sConsumer=true`, `tenantCount=1`, real techacct client id).
- `domain-urls returned a non-2xx status status=400` with `requestUrl="https://llmo.experiencecloud.live/v2/orgs/.../domain-urls?..."`, `durationMs=4`, Varnish error body → an **edge** rejection of the bare `/v2` path.
- Confirmed the UI calls `/api/v1/v2/...`.

## The fix

Compute one prefixed base and use it for **both** the login and the data URL so they can never drift:

```
apiBaseUrl = (LLMO_API_BASE_URL || default host) + (LLMO_API_PREFIX || '/api/v1')
login → `${apiBaseUrl}/auth/s2s/login`
data  → `${apiBaseUrl}/v2/orgs/.../domain-urls?...`
```

- New env override **`LLMO_API_PREFIX`** (default `/api/v1`) so non-prod (`/api/ci`) is a config change, not a code change.
- Replaces the login-only `S2S_LOGIN_DEFAULT_PATH` constant with the shared `LLMO_API_DEFAULT_PREFIX`; login's resulting URL is unchanged by default.
- `LLMO_S2S_LOGIN_URL` full-URL override still honored.

## Reviewer notes

- Login behavior is unchanged by default (same URL); only the **data** URL gains the prefix it was missing.
- Env-configurable per environment via `LLMO_API_PREFIX`.
- Loader module remains at 100% coverage; tests updated to assert the prefix on both URLs and the `LLMO_API_PREFIX` override; lint clean.

## Related Issues

LLMO-6709

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Andrei Paraschiv"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```