### PR TITLE
fix(offsite-brand-presence): domain-urls timeout 60s, page size 50 (LLMO-6709)

### DIFF
--- a/src/utils/offsite-brand-presence-semrush.js
+++ b/src/utils/offsite-brand-presence-semrush.js
@@ -55,18 +55,29 @@ export const LLMO_API_DEFAULT_BASE_URL = 'https://llmo.experiencecloud.live';
 export const LLMO_API_DEFAULT_PREFIX = '/api/v1';
 
 /**
- * `domain-urls` page size. One request (no `hostname`, `platform=all`) covers all three
- * buckets (youtube.com, reddit.com, cited third-party), sorted by citations globally, so
- * this needs to be generous or a low-citation bucket gets starved. 1000 is the server-side
- * clamp (`domain-urls` in spacecat-api-service), so this is the max we can actually get.
+ * `domain-urls` page size — the top N sources by citations (globally, across youtube.com /
+ * reddit.com / cited third-party). Deliberately small to cap the response size and latency of
+ * this heavy proxied query. The server clamp is 1000; we intentionally request far fewer.
+ *
+ * NOTE: because the page is a single citations-sorted list spanning all three buckets, a small
+ * page can starve a low-citation bucket (e.g. reddit on a press-heavy site) — see ADR 002,
+ * Decision 6. Raise this if a bucket is being starved.
  */
-export const PAGE_SIZE = 1000;
+export const PAGE_SIZE = 50;
 
 /**
- * Per-request timeout so a hung upstream can't stall the whole audit past the Lambda's
- * own timeout.
+ * Per-request timeout for the fast calls (the S2S login exchange) so a hung upstream can't
+ * stall the whole audit past the Lambda's own timeout (900s).
  */
 const FETCH_TIMEOUT_MS = 10_000;
+
+/**
+ * Timeout for the `domain-urls` data call specifically. This is a heavy query (all hosts,
+ * `platform=all`, proxied api-service → Semrush v4-raw), routinely slower than the 10s login
+ * timeout — 10s was aborting it mid-flight (`Request timeout after 10000ms`). The Lambda
+ * budget is 900s, so 60s is safe headroom.
+ */
+const DOMAIN_URLS_TIMEOUT_MS = 60_000;
 
 /**
  * Max chars of a non-2xx response body to log. The body of a rejected serenity/Semrush
@@ -347,11 +358,11 @@ export function buildDomainUrlsUrl({
  *   full page came back (LLMO-6711 shadow-run parity signal — a starved run is visible on
  *   `diagnostics` without grepping logs).
  */
-async function fetchDomainUrls(url, headers, olog, pageSize) {
+async function fetchDomainUrls(url, headers, olog, pageSize, timeoutMs) {
   let response;
   const startedAt = Date.now();
   try {
-    response = await fetch(url, { headers, timeout: FETCH_TIMEOUT_MS });
+    response = await fetch(url, { headers, timeout: timeoutMs });
   } catch (error) {
     olog.warn('data_acquisition_bp_data_semrush_read', 'Fetch failed for domain-urls', {
       peer: PEER.SEMRUSH, direction: 'inbound', requestUrl: url, durationMs: Date.now() - startedAt, reason: 'fetch_failed', outcome: OUTCOME.DEGRADED, ...errorField(error),
@@ -742,7 +753,7 @@ export async function loadCitedUrlsFromSemrush({
   });
   await notify(':satellite: Querying `domain-urls` (all hosts, all platforms) in a single request...');
 
-  const result = await fetchDomainUrls(url, headers, olog, PAGE_SIZE);
+  const result = await fetchDomainUrls(url, headers, olog, PAGE_SIZE, DOMAIN_URLS_TIMEOUT_MS);
   if (!result.ok) {
     if (result.authFailure) {
       // The session token was rejected by the data call — evict it so a revoked/rotated

--- a/test/utils/offsite-brand-presence-semrush.test.js
+++ b/test/utils/offsite-brand-presence-semrush.test.js
@@ -162,7 +162,13 @@ describe('offsite-brand-presence-semrush', function () {
     expect(opts.headers.Authorization).to.equal(`Bearer ${SESSION_TOKEN}`);
     expect(opts.headers.Accept).to.equal('application/json');
     expect(opts.headers).to.not.have.property('Content-Type');
-    expect(opts.timeout).to.equal(10000);
+    expect(opts.timeout).to.equal(60000); // domain-urls timeout (heavy query)
+  });
+
+  it('uses the short login timeout on the login call and the longer one on the data call', async () => {
+    await run();
+    expect(loginCall().args[1].timeout).to.equal(10000);
+    expect(dataCall().args[1].timeout).to.equal(60000);
   });
 
   it('mints the consumer IMS token via getServiceAccessTokenV3 (client_credentials) with SEMRUSH_S2S_* creds', async () => {
@@ -232,9 +238,10 @@ describe('offsite-brand-presence-semrush', function () {
     expect(loginCall().args[0]).to.equal('https://llmo.experiencecloud.page/api/ci/auth/s2s/login');
   });
 
-  it('always requests PAGE_SIZE', async () => {
+  it('requests the hardcoded PAGE_SIZE (50)', async () => {
     await run();
-    expect(new URL(dataCall().args[0]).searchParams.get('pageSize')).to.equal(String(mod.PAGE_SIZE));
+    expect(mod.PAGE_SIZE).to.equal(50);
+    expect(new URL(dataCall().args[0]).searchParams.get('pageSize')).to.equal('50');
   });
 
   // --- filtering / scope ----------------------------------------------------


### PR DESCRIPTION
## What changed

Two hardcoded tunables for the Semrush `domain-urls` data call:

1. **Its own 60s timeout** (was sharing the 10s login timeout). The login exchange stays at 10s; only the heavy data call gets 30s.
2. **Page size capped at 50** (down from 1000) — request only the top 50 sources by citations, to keep the response small and the query fast.

No env vars — both are constants.

## Why

With the `/api/v1` prefix fix (#2967), the `domain-urls` call now **reaches api-service and gets processed** — but it's a heavy query (all hosts, `platform=all`, proxied api-service → Semrush v4-raw) that ran past the old 10s fetch timeout and returned a large response:

```
reason=fetch_failed  durationMs=10006  errorMessage="Request timeout after 10000ms"
```

The Lambda budget is 900s, so 60s is safe headroom; and 50 rows is enough to validate the path end to end while keeping the response/latency down.

## Reviewer notes

- The **login** exchange still uses the 10s `FETCH_TIMEOUT_MS`; only the data call uses `DOMAIN_URLS_TIMEOUT_MS = 60_000`.
- **Trade-off (ADR 002, Decision 6):** the page is a single citations-sorted list spanning youtube/reddit/cited, so a small `PAGE_SIZE` can starve a low-citation bucket (e.g. reddit on a press-heavy site). `PAGE_SIZE = 50` is a deliberate small cap; raise it if a bucket is being starved. The doc comment on `PAGE_SIZE` notes this.
- Loader module remains at 100% coverage; lint clean.

## Related Issues

LLMO-6709

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Change Management

```yaml
cm-assessment: v1
changeType: standard
impact: unnoticeable
risk: minor
changeApprovedBy: ["Andrei Paraschiv"]
rationale: "Auto-added baseline (no PR assessment present at CI time); refine via the cmr skill if this change is higher-impact."
```